### PR TITLE
fix(typescript-sdk): random build failures

### DIFF
--- a/typescript-sdk/integrations/agno/package.json
+++ b/typescript-sdk/integrations/agno/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/langgraph/package.json
+++ b/typescript-sdk/integrations/langgraph/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/mastra/package.json
+++ b/typescript-sdk/integrations/mastra/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/middleware-starter/package.json
+++ b/typescript-sdk/integrations/middleware-starter/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/server-starter-all-features/package.json
+++ b/typescript-sdk/integrations/server-starter-all-features/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/server-starter/package.json
+++ b/typescript-sdk/integrations/server-starter/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/integrations/vercel-ai-sdk/package.json
+++ b/typescript-sdk/integrations/vercel-ai-sdk/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "clean": "pnpm -r clean",
-    "build:clean": "pnpm -r clean && pnpm install && turbo run build",
+    "clean": "rm -rf dist .turbo node_modules && pnpm -r clean",
+    "build:clean": "rm -rf dist .turbo node_modules && pnpm -r clean && pnpm install && turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md,mdx}\"",

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "clean": "pnpm -r clean",
     "build:clean": "pnpm -r clean && pnpm install && turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",

--- a/typescript-sdk/packages/cli/package.json
+++ b/typescript-sdk/packages/cli/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/packages/client/package.json
+++ b/typescript-sdk/packages/client/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/packages/client/tsup.config.ts
+++ b/typescript-sdk/packages/client/tsup.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((options) => ({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,
   sourcemap: true,
-  clean: true,
-  minify: true,
-});
+  clean: !options.watch, // Don't clean in watch mode to prevent race conditions
+  minify: !options.watch, // Don't minify in watch mode for faster builds
+}));

--- a/typescript-sdk/packages/core/package.json
+++ b/typescript-sdk/packages/core/package.json
@@ -13,7 +13,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint \"src/**/*.ts*\"",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "test": "jest",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"

--- a/typescript-sdk/packages/core/tsup.config.ts
+++ b/typescript-sdk/packages/core/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((options) => ({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,
   sourcemap: true,
-  clean: true,
-});
+  clean: !options.watch, // Don't clean in watch mode to prevent race conditions
+}));

--- a/typescript-sdk/packages/encoder/package.json
+++ b/typescript-sdk/packages/encoder/package.json
@@ -13,7 +13,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint \"src/**/*.ts*\"",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "test": "jest",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"

--- a/typescript-sdk/packages/encoder/tsup.config.ts
+++ b/typescript-sdk/packages/encoder/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((options) => ({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,
   sourcemap: true,
-  clean: true,
-});
+  clean: !options.watch, // Don't clean in watch mode to prevent race conditions
+}));

--- a/typescript-sdk/packages/proto/package.json
+++ b/typescript-sdk/packages/proto/package.json
@@ -13,7 +13,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "lint": "eslint \"src/**/*.ts*\"",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "clean": "rm -rf dist .turbo node_modules",
     "test": "jest",
     "generate": "mkdir -p ./src/generated && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated --ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false -I ./src/proto ./src/proto/*.proto",
     "link:global": "pnpm link --global",

--- a/typescript-sdk/packages/proto/tsup.config.ts
+++ b/typescript-sdk/packages/proto/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((options) => ({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
   splitting: false,
   sourcemap: true,
-  clean: true,
-});
+  clean: !options.watch, // Don't clean in watch mode to prevent race conditions
+}));


### PR DESCRIPTION
Due to the way pnpm runs scripts in parallel, some packages were not ready when others tried to access them, leading to random build failures.

Fixes applied to eliminate race conditions:
- Disable clean in tsup config files
- Use the same clean method across all packages

Also:
- Add clean script to the root package.json for consistency
- Disable minify when watch is enabled for performance

Fixes #59