### PR TITLE
fix(langgraph): recover from SSE stream drop instead of crashing conversation

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -382,11 +382,13 @@ class LangGraphAgent:
                 if last_user_message:
                     last_user_id = getattr(last_user_message, "id", None)
                     if last_user_id and last_user_id in checkpoint_ids:
-                        return await self.prepare_regenerate_stream(
+                        regenerate_result = await self.prepare_regenerate_stream(
                             input=input,
                             message_checkpoint=last_user_message,
                             config=config
                         )
+                        if regenerate_result is not None:
+                            return regenerate_result
 
         events_to_dispatch = []
         if has_active_interrupts and not resume_input:
@@ -1033,6 +1035,11 @@ class LangGraphAgent:
         if not thread_id:
             raise ValueError("Missing thread_id in config")
 
+        history_config = ensure_config(config.copy() if config else {})
+        configurable = history_config.setdefault("configurable", {})
+        if not configurable.get("thread_id"):
+            configurable["thread_id"] = thread_id
+
         history_list = []
         async for snapshot in self.graph.aget_state_history(history_config):
             history_list.append(snapshot)
@@ -1044,9 +1051,9 @@ class LangGraphAgent:
                 if idx == 0:
                     # No snapshot before this
                     # Return synthetic "empty before" version
-                    empty_snapshot = snapshot
-                    empty_snapshot.values["messages"] = []
-                    return empty_snapshot
+                    empty_values = snapshot.values.copy()
+                    empty_values["messages"] = []
+                    return snapshot._replace(values=empty_values)
 
                 snapshot_values_without_messages = snapshot.values.copy()
                 del snapshot_values_without_messages["messages"]
@@ -1057,7 +1064,7 @@ class LangGraphAgent:
 
                 return checkpoint
 
-        raise ValueError("Message ID not found in history")
+        return None
 
     def handle_node_change(self, node_name: Optional[str]):
         """

--- a/integrations/langgraph/python/tests/test_agent_recovery.py
+++ b/integrations/langgraph/python/tests/test_agent_recovery.py
@@ -1,0 +1,192 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ag_ui.core import UserMessage
+from ag_ui_langgraph.agent import LangGraphAgent
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+class _Snapshot:
+    def __init__(self, values, config=None, next_nodes=None):
+        self.values = values
+        self.config = config or {"configurable": {"thread_id": "thread-1"}}
+        self.next = next_nodes or ["assistant"]
+
+    def _replace(self, **kwargs):
+        return _Snapshot(
+            kwargs.get("values", self.values),
+            kwargs.get("config", self.config),
+            kwargs.get("next", self.next),
+        )
+
+
+class TestLangGraphAgentRecovery(unittest.TestCase):
+    def test_get_checkpoint_before_message_uses_supplied_config(self):
+        history_config = {
+            "configurable": {
+                "thread_id": "thread-1",
+                "checkpoint_ns": "fork-1",
+            }
+        }
+        previous = _Snapshot(
+            values={
+                "messages": [HumanMessage(content="before", id="before-user-id")],
+                "step": "before",
+            },
+            config=history_config,
+        )
+        current = _Snapshot(
+            values={
+                "messages": [HumanMessage(content="retry", id="target-user-id")],
+                "step": "current",
+            },
+            config=history_config,
+        )
+
+        captured = {}
+
+        async def history(config):
+            captured["config"] = config
+            for snapshot in [current, previous]:
+                yield snapshot
+
+        graph = MagicMock()
+        graph.aget_state_history = history
+        agent = LangGraphAgent(name="test", graph=graph)
+
+        result = asyncio.run(
+            agent.get_checkpoint_before_message(
+                "target-user-id",
+                "thread-1",
+                history_config,
+            )
+        )
+
+        self.assertEqual(
+            captured["config"]["configurable"],
+            history_config["configurable"],
+        )
+        self.assertEqual(result.values["step"], "current")
+        self.assertEqual(
+            [message.id for message in result.values["messages"]],
+            ["before-user-id"],
+        )
+
+    def test_get_checkpoint_before_message_returns_none_when_message_missing(self):
+        async def history(_config):
+            yield _Snapshot(
+                values={"messages": [HumanMessage(content="before", id="before-user-id")]},
+            )
+
+        graph = MagicMock()
+        graph.aget_state_history = history
+        agent = LangGraphAgent(name="test", graph=graph)
+
+        result = asyncio.run(
+            agent.get_checkpoint_before_message(
+                "missing-user-id",
+                "thread-1",
+                {"configurable": {"thread_id": "thread-1"}},
+            )
+        )
+
+        self.assertIsNone(result)
+
+    def test_get_checkpoint_before_message_does_not_mutate_first_snapshot(self):
+        current = _Snapshot(
+            values={
+                "messages": [HumanMessage(content="retry", id="target-user-id")],
+                "step": "current",
+            },
+        )
+
+        async def history(_config):
+            yield current
+
+        graph = MagicMock()
+        graph.aget_state_history = history
+        agent = LangGraphAgent(name="test", graph=graph)
+
+        result = asyncio.run(
+            agent.get_checkpoint_before_message(
+                "target-user-id",
+                "thread-1",
+                {"configurable": {"thread_id": "thread-1"}},
+            )
+        )
+
+        self.assertEqual(
+            [message.id for message in result.values["messages"]],
+            [],
+        )
+        self.assertEqual(
+            [message.id for message in current.values["messages"]],
+            ["target-user-id"],
+        )
+
+    def test_prepare_stream_falls_back_when_recovery_returns_none(self):
+        graph = MagicMock()
+        graph.astream_events = MagicMock(return_value="normal-stream")
+
+        agent = LangGraphAgent(name="test", graph=graph)
+        agent.active_run = {
+            "id": "run-1",
+            "mode": "start",
+            "schema_keys": [],
+            "node_name": None,
+        }
+        agent.langgraph_default_merge_state = MagicMock(return_value={})
+        agent.get_stream_kwargs = MagicMock(
+            return_value={
+                "input": {"ok": True},
+                "config": {"configurable": {"thread_id": "thread-1"}},
+                "subgraphs": False,
+                "version": "v2",
+            }
+        )
+        agent.prepare_regenerate_stream = AsyncMock(return_value=None)
+
+        input_obj = SimpleNamespace(
+            state={},
+            messages=[UserMessage(id="unused", role="user", content="retry")],
+            forwarded_props={},
+            context=[],
+            thread_id="thread-1",
+            run_id="run-1",
+            tools=None,
+        )
+        agent_state = SimpleNamespace(
+            values={
+                "messages": [
+                    HumanMessage(content="stored", id="same-user-id"),
+                    AIMessage(content="assistant", id="stored-ai-id"),
+                    AIMessage(content="extra assistant", id="extra-ai-id"),
+                ]
+            },
+            tasks=[],
+            metadata={},
+            next=[],
+        )
+        config = {"configurable": {"thread_id": "thread-1"}}
+
+        with patch(
+            "ag_ui_langgraph.agent.agui_messages_to_langchain",
+            return_value=[
+                AIMessage(content="frontend echo", id="fresh-ai-id"),
+                HumanMessage(content="retry", id="same-user-id"),
+            ],
+        ):
+            result = asyncio.run(
+                agent.prepare_stream(
+                    input=input_obj,
+                    agent_state=agent_state,
+                    config=config,
+                )
+            )
+
+        self.assertEqual(agent.prepare_regenerate_stream.await_count, 1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["stream"], "normal-stream")
+        self.assertEqual(result["config"], config)


### PR DESCRIPTION
## Summary

Fixes permanently broken conversations after SSE connection drops.

## Problem

When an SSE connection terminates before the `MESSAGES_SNAPSHOT` event is delivered, the client never learns the real message IDs persisted in the LangGraph checkpoint.

On the next turn:
1. Client sends `N+1` messages (with a fresh UUID for the new one)
2. Checkpoint has `N+2` messages (server completed the previous turn fully)
3. `prepare_stream()` sees `len(checkpoint) > len(incoming)` → routes to `prepare_regenerate_stream()`
4. `get_checkpoint_before_message(fresh_uuid)` walks every historical checkpoint, never finds the UUID
5. Raises `ValueError: 'Message ID not found in history'` → **500 error**
6. Client still doesn't get a `MESSAGES_SNAPSHOT` → **every subsequent turn crashes the same way**

The conversation thread is permanently broken.

## Fix

### 1. `get_checkpoint_before_message()`: return `None` instead of raising

```python
# Before (crashes)
raise ValueError('Message ID not found in history')

# After (communicates 'not found' without crashing)
return None
```

### 2. `prepare_stream()`: fall through on regeneration failure

```python
# Before (returns None, causing downstream crash)
return await self.prepare_regenerate_stream(...)

# After (falls through to normal continuation)
regenerate_result = await self.prepare_regenerate_stream(...)
if regenerate_result is not None:
    return regenerate_result
# Falls through to normal stream setup below
```

When the message ID is not found (SSE drop recovery), the count mismatch is treated as a dropped-connection recovery rather than a genuine regeneration request. The conversation continues normally, and the `MESSAGES_SNAPSHOT` event at the end of the stream re-syncs the client.

Closes #1278