### PR TITLE
fix(mastra): Pass through missing runtimeContext

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -82,7 +82,9 @@ export class MastraAgent extends AbstractAgent {
 
         // Handle local agent memory management (from Mastra implementation)
         if (this.isLocalMastraAgent(this.agent)) {
-          const memory = await this.agent.getMemory();
+          const memory = await this.agent.getMemory({
+            runtimeContext: this.runtimeContext
+          });
 
           if (
             memory &&
@@ -181,7 +183,9 @@ export class MastraAgent extends AbstractAgent {
             onRunFinished: async () => {
               if (this.isLocalMastraAgent(this.agent)) {
                 try {
-                  const memory = await this.agent.getMemory();
+                  const memory = await this.agent.getMemory({
+                    runtimeContext: this.runtimeContext
+                  });
                   if (memory) {
                     const workingMemory = await memory.getWorkingMemory({
                       threadId: input.threadId,
@@ -337,6 +341,7 @@ export class MastraAgent extends AbstractAgent {
           runId,
           messages: convertedMessages,
           clientTools,
+          runtimeContext,
         });
 
         // Remote agents should have a processDataStream method


### PR DESCRIPTION
Passes through the missing `runtimeContext` property to `getMemory`, as well as in a subsequent `stream` call that it was missing from.



<img width="1212" height="73" alt="image" src="https://github.com/user-attachments/assets/4f34a0bf-6227-4029-bd73-ce5034126954" />


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
