### PR TITLE
docs: remove duplicate custom event properties table

### DIFF
--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -446,11 +446,6 @@ implementation across frontends and agents.
 | `name`   | Name of the custom event        |
 | `value`  | Value associated with the event |
 
-| Property | Description                     |
-| -------- | ------------------------------- |
-| `name`   | Name of the custom event        |
-| `value`  | Value associated with the event |
-
 ## Event Flow Patterns
 
 Events in the protocol typically follow specific patterns:


### PR DESCRIPTION
The table describing the properties of the [Custom event](https://docs.ag-ui.com/concepts/events#custom) is duplicated. This commit removes it.