### PR TITLE
docs: add Amazon Bedrock AgentCore Runtime as AG-UI deployment infrastructure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | ---------- | ------- | ---------------- | ------------- |
 | [A2A]() | ✅ Supported | ➡️ [Docs](https://docs.copilotkit.ai/a2a-protocol) | Partnership |
 
+
+## Infrastructure / Deployment
+| Platform | Status | AG-UI Resources | Integrations |
+| ---------- | ------- | ---------------- | ------------- |
+| [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) | ✅ Supported | ➡️ [Docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html) | 1st Party |
+
+
 ## Specification (standard)
 | Framework | Status | AG-UI Resources |
 | ---------- | ------- | ---------------- |

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -24,6 +24,10 @@ that demonstrate the protocol's capabilities and versatility.
   powerful AI agents.
 - **[AG2](https://ag2.ai)** - The Open-Source AgentOS
 
+## Infrastructure / Deployment
+
+- **[Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)** - Fully managed infrastructure for deploying AG-UI agents to production with native protocol support, managed authentication, session isolation, and auto-scaling. See the [deployment guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html) and the [announcement](https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-agentcore-runtime-ag-ui-protocol/).
+
 ## Specification (standard)
 - **[Oracle Open Agent Spec](http://oracle.github.io/agent-spec/)** - A portable language for defining agentic systems
 - **[A2A Middleware](https://a2a-protocol.org/)** - Provides the definitive common language for agent interoperability

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -275,6 +275,13 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | :------- | ------ | --------------- | ------------ |
 | [A2A Middleware](https://a2a-protocol.org/) | Supported | [Docs](https://docs.copilotkit.ai/a2a-protocol) | Partnership |
 
+
+### Infrastructure / Deployment
+| Platform | Status | AG-UI Resources | Integrations |
+| :------- | ------ | --------------- | ------------ |
+| [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) | Supported | [Docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html) | 1st Party |
+
+
 ### Specification (standard)
 | Framework | Status | AG-UI Resources |
 | :-------- | ------ | --------------- |

--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -68,7 +68,18 @@ You can also use the helper functions `add_strands_fastapi_endpoint` and `add_pi
     add_ping(app, "/ping")
 ```
 
-Requests to AC endpoint needs to be authenticated and authorized. You can configure your agent runtime to accept JWT bearer tokens, and configure the server-side component of the UI to send access token as an HTTP header to AC.
+Requests to the AC endpoint must be authenticated. You can configure your agent runtime to accept JWT bearer tokens (via Amazon Cognito) or use SigV4. See [Set up authentication](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html) in the AgentCore documentation.
+
+For details on how AgentCore handles AG-UI requests, event streaming, and error formatting, see the [AG-UI protocol contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui-protocol-contract.html).
+
+To deploy, use the [AgentCore Starter Toolkit](https://github.com/awslabs/bedrock-agentcore-starter-toolkit):
+```bash
+pip install bedrock-agentcore-starter-toolkit
+agentcore configure -e my_agui_server.py --protocol AGUI
+agentcore deploy
+```
+
+For the complete deployment walkthrough, see [Deploy AG-UI servers in AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html).
 
 
 ## Next Steps


### PR DESCRIPTION
Amazon Bedrock AgentCore Runtime now has a dedicated AG-UI endpoint. This PR adds AgentCore to the documentation as deployment infrastructure and updates the aws-strands integration README with deployment instructions.

AgentCore is managed hosting infrastructure, not an agent framework. Developers build agents with frameworks like Strands or LangGraph, then deploy to AgentCore with native AG-UI protocol support (serverProtocol: "AGUI"). This PR adds a new "Infrastructure / Deployment" section in the docs rather than adding to the framework tables.

### Changes

|File                                       |Change                                                              |
|-------------------------------------------|--------------------------------------------------------------------|
|`README.md`                                |Add “Infrastructure / Deployment” section                           |
|`docs/introduction.mdx`                    |Add “Infrastructure / Deployment” table                             |
|`docs/integrations.mdx`                    |Add “Infrastructure / Deployment” section                           |
|`integrations/aws-strands/python/README.md`|Update AgentCore section with auth link, toolkit commands, docs link|

Links:

- Announcement: https://aws.amazon.com/about-aws/whats-new/2026/03/amazon-bedrock-agentcore-runtime-ag-ui-protocol/
- Deployment guide: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html
- Protocol contract: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui-protocol-contract.html