### PR TITLE
fix(adk-middleware): filter empty text events to prevent frontend crash

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -279,6 +279,8 @@ class EventTranslator:
             return
 
         combined_text = "".join(text_parts)
+        if not combined_text:
+            return
 
         # Use proper ADK streaming detection (handle None values)
         is_partial = getattr(adk_event, 'partial', False)


### PR DESCRIPTION
Fix and tests for https://github.com/ag-ui-protocol/ag-ui/issues/735#issuecomment-3583995275

AG-UI's TextMessageContentEvent validates that delta is non-empty. When ADK yielded events with empty string content, the validation would fail and crash the frontend.

Added early return in _translate_text_content when combined_text is empty, preventing the creation of TextMessageContentEvent with empty delta.

Added comprehensive tests for empty text event handling:
- test_empty_text_event_does_not_crash
- test_whitespace_only_text_event_does_not_crash
- test_multiple_empty_parts_filtered
- test_mixed_empty_and_valid_parts_filtering
- test_empty_combined_text_early_return
