### PR TITLE
fix(ci): use macos runner for Kotlin SDK publishing

### DIFF
--- a/.github/workflows/publish-kotlin-sdk.yml
+++ b/.github/workflows/publish-kotlin-sdk.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
Switch from ubuntu-latest to macos-latest to enable building Kotlin/Native iOS targets (iosArm64, iosSimulatorArm64, iosX64). iOS artifacts require macOS to compile.

Fixes [#1067](https://github.com/ag-ui-protocol/ag-ui/issues/1067)


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
