### PR TITLE
Add GitHub Issues bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: "Bug Report"
+name: "🐛 Bug Report"
 description: "Something isn't working as expected? Let us know so we can fix it."
 title: "[Bug]: "
 labels: ["bug", "triage"]
@@ -15,9 +15,9 @@ body:
     attributes:
       label: Pre-flight Checklist
       options:
-        - label: I have searched existing issues and this hasn't been reported yet.
+        - label: I have searched [existing issues](https://github.com/ag-ui-protocol/ag-ui/issues) and this hasn't been reported yet.
           required: true
-        - label: I am using the **latest** version of the relevant AG-UI packages.
+        - label: I am using the **latest** version AG-UI.
           required: true
 
   - type: textarea
@@ -59,20 +59,14 @@ body:
       placeholder: |
         AG-UI package(s) & version(s): e.g. @ag-ui/core@0.0.44
         Runtime: e.g. Node 22 / Python 3.12
-        OS: e.g. macOS 15 / Ubuntu 24.04
       render: text
     validations:
       required: true
 
-  - type: input
-    id: reproduction
+  - type: textarea
     attributes:
-      label: Reproduction URL
-      description: |
-        Link to a minimal repo, StackBlitz, or CodeSandbox that reproduces the issue. [Why?](https://antfu.me/posts/why-reproductions-are-required)
-      placeholder: "https://github.com/your-username/repro-repo"
-    validations:
-      required: false
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
 
   - type: textarea
     id: logs


### PR DESCRIPTION
Adds a structured YAML-based issue form template for bug reports with fields tailored to the AG-UI monorepo: SDK selection, area dropdown covering all core packages and integrations, environment details, reproduction steps, code snippets, and log output.

https://claude.ai/code/session_01UUvVYgTB67JFNNzPwyCKro


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
