### PR TITLE
fix: include the tool name on the top level per returned frontend tool

### DIFF
--- a/typescript-sdk/integrations/langgraph/src/agent.ts
+++ b/typescript-sdk/integrations/langgraph/src/agent.ts
@@ -1010,6 +1010,7 @@ export class LangGraphAgent extends AbstractAgent {
 
       return {
         type: "function",
+        name: tool.name,
         function: {
           name: tool.name,
           description: tool.description,


### PR DESCRIPTION
A common technique to avoid running frontend tools in a ReAct agent, is by doing something like this:
```
if (!tools || tools.every((tool) => tool.name !== toolCallName)) {
```
However, the tool name seems to be missing. This PR is about adding it
