### PR TITLE
[ADK] Add support for ADK App to ADKAgent

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **NEW**: `ADKAgent.from_app()` classmethod for creating agents from ADK App instances (#844)
+  - Enables access to App-level features: plugins, resumability, context caching, events compaction
+  - Creates per-request App copies with modified agents using `model_copy()` to preserve all configs
+  - Includes `plugin_close_timeout` parameter (requires ADK 1.19+, silently ignored on older versions)
+  - Runtime detection of ADK version capabilities for forward compatibility
+- **NEW**: Integration tests for `from_app()` functionality (`test_from_app_integration.py`)
+- **DOCUMENTATION**: Added "Using App for Full ADK Features" section to USAGE.md
+
 ## [0.4.0] - 2025-12-14
 
 ### Added

--- a/integrations/adk-middleware/python/USAGE.md
+++ b/integrations/adk-middleware/python/USAGE.md
@@ -75,6 +75,51 @@ agent = ADKAgent(
 )
 ```
 
+### Using App for Full ADK Features
+
+For access to App-level features like resumability, context caching, and plugins,
+use the `from_app()` constructor:
+
+```python
+from google.adk.apps import App
+from google.adk.agents import Agent
+from google.adk.plugins.logging_plugin import LoggingPlugin
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+
+# Create ADK App with plugins and configs
+app = App(
+    name="my_assistant",
+    root_agent=Agent(
+        name="assistant",
+        model="gemini-2.5-flash",
+        instruction="You are a helpful assistant.",
+    ),
+    plugins=[LoggingPlugin()],
+    # resumability_config=ResumabilityConfig(is_resumable=True),  # Optional
+)
+
+# Create ADKAgent from App
+agent = ADKAgent.from_app(
+    app,
+    user_id="demo_user",
+    plugin_close_timeout=10.0,  # Optional, requires ADK 1.19+
+)
+
+# Use with FastAPI
+from fastapi import FastAPI
+fastapi_app = FastAPI()
+add_adk_fastapi_endpoint(fastapi_app, agent, path="/chat")
+```
+
+The `from_app()` constructor enables:
+- **Plugin support**: Use ADK plugins like `LoggingPlugin` for debugging and tracing
+- **Resumability**: Configure pause/resume workflows for long-running operations
+- **Context caching**: Optimize LLM calls with context caching configuration
+- **Events compaction**: Configure how events are compacted in the application
+
+Note: The `plugin_close_timeout` parameter requires ADK 1.19.0 or later. On older
+versions, the parameter is silently ignored.
+
 ### Automatic Session Memory
 
 When you provide a `memory_service`, the middleware automatically preserves expired sessions in ADK's memory service before deletion. This enables powerful conversation history and context retrieval features.

--- a/integrations/adk-middleware/python/tests/test_from_app_integration.py
+++ b/integrations/adk-middleware/python/tests/test_from_app_integration.py
@@ -1,0 +1,168 @@
+"""Integration tests for ADKAgent.from_app() constructor.
+
+Requires GOOGLE_API_KEY environment variable to be set.
+"""
+import asyncio
+import os
+import pytest
+import uuid
+from ag_ui.core import EventType, RunAgentInput, UserMessage
+from ag_ui_adk import ADKAgent
+from ag_ui_adk.session_manager import SessionManager
+from google.adk.apps import App
+from google.adk.agents import LlmAgent
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("GOOGLE_API_KEY"),
+    reason="GOOGLE_API_KEY environment variable not set"
+)
+
+
+@pytest.fixture
+def sample_app():
+    """Create a simple App for testing."""
+    agent = LlmAgent(
+        name="test_agent",
+        model="gemini-2.0-flash",
+        instruction="You are a helpful assistant. Keep responses brief.",
+    )
+    return App(name="test_app", root_agent=agent)
+
+
+@pytest.fixture(autouse=True)
+def reset_session_manager():
+    """Reset session manager between tests."""
+    yield
+    SessionManager._instance = None
+
+
+@pytest.mark.asyncio
+async def test_from_app_basic_conversation(sample_app):
+    """Test that from_app() creates a working agent."""
+    adk_agent = ADKAgent.from_app(sample_app, user_id="test_user")
+
+    input_data = RunAgentInput(
+        thread_id=f"test_thread_{uuid.uuid4().hex[:8]}",
+        run_id=f"test_run_{uuid.uuid4().hex[:8]}",
+        messages=[UserMessage(id="msg1", content="Say hello in one word")],
+        state={},
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+    events = []
+    async for event in adk_agent.run(input_data):
+        events.append(event)
+
+    # Verify we got expected event types
+    event_types = [e.type for e in events]
+    assert EventType.RUN_STARTED in event_types
+    assert EventType.RUN_FINISHED in event_types
+
+
+@pytest.mark.asyncio
+async def test_from_app_preserves_app_name(sample_app):
+    """Test that app.name is used correctly."""
+    adk_agent = ADKAgent.from_app(sample_app, user_id="test_user")
+    assert adk_agent._static_app_name == "test_app"
+
+
+@pytest.mark.asyncio
+async def test_from_app_stores_app_reference(sample_app):
+    """Test that the App is stored for per-request use."""
+    adk_agent = ADKAgent.from_app(sample_app, user_id="test_user")
+    assert adk_agent._app is sample_app
+
+
+@pytest.mark.asyncio
+async def test_from_app_with_custom_timeout():
+    """Test that plugin_close_timeout is stored correctly."""
+    agent = LlmAgent(
+        name="test_agent",
+        model="gemini-2.0-flash",
+        instruction="You are helpful.",
+    )
+    app = App(name="test_app", root_agent=agent)
+
+    adk_agent = ADKAgent.from_app(
+        app,
+        user_id="test_user",
+        plugin_close_timeout=15.0,
+    )
+
+    assert adk_agent._plugin_close_timeout == 15.0
+
+
+@pytest.mark.asyncio
+async def test_from_app_type_validation():
+    """Test that from_app() validates the app parameter type."""
+    with pytest.raises(TypeError, match="Expected App instance"):
+        ADKAgent.from_app("not an app", user_id="test_user")
+
+
+@pytest.mark.asyncio
+async def test_from_app_extracts_root_agent(sample_app):
+    """Test that root_agent is correctly extracted from App."""
+    adk_agent = ADKAgent.from_app(sample_app, user_id="test_user")
+    assert adk_agent._adk_agent is sample_app.root_agent
+
+
+@pytest.mark.asyncio
+async def test_from_app_multi_turn_conversation(sample_app):
+    """Test multi-turn conversation with from_app()."""
+    adk_agent = ADKAgent.from_app(sample_app, user_id="test_user")
+    thread_id = f"test_thread_{uuid.uuid4().hex[:8]}"
+
+    # First turn
+    input1 = RunAgentInput(
+        thread_id=thread_id,
+        run_id=f"run1_{uuid.uuid4().hex[:8]}",
+        messages=[UserMessage(id="msg1", content="My name is Alice")],
+        state={},
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+    events1 = []
+    async for event in adk_agent.run(input1):
+        events1.append(event)
+
+    assert any(e.type == EventType.RUN_FINISHED for e in events1)
+
+    # Second turn - should maintain context
+    input2 = RunAgentInput(
+        thread_id=thread_id,
+        run_id=f"run2_{uuid.uuid4().hex[:8]}",
+        messages=[
+            UserMessage(id="msg1", content="My name is Alice"),
+            UserMessage(id="msg2", content="What is my name?"),
+        ],
+        state={},
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+    events2 = []
+    async for event in adk_agent.run(input2):
+        events2.append(event)
+
+    assert any(e.type == EventType.RUN_FINISHED for e in events2)
+
+
+@pytest.mark.asyncio
+async def test_runner_supports_plugin_close_timeout():
+    """Test that runtime detection of plugin_close_timeout works."""
+    agent = LlmAgent(
+        name="test_agent",
+        model="gemini-2.0-flash",
+        instruction="You are helpful.",
+    )
+    app = App(name="test_app", root_agent=agent)
+    adk_agent = ADKAgent.from_app(app, user_id="test_user")
+
+    # This should return True or False based on ADK version
+    result = adk_agent._runner_supports_plugin_close_timeout()
+    assert isinstance(result, bool)


### PR DESCRIPTION
…(#844)

Addresses https://github.com/ag-ui-protocol/ag-ui/issues/844 

Add ADKAgent.from_app() classmethod that accepts an ADK App instance, enabling access to App-level features like plugins, resumability, context caching, and events compaction.

- Create per-request App copies with modified agents using model_copy()
- Add plugin_close_timeout parameter (requires ADK 1.19+)
- Runtime detection of ADK version for forward compatibility
- Add integration tests and USAGE.md documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
