### PR TITLE
chore: speed up pkg.pr.new CI

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - run: npx pkg-pr-new publish ./sdks/typescript/packages/*
+      - run: npx pkg-pr-new publish --pnpm --packageManager pnpm ./sdks/typescript/packages/*


### PR DESCRIPTION
By default pkg.pr.new doesn't detect the package manager and relies for you to provide it, this adds pnpm as the package manager so it's used instead of npm for publishing, this skips teh build step per package as well
