### PR TITLE
fix(adk): emit final text response after backend tool completion

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1388,9 +1388,11 @@ class ADKAgent:
                     # Be conservative: if detection fails, do not block streaming path
                     has_lro_function_call = False
 
-                # Process as streaming if it's a chunk OR if it has content but no finish_reason,
+                # Process as streaming if it's a chunk OR if it has content,
                 # but only when there is no LRO function call present (LRO takes precedence)
-                if (not has_lro_function_call) and (is_streaming_chunk or (has_content and not getattr(adk_event, 'finish_reason', None))):
+                # Note: We don't exclude based on finish_reason - final responses with content
+                # (e.g., after backend tool completion) must still be translated.
+                if (not has_lro_function_call) and (is_streaming_chunk or has_content):
                     # Regular translation path
                     async for ag_ui_event in event_translator.translate(
                         adk_event,


### PR DESCRIPTION
When a backend (non-LRO) tool completes and the model generates a final text response, the response was being silently dropped because the conditional at line 1393 excluded events with finish_reason set.

The condition `has_content and not finish_reason` caused final responses to be routed through translate_lro_function_calls() which only processes LRO function calls, discarding any text content.

The fix removes the finish_reason exclusion, allowing all events with content (and no LRO function calls) to be properly translated.

Fixes [#796](https://github.com/ag-ui-protocol/ag-ui/issues/796)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
