### PR TITLE
fix(adk-middleware): filter empty text events to prevent frontend crash

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -279,6 +279,8 @@ class EventTranslator:
             return
 
         combined_text = "".join(text_parts)
+        if not combined_text:
+            return
 
         # Use proper ADK streaming detection (handle None values)
         is_partial = getattr(adk_event, 'partial', False)


### PR DESCRIPTION
AG-UI's TextMessageContentEvent validates that delta is non-empty. When ADK yielded events with empty string content, the validation would fail and crash the frontend.

Added early return in _translate_text_content when combined_text is empty, preventing the creation of TextMessageContentEvent with empty delta.

Added comprehensive tests for empty text event handling:
- test_empty_text_event_does_not_crash
- test_whitespace_only_text_event_does_not_crash
- test_multiple_empty_parts_filtered
- test_mixed_empty_and_valid_parts_filtering
- test_empty_combined_text_early_return


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
