### PR TITLE
fix(render): use actual Render service URLs (slugs differ from names)

### DIFF
--- a/integrations/ag2/python/examples/server/api/agentic_chat.py
+++ b/integrations/ag2/python/examples/server/api/agentic_chat.py
@@ -12,6 +12,7 @@ agent = ConversableAgent(
     name="support_bot",
     system_message="You are a helpful assistant. You answer product questions and help users.",
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/integrations/ag2/python/examples/server/api/agentic_generative_ui.py
+++ b/integrations/ag2/python/examples/server/api/agentic_generative_ui.py
@@ -98,6 +98,7 @@ agent = ConversableAgent(
     """),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
     functions=[create_plan, update_plan_step],
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/integrations/ag2/python/examples/server/api/backend_tool_rendering.py
+++ b/integrations/ag2/python/examples/server/api/backend_tool_rendering.py
@@ -101,6 +101,7 @@ Your primary function is to help users get weather details for specific location
 Use the get_weather tool to fetch current weather data.""",
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
     functions=[get_weather],
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/integrations/ag2/python/examples/server/api/human_in_the_loop.py
+++ b/integrations/ag2/python/examples/server/api/human_in_the_loop.py
@@ -26,6 +26,7 @@ agent = ConversableAgent(
         - If not accepted, ask the user for more information, DO NOT use the `generate_task_steps` tool again
     """),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/integrations/ag2/python/examples/server/api/shared_state.py
+++ b/integrations/ag2/python/examples/server/api/shared_state.py
@@ -144,6 +144,7 @@ agent = ConversableAgent(
     """),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
     functions=[get_current_recipe, display_recipe],
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/integrations/ag2/python/examples/server/api/tool_based_generative_ui.py
+++ b/integrations/ag2/python/examples/server/api/tool_based_generative_ui.py
@@ -11,6 +11,7 @@ from autogen.ag_ui import AGUIStream
 agent = ConversableAgent(
     name="haiku_bot",
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/render.yaml
+++ b/render.yaml
@@ -321,17 +321,17 @@ projects:
       - key: CREW_AI_URL
         value: https://ag-ui-dojo-crewai.onrender.com
       - key: AGENT_SPEC_URL
-        value: https://ag-ui-dojo-open-agent-spec.onrender.com
+        value: https://ag-ui-p7fw.onrender.com
       - key: PYDANTIC_AI_URL
-        value: https://ag-ui-dojo-pydantic-ai.onrender.com
+        value: https://pydantic-ai.onrender.com
       - key: ADK_MIDDLEWARE_URL
-        value: https://ag-ui-adk.onrender.com
+        value: https://ag-ui.onrender.com
       - key: AGENT_FRAMEWORK_PYTHON_URL
         value: https://ag-ui-dojo-maf-python.onrender.com
       - key: AGENT_FRAMEWORK_DOTNET_URL
         value: https://ag-ui-dojo-maf-dotnet.onrender.com
       - key: A2A_MIDDLEWARE_BUILDINGS_MANAGEMENT_URL
-        value: https://ag-ui-dojo-a2a-middleware-businesses-management.onrender.com
+        value: https://ag-ui-dojo-a2a-middleware-businesses.onrender.com
       - key: A2A_MIDDLEWARE_FINANCE_URL
         value: https://ag-ui-dojo-a2a-middleware-finance.onrender.com
       - key: A2A_MIDDLEWARE_IT_URL


### PR DESCRIPTION
Render's public URL uses the service slug, not the service name. Several services had slugs that differed:
- ag-ui-dojo-open-agent-spec → ag-ui-p7fw.onrender.com
- ag-ui-dojo-pydantic-ai → pydantic-ai.onrender.com
- ag-ui-adk → ag-ui.onrender.com
- a2a-middleware-businesses_management → ag-ui-dojo-a2a-middleware-businesses.onrender.com
