### PR TITLE
fix(python-sdk): align ReasoningMessageStartEvent.role with TypeScript SDK

### DIFF
--- a/sdks/python/tests/test_events.py
+++ b/sdks/python/tests/test_events.py
@@ -26,6 +26,7 @@ from ag_ui.core.events import (
     RunErrorEvent,
     StepStartedEvent,
     StepFinishedEvent,
+    ReasoningMessageStartEvent,
     Event
 )
 
@@ -636,6 +637,52 @@ class TestEvents(unittest.TestCase):
         
         # Verify Unicode and special characters are preserved
         self.assertEqual(deserialized.delta, text)
+
+
+    def test_reasoning_message_start_event_role_is_reasoning(self):
+        """Test that ReasoningMessageStartEvent uses role='reasoning' to match TypeScript SDK.
+
+        Regression test for GitHub issue #1169: the Python SDK previously used
+        role='assistant' while the TypeScript SDK used role='reasoning', causing
+        wire-incompatibility between the two SDKs.
+        """
+        # Creating with role="reasoning" should succeed
+        event = ReasoningMessageStartEvent(
+            message_id="msg_reasoning_1",
+            role="reasoning",
+            timestamp=1648214400000,
+        )
+        self.assertEqual(event.role, "reasoning")
+        self.assertEqual(event.message_id, "msg_reasoning_1")
+
+        # Test serialization produces role="reasoning"
+        serialized = event.model_dump(by_alias=True)
+        self.assertEqual(serialized["role"], "reasoning")
+        self.assertEqual(serialized["type"], "REASONING_MESSAGE_START")
+
+        # Test deserialization from JSON (simulating TypeScript SDK wire format)
+        event_adapter = TypeAdapter(Event)
+        json_data = json.dumps({
+            "type": "REASONING_MESSAGE_START",
+            "messageId": "msg_reasoning_2",
+            "role": "reasoning",
+            "timestamp": 1648214400000,
+        })
+        deserialized = event_adapter.validate_json(json_data)
+        self.assertIsInstance(deserialized, ReasoningMessageStartEvent)
+        self.assertEqual(deserialized.role, "reasoning")
+
+    def test_reasoning_message_start_event_rejects_assistant_role(self):
+        """Test that ReasoningMessageStartEvent rejects role='assistant'.
+
+        After fixing issue #1169, role='assistant' should no longer be accepted.
+        """
+        with self.assertRaises(ValidationError):
+            ReasoningMessageStartEvent(
+                message_id="msg_bad",
+                role="assistant",
+                timestamp=1648214400000,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1169

- Changed `ReasoningMessageRole` from `Literal["assistant"]` to `Literal["reasoning"]` in the Python SDK's `events.py`
- This aligns the Python SDK with the TypeScript SDK, which uses `z.literal("reasoning")` for the same field
- Both SDKs already agreed on `role: "reasoning"` in their `ReasoningMessage` type definitions — only the Python event definition was out of sync

## Root Cause

The Python SDK's `ReasoningMessageStartEvent` defined `role` as `Literal["assistant"]` (line 284 of `events.py`), while the TypeScript SDK defined it as `z.literal("reasoning")` (line 255 of `events.ts`). This made the two SDKs wire-incompatible: a Python backend emitting `REASONING_MESSAGE_START` with `role="assistant"` would be rejected by the TypeScript client's Zod parser, which expects `"reasoning"`.

## Changes

- **`sdks/python/ag_ui/core/events.py`** (line 284): Changed `ReasoningMessageRole = Literal["assistant"]` to `ReasoningMessageRole = Literal["reasoning"]`
- **`sdks/python/tests/test_events.py`**: Added two regression tests:
  - `test_reasoning_message_start_event_role_is_reasoning` — verifies creation, serialization, and deserialization with `role="reasoning"`
  - `test_reasoning_message_start_event_rejects_assistant_role` — verifies that `role="assistant"` is now rejected with a `ValidationError`

## Test plan

- [x] New tests fail before the fix (confirmed: `role="reasoning"` rejected by `Literal["assistant"]`)
- [x] New tests pass after the fix
- [x] Full Python SDK test suite passes (64 tests, 0 failures)
- [ ] CI passes
