### PR TITLE
fix(langgraph): pass graphId filter to assistants.search()

### DIFF
--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1267,15 +1267,16 @@ export class LangGraphAgent extends AbstractAgent {
 
   async getAssistant(): Promise<Assistant> {
     try {
-      const assistants = await this.client.assistants.search();
-      const retrievedAssistant = assistants.find(
-        (searchResult) => searchResult.graph_id === this.graphId,
-      );
+      const assistants = await this.client.assistants.search({
+        graphId: this.graphId,
+      });
+      const retrievedAssistant = assistants[0];
       if (!retrievedAssistant) {
+        const allAssistants = await this.client.assistants.search({ limit: 100 });
         const notFoundMessage = `
       No agent found with graph ID ${this.graphId} found..\n
 
-      These are the available agents: [${assistants.map((a) => `${a.graph_id} (ID: ${a.assistant_id})`).join(", ")}]
+      These are the available agents: [${allAssistants.map((a) => `${a.graph_id} (ID: ${a.assistant_id})`).join(", ")}]
       `
         console.error(notFoundMessage);
         throw new Error(notFoundMessage);


### PR DESCRIPTION
## Summary

- Pass `graphId` filter to `client.assistants.search()` in `getAssistant()` so the correct assistant is found regardless of pagination

## Problem

When a LangGraph server has more than 10 registered assistants, `getAssistant()` only receives the first page (default limit 10) from `client.assistants.search()`. If the target `graph_id` is beyond that page, initialization fails with "No agent found with graph ID X".

## Root Cause

`assistants.search()` is called without any filter parameters, returning all assistants with default pagination (limit 10).

## Fix

Pass `{ graphId: this.graphId }` to `assistants.search()` so the API filters server-side. The first result is the target assistant. On failure, a broader search (limit 100) is performed only for the diagnostic error message listing available agents.

## Testing

- With 11+ assistants where the target is on page 2: now found via filtered search
- With a single assistant: works as before (filter still returns it)
- With no matching assistant: error message now shows up to 100 available agents for debugging

Closes #1220