### PR TITLE
chore(python-sdk): add type literals for new events

### DIFF
--- a/python-sdk/ag_ui/core/events.py
+++ b/python-sdk/ag_ui/core/events.py
@@ -87,24 +87,20 @@ class ThinkingTextMessageStartEvent(BaseEvent):
     """
     Event indicating the start of a thinking text message.
     """
-    type: Literal[EventType.THINKING_TEXT_MESSAGE_START]
+    type: Literal[EventType.THINKING_TEXT_MESSAGE_START] = EventType.THINKING_TEXT_MESSAGE_START  # pyright: ignore[reportIncompatibleVariableOverride]
 
 class ThinkingTextMessageContentEvent(BaseEvent):
     """
     Event indicating a piece of a thinking text message.
     """
-    type: Literal[EventType.THINKING_TEXT_MESSAGE_CONTENT]
-    delta: str  # This should not be an empty string
-
-    def model_post_init(self, __context):
-        if len(self.delta) == 0:
-            raise ValueError("Delta must not be an empty string")
+    type: Literal[EventType.THINKING_TEXT_MESSAGE_CONTENT] = EventType.THINKING_TEXT_MESSAGE_CONTENT  # pyright: ignore[reportIncompatibleVariableOverride]
+    delta: str = Field(min_length=1)
 
 class ThinkingTextMessageEndEvent(BaseEvent):
     """
     Event indicating the end of a thinking text message.
     """
-    type: Literal[EventType.THINKING_TEXT_MESSAGE_END]
+    type: Literal[EventType.THINKING_TEXT_MESSAGE_END] = EventType.THINKING_TEXT_MESSAGE_END  # pyright: ignore[reportIncompatibleVariableOverride]
 
 class ToolCallStartEvent(BaseEvent):
     """
@@ -147,7 +143,7 @@ class ToolCallResultEvent(BaseEvent):
     Event containing the result of a tool call.
     """
     message_id: str
-    type: Literal[EventType.TOOL_CALL_RESULT]
+    type: Literal[EventType.TOOL_CALL_RESULT] = EventType.TOOL_CALL_RESULT  # pyright: ignore[reportIncompatibleVariableOverride]
     tool_call_id: str
     content: str
     role: Optional[Literal["tool"]] = None
@@ -156,14 +152,14 @@ class ThinkingStartEvent(BaseEvent):
     """
     Event indicating the start of a thinking step event.
     """
-    type: Literal[EventType.THINKING_START]
+    type: Literal[EventType.THINKING_START] = EventType.THINKING_START  # pyright: ignore[reportIncompatibleVariableOverride]
     title: Optional[str] = None
 
 class ThinkingEndEvent(BaseEvent):
     """
     Event indicating the end of a thinking step event.
     """
-    type: Literal[EventType.THINKING_END]
+    type: Literal[EventType.THINKING_END] = EventType.THINKING_END  # pyright: ignore[reportIncompatibleVariableOverride]
 
 class StateSnapshotEvent(BaseEvent):
     """


### PR DESCRIPTION
Add type literals for the new event types in the Python SDK, so users don't have to manually set the type field when creating event instances.