### PR TITLE
Validate #1060

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1733,6 +1733,8 @@ class ADKAgent:
             # Run ADK agent
             is_long_running_tool = False
             invocation_id_stored = False  # Track if we've stored the invocation_id this run
+            # Flag for LRO persistence fix: when True, we continue draining events until non-partial
+            lro_draining_for_persistence = False
             run_kwargs = {
                 "user_id": user_id,
                 "session_id": backend_session_id,  # Use backend session_id, not thread_id
@@ -1768,6 +1770,36 @@ class ADKAgent:
                             content_preview = f"[FunctionCall: {part.function_call.name}]"
                             break
                 logger.info(f"[ADK_EVENT] author={event_author}, partial={event_partial}, turn_complete={event_turn_complete}, content={content_preview[:80]}...")
+
+                # LRO persistence fix: if we're draining events after LRO detection,
+                # only translate text content and wait for non-partial event
+                if lro_draining_for_persistence:
+                    # Translate any text content so the frontend receives it
+                    has_remaining_content = (
+                        adk_event.content and
+                        hasattr(adk_event.content, 'parts') and
+                        adk_event.content.parts
+                    )
+                    if has_remaining_content:
+                        async for ag_ui_event in event_translator.translate_text_only(
+                            adk_event, input.thread_id, input.run_id
+                        ):
+                            await event_queue.put(ag_ui_event)
+                            logger.debug(
+                                f"Event queued (LRO drain): {type(ag_ui_event).__name__} "
+                                f"(thread {input.thread_id})"
+                            )
+                    
+                    # Check if we got a non-partial event (persistence complete)
+                    if not event_partial:
+                        logger.info(
+                            f"Received non-partial event during LRO drain, persistence complete "
+                            f"(thread={input.thread_id})"
+                        )
+                        return
+                    else:
+                        # Still partial, keep draining
+                        continue
 
                 # Store invocation_id for HITL resumption on first event with valid ID
                 # This enables SequentialAgent to restore its current_sub_agent position
@@ -1879,28 +1911,37 @@ class ADKAgent:
                             DeprecationWarning,
                             stacklevel=2,
                         )
