### PR TITLE
chore(python-sdk): adding MIT license

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.9"
 description = ""
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 readme = "README.md"
+license = "MIT"
 packages = [{include = "ag_ui", from = "."}]
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
This pull request adds the MIT license to the python-sdk

This change ensures that the package metadata accurately reflects the project's license, which is already stated as MIT in the main README. Explicitly defining the license in pyproject.toml is a best practice that improves clarity for developers and automated tooling.