### PR TITLE
fix(langgraph): use protocol run_id for RUN_STARTED/RUN_FINISHED events

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -128,8 +128,10 @@ class LangGraphAgent:
 
     async def _handle_stream_events(self, input: RunAgentInput) -> AsyncGenerator[str, None]:
         thread_id = input.thread_id or str(uuid.uuid4())
+        protocol_run_id = input.run_id
         INITIAL_ACTIVE_RUN = {
             "id": input.run_id,
+            "protocol_run_id": protocol_run_id,
             "thread_id": thread_id,
             "reasoning_process": None,
             "node_name": None,
@@ -158,7 +160,7 @@ class LangGraphAgent:
         prepared_stream_response = await self.prepare_stream(input=input, agent_state=agent_state, config=config)
 
         yield self._dispatch_event(
-            RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["id"])
+            RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["protocol_run_id"])
         )
         self.handle_node_change(node_name_input)
 
@@ -328,7 +330,7 @@ class LangGraphAgent:
                 yield ev
 
             yield self._dispatch_event(
-                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["id"])
+                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["protocol_run_id"])
             )
             # Reset active run to how it was before the stream started
             self.active_run = INITIAL_ACTIVE_RUN
@@ -391,7 +393,7 @@ class LangGraphAgent:
         events_to_dispatch = []
         if has_active_interrupts and not resume_input:
             events_to_dispatch.append(
-                RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["id"])
+                RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["protocol_run_id"])
             )
 
             for interrupt in interrupts:
@@ -405,7 +407,7 @@ class LangGraphAgent:
                 )
 
             events_to_dispatch.append(
-                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["id"])
+                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["protocol_run_id"])
             )
             return {
                 "stream": None,


### PR DESCRIPTION
## Summary

Fixes `RUN_FINISHED` emitting a different `run_id` than `RUN_STARTED`, breaking protocol run lifecycle tracking.

## Problem

In `_handle_stream_events`, line 191 unconditionally overwrites `self.active_run["id"]` with LangGraph's internal run ID on every stream event:

```python
self.active_run["id"] = event.get("run_id")
```

LangGraph's `astream_events` emits UUIDv7-format run IDs that differ from the protocol-level `run_id` (UUIDv4) passed in `RunAgentInput.run_id`. Since `RUN_FINISHED` reads from `self.active_run["id"]`, the emitted `run_id` doesn't match `RUN_STARTED`:

```
RUN_STARTED  → run_id=c0609373-b2ad-40f8-... (correct protocol UUIDv4)
RUN_FINISHED → run_id=019cd777-880c-7152-... (wrong, LangGraph UUIDv7)
```

## Fix

Store the original protocol `run_id` in a separate `protocol_run_id` key on `active_run` and use it for all 4 protocol-level events:

- `RUN_STARTED` in `_handle_stream_events` (line 157)
- `RUN_FINISHED` in `_handle_stream_events` (line 274)
- `RUN_STARTED` in `prepare_stream` interrupt path (line 317)
- `RUN_FINISHED` in `prepare_stream` interrupt path (line 331)

The LangGraph internal run ID (`self.active_run["id"]`) is still updated on every event for message-in-progress tracking, which requires matching LangGraph's internal IDs.

Closes #1279