### PR TITLE
fix(ag-ui-4k): lower minimum Android SDK to 24 and Kotlin to 2.1.20

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to ag-ui-4k will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-01-14
+
+### Changed
+- Lower minimum Android SDK from 26 to 24
+- Lower Kotlin version from 2.2.20 to 2.1.20
+- Update Android Gradle Plugin from 8.10.1 to 8.12.0
+- Fix artifact group ID references from `com.agui:` to `com.ag-ui.community:`
+
 ## [0.2.5] - 2025-12-29
 
 ### Added

--- a/sdks/community/kotlin/examples/chatapp-java/app/build.gradle
+++ b/sdks/community/kotlin/examples/chatapp-java/app/build.gradle
@@ -38,6 +38,8 @@ android {
     }
     
     compileOptions {
+        // Enable core library desugaring for java.time APIs on SDK < 26
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -52,6 +54,9 @@ android {
 }
 
 dependencies {
+    // Core library desugaring for java.time APIs on SDK < 26
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+
     implementation project(':chatapp-shared')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'

--- a/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.5"
+agui-core = "0.2.6"
+a2ui4k = "0.8.0"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
@@ -27,10 +28,10 @@ compose-material3 = "1.4.0"
 [libraries]
 # Ktor
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-agui-client = { module = "com.agui:kotlin-client", version.ref = "agui-core" }
-agui-core = { module = "com.agui:kotlin-core", version.ref = "agui-core" }
-agui-tools = { module = "com.agui:kotlin-tools", version.ref = "agui-core" }
-agui-a2ui = { module = "com.ag-ui.community:kotlin-a2ui", version.ref = "agui-core" }
+agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
+agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
+agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
+a2ui4k = { module = "com.contextable:a2ui-4k", version.ref = "a2ui4k" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 core = { module = "androidx.test:core", version.ref = "core" }

--- a/sdks/community/kotlin/examples/chatapp-java/settings.gradle
+++ b/sdks/community/kotlin/examples/chatapp-java/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 
     plugins {
-        def kotlinVersion = "2.2.20"
+        def kotlinVersion = "2.1.20"
         def agpVersion = "8.12.0"
 
         id("org.jetbrains.kotlin.android") version kotlinVersion
@@ -26,9 +26,9 @@ project(":chatapp-shared").projectDir = file("../chatapp-shared")
 // Include local library for development (using local modules with new Activity types)
 includeBuild("../../library") {
     dependencySubstitution {
-        substitute(module("com.agui:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.agui:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.agui:kotlin-tools")).using(project(":kotlin-tools"))
-        substitute(module("com.ag-ui.community:kotlin-a2ui")).using(project(":kotlin-a2ui"))
+        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
+        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
+        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
+        // kotlin-a2ui is fetched from Maven (com.contextable:kotlin-a2ui)
     }
 }

--- a/sdks/community/kotlin/examples/chatapp-shared/build.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-shared/build.gradle.kts
@@ -125,8 +125,15 @@ pluginManager.withPlugin("com.android.library") {
         }
 
         compileOptions {
+            // Enable core library desugaring for java.time APIs on SDK < 26
+            isCoreLibraryDesugaringEnabled = true
             sourceCompatibility = JavaVersion.VERSION_21
             targetCompatibility = JavaVersion.VERSION_21
         }
     }
+}
+
+dependencies {
+    // Core library desugaring for java.time APIs on SDK < 26
+    add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.5"
+agui-core = "0.2.6"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
@@ -27,9 +27,9 @@ compose-material3 = "1.4.0"
 [libraries]
 # Ktor
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-agui-client = { module = "com.agui:kotlin-client", version.ref = "agui-core" }
-agui-core = { module = "com.agui:kotlin-core", version.ref = "agui-core" }
-agui-tools = { module = "com.agui:kotlin-tools", version.ref = "agui-core" }
+agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
+agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
+agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
 agui-a2ui = { module = "com.ag-ui.community:kotlin-a2ui", version.ref = "agui-core" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }

--- a/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
@@ -9,9 +9,9 @@ project(":shared").projectDir = File(rootDir, "shared")
 // Include local library for development (using local modules with new Activity types)
 includeBuild("../../library") {
     dependencySubstitution {
-        substitute(module("com.agui:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.agui:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.agui:kotlin-tools")).using(project(":kotlin-tools"))
+        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
+        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
+        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
         substitute(module("com.ag-ui.community:kotlin-a2ui")).using(project(":kotlin-a2ui"))
     }
 }
@@ -26,7 +26,7 @@ pluginManagement {
     }
 
     plugins {
-        val kotlinVersion = "2.2.20"
+        val kotlinVersion = "2.1.20"
         val composeVersion = "1.9.0-rc02"
         val agpVersion = "8.12.0"
 

--- a/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.5"
+agui-core = "0.2.6"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
 kotlinx-coroutines = "1.10.2"
@@ -29,9 +29,9 @@ wear-compose = "1.5.0"
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-agui-client = { module = "com.agui:kotlin-client", version.ref = "agui-core" }
-agui-core = { module = "com.agui:kotlin-core", version.ref = "agui-core" }
-agui-tools = { module = "com.agui:kotlin-tools", version.ref = "agui-core" }
+agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
+agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
+agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
 agui-a2ui = { module = "com.ag-ui.community:kotlin-a2ui", version.ref = "agui-core" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }

--- a/sdks/community/kotlin/examples/chatapp-wearos/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-wearos/settings.gradle.kts
@@ -7,9 +7,9 @@ project(":chatapp-shared").projectDir = file("../chatapp-shared")
 // Include local library for development (using local modules with new Activity types)
 includeBuild("../../library") {
     dependencySubstitution {
-        substitute(module("com.agui:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.agui:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.agui:kotlin-tools")).using(project(":kotlin-tools"))
+        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
+        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
+        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
         substitute(module("com.ag-ui.community:kotlin-a2ui")).using(project(":kotlin-a2ui"))
     }
 }

--- a/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.5"
+agui-core = "0.2.6"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
@@ -26,9 +26,9 @@ compose-material3 = "1.4.0"
 [libraries]
 # Ktor
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-agui-client = { module = "com.agui:kotlin-client", version.ref = "agui-core" }
-agui-core = { module = "com.agui:kotlin-core", version.ref = "agui-core" }
-agui-tools = { module = "com.agui:kotlin-tools", version.ref = "agui-core" }
+agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
+agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
+agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
 a2ui4k = { module = "com.contextable:a2ui-4k", version = "0.8.0" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }

--- a/sdks/community/kotlin/examples/chatapp/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp/settings.gradle.kts
@@ -10,9 +10,9 @@ project(":chatapp-shared").projectDir = file("../chatapp-shared")
 // Include local library for development (using local modules with new Activity types)
 includeBuild("../../library") {
     dependencySubstitution {
-        substitute(module("com.agui:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.agui:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.agui:kotlin-tools")).using(project(":kotlin-tools"))
+        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
+        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
+        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
     }
 }
 
@@ -25,7 +25,7 @@ pluginManagement {
     }
 
     plugins {
-        val kotlinVersion = "2.2.20"
+        val kotlinVersion = "2.1.20"
         val composeVersion = "1.9.3"
         val agpVersion = "8.10.1"
 

--- a/sdks/community/kotlin/examples/tools/build.gradle.kts
+++ b/sdks/community/kotlin/examples/tools/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.ag-ui.community"
-version = "0.2.3"
+version = "0.2.6"
 
 repositories {
     google()
@@ -23,8 +23,8 @@ kotlin {
                     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                     freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                     freeCompilerArgs.add("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
-                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
                 }
             }
         }
@@ -64,22 +64,22 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Core and tools dependencies
-                api("com.agui:kotlin-core:0.2.3")
-                api("com.agui:kotlin-tools:0.2.3")
-                
+                api(libs.agui.core)
+                api(libs.agui.tools)
+
                 // Kotlinx libraries
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.kotlinx.datetime)
             }
         }
-        
+
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
                 // Add client module for integration testing (includes agent functionality)
-                implementation("com.agui:kotlin-client:0.2.3")
+                implementation(libs.agui.client)
             }
         }
         

