### PR TITLE
fix(mastra): handle non-JSON working memory templates gracefully

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -107,9 +107,14 @@ export class MastraAgent extends AbstractAgent {
               };
             }
 
-            const existingMemory = JSON.parse(
-              (thread.metadata?.workingMemory as string) ?? "{}",
-            );
+            let existingMemory: Record<string, unknown> = {};
+            try {
+              existingMemory = JSON.parse(
+                (thread.metadata?.workingMemory as string) ?? "{}",
+              );
+            } catch {
+              // Working memory may be a non-JSON template (e.g. markdown)
+            }
             const { messages, ...rest } = input.state;
             const workingMemory = JSON.stringify({
               ...existingMemory,
@@ -199,15 +204,24 @@ export class MastraAgent extends AbstractAgent {
                     });
 
                     if (typeof workingMemory === "string") {
-                      const snapshot = JSON.parse(workingMemory);
+                      try {
+                        const snapshot = JSON.parse(workingMemory);
 
-                      if (snapshot && !("$schema" in snapshot)) {
-                        const stateSnapshotEvent: StateSnapshotEvent = {
+                        if (snapshot && !("$schema" in snapshot)) {
+                          const stateSnapshotEvent: StateSnapshotEvent = {
+                            type: EventType.STATE_SNAPSHOT,
+                            snapshot,
+                          };
+
+                          subscriber.next(stateSnapshotEvent);
+                        }
+                      } catch {
+                        // Working memory may be a non-JSON template (e.g. markdown);
+                        // emit it as a raw snapshot value so consumers still receive it
+                        subscriber.next({
                           type: EventType.STATE_SNAPSHOT,
-                          snapshot,
-                        };
-
-                        subscriber.next(stateSnapshotEvent);
+                          snapshot: { workingMemory },
+                        } as StateSnapshotEvent);
                       }
                     }
                   }


### PR DESCRIPTION
## Summary

Fixes #461

When users configure WorkingMemory with a markdown template and `scope: "thread"`, the Mastra integration crashes with:

```
SyntaxError: Unexpected token '#', "# User Pro"… is not valid JSON
  at JSON.parse ()
  at onRunFinished (@ag-ui/mastra/dist/index.mjs)
```

### Root Cause

`JSON.parse` is called unconditionally on the working memory content in two locations:

1. **Thread metadata initialization** (line 110): `JSON.parse(thread.metadata?.workingMemory ?? "{}")`
2. **`onRunFinished` state snapshot** (line 202): `JSON.parse(workingMemory)`

When the working memory template is a markdown string (e.g. `# User Profile`), these calls throw.

### Fix

Wrap both `JSON.parse` calls in try-catch blocks:
- **Metadata initialization**: Falls back to an empty object `{}`, allowing the state merge to proceed
- **State snapshot emission**: Falls back to emitting the raw template string as a wrapped snapshot value (`{ workingMemory }`) so consumers still receive the content

This makes behavior consistent regardless of the `scope` setting (`"thread"` vs `"resource"`).

### Testing

- TypeScript type-check shows identical pre-existing errors before and after the change (0 regressions)
- No test files exist for the Mastra integration yet