### PR TITLE
Fix: ToolMessage.name None crash and concurrent request state bug

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -896,7 +896,7 @@ class LangGraphAgent:
                             ToolCallStartEvent(
                                 type=EventType.TOOL_CALL_START,
                                 tool_call_id=tool_msg.tool_call_id,
-                                tool_call_name=tool_msg.name,
+                                tool_call_name=tool_msg.name or event.get("name", ""),
                                 parent_message_id=tool_msg.id,
                                 raw_event=event,
                             )
@@ -933,7 +933,7 @@ class LangGraphAgent:
                     ToolCallStartEvent(
                         type=EventType.TOOL_CALL_START,
                         tool_call_id=tool_call_output.tool_call_id,
-                        tool_call_name=tool_call_output.name,
+                        tool_call_name=tool_call_output.name or event.get("name", ""),
                         parent_message_id=tool_call_output.id,
                         raw_event=event,
                     )

--- a/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
@@ -6,7 +6,7 @@ from ag_ui.encoder import EventEncoder
 
 from .agent import LangGraphAgent
 
-def add_langgraph_fastapi_endpoint(app: FastAPI, agent: LangGraphAgent, path: str = "/"):
+def add_langgraph_fastapi_endpoint(app: FastAPI, agent_factory, path: str = "/"):
     """Adds an endpoint to the FastAPI app."""
 
     @app.post(path)
@@ -16,6 +16,8 @@ def add_langgraph_fastapi_endpoint(app: FastAPI, agent: LangGraphAgent, path: st
 
         # Create an event encoder to properly format SSE events
         encoder = EventEncoder(accept=accept_header)
+
+        agent = agent_factory()
 
         async def event_generator():
             async for event in agent.run(input_data):


### PR DESCRIPTION
This PR fixes two critical issues in LangGraph integration:

1. Prevents Pydantic validation error when ToolMessage.name is None  
   - Added fallback to event["name"] in ToolCallStartEvent

2. Fixes concurrency issue caused by shared agent state  
   - Updated endpoint to create a new LangGraphAgent instance per request

These fixes prevent SSE crashes and ensure correct step event ordering under concurrent usage.