### PR TITLE
fix(client): guard process.env access for browser compatibility

### DIFF
--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -250,7 +250,9 @@ export async function runSubscribersWithMutation(
     } catch (error) {
       // Log subscriber errors but continue processing (silence during tests)
       const isTestEnvironment =
-        process.env.NODE_ENV === "test" || process.env.VITEST_WORKER_ID !== undefined;
+        typeof process !== "undefined" &&
+        typeof process.env !== "undefined" &&
+        (process.env.NODE_ENV === "test" || process.env.VITEST_WORKER_ID !== undefined);
 
       if (!isTestEnvironment) {
         console.error("Subscriber error:", error);

--- a/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
+++ b/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
@@ -33,7 +33,12 @@ export class BackwardCompatibility_0_0_45 extends Middleware {
   private currentMessageId: string | null = null;
 
   private warnAboutTransformation(from: string, to: string) {
-    if (process.env.SUPPRESS_TRANSFORMATION_WARNINGS) return;
+    if (
+      typeof process !== "undefined" &&
+      typeof process.env !== "undefined" &&
+      process.env.SUPPRESS_TRANSFORMATION_WARNINGS
+    )
+      return;
     console.warn(
       `AG-UI is converting ${from} to ${to}. To remove this warning, upgrade your AG-UI integration package (e.g. @ag-ui/langgraph). To surpress it, set SUPPRESS_TRANSFORMATION_WARNINGS=true in your .env file.`,
     );


### PR DESCRIPTION
## Summary

Fixes #1191

The `@ag-ui/client` package directly accesses `process.env` in two locations without checking if the `process` global exists:

1. **`subscriber.ts:253`** — Error handler in `processSubscribers()` accesses `process.env.NODE_ENV` and `process.env.VITEST_WORKER_ID` to detect test environments
2. **`backward-compatibility-0-0-45.ts:36`** — `warnAboutTransformation()` accesses `process.env.SUPPRESS_TRANSFORMATION_WARNINGS`

In browser environments where `process` is not defined, this throws a `ReferenceError` that:
- Swallows the original subscriber error and its stack trace (critical for debugging)
- Prevents transformation warnings from being displayed

## Fix

Add `typeof process !== 'undefined' && typeof process.env !== 'undefined'` guards before all `process.env` access. This is the standard pattern for isomorphic (Node.js + browser) code.

## Testing

- All 294 existing tests pass (2 consecutive clean runs)
- 12 proto-related test files fail with pre-existing `Cannot find module './generated/events'` error (unrelated)