### PR TITLE
fix(python): align ReasoningMessageStartEvent.role with TypeScript SDK

### DIFF
--- a/sdks/python/ag_ui/core/events.py
+++ b/sdks/python/ag_ui/core/events.py
@@ -282,8 +282,8 @@ class StepFinishedEvent(BaseEvent):
     step_name: str
 
 
-# Text message role for reasoning messages (only assistant can reason)
-ReasoningMessageRole = Literal["assistant"]
+# Text message role for reasoning messages (aligned with ReasoningMessage.role)
+ReasoningMessageRole = Literal["reasoning"]
 
 # Subtype for encrypted value
 ReasoningEncryptedValueSubtype = Literal["tool-call", "message"]


### PR DESCRIPTION
## Summary

Fixes #1169

The Python SDK defines `ReasoningMessageRole = Literal["assistant"]` while the TypeScript SDK uses `z.literal("reasoning")` for `ReasoningMessageStartEvent.role`. This makes the two SDKs **wire-incompatible** — a Python backend emitting `REASONING_MESSAGE_START` with `role: "assistant"` is rejected by the TypeScript client's Zod parser with:

```
ZodError: Invalid literal value, expected "reasoning"
```

### Root Cause

Both SDKs already agree that `ReasoningMessage.role` is `"reasoning"` in their type definitions:
- **Python** `types.py:144`: `role: Literal["reasoning"] = "reasoning"`
- **TypeScript** `types.ts:104`: `role: z.literal("reasoning")`

The Python **event** definition (`events.py:284`) was out of sync with both the TypeScript event and the shared `ReasoningMessage` type.

### Fix

Change `ReasoningMessageRole` from `Literal["assistant"]` to `Literal["reasoning"]` in `sdks/python/ag_ui/core/events.py`.

### Testing

All 62 Python unit tests pass (2 consecutive clean runs).