### PR TITLE
fix(client,encoder,proto): move @ag-ui/core to peerDependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,9 +1080,6 @@ importers:
 
   sdks/typescript/packages/client:
     dependencies:
-      '@ag-ui/core':
-        specifier: workspace:*
-        version: link:../core
       '@ag-ui/encoder':
         specifier: workspace:*
         version: link:../encoder
@@ -1111,6 +1108,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@ag-ui/core':
+        specifier: workspace:*
+        version: link:../core
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1163,13 +1163,13 @@ importers:
 
   sdks/typescript/packages/encoder:
     dependencies:
-      '@ag-ui/core':
-        specifier: workspace:*
-        version: link:../core
       '@ag-ui/proto':
         specifier: workspace:*
         version: link:../proto
     devDependencies:
+      '@ag-ui/core':
+        specifier: workspace:*
+        version: link:../core
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4
@@ -1191,9 +1191,6 @@ importers:
 
   sdks/typescript/packages/proto:
     dependencies:
-      '@ag-ui/core':
-        specifier: workspace:*
-        version: link:../core
       '@bufbuild/protobuf':
         specifier: ^2.2.5
         version: 2.9.0
@@ -1201,6 +1198,9 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1
     devDependencies:
+      '@ag-ui/core':
+        specifier: workspace:*
+        version: link:../core
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4

--- a/sdks/typescript/packages/client/package.json
+++ b/sdks/typescript/packages/client/package.json
@@ -27,7 +27,6 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/core": "workspace:*",
     "@ag-ui/encoder": "workspace:*",
     "@ag-ui/proto": "workspace:*",
     "@types/uuid": "^10.0.0",
@@ -38,7 +37,11 @@
     "uuid": "^11.1.0",
     "zod": "^3.22.4"
   },
+  "peerDependencies": {
+    "@ag-ui/core": ">=0.0.42"
+  },
   "devDependencies": {
+    "@ag-ui/core": "workspace:*",
     "@types/node": "^20.11.19",
     "@vitest/coverage-istanbul": "^4.0.18",
     "publint": "^0.3.12",

--- a/sdks/typescript/packages/encoder/package.json
+++ b/sdks/typescript/packages/encoder/package.json
@@ -22,10 +22,13 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/core": "workspace:*",
     "@ag-ui/proto": "workspace:*"
   },
+  "peerDependencies": {
+    "@ag-ui/core": ">=0.0.42"
+  },
   "devDependencies": {
+    "@ag-ui/core": "workspace:*",
     "@vitest/coverage-istanbul": "^4.0.18",
     "publint": "^0.3.12",
     "@arethetypeswrong/cli": "^0.17.4",

--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -23,11 +23,14 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/core": "workspace:*",
     "@bufbuild/protobuf": "^2.2.5",
     "@protobuf-ts/protoc": "^2.11.1"
   },
+  "peerDependencies": {
+    "@ag-ui/core": ">=0.0.42"
+  },
   "devDependencies": {
+    "@ag-ui/core": "workspace:*",
     "@vitest/coverage-istanbul": "^4.0.18",
     "publint": "^0.3.12",
     "@arethetypeswrong/cli": "^0.17.4",


### PR DESCRIPTION
## Summary

- Moves `@ag-ui/core` from `dependencies` to `peerDependencies` (>=0.0.42) in `@ag-ui/client`, `@ag-ui/encoder`, and `@ag-ui/proto`
- Adds `@ag-ui/core` to `devDependencies` in each package so local development and tests continue to work via the workspace link
- Prevents multiple nested copies of `@ag-ui/core` from being installed when consumers use different versions of these packages

## Root Cause

When `@ag-ui/core` is listed as a regular dependency in `@ag-ui/client`, `@ag-ui/encoder`, and `@ag-ui/proto`, each published version of those packages bundles its own copy of `@ag-ui/core`. In a project that uses multiple packages depending on different versions of `@ag-ui/client` (e.g., `@copilotkit/runtime` using `@ag-ui/client@0.0.43` alongside a direct dependency on `@ag-ui/client@0.0.45`), the package manager installs separate nested copies of `@ag-ui/core` (0.0.42, 0.0.43, 0.0.45). TypeScript treats these as distinct types, causing type mismatches with `AbstractAgent`, `BaseEvent`, `Message`, `RunAgentInput`, etc.

## Fix

Declaring `@ag-ui/core` as a `peerDependency` instructs the package manager to use the single `@ag-ui/core` instance provided by the consumer's project rather than nesting separate copies. This ensures all packages share the same type definitions.

## Tests

- All 330 existing tests pass across 42 test files (core, client, encoder, proto)
- TypeScript type checking passes
- A traditional unit test is not feasible for this issue because it is a dependency resolution / type compatibility problem that only manifests when multiple versions of `@ag-ui/core` are installed in a consumer project. The fix is verified by the dependency structure change itself and by confirming no regressions in the existing test suite.

Fixes #1176