### PR TITLE
fix: normalize wheel file permissions before publish

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -68,6 +68,32 @@ jobs:
         working-directory: ${{ inputs.package }}
         run: uv build
 
+      - name: Fix wheel permissions
+        working-directory: ${{ inputs.package }}
+        run: |
+          echo "## Normalizing wheel file permissions"
+          uv run python -c "
+          import glob, shutil, tempfile, zipfile, os
+
+          whl = glob.glob('dist/*.whl')[0]
+          print(f'Fixing permissions in {whl}')
+          tmp = whl + '.tmp'
+          with zipfile.ZipFile(whl, 'r') as zin, zipfile.ZipFile(tmp, 'w') as zout:
+              for info in zin.infolist():
+                  data = zin.read(info.filename)
+                  old_perms = (info.external_attr >> 16) & 0o777
+                  if info.is_dir():
+                      new_perms = 0o755
+                  else:
+                      new_perms = 0o644
+                  info.external_attr = (info.external_attr & ~(0o777 << 16)) | (new_perms << 16)
+                  zout.writestr(info, data)
+                  if old_perms != new_perms:
+                      print(f'  {oct(old_perms)} -> {oct(new_perms)}  {info.filename}')
+          shutil.move(tmp, whl)
+          print('Done.')
+          "
+
       - name: Verify wheel permissions
         working-directory: ${{ inputs.package }}
         run: |


### PR DESCRIPTION
## Summary

Adds a permission normalization step to the Python publish workflow that fixes file permissions inside the wheel zip after build but before verification/upload.

This addresses the same class of issue as #1028 — wheel files end up with broken permissions (`--w--wx---` / `0330`) when built on machines with restrictive umask settings. The existing verification step catches this but doesn't fix it, requiring a manual rebuild.

**The fix:** After `uv build`, rewrite all file entries in the wheel to `0644` and directories to `0755`. This runs before the existing verification step, which then confirms the normalization succeeded.

**Affected package:** `ag-ui-protocol` (and any future package built out-of-band)

Fixes #1341