### PR TITLE
Make the dojo hostable

### DIFF
--- a/typescript-sdk/apps/dojo/src/agents.ts
+++ b/typescript-sdk/apps/dojo/src/agents.ts
@@ -12,8 +12,10 @@ import { LangGraphAgent } from "@ag-ui/langgraph";
 import { AgnoAgent } from "@ag-ui/agno";
 import { LlamaIndexAgent } from "@ag-ui/llamaindex";
 import { CrewAIAgent } from "@ag-ui/crewai";
+import getEnvVars from "./env";
 import { mastra } from "./mastra";
 
+const envVars = getEnvVars();
 export const agentsIntegrations: AgentIntegrationConfig[] = [
   {
     id: "middleware-starter",
@@ -27,7 +29,7 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     id: "server-starter",
     agents: async () => {
       return {
-        agentic_chat: new ServerStarterAgent({ url: "http://localhost:8000/" }),
+        agentic_chat: new ServerStarterAgent({ url: envVars.serverStarterUrl }),
       };
     },
   },
@@ -36,22 +38,22 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/agentic_chat",
+          url: `${envVars.serverStarterAllFeaturesUrl}/agentic_chat`,
         }),
         human_in_the_loop: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/human_in_the_loop",
+          url: `${envVars.serverStarterAllFeaturesUrl}/human_in_the_loop`,
         }),
         agentic_generative_ui: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/agentic_generative_ui",
+          url: `${envVars.serverStarterAllFeaturesUrl}/agentic_generative_ui`,
         }),
         tool_based_generative_ui: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/tool_based_generative_ui",
+          url: `${envVars.serverStarterAllFeaturesUrl}/tool_based_generative_ui`,
         }),
         shared_state: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/shared_state",
+          url: `${envVars.serverStarterAllFeaturesUrl}/shared_state`,
         }),
         predictive_state_updates: new ServerStarterAllFeaturesAgent({
-          url: "http://localhost:8000/predictive_state_updates",
+          url: `${envVars.serverStarterAllFeaturesUrl}/predictive_state_updates`,
         }),
       };
     },
@@ -60,7 +62,7 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     id: "mastra",
     agents: async () => {
       const mastraClient = new MastraClient({
-        baseUrl: "http://localhost:4111",
+        baseUrl: envVars.mastraUrl,
       });
 
       return MastraAgent.getRemoteAgents({
@@ -87,27 +89,27 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "agentic_chat",
         }),
         agentic_generative_ui: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "agentic_generative_ui",
         }),
         human_in_the_loop: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "human_in_the_loop",
         }),
         predictive_state_updates: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "predictive_state_updates",
         }),
         shared_state: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "shared_state",
         }),
         tool_based_generative_ui: new LangGraphAgent({
-          deploymentUrl: "http://localhost:2024",
+          deploymentUrl: envVars.langgraphUrl,
           graphId: "tool_based_generative_ui",
         }),
       };
@@ -118,7 +120,7 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new AgnoAgent({
-          url: "http://localhost:8000/agui",
+          url: `${envVars.agnoUrl}/agui`,
         }),
       };
     },
@@ -128,16 +130,16 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new LlamaIndexAgent({
-          url: "http://localhost:9000/agentic_chat/run",
+          url: `${envVars.llamaIndexUrl}/agentic_chat/run`,
         }),
         human_in_the_loop: new LlamaIndexAgent({
-          url: "http://localhost:9000/human_in_the_loop/run",
+          url: `${envVars.llamaIndexUrl}/human_in_the_loop/run`,
         }),
         agentic_generative_ui: new LlamaIndexAgent({
-          url: "http://localhost:9000/agentic_generative_ui/run",
+          url: `${envVars.llamaIndexUrl}/agentic_generative_ui/run`,
         }),
         shared_state: new LlamaIndexAgent({
-          url: "http://localhost:9000/shared_state/run",
+          url: `${envVars.llamaIndexUrl}/shared_state/run`,
         }),
       };
     },
