### PR TITLE
fix: make Tool.parameters optional in both TypeScript and Python SDKs

### DIFF
--- a/sdks/python/ag_ui/core/types.py
+++ b/sdks/python/ag_ui/core/types.py
@@ -176,7 +176,7 @@ class Tool(ConfiguredBaseModel):
     """
     name: str
     description: str
-    parameters: Any  # JSON Schema for the tool parameters
+    parameters: Optional[Any] = None  # JSON Schema for the tool parameters
 
 
 class RunAgentInput(ConfiguredBaseModel):

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -134,7 +134,7 @@ export const ContextSchema = z.object({
 export const ToolSchema = z.object({
   name: z.string(),
   description: z.string(),
-  parameters: z.any(), // JSON Schema for the tool parameters
+  parameters: z.any().optional(), // JSON Schema for the tool parameters
 });
 
 export const RunAgentInputSchema = z.object({


### PR DESCRIPTION
The `parameters` field on the `Tool` type was effectively optional in TypeScript (z.any() accepts undefined) but required in Python's Pydantic model. This caused validation errors when passing Tool definitions without parameters from TypeScript to Python.

Align both SDKs by making `parameters` explicitly optional:
- TypeScript: `z.any()` → `z.any().optional()`
- Python: `parameters: Any` → `parameters: Optional[Any] = None`

Closes #1185

https://claude.ai/code/session_01DgjbeYXdWrfCKU8vq47m3Q


<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->
