### PR TITLE
fix(adk-middleware): skip function calls from partial events

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -276,7 +276,11 @@ class EventTranslator:
                     yield event
             
             # call _translate_function_calls function to yield Tool Events
-            if hasattr(adk_event, 'get_function_calls'):               
+            # Skip function calls from partial events - these are streaming previews in
+            # PROGRESSIVE_SSE_STREAMING mode (enabled by default in google-adk >= 1.22.0).
+            # Only process confirmed function calls (partial=False or partial not set).
+            # See: https://github.com/ag-ui-protocol/ag-ui/issues/968
+            if hasattr(adk_event, 'get_function_calls') and not is_partial:
                 function_calls = adk_event.get_function_calls()
                 if function_calls:
                     # Filter out long-running tool calls; those are handled by translate_lro_function_calls


### PR DESCRIPTION
## Summary

Fixes #968 - ADK middleware was emitting duplicate `TOOL_CALL_START` events with google-adk >= 1.22.0.

## Root Cause

google-adk 1.22.0 enables `PROGRESSIVE_SSE_STREAMING` by default, which sends function call "previews" in `partial=True` events before the confirmed call (`partial=False`). The middleware was translating both events, causing duplicate tool calls.

## Changes

- **`event_translator.py`**: Skip function calls from events where `partial=True`
- Uses `getattr(adk_event, 'partial', False)` for backwards compatibility with older google-adk versions

## New Tests

Added 3 tests in `test_lro_filtering.py`:
- `test_translate_skips_function_calls_from_partial_events` - Verifies partial events are skipped
- `test_translate_emits_function_calls_from_confirmed_events` - Verifies confirmed events are processed
- `test_translate_handles_missing_partial_attribute` - Verifies backwards compatibility

## Test Results

| google-adk Version | Before Fix | After Fix |
|-------------------|------------|-----------|
| 1.14.1 | ✅ passed | ✅ passed |
| 1.21.0 | ✅ passed | ✅ passed |
| 1.22.0 | ❌ failed | ✅ passed |
| 1.22.1 | ❌ failed | ✅ passed |

## Test plan
- [x] All 517 tests pass with google-adk 1.14.1 (original lock file)
- [x] Skip summarization tests pass with google-adk 1.22.0 and 1.22.1
- [x] New unit tests verify partial event handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)