### PR TITLE
feat: point CLAUDE.md to Notion for bug fix workflow and skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,16 @@ Each framework integration follows a similar pattern:
 - The AG-UI Dojo app showcases all protocol features with live examples
 
 
+## Bug Fix Workflow, Skills, and Guardrails
+
+All bug fix workflow instructions, custom skill definitions, and operational guardrails are maintained on the team's Notion page. Before starting any bug fix, triage, or code review task, read the source of truth:
+
+**Notion page ID**: `2e63aa38185280648a35dc4f43a80749`
+
+Fetch this page using the Notion MCP tool to get the current workflow steps, skills (e.g., `/triage`, `/reproduce`, `/bug-fix`, `/code-review`), constraints, and "What Claude Should Never Do" guardrails.
+
+This requires the Notion MCP tool to be configured. If it is not available, ask the user to enable it before proceeding with bug fix work.
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 


### PR DESCRIPTION
## Summary

- Adds a "Bug Fix Workflow, Skills, and Guardrails" section to CLAUDE.md that references the team's Notion page as the single source of truth
- Keeps skill definitions, constraints, and operational rules private
- Ensures engineers have the Notion MCP tool configured before starting bug fix work

## What Changed

**CLAUDE.md**: New section pointing to Notion page ID `2e63aa38185280648a35dc4f43a80749` for all workflow instructions

## Test Plan

- [ ] Clone the repo and open Claude Code
- [ ] Verify Claude reads CLAUDE.md and attempts to fetch the Notion page
- [ ] Confirm Notion MCP tool is required for bug fix workflows