### PR TITLE
fix(mastra): Set new memory property on agent.stream

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -343,7 +343,6 @@ export class MastraAgent extends AbstractAgent {
           runId,
           messages: convertedMessages,
           clientTools,
-          
           memory: {
             resource: resourceId,
             thread: {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -277,11 +277,19 @@ export class MastraAgent extends AbstractAgent {
       // Local agent - use the agent's stream method directly
       try {
         const response = await this.agent.stream(convertedMessages, {
-          threadId,
-          resourceId,
           runId,
           clientTools,
           runtimeContext,
+          memory: {
+            resource: resourceId,
+            thread: {
+              id: threadId
+            }
+          },
+          
+          // Deprecated but still set for compatability
+          threadId,
+          resourceId
         });
 
         // For local agents, the response should already be a stream
@@ -332,11 +340,20 @@ export class MastraAgent extends AbstractAgent {
       // Remote agent - use the remote agent's stream method
       try {
         const response = await this.agent.stream({
-          threadId,
-          resourceId,
           runId,
           messages: convertedMessages,
           clientTools,
+          
+          memory: {
+            resource: resourceId,
+            thread: {
+              id: threadId
+            }
+          },
+          
+          // Deprecated but still set for compatability
+          threadId,
+          resourceId
         });
 
         // Remote agents should have a processDataStream method


### PR DESCRIPTION
We're not setting the new `memory` property when callnig `mastra.stream`, which means that in newer versions of mastra that the `threadId` and `resourceId` properties aren't being persisted through.

I've now set this, but kept the old `threadId` and `resourceId` properties around with a deprecation comment instead.

<img width="922" height="130" alt="image" src="https://github.com/user-attachments/assets/fb8f7c16-e053-4059-ae11-9db1ff253e90" />

<img width="483" height="175" alt="image" src="https://github.com/user-attachments/assets/1c339590-1afa-4fa8-9d95-542a0f1aa1ee" />

<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
