### PR TITLE
test: add HITL resumption text output regression test

### DIFF
--- a/integrations/adk-middleware/python/tests/test_hitl_resumption_text_output.py
+++ b/integrations/adk-middleware/python/tests/test_hitl_resumption_text_output.py
@@ -6,7 +6,7 @@ during a Human-in-the-Loop flow, the agent actually generates a text response
 acknowledging the result. This is the core user-facing behavior.
 
 Background:
-- PR #1075 removed explicit FunctionResponse persistence (to fix duplicate events)
+- PR #1075 would remove explicit FunctionResponse persistence (to fix duplicate events)
 - This caused a regression where runner.run_async() returned ZERO events after
   HITL resumption — the LLM was never called, so no text was generated
 - The dojo test "Human in the Loop Feature" timed out waiting for assistant messages


### PR DESCRIPTION
## Summary
- Adds a regression test that verifies the agent produces text output after HITL tool result submission
- Catches regressions where changes to FunctionResponse persistence cause `runner.run_async()` to return zero events — the LLM never gets called and no text is generated
- Requires `GOOGLE_API_KEY` (skipped otherwise)

## Test plan
- [x] Passes on `main` (1 passed in ~7s)
- [x] Confirmed to fail against code that removes explicit FunctionResponse pre-persistence, with: `REGRESSION: Agent produced NO text output after HITL resumption! All events: ['EventType.RUN_STARTED', 'EventType.STATE_SNAPSHOT', 'EventType.RUN_FINISHED']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)