### PR TITLE
fix(a2a-middleware): Remove 'A2A Agent Response:' prefix from tool re…

### DIFF
--- a/typescript-sdk/integrations/a2a-middleware/src/index.ts
+++ b/typescript-sdk/integrations/a2a-middleware/src/index.ts
@@ -154,7 +154,7 @@ export class A2AMiddlewareAgent extends AbstractAgent {
                       id: randomUUID(),
                       role: "tool",
                       toolCallId: toolCallId,
-                      content: `A2A Agent Response: ${a2aResponse}`,
+                      content: a2aResponse,
                     };
                     if (this.debug) {
                       console.debug("newMessage From a2a agent", newMessage);


### PR DESCRIPTION
…sult messages

The A2A middleware was adding an "A2A Agent Response: " prefix to tool result messages stored in conversation history (line 157). This prefix broke JSON parsing when the orchestrator agent received these tool results, causing "Invalid JSON: Expecting value: line 1 column 1" errors.

The tool result content should contain the raw response from the A2A agent, not a prefixed version. The event content (line 172) was already correct.

This fix ensures tool results can be properly parsed by orchestrator agents, particularly when using ADK agents that expect valid JSON responses.

Fixes JSON parsing errors in orchestrator agents receiving A2A tool results.