### PR TITLE
Ignore e2e folder in dojo build

### DIFF
--- a/typescript-sdk/apps/dojo/tsconfig.json
+++ b/typescript-sdk/apps/dojo/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e"]
 }


### PR DESCRIPTION
Different typescript config means it breaks the top level build, just ignore it and build it separately for now