### PR TITLE
chore: rename AWS Strands integration package

### DIFF
--- a/apps/dojo/package.json
+++ b/apps/dojo/package.json
@@ -28,7 +28,7 @@
     "@ag-ui/server-starter-all-features": "workspace:*",
     "@ag-ui/spring-ai": "workspace:*",
     "@ag-ui/vercel-ai-sdk": "workspace:*",
-    "@ag-ui/aws-strands-integration": "workspace:*",
+    "@ag-ui/aws-strands": "workspace:*",
     "@ai-sdk/openai": "^2.0.42",
     "@copilotkit/react-core": "1.10.6",
     "@copilotkit/react-ui": "1.10.6",

--- a/apps/dojo/src/agents.ts
+++ b/apps/dojo/src/agents.ts
@@ -19,7 +19,7 @@ import { ADKAgent } from "@ag-ui/adk";
 import { SpringAiAgent } from "@ag-ui/spring-ai";
 import { HttpAgent } from "@ag-ui/client";
 import { A2AMiddlewareAgent } from "@ag-ui/a2a-middleware";
-import { AWSStrandsAgent } from "@ag-ui/aws-strands-integration";
+import { AWSStrandsAgent } from "@ag-ui/aws-strands";
 import { A2AAgent } from "@ag-ui/a2a";
 import { A2AClient } from "@a2a-js/sdk/client";
 import { LangChainAgent } from "@ag-ui/langchain";

--- a/integrations/aws-strands/typescript/README.md
+++ b/integrations/aws-strands/typescript/README.md
@@ -5,7 +5,7 @@ TypeScript client for the Strands integration using OpenAI models.
 ## Usage
 
 ```typescript
-import { AWSStrandsAgent } from "@ag-ui/aws-strands-integration";
+import { AWSStrandsAgent } from "@ag-ui/aws-strands";
 
 const agent = new AWSStrandsAgent({ url: "http://localhost:8000" });
 ```

--- a/integrations/aws-strands/typescript/package.json
+++ b/integrations/aws-strands/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ag-ui/aws-strands-integration",
+  "name": "@ag-ui/aws-strands",
   "author": "AG-UI Contributors",
   "version": "0.0.1",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
       '@ag-ui/agno':
         specifier: workspace:*
         version: link:../../integrations/agno/typescript
-      '@ag-ui/aws-strands-integration':
+      '@ag-ui/aws-strands':
         specifier: workspace:*
         version: link:../../integrations/aws-strands/typescript
       '@ag-ui/client':


### PR DESCRIPTION
Renames the `@ag-ui/aws-strands-integration` package to `@ag-ui/aws-strands` for brevity and consistency across the project.