### PR TITLE
Remove unnecessary secret injection from dojo e2e workflow

### DIFF
--- a/.github/workflows/dojo-e2e.yml
+++ b/.github/workflows/dojo-e2e.yml
@@ -235,25 +235,17 @@ jobs:
         if: steps.cache-playwright.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
 
-      - name: write langgraph env files
-        working-directory: integrations/langgraph
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-        if: ${{ contains(join(matrix.services, ','), 'langgraph-fastapi') || contains(join(matrix.services, ','), 'langgraph-platform-python') || contains(join(matrix.services, ','), 'langgraph-platform-typescript') }}
+      - name: Create langgraph stub .env files
+        if: ${{ contains(join(matrix.services, ','), 'langgraph-platform-python') || contains(join(matrix.services, ','), 'langgraph-platform-typescript') }}
         run: |
-          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" > python/examples/.env
-          echo "LANGSMITH_API_KEY=${LANGSMITH_API_KEY}" >> python/examples/.env
-          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" > typescript/examples/.env
-          echo "LANGSMITH_API_KEY=${LANGSMITH_API_KEY}" >> typescript/examples/.env
+          # langgraph.json declares "env": ".env" — the CLI requires this file
+          # to exist on disk. Values don't matter since run-dojo-everything.js
+          # injects LLMock env vars into the process environment.
+          touch integrations/langgraph/python/examples/.env
+          touch integrations/langgraph/typescript/examples/.env
 
       - name: Run dojo+agents
         uses: JarvusInnovations/background-action@v1
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         if: ${{ join(matrix.services, ',') != '' && contains(join(matrix.services, ','), 'dojo') }}
         with:
           run: |


### PR DESCRIPTION
## Summary

- Remove real API key injection (`OPENAI_API_KEY`, `LANGSMITH_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`) from the dojo e2e workflow
- Remove the "write langgraph env files" step that wrote `.env` files with real secrets
- Add stub `.env` file creation for langgraph-platform suites (the CLI requires the file to exist on disk)

## Why

`run-dojo-everything.js` already injects LLMock-routed env vars for all integration services. The workflow's secret injection was redundant and counterproductive: when real API keys were present, per-service conditionals like Mastra's `!process.env.OPENAI_API_KEY && {OPENAI_BASE_URL: ...}` would skip the mock URL, potentially routing requests to real APIs instead of LLMock.

## Test plan

- [ ] All 18+ dojo e2e suites pass (services route to LLMock without real keys)
- [ ] langgraph-platform-python and langgraph-platform-typescript pass (stub .env satisfies langgraph.json requirement)