### PR TITLE
Fix build by wrapping sidebar in a suspense

### DIFF
--- a/typescript-sdk/apps/dojo/src/components/layout/main-layout.tsx
+++ b/typescript-sdk/apps/dojo/src/components/layout/main-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { Suspense, useState } from "react";
 import { ViewerLayout } from "@/components/layout/viewer-layout";
 import { Sidebar } from "@/components/sidebar/sidebar";
 
@@ -9,10 +9,7 @@ import featureConfig from "@/config";
 
 export function MainLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
 
-  const sidebarDisabled = searchParams.get("sidebar") === "disabled";
-  const integrationPickerDisabled = searchParams.get("picker") === "false";
 
   // Extract the current demo ID from the pathname
   const pathParts = pathname.split("/");
@@ -23,7 +20,10 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
     <ViewerLayout showFileTree={false} showCodeEditor={false}>
       <div className="flex h-full w-full overflow-hidden">
         {/* Sidebar */}
-        {!sidebarDisabled && <Sidebar activeTab={"preview"} readmeContent={""} pickerDisabled={integrationPickerDisabled} />}
+        <Suspense>
+          <MaybeSidebar/>
+        </Suspense>
+
 
         {/* Content */}
         <div className="flex-1 overflow-auto">
@@ -32,4 +32,13 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
       </div>
     </ViewerLayout>
   );
+}
+
+function MaybeSidebar() {
+  const searchParams = useSearchParams();
+
+  const sidebarDisabled = searchParams.get("sidebar") === "disabled";
+  const integrationPickerDisabled = searchParams.get("picker") === "false";
+
+  return !sidebarDisabled && <Sidebar activeTab={"preview"} readmeContent={""} pickerDisabled={integrationPickerDisabled} />;
 }

--- a/typescript-sdk/apps/dojo/src/components/layout/main-layout.tsx
+++ b/typescript-sdk/apps/dojo/src/components/layout/main-layout.tsx
@@ -4,18 +4,9 @@ import React, { Suspense, useState } from "react";
 import { ViewerLayout } from "@/components/layout/viewer-layout";
 import { Sidebar } from "@/components/sidebar/sidebar";
 
-import { usePathname, useSearchParams } from "next/navigation";
-import featureConfig from "@/config";
+import { useSearchParams } from "next/navigation";
 
 export function MainLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-
-
-  // Extract the current demo ID from the pathname
-  const pathParts = pathname.split("/");
-  const currentFeatureId = pathParts[pathParts.length - 1];
-  const currentFeature = featureConfig.find((d) => d.id === currentFeatureId);
-
   return (
     <ViewerLayout showFileTree={false} showCodeEditor={false}>
       <div className="flex h-full w-full overflow-hidden">


### PR DESCRIPTION
useSearchParams was brought into the main layout in https://github.com/ag-ui-protocol/ag-ui/pull/190 but requires the component calling it to be inside a Suspense boundary. I moved it down into a "MaybeSidebar" that uses the hook and optionally renders the sidebar, and added it inside of a Suspense inside the main layout render. 