### PR TITLE
Fix lefthook generate-dojo-content filter name

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
     generate-dojo-content:
       tags: dojo
       glob: "apps/dojo/**"
-      run: pnpm --filter dojo run generate-content-json
+      run: pnpm --filter demo-viewer run generate-content-json
       stage_fixed: true
     lint-fix:
       tags: lint


### PR DESCRIPTION
## Summary

- The `generate-dojo-content` pre-commit hook used `pnpm --filter dojo` but the package is named `demo-viewer`
- pnpm filter misses are silent, so the hook reported success while doing nothing
- This is why `files.json` was never auto-regenerated on commit, causing CI failures on any PR that changes `agents.ts` or `menu.ts`
- Fixes the filter to `pnpm --filter demo-viewer`