### PR TITLE
chore(kotlin-sdk): bump version to 0.2.5

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to ag-ui-4k will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.4] - 2025-12-29
+## [0.2.5] - 2025-12-29
 
 ### Added
 - Agent subscriber system for opt-in lifecycle and event interception.

--- a/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.3"
+agui-core = "0.2.5"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.3"
+agui-core = "0.2.5"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.3"
+agui-core = "0.2.5"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp/CHANGELOG.md
+++ b/sdks/community/kotlin/examples/chatapp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AG-UI-4K Chat App example will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.4] - 2025-12-29
+## [0.2.5] - 2025-12-29
 
 ### Added
 - **A2UI (Agent-to-UI) support** - Render agent-driven dynamic UI surfaces within the chat

--- a/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.3"
+agui-core = "0.2.5"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.3"
+agui-core = "0.2.5"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 //   - publish.sh script (reads dynamically)
 //   - GitHub Actions workflow (reads dynamically)
 // Only update these values here - they propagate automatically
-version = "0.2.4"
+version = "0.2.5"
 group = "com.ag-ui.community"
 
 allprojects {


### PR DESCRIPTION
## Summary

Bump library version to 0.2.5 and update all example dependencies.

## Changes

- Update library version to 0.2.5 in `build.gradle.kts`
- Update CHANGELOG versions from 0.2.4 to 0.2.5
- Update all example dependencies from 0.2.3 to 0.2.5:
  - chatapp
  - chatapp-java
  - chatapp-swiftui
  - chatapp-wearos
  - tools

## Note

Examples will not build until 0.2.5 is published to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)