### PR TITLE
feat: add base http agent & http event stream handlers

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
@@ -1,5 +1,5 @@
 import { AbstractAgent } from "../agent";
-import { HttpAgent } from "../http";
+import { HttpAgent } from "../full-http";
 import { BaseEvent, Message, RunAgentInput } from "@ag-ui/core";
 import { EMPTY, Observable } from "rxjs";
 

--- a/sdks/typescript/packages/client/src/agent/__tests__/http.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/http.test.ts
@@ -1,4 +1,4 @@
-import { HttpAgent } from "../http";
+import { HttpAgent } from "../full-http";
 import { runHttpRequest, HttpEvent, HttpEventType } from "@/run/http-request";
 import { v4 as uuidv4 } from "uuid";
 import { Observable, of } from "rxjs";

--- a/sdks/typescript/packages/client/src/agent/base-http.ts
+++ b/sdks/typescript/packages/client/src/agent/base-http.ts
@@ -3,18 +3,20 @@ import { runHttpRequest } from "@/run/http-request";
 import { HttpAgentConfig, RunAgentParameters } from "./types";
 import { RunAgentInput, BaseEvent } from "@ag-ui/core";
 import { structuredClone_ } from "@/utils";
-import { transformHttpEventStream } from "@/transform/http";
 import { Observable } from "rxjs";
 import { AgentSubscriber } from "./subscriber";
+import { TransformHttpEventStreamHandlers } from "@/transform/base-type";
+import { transformHttpEventStreamFactory } from "@/transform/factory";
 
 interface RunHttpAgentConfig extends RunAgentParameters {
   abortController?: AbortController;
 }
 
