### PR TITLE
Update PyPI metadata and dependencies for adk-middleware

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-03-08
+
+### Fixed
+
+- **FIX**: Update PyPI metadata and lockfile for adk-middleware package (#1263)
+  - Added `description` field to `pyproject.toml` for proper PyPI display
+  - Added `license = "MIT"` designation
+  - Added `project.urls` section with Homepage and Issues links
+  - Expanded `uv_build` version constraint from `<0.9` to `<0.11`
+  - Added `pytest-xdist` as a dev dependency for faster parallel test execution
+  - Regenerated `uv.lock` with updated Python version bounds
+
 ## [0.5.1] - 2026-03-05
 
 ### Fixed


### PR DESCRIPTION
## Description

This PR updates the `pyproject.toml` configuration for the adk-middleware package to improve PyPI presentation and modernize dependencies.

### Changes

- **PyPI Metadata**: Added `description` field for proper package display on PyPI
- **License**: Added explicit `license = "MIT"` designation
- **Project URLs**: Added `project.urls` section with Homepage and Issues links for better discoverability
- **Dependencies**: 
  - Expanded `uv_build` version constraint from `<0.9` to `<0.11` to support newer versions
  - Added `pytest-xdist` as a dev dependency to enable faster parallel test execution
- **Lockfile**: Regenerated `uv.lock` with updated Python version bounds

### Test Plan

Existing tests pass. The changes are configuration-only and do not affect runtime behavior.

https://claude.ai/code/session_011VoxtbdiG9GSokycxxBkVZ