### PR TITLE
feat(adk-middleware): streaming function call arguments for Gemini 3+ (#822)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **NEW**: Streaming function call arguments support for Gemini 3+ models via Vertex AI (#822)
+  - Enables real-time streaming of `TOOL_CALL_ARGS` events as the model generates function call arguments incrementally
+  - Activated via `streaming_function_call_arguments=True` on `ADKAgent` / `ADKAgent.from_app()`
+  - Requires `google-adk >= 1.24.0` (version-gated; emits a warning and disables on older versions)
+  - Requires `stream_function_call_arguments=True` in the model's `GenerateContentConfig` and SSE streaming mode
+  - JSON deltas are emitted as concatenable fragments: clients join all `TOOL_CALL_ARGS.delta` values to reconstruct the complete arguments JSON
+  - Integrates with predictive state updates: `PredictState` CustomEvents are emitted before `TOOL_CALL_START` for configured tools
+  - New `stream_tool_call` field on `PredictStateMapping` defers `TOOL_CALL_END` for LRO/HITL workflows
+  - Final aggregated (non-partial) events are automatically suppressed to prevent duplicate tool call emissions
+  - Confirmed function call IDs are remapped to the streaming ID so `TOOL_CALL_RESULT` uses a consistent ID
+  - No upstream monkey-patches or workarounds required (google/adk-python#4311 is fixed in ADK 1.24.0)
+
 ### Deprecated
 
 - **DEPRECATED**: Non-resumable (fire-and-forget) HITL flow via `ADKAgent(adk_agent=...)` with client-side tools

--- a/integrations/adk-middleware/python/src/ag_ui_adk/config.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/config.py
@@ -21,12 +21,15 @@ class PredictStateMapping:
         tool_argument: The argument name from the tool that provides the value
         emit_confirm_tool: If True (default), emit a confirm_changes tool call
             after this tool completes. This triggers the confirmation dialog in the UI.
+        stream_tool_call: If True, defer TOOL_CALL_END during streaming FC args
+            to keep the tool call "open" for LRO/HITL flows.
     """
 
     state_key: str
     tool: str
     tool_argument: str
     emit_confirm_tool: bool = True
+    stream_tool_call: bool = False
 
     def to_payload(self) -> Dict[str, str]:
         """Convert to the payload format expected by the UI."""

--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -170,6 +170,7 @@ class EventTranslator:
         client_emitted_tool_call_ids: Optional[set] = None,
         client_tool_names: Optional[set] = None,
         is_resumable: bool = False,
+        streaming_function_call_arguments: bool = False,
     ):
         """Initialize the event translator.
 
@@ -232,6 +233,33 @@ class EventTranslator:
         # to ensure the frontend shows the confirmation dialog with buttons enabled
         self._deferred_confirm_events: List[BaseEvent] = []
 
+        # Streaming function call arguments state (Mode A)
+        # When enabled, partial events carrying streaming FC chunks from Gemini 3+
+        # are translated into incremental TOOL_CALL_START/ARGS/END events.
+        self._streaming_fc_args_enabled = streaming_function_call_arguments
+        # Stable tool_call_id generated for the active streaming FC.
+        # Each partial chunk gets a different ID from ADK, so we generate one
+        # on the first chunk and reuse it for all subsequent AG-UI events.
+        self._active_streaming_fc_id: Optional[str] = None
+        # Tool name for the active streaming FC (set on first chunk).
+        self._active_streaming_fc_name: Optional[str] = None
+        # JSON paths that have had their opening JSON emitted (for closing at end).
+        self._streaming_fc_open_paths: List[str] = []
+        # JSON paths that have already had their key prefix emitted.
+        self._streaming_fc_started_paths: set[str] = set()
+        # Tool names that were fully streamed (for suppressing final aggregated event).
+        self._completed_streaming_fc_names: set[str] = set()
+        # Last completed streaming FC name/id — used for one-shot suppression of
+        # the next confirmed event with this name, then cleared.
+        self._last_completed_streaming_fc_name: Optional[str] = None
+        self._last_completed_streaming_fc_id: Optional[str] = None
+        # Maps confirmed (non-partial) FC id → streaming FC id, so that
+        # TOOL_CALL_RESULT uses the same ID the client saw in TOOL_CALL_START.
+        self._confirmed_to_streaming_id: Dict[str, str] = {}
+        # Tool names that opted into deferred TOOL_CALL_END via stream_tool_call=True.
+        self._streaming_lro_tool_names: set[str] = {
+            m.tool for m in self._predict_state_mappings if m.stream_tool_call
+        }
 
     def get_and_clear_deferred_confirm_events(self) -> List[BaseEvent]:
         """Get and clear any deferred confirm_changes events.
@@ -298,7 +326,21 @@ class EventTranslator:
                 ):
                     yield event
             
-            # Handle streaming function calls from partial events
+            # Handle streaming function calls from partial events (Mode A)
+            if self._streaming_fc_args_enabled and is_partial and hasattr(adk_event, 'get_function_calls'):
+                function_calls = adk_event.get_function_calls()
+                if function_calls:
+                    try:
+                        lro_ids = set(getattr(adk_event, 'long_running_tool_ids', []) or [])
+                    except Exception:
+                        lro_ids = set()
+                    for func_call in function_calls:
+                        fc_id = getattr(func_call, 'id', None)
+                        if fc_id in lro_ids or fc_id in self._client_emitted_tool_call_ids:
+                            continue
+                        async for event in self._translate_streaming_function_call(func_call):
+                            yield event
+
             # Handle complete (non-partial) function calls
             if hasattr(adk_event, 'get_function_calls') and not is_partial:
                 function_calls = adk_event.get_function_calls()
@@ -320,7 +362,18 @@ class EventTranslator:
                         if getattr(fc, 'id', None) not in all_lro_ids
                         and getattr(fc, 'id', None) not in self._client_emitted_tool_call_ids
                         and getattr(fc, 'name', None) not in self._client_tool_names
+                        and getattr(fc, 'name', None) != self._last_completed_streaming_fc_name
                     ]
+
+                    # Map confirmed FC ids to streaming FC ids for result remapping
+                    if self._last_completed_streaming_fc_name:
+                        for fc in function_calls:
+                            fc_name = getattr(fc, 'name', None)
+                            fc_id = getattr(fc, 'id', None)
+                            if fc_name == self._last_completed_streaming_fc_name and fc_id and self._last_completed_streaming_fc_id:
+                                self._confirmed_to_streaming_id[fc_id] = self._last_completed_streaming_fc_id
+                        self._last_completed_streaming_fc_name = None
+                        self._last_completed_streaming_fc_id = None
 
                     if non_lro_calls:
                         logger.debug(f"ADK function calls detected (non-LRO, non-streamed): {len(non_lro_calls)} of {len(function_calls)} total")
@@ -837,6 +890,142 @@ class EventTranslator:
 
                     self._emitted_confirm_for_tools.add(tool_name)
 
+    async def _translate_streaming_function_call(
+        self,
+        func_call: Any,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Translate a streaming function call chunk to AG-UI tool call events.
+
+        With google-adk >= 1.24.0 and stream_function_call_arguments=True,
+        Gemini 3+ models send function call arguments as incremental chunks:
+
+        1. First chunk:  name="tool", will_continue=True, partial_args=None/[]
+        2. Middle chunks: name=None, partial_args=[PartialArg(...)], will_continue=True
+        3. End marker:   name=None, partial_args=None, will_continue=None/False
+        4. Final (aggregated): name="tool", args={...}, partial=False (handled by translate())
+
+        Each partial chunk gets a DIFFERENT ID from ADK. We generate a stable
+        tool_call_id on the first chunk and reuse it for all AG-UI events.
+
+        Args:
+            func_call: A FunctionCall from a partial ADK event.
+
+        Yields:
+            TOOL_CALL_START, TOOL_CALL_ARGS (incremental JSON), TOOL_CALL_END
+        """
+        tool_name = getattr(func_call, 'name', None)
+        partial_args = getattr(func_call, 'partial_args', None)
+        will_continue = getattr(func_call, 'will_continue', None)
+
+        # --- First chunk: has name + will_continue ---
+        if tool_name and will_continue and self._active_streaming_fc_id is None:
+            self._active_streaming_fc_id = str(uuid.uuid4())
+            self._active_streaming_fc_name = tool_name
+            self._streaming_fc_open_paths = []
+            self._streaming_fc_started_paths = set()
+
+            # Close any active text message stream before tool calls
+            async for event in self.force_close_streaming_message():
+                yield event
+
+            # Emit PredictState if configured for this tool
+            if tool_name in self._predict_state_by_tool:
+                self._predictive_state_tool_call_ids.add(self._active_streaming_fc_id)
+                if tool_name not in self._emitted_predict_state_for_tools:
+                    mappings = self._predict_state_by_tool[tool_name]
+                    predict_state_payload = [m.to_payload() for m in mappings]
+                    yield CustomEvent(
+                        type=EventType.CUSTOM,
+                        name="PredictState",
+                        value=predict_state_payload,
+                    )
+                    self._emitted_predict_state_for_tools.add(tool_name)
+
+            # Emit TOOL_CALL_START
+            yield ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=self._active_streaming_fc_id,
+                tool_call_name=tool_name,
+                parent_message_id=None,
+            )
+            self.emitted_tool_call_ids.add(self._active_streaming_fc_id)
+            logger.debug(f"Streaming FC started: tool={tool_name}, id={self._active_streaming_fc_id}")
+            return
+
+        # --- No active streaming FC — skip stray chunks ---
+        if self._active_streaming_fc_id is None:
+            return
+
+        tool_call_id = self._active_streaming_fc_id
+
+        # --- Continuation chunks: emit partial_args as TOOL_CALL_ARGS deltas ---
+        if partial_args:
+            for partial_arg in partial_args:
+                string_value = getattr(partial_arg, 'string_value', None)
+                if string_value is None:
+                    continue
+                json_path = getattr(partial_arg, 'json_path', None) or ''
+
+                if json_path and json_path not in self._streaming_fc_started_paths:
+                    # First occurrence of this json_path: emit JSON key prefix
+                    key = json_path.lstrip('$.')
+                    # Build opening: {"key": "escaped_start...
+                    # We use json.dumps for proper key quoting, then append escaped value
+                    escaped_value = json.dumps(string_value)[1:-1]  # strip wrapping quotes
+                    delta = '{' + json.dumps(key) + ': "' + escaped_value
+                    self._streaming_fc_started_paths.add(json_path)
+                    self._streaming_fc_open_paths.append(json_path)
+                elif string_value:
+                    # Continuation: just the escaped string fragment
+                    delta = json.dumps(string_value)[1:-1]  # strip wrapping quotes
+                else:
+                    continue
+
+                if delta:
+                    yield ToolCallArgsEvent(
+                        type=EventType.TOOL_CALL_ARGS,
+                        tool_call_id=tool_call_id,
+                        delta=delta,
+                    )
+
+        # --- End marker: no partial_args, will_continue is None/False ---
+        if not partial_args and not will_continue:
+            resolved_name = self._active_streaming_fc_name
+
+            # Close any open JSON paths with closing quote + brace
+            if self._streaming_fc_open_paths:
+                yield ToolCallArgsEvent(
+                    type=EventType.TOOL_CALL_ARGS,
+                    tool_call_id=tool_call_id,
+                    delta='"}',
+                )
+
+            # Determine if TOOL_CALL_END should be deferred (streaming LRO)
+            should_defer_end = (
+                resolved_name in self._streaming_lro_tool_names
+                if resolved_name else False
+            )
+
+            if not should_defer_end:
+                yield ToolCallEndEvent(
+                    type=EventType.TOOL_CALL_END,
+                    tool_call_id=tool_call_id,
+                )
+
+            # Record completion for duplicate suppression
+            if resolved_name:
+                self._completed_streaming_fc_names.add(resolved_name)
+                self._last_completed_streaming_fc_name = resolved_name
+                self._last_completed_streaming_fc_id = tool_call_id
+
+            logger.debug(f"Streaming FC ended: tool={resolved_name}, id={tool_call_id}")
+
+            # Reset active streaming state
+            self._active_streaming_fc_id = None
+            self._active_streaming_fc_name = None
+            self._streaming_fc_open_paths = []
+            self._streaming_fc_started_paths = set()
+
     async def _translate_function_response(
         self,
         function_response: list[types.FunctionResponse],
@@ -855,6 +1044,10 @@ class EventTranslator:
         for func_response in function_response:
 
             tool_call_id = getattr(func_response, 'id', str(uuid.uuid4()))
+
+            # Remap tool_call_id if this is a confirmed response for a streamed FC
+            if tool_call_id in self._confirmed_to_streaming_id:
+                tool_call_id = self._confirmed_to_streaming_id[tool_call_id]
 
             # Skip TOOL_CALL_RESULT for long-running tools (handled by frontend)
             if tool_call_id in self.long_running_tool_ids:
@@ -968,7 +1161,16 @@ class EventTranslator:
         self._is_thinking = False
         self._is_streaming_thinking = False
         self._current_thinking_text = ""
-        logger.debug("Reset EventTranslator state (including streaming and thinking state)")
+        # Reset streaming FC args state
+        self._active_streaming_fc_id = None
+        self._active_streaming_fc_name = None
+        self._streaming_fc_open_paths.clear()
+        self._streaming_fc_started_paths.clear()
+        self._completed_streaming_fc_names.clear()
+        self._last_completed_streaming_fc_name = None
+        self._last_completed_streaming_fc_id = None
+        self._confirmed_to_streaming_id.clear()
+        logger.debug("Reset EventTranslator state (including streaming, thinking, and streaming FC state)")
 
 
 def _translate_function_calls_to_tool_calls(function_calls: List[Any]) -> List[ToolCall]:

--- a/integrations/adk-middleware/python/tests/test_streaming_fc_args.py
+++ b/integrations/adk-middleware/python/tests/test_streaming_fc_args.py
@@ -1,0 +1,514 @@
+"""Tests for streaming function call arguments (Mode A, google-adk >= 1.24.0).
+
+These tests verify the EventTranslator correctly handles streaming function call
+chunks from Gemini 3+ models when streaming_function_call_arguments=True.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from ag_ui.core import EventType
+from ag_ui_adk import EventTranslator, ADKAgent
+from ag_ui_adk.config import PredictStateMapping
+
+
+def _event_types(events):
+    """Extract event type names from a list of events."""
+    return [str(ev.type).split('.')[-1] for ev in events]
+
+
+def _make_adk_event(
+    func_calls=None,
+    partial=False,
+    author="assistant",
+    lro_ids=None,
+):
+    """Create a mock ADK event with function calls."""
+    event = MagicMock()
+    event.author = author
+    event.partial = partial
+    event.content = MagicMock()
+    event.content.parts = []
+    event.get_function_calls = MagicMock(return_value=func_calls or [])
+    event.long_running_tool_ids = lro_ids or []
+    # get_function_responses should return empty by default
+    event.get_function_responses = MagicMock(return_value=[])
+    # Prevent MagicMock auto-creating truthy attributes for state/custom handlers
+    event.actions = None
+    event.custom_data = None
+    return event
+
+
+def _make_func_call(name=None, args=None, partial_args=None, will_continue=None, fc_id=None):
+    """Create a mock FunctionCall."""
+    fc = MagicMock()
+    fc.name = name
+    fc.id = fc_id or f"adk-{id(fc)}"
+    fc.args = args
+    fc.partial_args = partial_args
+    fc.will_continue = will_continue
+    return fc
+
+
+def _make_partial_arg(json_path, string_value):
+    """Create a mock PartialArg."""
+    pa = MagicMock()
+    pa.json_path = json_path
+    pa.string_value = string_value
+    return pa
+
+
+async def _collect_events(translator, adk_event, thread_id="thread", run_id="run"):
+    """Collect all events from a translator.translate() call."""
+    events = []
+    async for e in translator.translate(adk_event, thread_id, run_id):
+        events.append(e)
+    return events
+
+
+# ============================================================================
+# First chunk tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_first_chunk_emits_start():
+    """First chunk with name + will_continue=True emits TOOL_CALL_START."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    fc = _make_func_call(name="write_document", will_continue=True)
+    adk_event = _make_adk_event(func_calls=[fc], partial=True)
+
+    events = await _collect_events(translator, adk_event)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_START" in types
+    start_event = [e for e in events if "TOOL_CALL_START" in str(e.type)][0]
+    assert start_event.tool_call_name == "write_document"
+    assert start_event.tool_call_id is not None
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_disabled_by_default():
+    """Without flag, partial events with will_continue are skipped."""
+    translator = EventTranslator()  # Default: streaming_function_call_arguments=False
+
+    fc = _make_func_call(name="write_document", will_continue=True)
+    adk_event = _make_adk_event(func_calls=[fc], partial=True)
+
+    events = await _collect_events(translator, adk_event)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_START" not in types
+
+
+# ============================================================================
+# Continuation chunk tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_continuation_emits_args():
+    """Continuation chunks with partial_args emit TOOL_CALL_ARGS deltas."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    event1 = _make_adk_event(func_calls=[fc1], partial=True)
+    await _collect_events(translator, event1)
+
+    # Continuation chunk
+    pa = _make_partial_arg("$.document", "Hello world")
+    fc2 = _make_func_call(partial_args=[pa], will_continue=True, fc_id="adk-2")
+    event2 = _make_adk_event(func_calls=[fc2], partial=True)
+
+    events = await _collect_events(translator, event2)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_ARGS" in types
+    args_event = [e for e in events if "TOOL_CALL_ARGS" in str(e.type)][0]
+    assert "document" in args_event.delta
+    assert "Hello world" in args_event.delta
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_multiple_continuations():
+    """Multiple continuation chunks accumulate deltas correctly."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    event1 = _make_adk_event(func_calls=[fc1], partial=True)
+    start_events = await _collect_events(translator, event1)
+
+    # Continuation 1
+    pa1 = _make_partial_arg("$.document", "Once upon ")
+    fc2 = _make_func_call(partial_args=[pa1], will_continue=True, fc_id="adk-2")
+    event2 = _make_adk_event(func_calls=[fc2], partial=True)
+    chunk1_events = await _collect_events(translator, event2)
+
+    # Continuation 2
+    pa2 = _make_partial_arg("$.document", "a time")
+    fc3 = _make_func_call(partial_args=[pa2], will_continue=True, fc_id="adk-3")
+    event3 = _make_adk_event(func_calls=[fc3], partial=True)
+    chunk2_events = await _collect_events(translator, event3)
+
+    # First continuation has key prefix, second has just the value
+    assert len(chunk1_events) >= 1
+    assert len(chunk2_events) >= 1
+    assert "TOOL_CALL_ARGS" in _event_types(chunk1_events)
+    assert "TOOL_CALL_ARGS" in _event_types(chunk2_events)
+
+    # Second delta should just be the escaped text (no key prefix)
+    args2 = [e for e in chunk2_events if "TOOL_CALL_ARGS" in str(e.type)][0]
+    assert args2.delta == "a time"
+
+
+# ============================================================================
+# End marker tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_end_emits_end():
+    """End marker emits closing JSON + TOOL_CALL_END."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    event1 = _make_adk_event(func_calls=[fc1], partial=True)
+    await _collect_events(translator, event1)
+
+    # Continuation (opens JSON path)
+    pa = _make_partial_arg("$.document", "content")
+    fc2 = _make_func_call(partial_args=[pa], will_continue=True, fc_id="adk-2")
+    event2 = _make_adk_event(func_calls=[fc2], partial=True)
+    await _collect_events(translator, event2)
+
+    # End marker
+    fc_end = _make_func_call(fc_id="adk-3")  # no name, no partial_args, no will_continue
+    event_end = _make_adk_event(func_calls=[fc_end], partial=True)
+    events = await _collect_events(translator, event_end)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_ARGS" in types  # Closing JSON '"}'
+    assert "TOOL_CALL_END" in types
+
+    # Closing JSON delta should be '"}'
+    closing = [e for e in events if "TOOL_CALL_ARGS" in str(e.type)][0]
+    assert closing.delta == '"}'
+
+
+# ============================================================================
+# Full streaming sequence tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_full_sequence():
+    """Full streaming sequence produces START, ARGS..., ARGS (close), END."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    all_events = await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+
+    # Two continuations
+    pa1 = _make_partial_arg("$.document", "Hello ")
+    fc2 = _make_func_call(partial_args=[pa1], will_continue=True, fc_id="adk-2")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc2], partial=True))
+
+    pa2 = _make_partial_arg("$.document", "World")
+    fc3 = _make_func_call(partial_args=[pa2], will_continue=True, fc_id="adk-3")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc3], partial=True))
+
+    # End marker
+    fc_end = _make_func_call(fc_id="adk-4")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    types = _event_types(all_events)
+    assert types[0] == "TOOL_CALL_START"
+    assert types[-1] == "TOOL_CALL_END"
+    assert types.count("TOOL_CALL_ARGS") == 3  # open, continuation, close
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_json_deltas_concatenate():
+    """All TOOL_CALL_ARGS deltas concatenate to valid JSON."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    all_events = await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+
+    # Continuations
+    pa1 = _make_partial_arg("$.document", "Hello ")
+    fc2 = _make_func_call(partial_args=[pa1], will_continue=True, fc_id="adk-2")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc2], partial=True))
+
+    pa2 = _make_partial_arg("$.document", "World")
+    fc3 = _make_func_call(partial_args=[pa2], will_continue=True, fc_id="adk-3")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc3], partial=True))
+
+    # End marker
+    fc_end = _make_func_call(fc_id="adk-4")
+    all_events += await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    # Concatenate all TOOL_CALL_ARGS deltas
+    args_deltas = [e.delta for e in all_events if "TOOL_CALL_ARGS" in str(e.type)]
+    full_json = "".join(args_deltas)
+
+    # Should be valid JSON
+    parsed = json.loads(full_json)
+    assert parsed == {"document": "Hello World"}
+
+
+# ============================================================================
+# Duplicate suppression tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_suppresses_final_aggregated():
+    """Final aggregated (non-partial) event is suppressed after streaming."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # Stream: first -> end (minimal)
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+
+    fc_end = _make_func_call(fc_id="adk-2")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    # Final aggregated (non-partial) event
+    fc_final = _make_func_call(
+        name="write_document", args={"document": "full content"}, fc_id="adk-final"
+    )
+    final_event = _make_adk_event(func_calls=[fc_final], partial=False)
+    events = await _collect_events(translator, final_event)
+
+    types = _event_types(events)
+    # Should NOT emit duplicate TOOL_CALL events
+    assert "TOOL_CALL_START" not in types
+    assert "TOOL_CALL_END" not in types
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_confirmed_id_remapped():
+    """Confirmed FC id is remapped to streaming id for TOOL_CALL_RESULT."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # Stream: first -> end
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    start_events = await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+    streaming_id = start_events[0].tool_call_id
+
+    fc_end = _make_func_call(fc_id="adk-2")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    # Final aggregated triggers ID mapping
+    fc_final = _make_func_call(
+        name="write_document", args={"document": "content"}, fc_id="adk-final"
+    )
+    await _collect_events(translator, _make_adk_event(func_calls=[fc_final], partial=False))
+
+    # Check ID mapping exists
+    assert "adk-final" in translator._confirmed_to_streaming_id
+    assert translator._confirmed_to_streaming_id["adk-final"] == streaming_id
+
+
+# ============================================================================
+# Stable ID tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_uses_stable_id():
+    """All events in a streaming sequence use the same tool_call_id."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    events1 = await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+    start_id = events1[0].tool_call_id
+
+    # Continuation
+    pa = _make_partial_arg("$.document", "hello")
+    fc2 = _make_func_call(partial_args=[pa], will_continue=True, fc_id="adk-2")
+    events2 = await _collect_events(translator, _make_adk_event(func_calls=[fc2], partial=True))
+
+    # End
+    fc_end = _make_func_call(fc_id="adk-3")
+    events3 = await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    # All events should use the same stable ID
+    all_ids = set()
+    for e in events1 + events2 + events3:
+        if hasattr(e, 'tool_call_id'):
+            all_ids.add(e.tool_call_id)
+
+    assert len(all_ids) == 1
+    assert start_id in all_ids
+
+
+# ============================================================================
+# PredictState integration tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_with_predict_state():
+    """PredictState CustomEvent is emitted before TOOL_CALL_START during streaming."""
+    translator = EventTranslator(
+        streaming_function_call_arguments=True,
+        predict_state=[
+            PredictStateMapping(
+                state_key="document",
+                tool="write_document",
+                tool_argument="document",
+            )
+        ],
+    )
+
+    fc = _make_func_call(name="write_document", will_continue=True)
+    adk_event = _make_adk_event(func_calls=[fc], partial=True)
+    events = await _collect_events(translator, adk_event)
+
+    types = _event_types(events)
+    assert "CUSTOM" in types
+    assert "TOOL_CALL_START" in types
+    # PredictState should come before TOOL_CALL_START
+    custom_idx = types.index("CUSTOM")
+    start_idx = types.index("TOOL_CALL_START")
+    assert custom_idx < start_idx
+
+    custom_event = events[custom_idx]
+    assert custom_event.name == "PredictState"
+
+
+# ============================================================================
+# Reset tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_resets_on_reset():
+    """reset() clears all streaming FC state."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # Start streaming
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+    assert translator._active_streaming_fc_id is not None
+
+    # Reset
+    translator.reset()
+
+    # State should be clean
+    assert translator._active_streaming_fc_id is None
+    assert translator._active_streaming_fc_name is None
+    assert len(translator._streaming_fc_open_paths) == 0
+    assert len(translator._streaming_fc_started_paths) == 0
+    assert len(translator._completed_streaming_fc_names) == 0
+    assert translator._last_completed_streaming_fc_name is None
+
+
+# ============================================================================
+# Version gate tests
+# ============================================================================
+
+
+def test_adk_version_gate():
+    """_adk_supports_streaming_fc_args() returns True for current ADK (>=1.24.0)."""
+    assert ADKAgent._adk_supports_streaming_fc_args() is True
+
+
+# ============================================================================
+# Edge case tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_stray_chunk_ignored():
+    """Nameless chunks without active streaming are ignored."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # Send a continuation chunk without a preceding first chunk
+    pa = _make_partial_arg("$.document", "orphan")
+    fc = _make_func_call(partial_args=[pa], will_continue=True, fc_id="adk-stray")
+    adk_event = _make_adk_event(func_calls=[fc], partial=True)
+
+    events = await _collect_events(translator, adk_event)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_START" not in types
+    assert "TOOL_CALL_ARGS" not in types
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_special_chars_escaped():
+    """Special characters in partial_args are properly JSON-escaped in deltas."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+
+    # Continuation with special chars
+    pa = _make_partial_arg("$.document", 'He said "hello"\nNew line')
+    fc2 = _make_func_call(partial_args=[pa], will_continue=True, fc_id="adk-2")
+    events = await _collect_events(translator, _make_adk_event(func_calls=[fc2], partial=True))
+
+    # End
+    fc_end = _make_func_call(fc_id="adk-3")
+    end_events = await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+
+    # Concatenate all args deltas and verify valid JSON
+    all_events = events + end_events
+    args_deltas = [e.delta for e in all_events if "TOOL_CALL_ARGS" in str(e.type)]
+    full_json = "".join(args_deltas)
+    parsed = json.loads(full_json)
+    assert parsed == {"document": 'He said "hello"\nNew line'}
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_lro_skipped():
+    """LRO function calls in partial events are skipped by streaming detection."""
+    translator = EventTranslator(streaming_function_call_arguments=True)
+
+    fc = _make_func_call(name="write_document", will_continue=True, fc_id="lro-1")
+    adk_event = _make_adk_event(func_calls=[fc], partial=True, lro_ids=["lro-1"])
+
+    events = await _collect_events(translator, adk_event)
+    types = _event_types(events)
+
+    assert "TOOL_CALL_START" not in types
+
+
+@pytest.mark.asyncio
+async def test_streaming_fc_deferred_end_for_stream_tool_call():
+    """stream_tool_call=True defers TOOL_CALL_END."""
+    translator = EventTranslator(
+        streaming_function_call_arguments=True,
+        predict_state=[
+            PredictStateMapping(
+                state_key="document",
+                tool="write_document",
+                tool_argument="document",
+                stream_tool_call=True,
+            )
+        ],
+    )
+
+    # First chunk
+    fc1 = _make_func_call(name="write_document", will_continue=True, fc_id="adk-1")
+    await _collect_events(translator, _make_adk_event(func_calls=[fc1], partial=True))
+
+    # End marker
+    fc_end = _make_func_call(fc_id="adk-2")
+    events = await _collect_events(translator, _make_adk_event(func_calls=[fc_end], partial=True))
+    types = _event_types(events)
+
+    # TOOL_CALL_END should NOT be emitted (deferred)
+    assert "TOOL_CALL_END" not in types


### PR DESCRIPTION
Restore streaming FC args support now that google/adk-python#4311 is fixed upstream in google-adk 1.24.0.  The feature is version-gated: ADKAgent checks for the partial_args field on FunctionCall at init and silently disables itself on older ADK versions.

When enabled, partial events from SSE streaming are intercepted by a new Mode A path in EventTranslator which emits incremental TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END events with stable IDs.  JSON deltas are emitted as concatenable fragments so clients can reconstruct the full arguments by joining all deltas.  The final aggregated (non-partial) event is suppressed and its FC ID is remapped so TOOL_CALL_RESULT uses the streaming ID.

**Note:** This does **not** work when using a simple GOOGLE_API_KEY; you'll need to use Vertex AI to see this feature in action.

Also adds stream_tool_call to PredictStateMapping for deferring TOOL_CALL_END in LRO/HITL flows, and integrates PredictState CustomEvent emission on streaming start.
<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
