### PR TITLE
fix(aws-strands): use public API for agent state instead of private _state attribute

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -70,7 +70,7 @@ class StrandsAgent:
         if hasattr(agent, "agent_id") and agent.agent_id:
             self._agent_kwargs["agent_id"] = agent.agent_id
         if hasattr(agent, "state") and agent.state is not None:
-            self._agent_kwargs["state"] = agent.state._state
+            self._agent_kwargs["state"] = agent.state.get()
 
         self.name = name
         self.description = description


### PR DESCRIPTION
## Summary

One-line fix: `agent.state._state` → `agent.state.get()` in `StrandsAgent.__init__`.

## Problem

`ag_ui_strands/agent.py:73` accesses `agent.state._state`, but `strands-agents`' `JSONSerializableDict` uses `_data` as its internal attribute. Every `StrandsAgent` instantiation crashes with:

```
AttributeError: 'JSONSerializableDict' object has no attribute '_state'
```

## Fix

Use the public `agent.state.get()` method (returns the full state dict when called with no key) instead of the private `_state` attribute. No dependency on internal implementation details.

## Verified

```bash
# Before (published ag-ui-strands 0.1.3):
$ docker run --rm python:3.12-slim sh -c "pip install -q strands-agents ag-ui-strands openai && python -c 'from ag_ui_strands import StrandsAgent; from strands import Agent; StrandsAgent(agent=Agent(system_prompt=\"test\"), name=\"t\", description=\"t\")'"
# AttributeError: 'JSONSerializableDict' object has no attribute '_state'

# After (this fix):
# SUCCESS: StrandsAgent created without AttributeError
# state kwargs: {'foo': 'bar'}
```

Fixes #1440 — which proposed a different solution using `agent.state._data` — swapping one private attribute for another. It fixes the immediate crash but still couples to the internal implementation of `JSONSerializableDict`. If `strands-agents` renames `_data` to something else in a future version, the same bug returns.  This uses the public API — which is stable and documented. Same result, no fragile coupling.