### PR TITLE
feat: add Claude Code custom skills for bug-fix workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,16 @@ Each framework integration follows a similar pattern:
 - The AG-UI Dojo app showcases all protocol features with live examples
 
 
+## Bug Fix Workflow, Skills, and Guardrails
+
+All bug fix workflow instructions, custom skill definitions, and operational guardrails are maintained on the team's Notion page. Before starting any bug fix, triage, or code review task, read the source of truth:
+
+**Notion page ID**: `2e63aa38185280648a35dc4f43a80749`
+
+Fetch this page using the Notion MCP tool to get the current workflow steps, skills (e.g., `/triage`, `/reproduce`, `/bug-fix`, `/code-review`), constraints, and "What Claude Should Never Do" guardrails.
+
+This requires the Notion MCP tool to be configured. If it is not available, ask the user to enable it before proceeding with bug fix work.
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md to reference the team's Notion page as the single source of truth for bug fix workflow, skills, and guardrails
- Ensures engineers have the Notion MCP tool configured before starting bug fix work
- Keeps skill definitions, constraints, and operational rules private (not in the public repo)

## What Changed

- **CLAUDE.md**: Added a "Bug Fix Workflow, Skills, and Guardrails" section that points to the Notion page ID
- No skill files are committed to the repo — all workflow instructions live on Notion

## Test Plan

- [ ] Clone the repo and open Claude Code
- [ ] Verify Claude reads CLAUDE.md and attempts to fetch the Notion page
- [ ] Confirm Notion MCP tool is required for bug fix workflows