### PR TITLE
Lower Python requirement for ADK middleware to 3.9

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/python/examples/pyproject.toml
+++ b/typescript-sdk/integrations/adk-middleware/python/examples/pyproject.toml
@@ -7,7 +7,7 @@ description = "Example usage of the ADK middleware with FastAPI"
 license = "MIT"
 
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.9, <3.14"
 dependencies = [
     "fastapi>=0.104.0",
     "httpx>=0.27.0",

--- a/typescript-sdk/integrations/adk-middleware/python/examples/uv.lock
+++ b/typescript-sdk/integrations/adk-middleware/python/examples/uv.lock
@@ -1,9 +1,9 @@
 version = 1
 revision = 2
-requires-python = ">=3.12"
+requires-python = ">=3.9, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 
 [[package]]

--- a/typescript-sdk/integrations/adk-middleware/python/pyproject.toml
+++ b/typescript-sdk/integrations/adk-middleware/python/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.9, <3.14"
 dependencies = [
     "ag-ui-protocol>=0.1.7",
     "aiohttp>=3.12.0",

--- a/typescript-sdk/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
+++ b/typescript-sdk/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
@@ -4,6 +4,7 @@
 import json
 from dataclasses import asdict, dataclass
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 import uuid
@@ -136,13 +137,13 @@ class TestEventTranslatorComprehensive:
         class TextContent:
             type: str = "text"
             text: str = ""
-            annotations: list | None = None
-            meta: dict | None = None
+            annotations: Optional[list] = None
+            meta: Optional[dict] = None
 
         @dataclass
         class CallToolResult:
-            meta: dict | None
-            structuredContent: dict | None
+            meta: Optional[dict]
+            structuredContent: Optional[dict]
             isError: bool
             content: list[TextContent]
 

--- a/typescript-sdk/integrations/adk-middleware/python/uv.lock
+++ b/typescript-sdk/integrations/adk-middleware/python/uv.lock
@@ -1,9 +1,9 @@
 version = 1
 revision = 2
-requires-python = ">=3.12"
+requires-python = ">=3.9, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses https://github.com/ag-ui-protocol/ag-ui/issues/500.

## Summary
- align the ADK middleware package metadata with the AG-UI Python SDK's supported range (>=3.9, <3.14)
- mirror the same Python version floor for the FastAPI example package and associated uv lock files
- update the ADK middleware uv.lock files' resolution markers to reflect the relaxed upper bound (<3.14)
- adjust the comprehensive event translator test types so they remain valid on Python 3.9

## Testing
- uv run --python 3.9 --directory typescript-sdk/integrations/adk-middleware/python pytest

------
https://chatgpt.com/codex/tasks/task_e_68e917a103f48321a3c8d2bb32e4acfb