### PR TITLE
fix: Returned fixed orphaned msgs in `LangGraphAgent.langgraph_default_merge_state`

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -635,7 +635,7 @@ class LangGraphAgent:
 
         return {
             **state,
-            "messages": new_messages,
+            "messages": existing_messages + new_messages,
             "tools": unique_tools,
             "ag-ui": {
                 "tools": unique_tools,

--- a/integrations/langgraph/python/tests/test_orphan_tool_merge_e2e.py
+++ b/integrations/langgraph/python/tests/test_orphan_tool_merge_e2e.py
@@ -1,0 +1,185 @@
+"""End-to-end test: orphan tool-message replacement through LangGraphAgent.run().
+
+This test builds a real LangGraph with checkpointing, simulates two turns:
+  Turn 1: AI makes a tool call -> orphan placeholder is left in checkpoint
+  Turn 2: .run() is called with the real tool result in incoming messages
+
+It then verifies the exact message history in both the final checkpoint and
+the MESSAGES_SNAPSHOT event after .run() completes.
+"""
+import asyncio
+import unittest
+from typing import Annotated
+from typing_extensions import TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, END, START
+from langgraph.graph.message import add_messages
+
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core.types import (
+    UserMessage as AguiUserMessage,
+    AssistantMessage as AguiAssistantMessage,
+    ToolMessage as AguiToolMessage,
+    ToolCall,
+    FunctionCall,
+)
+from ag_ui_langgraph.agent import LangGraphAgent
+
+
+ORPHAN_CONTENT = "Tool call 'show_result' with id 'tc-1' was interrupted before completion."
+REAL_CONTENT = '{"rendered": true, "title": "Weather"}'
+THREAD_ID = "test-thread-orphan"
+
+
+def _build_graph():
+    """Build a minimal graph with a mock answer node."""
+    class GraphState(TypedDict):
+        messages: Annotated[list, add_messages]
+
+    def mock_answer(_state: GraphState):
+        return {"messages": [AIMessage(content="It's sunny, 22°C.", id="ai-3")]}
+
+    g = StateGraph(GraphState)
+    g.add_node("agent", mock_answer)
+    g.add_edge(START, "agent")
+    g.add_edge("agent", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+def _seed_checkpoint_with_orphan(graph):
+    """Manually invoke the graph to create a checkpoint containing an orphan.
+
+    Simulates Turn 1: user asks -> AI calls tool -> orphan placeholder is written.
+    """
+    seed_messages = [
+        HumanMessage(content="What is the weather?", id="msg-1"),
+        AIMessage(
+            content="",
+            id="ai-1",
+            tool_calls=[{
+                "name": "show_result",
+                "args": {"title": "Weather"},
+                "id": "tc-1",
+                "type": "tool_call",
+            }],
+        ),
+        ToolMessage(
+            content=ORPHAN_CONTENT,
+            tool_call_id="tc-1",
+            id="orphan-1",
+        ),
+        AIMessage(content="", id="ai-2"),
+    ]
+    asyncio.get_event_loop().run_until_complete(
+        graph.ainvoke(
+            {"messages": seed_messages},
+            config={"configurable": {"thread_id": THREAD_ID}},
+        )
+    )
+
+
+def _make_incoming_messages():
+    """Simulate Turn 2 incoming AG-UI messages with the real FE tool result."""
+    return [
+        AguiUserMessage(id="msg-1", role="user", content="What is the weather?"),
+        AguiAssistantMessage(
+            id="ai-1",
+            role="assistant",
+            content="",
+            tool_calls=[ToolCall(
+                id="tc-1",
+                type="function",
+                function=FunctionCall(name="show_result", arguments='{"title": "Weather"}'),
+            )],
+        ),
+        AguiToolMessage(
+            id="orphan-1",
+            role="tool",
+            content=REAL_CONTENT,
+            tool_call_id="tc-1",
+        ),
+    ]
+
+
+async def _collect_events(agent, run_input):
+    """Run the agent and collect all emitted events."""
+    events = []
+    async for event in agent.run(run_input):
+        events.append(event)
+    return events
+
+
+_LANGCHAIN_TYPE_TO_ROLE = {
+    "HumanMessage": "user",
+    "AIMessage": "assistant",
+    "ToolMessage": "tool",
+    "SystemMessage": "system",
+}
+
+EXPECTED_HISTORY = [
+    ("user",      "msg-1",    "What is the weather?"),
+    ("assistant", "ai-1",     ""),
+    ("tool",      "orphan-1", REAL_CONTENT),          # orphan replaced
+    ("assistant", "ai-2",     ""),
+    ("assistant", "ai-3",     "It's sunny, 22°C."),   # mock answer
+]
+
+
+class TestOrphanToolMergeE2E(unittest.TestCase):
+    """End-to-end: verify exact message history after .run() with orphan replacement."""
+
+    def test_orphan_replaced_in_checkpoint_and_snapshot(self):
+        """After .run(), both the checkpoint and the MESSAGES_SNAPSHOT must
+        contain the correct message history with the orphan replaced."""
+        graph = _build_graph()
+        _seed_checkpoint_with_orphan(graph)
+        agent = LangGraphAgent(name="e2e-test", graph=graph)
+
+        run_input = RunAgentInput(
+            threadId=THREAD_ID,
+            runId="run-2",
+            messages=_make_incoming_messages(),
+            tools=[],
+            state={},
+            context=[],
+            forwardedProps={},
+        )
+        events = asyncio.get_event_loop().run_until_complete(
+            _collect_events(agent, run_input)
+        )
+
+        # -- Checkpoint --
+        checkpoint_state = asyncio.get_event_loop().run_until_complete(
+            graph.aget_state({"configurable": {"thread_id": THREAD_ID}})
+        )
+        checkpoint_msgs = [
+            (_LANGCHAIN_TYPE_TO_ROLE[type(m).__name__], m.id, m.content)
+            for m in checkpoint_state.values.get("messages", [])
+        ]
+        self.assertEqual(
+            checkpoint_msgs, EXPECTED_HISTORY,
+            f"\nCheckpoint actual:\n{checkpoint_msgs}\nExpected:\n{EXPECTED_HISTORY}",
+        )
+
+        # -- MESSAGES_SNAPSHOT event --
+        snapshot_events = [
+            e for e in events
+            if hasattr(e, "type") and e.type == EventType.MESSAGES_SNAPSHOT
+        ]
+        self.assertTrue(snapshot_events, "No MESSAGES_SNAPSHOT event emitted")
+
+        snapshot_msgs = [
+            (m.role, m.id, m.content)
+            for m in snapshot_events[-1].messages
+        ]
+ 
+        self.assertEqual(
+            snapshot_msgs, EXPECTED_HISTORY,
+            f"\nSnapshot actual:\n{snapshot_msgs}\nExpected:\n{EXPECTED_HISTORY}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_orphan_tool_merge_e2e.py
+++ b/integrations/langgraph/python/tests/test_orphan_tool_merge_e2e.py
@@ -1,11 +1,13 @@
 """End-to-end test: orphan tool-message replacement through LangGraphAgent.run().
 
-This test builds a real LangGraph with checkpointing, simulates two turns:
-  Turn 1: AI makes a tool call -> orphan placeholder is left in checkpoint
-  Turn 2: .run() is called with the real tool result in incoming messages
+TODO is this the expected pattern with CopilotKit?
+This test builds a real LangGraph with checkpointing and runs .run() twice:
+  Turn 1: User asks a question -> AI makes a frontend tool call.
+  Turn 2: .run() is called with the real tool result in incoming messages.
+          The orphan must be replaced and the AI produces a final answer.
 
-It then verifies the exact message history in both the final checkpoint and
-the MESSAGES_SNAPSHOT event after .run() completes.
+It verifies the exact message history in both the final checkpoint and
+the MESSAGES_SNAPSHOT event after Turn 2 completes.
 """
 import asyncio
 import unittest
@@ -34,54 +36,64 @@ THREAD_ID = "test-thread-orphan"
 
 
 def _build_graph():
-    """Build a minimal graph with a mock answer node."""
+    """Build a graph whose node behaviour depends on a counter.
+
+    counter=0 (Turn 1): return an AIMessage with a tool_call (frontend tool).
+    counter>=1 (Turn 2+): return a plain AIMessage answer.
+    """
     class GraphState(TypedDict):
         messages: Annotated[list, add_messages]
+        counter: int
 
-    def mock_answer(_state: GraphState):
-        return {"messages": [AIMessage(content="It's sunny, 22°C.", id="ai-3")]}
+    def mock_agent(_state: GraphState):
+        turn = _state.get("counter", 0)
+        if turn == 0:
+            # Turn 1: AI calls a frontend tool + orphan placeholder is created
+            return {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        id="ai-1",
+                        tool_calls=[{
+                            "name": "show_result",
+                            "args": {"title": "Weather"},
+                            "id": "tc-1",
+                            "type": "tool_call",
+                        }],
+                    ),
+                    ToolMessage(
+                        content=ORPHAN_CONTENT,
+                        tool_call_id="tc-1",
+                        id="orphan-1",
+                    ),
+                ],
+                "counter": turn + 1,
+            }
+        # Turn 2+: AI answers based on the tool result
+        return {
+            "messages": [AIMessage(
+                content="It's sunny, 22°C.",
+                id=f"ai-{turn + 1}",
+            )],
+            "counter": turn + 1,
+        }
 
     g = StateGraph(GraphState)
-    g.add_node("agent", mock_answer)
+    g.add_node("agent", mock_agent)
     g.add_edge(START, "agent")
     g.add_edge("agent", END)
     return g.compile(checkpointer=MemorySaver())
 
 
-def _seed_checkpoint_with_orphan(graph):
-    """Manually invoke the graph to create a checkpoint containing an orphan.
-
-    Simulates Turn 1: user asks -> AI calls tool -> orphan placeholder is written.
-    """
-    seed_messages = [
-        HumanMessage(content="What is the weather?", id="msg-1"),
-        AIMessage(
-            content="",
-            id="ai-1",
-            tool_calls=[{
-                "name": "show_result",
-                "args": {"title": "Weather"},
-                "id": "tc-1",
-                "type": "tool_call",
-            }],
-        ),
-        ToolMessage(
-            content=ORPHAN_CONTENT,
-            tool_call_id="tc-1",
-            id="orphan-1",
-        ),
-        AIMessage(content="", id="ai-2"),
+def _make_turn1_messages():
+    """Turn 1: user asks a question."""
+    return [
+        AguiUserMessage(id="msg-1", role="user", content="What is the weather?"),
     ]
-    asyncio.get_event_loop().run_until_complete(
-        graph.ainvoke(
-            {"messages": seed_messages},
-            config={"configurable": {"thread_id": THREAD_ID}},
-        )
-    )
 
 
-def _make_incoming_messages():
-    """Simulate Turn 2 incoming AG-UI messages with the real FE tool result."""
+def _make_turn2_messages():
+    """Turn 2: replay history + orphan replaced with real tool result + new user msg."""
     return [
         AguiUserMessage(id="msg-1", role="user", content="What is the weather?"),
         AguiAssistantMessage(
@@ -100,6 +112,7 @@ def _make_incoming_messages():
             content=REAL_CONTENT,
             tool_call_id="tc-1",
         ),
+        AguiUserMessage(id="msg-2", role="user", content="Thanks, show me the weather"),
     ]
 
 
@@ -118,67 +131,89 @@ _LANGCHAIN_TYPE_TO_ROLE = {
     "SystemMessage": "system",
 }
 
-EXPECTED_HISTORY = [
-    ("user",      "msg-1",    "What is the weather?"),
-    ("assistant", "ai-1",     ""),
-    ("tool",      "orphan-1", REAL_CONTENT),          # orphan replaced
-    ("assistant", "ai-2",     ""),
-    ("assistant", "ai-3",     "It's sunny, 22°C."),   # mock answer
-]
+
+def _checkpoint_history(graph):
+    """Read checkpoint and return messages as (role, id, content) tuples."""
+    state = asyncio.get_event_loop().run_until_complete(
+        graph.aget_state({"configurable": {"thread_id": THREAD_ID}})
+    )
+    return [
+        (_LANGCHAIN_TYPE_TO_ROLE[type(m).__name__], m.id, m.content)
+        for m in state.values.get("messages", [])
+    ]
 
 
 class TestOrphanToolMergeE2E(unittest.TestCase):
-    """End-to-end: verify exact message history after .run() with orphan replacement."""
+    """End-to-end: two .run() turns verifying orphan replacement."""
 
-    def test_orphan_replaced_in_checkpoint_and_snapshot(self):
-        """After .run(), both the checkpoint and the MESSAGES_SNAPSHOT must
-        contain the correct message history with the orphan replaced."""
+    def test_orphan_replaced_across_two_runs(self):
+        """Run Turn 1 (tool call) then Turn 2 (real result). Verify both
+        the checkpoint and the MESSAGES_SNAPSHOT contain the correct history
+        with the orphan replaced."""
         graph = _build_graph()
-        _seed_checkpoint_with_orphan(graph)
         agent = LangGraphAgent(name="e2e-test", graph=graph)
 
-        run_input = RunAgentInput(
+        # ── Turn 1: user asks, AI makes a frontend tool call ──
+        turn1_input = RunAgentInput(
             threadId=THREAD_ID,
-            runId="run-2",
-            messages=_make_incoming_messages(),
+            runId="run-1",
+            messages=_make_turn1_messages(),
             tools=[],
             state={},
             context=[],
             forwardedProps={},
         )
-        events = asyncio.get_event_loop().run_until_complete(
-            _collect_events(agent, run_input)
+        asyncio.get_event_loop().run_until_complete(
+            _collect_events(agent, turn1_input)
         )
 
-        # -- Checkpoint --
-        checkpoint_state = asyncio.get_event_loop().run_until_complete(
-            graph.aget_state({"configurable": {"thread_id": THREAD_ID}})
-        )
-        checkpoint_msgs = [
-            (_LANGCHAIN_TYPE_TO_ROLE[type(m).__name__], m.id, m.content)
-            for m in checkpoint_state.values.get("messages", [])
+        # After Turn 1: checkpoint has user msg + AI tool call
+        turn1_history = _checkpoint_history(graph)
+        turn1_history_expected = [
+            ("user",      "msg-1", "What is the weather?"),
+            ("assistant", "ai-1",  ""),  
+            ('tool', 'orphan-1', ORPHAN_CONTENT)
         ]
-        self.assertEqual(
-            checkpoint_msgs, EXPECTED_HISTORY,
-            f"\nCheckpoint actual:\n{checkpoint_msgs}\nExpected:\n{EXPECTED_HISTORY}",
+        self.assertEqual(turn1_history, turn1_history_expected)
+
+        # ── Turn 2: real tool result + new user message ──
+        turn2_input = RunAgentInput(
+            threadId=THREAD_ID,
+            runId="run-2",
+            messages=_make_turn2_messages(),
+            tools=[],
+            state={},
+            context=[],
+            forwardedProps={},
+        )
+        turn2_events = asyncio.get_event_loop().run_until_complete(
+            _collect_events(agent, turn2_input)
         )
 
-        # -- MESSAGES_SNAPSHOT event --
+        # ── Verify checkpoint ──
+        turn_2_history_expected = [
+            ("user",      "msg-1",      "What is the weather?"),
+            ("assistant", "ai-1",       ""),                            # tool call
+            ("tool",      "orphan-1",   REAL_CONTENT),                  # orphan replaced
+            ("user",      "msg-2",      "Thanks, show me the weather"),
+            ("assistant", "ai-2",  "It's sunny, 22°C."),          # Turn 2 answer
+        ]
+
+        checkpoint_msgs = _checkpoint_history(graph)
+        self.assertEqual(checkpoint_msgs, turn_2_history_expected)
+
+        # ── Verify MESSAGES_SNAPSHOT ──
         snapshot_events = [
-            e for e in events
+            e for e in turn2_events
             if hasattr(e, "type") and e.type == EventType.MESSAGES_SNAPSHOT
         ]
-        self.assertTrue(snapshot_events, "No MESSAGES_SNAPSHOT event emitted")
+        self.assertTrue(snapshot_events)
 
         snapshot_msgs = [
             (m.role, m.id, m.content)
             for m in snapshot_events[-1].messages
         ]
- 
-        self.assertEqual(
-            snapshot_msgs, EXPECTED_HISTORY,
-            f"\nSnapshot actual:\n{snapshot_msgs}\nExpected:\n{EXPECTED_HISTORY}",
-        )
+        self.assertEqual(snapshot_msgs, turn_2_history_expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--

**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.gg/Jd3FzfdJa8

Take a look at the contributing guide:
https://github.com/ag-ui-protocol/ag-ui/blob/main/CONTRIBUTING.md

-->

## Context

- Addressing issue https://github.com/ag-ui-protocol/ag-ui/issues/1412.

- Bug in python LangGraph integration: the orphaned tools replacement in `langgraph_default_merge_state` is not returned, so any replacement is not actually propageted to the graph.

- Fix: return all messages in `langgraph_default_merge_state` (not only new messages)

- Added a test for this case.


### Comments

I'm not 100% sure about the full  CopilotKit cycle for this orphaned tools scenario. 

Is CopilotKit supposed to handle this flow:
1. CopilotKit sees two ag-ui events:
    a tool call -> then CopilotKit runs the tool (while graph completes)
    b orphan tool response-> then CopilotKit remembers to replace it with real response in step 2
2. On the next user message, CopilotKit fetches the tool real tool response and sends it back along with new user message?


Also, if this is the case, I feel that this package should offer a standard [LangGraph middleware](https://reference.langchain.com/python/langchain/agents/middleware/summarization) compatible with [`create_agent`](https://reference.langchain.com/python/langchain/agents/factory/create_agent), that catches FE tools and turn them into nodes that return the ToolMessage response placeholder. 


<details><summary>Middleware example code</summary>

```python

class FrontendToolsMiddleware(AgentMiddleware):
    """Injects FE tools from state per-request and short-circuits their execution.

    FEToolsState ensures state["tools"] is preserved across all graph steps.
    awrap_model_call reads it on every model call; awrap_tool_call short-circuits
    execution for FE tools since they aren't compiled into ToolNode.
    """

    state_schema = FEToolsState

    async def awrap_model_call(self, request: object, handler: object) -> object:  # type: ignore[override]
        """Inject FE tools from state["tools"] into the LLM binding before each call."""
        fe_tool_specs = request.state.get("tools", [])  # type: ignore[attr-defined]
        if fe_tool_specs:
            extra = [_ag_ui_tool_to_langchain(t) for t in fe_tool_specs]
            return await handler(request.override(tools=[*request.tools, *extra]))  # type: ignore[union-attr,operator]
        return await handler(request)  # type: ignore[operator]

    async def awrap_tool_call(self, request: object, handler: object) -> object:  # type: ignore[override]
        """Short-circuit ToolNode for FE tools — return placeholder directly.

        FE tools are NOT compiled into ToolNode, so calling handler(request) would
        raise a KeyError.  We return a ToolMessage placeholder instead; the real
        result arrives from the browser in the next RunAgentInput.messages turn.
        """
        fe_tool_names = {
            (t.get("name") if isinstance(t, dict) else t.name)
            for t in request.state.get("tools", [])  # type: ignore[attr-defined]
        }
        if request.tool_call["name"] in fe_tool_names:  # type: ignore[index]
            return ToolMessage(
                content=(
                    f"Tool call '{request.tool_call['name']}' with id '{request.tool_call['id']}' was "
                    "interrupted before completion."
                ),  # type: ignore[index]
                tool_call_id=request.tool_call["id"],  # type: ignore[index]
            )
        return await handler(request)  # type: ignore[operator]

```

</details>



#### Note

- The TypeScript version seems to not have this orphaned logic (but I did not look at it in detail)