### PR TITLE
docs: tighten middleware examples and add helper guidance

### DIFF
--- a/docs/concepts/middleware.mdx
+++ b/docs/concepts/middleware.mdx
@@ -7,6 +7,8 @@ description: "Transform and intercept events in AG-UI agents"
 
 Middleware in AG-UI provides a powerful way to transform, filter, and augment the event streams that flow through agents. It enables you to add cross-cutting concerns like logging, authentication, rate limiting, and event filtering without modifying the core agent logic.
 
+Examples below assume the relevant RxJS operators/utilities (`map`, `tap`, `catchError`, `switchMap`, `timer`, etc.) are imported.
+
 ## What is Middleware?
 
 Middleware sits between the agent execution and the event consumer, allowing you to:
@@ -33,6 +35,8 @@ agent.use(loggingMiddleware, authMiddleware, filterMiddleware)
 await agent.runAgent()
 ```
 
+Middleware added with `agent.use(...)` is applied in `runAgent()`. `connectAgent()` currently calls `connect()` directly and does not run middleware.
+
 ## Function-Based Middleware
 
 For simple transformations, you can use function-based middleware. This is the most concise way to add middleware:
@@ -44,7 +48,10 @@ import { EventType } from "@ag-ui/core"
 const prefixMiddleware: MiddlewareFunction = (input, next) => {
   return next.run(input).pipe(
     map(event => {
-      if (event.type === EventType.TEXT_MESSAGE_CHUNK) {
+      if (
+        event.type === EventType.TEXT_MESSAGE_CHUNK ||
+        event.type === EventType.TEXT_MESSAGE_CONTENT
+      ) {
         return {
           ...event,
           delta: `[AI]: ${event.delta}`
@@ -77,7 +84,7 @@ class MetricsMiddleware extends Middleware {
   run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
     const startTime = Date.now()
 
-    return next.run(input).pipe(
+    return this.runNext(input, next).pipe(
       tap(event => {
         this.eventCount++
         this.metricsService.recordEvent(event.type)
@@ -93,6 +100,10 @@ class MetricsMiddleware extends Middleware {
 
 agent.use(new MetricsMiddleware(metricsService))
 ```
+
+If you are writing class middleware, prefer the helper methods:
+- `runNext(input, next)` normalizes chunk events into full `TEXT_MESSAGE_*`/`TOOL_CALL_*` sequences.
+- `runNextWithState(input, next)` also provides accumulated `messages` and `state` after each event.
 
 ## Built-in Middleware
 
@@ -118,102 +129,22 @@ const blockedFilter = new FilterToolCallsMiddleware({
 agent.use(allowedFilter)
 ```
 
+`FilterToolCallsMiddleware` filters emitted `TOOL_CALL_*` events. It does not block tool execution in the upstream model/runtime.
+
 ## Middleware Patterns
 
-### Logging Middleware
-
-```typescript
-const loggingMiddleware: MiddlewareFunction = (input, next) => {
-  console.log("Request:", input.messages)
-
-  return next.run(input).pipe(
-    tap(event => console.log("Event:", event.type)),
-    catchError(error => {
-      console.error("Error:", error)
-      throw error
-    })
-  )
-}
-```
-
-### Authentication Middleware
-
-```typescript
-class AuthMiddleware extends Middleware {
-  constructor(private apiKey: string) {
-    super()
-  }
-
-  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    // Add authentication to the context
-    const authenticatedInput = {
-      ...input,
-      context: [
-        ...input.context,
-        { type: "auth", apiKey: this.apiKey }
-      ]
-    }
-
-    return next.run(authenticatedInput)
-  }
-}
-```
-
-### Rate Limiting Middleware
-
-```typescript
-class RateLimitMiddleware extends Middleware {
-  private lastCall = 0
-
-  constructor(private minInterval: number) {
-    super()
-  }
-
-  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    const now = Date.now()
-    const timeSinceLastCall = now - this.lastCall
-
-    if (timeSinceLastCall < this.minInterval) {
-      const delay = this.minInterval - timeSinceLastCall
-      return timer(delay).pipe(
-        switchMap(() => {
-          this.lastCall = Date.now()
-          return next.run(input)
-        })
-      )
-    }
-
-    this.lastCall = now
-    return next.run(input)
-  }
-}
-```
+Common patterns include logging, auth via `forwardedProps`, and rate limiting. See the [JS middleware reference](/sdk/js/client/middleware) for concrete implementations.
 
 ## Combining Middleware
 
 You can combine multiple middleware to create sophisticated processing pipelines:
 
 ```typescript
