### PR TITLE
Feature: Publish Kotlin libraries to Sonatype

### DIFF
--- a/.github/workflows/publish-kotlin-sdk.yml
+++ b/.github/workflows/publish-kotlin-sdk.yml
@@ -1,0 +1,166 @@
+name: Publish Kotlin SDK to Maven Central
+
+on:
+  # Manual trigger only - no automatic publishing
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (test without uploading)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Install Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK 36 components
+        run: |
+          echo "Installing Android SDK 36 components..."
+          sdkmanager --install "platforms;android-36"
+          sdkmanager --install "build-tools;36.0.0"
+
+      - name: Accept Android licenses
+        run: yes | sdkmanager --licenses || true
+
+      - name: Verify Android SDK installation
+        run: |
+          echo "Checking Android SDK installation..."
+          sdkmanager --list_installed | grep -E "(platforms;android-36|build-tools;36)"
+
+      - name: Run tests
+        working-directory: sdks/community/kotlin/library
+        run: ./gradlew allTests --no-daemon --stacktrace
+
+      - name: Parse test results
+        if: always()
+        working-directory: sdks/community/kotlin/library
+        run: |
+          echo "## Kotlin SDK Test Results Summary"
+          echo ""
+
+          total_tests=0
+          total_failures=0
+          total_errors=0
+
+          for module in core client tools; do
+            xml_dir="$module/build/test-results/jvmTest"
+
+            if [ -d "$xml_dir" ]; then
+              # Sum up test counts from all XML files in the directory
+              module_tests=$(find "$xml_dir" -name "*.xml" -exec grep -h '<testsuite' {} \; | grep -o 'tests="[0-9]*"' | sed 's/tests="\([0-9]*\)"/\1/' | awk '{sum += $1} END {print sum}')
+              module_failures=$(find "$xml_dir" -name "*.xml" -exec grep -h '<testsuite' {} \; | grep -o 'failures="[0-9]*"' | sed 's/failures="\([0-9]*\)"/\1/' | awk '{sum += $1} END {print sum}')
+              module_errors=$(find "$xml_dir" -name "*.xml" -exec grep -h '<testsuite' {} \; | grep -o 'errors="[0-9]*"' | sed 's/errors="\([0-9]*\)"/\1/' | awk '{sum += $1} END {print sum}')
+
+              # Default to 0 if empty
+              module_tests=${module_tests:-0}
+              module_failures=${module_failures:-0}
+              module_errors=${module_errors:-0}
+
+              if [ "$module_tests" -gt 0 ]; then
+                echo "✅ kotlin-$module: $module_tests tests, $module_failures failures, $module_errors errors"
+                total_tests=$((total_tests + module_tests))
+                total_failures=$((total_failures + module_failures))
+                total_errors=$((total_errors + module_errors))
+              fi
+            fi
+          done
+
+          echo ""
+          echo "---"
+          echo "### Overall Results: $total_tests tests, $total_failures failures, $total_errors errors"
+
+          if [ $total_failures -gt 0 ] || [ $total_errors -gt 0 ]; then
+            echo "❌ Some tests failed - aborting publish"
+            exit 1
+          elif [ $total_tests -eq 0 ]; then
+            echo "⚠️ No tests were found or executed - aborting publish"
+            exit 1
+          else
+            echo "✅ All $total_tests tests passed!"
+          fi
+
+      - name: Publish to Maven Central (dry-run)
+        if: inputs.dry_run == true
+        working-directory: sdks/community/kotlin
+        env:
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "🔍 Running publish script in dry-run mode..."
+          ./publish.sh --dry-run
+
+      - name: Publish to Maven Central
+        if: inputs.dry_run == false
+        working-directory: sdks/community/kotlin
+        env:
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "🚀 Publishing to Maven Central..."
+          ./publish.sh
+
+      - name: Upload JReleaser logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-logs
+          path: sdks/community/kotlin/library/build/jreleaser/
+          retention-days: 7
+
+      - name: Summary
+        if: success() && inputs.dry_run == false
+        working-directory: sdks/community/kotlin/library
+        run: |
+          # Extract version from build.gradle.kts
+          VERSION=$(grep "^version = " build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+
+          echo "## ✅ Publishing Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The Kotlin SDK has been published to Maven Central." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Published Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "- \`com.ag-ui.community:kotlin-core:${VERSION}\` (JVM, Android, iOS)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`com.ag-ui.community:kotlin-client:${VERSION}\` (JVM, Android, iOS)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`com.ag-ui.community:kotlin-tools:${VERSION}\` (JVM, Android, iOS)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Note:** All platforms published including iOS artifacts in .klib format." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Check deployment status: https://central.sonatype.com/publishing" >> $GITHUB_STEP_SUMMARY
+          echo "2. Artifacts will be validated automatically" >> $GITHUB_STEP_SUMMARY
+          echo "3. Publishing completes in ~10-30 minutes" >> $GITHUB_STEP_SUMMARY
+
+      - name: Dry-run Summary
+        if: success() && inputs.dry_run == true
+        run: |
+          echo "## ✅ Dry-run Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The dry-run completed successfully. No artifacts were uploaded." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run without the dry-run flag to publish to Maven Central." >> $GITHUB_STEP_SUMMARY

--- a/sdks/community/kotlin/build.gradle.kts
+++ b/sdks/community/kotlin/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
     id("signing")
 }
 
