### PR TITLE
chore(kotlin-sdk): bump version to 0.2.7

### DIFF
--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 //   - publish.sh script (reads dynamically)
 //   - GitHub Actions workflow (reads dynamically)
 // Only update these values here - they propagate automatically
-version = "0.2.6"
+version = "0.2.7"
 group = "com.ag-ui.community"
 
 allprojects {


### PR DESCRIPTION
## Summary
- Bumps Kotlin SDK version from 0.2.6 to 0.2.7
- Enables publishing an updated release with all platform artifacts now that macOS runners are available

Closes #1067

## Test plan
- [ ] CI passes
- [ ] After merge, trigger the publish workflow manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)