### PR TITLE
fix: use more explicit dependencies on the langgraph version

### DIFF
--- a/typescript-sdk/integrations/langgraph/package.json
+++ b/typescript-sdk/integrations/langgraph/package.json
@@ -23,11 +23,9 @@
   },
   "dependencies": {
     "@ag-ui/client": "workspace:*",
-    "partial-json": "^0.1.7"
-  },
-  "peerDependencies": {
     "@langchain/core": "^0.3.38",
     "@langchain/langgraph-sdk": "^0.0.78",
+    "partial-json": "^0.1.7",
     "rxjs": "7.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Force rxjs version and langgraph dependencies when the langgraph integration is used