### PR TITLE
feat(go-sdk): use core/types Message in events

### DIFF
--- a/sdks/community/go/example/client/internal/message/message.go
+++ b/sdks/community/go/example/client/internal/message/message.go
@@ -156,14 +156,15 @@ func getMessageFromEvent(event events.Event) *Message {
 		}
 		var contents []string
 		for _, msg := range snapshot.Messages {
-			if msg.Content != nil && msg.Role != "user" {
-				contents = append(contents, *msg.Content)
-			}
-			if msg.ToolCalls != nil {
-				for _, toolCall := range msg.ToolCalls {
-					toolCallContent := serverStyle.Render("Tool Call: ") + toolCall.Function.Name + " - " + toolCall.Function.Arguments
-					contents = append(contents, toolCallContent)
+			if msg.Role != "user" {
+				content, ok := msg.ContentString()
+				if ok {
+					contents = append(contents, content)
 				}
+			}
+			for _, toolCall := range msg.ToolCalls {
+				toolCallContent := serverStyle.Render("Tool Call: ") + toolCall.Function.Name + " - " + toolCall.Function.Arguments
+				contents = append(contents, toolCallContent)
 			}
 		}
 


### PR DESCRIPTION
This PR aligns the Go SDK events package with the shared core/types Message model, tightens role-based message validation (including multimodal user content and activity/tool semantics), and updates the example client message rendering to rely on the new content helpers.