### PR TITLE
fix(adk): persist client-side tool results to ADK session database

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1272,7 +1272,7 @@ class ADKAgent:
                     content=function_response_content
                 )
 
-                session.events.append(function_response_event)
+                await self._session_manager._session_service.append_event(session, function_response_event)
 
                 # Mark user messages from message_batch as processed
                 if message_batch:


### PR DESCRIPTION
## Summary

- Fixed issue where client-side (HITL) tool results were not being persisted to the ADK Session DB when they arrived alongside a user message
- The fix uses `append_event()` instead of `session.events.append()` to properly persist FunctionResponse events
- Added integration tests to verify persistence behavior for both client-side and backend tools

## Root Cause

When client-side tool results arrived with a trailing user message, the code at `adk_agent.py:1275` was using `session.events.append(function_response_event)` which only modifies the in-memory session object without persisting to the database.

Backend tool results worked correctly because they are handled entirely by `runner.run_async()`, which automatically persists events.

## Test plan

- [x] Added positive test: `test_client_tool_result_persisted_to_session_db` - verifies client-side tool results ARE persisted
- [x] Added negative test: `test_backend_tool_results_not_double_persisted` - verifies backend tools are NOT double-persisted by our code
- [x] All 385 tests pass

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)