### PR TITLE
refactor(client): Relax connect validation for live connections

### DIFF
--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -208,7 +208,6 @@ export abstract class AbstractAgent {
       const pipeline = pipe(
         () => this.connect(input),
         transformChunks(this.debug),
-        verifyEvents(this.debug),
         // Stop processing immediately when this run is detached
         (source$) => source$.pipe(takeUntil(this.activeRunDetach$!)),
         (source$) => this.apply(input, source$, subscribers),


### PR DESCRIPTION
This removes what appears to be a superfluous check in `Agent#connect(...)`, where `verifyEvents` is called on the event stream. The problem is that `verifyEvents` expects to have `RUN_STARTED` be the first message, which isn't true in situations where you connect to in-progress threads.

As you can see from CI, there were no tests around this behavior. None of our implementations of `AbstractAgent` expect this behavior. In fact, `Agent#run(...)` doesn't impose such strict event correctness checks. 