### PR TITLE
chore(.github): Add contribution options to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -51,3 +51,15 @@ body:
       description: Anything else — mockups, code snippets, related issues, links, etc.
     validations:
       required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Would you like to work on this?
+      description: We welcome contributions! Let us know if you’d like to help implement this feature.
+      options:
+        - label: Yes, I’d love to work on it!
+        - label: I’m open to collaborating but need guidance.
+        - label: No, I’m just sharing the idea.
+    validations:
+      required: false


### PR DESCRIPTION
Added a contribution checkbox section to the feature request template to gauge interest in collaboration.


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