-                        # With PROGRESSIVE_SSE_STREAMING (ADK >= 1.22.0), the
-                        # FunctionCall may arrive as a partial event that ADK
-                        # hasn't persisted to the session.  We must persist it
-                        # so the next run can match the FunctionResponse.
-                        if getattr(adk_event, 'partial', False) and adk_event.content:
-                            from google.adk.sessions.session import Event as ADKSessionEvent
-                            import time as _time_mod
-                            fc_event = ADKSessionEvent(
-                                timestamp=_time_mod.time(),
-                                author=getattr(adk_event, 'author', 'assistant'),
-                                content=adk_event.content,
-                                invocation_id=getattr(adk_event, 'invocation_id', None) or input.run_id,
+                        # FIX for GitHub issue: LRO events not persisted with SSE streaming.
+                        #
+                        # With SSE streaming enabled (default), ADK yields events in two phases:
+                        # 1. partial=True events (streaming chunks) - NOT persisted by ADK
+                        # 2. partial=False event (final aggregated) - IS persisted by ADK
+                        #
+                        # ADK's persistence happens BEFORE yielding the non-partial event.
+                        # Previously, we returned immediately after detecting the LRO tool,
+                        # which abandoned the runner's async generator before the final
+                        # non-partial event was consumed. This meant ADK never persisted
+                        # the agent's response, causing lost session history.
+                        #
+                        # Fix: If the current event is partial, set a flag to drain the
+                        # remaining events until we receive a non-partial event. The flag
+                        # is checked at the START of each loop iteration.
+                        current_partial = getattr(adk_event, 'partial', False)
+                        if current_partial:
+                            logger.info(
+                                f"LRO detected with partial=True, will drain until persistence completes "
+                                f"(thread={input.thread_id})"
                             )
-                            try:
-                                await self._session_manager._session_service.append_event(session, fc_event)
-                                logger.info(
-                                    f"Persisted FunctionCall event to session for LRO early return "
-                                    f"(partial event, thread={input.thread_id})"
-                                )
-                            except Exception as e:
-                                logger.warning(f"Failed to persist FunctionCall event: {e}")
-                        return
+                            # Set flag to continue draining - checked at loop start
+                            lro_draining_for_persistence = True
+                            continue  # Continue the OUTER loop to get more events
+                        else:
+                            # Already non-partial, ADK has already persisted
+                            logger.info(
+                                f"LRO detected with partial=False, persistence already complete "
+                                f"(thread={input.thread_id})"
+                            )
+                            return
 
             # Force close any streaming messages
             async for ag_ui_event in event_translator.force_close_streaming_message():

--- a/integrations/adk-middleware/python/tests/test_lro_sse_persistence.py
+++ b/integrations/adk-middleware/python/tests/test_lro_sse_persistence.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python
+"""Tests for LRO (Long Running Operation) SSE streaming persistence fix.
+
+This module tests the fix for the bug where agent events were NOT persisted
+to the session database when using LongRunningFunctionTool with SSE streaming
+enabled (the default).
+
+Bug Summary:
+- With SSE streaming, ADK yields partial=True events (not persisted) then
+  partial=False events (persisted)
+- The middleware previously returned early when detecting LRO tools, abandoning
+  the runner's async generator before the final non-partial event was consumed
+- This caused ADK to never persist the agent's response, losing session history
+
+Fix:
+- Continue consuming events from the runner until a non-partial event is received
+- This allows ADK's natural persistence mechanism to complete
+
+Integration tests require one of the following authentication methods:
+- GOOGLE_API_KEY environment variable (for Google AI Studio)
+- GOOGLE_GENAI_USE_VERTEXAI=TRUE with gcloud auth (for Vertex AI)
+"""
+
+import asyncio
+import os
+import uuid
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from ag_ui.core import (
+    RunAgentInput,
+    UserMessage,
+    EventType,
+    Tool as AGUITool,
+)
+from ag_ui_adk import ADKAgent
+from ag_ui_adk.session_manager import SessionManager
+
+
+# =============================================================================
+# Unit Tests (Mocked - No API Key Required)
+# =============================================================================
+
+class TestLROSSEPersistenceUnit:
+    """Unit tests for the LRO SSE persistence fix using mocks."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        """Reset session manager between tests."""
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest.fixture
+    def adk_agent(self):
+        """Create an ADKAgent with a mocked ADK agent."""
+        from google.adk.agents import Agent
+        mock_agent = MagicMock(spec=Agent)
+        mock_agent.name = "test_agent"
+        mock_agent.model_copy = MagicMock(return_value=mock_agent)
+        return ADKAgent(
+            adk_agent=mock_agent,
+            app_name="test_app",
+            user_id="test_user"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lro_with_partial_true_drains_until_non_partial(self, adk_agent):
+        """Test that when LRO is detected with partial=True, we drain until partial=False.
+        
+        This is the core fix: instead of returning immediately when an LRO tool is
+        detected, we continue consuming events until ADK yields a non-partial event,
+        which signals that persistence has completed.
+        """
+        lro_tool_id = "lro-tool-123"
+        events_consumed = []
+        
+        def create_event(partial, has_lro=True):
+            """Create a mock ADK event."""
+            func_call = MagicMock()
+            func_call.id = lro_tool_id
+            func_call.name = "client_tool"
+            func_call.args = {"key": "value"}
+            
+            func_part = MagicMock()
+            func_part.text = None
+            func_part.function_call = func_call
+            
+            evt = MagicMock()
+            evt.author = "assistant"
+            evt.content = MagicMock()
+            evt.content.parts = [func_part]
+            evt.partial = partial
+            evt.turn_complete = not partial
+            evt.is_final_response = MagicMock(return_value=not partial)
+            evt.get_function_calls = MagicMock(return_value=[func_call] if has_lro else [])
+            evt.get_function_responses = MagicMock(return_value=[])
+            evt.long_running_tool_ids = [lro_tool_id] if has_lro else []
+            evt.invocation_id = "inv-123"
+            return evt
+
+        async def mock_run_async(**kwargs):
+            """Simulate SSE streaming: partial=True, then partial=False."""
+            # Event 1: partial=True (streaming chunk - NOT persisted by ADK)
+            evt1 = create_event(partial=True)
+            events_consumed.append(("event1", "partial=True"))
+            yield evt1
+            
+            # Event 2: partial=False (final - IS persisted by ADK)
+            evt2 = create_event(partial=False)
+            events_consumed.append(("event2", "partial=False"))
+            yield evt2
+
+        mock_runner = MagicMock()
+        mock_runner.run_async = mock_run_async
+
+        input_data = RunAgentInput(
+            thread_id=f"test_thread_{uuid.uuid4().hex[:8]}",
+            run_id=f"test_run_{uuid.uuid4().hex[:8]}",
+            messages=[UserMessage(id="u1", role="user", content="Test message")],
+            tools=[],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        with patch.object(adk_agent, "_create_runner", return_value=mock_runner):
+            events = []
+            # Suppress the deprecation warning for this test
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                async for e in adk_agent.run(input_data):
+                    events.append(e)
+
+        # CRITICAL ASSERTION: Both events should have been consumed
+        # Before the fix, only event1 would be consumed, then early return
+        # After the fix, we drain until event2 (partial=False) is consumed
+        assert len(events_consumed) == 2, (
+            f"Expected 2 events to be consumed (partial=True then partial=False), "
+            f"but only {len(events_consumed)} were consumed: {events_consumed}. "
+            f"This means the runner was abandoned early, breaking persistence!"
+        )
+        
+        # Verify we got the final non-partial event
+        assert events_consumed[-1] == ("event2", "partial=False"), (
+            f"Last event consumed should be partial=False (the persistence trigger), "
+            f"got: {events_consumed[-1]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lro_with_partial_false_returns_immediately(self, adk_agent):
+        """Test that when LRO is detected with partial=False, we return without draining.
+        
+        If the LRO event already has partial=False, ADK has already persisted it,
+        so we don't need to drain further.
+        """
+        lro_tool_id = "lro-tool-456"
+        events_consumed = []
+        
+        def create_event(partial):
+            func_call = MagicMock()
+            func_call.id = lro_tool_id
+            func_call.name = "client_tool"
+            func_call.args = {}
+            
+            func_part = MagicMock()
+            func_part.text = None
+            func_part.function_call = func_call
+            
+            evt = MagicMock()
+            evt.author = "assistant"
+            evt.content = MagicMock()
+            evt.content.parts = [func_part]
+            evt.partial = partial
+            evt.turn_complete = not partial
+            evt.is_final_response = MagicMock(return_value=not partial)
+            evt.get_function_calls = MagicMock(return_value=[func_call])
+            evt.get_function_responses = MagicMock(return_value=[])
+            evt.long_running_tool_ids = [lro_tool_id]
+            evt.invocation_id = "inv-456"
+            return evt
+
+        async def mock_run_async(**kwargs):
+            # Only one event with partial=False (already persisted)
+            evt = create_event(partial=False)
+            events_consumed.append("partial=False")
+            yield evt
+            
+            # This event should NOT be consumed (we return after the LRO)
+            evt2 = create_event(partial=False)
+            events_consumed.append("should_not_reach")
+            yield evt2
+
+        mock_runner = MagicMock()
+        mock_runner.run_async = mock_run_async
+
+        input_data = RunAgentInput(
+            thread_id=f"test_thread_{uuid.uuid4().hex[:8]}",
+            run_id=f"test_run_{uuid.uuid4().hex[:8]}",
+            messages=[UserMessage(id="u1", role="user", content="Test")],
+            tools=[],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        with patch.object(adk_agent, "_create_runner", return_value=mock_runner):
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                events = []
+                async for e in adk_agent.run(input_data):
+                    events.append(e)
+
+        # Should only consume the first event (partial=False means already persisted)
+        assert len(events_consumed) == 1, (
+            f"Expected only 1 event consumed (partial=False already persisted), "
+            f"got {len(events_consumed)}: {events_consumed}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_text_content_emitted_during_drain(self, adk_agent):
+        """Test that text content from remaining events is emitted during drain.
+        
+        When draining until non-partial, any text content in the remaining events
+        should still be translated and emitted to the frontend.
+        """
+        lro_tool_id = "lro-tool-789"
+        
+        def create_event(partial, text=None, has_lro=True):
+            func_call = MagicMock()
+            func_call.id = lro_tool_id
+            func_call.name = "client_tool"
+            func_call.args = {}
+            
+            parts = []
+            if text:
+                text_part = MagicMock()
+                text_part.text = text
+                text_part.function_call = None
+                parts.append(text_part)
+            
+            if has_lro:
+                func_part = MagicMock()
+                func_part.text = None
+                func_part.function_call = func_call
+                parts.append(func_part)
+            
+            evt = MagicMock()
+            evt.author = "assistant"
+            evt.content = MagicMock()
+            evt.content.parts = parts
+            evt.partial = partial
+            evt.turn_complete = not partial
+            evt.is_final_response = MagicMock(return_value=not partial)
+            evt.get_function_calls = MagicMock(return_value=[func_call] if has_lro else [])
+            evt.get_function_responses = MagicMock(return_value=[])
+            evt.long_running_tool_ids = [lro_tool_id] if has_lro else []
+            evt.invocation_id = "inv-789"
+            return evt
+
+        async def mock_run_async(**kwargs):
+            # Event 1: partial=True with LRO tool
+            yield create_event(partial=True, text="Starting...")
+            # Event 2: partial=False with final text
+            yield create_event(partial=False, text="Done!", has_lro=False)
+
+        mock_runner = MagicMock()
+        mock_runner.run_async = mock_run_async
+
+        input_data = RunAgentInput(
+            thread_id=f"test_thread_{uuid.uuid4().hex[:8]}",
+            run_id=f"test_run_{uuid.uuid4().hex[:8]}",
+            messages=[UserMessage(id="u1", role="user", content="Test")],
+            tools=[],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        with patch.object(adk_agent, "_create_runner", return_value=mock_runner):
+            import warnings
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                events = []
+                async for e in adk_agent.run(input_data):
+                    events.append(e)
+
+        # Should have run lifecycle events and tool call events
+        event_types = [str(e.type).split('.')[-1] for e in events]
+        assert "RUN_STARTED" in event_types
+        assert "RUN_FINISHED" in event_types
+        assert "TOOL_CALL_START" in event_types or "TOOL_CALL_END" in event_types
+
+
+# =============================================================================
+# Integration Tests (Require Google AI or Vertex AI Authentication)
+# =============================================================================
+
+def _has_google_auth():
+    """Check if Google AI or Vertex AI authentication is available."""
+    # Check for Google AI Studio API key
+    if os.environ.get("GOOGLE_API_KEY"):
+        return True
+    # Check for Vertex AI (gcloud auth)
+    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").upper() == "TRUE":
+        # Vertex AI also needs project and location
+        if os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("VERTEXAI_PROJECT"):
+            return True
+    return False
+
+
+class TestLROSSEPersistenceIntegration:
+    """Integration tests that verify persistence with real ADK.
+    
+    These tests require one of:
+    - GOOGLE_API_KEY environment variable (for Google AI Studio)
+    - GOOGLE_GENAI_USE_VERTEXAI=TRUE with gcloud auth and GOOGLE_CLOUD_PROJECT (for Vertex AI)
+    """
+
+    pytestmark = pytest.mark.skipif(
+        not _has_google_auth(),
+        reason="No Google authentication available (set GOOGLE_API_KEY or configure Vertex AI)"
+    )
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        """Reset session manager between tests."""
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest.fixture
+    def lro_tool(self):
+        """Create a sample LRO tool (simulates useFrontendTool)."""
+        return AGUITool(
+            name="get_greeting",
+            description="Get a greeting for the given name",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name to greet"
+                    }
+                },
+                "required": ["name"]
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_events_persisted_with_sse_streaming(self, lro_tool):
+        """Test that agent events ARE persisted when using LRO tool + SSE streaming.
+        
+        This is the main regression test for the bug. It verifies that:
+        1. Agent response is emitted to the frontend
+        2. Agent response is persisted to the session
+        """
+        from google.adk.agents import LlmAgent
+        from google.adk.sessions import InMemorySessionService
+        from google.adk.agents.run_config import RunConfig, StreamingMode
+        from ag_ui_adk.agui_toolset import AGUIToolset
+
+        session_service = InMemorySessionService()
+        app_name = f"test_sse_persistence_{uuid.uuid4().hex[:8]}"
+        user_id = "test_user"
+
+        # Create agent that will use the LRO tool
+        agent = LlmAgent(
+            name="greeter",
+            model="gemini-2.0-flash",
+            instruction="When asked to greet someone, use the get_greeting tool with their name.",
+            tools=[AGUIToolset()],
+        )
+
+        # SSE streaming is the default, but be explicit
+        def sse_streaming_config(input):
+            return RunConfig(streaming_mode=StreamingMode.SSE)
+
+        adk_agent = ADKAgent(
+            adk_agent=agent,
+            app_name=app_name,
+            user_id=user_id,
+            session_service=session_service,
+            run_config_factory=sse_streaming_config,
+        )
+
+        thread_id = f"thread_{uuid.uuid4().hex[:8]}"
+        input_data = RunAgentInput(
+            thread_id=thread_id,
+            run_id=f"run_{uuid.uuid4().hex[:8]}",
+            messages=[UserMessage(id="msg1", role="user", content="Please greet Alice")],
+            state={},
+            tools=[lro_tool],
+            context=[],
+            forwarded_props={},
+        )
+
+        # Run the agent
+        events = []
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            async for event in adk_agent.run(input_data):
+                events.append(event)
+
+        # Verify we got events
+        event_types = [str(e.type).split('.')[-1] for e in events]
+        assert "RUN_STARTED" in event_types, f"Missing RUN_STARTED. Got: {event_types}"
+        assert "RUN_FINISHED" in event_types, f"Missing RUN_FINISHED. Got: {event_types}"
+
+        # Check persisted events in session
+        sessions = await session_service.list_sessions(app_name=app_name, user_id=user_id)
+        assert sessions.sessions, "No sessions found"
+
+        session = await session_service.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=sessions.sessions[0].id
+        )
+
+        # Count agent events (author != 'user')
+        agent_events = [
+            e for e in session.events 
+            if getattr(e, 'author', None) != 'user'
+        ]
+
+        # THE KEY ASSERTION: Agent events should be persisted
+        assert len(agent_events) > 0, (
+            f"BUG NOT FIXED: No agent events persisted with SSE streaming! "
+            f"Total events: {len(session.events)}, "
+            f"Event authors: {[getattr(e, 'author', 'unknown') for e in session.events]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_agent_events_persisted_without_streaming_baseline(self, lro_tool):
+        """Baseline test: Agent events ARE persisted when streaming is disabled.
+        
+        This test confirms that the issue is specific to SSE streaming.
+        With streaming disabled, persistence should always work.
+        """
+        from google.adk.agents import LlmAgent
+        from google.adk.sessions import InMemorySessionService
+        from google.adk.agents.run_config import RunConfig, StreamingMode
+        from ag_ui_adk.agui_toolset import AGUIToolset
+
+        session_service = InMemorySessionService()
+        app_name = f"test_no_streaming_{uuid.uuid4().hex[:8]}"
+        user_id = "test_user"
+
+        agent = LlmAgent(
+            name="greeter",
+            model="gemini-2.0-flash",
+            instruction="When asked to greet someone, use the get_greeting tool with their name.",
+            tools=[AGUIToolset()],
+        )
+
+        # Disable streaming
+        def no_streaming_config(input):
+            return RunConfig(streaming_mode=StreamingMode.NONE)
+
+        adk_agent = ADKAgent(
+            adk_agent=agent,
+            app_name=app_name,
+            user_id=user_id,
+            session_service=session_service,
+            run_config_factory=no_streaming_config,
+        )
+
+        thread_id = f"thread_{uuid.uuid4().hex[:8]}"
+        input_data = RunAgentInput(
+            thread_id=thread_id,
+            run_id=f"run_{uuid.uuid4().hex[:8]}",
+            messages=[UserMessage(id="msg1", role="user", content="Please greet Bob")],
+            state={},
+            tools=[lro_tool],
+            context=[],
+            forwarded_props={},
+        )
+
+        # Run the agent
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            async for _ in adk_agent.run(input_data):
+                pass
+
+        # Check persisted events
+        sessions = await session_service.list_sessions(app_name=app_name, user_id=user_id)
+        assert sessions.sessions, "No sessions found"
+
+        session = await session_service.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=sessions.sessions[0].id
+        )
+
+        agent_events = [
+            e for e in session.events 
+            if getattr(e, 'author', None) != 'user'
+        ]
+
+        # Baseline: Without streaming, persistence should work
+        assert len(agent_events) > 0, (
+            f"Baseline failed: No agent events persisted even without streaming! "
+            f"This indicates a different issue."
+        )
+
+
+# =============================================================================
+# Direct Execution
+# =============================================================================
+
+if __name__ == "__main__":
+    import sys
+    
+    if _has_google_auth():
+        print("Running all tests (Google authentication available)")
+        pytest.main([__file__, "-v", "-s"])
+    else:
+        print("No Google authentication - running unit tests only")
+        print("Set GOOGLE_API_KEY or configure Vertex AI to run integration tests")
+        pytest.main([__file__, "-v", "-s", "-k", "Unit"])


### PR DESCRIPTION
This commit addresses a bug where agent events were not persisted to the session database when using LongRunningFunctionTool with SSE streaming enabled. The fix ensures that when a partial event is detected, the system continues to consume events until a non-partial event is received, allowing ADK's persistence mechanism to complete successfully.

Additionally, a new test suite has been added to validate the LRO SSE persistence behavior, ensuring that both partial and non-partial events are handled correctly during streaming.

Closes: [GitHub issue link if applicable]


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
