### PR TITLE
fix(langgraph): pass graphId filter when searching for assistant

### DIFF
--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1134,16 +1134,12 @@ export class LangGraphAgent extends AbstractAgent {
 
   async getAssistant(): Promise<Assistant> {
     try {
-      const assistants = await this.client.assistants.search();
-      const retrievedAssistant = assistants.find(
-        (searchResult) => searchResult.graph_id === this.graphId,
-      );
+      const assistants = await this.client.assistants.search({
+        graphId: this.graphId,
+      });
+      const retrievedAssistant = assistants[0];
       if (!retrievedAssistant) {
-        const notFoundMessage = `
-      No agent found with graph ID ${this.graphId} found..\n
-
-      These are the available agents: [${assistants.map((a) => `${a.graph_id} (ID: ${a.assistant_id})`).join(", ")}]
-      `
+        const notFoundMessage = `No assistant found with graph ID "${this.graphId}".`;
         console.error(notFoundMessage);
         throw new Error(notFoundMessage);
       }


### PR DESCRIPTION
## Summary
- Passes `graphId` filter to `client.assistants.search()` so the LangGraph server filters results server-side
- Previously, only the first page (default 10) of assistants was returned and filtered client-side, causing "not found" errors when the target assistant wasn't in the first page
- Simplified the error message since the search is now filtered

Closes #1220

## Test plan
- [x] TypeScript: `pnpm test` — 9 tests pass
- [ ] CI passes on all checks
- [ ] Manual: Create a LangGraph server with >10 assistants, verify the correct one is found regardless of position