### PR TITLE
Add changelog entry for PR #932 (APIRouter support)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enables extraction of request attributes beyond just headers (e.g., cookies, query params, authentication info)
   - `extract_headers` parameter has been marked for deprecation in favor of `extract_state`
   - Thanks to @jplikesbikes for the contribution
+- **NEW**: `add_adk_fastapi_endpoint()` now accepts both `FastAPI` and `APIRouter` objects (#932)
+  - Enables better organization of large FastAPI codebases by allowing routes to be added to APIRouters
+  - The `app` parameter now accepts `FastAPI | APIRouter` types
+  - Note: Using APIRouter may result in different validation error response codes (500 instead of 422 in some edge cases)
+  - Thanks to @jplikesbikes for the contribution
 
 ### Fixed
 - **FIXED**: Text message events not emitted when non-streaming response includes client function call (issue #906)


### PR DESCRIPTION
Documents the new feature allowing add_adk_fastapi_endpoint() to accept both FastAPI and APIRouter objects for better codebase organization.


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