-group = "com.agui"
+// Group and version from gradle.properties
+group = findProperty("group")?.toString() ?: "com.ag-ui.community"
 version = "0.1.0"
 
 repositories {
@@ -154,55 +155,6 @@ android {
         getByName("main") {
             manifest.srcFile("library/src/androidMain/AndroidManifest.xml")
         }
-    }
-}
-
-// Publishing configuration
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = project.group.toString()
-            artifactId = "agui4k"
-            version = project.version.toString()
-            
-            pom {
-                name.set("AGUI4K")
-                description.set("Kotlin Multiplatform implementation of the Agent User Interaction Protocol")
-                url.set("https://github.com/ag-ui-protocol/ag-ui")
-                
-                licenses {
-                    license {
-                        name.set("MIT License")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
-                
-                developers {
-                    developer {
-                        id.set("contextablemark")
-                        name.set("Mark Fogle")
-                        email.set("mark@contextable.com")
-                    }
-                }
-                
-                scm {
-                    url.set("https://github.com/ag-ui-protocol/ag-ui")
-                    connection.set("scm:git:git://github.com/ag-ui-protocol/ag-ui.git")
-                    developerConnection.set("scm:git:ssh://github.com:ag-ui-protocol/ag-ui.git")
-                }
-            }
-        }
-    }
-}
-
-// Signing configuration (for Maven Central)
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications)
     }
 }
 

--- a/sdks/community/kotlin/examples/chatapp-shared/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-shared/settings.gradle.kts
@@ -1,0 +1,16 @@
+rootProject.name = "chatapp-shared"
+
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/sdks/community/kotlin/examples/tools/build.gradle.kts
+++ b/sdks/community/kotlin/examples/tools/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.android.library")
 }
 
