### PR TITLE
Raise binary check file size limit to 1MB

### DIFF
--- a/.github/workflows/pr-check-binaries.yml
+++ b/.github/workflows/pr-check-binaries.yml
@@ -54,19 +54,19 @@ jobs:
             VIOLATIONS=1
           fi
 
-          # Check for large files (>500KB) among changed files
+          # Check for large files (>1MB) among changed files
           LARGE_FILES=""
           while IFS= read -r file; do
             if [ -f "$file" ]; then
               SIZE=$(wc -c < "$file" | tr -d ' ')
-              if [ "$SIZE" -gt 512000 ]; then
+              if [ "$SIZE" -gt 1048576 ]; then
                 LARGE_FILES="${LARGE_FILES}${file} ($(( SIZE / 1024 )) KB)\n"
               fi
             fi
           done <<< "$CHANGED_FILES"
 
           if [ -n "$LARGE_FILES" ]; then
-            echo "::error::Files over 500 KB detected in PR:"
+            echo "::error::Files over 1 MB detected in PR:"
             echo -e "$LARGE_FILES"
             VIOLATIONS=1
           fi


### PR DESCRIPTION
## Summary
- Raises the large file threshold in `pr-check-binaries.yml` from 500KB to 1MB
- `pnpm-lock.yaml` is 783KB and triggers false positives on dependency changes

## Test plan
- [x] PR with pnpm-lock.yaml changes no longer fails check-binaries