### PR TITLE
fix(python-sdk): invalid config dict parameter

### DIFF
--- a/python-sdk/ag_ui/core/types.py
+++ b/python-sdk/ag_ui/core/types.py
@@ -14,7 +14,6 @@ class ConfiguredBaseModel(BaseModel):
         extra="forbid",
         alias_generator=to_camel,
         populate_by_name=True,
-        ser_json_by_alias=True
     )
 
 


### PR DESCRIPTION
Remove the invalid ser_json_by_alias parameter from the ConfigDict constructor in ConfiguredBaseModel.

Fixes #52