### PR TITLE
Fix/adk event invocation (#960)

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1388,6 +1388,18 @@ class ADKAgent:
             # Recipe Demo Example: if there is a state "salt" in the ingredients state and in frontend user remove this salt state using UI from the ingredients list then our backend should also update these state changes as well to sync both the states
             await self._session_manager.update_session_state(backend_session_id, app_name, user_id, input.state)
 
+            # Refresh session to get updated last_update_time after state update
+            # This prevents "stale session" errors when using DatabaseSessionService
+            # See: https://github.com/ag-ui-protocol/ag-ui/issues/957
+            refreshed_session = await self._session_manager.get_session(backend_session_id, app_name, user_id)
+            if refreshed_session:
+                session = refreshed_session
+            else:
+                logger.warning(
+                    f"Failed to refresh session {backend_session_id} after state update. "
+                    "Continuing with potentially stale session."
+                )
+
             # Convert messages
             unseen_messages = message_batch if message_batch is not None else await self._get_unseen_messages(input)
 
@@ -1461,7 +1473,8 @@ class ADKAgent:
                 function_response_event = Event(
                     timestamp=time.time(),
                     author='user',
-                    content=function_response_content
+                    content=function_response_content,
+                    invocation_id=input.run_id,
                 )
 
                 await self._session_manager._session_service.append_event(session, function_response_event)
@@ -1511,7 +1524,21 @@ class ADKAgent:
                     )
                     function_response_parts.append(updated_function_response_part)
 
-                new_message = types.Content(parts=function_response_parts, role='user')
+                # Persist FunctionResponse event so DatabaseSessionService has invocation_id
+                from google.adk.sessions.session import Event
+                import time
+
+                function_response_content = types.Content(parts=function_response_parts, role='user')
+                function_response_event = Event(
+                    timestamp=time.time(),
+                    author='user',
+                    content=function_response_content,
+                    invocation_id=input.run_id,
+                )
+
+                await self._session_manager._session_service.append_event(session, function_response_event)
+
+                new_message = function_response_content
             else:
                 # No tool results, just use the user message
                 # If user_message is None (e.g., unseen_messages was empty because all were


### PR DESCRIPTION
* fix(adk-middleware): DatabaseSessionService compatibility

Fix two issues when using ADKAgent with DatabaseSessionService:

1. Add invocation_id to Event creation
   - DatabaseSessionService requires invocation_id (non-nullable column)
   - Use input.run_id (AG-UI run identifier) for traceability

2. Refresh session after update_session_state
   - update_session_state modifies last_update_time in DB
   - Without refresh, subsequent append_event fails with "stale session"
   - Now refreshes session to get updated timestamp

Fixes #957



* test(adk-middleware): add tests for DatabaseSessionService compatibility

- Add test for invocation_id on FunctionResponse events (tool results + user message)
- Add test for invocation_id on tool-results-only path (HITL workflows)
- Add test for session refresh after state update with adjacency assertion
- Fix: set invocation_id in tool-results-only branch (was missing)

Addresses reviewer feedback on PR #958.



* fix(adk-middleware): add warning log when session refresh fails

Address reviewer feedback: log a warning if the session refresh after state update returns None, so operators can diagnose stale session issues.

---------


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