-group = "com.agui.examples"
+group = "com.ag-ui.community"
 version = "0.2.3"
 
 repositories {

--- a/sdks/community/kotlin/gradle.properties
+++ b/sdks/community/kotlin/gradle.properties
@@ -1,0 +1,6 @@
+# AG-UI Kotlin SDK Properties
+# This file is used by the SDK root build.gradle.kts
+
+# Maven group ID - used by SDK root build file
+# Note: library/build.gradle.kts has its own group declaration
+group=com.ag-ui.community

--- a/sdks/community/kotlin/library/README.md
+++ b/sdks/community/kotlin/library/README.md
@@ -1,60 +1,247 @@
-# AG-UI Kotlin SDK Library
+# AG-UI Kotlin SDK
 
-This directory contains the main AG-UI Kotlin SDK library source code and build infrastructure.
+A Kotlin Multiplatform implementation of the AG-UI (Agent User Interaction) Protocol, supporting JVM, Android, and iOS platforms.
 
-## Structure
+## Features
 
-- `src/commonMain/` - Shared code for all platforms
-- `src/androidMain/` - Android-specific implementations
-- `src/iosMain/` - iOS-specific implementations
-- `src/jvmMain/` - JVM-specific implementations
-- `src/commonTest/` - Shared test code
-- `build.gradle.kts` - Build configuration
-- `settings.gradle.kts` - Gradle settings
-- `gradle.properties` - Build properties
+- 🎯 **Kotlin Multiplatform** - Write once, run on JVM, Android, and iOS
+- 🔄 **Full Protocol Support** - Complete implementation of the AG-UI protocol
+- 📦 **Modular Architecture** - Three focused modules: core, client, and tools
+- 🌐 **Multiple Transports** - HTTP, SSE (Server-Sent Events), and extensible transport layer
+- 📱 **Native iOS Support** - Published as .klib artifacts to Maven Central
+- 🔧 **Tool Execution Framework** - Built-in circuit breaker and retry logic
 
-## Building
+## Modules
 
-All build commands should be run from this directory:
+- **kotlin-core** - Protocol types, events, and message definitions
+- **kotlin-client** - HTTP transport, SSE parsing, state management, and high-level agent APIs
+- **kotlin-tools** - Tool execution framework with registry and orchestration
 
-```bash
-# Build all targets
-./gradlew build
+## Installation
 
-# Run tests
-./gradlew test
+### Maven Central Coordinates
 
-# Run specific platform tests
-./gradlew androidTest
-./gradlew iosSimulatorArm64Test
-./gradlew jvmTest
+The SDK is published to Maven Central under the group `com.ag-ui.community`.
 
-# Run static analysis
-./gradlew detekt
+Latest version: **Check [Maven Central](https://central.sonatype.com/artifact/com.ag-ui.community/kotlin-core) for the current version**
 
-# Clean build artifacts
-./gradlew clean
+### JVM / Android Projects
+
+Add Maven Central to your repositories and include the dependencies:
+
+```kotlin
+// build.gradle.kts
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    val agUiVersion = "0.2.3" // Check Maven Central for latest version
+
+    implementation("com.ag-ui.community:kotlin-core:$agUiVersion")
+    implementation("com.ag-ui.community:kotlin-client:$agUiVersion")
+    implementation("com.ag-ui.community:kotlin-tools:$agUiVersion")
+}
 ```
 
-## Publishing
+## Quick Start
 
-To publish to Maven repositories:
+### Basic Agent Usage
+
+```kotlin
+import com.agui.client.HttpAgent
+import com.agui.core.RunAgentInput
+import kotlinx.coroutines.flow.collect
+
+// Create an HTTP agent
+val agent = HttpAgent(baseUrl = "https://your-agent-api.com")
+
+// Run the agent and collect events
+agent.run(RunAgentInput(prompt = "Hello, agent!")).collect { event ->
+    when (event) {
+        is TextMessageDeltaEvent -> println(event.delta.text)
+        is RunFinishedEvent -> println("Run completed")
+        // Handle other event types...
+    }
+}
+```
+
+### Stateful Agent (Maintains Conversation History)
+
+```kotlin
+import com.agui.client.StatefulAgUiAgent
+
+val statefulAgent = StatefulAgUiAgent(baseUrl = "https://your-agent-api.com")
+
+// First request
+statefulAgent.run("Tell me about Kotlin")
+
+// Follow-up request (maintains context)
+statefulAgent.run("What about multiplatform support?")
+
+// Access conversation history
+val messages = statefulAgent.getMessages()
+```
+
+## iOS Projects (Kotlin Multiplatform)
+
+iOS artifacts are published as `.klib` files to Maven Central and can be consumed directly in Kotlin Multiplatform projects.
+
+#### Setup in Kotlin Multiplatform Project
+
+```kotlin
+// In your shared module's build.gradle.kts
+kotlin {
+    // Configure iOS targets
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                val agUiVersion = "0.2.3" // Check Maven Central for latest version
+
+                implementation("com.ag-ui.community:kotlin-core:$agUiVersion")
+                implementation("com.ag-ui.community:kotlin-client:$agUiVersion")
+                implementation("com.ag-ui.community:kotlin-tools:$agUiVersion")
+            }
+        }
+    }
+}
+```
+
+The Kotlin Multiplatform plugin will automatically resolve the correct iOS variant:
+- `kotlin-core-iosx64` - for macOS/iOS Simulator on Intel Macs
+- `kotlin-core-iosarm64` - for physical iOS devices
+- `kotlin-core-iossimulatorarm64` - for iOS Simulator on Apple Silicon Macs
+
+#### Using with Xcode
+
+1. **Build the shared framework** in your Kotlin Multiplatform project:
+   ```bash
+   ./gradlew :shared:linkDebugFrameworkIosArm64
+   # or for simulator:
+   ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+   ```
+
+2. **Link the framework** to your Xcode project as you would with any KMP framework
+
+3. **Import and use** in Swift:
+   ```swift
+   import Shared
+
+   // Use AG-UI types
+   let agent = HttpAgent(/* ... */)
+   ```
+
+#### Important Notes for iOS Developers
+
+- ✅ **iOS artifacts ARE published to Maven Central** (since version 0.2.3)
+- 📦 iOS artifacts use Kotlin's native `.klib` format
+- 🔧 They must be consumed through a Kotlin Multiplatform shared module
+- ⚠️ They cannot be used directly in pure Swift/Objective-C projects without the KMP framework layer
+- 🎯 The KMP plugin handles variant resolution automatically based on your build target
+
+#### Alternative: Local Maven Installation
+
+If you need to test locally or work with unreleased versions:
 
 ```bash
