### PR TITLE
chore(typescipt-sdk/vercel-ai-sdk): moves @ag-ui/client to dependencies

### DIFF
--- a/typescript-sdk/integrations/vercel-ai-sdk/package.json
+++ b/typescript-sdk/integrations/vercel-ai-sdk/package.json
@@ -18,7 +18,6 @@
     "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
-    "@ag-ui/client": "workspace:*",
     "rxjs": "7.8.1"
   },
   "devDependencies": {
@@ -30,6 +29,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@ag-ui/client": "workspace:*",
     "ai": "^4.3.16",
     "zod": "^3.22.4"
   }

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/dojo:
     dependencies:
+      '@ag-ui/agno':
+        specifier: workspace:*
+        version: link:../../integrations/agno
       '@ag-ui/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -246,10 +249,10 @@ importers:
         version: link:../../packages/core
       '@langchain/core':
         specifier: ^0.3.38
-        version: 0.3.56(openai@4.100.0(zod@3.25.17))
+        version: 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/langgraph-sdk':
         specifier: ^0.0.78
-        version: 0.0.78(@langchain/core@0.3.56(openai@4.100.0(zod@3.25.17)))(react@19.1.0)
+        version: 0.0.78(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(react@19.1.0)
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -8828,7 +8831,7 @@ snapshots:
       '@copilotkit/shared': 1.8.13
       '@graphql-yoga/plugin-defer-stream': 3.13.4(graphql-yoga@5.13.4(graphql@16.11.0))(graphql@16.11.0)
       '@langchain/community': 0.3.43(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.821.0)(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(zod@3.25.17))(@ibm-cloud/watsonx-ai@1.6.6)(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(@smithy/util-utf8@2.3.0)(axios@1.9.0)(cohere-ai@7.17.1)(fast-xml-parser@4.4.1)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(playwright@1.52.0)(ws@8.18.2)
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/google-gauth': 0.1.8(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(zod@3.25.17)
       '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(react@19.1.0)
       '@langchain/openai': 0.4.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(ws@8.18.2)
@@ -9005,7 +9008,7 @@ snapshots:
       '@copilotkit/shared': 1.8.14-next.4
       '@graphql-yoga/plugin-defer-stream': 3.13.4(graphql-yoga@5.13.4(graphql@16.11.0))(graphql@16.11.0)
       '@langchain/community': 0.3.43(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.821.0)(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(zod@3.25.17))(@ibm-cloud/watsonx-ai@1.6.6)(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(@smithy/util-utf8@2.3.0)(axios@1.9.0)(cohere-ai@7.17.1)(fast-xml-parser@4.4.1)(google-auth-library@8.9.0)(ibm-cloud-sdk-core@5.3.2)(ignore@5.3.2)(jsonwebtoken@9.0.2)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(playwright@1.52.0)(ws@8.18.2)
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/google-gauth': 0.1.8(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(zod@3.25.17)
       '@langchain/langgraph-sdk': 0.0.70(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(react@19.1.0)
       '@langchain/openai': 0.4.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(ws@8.18.2)
@@ -9759,7 +9762,7 @@ snapshots:
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.52.0)(deepmerge@4.3.1)(dotenv@16.5.0)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(zod@3.25.17)
       '@ibm-cloud/watsonx-ai': 1.6.6
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/openai': 0.4.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(ws@8.18.2)
       binary-extensions: 2.3.0
       expr-eval: 2.0.2
@@ -9767,7 +9770,7 @@ snapshots:
       ibm-cloud-sdk-core: 5.3.2
       js-yaml: 4.1.0
       langchain: 0.3.26(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(axios@1.9.0)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(ws@8.18.2)
-      langsmith: 0.3.29(openai@4.100.0(zod@3.25.17))
+      langsmith: 0.3.29(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       openai: 4.100.0(ws@8.18.2)(zod@3.25.17)
       uuid: 10.0.0
       zod: 3.25.17
@@ -9802,14 +9805,14 @@ snapshots:
       - handlebars
       - peggy
 
-  '@langchain/core@0.3.56(openai@4.100.0(zod@3.25.17))':
+  '@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.29(openai@4.100.0(zod@3.25.17))
+      langsmith: 0.3.29(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -9821,7 +9824,7 @@ snapshots:
 
   '@langchain/google-common@0.1.8(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(zod@3.25.17)':
     dependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       uuid: 10.0.0
       zod-to-json-schema: 3.24.5(zod@3.25.17)
     transitivePeerDependencies:
@@ -9829,7 +9832,7 @@ snapshots:
 
   '@langchain/google-gauth@0.1.8(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(zod@3.25.17)':
     dependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/google-common': 0.1.8(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(zod@3.25.17)
       google-auth-library: 8.9.0
     transitivePeerDependencies:
@@ -9844,22 +9847,22 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       react: 19.1.0
 
-  '@langchain/langgraph-sdk@0.0.78(@langchain/core@0.3.56(openai@4.100.0(zod@3.25.17)))(react@19.1.0)':
+  '@langchain/langgraph-sdk@0.0.78(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(react@19.1.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       react: 19.1.0
 
   '@langchain/openai@0.4.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(ws@8.18.2)':
     dependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       js-tiktoken: 1.0.20
       openai: 4.100.0(ws@8.18.2)(zod@3.25.17)
       zod: 3.25.17
@@ -9870,7 +9873,7 @@ snapshots:
 
   '@langchain/textsplitters@0.1.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))':
     dependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       js-tiktoken: 1.0.20
 
   '@lukeed/csprng@1.1.0': {}
@@ -13028,7 +13031,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13050,7 +13053,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14575,13 +14578,13 @@ snapshots:
 
   langchain@0.3.26(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(axios@1.9.0)(openai@4.100.0(ws@8.18.2)(zod@3.25.17))(ws@8.18.2):
     dependencies:
-      '@langchain/core': 0.3.56(openai@4.100.0(zod@3.25.17))
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       '@langchain/openai': 0.4.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))(ws@8.18.2)
       '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.25.17)))
       js-tiktoken: 1.0.20
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.3.29(openai@4.100.0(zod@3.25.17))
+      langsmith: 0.3.29(openai@4.100.0(ws@8.18.2)(zod@3.25.17))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -14595,7 +14598,7 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.3.29(openai@4.100.0(zod@3.25.17)):
+  langsmith@0.3.29(openai@4.100.0(ws@8.18.2)(zod@3.25.17)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2


### PR DESCRIPTION
Moves `@ag-ui/client` package to dependencies instead of peerDependecies inside `vercel-ai-sdk` integration to prevent build error.

Fixes: https://github.com/ag-ui-protocol/ag-ui/issues/67