### PR TITLE
fix (langgraph): resolve deprecation warnings in ag-ui-langgraph for Pydantic v2 …

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -111,7 +111,7 @@ class LangGraphAgent:
             forwarded_props = {
                 camel_to_snake(k): v for k, v in input.forwarded_props.items()
             }
-        async for event_str in self._handle_stream_events(input.copy(update={"forwarded_props": forwarded_props})):
+        async for event_str in self._handle_stream_events(input.model_copy(update={"forwarded_props": forwarded_props})):
             yield event_str
 
     async def _handle_stream_events(self, input: RunAgentInput) -> AsyncGenerator[str, None]:
@@ -413,15 +413,15 @@ class LangGraphAgent:
         try:
             input_schema = self.graph.get_input_jsonschema(config)
             output_schema = self.graph.get_output_jsonschema(config)
-            config_schema = self.graph.config_schema().schema()
+            config_schema = self.graph.get_context_jsonschema() or {}
 
             input_schema_keys = list(input_schema["properties"].keys()) if "properties" in input_schema else []
             output_schema_keys = list(output_schema["properties"].keys()) if "properties" in output_schema else []
             config_schema_keys = list(config_schema["properties"].keys()) if "properties" in config_schema else []
             context_schema_keys = []
 
-            if hasattr(self.graph, "context_schema") and self.graph.context_schema is not None:
-                context_schema = self.graph.context_schema().schema()
+            context_schema = self.graph.get_context_jsonschema()
+            if context_schema is not None:
                 context_schema_keys = list(context_schema["properties"].keys()) if "properties" in context_schema else []
 
 


### PR DESCRIPTION
…and LangGraph v1.0

- Replace Pydantic `copy()` with `model_copy()` (deprecated in Pydantic v2, removal in v3)
- Replace `config_schema().schema()` with `get_context_jsonschema()` (config_schema deprecated in LangGraph v0.6.0)
- Replace `context_schema().schema()` with `get_context_jsonschema()` (schema() deprecated in Pydantic v2)

Closes #1128

https://claude.ai/code/session_01Ri9H5D3FUemQHPZbby6DT1


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
