### PR TITLE
Retry pkg-pr-new publish on transient 404s

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -26,4 +26,7 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - run: npx pkg-pr-new publish --pnpm --packageManager pnpm ./sdks/typescript/packages/* ./middlewares/* ./integrations/*/typescript
+      - name: Publish via pkg-pr-new
+        run: |
+          npx pkg-pr-new publish --pnpm --packageManager pnpm ./sdks/typescript/packages/* ./middlewares/* ./integrations/*/typescript || \
+          (sleep 10 && npx pkg-pr-new publish --pnpm --packageManager pnpm ./sdks/typescript/packages/* ./middlewares/* ./integrations/*/typescript)


### PR DESCRIPTION
## Summary
- The `pkg-pr-new` service occasionally returns a transient 404 (`"There is no workflow defined for ..."`) causing the CI job to fail
- Adds a single retry with a 10-second backoff: if the first `npx pkg-pr-new publish` fails, wait 10s and try once more
- No behavior change on permanent failures — the second attempt will still fail and surface the error

## Context
Example failure: run [22764140493](https://github.com/ag-ui-protocol/ag-ui/actions/runs/22764140493) — `Check failed (404): {"message":"There is no workflow defined for 29WdKpXIp8"}`

## Test plan
- [x] Verify workflow YAML syntax is valid
- [ ] Observe next transient 404 resolves via retry instead of requiring manual re-run