### PR TITLE
Update build.mdx

### DIFF
--- a/docs/quickstart/build.mdx
+++ b/docs/quickstart/build.mdx
@@ -19,7 +19,7 @@ Make sure to have [Python](https://www.python.org/downloads/) and
 First, let's create a new project and set up Poetry for dependency management:
 
 ```bash
-poetry new my-endpoint && cd my-endpoint
+poetry new my-endpoint --python=">=3.12,<4.0" && cd my-endpoint
 ```
 
 ## Install Dependencies
@@ -27,7 +27,7 @@ poetry new my-endpoint && cd my-endpoint
 Now, let's install the necessary packages:
 
 ```bash
-poetry add ag-ui openai fastapi uvicorn
+poetry add ag-ui-protocol openai fastapi uvicorn
 ```
 
 ## Create a Basic Endpoint with FastAPI


### PR DESCRIPTION
**Errors** (tested in ubuntu and windows) : 
1,  `Could not find a matching version of package ag-ui`
```
-> # poetry add ag-ui

Could not find a matching version of package ag-ui
```
![image](https://github.com/user-attachments/assets/89999e36-ded1-40b3-96d2-fe32fd38236e)

2, ` For ag-ui-protocol, a possible solution would be to set the `python` property to ">=3.12,<4.0"`
```
-> # poetry add ag-ui-protocol
Using version ^0.1.4 for ag-ui-protocol

Updating dependencies
Resolving dependencies... (0.3s)

The current project's supported Python range (>=3.12) is not compatible with some of the required packages Python requirement:
  - ag-ui-protocol requires Python <4.0,>=3.9, so it will not be installable for Python >=4.0

Because no versions of ag-ui-protocol match >0.1.4,<0.2.0
 and ag-ui-protocol (0.1.4) requires Python <4.0,>=3.9, ag-ui-protocol is forbidden.
So, because my-endpoint depends on ag-ui-protocol (^0.1.4), version solving failed.

  * Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For ag-ui-protocol, a possible solution would be to set the `python` property to ">=3.12,<4.0"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

FIX:
```
poetry new my-endpoint --python=">=3.12,<4.0" && cd my-endpoint
poetry add ag-ui-protocol openai fastapi uvicorn
```

```
😀💬 ~ poetry new my-endpoint --python=">=3.12,<4.0"
Created package my_endpoint in my-endpoint
😺💬 Meow! What should I do next? ...                                                               🏡 Desktop ⌚ 09:14 😀💬 ~ cd my-endpoint
😺💬 Meow! What should I do next? ...                                                           🏡 my-endpoint ⌚ 09:14 😀💬 ~ poetry add ag-ui-protocol openai fastapi uvicorn
Using version ^0.1.4 for ag-ui-protocol
Using version ^1.78.1 for openai
Using version ^0.115.12 for fastapi
Using version ^0.34.2 for uvicorn

Updating dependencies
Resolving dependencies... (4.5s)

Package operations: 22 installs, 0 updates, 0 removals

  - Installing certifi (2025.4.26)
  - Installing h11 (0.16.0)
  - Installing idna (3.10)
  - Installing sniffio (1.3.1)
  - Installing typing-extensions (4.13.2)
  - Installing annotated-types (0.7.0)
  - Installing anyio (4.9.0)
  - Installing colorama (0.4.6)
  - Installing httpcore (1.0.9)
  - Installing pydantic-core (2.33.2)
  - Installing typing-inspection (0.4.0)
  - Installing click (8.2.0)
  - Installing distro (1.9.0)
  - Installing httpx (0.28.1)
  - Installing jiter (0.9.0)
  - Installing pydantic (2.11.4)
  - Installing starlette (0.46.2)
  - Installing tqdm (4.67.1)
  - Installing ag-ui-protocol (0.1.4)
  - Installing fastapi (0.115.12)
  - Installing openai (1.78.1)
  - Installing uvicorn (0.34.2)

Writing lock file
```

![image](https://github.com/user-attachments/assets/972941b5-1ac2-4963-818d-7279f1e24793)
