### PR TITLE
Fix step verification bug: use stepName instead of name

### DIFF
--- a/typescript-sdk/packages/client/src/verify/__tests__/verify.steps.test.ts
+++ b/typescript-sdk/packages/client/src/verify/__tests__/verify.steps.test.ts
@@ -53,7 +53,7 @@ describe("verifyEvents steps", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     // Verify only events before the error were processed
-    expect(events.length).toBe(3);
+    expect(events.length).toBe(2);
     expect(events[1].type).toBe(EventType.STEP_STARTED);
   });
 
@@ -68,7 +68,7 @@ describe("verifyEvents steps", () => {
       error: (err) => {
         expect(err).toBeInstanceOf(AGUIError);
         expect(err.message).toContain(
-          `Cannot send 'STEP_FINISHED' for step "undefined" that was not started`,
+          `Cannot send 'STEP_FINISHED' for step "test-step" that was not started`,
         );
         subscription.unsubscribe();
       },
@@ -106,7 +106,7 @@ describe("verifyEvents steps", () => {
       next: (event) => events.push(event),
       error: (err) => {
         expect(err).toBeInstanceOf(AGUIError);
-        expect(err.message).toContain(`Step "undefined" is already active for 'STEP_STARTED'`);
+        expect(err.message).toContain(`Step "test-step" is already active for 'STEP_STARTED'`);
         subscription.unsubscribe();
       },
     });

--- a/typescript-sdk/packages/client/src/verify/verify.ts
+++ b/typescript-sdk/packages/client/src/verify/verify.ts
@@ -14,8 +14,8 @@ export const verifyEvents =
     let firstEventReceived = false;
     // Track active steps
     let activeSteps = new Map<string, boolean>(); // Map of step name -> active status
-    let activeThinkingStep = false
-    let activeThinkingStepMessage = false
+    let activeThinkingStep = false;
+    let activeThinkingStepMessage = false;
 
     return source$.pipe(
       // Process each event through our state machine
@@ -244,7 +244,7 @@ export const verifyEvents =
 
           // Step flow
           case EventType.STEP_STARTED: {
-            const stepName = (event as any).name;
+            const stepName = (event as any).stepName;
             if (activeSteps.has(stepName)) {
               return throwError(
                 () => new AGUIError(`Step "${stepName}" is already active for 'STEP_STARTED'`),
@@ -255,7 +255,7 @@ export const verifyEvents =
           }
 
           case EventType.STEP_FINISHED: {
-            const stepName = (event as any).name;
+            const stepName = (event as any).stepName;
             if (!activeSteps.has(stepName)) {
               return throwError(
                 () =>


### PR DESCRIPTION
- Fixed verification logic in verify.ts to check event.stepName instead of event.name
- This resolves the 'Cannot send STEP_FINISHED for step "undefined"' error
- Updated test expectations to match the corrected behavior
- Bug was causing second requests to LangGraph agents to fail
- All integrations correctly use stepName property per official schemas