### PR TITLE
feat(langgraph): add messages-tuple stream mode as fallback for LangGraph Platform

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - run: npx pkg-pr-new publish ./sdks/typescript/packages/*
+      - run: npx pkg-pr-new publish ./sdks/typescript/packages/* ./integrations/*/typescript

--- a/integrations/langgraph/typescript/src/agent.test.ts
+++ b/integrations/langgraph/typescript/src/agent.test.ts
@@ -1,0 +1,636 @@
+import { Subscriber, Observable } from "rxjs";
+import { EventType } from "@ag-ui/client";
+import { LangGraphAgent } from "./agent";
+import type { ProcessedEvents } from "./types";
+
+/**
+ * Helper: create a LangGraphAgent with a minimal mock client.
+ * The mock client stubs out API calls so we can test event handling logic
+ * without hitting a real LangGraph deployment.
+ */
+function createTestAgent(overrides?: Partial<ConstructorParameters<typeof LangGraphAgent>[0]>) {
+  return new LangGraphAgent({
+    deploymentUrl: "http://localhost:8000",
+    graphId: "test-graph",
+    ...overrides,
+  });
+}
+
+/**
+ * Helper: set up an agent with an activeRun and subscriber so we can call
+ * handleSingleEvent / handleMessagesTupleEvent directly and collect dispatched events.
+ */
+function setupAgentForEventHandling() {
+  const agent = createTestAgent();
+  const events: ProcessedEvents[] = [];
+  const subscriber = {
+    next: (event: ProcessedEvents) => events.push(event),
+    error: () => {},
+    complete: () => {},
+  } as unknown as Subscriber<ProcessedEvents>;
+
+  agent.subscriber = subscriber;
+  (agent as any).activeRun = {
+    id: "test-run",
+    threadId: "test-thread",
+    hasFunctionStreaming: false,
+  };
+  (agent as any).messagesInProcess = {};
+
+  return { agent, events };
+}
+
+describe("LangGraphAgent", () => {
+  describe("default stream modes", () => {
+    it("includes messages-tuple in default stream modes", async () => {
+      const agent = createTestAgent();
+
+      // Pre-set assistant to skip the API call
+      (agent as any).assistant = { assistant_id: "test-assistant", graph_id: "test-graph" };
+
+      let capturedStreamMode: any;
+      // Override prepareStream to capture the stream mode that was passed
+      (agent as any).prepareStream = async (input: any, streamMode: any) => {
+        capturedStreamMode = streamMode;
+        return null; // Will cause early return
+      };
+
+      const subscriber = {
+        next: () => {},
+        error: () => {},
+        complete: () => {},
+      } as unknown as Subscriber<ProcessedEvents>;
+
+      await agent.runAgentStream({ runId: "run-1", threadId: "thread-1" } as any, subscriber);
+
+      expect(capturedStreamMode).toEqual(["events", "values", "updates", "messages-tuple"]);
+    });
+
+    it("respects custom streamMode from forwardedProps", async () => {
+      const agent = createTestAgent();
+      (agent as any).assistant = { assistant_id: "test-assistant", graph_id: "test-graph" };
+
+      let capturedStreamMode: any;
+      (agent as any).prepareStream = async (input: any, streamMode: any) => {
+        capturedStreamMode = streamMode;
+        return null;
+      };
+
+      const subscriber = {
+        next: () => {},
+        error: () => {},
+        complete: () => {},
+      } as unknown as Subscriber<ProcessedEvents>;
+
+      await agent.runAgentStream(
+        {
+          runId: "run-1",
+          threadId: "thread-1",
+          forwardedProps: { streamMode: ["events", "values"] },
+        } as any,
+        subscriber,
+      );
+
+      expect(capturedStreamMode).toEqual(["events", "values"]);
+    });
+  });
+
+  describe("handleMessagesTupleEvent", () => {
+    it("emits TEXT_MESSAGE_START and TEXT_MESSAGE_CONTENT for text chunks", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          type: EventType.TEXT_MESSAGE_START,
+          role: "assistant",
+          messageId: "msg-1",
+        }),
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "Hello",
+        }),
+      );
+    });
+
+    it("streams multiple text content chunks under the same message", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      // First chunk starts the message
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      // Second chunk continues the message
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: " world",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(3);
+      expect(events[0].type).toBe(EventType.TEXT_MESSAGE_START);
+      expect(events[1].type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+      expect(events[2].type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+      expect((events[2] as any).delta).toBe(" world");
+    });
+
+    it("emits TEXT_MESSAGE_END on finish_reason stop", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      // Start a message
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      // Finish the message
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "",
+          tool_call_chunks: [],
+          response_metadata: { finish_reason: "stop" },
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(3);
+      expect(events[2]).toEqual(
+        expect.objectContaining({
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: "msg-1",
+        }),
+      );
+    });
+
+    it("emits TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END for tool calls", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      // Tool call start
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-1",
+          content: "",
+          tool_call_chunks: [{ id: "tc-1", name: "search", args: "" }],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      // Tool call args
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-1",
+          content: "",
+          tool_call_chunks: [{ args: '{"query":' }],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-1",
+          content: "",
+          tool_call_chunks: [{ args: '"test"}' }],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      // Finish
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-1",
+          content: "",
+          tool_call_chunks: [],
+          response_metadata: { finish_reason: "stop" },
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(4);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          type: EventType.TOOL_CALL_START,
+          toolCallId: "tc-1",
+          toolCallName: "search",
+        }),
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: "tc-1",
+          delta: '{"query":',
+        }),
+      );
+      expect(events[2]).toEqual(
+        expect.objectContaining({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: "tc-1",
+          delta: '"test"}',
+        }),
+      );
+      expect(events[3]).toEqual(
+        expect.objectContaining({
+          type: EventType.TOOL_CALL_END,
+          toolCallId: "tc-1",
+        }),
+      );
+    });
+
+    it("ends text message before starting a tool call", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      // Text message
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Let me search",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      // Tool call starts (should end text message first)
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-2",
+          content: "",
+          tool_call_chunks: [{ id: "tc-1", name: "search", args: "" }],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(4);
+      expect(events[0].type).toBe(EventType.TEXT_MESSAGE_START);
+      expect(events[1].type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+      expect(events[2].type).toBe(EventType.TEXT_MESSAGE_END); // auto-ended
+      expect(events[3].type).toBe(EventType.TOOL_CALL_START);
+    });
+
+    it("skips non-AI message chunks", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "HumanMessageChunk",
+          id: "human-1",
+          content: "user message",
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("skips non-array data", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      (agent as any).handleMessagesTupleEvent({ not: "an array" });
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("skips empty initialization chunks", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "",
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("handles content as array with text type", () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: [
+            { type: "text", text: "Array content" },
+          ],
+          tool_call_chunks: [],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          delta: "Array content",
+        }),
+      );
+    });
+
+    it("sets hasFunctionStreaming when tool calls are received", () => {
+      const { agent } = setupAgentForEventHandling();
+
+      expect((agent as any).activeRun.hasFunctionStreaming).toBe(false);
+
+      (agent as any).handleMessagesTupleEvent([
+        {
+          type: "AIMessageChunk",
+          id: "ai-msg-1",
+          content: "",
+          tool_call_chunks: [{ id: "tc-1", name: "search", args: "" }],
+          response_metadata: {},
+        },
+        {},
+      ]);
+
+      expect((agent as any).activeRun.hasFunctionStreaming).toBe(true);
+    });
+  });
+
+  describe("events-mode dedup", () => {
+    it("sets _eventsStreamActive when on_chat_model_stream event is received", () => {
+      const { agent } = setupAgentForEventHandling();
+
+      expect((agent as any)._eventsStreamActive).toBe(false);
+
+      agent.handleSingleEvent({
+        event: "on_chat_model_stream",
+        metadata: { "emit-messages": true, "emit-tool-calls": true },
+        data: {
+          chunk: {
+            id: "chunk-1",
+            content: "Hello",
+            response_metadata: { finish_reason: null },
+            tool_call_chunks: [],
+          },
+        },
+      });
+
+      expect((agent as any)._eventsStreamActive).toBe(true);
+    });
+
+    it("resets _eventsStreamActive on new runAgentStream call", async () => {
+      const agent = createTestAgent();
+      (agent as any).assistant = { assistant_id: "test-assistant", graph_id: "test-graph" };
+      (agent as any)._eventsStreamActive = true;
+
+      (agent as any).prepareStream = async () => null;
+
+      const subscriber = {
+        next: () => {},
+        error: () => {},
+        complete: () => {},
+      } as unknown as Subscriber<ProcessedEvents>;
+
+      await agent.runAgentStream({ runId: "run-1", threadId: "thread-1" } as any, subscriber);
+
+      expect((agent as any)._eventsStreamActive).toBe(false);
+    });
+
+    it("resets _messagesTupleTracker on new runAgentStream call", async () => {
+      const agent = createTestAgent();
+      (agent as any).assistant = { assistant_id: "test-assistant", graph_id: "test-graph" };
+      (agent as any)._messagesTupleTracker = { messageId: "old-msg" };
+
+      (agent as any).prepareStream = async () => null;
+
+      const subscriber = {
+        next: () => {},
+        error: () => {},
+        complete: () => {},
+      } as unknown as Subscriber<ProcessedEvents>;
+
+      await agent.runAgentStream({ runId: "run-1", threadId: "thread-1" } as any, subscriber);
+
+      expect((agent as any)._messagesTupleTracker).toEqual({});
+    });
+  });
+
+  describe("handleStreamEvents filter", () => {
+    it("allows messages events through when messages-tuple is in streamModes", async () => {
+      const { agent, events } = setupAgentForEventHandling();
+
+      // Set up graphInfo so node change handling doesn't error
+      (agent as any).activeRun.graphInfo = { nodes: [] };
+
+      // Create a minimal async iterable that yields a messages event then a values event
+      const streamChunks = [
+        { event: "messages", data: [
+          {
+            type: "AIMessageChunk",
+            id: "msg-1",
+            content: "Hello",
+            tool_call_chunks: [],
+            response_metadata: {},
+          },
+          {},
+        ]},
+        // Need values event so state is populated
+        { event: "values", data: { messages: [] } },
+      ];
+
+      async function* fakeStream() {
+        for (const chunk of streamChunks) {
+          yield chunk;
+        }
+      }
+
+      const mockStream = {
+        streamResponse: fakeStream(),
+        state: { values: {}, metadata: {} },
+      };
+
+      // Mock client.threads.getState to return final state
+      (agent as any).client = {
+        threads: {
+          getState: async () => ({
+            values: {},
+            metadata: { writes: {} },
+            next: [],
+            tasks: [],
+          }),
+        },
+        runs: { cancel: async () => {} },
+      };
+
+      await agent.handleStreamEvents(
+        mockStream as any,
+        "thread-1",
+        agent.subscriber,
+        { runId: "run-1" } as any,
+        ["events", "values", "updates", "messages-tuple"],
+      );
+
+      // Should have processed the messages event
+      const textEvents = events.filter(
+        (e) => e.type === EventType.TEXT_MESSAGE_START || e.type === EventType.TEXT_MESSAGE_CONTENT,
+      );
+      expect(textEvents.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("filters out messages events when messages-tuple is NOT in streamModes", async () => {
+      const { agent, events } = setupAgentForEventHandling();
+      (agent as any).activeRun.graphInfo = { nodes: [] };
+
+      const streamChunks = [
+        { event: "messages", data: [
+          {
+            type: "AIMessageChunk",
+            id: "msg-1",
+            content: "Hello",
+            tool_call_chunks: [],
+            response_metadata: {},
+          },
+          {},
+        ]},
+        { event: "values", data: { messages: [] } },
+      ];
+
+      async function* fakeStream() {
+        for (const chunk of streamChunks) {
+          yield chunk;
+        }
+      }
+
+      const mockStream = {
+        streamResponse: fakeStream(),
+        state: { values: {}, metadata: {} },
+      };
+
+      (agent as any).client = {
+        threads: {
+          getState: async () => ({
+            values: {},
+            metadata: { writes: {} },
+            next: [],
+            tasks: [],
+          }),
+        },
+        runs: { cancel: async () => {} },
+      };
+
+      await agent.handleStreamEvents(
+        mockStream as any,
+        "thread-1",
+        agent.subscriber,
+        { runId: "run-1" } as any,
+        ["events", "values", "updates"], // no messages-tuple
+      );
+
+      // Messages event should be filtered out — no text events
+      const textEvents = events.filter(
+        (e) => e.type === EventType.TEXT_MESSAGE_START || e.type === EventType.TEXT_MESSAGE_CONTENT,
+      );
+      expect(textEvents).toHaveLength(0);
+    });
+
+    it("skips messages-tuple events when _eventsStreamActive is true", async () => {
+      const { agent, events } = setupAgentForEventHandling();
+      (agent as any).activeRun.graphInfo = { nodes: [] };
+
+      // Simulate events mode already producing data
+      (agent as any)._eventsStreamActive = true;
+
+      const streamChunks = [
+        { event: "messages", data: [
+          {
+            type: "AIMessageChunk",
+            id: "msg-1",
+            content: "Duplicate",
+            tool_call_chunks: [],
+            response_metadata: {},
+          },
+          {},
+        ]},
+        { event: "values", data: { messages: [] } },
+      ];
+
+      async function* fakeStream() {
+        for (const chunk of streamChunks) {
+          yield chunk;
+        }
+      }
+
+      const mockStream = {
+        streamResponse: fakeStream(),
+        state: { values: {}, metadata: {} },
+      };
+
+      (agent as any).client = {
+        threads: {
+          getState: async () => ({
+            values: {},
+            metadata: { writes: {} },
+            next: [],
+            tasks: [],
+          }),
+        },
+        runs: { cancel: async () => {} },
+      };
+
+      await agent.handleStreamEvents(
+        mockStream as any,
+        "thread-1",
+        agent.subscriber,
+        { runId: "run-1" } as any,
+        ["events", "values", "updates", "messages-tuple"],
+      );
+
+      // Messages-tuple events should be skipped because _eventsStreamActive
+      const textEvents = events.filter(
+        (e) => e.type === EventType.TEXT_MESSAGE_START || e.type === EventType.TEXT_MESSAGE_CONTENT,
+      );
+      expect(textEvents).toHaveLength(0);
+    });
+  });
+});

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -672,7 +672,8 @@ export class LangGraphAgent extends AbstractAgent {
           ? chunk.content.find((c: any) => c.type === "text")?.text
           : null;
     const toolCallChunks = chunk.tool_call_chunks;
-    const isFinished = chunk.response_metadata?.finish_reason === "stop";
+    const finishReason = chunk.response_metadata?.finish_reason;
+    const isFinished = finishReason === "stop" || finishReason === "tool_calls";
 
     // Handle tool call chunks
     if (toolCallChunks?.length > 0) {
@@ -727,7 +728,9 @@ export class LangGraphAgent extends AbstractAgent {
 
     // Handle text content streaming
     if (content) {
-      if (!this._messagesTupleTracker.messageId) {
+      // Start a new text message if there isn't one active, or if the previous
+      // tracker was for a tool call (different message context).
+      if (!this._messagesTupleTracker.messageId || this._messagesTupleTracker.toolCallId) {
         this.dispatchEvent({
           type: EventType.TEXT_MESSAGE_START,
           role: "assistant",


### PR DESCRIPTION
## Summary

- Adds `messages-tuple` as a default stream mode alongside `events`, `values`, and `updates` for LangGraph Platform compatibility
- Fixes filter mismatch where `messages-tuple` produces SSE events with event type `"messages"` that were being filtered out
- Adds `handleMessagesTupleEvent` to convert `[AIMessageChunk, metadata]` tuples into AG-UI text message and tool call events
- Uses dedup flag (`_eventsStreamActive`) so messages-tuple events are skipped when `events` mode works (local dev), avoiding duplicates

## Problem

When using `LangGraphAgent` with a LangGraph Platform deployment (e.g., graphs built with `create_agent` from `langchain`), the `events` stream mode does not emit `on_chat_model_stream` data. This causes all content to arrive as a single `MessagesSnapshot` at the end instead of streaming token-by-token.

The `messages-tuple` stream mode **does** work on LangGraph Platform and produces token-level streaming data, but `@ag-ui/langgraph` had two issues preventing it from being used:

1. **Filter mismatch**: `streamMode: ["messages-tuple"]` produces SSE events with `event: "messages"`, but the filter checks `streamModes.includes(event.event)` — `"messages"` != `"messages-tuple"`
2. **Data shape mismatch**: Messages-tuple data arrives as `[AIMessageChunk, metadata]` tuples, not objects with `.event`/`.metadata` properties like events-mode data

## Test plan

- [ ] Build succeeds (`pnpm build` in `integrations/langgraph/typescript`)
- [ ] Local dev (langgraph dev): streaming works via events mode (no regressions, dedup prevents duplicates from messages-tuple)
- [ ] LangGraph Platform deployment: token-by-token streaming now works via messages-tuple fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)