### PR TITLE
Use DefaultAzureCredential for MAF Python chat client

### DIFF
--- a/integrations/microsoft-agent-framework/python/examples/agents/dojo.py
+++ b/integrations/microsoft-agent-framework/python/examples/agents/dojo.py
@@ -32,7 +32,7 @@ from agent_framework_ag_ui_examples.agents import (
     ui_generator_agent,
     weather_agent,
 )
-from azure.identity import AzureCliCredential
+from azure.identity import DefaultAzureCredential
 
 load_dotenv()
 
@@ -50,7 +50,7 @@ app = FastAPI(title="Microsoft Agent Framework Python Dojo")
 # add_agent_framework_fastapi_endpoint(app, weather_agent(openai_client), "/backend_tool_rendering")
 
 # If using api_key authentication remove the credential parameter
-chat_client = AzureOpenAIChatClient(credential=AzureCliCredential())
+chat_client = AzureOpenAIChatClient(credential=DefaultAzureCredential())
 
 # Agentic Chat - simple_agent
 add_agent_framework_fastapi_endpoint(app, simple_agent(chat_client), "/agentic_chat")


### PR DESCRIPTION
<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->

The current MAF Python dojo sample assumes that Azure CLI is installed and working for deployments. To broaden the scope a bit (and use what .NET has implemented) I'm switching from `AzureCliCredential` to `DefaultAzureCredential`.
