### PR TITLE
fix(langgraph): pass fork config correctly in prepare_regenerate_stream

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -387,7 +387,7 @@ class LangGraphAgent:
 
         kwargs = self.get_stream_kwargs(
             input=stream_input,
-            fork=fork,
+            config=fork,
             subgraphs=bool(subgraphs_stream_enabled),
             version="v2",
         )
@@ -897,7 +897,6 @@ class LangGraphAgent:
             version: Literal["v1", "v2"] = "v2",
             config: Optional[RunnableConfig] = None,
             context: Optional[Dict[str, Any]] = None,
-            fork: Optional[Any] = None,
     ):
         kwargs = dict(
             input=input,
@@ -918,9 +917,6 @@ class LangGraphAgent:
 
         if config:
             kwargs['config'] = config
-
-        if fork:
-            kwargs.update(fork)
 
         return kwargs
 


### PR DESCRIPTION
## Problem

The "Regenerate" button crashes with:
```
ValueError: Checkpointer requires one or more of the following
'configurable' keys: thread_id, checkpoint_ns, checkpoint_id
```

In `prepare_regenerate_stream` (line 388-393), the forked checkpoint config is passed as `fork=fork` to `get_stream_kwargs`. Inside `get_stream_kwargs`, `kwargs.update(fork)` spreads the `RunnableConfig` dict, placing `configurable` as a top-level kwarg:

```python
# get_stream_kwargs receives fork={'configurable': {'thread_id': ..., 'checkpoint_id': ...}}
if fork:
    kwargs.update(fork)  # Spreads 'configurable' into kwargs — wrong!
```

`astream_events` expects `config={'configurable': {...}}`, not `configurable={...}` as a top-level kwarg.

## Fix

The `fork` returned by `aupdate_state()` is already a `RunnableConfig`, so pass it as `config`:

```python
# Before (broken):
kwargs = self.get_stream_kwargs(input=stream_input, fork=fork, ...)

# After (fixed):
kwargs = self.get_stream_kwargs(input=stream_input, config=fork, ...)
```

Also removed the now-unused `fork` parameter and `kwargs.update(fork)` from `get_stream_kwargs` to prevent future misuse.

## Impact

- Regenerate button now works correctly with checkpointed graphs
- No behavior change for normal (non-regenerate) streaming — `config` parameter was already handled correctly in `get_stream_kwargs`

Fixes #683
Related: #833, #616