### PR TITLE
fix a2a-middleware peerdep

### DIFF
--- a/typescript-sdk/integrations/a2a-middleware/package.json
+++ b/typescript-sdk/integrations/a2a-middleware/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.2.2",
-    "@ag-ui/client": ">=0.0.40",
     "ai": "^4.3.16",
     "zod": "^3.22.4"
   },
   "peerDependencies": {
+    "@ag-ui/client": ">=0.0.40",
     "rxjs": "7.8.1"
   },
   "devDependencies": {

--- a/typescript-sdk/pnpm-lock.yaml
+++ b/typescript-sdk/pnpm-lock.yaml
@@ -319,9 +319,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.2.2
         version: 0.2.5
-      '@ag-ui/client':
-        specifier: '>=0.0.40'
-        version: 0.0.40
       ai:
         specifier: ^4.3.16
         version: 4.3.19(react@19.1.0)(zod@3.25.76)
@@ -332,6 +329,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@ag-ui/client':
+        specifier: workspace:*
+        version: link:../../packages/client
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -14871,7 +14871,7 @@ snapshots:
 
   '@langchain/textsplitters@0.1.0(@langchain/core@0.3.66(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.66(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.104.0(ws@8.18.3)(zod@3.25.76))
+      '@langchain/core': 0.3.66(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0))(openai@4.100.0(ws@8.18.3)(zod@3.25.76))
       js-tiktoken: 1.0.20
 
   '@libsql/client@0.15.10':


### PR DESCRIPTION
ag-ui/client was listed as a dep rather than a peerdep