### PR TITLE
fix: health check at `//health` when using default value to path arg

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/__init__.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/__init__.py
@@ -12,9 +12,9 @@ from .types import (
     LangGraphPlatformResultMessage,
     LangGraphPlatformActionExecutionMessage,
     LangGraphPlatformMessage,
-    PredictStateTool
+    PredictStateTool,
 )
-from .endpoint import add_langgraph_fastapi_endpoint
+from .endpoint import add_langgraph_fastapi_endpoints
 
 __all__ = [
     "LangGraphAgent",
@@ -31,5 +31,5 @@ __all__ = [
     "LangGraphPlatformActionExecutionMessage",
     "LangGraphPlatformMessage",
     "PredictStateTool",
-    "add_langgraph_fastapi_endpoint"
+    "add_langgraph_fastapi_endpoints",
 ]

--- a/integrations/langgraph/python/ag_ui_langgraph/__init__.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/__init__.py
@@ -14,7 +14,7 @@ from .types import (
     LangGraphPlatformMessage,
     PredictStateTool,
 )
-from .endpoint import add_langgraph_fastapi_endpoints
+from .endpoint import add_langgraph_fastapi_endpoint
 
 __all__ = [
     "LangGraphAgent",
@@ -31,5 +31,5 @@ __all__ = [
     "LangGraphPlatformActionExecutionMessage",
     "LangGraphPlatformMessage",
     "PredictStateTool",
-    "add_langgraph_fastapi_endpoints",
+    "add_langgraph_fastapi_endpoint",
 ]

--- a/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
@@ -7,7 +7,7 @@ from ag_ui.encoder import EventEncoder
 from .agent import LangGraphAgent
 
 
-def add_langgraph_fastapi_endpoints(
+def add_langgraph_fastapi_endpoint(
     app: FastAPI, agent: LangGraphAgent, path: str = "/"
 ):
     """Adds endpoints to the FastAPI app."""


### PR DESCRIPTION
Fixes: https://github.com/ag-ui-protocol/ag-ui/issues/700 by using an [`APIRouter`](https://fastapi.tiangolo.com/reference/apirouter/) which provides with the expected prefix path behavior we were looking for here (that correctly handles trailing slashes).

[See here for how `APIRouter` expects prefix](https://arc.net/l/quote/aqgmjeti).