### PR TITLE
Subscriber Type exported

### DIFF
--- a/typescript-sdk/packages/client/src/agent/index.ts
+++ b/typescript-sdk/packages/client/src/agent/index.ts
@@ -2,3 +2,4 @@ export { AbstractAgent } from "./agent";
 export type { RunAgentResult } from "./agent";
 export { HttpAgent } from "./http";
 export type { AgentConfig, HttpAgentConfig, RunAgentParameters } from "./types";
+export type { AgentSubscriber, AgentStateMutation, AgentSubscriberParams} from "./subscriber";


### PR DESCRIPTION
The current AG-UI release does not export the following subscriber-related types from the SDK:
* AgentSubscriber
* AgentStateMutation
* AgentSubscriberParams
This update adds explicit exports for these types in packages/client/src/agent/index.ts, making them accessible to downstream consumers of the SDK.