@@ -147,22 +149,22 @@ export const agentsIntegrations: AgentIntegrationConfig[] = [
     agents: async () => {
       return {
         agentic_chat: new CrewAIAgent({
-          url: "http://localhost:8000/agentic_chat",
+          url: `${envVars.crewAiUrl}/agentic_chat`,
         }),
         human_in_the_loop: new CrewAIAgent({
-          url: "http://localhost:8000/human_in_the_loop",
+          url: `${envVars.crewAiUrl}/human_in_the_loop`,
         }),
         tool_based_generative_ui: new CrewAIAgent({
-          url: "http://localhost:8000/tool_based_generative_ui",
+          url: `${envVars.crewAiUrl}/tool_based_generative_ui`,
         }),
         agentic_generative_ui: new CrewAIAgent({
-          url: "http://localhost:8000/agentic_generative_ui",
+          url: `${envVars.crewAiUrl}/agentic_generative_ui`,
         }),
         shared_state: new CrewAIAgent({
-          url: "http://localhost:8000/shared_state",
+          url: `${envVars.crewAiUrl}/shared_state`,
         }),
         predictive_state_updates: new CrewAIAgent({
-          url: "http://localhost:8000/predictive_state_updates",
+          url: `${envVars.crewAiUrl}/predictive_state_updates`,
         }),
       };
     },

--- a/typescript-sdk/apps/dojo/src/env.ts
+++ b/typescript-sdk/apps/dojo/src/env.ts
@@ -1,0 +1,21 @@
+type envVars = {
+  serverStarterUrl: string;
+  serverStarterAllFeaturesUrl: string;
+  mastraUrl: string;
+  langgraphUrl: string;   
+  agnoUrl: string;
+  llamaIndexUrl: string;
+  crewAiUrl: string;
+}
+
+export default function getEnvVars(): envVars {
+    return {
+        serverStarterUrl: process.env.SERVER_STARTER_URL || 'http://localhost:8000',
+        serverStarterAllFeaturesUrl: process.env.SERVER_STARTER_ALL_FEATURES_URL || 'http://localhost:8000',
+        mastraUrl: process.env.MASTRA_URL || 'http://localhost:4111',
+        langgraphUrl: process.env.LANGGRAPH_URL || 'http://localhost:2024',
+        agnoUrl: process.env.AGNO_URL || 'http://localhost:9001',
+        llamaIndexUrl: process.env.LLAMA_INDEX_URL || 'http://localhost:9000',
+        crewAiUrl: process.env.CREW_AI_URL || 'http://localhost:9002',
+    }
+}

--- a/typescript-sdk/integrations/agno/examples/.gitignore
+++ b/typescript-sdk/integrations/agno/examples/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+
+# LangGraph API
+.langgraph_api

--- a/typescript-sdk/integrations/agno/examples/README.md
+++ b/typescript-sdk/integrations/agno/examples/README.md
@@ -1,0 +1,7 @@
+Extracted from with-agno
+
+To install deps
+pip install -r requirements.txt
+
+to run 
+python agent.py

--- a/typescript-sdk/integrations/agno/examples/agent.py
+++ b/typescript-sdk/integrations/agno/examples/agent.py
@@ -1,0 +1,32 @@
+"""Example: Agno Agent with Finance tools
+
+This example shows how to create an Agno Agent with tools (YFinanceTools) and expose it in an AG-UI compatible way.
+"""
+
+from agno.agent.agent import Agent
+from agno.app.agui.app import AGUIApp
+from agno.models.openai import OpenAIChat
+from agno.tools.yfinance import YFinanceTools
+
+agent = Agent(
+  model=OpenAIChat(id="gpt-4o"),
+  tools=[
+    YFinanceTools(
+      stock_price=True, analyst_recommendations=True, stock_fundamentals=True
+    )
+  ],
+  description="You are an investment analyst that researches stock prices, analyst recommendations, and stock fundamentals.",
+  instructions="Format your response using markdown and use tables to display data where possible.",
+)
+
+agui_app = AGUIApp(
+  agent=agent,
+  name="Investment Analyst",
+  app_id="investment_analyst",
+  description="An investment analyst that researches stock prices, analyst recommendations, and stock fundamentals.",
+)
+
+app = agui_app.get_app()
+
+if __name__ == "__main__":
+  agui_app.serve(app="agent:app", host="0.0.0.0", port=9001, reload=True)

--- a/typescript-sdk/integrations/agno/examples/requirements.txt
+++ b/typescript-sdk/integrations/agno/examples/requirements.txt
@@ -1,0 +1,6 @@
+agno>=1.6.3
+openai>=1.88.0
+yfinance>=0.2.63
+fastapi>=0.115.13
+uvicorn>=0.34.3
+ag-ui-protocol>=0.1.5

--- a/typescript-sdk/packages/proto/package.json
+++ b/typescript-sdk/packages/proto/package.json
@@ -15,13 +15,14 @@
     "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "jest",
-    "generate": "mkdir -p ./src/generated && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated --ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false -I ./src/proto ./src/proto/*.proto",
+    "generate": "mkdir -p ./src/generated && npx protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated --ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false -I ./src/proto ./src/proto/*.proto",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
     "@ag-ui/core": "workspace:*",
-    "@bufbuild/protobuf": "^2.2.5"
+    "@bufbuild/protobuf": "^2.2.5",
+    "@protobuf-ts/protoc": "^2.11.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.2.5
         version: 2.4.0
+      '@protobuf-ts/protoc':
+        specifier: ^2.11.1
+        version: 2.11.1
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -3611,6 +3614,10 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@protobuf-ts/protoc@2.11.1':
+    resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -14300,6 +14307,8 @@ snapshots:
     optional: true
 
   '@popperjs/core@2.11.8': {}
+
+  '@protobuf-ts/protoc@2.11.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 


### PR DESCRIPTION
A few small changes, ripped out most of the bigger organizational ones in the end. 

- Make the default URLs unique (previously multiple example servers shared the same port)
- Make the agent server URLs load from env vars (which default to the previous defaults if the environment var isn't specified)
- Adds an agno example (pulled from https://github.com/CopilotKit/with-agno/tree/main/agent with only a modest change to the host binding)
- uses `@protobuf-ts/protoc`, which will call out to the existing `protoc` binary if it's already on the path, otherwise it will install a copy in it's own automagic way so that the Vercel deploy can run. 
