### PR TITLE
fix(python): make Tool.parameters optional to match TypeScript SDK

### DIFF
--- a/sdks/python/ag_ui/core/types.py
+++ b/sdks/python/ag_ui/core/types.py
@@ -176,7 +176,7 @@ class Tool(ConfiguredBaseModel):
     """
     name: str
     description: str
-    parameters: Any  # JSON Schema for the tool parameters
+    parameters: Optional[Any] = None  # JSON Schema for the tool parameters
 
 
 class RunAgentInput(ConfiguredBaseModel):


### PR DESCRIPTION
## Summary

Fixes #1185

In the TypeScript SDK, `ToolSchema.parameters` uses `z.any()` which accepts `undefined`, making the field effectively optional:

```typescript
// TypeScript — parameters is optional
const ToolSchema = z.object({
  name: z.string(),
  description: z.string(),
  parameters: z.any(), // accepts undefined
});
type Tool = z.infer<typeof ToolSchema>;
// -> { name: string; description: string; parameters?: any }
```

The Python SDK defines `parameters: Any` without a default, making it **required** by Pydantic:

```python
# Python — parameters is required
class Tool(ConfiguredBaseModel):
    parameters: Any  # Pydantic requires this field
```

This causes `ValidationError: Field required` when a Tool definition from TypeScript (omitting parameters) is deserialized by the Python SDK.

### Fix

Change `parameters: Any` to `parameters: Optional[Any] = None` to align with TypeScript behavior.

### Testing

All 62 Python unit tests pass (2 consecutive clean runs).