### PR TITLE
fix: include payload with regenerated message

### DIFF
--- a/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -685,7 +685,12 @@ class LangGraphAgent:
                     empty_snapshot = snapshot
                     empty_snapshot.values["messages"] = []
                     return empty_snapshot
-                return history_list[idx - 1]  # return one snapshot *before* the one that includes the message
+
+                snapshot_values_without_messages = snapshot.values.copy()
+                del snapshot_values_without_messages["messages"]
+                checkpoint = history_list[idx - 1] # use one snapshot *before* the one that includes the message
+                checkpoint.values = {**checkpoint.values, **snapshot_values_without_messages}
+                return checkpoint
 
         raise ValueError("Message ID not found in history")
 

--- a/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -688,8 +688,11 @@ class LangGraphAgent:
 
                 snapshot_values_without_messages = snapshot.values.copy()
                 del snapshot_values_without_messages["messages"]
-                checkpoint = history_list[idx - 1] # use one snapshot *before* the one that includes the message
-                checkpoint.values = {**checkpoint.values, **snapshot_values_without_messages}
+                checkpoint = history_list[idx - 1]
+
+                merged_values = {**checkpoint.values, **snapshot_values_without_messages}
+                checkpoint = checkpoint._replace(values=merged_values)
+
                 return checkpoint
 
         raise ValueError("Message ID not found in history")

--- a/typescript-sdk/integrations/langgraph/python/pyproject.toml
+++ b/typescript-sdk/integrations/langgraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ag-ui-langgraph"
-version = "0.0.5"
+version = "0.0.6"
 description = "Implementation of the AG-UI protocol for LangGraph."
 authors = ["Ran Shem Tov <ran@copilotkit.ai>"]
 readme = "README.md"

--- a/typescript-sdk/integrations/langgraph/src/agent.ts
+++ b/typescript-sdk/integrations/langgraph/src/agent.ts
@@ -992,7 +992,9 @@ export class LangGraphAgent extends AbstractAgent {
 
     const targetStateIndex = reversed.indexOf(targetState);
 
-    return reversed[targetStateIndex - 1] ?? { ...targetState, values: {} };
+    const { messages, ...targetStateValuesWithoutMessages } = targetState.values as State
+    const selectedCheckpoint = reversed[targetStateIndex - 1] ?? { ...targetState, values: {} }
+    return { ...selectedCheckpoint, values: { ...selectedCheckpoint.values, ...targetStateValuesWithoutMessages } };
   }
 }
 


### PR DESCRIPTION
Fixing LG regenerate mechanism: When resending the message, send it along with all the state it had at that point