### PR TITLE
Fix changing rendered code/readme when changing pages

### DIFF
--- a/apps/dojo/src/app/[integrationId]/feature/layout-client.tsx
+++ b/apps/dojo/src/app/[integrationId]/feature/layout-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useMemo } from "react";
+import { usePathname } from "next/navigation";
 import filesJSON from '../../../files.json'
 import Readme from "@/components/readme/readme";
 import CodeViewer from "@/components/code-viewer/code-viewer";
@@ -18,14 +19,18 @@ type FileItem = {
 type FilesJsonType = Record<string, FileItem[]>;
 
 interface Props {
-  integrationId: string;
-  featureId: Feature;
   children: React.ReactNode;
 }
 
-export default function FeatureLayoutClient({ children, integrationId, featureId }: Props) {
+export default function FeatureLayoutClient({ children }: Props) {
   const { sidebarHidden } = useURLParams();
   const { view } = useURLParams();
+  const pathname = usePathname();
+
+  // Extract integrationId and featureId from pathname: /[integrationId]/feature/[featureId]
+  const pathParts = pathname.split("/").filter(Boolean);
+  const integrationId = pathParts[0] || "";
+  const featureId = pathParts[2] as Feature;
 
   const files = (filesJSON as FilesJsonType)[`${integrationId}::${featureId}`] || [];
 
@@ -38,18 +43,18 @@ export default function FeatureLayoutClient({ children, integrationId, featureId
     switch (view) {
       case "code":
         return (
-          <CodeViewer codeFiles={codeFiles} />
+          <CodeViewer key={`${integrationId}::${featureId}`} codeFiles={codeFiles} />
         )
       case "readme":
         return (
-          <Readme content={readme?.content ?? ''} />
+          <Readme key={`${integrationId}::${featureId}`} content={readme?.content ?? ''} />
         )
       default:
         return (
           <div className="h-full">{children}</div>
         )
     }
-  }, [children, codeFiles, readme, view])
+  }, [children, codeFiles, readme, view, integrationId, featureId])
 
   return (
     <div className={cn(
@@ -65,4 +70,3 @@ export default function FeatureLayoutClient({ children, integrationId, featureId
     </div>
   );
 }
-

--- a/apps/dojo/src/app/[integrationId]/feature/layout.tsx
+++ b/apps/dojo/src/app/[integrationId]/feature/layout.tsx
@@ -1,24 +1,17 @@
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
-import type { Feature } from "@/types/integration";
 import FeatureLayoutClient from "./layout-client";
 
 // Force dynamic rendering to ensure proper 404 handling
 export const dynamic = "force-dynamic";
 
 interface Props {
-  params: Promise<{
-    integrationId: string;
-  }>;
   children: React.ReactNode;
 }
 
-export default async function FeatureLayout({ children, params }: Props) {
-  const { integrationId } = await params;
-
+export default async function FeatureLayout({ children }: Props) {
   // Get headers set by proxy
   const headersList = await headers();
-  const pathname = headersList.get("x-pathname") || "";
   const notFoundType = headersList.get("x-not-found");
 
   // If proxy flagged this as not found, trigger 404
@@ -26,12 +19,8 @@ export default async function FeatureLayout({ children, params }: Props) {
     notFound();
   }
 
-  // Extract featureId from pathname: /[integrationId]/feature/[featureId]
-  const pathParts = pathname.split("/");
-  const featureId = pathParts[pathParts.length - 1] as Feature;
-
   return (
-    <FeatureLayoutClient integrationId={integrationId} featureId={featureId}>
+    <FeatureLayoutClient>
       {children}
     </FeatureLayoutClient>
   );


### PR DESCRIPTION
Client side navigation wasn't triggering updates to the rendered code/readme, so I moved the handling of that down a layer into a client side handled spot using the location hook. 