### PR TITLE
Enable codeowners on specific paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @mme @ranst91 @ataibarkai @maxkorp @tylerslaton @NathanTarbert
+
+sdks/community/java @pascalwilbrink
+sdks/community/kotlin @contextablemark
+sdks/community/go @mattsp1290


### PR DESCRIPTION
For now this adds 
@mattsp1290 to the go sdk
@pascalwilbrink to the java sdk
@contextablemark to the kotlin sdk

We will probably dig a bit deeper on this: I suspect we might have a "@java" team, "@rust" team, etc to require fewer code changes, but we'll see. For now, this should get people working. 