### PR TITLE
Update Mastra's license for Mastras integration to Apache 2.0

### DIFF
--- a/typescript-sdk/integrations/mastra/package.json
+++ b/typescript-sdk/integrations/mastra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ag-ui/mastra",
   "version": "0.0.5",
-  "license": "Elastic-2.0",
+  "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Update and Fix: https://github.com/ag-ui-protocol/ag-ui/issues/219

Mastra changed its license to Apache 2.0

https://github.com/mastra-ai/mastra/pull/5765

Mastra's License link: https://github.com/mastra-ai/mastra/blob/main/LICENSE.md