### PR TITLE
python-sdk: support nested step event

### DIFF
--- a/python-sdk/ag_ui/core/events.py
+++ b/python-sdk/ag_ui/core/events.py
@@ -241,6 +241,8 @@ class StepStartedEvent(BaseEvent):
     """
     type: Literal[EventType.STEP_STARTED] = EventType.STEP_STARTED  # pyright: ignore[reportIncompatibleVariableOverride]
     step_name: str
+    step_id: str
+    parent_step_id: Optional[str] = None
 
 
 class StepFinishedEvent(BaseEvent):
@@ -249,6 +251,8 @@ class StepFinishedEvent(BaseEvent):
     """
     type: Literal[EventType.STEP_FINISHED] = EventType.STEP_FINISHED  # pyright: ignore[reportIncompatibleVariableOverride]
     step_name: str
+    step_id: str
+    parent_step_id: Optional[str] = None
 
 
 Event = Annotated[


### PR DESCRIPTION
#174 
For support nested step event, added `step_id` and `parent_step_id` to step event.

This is only a draft pr now, any advices are welcome.