### PR TITLE
fix(client): preserve reasoning messages after MESSAGES_SNAPSHOT

### DIFF
--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -525,14 +525,18 @@ export const defaultApplyEvents = (
             const { messages: newMessages } = event as MessagesSnapshotEvent;
 
             // Edit-based merge: update existing messages with snapshot data while
-            // preserving activity messages (which the backend doesn't know about).
+            // preserving activity and reasoning messages (which the backend
+            // doesn't include in the snapshot).
             const snapshotMap = new Map(newMessages.map((m) => [m.id, m]));
 
-            // Step 1 + 2: Keep activity messages as-is, keep messages present in
-            // the snapshot (replaced with snapshot version), drop everything else.
+            // Step 1 + 2: Keep activity/reasoning messages as-is, keep messages
+            // present in the snapshot (replaced with snapshot version), drop
+            // everything else.
+            const isClientOnlyRole = (role: string) =>
+              role === "activity" || role === "reasoning";
             messages = messages
-              .filter((m) => m.role === "activity" || snapshotMap.has(m.id))
-              .map((m) => (m.role === "activity" ? m : snapshotMap.get(m.id)!));
+              .filter((m) => isClientOnlyRole(m.role) || snapshotMap.has(m.id))
+              .map((m) => (isClientOnlyRole(m.role) ? m : snapshotMap.get(m.id)!));
 
             // Step 3: Append messages from the snapshot that we don't have yet.
             const existingIds = new Set(messages.map((m) => m.id));


### PR DESCRIPTION
## Summary

Fixes reasoning messages disappearing from `agent.messages` after `MESSAGES_SNAPSHOT` is applied.

## Problem

Reasoning messages (`role: "reasoning"`) are created during streaming via `REASONING_MESSAGE_START`/`REASONING_MESSAGE_CONTENT` events and appear correctly in `agent.messages` during the stream.

However, when the final `MESSAGES_SNAPSHOT` arrives:

1. **LangGraph integration** builds the snapshot from `langchainMessagesToAgui()`, which only maps `human`/`ai`/`system`/`tool` — reasoning is not a LangChain message type (it's metadata on AI chunks), so the snapshot never contains reasoning messages.

2. **Client-side filter** (`default.ts` L534) only exempts `"activity"` role:
   ```typescript
   .filter((m) => m.role === "activity" || snapshotMap.has(m.id))
   ```
   Reasoning message IDs aren't in the snapshot → they're dropped.

## Fix

Extract a helper `isClientOnlyRole()` that exempts both `"activity"` and `"reasoning"` from snapshot filtering:

```typescript
const isClientOnlyRole = (role: string) =>
  role === "activity" || role === "reasoning";
messages = messages
  .filter((m) => isClientOnlyRole(m.role) || snapshotMap.has(m.id))
```

This preserves reasoning messages across the snapshot merge, matching the behavior already established for activity messages.

Closes #1262