### PR TITLE
fix(adk-middleware): reload session on cache miss to populate events

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
@@ -248,6 +248,13 @@ def add_adk_fastapi_endpoint(
                     session_id = session.id
                     agent._session_lookup_cache[thread_id] = (session_id, app_name, user_id)
 
+                    # Reload session to populate events (list_sessions returns metadata only)
+                    session = await agent._session_manager._session_service.get_session(
+                        session_id=session_id,
+                        app_name=app_name,
+                        user_id=user_id
+                    )
+
             thread_exists = session is not None
 
             # Get state


### PR DESCRIPTION
## Summary

Fixes #1019

- Reload session via `get_session()` after cache miss to populate events
- `_find_session_by_thread_id()` uses `list_sessions()` which returns metadata only

## Test plan

- [x] Added `test_agents_state_cache_miss_loads_events` to verify fix
- [x] All 53 existing tests pass