### PR TITLE
fix(client): guard process.env access for browser compatibility

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -1,5 +1,5 @@
 import { AbstractAgent } from "../agent";
-import { AgentSubscriber } from "../subscriber";
+import { AgentSubscriber, runSubscribersWithMutation } from "../subscriber";
 import {
   BaseEvent,
   EventType,
@@ -1103,6 +1103,70 @@ describe("AgentSubscriber", () => {
 
       expect(errorSubscriber.onTextMessageStartEvent).toHaveBeenCalled();
       expect(workingSubscriber.onTextMessageStartEvent).toHaveBeenCalled();
+    });
+
+    test("should not crash when process is undefined (browser environment) and a subscriber throws", async () => {
+      // Save original process reference
+      const originalProcess = globalThis.process;
+
+      try {
+        // Simulate a browser environment where process is not defined
+        // @ts-expect-error - intentionally removing process to simulate browser
+        delete globalThis.process;
+
+        const errorSubscriber: AgentSubscriber = {
+          onEvent: vi.fn().mockImplementation(() => {
+            throw new Error("Subscriber error in browser");
+          }),
+        };
+
+        const workingSubscriber: AgentSubscriber = {
+          onEvent: vi.fn(),
+        };
+
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        // This should NOT throw a ReferenceError about process being undefined
+        // It should gracefully handle the subscriber error and continue
+        let caughtError: Error | undefined;
+        let result: Awaited<ReturnType<typeof runSubscribersWithMutation>> | undefined;
+        try {
+          result = await runSubscribersWithMutation(
+            [errorSubscriber, workingSubscriber],
+            [],
+            {},
+            (subscriber, messages, state) => {
+              if (subscriber.onEvent) {
+                return subscriber.onEvent({
+                  event: { type: EventType.TEXT_MESSAGE_START } as any,
+                  messages,
+                  state,
+                  agent: agent,
+                  input: {} as RunAgentInput,
+                });
+              }
+            },
+          );
+        } catch (e) {
+          caughtError = e as Error;
+        }
+
+        // Explicitly verify no ReferenceError was thrown
+        expect(caughtError).toBeUndefined();
+
+        // The error subscriber threw, but processing should continue
+        expect(errorSubscriber.onEvent).toHaveBeenCalled();
+        expect(workingSubscriber.onEvent).toHaveBeenCalled();
+        expect(result).toBeDefined();
+
+        // Verify console.error was called for the subscriber error
+        expect(consoleSpy).toHaveBeenCalled();
+
+        consoleSpy.mockRestore();
+      } finally {
+        // Restore process
+        globalThis.process = originalProcess;
+      }
     });
   });
 

--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -250,7 +250,9 @@ export async function runSubscribersWithMutation(
     } catch (error) {
       // Log subscriber errors but continue processing (silence during tests)
       const isTestEnvironment =
-        process.env.NODE_ENV === "test" || process.env.VITEST_WORKER_ID !== undefined;
+        typeof process !== "undefined" &&
+        typeof process.env !== "undefined" &&
+        (process.env.NODE_ENV === "test" || process.env.VITEST_WORKER_ID !== undefined);
 
       if (!isTestEnvironment) {
         console.error("Subscriber error:", error);


### PR DESCRIPTION
## Summary
- Fixes #1191 — `process.env` access in `subscriber.ts` catch block crashes in browser environments without a `process` polyfill
- Adds `typeof process !== "undefined"` and `typeof process.env !== "undefined"` guards before accessing `process.env.NODE_ENV` and `process.env.VITEST_WORKER_ID`

## Root Cause
The catch block in `runSubscribersWithMutation` unconditionally accesses `process.env` to check if we're in a test environment. In browsers without a `process` polyfill, this throws a `ReferenceError` that swallows the original subscriber error and its stack trace.

## Fix
Added `typeof` guards (the idiomatic cross-runtime approach) before accessing `process.env` properties.

## Test Plan
- [x] Added test that simulates browser environment by deleting `globalThis.process`, verifies no `ReferenceError` is thrown when a subscriber errors
- [x] All 349 existing client tests pass
- [x] Build succeeds

> **Note:** This is a scoped resubmission of the fix from #1192, which contained unrelated changes. This PR contains only the subscriber fix and its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)