### PR TITLE
fix: make Tool.parameters optional in Python SDK

### DIFF
--- a/sdks/python/ag_ui/core/types.py
+++ b/sdks/python/ag_ui/core/types.py
@@ -176,7 +176,7 @@ class Tool(ConfiguredBaseModel):
     """
     name: str
     description: str
-    parameters: Any  # JSON Schema for the tool parameters
+    parameters: Optional[Any] = None  # JSON Schema for the tool parameters
 
 
 class RunAgentInput(ConfiguredBaseModel):

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -4,6 +4,7 @@ from pydantic import TypeAdapter
 
 from ag_ui.core.types import (
     FunctionCall,
+    Tool,
     ToolCall,
     DeveloperMessage,
     SystemMessage,
@@ -757,6 +758,55 @@ class TestBaseTypes(unittest.TestCase):
             deserialized.state["session"]["user"]["preferences"]["filters"],
             ["important", "urgent"]
         )
+
+
+    def test_tool_without_parameters(self):
+        """Test that Tool can be created without parameters (issue #1185).
+
+        In TypeScript, z.any() accepts undefined, making parameters optional.
+        The Python SDK should match this behavior by allowing parameters to be
+        omitted.
+        """
+        # Creating a Tool without parameters should succeed
+        tool = Tool(name="simple_tool", description="A tool with no parameters")
+        self.assertEqual(tool.name, "simple_tool")
+        self.assertEqual(tool.description, "A tool with no parameters")
+        self.assertIsNone(tool.parameters)
+
+    def test_tool_without_parameters_json(self):
+        """Test that Tool can be deserialized from JSON without parameters."""
+        json_data = {
+            "name": "simple_tool",
+            "description": "A tool with no parameters"
+        }
+        tool = Tool.model_validate(json_data)
+        self.assertEqual(tool.name, "simple_tool")
+        self.assertIsNone(tool.parameters)
+
+    def test_tool_with_parameters_still_works(self):
+        """Test that Tool with parameters continues to work after the fix."""
+        tool = Tool(
+            name="parameterized_tool",
+            description="A tool with parameters",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"}
+                },
+                "required": ["query"]
+            }
+        )
+        self.assertEqual(tool.name, "parameterized_tool")
+        self.assertIsNotNone(tool.parameters)
+        self.assertEqual(tool.parameters["type"], "object")
+
+    def test_tool_without_parameters_serialization_round_trip(self):
+        """Test serialization round-trip for Tool without parameters."""
+        tool = Tool(name="no_params", description="No params tool")
+        serialized = tool.model_dump(by_alias=True)
+        deserialized = Tool.model_validate(serialized)
+        self.assertEqual(deserialized.name, "no_params")
+        self.assertIsNone(deserialized.parameters)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1185

The `Tool.parameters` field was **required** in the Python Pydantic model but **optional** in the TypeScript SDK (`z.any()` accepts `undefined`). This caused `Pydantic ValidationError` when passing Tool definitions without `parameters` from TypeScript to Python.

## Root Cause

In `sdks/python/ag_ui/core/types.py`, the `Tool` class defined `parameters: Any` which Pydantic treats as a required field. In contrast, the TypeScript SDK uses `z.any()` which accepts `undefined`, making it effectively optional.

## Fix

- Changed `parameters: Any` to `parameters: Optional[Any] = None` in the Python `Tool` model
- No TypeScript changes needed — `z.any()` already accepts `undefined`

## Tests Added

Four new tests in `sdks/python/tests/test_types.py`:

- `test_tool_without_parameters` — creates a `Tool` without parameters via constructor
- `test_tool_without_parameters_json` — deserializes a `Tool` from JSON without parameters
- `test_tool_with_parameters_still_works` — ensures existing behavior with parameters is preserved
- `test_tool_without_parameters_serialization_round_trip` — verifies serialize/deserialize round-trip

All 66 tests pass (0 failures, 0 regressions).