### PR TITLE
fix(ci): auto-approve workflow for fork PRs

### DIFF
--- a/.github/workflows/auto-approve-community.yml
+++ b/.github/workflows/auto-approve-community.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch PR branch
+      - name: Fetch PR head
         run: |
-          git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -32,7 +32,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           node << 'EOF'
           const { execSync } = require('child_process');
@@ -42,9 +41,9 @@ jobs:
           const prAuthor = process.env.PR_AUTHOR;
           const prNumber = process.env.PR_NUMBER;
 
-          // Get changed files
+          // Get changed files (use pr-head ref which works for both forks and same-repo PRs)
           const changedFiles = execSync(
-            `git diff --name-only origin/${process.env.BASE_REF}...origin/${process.env.HEAD_REF}`,
+            `git diff --name-only origin/${process.env.BASE_REF}...pr-head`,
             { encoding: 'utf-8' }
           )
             .trim()


### PR DESCRIPTION
## Summary

- The `auto-approve-community` workflow was failing for fork PRs because it tried to `git fetch origin <branch-name>` using the head branch name, which only exists in the fork's repository — not on `origin`
- Similarly, the `git diff` used `origin/<head-ref>` which doesn't resolve for fork branches

## How it was fixed

**Fetch step:** Changed from fetching by branch name (`github.event.pull_request.head.ref`) to using GitHub's PR ref (`pull/<number>/head`). GitHub automatically creates `refs/pull/<number>/head` for every PR, including those from forks, so this always resolves on `origin`.

```diff
- git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
+ git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
```

**Diff step:** Updated the `git diff` to compare against the `pr-head` local ref instead of `origin/<head-ref>`. Also removed the now-unused `HEAD_REF` env var.

```diff
- git diff --name-only origin/${BASE_REF}...origin/${HEAD_REF}
+ git diff --name-only origin/${BASE_REF}...pr-head
```

## Test plan

- [ ] Open a PR from a fork and verify the workflow runs successfully (green check)
- [ ] Open a PR from the same repo and verify the workflow still works as before