### PR TITLE
fix: normalize empty tool results for LlamaIndex to prevent loop

### DIFF
--- a/typescript-sdk/integrations/llamaindex/src/index.ts
+++ b/typescript-sdk/integrations/llamaindex/src/index.ts
@@ -4,5 +4,41 @@
  */
 
 import { HttpAgent } from "@ag-ui/client";
+import type { BaseEvent, Message, RunAgentInput } from "@ag-ui/core";
+import { Observable } from "rxjs";
 
-export class LlamaIndexAgent extends HttpAgent {}
+/**
+ * Normalizes AG-UI tool result messages before sending them to the LlamaIndex server.
+ *
+ * Context: When a frontend tool returns `undefined`, upstream encoders serialize the
+ * result as an empty string (""). Some LlamaIndex workflows treat an empty tool
+ * result as insufficient evidence and immediately re-plan the same tool call,
+ * which can produce repeated frontend tool invocations (e.g., duplicate alerts).
+ *
+ * This integration adapts those messages for LlamaIndex by converting empty tool
+ * results into a non-empty canonical value ("ok"). This preserves semantics for
+ * tools that return no meaningful payload while preventing the planner from
+ * needlessly re-invoking the same tool.
+ */
+function normalizeEmptyToolResults(messages: Message[]): Message[] {
+  return messages.map((message: Message): Message => {
+    if (message.role === "tool") {
+      const content: string | undefined = message.content;
+      const isEmpty: boolean = (content ?? "").trim().length === 0;
+      if (isEmpty) {
+        return { ...message, content: "ok" };
+      }
+    }
+    return message;
+  });
+}
+
+export class LlamaIndexAgent extends HttpAgent {
+  public override run(input: RunAgentInput): Observable<BaseEvent> {
+    const sanitizedInput: RunAgentInput = {
+      ...input,
+      messages: normalizeEmptyToolResults(input.messages),
+    };
+    return super.run(sanitizedInput);
+  }
+}


### PR DESCRIPTION
Adapts AG-UI tool result messages for LlamaIndex by converting empty results to a canonical value ("ok").

Prevents unnecessary re-invocation of tools in LlamaIndex workflows when tools return no meaningful payload.
