### PR TITLE
Serialize pnpm installs in prep-dojo-everything.js to fix race condition

### DIFF
--- a/apps/dojo/scripts/prep-dojo-everything.js
+++ b/apps/dojo/scripts/prep-dojo-everything.js
@@ -175,7 +175,37 @@ async function main() {
     printDryRunServices(procs);
   }
 
-  const { result } = concurrently(procs);
+  // Separate pnpm targets from others to avoid concurrent install races.
+  // Multiple pnpm installs within the same workspace race on the shared
+  // node_modules/.pnpm/ directory, causing ENOENT errors.
+  const pnpmProcs = [];
+  const otherProcs = [];
+
+  for (const proc of procs) {
+    if (proc.command.startsWith("pnpm")) {
+      pnpmProcs.push(proc);
+    } else {
+      otherProcs.push(proc);
+    }
+  }
+
+  // Run pnpm targets sequentially to avoid races on shared node_modules
+  for (const proc of pnpmProcs) {
+    console.log(`\n=== [${proc.name}] ${proc.command} ===`);
+    try {
+      execSync(proc.command, { cwd: proc.cwd, stdio: "inherit" });
+    } catch (err) {
+      console.error(`[${proc.name}] Failed: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  // Run remaining targets concurrently (uv, poetry, dotnet — all independent)
+  if (otherProcs.length === 0) {
+    process.exit(0);
+  }
+
+  const { result } = concurrently(otherProcs);
 
   result
     .then(() => process.exit(0))


### PR DESCRIPTION
## Summary
- `prep-dojo-everything.js` runs all targets via `concurrently()`, but pnpm targets sharing the same workspace (dojo at root, mastra as workspace member) race on `node_modules/.pnpm/`, causing `ENOENT: no such file or directory, unlink '.../node_modules/.pnpm/node_modules/quansync'`
- pnpm targets now run sequentially; uv/poetry/dotnet targets still run concurrently since they're fully independent

## Root cause
`integrations/mastra/typescript/examples` is listed in `pnpm-workspace.yaml`, so both `dojo` (`pnpm install` at workspace root) and `mastra` (`pnpm install` in workspace member dir) resolve to the same workspace and write to the same `node_modules/.pnpm/` directory. Running them concurrently causes one process to unlink a symlink that the other is trying to read.

## Test plan
- CI dojo E2E jobs that previously failed with ENOENT should now pass
- `--dry-run` output unchanged
- Non-pnpm targets still run concurrently (no perf regression for the common case)