### PR TITLE
add relevant docs folders to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 * @mme @ranst91 @ataibarkai @maxkorp @tylerslaton @NathanTarbert
 
 sdks/community/java @pascalwilbrink
+docs/sdk/java @pascalwilbrink
+
 sdks/community/kotlin @contextablemark
+docs/sdk/kotlin @contextablemark
+
 sdks/community/go @mattsp1290
+docs/sdk/go @mattsp1290


### PR DESCRIPTION
Docs folders for community SDKs need CODEOWNERS access as well