### PR TITLE
fix(adk-middleware): fix broken LRO integration tests

### DIFF
--- a/integrations/adk-middleware/python/tests/test_hitl_resumption_text_output.py
+++ b/integrations/adk-middleware/python/tests/test_hitl_resumption_text_output.py
@@ -411,9 +411,7 @@ after receiving tool results.""",
         # Property 3: No duplicate FunctionResponse in session
         app_name = hitl_agent._get_app_name(run_input_2)
         user_id = hitl_agent._get_user_id(run_input_2)
-        backend_session_id = hitl_agent._session_manager.get_backend_session_id(
-            app_name, thread_id
-        )
+        backend_session_id = hitl_agent._get_backend_session_id(thread_id)
 
         if backend_session_id:
             session = await hitl_agent._session_manager._session_service.get_session(


### PR DESCRIPTION
## Summary
- Fixes 4 failing integration tests on main introduced by PRs #1077/#1078 and #1087
- Tests had code bugs (calling non-existent `SessionManager.get_backend_session_id` method, using wrong agent fixture) that prevented them from running
- Marks tests as `xfail` since they validate issue #1074 (duplicate FunctionResponse persistence) which hasn't been fixed yet

## Changes
- **`get_backend_session_id` fix**: 5 call sites across 2 test files called `agent._session_manager.get_backend_session_id(app_name, thread_id)` — a method that doesn't exist on `SessionManager`. Fixed to use `agent._get_backend_session_id(thread_id)` on `ADKAgent`
- **`simple_agent` fixture fix**: Used `ADKAgent()` directly without `ResumabilityConfig`, but the HITL tool-result flow requires a resumable app. Changed to `ADKAgent.from_app()` with `ResumabilityConfig`
- **xfail markers**: 4 tests in `test_lro_tool_response_persistence.py` now marked `xfail` — they document known bugs (#1074) and will pass once PR #1075 lands

## Test plan
- [x] Full test suite passes: 586 passed, 1 skipped, 4 xfailed
- [x] Previously failing tests now report as xfailed instead of errors

Refs: #1074, #1077, #1078, #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)