-export class HttpAgent extends AbstractAgent {
+export class BaseHttpAgent extends AbstractAgent {
   public url: string;
   public headers: Record<string, string>;
   public abortController: AbortController = new AbortController();
+  private httpEventStreamHandlers: TransformHttpEventStreamHandlers[] = [];
 
   /**
    * Returns the fetch config for the http request.
@@ -52,15 +54,16 @@ export class HttpAgent extends AbstractAgent {
     super(config);
     this.url = config.url;
     this.headers = structuredClone_(config.headers ?? {});
+    this.httpEventStreamHandlers = config.streamHandlers ?? [];
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
     const httpEvents = runHttpRequest(this.url, this.requestInit(input));
-    return transformHttpEventStream(httpEvents);
+    return transformHttpEventStreamFactory(this.httpEventStreamHandlers)(httpEvents);
   }
 
-  public clone(): HttpAgent {
-    const cloned = super.clone() as HttpAgent;
+  public clone(): BaseHttpAgent {
+    const cloned = super.clone() as BaseHttpAgent;
     cloned.url = this.url;
     cloned.headers = structuredClone_(this.headers ?? {});
 

--- a/sdks/typescript/packages/client/src/agent/full-http.ts
+++ b/sdks/typescript/packages/client/src/agent/full-http.ts
@@ -1,0 +1,23 @@
+import { HttpAgentConfig } from "./types";
+import { defaultSSEStreamParser } from "@/transform/sse";
+import { defaultAGUIProtoStreamParser } from "@/transform/proto";
+import { AGUI_MEDIA_TYPE } from "@ag-ui/encoder";
+import { BaseHttpAgent } from "./base-http";
+
+export class HttpAgent extends BaseHttpAgent {
+  constructor(config: HttpAgentConfig) {
+    super({
+      streamHandlers: [
+        {
+          condition: (event) => event.headers.get("content-type") === AGUI_MEDIA_TYPE,
+          parser: defaultAGUIProtoStreamParser
+        },
+        {
+          condition: (event) => event.headers.get("content-type") === "text/event-stream",
+          parser: defaultSSEStreamParser
+        },
+      ] as HttpAgentConfig["streamHandlers"],
+      ...config
+    });
+  }
+}

--- a/sdks/typescript/packages/client/src/agent/index.ts
+++ b/sdks/typescript/packages/client/src/agent/index.ts
@@ -1,5 +1,6 @@
 export { AbstractAgent } from "./agent";
 export type { RunAgentResult } from "./agent";
-export { HttpAgent } from "./http";
+export { HttpAgent } from "./full-http";
+export {BaseHttpAgent} from "./base-http";
 export type { AgentConfig, HttpAgentConfig, RunAgentParameters } from "./types";
 export type { AgentSubscriber, AgentStateMutation, AgentSubscriberParams } from "./subscriber";

--- a/sdks/typescript/packages/client/src/agent/types.ts
+++ b/sdks/typescript/packages/client/src/agent/types.ts
@@ -1,3 +1,4 @@
+import { TransformHttpEventStreamHandlers } from "@/transform/base-type";
 import { Message, RunAgentInput, State } from "@ag-ui/core";
 
 export interface AgentConfig {
@@ -12,6 +13,7 @@ export interface AgentConfig {
 export interface HttpAgentConfig extends AgentConfig {
   url: string;
   headers?: Record<string, string>;
+  streamHandlers?: TransformHttpEventStreamHandlers[];
 }
 
 export type RunAgentParameters = Partial<

--- a/sdks/typescript/packages/client/src/transform/__tests__/http.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/http.test.ts
@@ -1,8 +1,8 @@
 import { transformHttpEventStream } from "../http";
 import { HttpEvent, HttpEventType } from "../../run/http-request";
 import { parseProtoStream } from "../proto";
-import * as proto from "@ag-ui/proto";
 import { BaseEvent, EventType } from "@ag-ui/core";
+import { AGUI_MEDIA_TYPE } from "@ag-ui/proto";
 import { Subject, of, throwError } from "rxjs";
 import { describe, it, expect, vi, beforeEach, Mock, test } from "vitest";
 
@@ -40,7 +40,7 @@ describe("transformHttpEventStream", () => {
     mockHttpSource.next({
       type: HttpEventType.HEADERS,
       status: 200,
-      headers: new Headers([["content-type", proto.AGUI_MEDIA_TYPE]]),
+      headers: new Headers([["content-type", AGUI_MEDIA_TYPE]]),
     });
 
     // Send a DATA event
@@ -118,7 +118,7 @@ describe("transformHttpEventStream", () => {
       mockHttpSource.next({
         type: HttpEventType.HEADERS,
         status: 200,
-        headers: new Headers([["content-type", proto.AGUI_MEDIA_TYPE]]),
+        headers: new Headers([["content-type", AGUI_MEDIA_TYPE]]),
       });
     });
   });

--- a/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
@@ -7,13 +7,13 @@ import {
   StateDeltaEvent,
   MessagesSnapshotEvent,
 } from "@ag-ui/core";
-import * as proto from "@ag-ui/proto";
+import { AGUI_MEDIA_TYPE } from "@ag-ui/proto";
+import { EventEncoder } from "@ag-ui/encoder";
 import { transformHttpEventStream } from "../http";
-import * as encoder from "@ag-ui/encoder";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const eventEncoder = new encoder.EventEncoder({
-  accept: proto.AGUI_MEDIA_TYPE,
+const eventEncoder = new EventEncoder({
+  accept: AGUI_MEDIA_TYPE,
 });
 
 // Don't mock the proto package so we can use real encoding/decoding
@@ -36,7 +36,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,
@@ -98,7 +98,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,
@@ -164,7 +164,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,
@@ -246,7 +246,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,
@@ -288,7 +288,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,
@@ -359,7 +359,7 @@ describe("parseProtoStream", () => {
 
     // Send headers event first with protobuf content type
     const headers = new Headers();
-    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    headers.append("Content-Type", AGUI_MEDIA_TYPE);
 
     chunk$.next({
       type: HttpEventType.HEADERS,

--- a/sdks/typescript/packages/client/src/transform/base-type.d.ts
+++ b/sdks/typescript/packages/client/src/transform/base-type.d.ts
@@ -1,0 +1,6 @@
+export type EventStreamParser = (source$: Observable<HttpEvent>, eventSubject: Subject<BaseEvent>) => Subscription;
+
+export interface TransformHttpEventStreamHandlers {
+  condition: (event: HttpHeadersEvent) => boolean;
+  parser: EventStreamParser
+}

--- a/sdks/typescript/packages/client/src/transform/factory.ts
+++ b/sdks/typescript/packages/client/src/transform/factory.ts
@@ -1,0 +1,68 @@
+import { BaseEvent } from "@ag-ui/core";
+import { Subject, ReplaySubject, Observable } from "rxjs";
+import { HttpEvent, HttpEventType } from "../run/http-request";
+import { TransformHttpEventStreamHandlers } from "./base-type";
+
+/**
+ * Factory function to create a transformHttpEventStream operator with customizable handlers for different content types.
+ * It listens for the initial HttpHeadersEvent to determine the content type and then applies the appropriate parser to transform the stream of HttpEvents into BaseEvents.
+ * Handlers are provided as an array of objects, each containing a condition function to match the headers and a parser function to process the events if the condition is met.
+ * If no handlers match the content type, an error is emitted on the eventSubject.
+ * The factory allows for flexible handling of various streaming formats (e.g., SSE, protocol buffers) based on the content type specified in the HTTP response headers.
+ * 
+ * Example usage:
+ * 
+ * const transformStream = transformHttpEventStreamFactory([
+ *  {
+ *   condition: (event) => event.headers.get("content-type") === "text/event-stream", parser: defaultSSEStreamParser
+ *  },
+ *  {
+ *   condition: (event) => event.headers.get("content-type") === AGUI_MEDIA_TYPE, parser: defaultAGUIProtoStreamParser
+ *  }
+ * ]);
+ */
+export const transformHttpEventStreamFactory = (handlers: TransformHttpEventStreamHandlers[]) =>
+  (source$: Observable<HttpEvent>): Observable<BaseEvent> => {
+    const eventSubject = new Subject<BaseEvent>();
+
+    // Use ReplaySubject to buffer events until we decide on the parser
+    const bufferSubject = new ReplaySubject<HttpEvent>();
+
+    // Flag to track whether we've set up the parser
+    let parserInitialized = false;
+
+    // Subscribe to source and buffer events while we determine the content type
+    source$.subscribe({
+      next: (event: HttpEvent) => {
+        // Forward event to buffer
+        bufferSubject.next(event);
+
+        // If we get headers and haven't initialized a parser yet, check content type
+        if (event.type === HttpEventType.HEADERS && !parserInitialized) {
+          parserInitialized = true;
+          const contentType = event.headers.get("content-type");
+
+
+          // Choose parser based on content type
+          const handler = handlers.find(h => h.condition(event));
+          if (handler) {
+            // Set up the parser with the buffered events
+            handler.parser(bufferSubject, eventSubject);
+          } else {
+            eventSubject.error(new Error(`Unsupported content type: ${contentType}`));
+          }
+        } else if (!parserInitialized) {
+          eventSubject.error(new Error("No headers event received before data events"));
+        }
+      },
+      error: (err) => {
+        bufferSubject.error(err);
+        eventSubject.error(err);
+      },
+      complete: () => {
+        bufferSubject.complete();
+      },
+    });
+
+    return eventSubject.asObservable();
+  };

--- a/sdks/typescript/packages/client/src/transform/http.ts
+++ b/sdks/typescript/packages/client/src/transform/http.ts
@@ -1,81 +1,16 @@
-import { BaseEvent, EventSchemas } from "@ag-ui/core";
-import { Subject, ReplaySubject, Observable } from "rxjs";
-import { HttpEvent, HttpEventType } from "../run/http-request";
-import { parseSSEStream } from "./sse";
-import { parseProtoStream } from "./proto";
-import * as proto from "@ag-ui/proto";
-import { EventType } from "@ag-ui/core";
+import { defaultSSEStreamParser } from "./sse";
+import { AGUI_MEDIA_TYPE } from "@ag-ui/proto";
+import { transformHttpEventStreamFactory } from "./factory";
+import { defaultAGUIProtoStreamParser } from "./proto";
 
 /**
  * Transforms HTTP events into BaseEvents using the appropriate format parser based on content type.
  */
-export const transformHttpEventStream = (source$: Observable<HttpEvent>): Observable<BaseEvent> => {
-  const eventSubject = new Subject<BaseEvent>();
-
-  // Use ReplaySubject to buffer events until we decide on the parser
-  const bufferSubject = new ReplaySubject<HttpEvent>();
-
-  // Flag to track whether we've set up the parser
-  let parserInitialized = false;
-
-  // Subscribe to source and buffer events while we determine the content type
-  source$.subscribe({
-    next: (event: HttpEvent) => {
-      // Forward event to buffer
-      bufferSubject.next(event);
-
-      // If we get headers and haven't initialized a parser yet, check content type
-      if (event.type === HttpEventType.HEADERS && !parserInitialized) {
-        parserInitialized = true;
-        const contentType = event.headers.get("content-type");
-
-        // Choose parser based on content type
-        if (contentType === proto.AGUI_MEDIA_TYPE) {
-          // Use protocol buffer parser
-          parseProtoStream(bufferSubject).subscribe({
-            next: (event) => eventSubject.next(event),
-            error: (err) => eventSubject.error(err),
-            complete: () => eventSubject.complete(),
-          });
-        } else {
-          // Use SSE JSON parser for all other cases
-          parseSSEStream(bufferSubject).subscribe({
-            next: (json) => {
-              try {
-                const parsedEvent = EventSchemas.parse(json);
-                eventSubject.next(parsedEvent as BaseEvent);
-              } catch (err) {
-                eventSubject.error(err);
-              }
-            },
-            error: (err) => {
-              if ((err as DOMException)?.name === "AbortError") {
-                eventSubject.next({
-                  type: EventType.RUN_ERROR,
-                  message: (err as DOMException).message || "Request aborted",
-                  code: "abort",
-                  rawEvent: err,
-                });
-                eventSubject.complete();
-                return;
-              }
-              return eventSubject.error(err)
-            },
-            complete: () => eventSubject.complete(),
-          });
-        }
-      } else if (!parserInitialized) {
-        eventSubject.error(new Error("No headers event received before data events"));
-      }
-    },
-    error: (err) => {
-      bufferSubject.error(err);
-      eventSubject.error(err);
-    },
-    complete: () => {
-      bufferSubject.complete();
-    },
-  });
-
-  return eventSubject.asObservable();
-};
+export const transformHttpEventStream = transformHttpEventStreamFactory([
+  {
+    condition: (event) => event.headers.get("content-type") === AGUI_MEDIA_TYPE, parser: defaultAGUIProtoStreamParser
+  },
+  {
+    condition: () => true, parser: defaultSSEStreamParser
+  }
+]);

--- a/sdks/typescript/packages/client/src/transform/proto.ts
+++ b/sdks/typescript/packages/client/src/transform/proto.ts
@@ -1,7 +1,8 @@
 import { Observable, Subject } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
 import { BaseEvent } from "@ag-ui/core";
-import * as proto from "@ag-ui/proto";
+import {decode} from "@ag-ui/proto";
+import { EventStreamParser } from "./base-type";
 
 /**
  * Parses a stream of HTTP events into a stream of BaseEvent objects using Protocol Buffer format.
@@ -65,7 +66,7 @@ export const parseProtoStream = (source$: Observable<HttpEvent>): Observable<Bas
         const message = buffer.slice(4, totalLength);
 
         // Decode the protocol buffer message using the imported decode function
-        const event = proto.decode(message);
+        const event = decode(message);
 
         // Emit the parsed event
         eventSubject.next(event);
@@ -82,3 +83,21 @@ export const parseProtoStream = (source$: Observable<HttpEvent>): Observable<Bas
 
   return eventSubject.asObservable();
 };
+
+/**
+ * The default parser for AGUI protocol buffer streams. It uses the parseProtoStream function to convert HTTP events into BaseEvents.
+ * To use as part of the argument for transformHttpEventStreamFactory, simply pass in the parser function along with a condition that checks for the AGUI media type in the headers.
+ * 
+ * Example usage:
+ * 
+ * const transformStream = transformHttpEventStreamFactory([
+ *  {
+ *   condition: (event) => event.headers.get("content-type") === AGUI_MEDIA_TYPE, parser: defaultAGUIProtoStreamParser
+ *  },
+ * ]);
+ */
+export const defaultAGUIProtoStreamParser: EventStreamParser = (source$, eventSubject) => parseProtoStream(source$).subscribe({
+  next: (event) => eventSubject.next(event),
+  error: (err) => eventSubject.error(err),
+  complete: () => eventSubject.complete(),
+})

--- a/sdks/typescript/packages/client/src/transform/sse.ts
+++ b/sdks/typescript/packages/client/src/transform/sse.ts
@@ -1,5 +1,7 @@
 import { Observable, Subject } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
+import { EventStreamParser } from "./base-type";
+import { BaseEvent, EventSchemas, EventType } from "@ag-ui/core";
 
 /**
  * Parses a stream of HTTP events into a stream of JSON objects using Server-Sent Events (SSE) format.
@@ -84,3 +86,46 @@ export const parseSSEStream = (source$: Observable<HttpEvent>): Observable<any> 
 
   return jsonSubject.asObservable();
 };
+
+
+/**
+ * SSE Stream Parser that converts a stream of HttpEvents into parsed JSON objects based on the SSE format.
+ * It listens for HttpDataEvents, decodes the data as UTF-8 text, and processes it according to SSE rules (lines starting with "data:").
+ * Parsed JSON objects are emitted through the provided eventSubject.
+ * Errors in parsing or unexpected formats will be emitted as errors on the eventSubject.
+ * The parser will ignore HttpHeadersEvents and only process HttpDataEvents.
+ * 
+ * To use as part of the argument for transformHttpEventStreamFactory, simply pass in the parser function along with a condition that checks for the appropriate media type in the headers.
+ * 
+ * Example usage:
+ * 
+ * const transformStream = transformHttpEventStreamFactory([
+ *  {
+ *   condition: (event) => event.headers.get("content-type") === "text/event-stream", parser: defaultSSEStreamParser
+ *  },
+ * ]);
+ */
+export const defaultSSEStreamParser: EventStreamParser = (source$, eventSubject) => parseSSEStream(source$).subscribe({
+  next: (json) => {
+    try {
+      const parsedEvent = EventSchemas.parse(json);
+      eventSubject.next(parsedEvent as BaseEvent);
+    } catch (err) {
+      eventSubject.error(err);
+    }
+  },
+  error: (err) => {
+    if ((err as DOMException)?.name === "AbortError") {
+      eventSubject.next({
+        type: EventType.RUN_ERROR,
+        message: (err as DOMException).message || "Request aborted",
+        code: "abort",
+        rawEvent: err,
+      });
+      eventSubject.complete();
+      return;
+    }
+    return eventSubject.error(err)
+  },
+  complete: () => eventSubject.complete(),
+})

--- a/sdks/typescript/packages/client/tsdown.config.ts
+++ b/sdks/typescript/packages/client/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig((inlineConfig) => ({
   exports: true,
   fixedExtension: false,
   sourcemap: true,
+  unbundle: true, // Don't bundle dependencies to allow for better tree-shaking in consuming projects
   clean: !inlineConfig.watch, // Don't clean in watch mode to prevent race conditions
   minify: !inlineConfig.watch, // Don't minify in watch mode for faster builds
 }));

--- a/sdks/typescript/packages/encoder/src/__tests__/encoder.test.ts
+++ b/sdks/typescript/packages/encoder/src/__tests__/encoder.test.ts
@@ -1,6 +1,6 @@
 import { EventEncoder } from "../encoder";
 import { BaseEvent, EventType, TextMessageStartEvent } from "@ag-ui/core";
-import * as proto from "@ag-ui/proto";
+import { AGUI_MEDIA_TYPE } from "@ag-ui/proto";
 
 describe("Encoder Tests", () => {
   // Create a valid TextMessageStartEvent event
@@ -15,7 +15,7 @@ describe("Encoder Tests", () => {
     it("should return protobuf encoded data when accept header includes protobuf media type", () => {
       // Setup an encoder with protobuf accepted
       const encoder = new EventEncoder({
-        accept: `text/event-stream, ${proto.AGUI_MEDIA_TYPE}`,
+        accept: `text/event-stream, ${AGUI_MEDIA_TYPE}`,
       });
 
       // Get the binary encoding

--- a/sdks/typescript/packages/encoder/src/encoder.ts
+++ b/sdks/typescript/packages/encoder/src/encoder.ts
@@ -1,7 +1,6 @@
 import { BaseEvent } from "@ag-ui/core";
-import * as proto from "@ag-ui/proto";
+import {AGUI_MEDIA_TYPE, encode,} from "@ag-ui/proto";
 import { preferredMediaTypes } from "./media-type";
-
 export interface EventEncoderParams {
   accept?: string;
 }
@@ -15,7 +14,7 @@ export class EventEncoder {
 
   getContentType(): string {
     if (this.acceptsProtobuf) {
-      return proto.AGUI_MEDIA_TYPE;
+      return AGUI_MEDIA_TYPE;
     } else {
       return "text/event-stream";
     }
@@ -41,7 +40,7 @@ export class EventEncoder {
   }
 
   encodeProtobuf(event: BaseEvent): Uint8Array {
-    const messageBytes = proto.encode(event);
+    const messageBytes = encode(event);
     const length = messageBytes.length;
 
     // Create a buffer for 4 bytes (for the uint32 length) plus the message bytes
@@ -61,9 +60,9 @@ export class EventEncoder {
 
   private isProtobufAccepted(acceptHeader: string): boolean {
     // Pass the Accept header and an array with your media type
-    const preferred = preferredMediaTypes(acceptHeader, [proto.AGUI_MEDIA_TYPE]);
+    const preferred = preferredMediaTypes(acceptHeader, [AGUI_MEDIA_TYPE]);
 
     // If the returned array includes your media type, it's acceptable
-    return preferred.includes(proto.AGUI_MEDIA_TYPE);
+    return preferred.includes(AGUI_MEDIA_TYPE);
   }
 }

--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -3,6 +3,7 @@
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.46",
   "private": false,
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes #1230

Add & expose a new BaseHttpAgent that encompasses almost all the logic of the current HttpAgent, except the actual definition of what parser to run when.
Instead, it supports a `httpEventStreamHandlers` config, which associates a parser to a condition:
```ts
interface TransformHttpEventStreamHandlers {
  condition: (event: HttpHeadersEvent) => boolean;
  parser: EventStreamParser
}
```

The BaseHttpAgent goes through the `httpEventStreamHandlers`'s condition, and will use the first one that match.

This offers an 80kb (21%) uncompressed / 8kb (13%) bundle size reduction from what I've tried.

Attached are two metafiles generated by esbuild with my MRE, to help visualize the bundle size changes with https://esbuild.github.io/analyze/

[protoless.json](https://github.com/user-attachments/files/25726649/protoless.json)
[baseline.json](https://github.com/user-attachments/files/25696321/baseline.json)