### PR TITLE
Fix permissions on publish script

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # Required for PyPI trusted publishing
+      organization: read # Required for CODEOWNERS team membership checks
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The script needs read org permissions for checking codeowners groups