### PR TITLE
fix(mastra): handle binary content parts in user messages

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -59,6 +59,89 @@ describe("convertAGUIMessagesToMastra", () => {
       expect(result).toEqual([{ role: "user", content: "Keep this" }]);
     });
 
+    it("converts binary content parts to image format", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "binary",
+              mimeType: "image/png",
+              data: "iVBORw0KGgoAAAANS",
+            },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image",
+              image: "iVBORw0KGgoAAAANS",
+              mimeType: "image/png",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("handles binary-only content", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "user",
+          content: [
+            {
+              type: "binary",
+              mimeType: "image/jpeg",
+              data: "/9j/4AAQ",
+            },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              image: "/9j/4AAQ",
+              mimeType: "image/jpeg",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("falls back to text-only for content without binary parts", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "user",
+          content: [
+            { type: "text", text: "Just text" },
+            { type: "text", text: "More text" },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        { role: "user", content: "Just text\nMore text" },
+      ]);
+    });
+
     it("trims whitespace from text parts and filters empty", () => {
       const messages: Message[] = [
         {

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -53,11 +53,33 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
         content: parts,
       });
     } else if (message.role === "user") {
-      const userContent = toMastraTextContent(message.content);
-      result.push({
-        role: "user",
-        content: userContent,
-      });
+      const content = message.content;
+      if (
+        Array.isArray(content) &&
+        content.some((part) => part.type === "binary")
+      ) {
+        const parts: any[] = [];
+        for (const part of content) {
+          if (part.type === "text") {
+            const text = part.text.trim();
+            if (text) {
+              parts.push({ type: "text", text });
+            }
+          } else if (part.type === "binary") {
+            parts.push({
+              type: "image",
+              image: part.data,
+              mimeType: part.mimeType,
+            });
+          }
+        }
+        result.push({ role: "user", content: parts });
+      } else {
+        result.push({
+          role: "user",
+          content: toMastraTextContent(content),
+        });
+      }
     } else if (message.role === "tool") {
       let toolName = "unknown";
       for (const msg of messages) {


### PR DESCRIPTION
## Summary

- `convertAGUIMessagesToMastra()` silently dropped all non-text content parts from user messages via `toMastraTextContent()`, stripping `{ type: "binary", mimeType, data }` image content before it reached the LLM
- Add handling for binary content parts in user messages, converting AG-UI `{ type: "binary", data, mimeType }` → Vercel AI SDK `{ type: "image", image, mimeType }` format
- Falls back to original text-only behavior when no binary parts are present

## Test plan

- [x] Added 3 new unit tests covering mixed text+binary, binary-only, and text-only fallback
- [x] All 43 existing tests pass (`pnpm test`)
- [x] TypeScript type checking passes (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)