### PR TITLE
If state is empty on run_finished event, don't trigger a state update

### DIFF
--- a/typescript-sdk/packages/client/src/agent/__tests__/legacy-bridged.test.ts
+++ b/typescript-sdk/packages/client/src/agent/__tests__/legacy-bridged.test.ts
@@ -160,7 +160,7 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     const legacyEvents = await lastValueFrom(legacy$.pipe(toArray()));
 
     // Verify events are in correct legacy format
-    expect(legacyEvents).toHaveLength(4); // Start, Content, End, AgentStateMessage
+    expect(legacyEvents).toHaveLength(3); // Start, Content, End
 
     // TextMessageStart
     expect(legacyEvents[0]).toMatchObject({
@@ -182,12 +182,12 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     });
 
     // Final AgentStateMessage
-    expect(legacyEvents[3]).toMatchObject({
-      type: "AgentStateMessage",
-      threadId: "test-thread-id",
-      agentName: "test-agent-id",
-      active: false,
-    });
+    // expect(legacyEvents[3]).toMatchObject({
+    //   type: "AgentStateMessage",
+    //   threadId: "test-thread-id",
+    //   agentName: "test-agent-id",
+    //   active: false,
+    // });
   });
 
   it("should pass configuration to the underlying run method", async () => {
@@ -304,7 +304,7 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     const legacyEvents = await lastValueFrom(legacy$.pipe(toArray()));
 
     // Verify events are in correct legacy format
-    expect(legacyEvents).toHaveLength(4); // Start, Content, End, AgentStateMessage
+    expect(legacyEvents).toHaveLength(3); // Start, Content, End
 
     // TextMessageStart
     expect(legacyEvents[0]).toMatchObject({
@@ -326,12 +326,12 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     });
 
     // Final AgentStateMessage
-    expect(legacyEvents[3]).toMatchObject({
-      type: "AgentStateMessage",
-      threadId: "test-thread-id",
-      agentName: "test-agent-id",
-      active: false,
-    });
+    // expect(legacyEvents[3]).toMatchObject({
+    //   type: "AgentStateMessage",
+    //   threadId: "test-thread-id",
+    //   agentName: "test-agent-id",
+    //   active: false,
+    // });
   });
 
   it("should transform tool call events with results into legacy events with correct tool name", async () => {
@@ -348,7 +348,7 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     const legacyEvents = await lastValueFrom(legacy$.pipe(toArray()));
 
     // Verify events are in correct legacy format
-    expect(legacyEvents).toHaveLength(5); // ActionExecutionStart, ActionExecutionArgs, ActionExecutionEnd, ActionExecutionResult, AgentStateMessage
+    expect(legacyEvents).toHaveLength(4); // ActionExecutionStart, ActionExecutionArgs, ActionExecutionEnd, ActionExecutionResult
 
     // ActionExecutionStart
     expect(legacyEvents[0]).toMatchObject({
@@ -379,11 +379,11 @@ describe("AbstractAgent.legacy_to_be_removed_runAgentBridged", () => {
     });
 
     // Final AgentStateMessage
-    expect(legacyEvents[4]).toMatchObject({
-      type: "AgentStateMessage",
-      threadId: "test-thread-id",
-      agentName: "test-agent-id",
-      active: false,
-    });
+    // expect(legacyEvents[4]).toMatchObject({
+    //   type: "AgentStateMessage",
+    //   threadId: "test-thread-id",
+    //   agentName: "test-agent-id",
+    //   active: false,
+    // });
   });
 });

--- a/typescript-sdk/packages/client/src/legacy/convert.ts
+++ b/typescript-sdk/packages/client/src/legacy/convert.ts
@@ -297,6 +297,11 @@ export const convertToLegacyEvents =
               currentState.messages = syncedMessages;
             }
 
+            // Only do an update if state is not empty
+            if (Object.keys(currentState).length === 0) {
+              return [];
+            }
+
             return [
               {
                 type: LegacyRuntimeEventTypes.enum.AgentStateMessage,


### PR DESCRIPTION
When a RUN_FINISHED event comes in, we convert it to a legacy AgentStateMessage, even if state is empty (I'm not convinced that it is ever not empty). This causes things like pedantic's integration to fail when a user sends a message that does not affect state, since the integration doesn't send anything back. 