### PR TITLE
Fix: Add Support for Model Thinking Process Events

### DIFF
--- a/typescript-sdk/packages/core/src/events.ts
+++ b/typescript-sdk/packages/core/src/events.ts
@@ -177,6 +177,8 @@ export const EventSchemas = z.discriminatedUnion("type", [
   TextMessageContentEventSchema,
   TextMessageEndEventSchema,
   TextMessageChunkEventSchema,
+  ThinkingStartEventSchema,
+  ThinkingEndEventSchema,
   ThinkingTextMessageStartEventSchema,
   ThinkingTextMessageContentEventSchema,
   ThinkingTextMessageEndEventSchema,


### PR DESCRIPTION
## Background

Modern AI models like DeepSeek and Doubao support a "thinking" process where they can expose their internal reasoning before generating the final response. This thinking process provides valuable insights into the model's decision-making and improves transparency.

## Error

When these models send THINK_START events,`typescript-sdk/packages/core/src/events.ts` was failing with `invalid_union_discriminator` errors. And if not send THINK_START, `typescript-sdk/packages/client/src/verify/verify.ts` will raise error: 

> Cannot send 'THINKING_TEXT_MESSAGE_START' event: A thinking step is not in progress. Create one with 'THINKING_START' first.

This caused the zod validation to reject any THINKING_START or THINKING_END events, breaking the thinking flow entirely.

## Solution
Added the missing schemas to the EventSchemas discriminated union in `typescript-sdk/packages/core/src/events.ts`