### PR TITLE
Add skills to agent roster in a2a middleware

### DIFF
--- a/middlewares/a2a-middleware/src/utils.ts
+++ b/middlewares/a2a-middleware/src/utils.ts
@@ -58,7 +58,7 @@ THEN REACH OUT TO THE APPROPRIATE AGENTS TO COMPLETE THE TASK.
 
 **Agent Roster:**
 * Available Agents:
-${JSON.stringify(agentCards.map((agent) => ({ name: agent.name, description: agent.description })))}
+${JSON.stringify(agentCards.map((agent) => ({ name: agent.name, description: agent.description, skills: agent.skills })))}
 **END General Instructions:**
 `.trim();
 


### PR DESCRIPTION
## Summary
- Include agent skills in the roster sent to orchestrator agents
- Enables better agent selection decisions based on skill information

## Changes
- Updated agent roster mapping to include `skills` field alongside name and description