### PR TITLE
fix: correctly resolve anthropic message content

### DIFF
--- a/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -543,7 +543,7 @@ class LangGraphAgent:
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT,
                         message_id=current_stream["id"],
-                        delta=event["data"]["chunk"].content,
+                        delta=message_content,
                         raw_event=event,
                     )
                 )


### PR DESCRIPTION
Anthropic may return an object/dict as message content, we have a resolving function to deal with this. It was just not used in the right spot