### PR TITLE
fix(typescript-sdk): Don't require a space after `data:` when processing SSE events

### DIFF
--- a/sdks/typescript/packages/client/src/transform/sse.ts
+++ b/sdks/typescript/packages/client/src/transform/sse.ts
@@ -52,7 +52,10 @@ export const parseSSEStream = (source$: Observable<HttpEvent>): Observable<any> 
   /**
    * Helper function to process an SSE event.
    * Extracts and joins data lines, then parses the result as JSON.
-   * Follows the SSE spec by only processing 'data:' prefixed lines.
+   * 
+   * Follows the SSE spec by processing lines starting with 'data:',
+   * ignoring a single space if it is present after the colon.
+   * 
    * @param eventText The raw event text to process
    */
   function processSSEEvent(eventText: string) {
@@ -60,9 +63,9 @@ export const parseSSEStream = (source$: Observable<HttpEvent>): Observable<any> 
     const dataLines: string[] = [];
 
     for (const line of lines) {
-      if (line.startsWith("data: ")) {
-        // Extract data content (remove 'data: ' prefix)
-        dataLines.push(line.slice(6));
+      if (line.startsWith("data:")) {
+        // Remove 'data:' prefix, and optionally a single space afterwards
+        dataLines.push(line.slice(5).replace(/^ /, ""));
       }
     }
 


### PR DESCRIPTION
The [official SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) from WHATWG, which MDN is based on, states that the space after the colon should always be ignored.

The `processSSEEvent` utility previously required `data: ` and didn't accept `data:`, which breaks valid implementations of the spec, such as the widely-used [manucorporat/sse](https://github.com/manucorporat/sse).

---

Fixes #771 