### PR TITLE
fix(client): connectAgent() hangs when connect() throws synchronously

### DIFF
--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -16,7 +16,7 @@ import { compareVersions } from "compare-versions";
 import { catchError, map, tap } from "rxjs/operators";
 import { finalize } from "rxjs/operators";
 import { takeUntil } from "rxjs/operators";
-import { pipe, Observable, from, of, EMPTY, Subject } from "rxjs";
+import { pipe, Observable, from, of, EMPTY, Subject, defer } from "rxjs";
 import { verifyEvents } from "@/verify";
 import { convertToLegacyEvents } from "@/legacy/convert";
 import { LegacyRuntimeProtocolEvent } from "@/legacy/types";
@@ -224,7 +224,7 @@ export abstract class AbstractAgent {
       });
 
       const pipeline = pipe(
-        () => this.connect(input),
+        () => defer(() => this.connect(input)),
         transformChunks(this.debug),
         verifyEvents(this.debug),
         // Stop processing immediately when this run is detached
@@ -248,7 +248,9 @@ export abstract class AbstractAgent {
         }),
       );
 
-      await lastValueFrom(pipeline(of(null))); // wait for stream completion before toggling isRunning
+      // defaultValue prevents EmptyError when catchError returns EMPTY
+      // (e.g. ConnectNotImplementedError path)
+      await lastValueFrom(pipeline(of(null)), { defaultValue: undefined });
       const newMessages = structuredClone_(this.messages).filter(
         (message: Message) => !currentMessageIds.has(message.id),
       );


### PR DESCRIPTION
When `connect()` throws `AGUIConnectNotImplementedError` synchronously (the default for agents that don't implement connect), the error is thrown during pipe() composition rather than within the observable stream. This means `catchError` and `finalize` operators never execute, so `activeRunCompletionPromise` is never resolved and `detachActiveRun()` hangs forever.

Two fixes:
1. Wrap `this.connect(input)` with `defer()` so the synchronous throw becomes an error notification within the observable stream, allowing `catchError` and `finalize` to run properly.
2. Add `{ defaultValue: undefined }` to `lastValueFrom` so it doesn't throw `EmptyError` when `catchError` returns 