### PR TITLE
fix: comment out iOS build targets to prevent Gradle sync failures

### DIFF
--- a/sdks/community/kotlin/examples/chatapp/shared/build.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp/shared/build.gradle.kts
@@ -28,16 +28,17 @@ kotlin {
         }
     }
 
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach { iosTarget ->
-        iosTarget.binaries.framework {
-            baseName = "shared"
-            isStatic = true
-        }
-    }
+    // iOS targets commented out to prevent Gradle sync issues
+//    listOf(
+//        iosX64(),
+//        iosArm64(),
+//        iosSimulatorArm64()
+//    ).forEach { iosTarget ->
+//        iosTarget.binaries.framework {
+//            baseName = "shared"
+//            isStatic = true
+//        }
+//    }
 
     sourceSets {
         val commonMain by getting {
@@ -143,30 +144,31 @@ kotlin {
             }
         }
 
-        // Get the existing specific iOS targets
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
-
-        // Create an iosMain source set and link the others to it
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-            iosSimulatorArm64Main.dependsOn(this)
-        }
-
-        // Also create iosTest
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosSimulatorArm64Test by getting
-
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-            iosSimulatorArm64Test.dependsOn(this)
-        }
+        // iOS source sets commented out to prevent Gradle sync issues
+//        // Get the existing specific iOS targets
+//        val iosX64Main by getting
+//        val iosArm64Main by getting
+//        val iosSimulatorArm64Main by getting
+//
+//        // Create an iosMain source set and link the others to it
+//        val iosMain by creating {
+//            dependsOn(commonMain)
+//            iosX64Main.dependsOn(this)
+//            iosArm64Main.dependsOn(this)
+//            iosSimulatorArm64Main.dependsOn(this)
+//        }
+//
+//        // Also create iosTest
+//        val iosX64Test by getting
+//        val iosArm64Test by getting
+//        val iosSimulatorArm64Test by getting
+//
+//        val iosTest by creating {
+//            dependsOn(commonTest)
+//            iosX64Test.dependsOn(this)
+//            iosArm64Test.dependsOn(this)
+//            iosSimulatorArm64Test.dependsOn(this)
+//        }
     }
 }
 


### PR DESCRIPTION
Addresses : https://github.com/ag-ui-protocol/ag-ui/issues/573

Disabled iOS targets (iosX64, iosArm64, iosSimulatorArm64) and their associated source sets in the chatapp example to resolve Gradle sync issues caused by missing iOS libraries.

The Android and Desktop targets remain fully functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)