### PR TITLE
fix(langgraph-python): replace deprecated Pydantic and LangGraph method calls

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -123,7 +123,7 @@ class LangGraphAgent:
             forwarded_props = {
                 camel_to_snake(k): v for k, v in input.forwarded_props.items()
             }
-        async for event_str in self._handle_stream_events(input.copy(update={"forwarded_props": forwarded_props})):
+        async for event_str in self._handle_stream_events(input.model_copy(update={"forwarded_props": forwarded_props})):
             yield event_str
 
     async def _handle_stream_events(self, input: RunAgentInput) -> AsyncGenerator[str, None]:
@@ -482,15 +482,23 @@ class LangGraphAgent:
         try:
             input_schema = self.graph.get_input_jsonschema(config)
             output_schema = self.graph.get_output_jsonschema(config)
-            config_schema = self.graph.config_schema().schema()
+            if hasattr(self.graph, "get_config_jsonschema"):
+                config_schema = self.graph.get_config_jsonschema(config)
+            else:
+                config_schema = self.graph.config_schema().model_json_schema()
 
             input_schema_keys = list(input_schema["properties"].keys()) if "properties" in input_schema else []
             output_schema_keys = list(output_schema["properties"].keys()) if "properties" in output_schema else []
             config_schema_keys = list(config_schema["properties"].keys()) if "properties" in config_schema else []
             context_schema_keys = []
 
-            if hasattr(self.graph, "context_schema") and self.graph.context_schema is not None:
-                context_schema = self.graph.context_schema().schema()
+            if hasattr(self.graph, "get_context_jsonschema"):
+                context_schema = self.graph.get_context_jsonschema(config)
+            elif hasattr(self.graph, "context_schema") and self.graph.context_schema is not None:
+                context_schema = self.graph.context_schema().model_json_schema()
+            else:
+                context_schema = None
+            if context_schema is not None:
                 context_schema_keys = list(context_schema["properties"].keys()) if "properties" in context_schema else []
 
 


### PR DESCRIPTION
## Summary

- Replace deprecated `copy()`, `config_schema().schema()`, and `context_schema().schema()` calls in the Python LangGraph integration

## Problem

Three deprecation warnings fire on every agent run:

1. **Pydantic `copy`**: `input.copy(update=...)` triggers `PydanticDeprecatedSince20` — will be removed in Pydantic V3
2. **LangGraph `config_schema`**: `self.graph.config_schema()` triggers `LangGraphDeprecatedSinceV10` — use `get_context_jsonschema` instead, will be removed in LangGraph V2
3. **Pydantic `schema`**: `.schema()` triggers `PydanticDeprecatedSince20` — use `model_json_schema` instead

## Fix

| Before | After |
|--------|-------|
| `input.copy(update={...})` | `input.model_copy(update={...})` |
| `self.graph.config_schema().schema()` | `self.graph.get_config_jsonschema(config)` (with fallback) |
| `self.graph.context_schema().schema()` | `self.graph.get_context_jsonschema(config)` (with fallback) |

All replacements use `hasattr()` guards so older LangGraph versions without the new methods still work via the `.model_json_schema()` fallback (Pydantic V2 replacement for `.schema()`).

## Testing

- With LangGraph >= 1.0: uses `get_config_jsonschema()` and `get_context_jsonschema()` — no warnings
- With older LangGraph: falls back to `config_schema().model_json_schema()` — eliminates Pydantic `.schema()` warning, LangGraph warning remains until upgrade
- `model_copy()` is available in all Pydantic V2 versions

Closes #1128