-// Function middleware for simple logging
-const logMiddleware: MiddlewareFunction = (input, next) => {
-  console.log(`Starting run ${input.runId}`)
-  return next.run(input)
-}
+const logMiddleware: MiddlewareFunction = (input, next) => next.run(input)
+const metricsMiddleware = new MetricsMiddleware(metricsService)
+const filterMiddleware = new FilterToolCallsMiddleware({ allowedToolCalls: ["search"] })
 
-// Class middleware for authentication
-const authMiddleware = new AuthMiddleware(apiKey)
-
-// Built-in middleware for filtering
-const filterMiddleware = new FilterToolCallsMiddleware({
-  allowedToolCalls: ["search", "summarize"]
-})
-
-// Apply all middleware in order
-agent.use(
-  logMiddleware,        // First: log the request
-  authMiddleware,       // Second: add authentication
-  filterMiddleware      // Third: filter tool calls
-)
+agent.use(logMiddleware, metricsMiddleware, filterMiddleware)
 ```
 
 ## Execution Order
@@ -255,7 +186,7 @@ Apply middleware based on runtime conditions:
 
 ```typescript
 const conditionalMiddleware: MiddlewareFunction = (input, next) => {
-  if (input.context.some(c => c.type === "debug")) {
+  if (input.forwardedProps?.debug === true) {
     // Apply debug logging
     return next.run(input).pipe(
       tap(event => console.debug(event))
@@ -265,42 +196,7 @@ const conditionalMiddleware: MiddlewareFunction = (input, next) => {
 }
 ```
 
-### Event Transformation
-
-Transform specific event types:
-
-```typescript
-const transformMiddleware: MiddlewareFunction = (input, next) => {
-  return next.run(input).pipe(
-    map(event => {
-      if (event.type === EventType.TOOL_CALL_START) {
-        // Add timestamp to tool calls
-        return {
-          ...event,
-          metadata: {
-            ...event.metadata,
-            timestamp: Date.now()
-          }
-        }
-      }
-      return event
-    })
-  )
-}
-```
-
-### Stream Control
-
-Control the flow of events:
-
-```typescript
-const throttleMiddleware: MiddlewareFunction = (input, next) => {
-  return next.run(input).pipe(
-    // Throttle text message chunks to prevent overwhelming the UI
-    throttleTime(50, undefined, { leading: true, trailing: true })
-  )
-}
-```
+For event transformation and stream-control variants, see the [JS middleware reference](/sdk/js/client/middleware).
 
 ## Conclusion
 

--- a/docs/sdk/js/client/abstract-agent.mdx
+++ b/docs/sdk/js/client/abstract-agent.mdx
@@ -123,7 +123,7 @@ agent.use(new FilterToolCallsMiddleware({
 agent.use(loggingMiddleware, authMiddleware, filterMiddleware);
 ```
 
-Middleware executes in the order added, with each wrapping the next. See the [Middleware documentation](/sdk/js/client/middleware) for more details.
+Middleware executes in the order added, with each wrapping the next. Middleware is applied in `runAgent()`; `connectAgent()` currently calls `connect()` directly. See the [Middleware documentation](/sdk/js/client/middleware) for more details.
 
 ### abortRun()
 

--- a/docs/sdk/js/client/middleware.mdx
+++ b/docs/sdk/js/client/middleware.mdx
@@ -8,8 +8,20 @@ description: "Event stream transformation and filtering for AG-UI agents"
 The middleware system in `@ag-ui/client` provides a powerful way to transform, filter, and augment event streams flowing through agents. Middleware can intercept and modify events, add logging, implement authentication, filter tool calls, and more.
 
 ```typescript
-import { Middleware, MiddlewareFunction, FilterToolCallsMiddleware } from "@ag-ui/client"
+import {
+  AbstractAgent,
+  BaseEvent,
+  EventType,
+  FilterToolCallsMiddleware,
+  Message,
+  Middleware,
+  MiddlewareFunction,
+  RunAgentInput
+} from "@ag-ui/client"
+import { Observable } from "rxjs"
 ```
+
+Examples below assume the relevant RxJS operators/utilities (`map`, `tap`, `filter`, `finalize`, `catchError`, `switchMap`, `timer`, `of`, etc.) are imported.
 
 ## Types
 
@@ -24,18 +36,39 @@ type MiddlewareFunction = (
 ) => Observable<BaseEvent>
 ```
 
+Function middleware receives events exactly as emitted by the next middleware or agent.
+
 ### Middleware
 
 Abstract base class for creating middleware.
 
 ```typescript
+interface EventWithState {
+  event: BaseEvent
+  messages: Message[]
+  state: unknown
+}
+
 abstract class Middleware {
   abstract run(
     input: RunAgentInput,
     next: AbstractAgent
   ): Observable<BaseEvent>
+
+  protected runNext(
+    input: RunAgentInput,
+    next: AbstractAgent
+  ): Observable<BaseEvent>
+
+  protected runNextWithState(
+    input: RunAgentInput,
+    next: AbstractAgent
+  ): Observable<EventWithState>
 }
 ```
+
+- `runNext()` runs `next.run(...)` and normalizes chunk events into complete `TEXT_MESSAGE_*` / `TOOL_CALL_*` sequences.
+- `runNextWithState()` does the same and also provides accumulated `messages` and `state` after each event is applied.
 
 ## Function-Based Middleware
 
@@ -59,13 +92,13 @@ agent.use(loggingMiddleware)
 ### Transforming Events
 
 ```typescript
-const prefixMiddleware: MiddlewareFunction = (input, next) => {
+const timestampMiddleware: MiddlewareFunction = (input, next) => {
   return next.run(input).pipe(
     map(event => {
-      if (event.type === EventType.TEXT_MESSAGE_CHUNK) {
+      if (event.type === EventType.RUN_STARTED) {
         return {
           ...event,
-          delta: `[Assistant]: ${event.delta}`
+          timestamp: Date.now()
         }
       }
       return event
@@ -105,7 +138,7 @@ class CounterMiddleware extends Middleware {
   run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
     let runEvents = 0
 
-    return next.run(input).pipe(
+    return this.runNext(input, next).pipe(
       tap(() => {
         runEvents++
         this.totalEvents++
@@ -132,23 +165,55 @@ class AuthMiddleware extends Middleware {
   }
 
   run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    // Add authentication to context
-    const authenticatedInput = {
+    // Attach auth data in forwardedProps for downstream transport/agent logic
+    const authenticatedInput: RunAgentInput = {
       ...input,
-      context: [
-        ...input.context,
-        {
-          type: "auth",
-          [this.headerName]: `Bearer ${this.apiKey}`
+      forwardedProps: {
+        ...input.forwardedProps,
+        auth: {
+          headerName: this.headerName,
+          value: `Bearer ${this.apiKey}`
         }
-      ]
+      }
     }
 
-    return next.run(authenticatedInput)
+    return this.runNext(authenticatedInput, next)
   }
 }
 
-agent.use(new AuthMiddleware(process.env.API_KEY))
+const apiKey = process.env.API_KEY ?? ""
+agent.use(new AuthMiddleware(apiKey))
+```
+
+## Accumulator Helpers (Class Middleware)
+
+Class middleware can use helper methods from `Middleware` to work with normalized events and accumulated state.
+
+### `runNext()`
+
+`runNext()` forwards execution and normalizes chunk events into full `TEXT_MESSAGE_*` and `TOOL_CALL_*` events.
+
+### `runNextWithState()`
+
+`runNextWithState()` returns `{ event, messages, state }`, where `messages` and `state` are the accumulated values after each event has been applied.
+
+```typescript
+class MetricsWithStateMiddleware extends Middleware {
+  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    return this.runNextWithState(input, next).pipe(
+      tap(({ event, messages, state }) => {
+        if (event.type === EventType.RUN_FINISHED) {
+          const stateKeyCount =
+            state && typeof state === "object" ? Object.keys(state).length : 0
+
+          console.log("Assistant messages:", messages.filter(m => m.role === "assistant").length)
+          console.log("Final state keys:", stateKeyCount)
+        }
+      }),
+      map(({ event }) => event)
+    )
+  }
+}
 ```
 
 ## Built-in Middleware
@@ -156,6 +221,8 @@ agent.use(new AuthMiddleware(process.env.API_KEY))
 ### FilterToolCallsMiddleware
 
 Filters tool calls based on allowed or disallowed lists.
+
+`FilterToolCallsMiddleware` filters emitted `TOOL_CALL_*` events (including args/results for blocked calls). It does not prevent tool execution in the upstream model/runtime.
 
 ```typescript
 import { FilterToolCallsMiddleware } from "@ag-ui/client"
@@ -179,15 +246,7 @@ const allowFilter = new FilterToolCallsMiddleware({
 agent.use(allowFilter)
 ```
 
-#### Block Specific Tools
-
-```typescript
-const blockFilter = new FilterToolCallsMiddleware({
-  disallowedToolCalls: ["delete", "modify", "execute"]
-})
-
-agent.use(blockFilter)
-```
+You can also use `disallowedToolCalls` instead of `allowedToolCalls`.
 
 ## Middleware Patterns
 
@@ -225,13 +284,13 @@ class RateLimitMiddleware extends Middleware {
       return timer(this.minInterval - elapsed).pipe(
         switchMap(() => {
           this.lastCall = Date.now()
-          return next.run(input)
+          return this.runNext(input, next)
         })
       )
     }
 
     this.lastCall = now
-    return next.run(input)
+    return this.runNext(input, next)
   }
 }
 
@@ -239,79 +298,21 @@ class RateLimitMiddleware extends Middleware {
 agent.use(new RateLimitMiddleware(1000))
 ```
 
-### Retry Logic
-
-```typescript
-const retryMiddleware: MiddlewareFunction = (input, next) => {
-  return next.run(input).pipe(
-    retry({
-      count: 3,
-      delay: (error, retryCount) => {
-        console.log(`Retry attempt ${retryCount}`)
-        return timer(1000 * retryCount) // Exponential backoff
-      }
-    })
-  )
-}
-```
-
-### Caching
-
-```typescript
-class CacheMiddleware extends Middleware {
-  private cache = new Map<string, BaseEvent[]>()
-
-  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    const cacheKey = this.getCacheKey(input)
-
-    if (this.cache.has(cacheKey)) {
-      console.log("Cache hit")
-      return from(this.cache.get(cacheKey)!)
-    }
-
-    const events: BaseEvent[] = []
-
-    return next.run(input).pipe(
-      tap(event => events.push(event)),
-      finalize(() => {
-        this.cache.set(cacheKey, events)
-      })
-    )
-  }
-
-  private getCacheKey(input: RunAgentInput): string {
-    // Create a cache key from the input
-    return JSON.stringify({
-      messages: input.messages,
-      tools: input.tools.map(t => t.name)
-    })
-  }
-}
-```
+Other common patterns include retry logic and response caching.
 
 ## Chaining Middleware
 
 Multiple middleware can be combined to create sophisticated processing pipelines.
 
 ```typescript
-// Create middleware instances
 const logger = loggingMiddleware
 const auth = new AuthMiddleware(apiKey)
-const filter = new FilterToolCallsMiddleware({
-  allowedToolCalls: ["search"]
-})
-const rateLimit = new RateLimitMiddleware(1000)
+const filter = new FilterToolCallsMiddleware({ allowedToolCalls: ["search"] })
 
-// Apply middleware in order
-agent.use(
-  logger,      // First: Log all events
-  auth,        // Second: Add authentication
-  rateLimit,   // Third: Apply rate limiting
-  filter       // Fourth: Filter tool calls
-)
+agent.use(logger, auth, filter)
 
 // Execution flow:
-// logger → auth → rateLimit → filter → agent → filter → rateLimit → auth → logger
+// logger → auth → filter → agent → filter → auth → logger
 ```
 
 ## Advanced Usage
@@ -320,7 +321,7 @@ agent.use(
 
 ```typescript
 const debugMiddleware: MiddlewareFunction = (input, next) => {
-  const isDebug = input.context.some(c => c.type === "debug")
+  const isDebug = input.forwardedProps?.debug === true
 
   if (!isDebug) {
     return next.run(input)
@@ -334,38 +335,9 @@ const debugMiddleware: MiddlewareFunction = (input, next) => {
 }
 ```
 
-### Event Filtering
+## Lifecycle Notes
 
-```typescript
-const filterEventsMiddleware: MiddlewareFunction = (input, next) => {
-  return next.run(input).pipe(
-    filter(event => {
-      // Only allow specific event types
-      return [
-        EventType.RUN_STARTED,
-        EventType.TEXT_MESSAGE_CHUNK,
-        EventType.RUN_FINISHED
-      ].includes(event.type)
-    })
-  )
-}
-```
-
-### Stream Manipulation
-
-```typescript
-const bufferMiddleware: MiddlewareFunction = (input, next) => {
-  return next.run(input).pipe(
-    // Buffer text chunks and emit them in batches
-    bufferWhen(() =>
-      interval(100).pipe(
-        filter(() => true)
-      )
-    ),
-    map(events => events.flat())
-  )
-}
-```
+Middleware added with `agent.use(...)` runs in `runAgent()` (and the legacy bridge path). `connectAgent()` currently calls `connect()` directly and does not run middleware.
 
 ## Best Practices
 
@@ -382,11 +354,12 @@ The middleware system is fully typed for excellent IDE support:
 
 ```typescript
 import {
-  Middleware,
+  AbstractAgent,
+  BaseEvent,
   MiddlewareFunction,
-  FilterToolCallsMiddleware
+  RunAgentInput
 } from "@ag-ui/client"
-import { RunAgentInput, BaseEvent, EventType } from "@ag-ui/core"
+import { Observable } from "rxjs"
 
 // Type-safe middleware function
 const typedMiddleware: MiddlewareFunction = (
@@ -394,15 +367,5 @@ const typedMiddleware: MiddlewareFunction = (
   next: AbstractAgent
 ): Observable<BaseEvent> => {
   return next.run(input)
-}
-
-// Type-safe middleware class
-class TypedMiddleware extends Middleware {
-  run(
-    input: RunAgentInput,
-    next: AbstractAgent
-  ): Observable<BaseEvent> {
-    return next.run(input)
-  }
 }
 ```


### PR DESCRIPTION
## Summary
- tighten and de-duplicate JS middleware docs examples
- add explicit coverage for class middleware helper methods (runNext, runNextWithState) and accumulated state usage
- align middleware examples with current TS types (notably forwardedProps vs context)
- clarify current lifecycle behavior: middleware applies to runAgent() and not connectAgent()

## Scope
- docs/sdk/js/client/middleware.mdx
- docs/concepts/middleware.mdx
- docs/sdk/js/client/abstract-agent.mdx

## Notes
- intentionally did not document BackwardCompatibility_0_0_39