-# Publish to local Maven repository
+cd library
 ./gradlew publishToMavenLocal
-
-# Publish to remote repository (requires credentials)
-./gradlew publish
 ```
+
+Then add `mavenLocal()` to your repositories:
+
+```kotlin
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+```
+
+## Platform Support
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| **JVM** | ✅ Full Support | Java 21+ |
+| **Android** | ✅ Full Support | API 26+ (Android 8.0) |
+| **iOS** | ✅ Full Support | arm64, x64, simulator arm64 |
+
+## Dependencies
+
+- **Kotlin** 2.2.20 with K2 compiler
+- **Ktor** 3.1.3 for HTTP client
+- **Kotlinx Serialization** 1.8.1
+- **Kotlinx Coroutines** 1.10.2
+- **Kotlinx Datetime** 0.6.2
+- **Kermit** 2.0.6 for multiplatform logging
 
 ## Development
 
-When developing:
-1. Always work from this directory as the root
-2. Use `./gradlew` instead of system gradle
-3. IDE should open this directory as the project root
+### Building from Source
+
+```bash
+# Build all modules
+./gradlew build
+
+# Run tests
+./gradlew allTests
+
+# Run tests for specific module
+./gradlew :kotlin-core:jvmTest
+./gradlew :kotlin-client:jvmTest
+./gradlew :kotlin-tools:jvmTest
+
+# Run tests for specific platform
+./gradlew jvmTest                    # JVM platform tests
+./gradlew iosSimulatorArm64Test      # iOS simulator tests
+./gradlew connectedDebugAndroidTest  # Android device tests
+
+# Publish to local Maven
+./gradlew publishToMavenLocal
+
+# Generate documentation
+./gradlew dokkaHtmlMultiModule
+# View at: build/dokka/htmlMultiModule/index.html
+
+# Generate coverage reports
+./gradlew koverHtmlReportAll
+```
+
+### Project Structure
+
+```
+library/
+├── core/               # Core protocol types and events
+├── client/             # HTTP client and state management
+├── tools/              # Tool execution framework
+├── build.gradle.kts    # Root build configuration
+└── settings.gradle.kts # Module configuration
+```
 
 ## Documentation
 
-For detailed API documentation and usage guides, see the **[complete SDK documentation](../../../docs/sdk/kotlin/)**.
+- 📚 [API Documentation](../../docs/) - Generated KDoc documentation
+- 💡 [Examples](../examples/) - Sample applications for all platforms
+- 🌐 [AG-UI Protocol Specification](https://github.com/ag-ui-protocol/ag-ui)
+- 🔧 [Development Guide](../CLAUDE.md) - Build commands and architecture
+
+## License
+
+MIT License - See [LICENSE](../../../../LICENSE) for details
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](../../../../CONTRIBUTING.md) for guidelines.
+
+## Support
+
+- 🐛 [Report Issues](https://github.com/ag-ui-protocol/ag-ui/issues)
+- 💬 [Discussions](https://github.com/ag-ui-protocol/ag-ui/discussions)
+- 📧 Community: [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui)
+
+## Acknowledgments
+
+Built with ❤️ by the AG-UI community. Part of the [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui) project.

--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -1,13 +1,32 @@
 // Root build script for AG-UI-4K multiplatform library
 // All modules are configured individually - see each module's build.gradle.kts
 
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import org.jreleaser.gradle.plugin.tasks.JReleaserDeployTask
+
 plugins {
     kotlin("multiplatform") version "2.2.20" apply false
     kotlin("plugin.serialization") version "2.2.20" apply false
     id("com.android.library") version "8.10.1" apply false
     id("org.jetbrains.dokka") version "2.0.0"
     id("org.jetbrains.kotlinx.kover") version "0.8.3"
+    id("org.jreleaser") version "1.20.0"
 }
+
+// Single source of truth for version and group (for library modules)
+// Used by:
+//   - All subprojects (core, client, tools) inherit these values
+//   - JReleaser configuration
+//   - publish.sh script (reads dynamically)
+//   - GitHub Actions workflow (reads dynamically)
+// Only update these values here - they propagate automatically
+version = "0.2.3"
+group = "com.ag-ui.community"
 
 allprojects {
     repositories {
@@ -18,17 +37,77 @@ allprojects {
 
 // Configure all subprojects with common settings
 subprojects {
-    group = "com.agui"
-    version = "0.2.3"
+
+    // Apply the publishing plugin to all subprojects
+    apply(plugin = "maven-publish")
+
+    // Configure all subprojects to publish to the root staging directory
+    // All artifacts (JVM, Android, iOS) publish to the same staging location
+    extensions.configure<PublishingExtension> {
+        repositories {
+            maven {
+                name = "jreleaserStaging"
+                // Use rootProject.buildDir to ensure all modules publish to one
+                // single /build/staging-deploy directory at the project root
+                url = uri(rootProject.layout.buildDirectory.dir("staging-deploy"))
+            }
+        }
+    }
+
+    group = rootProject.group
+    version = rootProject.version
 
     apply(plugin = "org.jetbrains.kotlinx.kover")
-    
+    extensions.configure<KoverProjectExtension>("kover") {
+        currentProject {
+            instrumentation {
+                disabledForTestTasks.addAll(
+                    "jvmTest",
+                    "testDebugUnitTest",
+                    "testReleaseUnitTest"
+                )
+            }
+        }
+    }
+
     tasks.withType<Test> {
         useJUnitPlatform()
+    }
+
+    afterEvaluate {
+        group = rootProject.group
+        version = rootProject.version
     }
     
     // Apply Dokka to all subprojects
     apply(plugin = "org.jetbrains.dokka")
+        plugins.withId("org.jetbrains.dokka") {
+
+        val dokkaTask = tasks.findByName("dokkaHtml") ?: tasks.findByName("dokkaGenerate")
+
+        if (dokkaTask == null) {
+            logger.warn("Dokka task not found in project ${project.name}; skipping javadocJar attachment.")
+            return@withId
+        }
+
+        val javadocJar = tasks.register("javadocJar", Jar::class.java) {
+            dependsOn(dokkaTask)
+            archiveClassifier.set("javadoc")
+            from(dokkaTask.outputs.files)
+        }
+
+        extensions.configure(PublishingExtension::class.java) {
+            publications.withType(MavenPublication::class.java) {
+                // NEW, SIMPLIFIED LOGIC:
+                // ONLY attach javadoc to the 'jvm' publication.
+                // All other publications (android, ios) are handled
+                // by the artifactOverride rules.
+                if (name.equals("jvm", ignoreCase = true)) {
+                    artifact(javadocJar)
+                }
+            }
+        }
+    }
 }
 
 // Simple Dokka V2 configuration - let it use defaults for navigation
@@ -104,4 +183,137 @@ tasks.register("dokkaHtmlMultiModule") {
         
         println("Unified documentation generated at: ${outputDir.absolutePath}/index.html")
     }
+}
+
+// JReleaser configuration for publishing to Maven Central
+// Uses artifactOverride to handle iOS .klib files (jar: false skips .jar validation)
+afterEvaluate {
+    jreleaser {
+        gitRootSearch = true
+
+        // Project information
+        project {
+            name.set("ag-ui-kotlin-sdk")
+            version.set(rootProject.version.toString())
+            description.set("Kotlin Multiplatform SDK for the Agent User Interaction Protocol")
+            links {
+                homepage.set("https://github.com/ag-ui-protocol/ag-ui")
+            }
+            authors.set(listOf("Mark Fogle"))
+            license.set("MIT")
+            inceptionYear.set("2024")
+
+            // Java configuration - suppress deprecation warning for KMP projects
+            @Suppress("DEPRECATION")
+            java {
+                groupId.set("com.ag-ui.community")
+                multiProject.set(true)
+            }
+        }
+
+        // Enable GPG signing
+        signing {
+            active.set(org.jreleaser.model.Active.ALWAYS)
+            armored.set(true)
+        }
+
+        // Configure Maven Central deployment
+        deploy {
+            maven {
+                // Disable PomChecker for Kotlin Multiplatform artifacts
+                pomchecker {
+                    version.set("1.14.0")
+                    failOnWarning.set(false)
+                    failOnError.set(false)
+                }
+
+                mavenCentral {
+                    create("sonatype") {
+                        active.set(org.jreleaser.model.Active.ALWAYS)
+                        url.set("https://central.sonatype.com/api/v1/publisher")
+
+                        stagingRepository("build/staging-deploy")
+
+                        namespace.set("com.ag-ui.community")
+                        sign.set(true)
+                        checksums.set(true)
+
+                        // Disable strict Maven Central rules for Kotlin Multiplatform
+                        // KMP artifacts (metadata, Android, iOS) don't follow traditional JAR structure
+                        applyMavenCentralRules.set(false)
+                        verifyPom.set(false)
+                        sourceJar.set(false)
+                        javadocJar.set(false)
+
+                        // iOS artifact overrides - disable jar validation for .klib files
+                        // This allows iOS artifacts to be published to Maven Central
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-core-iosx64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-core-iosarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-core-iossimulatorarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-client-iosx64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-client-iosarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-client-iossimulatorarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-tools-iosx64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-tools-iosarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                        artifactOverride {
+                            groupId.set("com.ag-ui.community")
+                            artifactId.set("kotlin-tools-iossimulatorarm64")
+                            jar.set(false)
+                            sourceJar.set(false)
+                            javadocJar.set(false)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // --- End: The ENTIRE JReleaser Config ---
 }

--- a/sdks/community/kotlin/library/client/build.gradle.kts
+++ b/sdks/community/kotlin/library/client/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
     id("signing")
 }
 
-group = "com.agui"
-    version = "0.2.3"
+// Group and version inherited from parent build.gradle.kts
 
 repositories {
     google()
@@ -155,6 +154,7 @@ android {
 publishing {
     publications {
         withType<MavenPublication> {
+            version = project.version.toString()
             pom {
                 name.set("kotlin-client")
                 description.set("Client SDK for the Agent User Interaction Protocol")

--- a/sdks/community/kotlin/library/core/build.gradle.kts
+++ b/sdks/community/kotlin/library/core/build.gradle.kts
@@ -6,8 +6,7 @@ plugins {
     id("signing")
 }
 
-group = "com.agui"
-    version = "0.2.3"
+// Group and version inherited from parent build.gradle.kts
 
 repositories {
     google()
@@ -132,6 +131,7 @@ android {
 publishing {
     publications {
         withType<MavenPublication> {
+            version = project.version.toString()
             pom {
                 name.set("kotlin-core")
                 description.set("Core types and protocol definitions for the Agent User Interaction Protocol")

--- a/sdks/community/kotlin/library/gradle.properties
+++ b/sdks/community/kotlin/library/gradle.properties
@@ -26,7 +26,21 @@ android.nonTransitiveRClass=true
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
-# Publishing (replace with your actual values when publishing)
+# Maven Central compatibility
+org.gradle.internal.publish.checksums.insecure=true
+
+# Publishing Configuration
+# JReleaser reads credentials from environment variables or ~/.jreleaser/config.toml
+# For local publishing, set these environment variables:
+#   JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME - Portal username (user token)
+#   JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD - Portal password (user token)
+#   JRELEASER_GPG_PASSPHRASE - GPG key passphrase
+#   JRELEASER_GPG_PUBLIC_KEY - Base64-encoded GPG public key
+#   JRELEASER_GPG_SECRET_KEY - Base64-encoded GPG private key
+#
+# Generate user tokens at: https://central.sonatype.com/account
+#
+# Legacy OSSRH credentials (no longer used as of 2025):
 # signingKey=YOUR_SIGNING_KEY
 # signingPassword=YOUR_SIGNING_PASSWORD
 # ossrhUsername=YOUR_OSSRH_USERNAME

--- a/sdks/community/kotlin/library/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/library/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"
 android-gradle = "8.10.1"
 kermit = "2.0.6"
+jreleaser = "1.20.0"
 
 [libraries]
 # Ktor
@@ -37,6 +38,7 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 
 [bundles]
 ktor-common = [

--- a/sdks/community/kotlin/library/tools/build.gradle.kts
+++ b/sdks/community/kotlin/library/tools/build.gradle.kts
@@ -6,10 +6,9 @@ plugins {
     id("signing")
 }
 
-group = "com.agui"
-    version = "0.2.3"
+// Group and version inherited from parent build.gradle.kts
 
-repositories {
+repositories{
     google()
     mavenCentral()
 }
@@ -125,6 +124,7 @@ android {
 publishing {
     publications {
         withType<MavenPublication> {
+            version = project.version.toString()
             pom {
                 name.set("kotlin-tools")
                 description.set("Tool execution system for the Agent User Interaction Protocol")

--- a/sdks/community/kotlin/publish.sh
+++ b/sdks/community/kotlin/publish.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# AG-UI Kotlin SDK Publishing Script
+# Publishes kotlin-core, kotlin-client, and kotlin-tools to Maven Central via Sonatype Portal
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse command line arguments
+DRY_RUN=false
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --dry-run    Test the publishing process without uploading to Maven Central"
+            echo "  -h, --help   Show this help message"
+            echo ""
+            echo "Required Environment Variables:"
+            echo "  JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME - Sonatype Portal username (user token)"
+            echo "  JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD - Sonatype Portal password (user token)"
+            echo "  JRELEASER_GPG_PASSPHRASE                 - GPG key passphrase"
+            echo "  JRELEASER_GPG_PUBLIC_KEY                 - Base64-encoded GPG public key"
+            echo "  JRELEASER_GPG_SECRET_KEY                 - Base64-encoded GPG private key"
+            echo ""
+            echo "Generate user tokens at: https://central.sonatype.com/account"
+            exit 0
+            ;;
+    esac
+done
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}AG-UI Kotlin SDK Publishing Script${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if running in dry-run mode
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}⚠️  DRY RUN MODE - No artifacts will be uploaded${NC}"
+    echo ""
+fi
+
+# Verify required environment variables (unless dry-run)
+if [ "$DRY_RUN" = false ]; then
+    echo -e "${BLUE}🔍 Checking required environment variables...${NC}"
+
+    MISSING_VARS=()
+
+    if [ -z "$JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME" ]; then
+        MISSING_VARS+=("JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME")
+    fi
+
+    if [ -z "$JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD" ]; then
+        MISSING_VARS+=("JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD")
+    fi
+
+    if [ -z "$JRELEASER_GPG_PASSPHRASE" ]; then
+        MISSING_VARS+=("JRELEASER_GPG_PASSPHRASE")
+    fi
+
+    if [ -z "$JRELEASER_GPG_PUBLIC_KEY" ]; then
+        MISSING_VARS+=("JRELEASER_GPG_PUBLIC_KEY")
+    fi
+
+    if [ -z "$JRELEASER_GPG_SECRET_KEY" ]; then
+        MISSING_VARS+=("JRELEASER_GPG_SECRET_KEY")
+    fi
+
+    if [ ${#MISSING_VARS[@]} -ne 0 ]; then
+        echo -e "${RED}❌ Error: Missing required environment variables:${NC}"
+        for var in "${MISSING_VARS[@]}"; do
+            echo -e "${RED}   - $var${NC}"
+        done
+        echo ""
+        echo "Generate credentials at: https://central.sonatype.com/account"
+        echo "Run with --help for more information"
+        exit 1
+    fi
+
+    echo -e "${GREEN}✅ All required environment variables are set${NC}"
+    echo ""
+fi
+
+# Navigate to library directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/library" || exit 1
+
+echo -e "${BLUE}📂 Working directory: $(pwd)${NC}"
+
+# Extract version from build.gradle.kts
+VERSION=$(grep "^version = " build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+echo -e "${BLUE}📦 Version: ${VERSION}${NC}"
+echo ""
+
+# Step 1: Clean previous builds and staging directory
+echo -e "${BLUE}🧹 Cleaning previous builds...${NC}"
+./gradlew clean --no-daemon
+
+# Also clean the staging directory to remove any leftover artifacts
+if [ -d "build/staging-deploy" ]; then
+    echo -e "${BLUE}🧹 Cleaning staging directory...${NC}"
+    rm -rf build/staging-deploy
+fi
+
+echo -e "${GREEN}✅ Clean complete${NC}"
+echo ""
+
+# Step 2: Run tests
+echo -e "${BLUE}🧪 Running tests...${NC}"
+./gradlew allTests --no-daemon
+if [ $? -ne 0 ]; then
+    echo -e "${RED}❌ Tests failed! Publishing aborted.${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ All tests passed${NC}"
+echo ""
+
+# Step 3: Build and publish to staging
+echo -e "${BLUE}📦 Building and staging artifacts...${NC}"
+./gradlew publish --no-daemon
+if [ $? -ne 0 ]; then
+    echo -e "${RED}❌ Build failed! Publishing aborted.${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ Artifacts built and staged${NC}"
+echo ""
+
+# Step 4: Deploy to Maven Central (or dry-run)
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}🔍 Running JReleaser in dry-run mode...${NC}"
+    ./gradlew jreleaserDeploy --dry-run --no-daemon
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo ""
+        echo -e "${GREEN}✅ Dry-run completed successfully!${NC}"
+        echo -e "${YELLOW}⚠️  No artifacts were uploaded (dry-run mode)${NC}"
+    else
+        echo ""
+        echo -e "${RED}❌ Dry-run failed!${NC}"
+        exit $EXIT_CODE
+    fi
+else
+    echo -e "${BLUE}🚀 Deploying to Maven Central...${NC}"
+    ./gradlew jreleaserDeploy --no-daemon
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -eq 0 ]; then
+        echo ""
+        echo -e "${GREEN}========================================${NC}"
+        echo -e "${GREEN}✅ Publishing completed successfully!${NC}"
+        echo -e "${GREEN}========================================${NC}"
+        echo ""
+        echo -e "${BLUE}📋 Next steps:${NC}"
+        echo "   1. Check deployment status at: https://central.sonatype.com/publishing"
+        echo "   2. Artifacts will be validated automatically"
+        echo "   3. Publishing to Maven Central will complete in ~10-30 minutes"
+        echo ""
+        echo -e "${BLUE}📦 Published artifacts:${NC}"
+        echo "   - com.ag-ui.community:kotlin-core:${VERSION} (JVM, Android, iOS)"
+        echo "   - com.ag-ui.community:kotlin-client:${VERSION} (JVM, Android, iOS)"
+        echo "   - com.ag-ui.community:kotlin-tools:${VERSION} (JVM, Android, iOS)"
+        echo ""
+        echo -e "${BLUE}ℹ️  All platforms published including iOS (.klib format)${NC}"
+    else
+        echo ""
+        echo -e "${RED}❌ Publishing failed!${NC}"
+        echo "Check the output above for error details."
+        exit $EXIT_CODE
+    fi
+fi
+
+echo ""


### PR DESCRIPTION
feat(kotlin-sdk): add Maven Central publishing with JReleaser
Implements publishing infrastructure for kotlin-core, kotlin-client, and
kotlin-tools to Maven Central using JReleaser and Sonatype's Central Portal API.

Changes:
- Add JReleaser Gradle plugin (v1.17.0) to library/build.gradle.kts
- Configure Maven Central deployment via Sonatype Portal API
- Implement Kotlin Multiplatform workaround for iOS targets (non-JAR artifacts)
- Create publish.sh script with dry-run support and credential validation
- Add GitHub Actions workflow for manual publishing with Android SDK 36 setup
- Update gradle.properties with JReleaser environment variable documentation

Publishing workflow:
1. Local: ./publish.sh --dry-run (test) or ./publish.sh (publish)
2. CI/CD: Manual workflow trigger in GitHub Actions

Required credentials (via Github Secrets):

GPG_PASSPHRASE - Passphrase to unlock GPG private key
GPG_PRIVATEKEY, GPG_PUBLICKEY - Private and public key used for signing artifacts
SONATYPE_PASSWORD, SONATYPE_USERNAME - Publishing tokens created from Sonatype

<img width="1592" height="594" alt="image" src="https://github.com/user-attachments/assets/6cf9edde-a37b-4fcc-9bbe-b881ac2c8525" />