### PR TITLE
fix(dojo): pin @langchain/langgraph-cli to 1.1.13

### DIFF
--- a/apps/dojo/scripts/run-dojo-everything.js
+++ b/apps/dojo/scripts/run-dojo-everything.js
@@ -4,6 +4,10 @@ const { execSync } = require('child_process');
 const path = require('path');
 const concurrently = require('concurrently');
 
+// Pinned: @langchain/langgraph-api@1.1.14 regressed schema extraction, causing
+// worker timeouts on CI runners. Re-evaluate when a newer version fixes the issue.
+const LANGGRAPH_CLI_VERSION = '1.1.13';
+
 // Parse command line arguments
 const args = process.argv.slice(2);
 const showHelp = args.includes('--help') || args.includes('-h');
@@ -85,13 +89,13 @@ const ALL_SERVICES = {
     env: { PORT: 8004 },
   }],
   'langgraph-platform-python': [{
-    command: 'pnpx @langchain/langgraph-cli@latest dev --no-browser --host 127.0.0.1 --port 8005',
+    command: `pnpx @langchain/langgraph-cli@${LANGGRAPH_CLI_VERSION} dev --no-browser --host 127.0.0.1 --port 8005`,
     name: 'LG Platform Py',
     cwd: path.join(integrationsRoot, 'langgraph/python/examples'),
     env: { PORT: 8005 },
   }],
   'langgraph-platform-typescript': [{
-    command: 'pnpx @langchain/langgraph-cli@latest dev --no-browser --host 127.0.0.1 --port 8006',
+    command: `pnpx @langchain/langgraph-cli@${LANGGRAPH_CLI_VERSION} dev --no-browser --host 127.0.0.1 --port 8006`,
     name: 'LG Platform TS',
     cwd: path.join(integrationsRoot, 'langgraph/typescript/examples'),
     env: { PORT: 8006 },

--- a/integrations/langgraph/python/examples/README.md
+++ b/integrations/langgraph/python/examples/README.md
@@ -7,7 +7,7 @@ First, make sure to create a new .env file from the .env.example and include the
 To run the Python examples for langgraph platform, run:
 ```
 cd integrations/langgraph/python/examples
-pnpx @langchain/langgraph-cli@latest dev
+pnpx @langchain/langgraph-cli@1.1.13 dev
 ```
 
 To run the python examples using FastAPI, run:

--- a/integrations/langgraph/typescript/examples/README.md
+++ b/integrations/langgraph/typescript/examples/README.md
@@ -24,7 +24,7 @@ For TypeScript development, run:
 
 ```bash
 npm run build
-pnpx @langchain/langgraph-cli@latest dev
+pnpx @langchain/langgraph-cli@1.1.13 dev
 ```
 
 ## Available Agents

--- a/integrations/langgraph/typescript/examples/package.json
+++ b/integrations/langgraph/typescript/examples/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "dev": "pnpx @langchain/langgraph-cli@latest dev",
+    "dev": "pnpx @langchain/langgraph-cli@1.1.13 dev",
     "start": "node dist/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Pins `@langchain/langgraph-cli` from `@latest` to `@1.1.13` across all references
- `@langchain/langgraph-api@1.1.14` (released Feb 26) introduced a schema extraction regression that causes worker timeouts on CI runners
- Last passing CI: Feb 25 (pre-1.1.14). Every run since Feb 27 fails `langgraph-typescript`
- Centralizes the version in a `LANGGRAPH_CLI_VERSION` constant in `run-dojo-everything.js` with an explanatory comment

**Files changed:**
- `apps/dojo/scripts/run-dojo-everything.js` — constant + 2 template literal references
- `integrations/langgraph/typescript/examples/package.json` — dev script
- `integrations/langgraph/typescript/examples/README.md`
- `integrations/langgraph/python/examples/README.md`

This unblocks all PRs (including CopilotKit's `e2e_dojo.yml` which checks out ag-ui at `ref: main`).

## Test plan

- [ ] `langgraph-typescript` dojo e2e test passes in CI
- [x] Verified locally that 1.1.13 starts and serves schemas correctly