### PR TITLE
fix: excessive cloning in `runSubscribersWithMutation`

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -1306,7 +1306,7 @@ describe("AgentSubscriber", () => {
     it("should not report changes when subscriber returns the same messages reference", async () => {
       const passThroughSubscriber: AgentSubscriber = {
         onEvent: ({ messages }) => ({
-          messages,
+          messages: messages as Message[],
         }),
       };
 
@@ -1333,7 +1333,7 @@ describe("AgentSubscriber", () => {
       const inPlaceMutator: AgentSubscriber = {
         onEvent: ({ messages }) => {
           // In-place mutation without returning — evades change detection
-          messages.push({
+          (messages as Message[]).push({
             id: "injected",
             role: "assistant",
             content: "injected",
@@ -1355,7 +1355,7 @@ describe("AgentSubscriber", () => {
       const inPlaceMutator: AgentSubscriber = {
         onEvent: ({ messages }) => {
           try {
-            messages.push({ id: "bad", role: "assistant", content: "bad" });
+            (messages as Message[]).push({ id: "bad", role: "assistant", content: "bad" });
           } catch (e) {
             caughtError = e;
             throw e;

--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -41,8 +41,8 @@ export interface AgentStateMutation {
 }
 
 export interface AgentSubscriberParams {
-  messages: Message[];
-  state: State;
+  messages: ReadonlyArray<Readonly<Message>>;
+  state: Readonly<State>;
   agent: AbstractAgent;
   input: RunAgentInput;
 }
@@ -223,8 +223,8 @@ export async function runSubscribersWithMutation(
   initialState: State,
   executor: (
     subscriber: AgentSubscriber,
-    messages: Message[],
-    state: State,
+    messages: ReadonlyArray<Readonly<Message>>,
+    state: Readonly<State>,
   ) => MaybePromise<AgentStateMutation | void>,
 ): Promise<AgentStateMutation> {
   const isDev =


### PR DESCRIPTION
This PR fixes #883

The `runSubscribersWithMutation` function has a critical performance bottleneck causing long execution time with the potential to hang the browser completely.

## Impact

- The example dojo app has 26 active subscribers during streaming
- Message arrays grow from 0 to 42 messages during a 742KB test run with ~200 events
- Current execution time: 810ms

| Traffic                                                                                                                              | Events                                                                                                                               | Trace                                                                                                                                |
| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
| <img width="3248" height="2112" alt="Image" src="https://github.com/user-attachments/assets/dc968658-5396-4389-a20b-43cbba21ff20" /> | <img width="3248" height="2112" alt="Image" src="https://github.com/user-attachments/assets/5966c80f-a32f-446e-b382-e35e572b3922" /> | <img width="3248" height="2112" alt="Image" src="https://github.com/user-attachments/assets/66ac3cdd-c344-4acd-8608-b7a3053c1f33" /> |

## Root Cause

This is in the hot path, called 2× per streaming event (once for `onEvent`, once for specific event handler), but it:

- Clones per subscriber even if they do not mutate
- Does expensive change detection via `JSON.stringify()`

## The Fix

- Move cloning from inputs to outputs
- Use reference equality to identify changes

## Expected Results

<img width="3248" height="2112" alt="Image" src="https://github.com/user-attachments/assets/209210d8-0f67-4953-9d17-99c4d9c32714" />

- New execution time: ~53ms (15x faster)
- Eliminate serialization bottleneck visible in flame graphs
