### PR TITLE
fix: silence abort error in http agent

### DIFF
--- a/typescript-sdk/packages/client/src/run/http-request.ts
+++ b/typescript-sdk/packages/client/src/run/http-request.ts
@@ -71,10 +71,6 @@ export const runHttpRequest = (url: string, requestInit: RequestInit): Observabl
             }
             subscriber.complete();
           } catch (error) {
-            if ((error as DOMException)?.name === "AbortError") {
-              subscriber.complete();
-              return;
-            }
             subscriber.error(error);
           }
         })();

--- a/typescript-sdk/packages/client/src/run/http-request.ts
+++ b/typescript-sdk/packages/client/src/run/http-request.ts
@@ -71,12 +71,22 @@ export const runHttpRequest = (url: string, requestInit: RequestInit): Observabl
             }
             subscriber.complete();
           } catch (error) {
+            if ((error as DOMException)?.name === "AbortError") {
+              subscriber.complete();
+              return;
+            }
             subscriber.error(error);
           }
         })();
 
         return () => {
-          reader.cancel();
+          reader.cancel().catch((error) => {
+            if ((error as DOMException)?.name === "AbortError") {
+              return;
+            }
+
+            throw error;
+          });
         };
       });
     }),


### PR DESCRIPTION
Abort errors when using `abortRun` are expected. However, the abort controller will throw an error (default behaviour). These should be silenced as they fail the server running a runtime against AGUI HTTP agent