### PR TITLE
Update crypto imports to support React Native

### DIFF
--- a/typescript-sdk/integrations/langgraph/src/index.ts
+++ b/typescript-sdk/integrations/langgraph/src/index.ts
@@ -10,7 +10,7 @@ import {
   Config,
   Interrupt,
 } from "@langchain/langgraph-sdk";
-import { randomUUID } from "node:crypto";
+import { randomUUID } from "@ag-ui/client";
 import { RemoveMessage } from "@langchain/core/messages";
 import {
   LangGraphPlatformMessage,

--- a/typescript-sdk/integrations/mastra/src/index.ts
+++ b/typescript-sdk/integrations/mastra/src/index.ts
@@ -27,7 +27,7 @@ import { registerApiRoute } from "@mastra/core/server";
 import type { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import type { Context } from "hono";
 import { RuntimeContext } from "@mastra/core/runtime-context";
-import { randomUUID } from "crypto";
+import { randomUUID } from "@ag-ui/client";
 import { Observable } from "rxjs";
 import { MastraClient } from "@mastra/client-js";
 type RemoteMastraAgent = ReturnType<MastraClient["getAgent"]>;

--- a/typescript-sdk/integrations/vercel-ai-sdk/src/index.ts
+++ b/typescript-sdk/integrations/vercel-ai-sdk/src/index.ts
@@ -26,7 +26,7 @@ import {
   ToolChoice,
   ToolSet,
 } from "ai";
-import { randomUUID } from "crypto";
+import { randomUUID } from "@ag-ui/client";
 import { z } from "zod";
 
 type ProcessedEvent =

--- a/typescript-sdk/packages/client/src/index.ts
+++ b/typescript-sdk/packages/client/src/index.ts
@@ -4,4 +4,5 @@ export * from "./transform";
 export * from "./run";
 export * from "./legacy";
 export * from "./agent";
+export * from "./utils";
 export * from "@ag-ui/core";

--- a/typescript-sdk/packages/client/src/utils.ts
+++ b/typescript-sdk/packages/client/src/utils.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export const structuredClone_ = (obj: any) => {
   if (typeof structuredClone === "function") {
     return structuredClone(obj);
@@ -9,3 +11,11 @@ export const structuredClone_ = (obj: any) => {
     return { ...obj };
   }
 };
+
+/**
+ * Generate a random UUID v4
+ * Cross-platform compatible (Node.js, browsers, React Native)
+ */
+export function randomUUID(): string {
+  return uuidv4();
+}


### PR DESCRIPTION
@mme I am trying to run the typescript-sdk in a React Native / Expo environment using the Metro bundler, I got a build error due to the package's reliance on crypto:

_The package at "apps/dojo-rn/node_modules/@ag-ui/langgraph/dist/index.js" attempted to import the Node standard library module "crypto".
It failed because the native React runtime does not include the Node standard library._

I am currently employing a polyfill using expo-standard-web-crypto combined with a package patch to resolve this issue, here is a sample of the patch I am currently using [@ag-ui+langgraph+0.0.1-alpha.0.patch](https://github.com/user-attachments/files/20653370/%40ag-ui%2Blanggraph%2B0.0.1-alpha.0.patch)

It basically replaces the ot=require("crypto") with ot={randomUUID:()=>global.crypto.randomUUID()} that is supplied via a polyfill.

This PR basically replaces the direct crypto imports and function calls with UUID v11 which is already an existing dependency, this can then be combined with expo-standard-web-crypto in React Native / Expo projects to provide the required polyfill without additional patches https://github.com/expo/expo/tree/main/packages/expo-standard-web-crypto.