### PR TITLE
Addressing https://github.com/ag-ui-protocol/ag-ui/issues/278

### DIFF
--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -7,6 +7,7 @@
     "clean": "rm -rf dist .turbo node_modules && pnpm -r clean",
     "build:clean": "rm -rf dist .turbo node_modules && pnpm -r clean && pnpm install && turbo run build",
     "dev": "turbo run dev",
+    "start": "turbo run start",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md,mdx}\"",
     "check-types": "turbo run check-types",

--- a/typescript-sdk/turbo.json
+++ b/typescript-sdk/turbo.json
@@ -42,6 +42,11 @@
     },
     "unlink:global": {
       "cache": false
+    },
+    "start": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
Adding a couple of "start" commands to enable the dojo to be run in production mode (e.g., "pnpm run start" vs. "pnpm run dev").