### PR TITLE
Validation run

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FIXED**: Invocation ID handling for HITL resumption with composite agents (#1080)
+  - Fixed "No agent to transfer to" errors when resuming after HITL pauses by conditionally passing `invocation_id` based on root agent type
+  - Composite orchestrators (SequentialAgent, LoopAgent) now correctly receive `invocation_id` in `run_async()` to restore internal state on HITL resumption
+  - Standalone LlmAgents and LlmAgents with transfer targets no longer receive `invocation_id`, preventing ValueError in `_get_subagent_to_resume()`
+  - Deferred `invocation_id` storage to post-run lifecycle to avoid stale session errors with DatabaseSessionService
+  - Tool result submissions with trailing user messages now work correctly without causing ADK resumption errors
+  - Thanks to **@lakshminarasimmanv** for this comprehensive fix!
 - **FIXED**: Reload session on cache miss to populate events (#1021)
   - `_find_session_by_thread_id()` uses `list_sessions()` which returns metadata only; now reloads via `get_session()` after a cache miss so that session events are available
   - Thanks to **@lakshminarasimmanv** for this fix!

--- a/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
+++ b/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
@@ -286,11 +286,6 @@ class TestLROToolResponseIntegration:
             )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="On main the middleware uses the stored ADK invocation_id, not the "
-               "AG-UI run_id. Correct behaviour expected after PR #1075.",
-        strict=False,
-    )
     async def test_function_response_has_correct_invocation_id(
         self, check_api_key, simple_agent
     ):
@@ -384,11 +379,6 @@ class TestLROToolResponseIntegration:
                 )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="Trailing user message + stored invocation_id causes ADK resumption "
-               "error ('No agent to transfer to'). Requires fix in PR #1075.",
-        strict=False,
-    )
     async def test_tool_result_with_trailing_user_message(
         self, check_api_key, simple_agent
     ):


### PR DESCRIPTION
test(adk-middleware): remove xfail from passing invocation_id tests
Remove xfail markers from two tests that now pass with PR https://github.com/ag-ui-protocol/ag-ui/pull/1080:
- test_function_response_has_correct_invocation_id
- test_tool_result_with_trailing_user_message

These tests were previously marked as xfail with incorrect PR references
(https://github.com/ag-ui-protocol/ag-ui/pull/1075) but are actually fixed by PR https://github.com/ag-ui-protocol/ag-ui/pull/1080's invocation_id handling
improvements.

Also add CHANGELOG entry crediting @lakshminarasimmanv for the
comprehensive invocation_id fix that resolves HITL resumption errors.