### PR TITLE
use 0.0.0.0 as host for mastra example since default changed

### DIFF
--- a/typescript-sdk/integrations/mastra/example/src/mastra/index.ts
+++ b/typescript-sdk/integrations/mastra/example/src/mastra/index.ts
@@ -8,6 +8,7 @@ import { toolBasedGenerativeUIAgent } from "./agents/tool-based-generative-ui";
 export const mastra = new Mastra({
   server: {
     port: process.env.PORT ? parseInt(process.env.PORT) : 4111,
+    host: "0.0.0.0",
   },
   agents: { agentic_chat: agenticChatAgent, tool_based_generative_ui: toolBasedGenerativeUIAgent },
   storage: new LibSQLStore({


### PR DESCRIPTION
It looks like Mastra changed the default host to localhost, which breaks render hosting