### PR TITLE
feat(adk): add HTTP header extraction to FastAPI endpoint

### DIFF
--- a/integrations/adk-middleware/python/CONFIGURATION.md
+++ b/integrations/adk-middleware/python/CONFIGURATION.md
@@ -85,6 +85,26 @@ agent = ADKAgent(
 )
 ```
 
+### Using Extracted Headers
+
+When combined with `extract_headers` (see [Header Extraction](#header-extraction)), extractors can use HTTP headers for identification:
+
+```python
+from fastapi import FastAPI
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+
+agent = ADKAgent(
+    adk_agent=my_agent,
+    user_id_extractor=lambda input: input.state.get("headers", {}).get("user_id", "anonymous"),
+)
+
+app = FastAPI()
+add_adk_fastapi_endpoint(
+    app, agent, "/chat",
+    extract_headers=["x-user-id"]  # x-user-id header becomes state.headers.user_id
+)
+```
+
 ## Session Management
 
 Sessions are managed automatically by the singleton `SessionManager`. Configuration options include:
@@ -330,6 +350,56 @@ add_adk_fastapi_endpoint(
 # Multiple agents on different endpoints
 add_adk_fastapi_endpoint(app, general_agent, path="/agents/general")
 add_adk_fastapi_endpoint(app, technical_agent, path="/agents/technical")
+```
+
+### Header Extraction
+
+Extract HTTP headers into `state.headers` for use by extractors and agents:
+
+```python
+add_adk_fastapi_endpoint(
+    app, agent, "/chat",
+    extract_headers=["x-user-id", "x-tenant-id"]
+)
+```
+
+**Transformation rules:**
+- `x-` prefix is stripped: `x-user-id` → `user_id`
+- Hyphens converted to underscores: `x-tenant-id` → `tenant_id`
+- Missing headers are silently skipped
+- Client-provided `state.headers` values take precedence
+
+**Example with user_id extractor:**
+
+```python
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+
+agent = ADKAgent(
+    adk_agent=my_agent,
+    user_id_extractor=lambda input: input.state.get("headers", {}).get("user_id", "anonymous"),
+)
+
+add_adk_fastapi_endpoint(
+    app, agent, "/chat",
+    extract_headers=["x-user-id", "x-tenant-id"]
+)
+```
+
+Client request:
+```
+POST /chat
+x-user-id: user123
+x-tenant-id: tenant456
+
+{"state": {"foo": "bar"}, ...}
+```
+
+Agent receives:
+```python
+input.state = {
+    "headers": {"user_id": "user123", "tenant_id": "tenant456"},
+    "foo": "bar"
+}
 ```
 
 ## Logging Configuration

--- a/integrations/adk-middleware/python/README.md
+++ b/integrations/adk-middleware/python/README.md
@@ -155,7 +155,10 @@ agent = ADKAgent(
 
 # 3. Create FastAPI app
 app = FastAPI()
-add_adk_fastapi_endpoint(app, agent, path="/chat")
+add_adk_fastapi_endpoint(
+    app, agent, path="/chat",
+    extract_headers=["x-user-id", "x-tenant-id"]  # Extract HTTP headers into state.headers
+)
 
 # Run with: uvicorn your_module:app --host 0.0.0.0 --port 8000
 ```


### PR DESCRIPTION
## Summary

- Adds `extract_headers` parameter to `add_adk_fastapi_endpoint()` and `create_adk_app()` for extracting HTTP headers into `state.headers`
- Enables `user_id_extractor` functions to read from HTTP headers for multi-tenant authentication scenarios
- Implements whitelist approach with auto key transformation (`x-user-id` → `user_id`)

Closes #740

## Features

- **Explicit header list**: Whitelist approach for security (vs auto-extracting all x-* headers)
- **Nested `state.headers`**: Prevents collision with client state keys
- **Auto key transformation**: `x-user-id` → `user_id` (strip x- prefix, hyphens to underscores)
- **Client precedence**: Client-provided `state.headers` values take precedence over extracted headers
- **Missing headers skipped**: No errors for missing optional headers

## Usage

```python
from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint

agent = ADKAgent(
    adk_agent=my_agent,
    user_id_extractor=lambda input: input.state.get("headers", {}).get("user_id", "anonymous"),
)

add_adk_fastapi_endpoint(
    app, agent, "/chat",
    extract_headers=["x-user-id", "x-tenant-id"]
)
```

## Test plan

- [x] 12 new tests added for header extraction functionality
- [x] All 397 tests pass
- [x] Documentation added to CONFIGURATION.md and README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)