--- a/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.2.5"
+agui-core = "0.2.6"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
@@ -24,9 +24,9 @@ voyager-navigator = "1.0.0"
 [libraries]
 # Ktor
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
-agui-client = { module = "com.agui:kotlin-client", version.ref = "agui-core" }
-agui-core = { module = "com.agui:kotlin-core", version.ref = "agui-core" }
-agui-tools = { module = "com.agui:kotlin-tools", version.ref = "agui-core" }
+agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
+agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
+agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 core = { module = "androidx.test:core", version.ref = "core" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }

--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -10,11 +10,11 @@ import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jreleaser.gradle.plugin.tasks.JReleaserDeployTask
 
 plugins {
-    kotlin("multiplatform") version "2.2.20" apply false
-    kotlin("plugin.serialization") version "2.2.20" apply false
-    kotlin("plugin.compose") version "2.2.20" apply false
+    kotlin("multiplatform") version "2.1.20" apply false
+    kotlin("plugin.serialization") version "2.1.20" apply false
+    kotlin("plugin.compose") version "2.1.20" apply false
     id("org.jetbrains.compose") version "1.7.3" apply false
-    id("com.android.library") version "8.10.1" apply false
+    id("com.android.library") version "8.12.0" apply false
     id("org.jetbrains.dokka") version "2.0.0"
     id("org.jetbrains.kotlinx.kover") version "0.8.3"
     id("org.jreleaser") version "1.20.0"
@@ -27,7 +27,7 @@ plugins {
 //   - publish.sh script (reads dynamically)
 //   - GitHub Actions workflow (reads dynamically)
 // Only update these values here - they propagate automatically
-version = "0.2.5"
+version = "0.2.6"
 group = "com.ag-ui.community"
 
 allprojects {

--- a/sdks/community/kotlin/library/client/build.gradle.kts
+++ b/sdks/community/kotlin/library/client/build.gradle.kts
@@ -23,8 +23,8 @@ kotlin {
                     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                     freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                     freeCompilerArgs.add("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
-                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
                 }
             }
         }
@@ -134,7 +134,7 @@ android {
     compileSdk = 36
     
     defaultConfig {
-        minSdk = 26
+        minSdk = 24
         consumerProguardFiles("consumer-rules.pro")
     }
     

--- a/sdks/community/kotlin/library/core/build.gradle.kts
+++ b/sdks/community/kotlin/library/core/build.gradle.kts
@@ -23,8 +23,8 @@ kotlin {
                     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                     freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                     freeCompilerArgs.add("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
-                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
                 }
             }
         }
@@ -112,7 +112,7 @@ android {
     compileSdk = 36
     
     defaultConfig {
-        minSdk = 26
+        minSdk = 24
     }
     
     testOptions {

--- a/sdks/community/kotlin/library/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/library/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 core-ktx = "1.16.0"
-kotlin = "2.2.20"
+kotlin = "2.1.20"
 kotlin-json-patch = "1.0.0"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"

--- a/sdks/community/kotlin/library/tools/build.gradle.kts
+++ b/sdks/community/kotlin/library/tools/build.gradle.kts
@@ -23,8 +23,8 @@ kotlin {
                     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                     freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                     freeCompilerArgs.add("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
-                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
                 }
             }
         }
@@ -105,7 +105,7 @@ android {
     compileSdk = 36
     
     defaultConfig {
-        minSdk = 26
+        minSdk = 24
     }
     
     testOptions {


### PR DESCRIPTION
Library changes:
- Lower minSdk from 26 to 24 in kotlin-core, kotlin-client, and kotlin-tools
- Lower Kotlin version from 2.2.20 to 2.1.20
- Update AGP from 8.10.1 to 8.12.0 for consistency
- Bump version to 0.2.6

Example changes:
- Update all examples to Kotlin 2.1.20
- Fix group ID from com.agui: to com.ag-ui.community: in all version catalogs
- Fix dependency substitution group IDs in all settings files
- Update chatapp-java with core library desugaring support
- Bump all example versions to 0.2.6

Fixes [#935](https://github.com/ag-ui-protocol/ag-ui/issues/935)


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
