### PR TITLE
Ignore some more build artifacts generically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,14 @@ node_modules
 *.egg-info
 
 **/python/**/__pycache__/
+**/python/**/.venv/
+
+**/typescript/**/node_modules/
+**/typescript/**/dist/
+
+# Turborepo
+.turbo
+**/.turbo
 
 # Build artifacts and binaries
 **/build/


### PR DESCRIPTION
When switching between PR branches, new integrations tend to add the relevant gitignores to their own directories, which is fine. But when switching back to main or other branches during dev, I end up with build artifacts left over unignored. 

Didn't want to go too hard on this since we've run into cross language ignore issues before, but the most common ones for python and typescript should be resolved by this. 

Also re-ignores turbo stuff just to help with branches from prs before the switch to nx