### PR TITLE
fix(adk): reload session on cache miss to populate events

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
@@ -248,6 +248,13 @@ def add_adk_fastapi_endpoint(
                     session_id = session.id
                     agent._session_lookup_cache[thread_id] = (session_id, app_name, user_id)
 
+                    # Reload session to populate events (list_sessions returns metadata only)
+                    session = await agent._session_manager._session_service.get_session(
+                        session_id=session_id,
+                        app_name=app_name,
+                        user_id=user_id
+                    )
+
             thread_exists = session is not None
 
             # Get state


### PR DESCRIPTION
_find_session_by_thread_id() uses list_sessions() which returns session metadata only, not events. This caused /agents/state to return empty messages on cache miss. Now calls get_session() after finding session to populate events needed for message history.


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
