### PR TITLE
Fix issue with toolcalls before text messages causing message id duplication

### DIFF
--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -107,17 +107,25 @@ export const defaultApplyEvents = (
           if (mutation.stopPropagation !== true) {
             const { messageId, role = "assistant" } = event as TextMessageStartEvent;
 
-            // Create a new message using properties from the event
-            // Text messages can be developer, system, assistant, or user (not tool)
-            const newMessage: Message = {
-              id: messageId,
-              role: role,
-              content: "",
-            };
+            // Check if a message with this ID already exists (e.g., created by TOOL_CALL_START
+            // with the same parentMessageId)
+            const existingMessage = messages.find((m) => m.id === messageId);
 
-            // Add the new message to the messages array
-            messages.push(newMessage);
-            applyMutation({ messages });
+            if (!existingMessage) {
+              // Create a new message using properties from the event
+              // Text messages can be developer, system, assistant, or user (not tool)
+              const newMessage: Message = {
+                id: messageId,
+                role: role,
+                content: "",
+              };
+
+              // Add the new message to the messages array
+              messages.push(newMessage);
+              applyMutation({ messages });
+            }
+            // If message already exists, we don't need to create a new one
+            // The TEXT_MESSAGE_CONTENT events will update the existing message's content
           }
           return emitUpdates();
         }


### PR DESCRIPTION
NOTE: There is a test commit here that should be dropped before this is merged. 

This was found in the with-mastra repo, but when mastra calls its updateWorkingMemory tool (or whatever it's called) it outputs a toolcall message with `parentMessageId: "foo"`, THEN comes TEXT_MESSAGE_START with `id: "foo"`. The toolcall caused the text message to get created, then the text message start caused it to get created again. This update changes textmessagestart to not create the message if it already exists. 

Test code is in apps/with-mastra. You can try that with and without the fix commit, to see it break. 