### PR TITLE
fix-mastra-ts-adapter: reset message id on text-end

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -39,7 +39,7 @@ export interface MastraAgentConfig extends AgentConfig {
 
 interface MastraAgentStreamOptions {
   onTextPart?: (text: string) => void;
-  onFinishMessagePart?: () => void;
+  onTextEndPart?: () => void;
   onToolCallPart?: (streamPart: {
     toolCallId: string;
     toolName: string;
@@ -170,7 +170,7 @@ export class MastraAgent extends AbstractAgent {
 
               subscriber.next(toolCallResultEvent);
             },
-            onFinishMessagePart: async () => {
+            onTextEndPart: async () => {
               messageId = randomUUID();
             },
             onError: (error) => {
@@ -249,7 +249,7 @@ export class MastraAgent extends AbstractAgent {
     { threadId, runId, messages, tools, context: inputContext }: RunAgentInput,
     {
       onTextPart,
-      onFinishMessagePart,
+      onTextEndPart,
       onToolCallPart,
       onToolResultPart,
       onError,
@@ -314,8 +314,8 @@ export class MastraAgent extends AbstractAgent {
                 break;
               }
 
-              case "finish": {
-                onFinishMessagePart?.();
+              case "text-end": {
+                onTextEndPart?.();
                 break;
               }
             }
@@ -364,8 +364,8 @@ export class MastraAgent extends AbstractAgent {
                   break;
                 }
 
-                case "finish": {
-                  onFinishMessagePart?.();
+                case "text-end": {
+                  onTextEndPart?.();
                   break;
                 }
               }


### PR DESCRIPTION
Fixes #836 