### PR TITLE
deparallelize the tests in CI for now

### DIFF
--- a/typescript-sdk/apps/dojo/e2e/playwright.config.ts
+++ b/typescript-sdk/apps/dojo/e2e/playwright.config.ts
@@ -47,7 +47,9 @@ export default defineConfig({
   timeout: process.env.CI ? 300_000 : 120_000, // 5min in CI, 2min locally for AI tests
   testDir: "./tests",
   retries: process.env.CI ? 1 : 0, // More retries for flaky AI tests in CI, 0 for local
-  fullyParallel: true,
+  // Make this sequential for now to avoid race conditions
+  workers: process.env.CI ? 1 : undefined,
+  fullyParallel: process.env.CI ? false : true,
   use: {
     headless: true,
     viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
Something gets weird with the tests running in parallel, especially in CI. For now making them serial so people and PRs can get unblocked while I dig in