### PR TITLE
feat: return tool call events for models that does not stream tool calls

### DIFF
--- a/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/typescript-sdk/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -48,7 +48,8 @@ RunMetadata = TypedDict("RunMetadata", {
     "exiting_node": NotRequired[bool],
     "manually_emitted_state": NotRequired[Optional[State]],
     "thread_id": NotRequired[Optional[ThinkingProcess]],
-    "thinking_process": NotRequired[Optional[str]]
+    "thinking_process": NotRequired[Optional[str]],
+    "has_function_streaming": NotRequired[bool],
 })
 
 MessagesInProgressRecord = Dict[str, Optional[MessageInProgress]]

--- a/typescript-sdk/integrations/langgraph/src/types.ts
+++ b/typescript-sdk/integrations/langgraph/src/types.ts
@@ -63,6 +63,7 @@ export interface RunMetadata {
   manuallyEmittedState?: State | null;
   threadId?: string;
   graphInfo?: AssistantGraph
+  hasFunctionStreaming?: boolean;
 }
 
 export type MessagesInProgressRecord = Record<string, MessageInProgress | null>;


### PR DESCRIPTION
Some models will not stream function calls. This means using these models with LangGraph will not yield the expected tool events.
This PR fixes this issue