### PR TITLE
Fix typo in CopilotKit link

### DIFF
--- a/docs/quickstart/clients.mdx
+++ b/docs/quickstart/clients.mdx
@@ -15,7 +15,7 @@ AG-UI protocol.
 
 Building your own client is useful if you want to explore/hack on the AG-UI
 protocol. For production use, use a full-featured client like
-[CopilotKit ](https://copilokit.ai).
+[CopilotKit](https://copilotkit.ai).
 
 ## What you'll build
 


### PR DESCRIPTION
This fixes a broken link in the docs caused by a small typo in the URL for CopilotKit. 