### PR TITLE
chore: bump adk middleware to 0.3.2

### DIFF
--- a/typescript-sdk/integrations/adk-middleware/python/examples/uv.lock
+++ b/typescript-sdk/integrations/adk-middleware/python/examples/uv.lock
@@ -40,7 +40,7 @@ requires-dist = [
 
 [[package]]
 name = "ag-ui-adk"
-version = "0.3.1"
+version = "0.3.2"
 source = { directory = "../" }
 dependencies = [
     { name = "ag-ui-protocol" },

--- a/typescript-sdk/integrations/adk-middleware/python/pyproject.toml
+++ b/typescript-sdk/integrations/adk-middleware/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag_ui_adk"
-version = "0.3.1"
+version = "0.3.2"
 readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }


### PR DESCRIPTION
Bumping ag_ui_adk version in preparation for publishing.
