### PR TITLE
feat(claude-agents-sdk): add a render blueprint for deploying the typescript and python SDK examples

### DIFF
--- a/integrations/claude-agent-sdk/python/examples/Dockerfile
+++ b/integrations/claude-agent-sdk/python/examples/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Copy the claude-agent-sdk python package (SDK + examples)
+COPY integrations/claude-agent-sdk/python/ ./
+
+# Install SDK and all dependencies (covers everything examples need)
+RUN uv pip install --system -e .
+
+WORKDIR /app/examples
+
+CMD ["python", "server.py"]

--- a/integrations/claude-agent-sdk/typescript/examples/Dockerfile
+++ b/integrations/claude-agent-sdk/typescript/examples/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-slim
+
+RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+WORKDIR /app
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+
+# Build required workspace packages in dependency order
+RUN pnpm --filter @ag-ui/proto build && \
+    pnpm --filter @ag-ui/core build && \
+    pnpm --filter @ag-ui/client build && \
+    pnpm --filter @ag-ui/encoder build && \
+    pnpm --filter @ag-ui/claude-agent-sdk build
+
+WORKDIR /app/integrations/claude-agent-sdk/typescript
+
+CMD ["npx", "tsx", "examples/server.ts"]

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+services:
+  - type: web
+    name: ag-ui-claude-sdk-python
+    runtime: docker
+    plan: standard
+    dockerfilePath: integrations/claude-agent-sdk/python/examples/Dockerfile
+    dockerContext: .
+    healthCheckPath: /health
+    buildFilter:
+      paths:
+        - integrations/claude-agent-sdk/python/**
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+
+  - type: web
+    name: ag-ui-claude-sdk-typescript
+    runtime: docker
+    plan: standard
+    dockerfilePath: integrations/claude-agent-sdk/typescript/examples/Dockerfile
+    dockerContext: .
+    healthCheckPath: /health
+    buildFilter:
+      paths:
+        - integrations/claude-agent-sdk/typescript/**
+        - sdks/typescript/packages/**
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false


### PR DESCRIPTION
Adding a render deployment for the Claude Agents SDK examples to be consumed in the Dojo