### PR TITLE
remove group from subrows on codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
 * @ag-ui-protocol/copilotkit
 
-sdks/community/java @pascalwilbrink @ag-ui-protocol/copilotkit
-docs/sdk/java @pascalwilbrink @ag-ui-protocol/copilotkit
+sdks/community/java @pascalwilbrink
+docs/sdk/java @pascalwilbrink
 
-sdks/community/kotlin @contextablemark @ag-ui-protocol/copilotkit
-docs/sdk/kotlin @contextablemark @ag-ui-protocol/copilotkit
+sdks/community/kotlin @contextablemark
+docs/sdk/kotlin @contextablemark
 
-sdks/community/go @mattsp1290 @ag-ui-protocol/copilotkit
-docs/sdk/go @mattsp1290 @ag-ui-protocol/copilotkit
+sdks/community/go @mattsp1290
+docs/sdk/go @mattsp1290
 
-sdks/community/dart @mattsp1290 @ag-ui-protocol/copilotkit
-docs/sdk/dart @mattsp1290 @ag-ui-protocol/copilotkit
+sdks/community/dart @mattsp1290
+docs/sdk/dart @mattsp1290
 
-integrations/adk-middleware @contextablemark @ag-ui-protocol/copilotkit
+integrations/adk-middleware @contextablemark
 
-integrations/agent-spec @sonleoracle @ag-ui-protocol/copilotkit
+integrations/agent-spec @sonleoracle


### PR DESCRIPTION
Since reordering didn't remove the gate, perhaps not having it sublisted will?