### PR TITLE
feat(aws-strands): add tools_provider for per-request tool filtering

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -74,6 +74,8 @@ class StrandsAgent:
         self._agents_by_thread: Dict[str, StrandsAgentCore] = {}
         # Track proxy tool names registered per thread
         self._proxy_tool_names_by_thread: Dict[str, set] = {}
+        # Track tool names per thread to detect tools_provider changes
+        self._tool_names_by_thread: Dict[str, frozenset] = {}
 
     async def run(self, input_data: RunAgentInput) -> AsyncIterator[Any]:
         """Run the Strands agent and yield AG-UI events."""
@@ -81,13 +83,38 @@ class StrandsAgent:
         # Get or create agent instance for this thread
         # Each thread (user session) maintains its own conversation state
         thread_id = input_data.thread_id or "default"
-        if thread_id not in self._agents_by_thread:
+
+        # Resolve tools for this request
+        request_tools = self._tools
+        if self.config.tools_provider:
+            try:
+                provided_tools = self.config.tools_provider(input_data)
+                if provided_tools is not None:
+                    request_tools = provided_tools
+            except Exception as e:
+                logger.warning(f"tools_provider failed, using default tools: {e}")
+
+        # Determine whether the agent needs to be (re)created
+        need_new_agent = thread_id not in self._agents_by_thread
+        if not need_new_agent and self.config.tools_provider:
+            tool_names = frozenset(
+                t.__name__ if hasattr(t, "__name__") else str(t) for t in request_tools
+            )
+            if self._tool_names_by_thread.get(thread_id) != tool_names:
+                logger.info(f"Tools changed for thread {thread_id}, recreating agent")
+                need_new_agent = True
+
+        if need_new_agent:
             self._agents_by_thread[thread_id] = StrandsAgentCore(
                 model=self._model,
                 system_prompt=self._system_prompt,
-                tools=self._tools,
+                tools=request_tools,
                 **self._agent_kwargs,
             )
+            if self.config.tools_provider:
+                self._tool_names_by_thread[thread_id] = frozenset(
+                    t.__name__ if hasattr(t, "__name__") else str(t) for t in request_tools
+                )
         strands_agent = self._agents_by_thread[thread_id]
 
         # Sync proxy tools from client-defined tools

--- a/integrations/aws-strands/python/src/ag_ui_strands/config.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/config.py
@@ -45,6 +45,7 @@ StateFromArgs = Callable[[ToolCallContext], Awaitable[Optional[StatePayload]] | 
 StateFromResult = Callable[[ToolResultContext], Awaitable[Optional[StatePayload]] | Optional[StatePayload]]
 CustomResultHandler = Callable[[ToolResultContext], AsyncIterator[Any]]
 StateContextBuilder = Callable[[RunAgentInput, str], str]
+ToolsProvider = Callable[[RunAgentInput], Optional[List[Any]]]
 
 
 @dataclass
@@ -83,6 +84,7 @@ class StrandsAgentConfig:
 
     tool_behaviors: Dict[str, ToolBehavior] = field(default_factory=dict)
     state_context_builder: Optional[StateContextBuilder] = None
+    tools_provider: Optional[ToolsProvider] = None
 
 
 async def maybe_await(value: Any) -> Any:


### PR DESCRIPTION
## Summary

Adds a `tools_provider` callback to `StrandsAgentConfig` that resolves the tool set per request, enabling role-based and context-dependent tool filtering.

- New `ToolsProvider = Callable[[RunAgentInput], Optional[List[Any]]]` type in `config.py`
- New `tools_provider` field on `StrandsAgentConfig`
- Agent logic in `agent.py` calls the provider before each run; if the tool set changes between requests on the same thread, the agent instance is recreated with the new tools
- Falls back to the template agent's default tools if the provider returns `None` or is not configured

## Motivation

`StrandsAgent` currently uses a fixed tool set. In multi-user deployments, different users often need different tools based on identity, role, or context (e.g. admin vs read-only, feature gating, workflow-specific tools). See #1372 for the full use case.

## Usage

```python
def resolve_tools(input_data: RunAgentInput) -> list:
    role = input_data.forwarded_props.get("user_role", "viewer")
    if role == "admin":
        return [read_tool, write_tool, delete_tool]
    return [read_tool]

agent = StrandsAgent(
    agent=base_agent,
    name="my_agent",
    config=StrandsAgentConfig(tools_provider=resolve_tools),
)
```

## Test plan

- [ ] Verify default behavior unchanged when `tools_provider` is not set
- [ ] Verify tools resolve per-request when provider is configured
- [ ] Verify agent is recreated when tool set changes on the same thread
- [ ] Verify fallback to default tools when provider returns `None` or raises

Closes #1372