### PR TITLE
Claude/investigate issue 1028 uo u9c

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -33,6 +33,75 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Authorize actor against CODEOWNERS
+        env:
+          ACTOR: ${{ github.actor }}
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          node << 'SCRIPT'
+          const fs = require('fs');
+          const actor = process.env.ACTOR;
+          const pkg = process.env.PACKAGE;
+
+          // Parse CODEOWNERS
+          const lines = fs.readFileSync('.github/CODEOWNERS', 'utf-8').split('\n');
+          const rules = [];
+          let rootOwners = [];
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed.startsWith('#')) continue;
+            const parts = trimmed.split(/\s+/);
+            const pattern = parts[0];
+            const owners = parts.slice(1).map(o => o.replace('@', ''));
+            if (pattern === '*') {
+              rootOwners = owners;
+            } else {
+              rules.push({ pattern, owners });
+            }
+          }
+
+          // Find the most specific matching rule for this package path
+          // Strip trailing /python to match CODEOWNERS entries like "integrations/adk-middleware"
+          const pathsToCheck = [pkg];
+          const pythonSuffix = '/python';
+          if (pkg.endsWith(pythonSuffix)) {
+            pathsToCheck.push(pkg.slice(0, -pythonSuffix.length));
+          }
+
+          let authorized = false;
+          let matchedRule = null;
+
+          for (const checkPath of pathsToCheck) {
+            for (const rule of rules) {
+              const pattern = rule.pattern.replace(/\/$/, '');
+              if (checkPath === pattern || checkPath.startsWith(pattern + '/')) {
+                matchedRule = rule;
+                authorized = rule.owners.includes(actor);
+                break;
+              }
+            }
+            if (matchedRule) break;
+          }
+
+          // Fall back to root owners if no specific rule matched
+          if (!matchedRule) {
+            matchedRule = { pattern: '*', owners: rootOwners };
+            authorized = rootOwners.includes(actor);
+          }
+
+          console.log(`Actor:          ${actor}`);
+          console.log(`Package:        ${pkg}`);
+          console.log(`Matched rule:   ${matchedRule.pattern} -> ${matchedRule.owners.join(', ')}`);
+          console.log(`Authorized:     ${authorized}`);
+
+          if (!authorized) {
+            console.error(`\nERROR: ${actor} is not a CODEOWNERS owner for ${pkg}`);
+            console.error(`Allowed users: ${matchedRule.owners.join(', ')}`);
+            process.exit(1);
+          }
+          SCRIPT
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
Addresses #1028 — the ag_ui_adk wheel on PyPI had broken file permissions because it was built out-of-band. This workflow provides a consistent, repeatable publish process with a permission verification step to prevent the issue from recurring.

Supports all six Python packages via a dropdown selector, with dry-run mode and trusted publishing support.

<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
