### PR TITLE
fix(client): guard process.env access for browser/edge runtimes

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -1475,6 +1475,92 @@ describe("AgentSubscriber", () => {
     });
   });
 
+  describe("process.env guard (issue #1191)", () => {
+    const runWith = (
+      subscribers: AgentSubscriber[],
+      messages: Message[] = [{ id: "orig", role: "user", content: "hi" }],
+      state: Record<string, any> = {},
+    ) =>
+      runSubscribersWithMutation(subscribers, messages, state, (subscriber, msgs, st) =>
+        subscriber.onEvent?.({
+          messages: msgs,
+          state: st,
+          agent: {} as any,
+          input: {} as any,
+          event: { type: EventType.RUN_STARTED } as any,
+        }),
+      );
+
+    it("should not throw when process is undefined (browser-like environment)", async () => {
+      // Simulate a browser runtime where `process` does not exist at all.
+      const originalProcess = globalThis.process;
+      // @ts-expect-error — intentionally removing process to simulate browser
+      delete globalThis.process;
+      try {
+        const subscriber: AgentSubscriber = {
+          onEvent: () => ({
+            messages: [{ id: "ok", role: "assistant", content: "ok" }],
+          }),
+        };
+
+        const result = await runWith([subscriber]);
+        expect(result.messages).toBeDefined();
+        expect(result.messages![0].id).toBe("ok");
+      } finally {
+        globalThis.process = originalProcess;
+      }
+    });
+
+    it("should preserve original error when subscriber throws in a browser-like env", async () => {
+      const originalProcess = globalThis.process;
+      // @ts-expect-error — intentionally removing process
+      delete globalThis.process;
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const originalError = new Error("subscriber boom");
+        const throwingSubscriber: AgentSubscriber = {
+          onEvent: () => {
+            throw originalError;
+          },
+        };
+        const passThroughSubscriber: AgentSubscriber = {
+          onEvent: () => ({
+            messages: [{ id: "after", role: "assistant", content: "after" }],
+          }),
+        };
+
+        // Should NOT throw — the error should be caught and logged, not masked.
+        const result = await runWith([throwingSubscriber, passThroughSubscriber]);
+        expect(result.messages).toBeDefined();
+        expect(result.messages![0].id).toBe("after");
+
+        // The original error must be logged, not a ReferenceError about process.
+        expect(consoleErrorSpy).toHaveBeenCalledWith("Subscriber error:", originalError);
+      } finally {
+        consoleErrorSpy.mockRestore();
+        globalThis.process = originalProcess;
+      }
+    });
+
+    it("should not throw when process.env is undefined", async () => {
+      const originalEnv = process.env;
+      // @ts-expect-error — intentionally removing env
+      delete process.env;
+      try {
+        const subscriber: AgentSubscriber = {
+          onEvent: () => ({
+            messages: [{ id: "ok", role: "assistant", content: "ok" }],
+          }),
+        };
+
+        const result = await runWith([subscriber]);
+        expect(result.messages).toBeDefined();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+  });
+
   describe("EmptyError Bug Reproduction", () => {
     test("should demonstrate EmptyError with STEP_STARTED/STEP_FINISHED events that cause no mutations", async () => {
       const emptyAgent = new TestAgent();

--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -220,6 +220,24 @@ function deepFreeze<T>(obj: T): T {
   return obj;
 }
 
+/**
+ * Safely read an environment variable without assuming `process` or `process.env`
+ * exists. Returns `undefined` in browser/edge runtimes where the Node.js `process`
+ * global is absent and no bundler polyfill has been configured.
+ */
+function getEnvVar(name: string): string | undefined {
+  try {
+    // Guard with `typeof` to avoid ReferenceError in runtimes where `process`
+    // is not defined at all (browsers, Cloudflare Workers, Deno, etc.).
+    if (typeof process !== "undefined" && process?.env) {
+      return process.env[name];
+    }
+  } catch {
+    // Swallow — some edge runtimes throw on property access even after typeof check.
+  }
+  return undefined;
+}
+
 export async function runSubscribersWithMutation(
   subscribers: AgentSubscriber[],
   initialMessages: Message[],
@@ -230,12 +248,13 @@ export async function runSubscribersWithMutation(
     state: Readonly<State>,
   ) => MaybePromise<AgentStateMutation | void>,
 ): Promise<AgentStateMutation> {
+  const nodeEnv = getEnvVar("NODE_ENV");
   const isTestEnvironment =
-    process.env.NODE_ENV === "test" || Boolean(process.env.VITEST_WORKER_ID);
+    nodeEnv === "test" || Boolean(getEnvVar("VITEST_WORKER_ID"));
   const isDev =
-    process.env.NODE_ENV === "development" ||
-    process.env.NODE_ENV === "test" ||
-    Boolean(process.env.VITEST_WORKER_ID);
+    nodeEnv === "development" ||
+    nodeEnv === "test" ||
+    Boolean(getEnvVar("VITEST_WORKER_ID"));
   const baselineMessages = structuredClone_(initialMessages);
   const baselineState = structuredClone_(initialState);
   let messages: Message[] = baselineMessages;

--- a/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
+++ b/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
@@ -33,7 +33,15 @@ export class BackwardCompatibility_0_0_45 extends Middleware {
   private currentMessageId: string | null = null;
 
   private warnAboutTransformation(from: string, to: string) {
-    if (process.env.SUPPRESS_TRANSFORMATION_WARNINGS) return;
+    try {
+      if (
+        typeof process !== "undefined" &&
+        process?.env?.SUPPRESS_TRANSFORMATION_WARNINGS
+      )
+        return;
+    } catch {
+      // process.env may not exist in browser/edge runtimes — fall through to warn.
+    }
     console.warn(
       `AG-UI is converting ${from} to ${to}. To remove this warning, upgrade your AG-UI integration package (e.g. @ag-ui/langgraph). To surpress it, set SUPPRESS_TRANSFORMATION_WARNINGS=true in your .env file.`,
     );


### PR DESCRIPTION
## Summary

Fixes #1191 — the subscriber catch block (and the env-detection logic at the top of `runSubscribersWithMutation`) accessed `process.env` directly. In browser/edge runtimes where `process` is not defined, this throws a `ReferenceError` that **masks the original subscriber error and its stack trace**.

## Root Cause

```ts
// Before — throws ReferenceError in browsers
const isTestEnvironment =
  process.env.NODE_ENV === "test" || Boolean(process.env.VITEST_WORKER_ID);
```

## Fix

- Added a `getEnvVar(name)` helper that safely reads environment variables using a `typeof process !== 'undefined'` guard with a `catch` fallback for exotic runtimes.
- Replaced all bare `process.env` reads in `subscriber.ts`.
- Applied the same guard to the `SUPPRESS_TRANSFORMATION_WARNINGS` check in `backward-compatibility-0-0-45.ts`.

## Regression Tests (3 new)

| Test | Validates |
|------|-----------|
| `should not throw when process is undefined` | Function works in a browser-like env with no `process` global |
| `should preserve original error when subscriber throws in a browser-like env` | Original error is logged (not masked by a ReferenceError) |
| `should not throw when process.env is undefined` | Handles edge case where `process` exists but `env` does not |

All 44 subscriber tests pass (311 total client tests pass; 14 pre-existing proto-codegen failures unrelated to this change).