### PR TITLE
chore: publish prereleases for PRs on python

### DIFF
--- a/.github/workflows/build-python-preview.yml
+++ b/.github/workflows/build-python-preview.yml
@@ -1,0 +1,91 @@
+name: Build Python Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: ">=0.8.0"
+
+      - name: Compute preview version
+        id: version
+        run: |
+          TIMESTAMP=$(git log -1 --format=%ct HEAD)
+          VERSION="0.0.0.dev${TIMESTAMP}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Preview version: ${VERSION}"
+
+      - name: Rewrite pyproject.toml versions
+        run: uv run python scripts/rewrite-python-preview-versions.py ${{ steps.version.outputs.version }}
+
+      - name: Build ag-ui-protocol
+        working-directory: sdks/python
+        run: uv build
+
+      - name: Build ag-ui-langgraph
+        working-directory: integrations/langgraph/python
+        run: uv build
+
+      - name: Build ag-ui-crewai
+        working-directory: integrations/crew-ai/python
+        run: uv build
+
+      - name: Build ag-ui-agent-spec
+        working-directory: integrations/agent-spec/python
+        run: uv build
+
+      - name: Build ag_ui_adk
+        working-directory: integrations/adk-middleware/python
+        run: uv build
+
+      - name: Build ag_ui_strands
+        working-directory: integrations/aws-strands/python
+        run: uv build
+
+      - name: Collect dist artifacts
+        run: |
+          mkdir -p dist-preview
+          cp sdks/python/dist/*                        dist-preview/
+          cp integrations/langgraph/python/dist/*      dist-preview/
+          cp integrations/crew-ai/python/dist/*        dist-preview/
+          cp integrations/agent-spec/python/dist/*     dist-preview/
+          cp integrations/adk-middleware/python/dist/*  dist-preview/
+          cp integrations/aws-strands/python/dist/*    dist-preview/
+          echo "Artifacts to publish:"
+          ls -1 dist-preview/
+
+      # Save metadata so the publish workflow can find the PR and version.
+      - name: Save PR metadata
+        run: |
+          mkdir -p pr-metadata
+          echo "${{ github.event.pull_request.number }}" > pr-metadata/pr-number
+          echo "${{ steps.version.outputs.version }}" > pr-metadata/version
+          echo "${{ github.sha }}" > pr-metadata/sha
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-preview-dist
+          path: dist-preview/
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-preview-metadata
+          path: pr-metadata/

--- a/.github/workflows/publish-python-preview.yml
+++ b/.github/workflows/publish-python-preview.yml
@@ -1,0 +1,138 @@
+name: Publish Python Preview to TestPyPI
+
+# Triggered when the build workflow completes. Runs in the base repo context,
+# so it has access to secrets even for fork PRs. The code executed here comes
+# from the base branch, not the fork — only the built wheel artifacts come
+# from the fork's workflow run.
+on:
+  workflow_run:
+    workflows: ["Build Python Preview"]
+    types: [completed]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read
+      pull-requests: write
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-preview-dist
+          path: dist-preview/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: python-preview-metadata
+          path: pr-metadata/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          echo "pr-number=$(cat pr-metadata/pr-number)" >> "$GITHUB_OUTPUT"
+          echo "version=$(cat pr-metadata/version)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(cat pr-metadata/sha)" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: ">=0.8.0"
+
+      - name: Publish all packages to TestPyPI
+        run: |
+          echo "Publishing artifacts:"
+          ls -1 dist-preview/
+          uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --skip-existing \
+            dist-preview/*
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
+      - name: Find existing preview comment
+        if: always()
+        id: find-comment
+        uses: peter-evans/find-comment@v4
+        with:
+          issue-number: ${{ steps.meta.outputs.pr-number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- ag-ui-python-preview -->'
+
+      - name: Post or update install instructions
+        if: success()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr-number }}
+          edit-mode: replace
+          body: |
+            <!-- ag-ui-python-preview -->
+            ## Python Preview Packages
+
+            Version `${{ steps.meta.outputs.version }}` published to [TestPyPI](https://test.pypi.org).
+
+            > **Warning**: These packages are built from contributor code that may not yet have been vetted for correctness or security. Install at your own risk and do not use in production.
+
+            ### Install with uv
+
+            Add the TestPyPI index to your `pyproject.toml`:
+
+            ```toml
+            [[tool.uv.index]]
+            name = "testpypi"
+            url = "https://test.pypi.org/simple/"
+            explicit = true
+            ```
+
+            Then install the packages you need:
+
+            ```bash
+            # Core SDK
+            uv add 'ag-ui-protocol==${{ steps.meta.outputs.version }}' --index testpypi
+
+            # Integrations (each already depends on the matching ag-ui-protocol preview)
+            uv add 'ag-ui-langgraph==${{ steps.meta.outputs.version }}' --index testpypi
+            uv add 'ag-ui-crewai==${{ steps.meta.outputs.version }}' --index testpypi
+            # NOTE: ag-ui-agent-spec depends on pyagentspec (git-only, not on PyPI).
+            # You will need to install pyagentspec separately from its git repo.
+            uv add 'ag-ui-agent-spec==${{ steps.meta.outputs.version }}' --index testpypi
+            uv add 'ag_ui_adk==${{ steps.meta.outputs.version }}' --index testpypi
+            uv add 'ag_ui_strands==${{ steps.meta.outputs.version }}' --index testpypi
+            ```
+
+            ### Install with pip
+
+            ```bash
+            pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              ag-ui-protocol==${{ steps.meta.outputs.version }}
+            ```
+
+            > Use `--extra-index-url https://pypi.org/simple/` so pip can resolve
+            > transitive dependencies (pydantic, fastapi, etc.) from real PyPI.
+
+            ---
+            _Commit: ${{ steps.meta.outputs.sha }}_
+
+      - name: Post failure comment
+        if: failure()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr-number }}
+          edit-mode: replace
+          body: |
+            <!-- ag-ui-python-preview -->
+            ## Python Preview Packages — Publish Failed
+
+            Preview publish failed for commit ${{ steps.meta.outputs.sha }}.
+            See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.

--- a/scripts/rewrite-python-preview-versions.py
+++ b/scripts/rewrite-python-preview-versions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Rewrites pyproject.toml files in-place for preview publishing to TestPyPI.
+
+Usage:
+    python scripts/rewrite-python-preview-versions.py 0.0.0.dev1741617123
+
+For each package in PACKAGES:
+  - Rewrites the package version to the given preview version
+  - Rewrites any ag-ui-protocol dependency to pin the exact same preview
+    version (so TestPyPI resolution finds the preview SDK, not a real one)
+
+Handles all three build backends used in this repo:
+  - uv_build / hatchling : version at [project].version,
+                           deps at [project].dependencies (PEP 508 list)
+  - poetry-core          : version at [tool.poetry].version,
+                           deps at [tool.poetry.dependencies] (TOML table)
+"""
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Ordered: ag-ui-protocol (no internal deps) first.
+PACKAGES = [
+    "sdks/python",
+    "integrations/langgraph/python",
+    "integrations/crew-ai/python",
+    "integrations/agent-spec/python",
+    "integrations/adk-middleware/python",
+    "integrations/aws-strands/python",
+]
+
+SDK_PACKAGE_NAME = "ag-ui-protocol"
+
+
+def _rewrite_key_in_section(text: str, section_re: str, key: str, value: str) -> str:
+    """
+    Replace the first `key = "..."` that appears after the section header
+    matched by section_re and before the next section header.
+    """
+    pattern = re.compile(
+        r"(?ms)"
+        r"(" + section_re + r"[^\[]*?)"
+        r"(" + re.escape(key) + r'\s*=\s*)"[^"]*"',
+    )
+    return pattern.sub(rf'\1\2"{value}"', text, count=1)
+
+
+def rewrite_file(path: Path, new_version: str) -> None:
+    original = path.read_text(encoding="utf-8")
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+
+    text = original
+    build_backend = data.get("build-system", {}).get("build-backend", "")
+
+    if build_backend == "poetry.core.masonry.api":
+        # poetry-core: version in [tool.poetry], deps in [tool.poetry.dependencies]
+        text = _rewrite_key_in_section(text, r"\[tool\.poetry\]", "version", new_version)
+
+        # ag-ui-protocol = ">=0.1.10"  ->  ag-ui-protocol = "==0.0.0.devN"
+        text = re.sub(
+            r'(?m)^(ag-ui-protocol\s*=\s*)"[^"]*"',
+            rf'\1"=={new_version}"',
+            text,
+        )
+    else:
+        # uv_build / hatchling: version in [project], deps in [project].dependencies
+        text = _rewrite_key_in_section(text, r"\[project\]", "version", new_version)
+
+        # "ag-ui-protocol>=0.1.10"  ->  "ag-ui-protocol==0.0.0.devN"
+        # Require a version specifier after the name (>=, >, ==, etc.)
+        # to avoid matching the package's own name field.
+        text = re.sub(
+            r'("ag-ui-protocol)[><=!~][^"]*(")',
+            rf"\g<1>=={new_version}\2",
+            text,
+        )
+
+    if text == original:
+        print(f"  WARNING: no changes made to {path}")
+
+    path.write_text(text, encoding="utf-8")
+
+
+def verify_version(path: Path, new_version: str) -> None:
+    """Re-parse the file and assert the version was written correctly."""
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+
+    build_backend = data.get("build-system", {}).get("build-backend", "")
+    if build_backend == "poetry.core.masonry.api":
+        got = data["tool"]["poetry"]["version"]
+    else:
+        got = data["project"]["version"]
+
+    if got != new_version:
+        print(
+            f"  ERROR: version verification failed for {path}: "
+            f"expected {new_version!r}, got {got!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(f"    verified: {got}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(
+            "Usage: rewrite-python-preview-versions.py <version>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    new_version = sys.argv[1]
+    repo_root = Path(__file__).resolve().parent.parent
+
+    print(f"Rewriting all packages to version: {new_version}")
+    for pkg_rel in PACKAGES:
+        toml_path = repo_root / pkg_rel / "pyproject.toml"
+        if not toml_path.exists():
+            print(f"  ERROR: {toml_path} not found", file=sys.stderr)
+            sys.exit(1)
+        print(f"  {pkg_rel}/pyproject.toml")
+        rewrite_file(toml_path, new_version)
+        verify_version(toml_path, new_version)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Adds automated Python preview package publishing to TestPyPI on every PR push
- Uses a two-workflow design (build-python-preview.yml + publish-python-preview.yml) to safely handle fork PRs — the build runs without secrets, and publishing runs in the base repo context via workflow_run
- A Python script (scripts/rewrite-python-preview-versions.py) rewrites all 6 Python package versions to a shared 0.0.0.dev{timestamp} and pins inter-package dependencies (e.g., ag-ui-protocol) to the same version
- Posts/updates a PR comment with install instructions for uv and pip


### Testing
   - Add TEST_PYPI_API_TOKEN secret to repo settings
   - Open a test PR and verify the build workflow completes and uploads artifacts
   - Verify the publish workflow triggers on build completion and publishes to TestPyPI
   - Verify the PR comment appears with correct version and install instructions
   - Test uv add ag-ui-protocol==<version> --index testpypi resolves correctly
   - Test from a fork PR to confirm secrets are not exposed and publishing still works
   - Test using pyproject+uv in some test repo
   ```
     [[tool.uv.index]]
  name = "testpypi"
  url = "https://test.pypi.org/simple/"
  explicit = true

  [tool.uv.sources]
  ag-ui-protocol = { index = "testpypi" }
  # Add any other ag-ui packages you need, e.g.:
  # ag-ui-langgraph = { index = "testpypi" }

  Then in your dependencies:

  [project]
  dependencies = [
      "ag-ui-protocol==0.0.0.dev<timestamp>",
  ]
  ```