### PR TITLE
fix(langgraph-python): reuse stable text message ID across tool call boundaries

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -123,7 +123,7 @@ class LangGraphAgent:
             forwarded_props = {
                 camel_to_snake(k): v for k, v in input.forwarded_props.items()
             }
-        async for event_str in self._handle_stream_events(input.copy(update={"forwarded_props": forwarded_props})):
+        async for event_str in self._handle_stream_events(input.model_copy(update={"forwarded_props": forwarded_props})):
             yield event_str
 
     async def _handle_stream_events(self, input: RunAgentInput) -> AsyncGenerator[str, None]:
@@ -136,6 +136,7 @@ class LangGraphAgent:
             "has_function_streaming": False,
             "model_made_tool_call": False,
             "state_reliable": True,
+            "text_message_id": None,
         }
         self.active_run = INITIAL_ACTIVE_RUN
 
@@ -482,15 +483,23 @@ class LangGraphAgent:
         try:
             input_schema = self.graph.get_input_jsonschema(config)
             output_schema = self.graph.get_output_jsonschema(config)
-            config_schema = self.graph.config_schema().schema()
+            if hasattr(self.graph, "get_config_jsonschema"):
+                config_schema = self.graph.get_config_jsonschema(config)
+            else:
+                config_schema = self.graph.config_schema().model_json_schema()
 
             input_schema_keys = list(input_schema["properties"].keys()) if "properties" in input_schema else []
             output_schema_keys = list(output_schema["properties"].keys()) if "properties" in output_schema else []
             config_schema_keys = list(config_schema["properties"].keys()) if "properties" in config_schema else []
             context_schema_keys = []
 
-            if hasattr(self.graph, "context_schema") and self.graph.context_schema is not None:
-                context_schema = self.graph.context_schema().schema()
+            if hasattr(self.graph, "get_context_jsonschema"):
+                context_schema = self.graph.get_context_jsonschema(config)
+            elif hasattr(self.graph, "context_schema") and self.graph.context_schema is not None:
+                context_schema = self.graph.context_schema().model_json_schema()
+            else:
+                context_schema = None
+            if context_schema is not None:
                 context_schema_keys = list(context_schema["properties"].keys()) if "properties" in context_schema else []
 
 
@@ -774,18 +783,20 @@ class LangGraphAgent:
 
             if is_message_content_event and should_emit_messages:
                 if bool(current_stream and current_stream.get("id")) == False:
+                    stable_id = self.active_run.get("text_message_id") or event["data"]["chunk"].id
+                    self.active_run["text_message_id"] = stable_id
                     yield self._dispatch_event(
                         TextMessageStartEvent(
                             type=EventType.TEXT_MESSAGE_START,
                             role="assistant",
-                            message_id=event["data"]["chunk"].id,
+                            message_id=stable_id,
                             raw_event=event,
                         )
                     )
                     self.set_message_in_progress(
                         self.active_run["id"],
                         MessageInProgress(
-                            id=event["data"]["chunk"].id,
+                            id=stable_id,
                             tool_call_id=None,
                             tool_call_name=None
                         )


### PR DESCRIPTION
## Summary

- Reuse a single stable text message ID across tool call boundaries within one agent run, preventing the frontend from splitting responses into multiple message chunks

## Problem

When using LangChain/LangGraph agents with tool-calling capabilities, each time the model resumes text generation after processing a tool call result, a new `TEXT_MESSAGE_START` event is emitted with a fresh chunk ID. The frontend (CopilotKit) interprets each new `TEXT_MESSAGE_START` as a separate message, causing the assistant's response to be displayed as multiple disconnected message bubbles.

## Root Cause

In `_stream_events()`, when `is_message_content_event` fires and there is no `current_stream` (because the previous stream was cleared on `OnChatModelEnd` after a tool call), a new `TextMessageStartEvent` is emitted using `event["data"]["chunk"].id`. Since each model invocation produces a different chunk ID, the message ID changes across tool call boundaries.

## Fix

Add a `text_message_id` field to `active_run` that is initialized to `None` at run start. When the first text segment arrives, the chunk's ID is captured and stored as the stable ID. On all subsequent text segments within the same run (after tool calls), the stored ID is reused:

```python
stable_id = self.active_run.get("text_message_id") or event["data"]["chunk"].id
self.active_run["text_message_id"] = stable_id
```

This ensures `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, and `TEXT_MESSAGE_END` events all share the same message ID throughout the entire run.

## Testing

- Single tool call: text before and after the tool call uses the same message ID
- Multiple tool calls: all text segments share one message ID
- No tool calls: behavior unchanged (first chunk ID is used and persisted)
- Custom events (`ManuallyEmitMessage`): unaffected (they supply their own message_id)

Closes #1317