### PR TITLE
fix(mastra): rotate messageId at text-segment boundaries, not just at finish

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/text-end-message-id.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/text-end-message-id.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Regression tests for ag-ui-protocol/ag-ui#836
+ *
+ * The Mastra adapter was rotating messageId only on "finish" (end-of-run),
+ * not on text-segment boundaries. This caused text chunks before and after
+ * tool calls within the same run to share a single messageId, merging what
+ * should be separate messages on the client side.
+ *
+ * The fix rotates messageId when a text segment ends — i.e., when a non-text
+ * event (tool-call, tool-result, finish) arrives after text-delta events.
+ */
+import { EventType } from "@ag-ui/client";
+import type { TextMessageChunkEvent, ToolCallStartEvent } from "@ag-ui/client";
+import {
+  makeLocalMastraAgent,
+  makeRemoteMastraAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Helper: stream chunk factories
+// ---------------------------------------------------------------------------
+const textDelta = (text: string) => ({
+  type: "text-delta" as const,
+  payload: { text },
+});
+const toolCall = (id: string, name: string, args: Record<string, unknown> = {}) => ({
+  type: "tool-call" as const,
+  payload: { toolCallId: id, toolName: name, args },
+});
+const toolResult = (id: string, result: unknown) => ({
+  type: "tool-result" as const,
+  payload: { toolCallId: id, result },
+});
+const finish = () => ({
+  type: "finish" as const,
+  payload: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, finishReason: "stop" },
+});
+const stepFinish = () => ({
+  type: "step-finish" as const,
+  payload: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, finishReason: "tool-calls" },
+});
+
+// ---------------------------------------------------------------------------
+// Helpers: extract text events and unique messageIds
+// ---------------------------------------------------------------------------
+function textChunks(events: any[]): TextMessageChunkEvent[] {
+  return events.filter((e) => e.type === EventType.TEXT_MESSAGE_CHUNK);
+}
+
+function uniqueMessageIds(chunks: TextMessageChunkEvent[]): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const c of chunks) {
+    if (!seen.has(c.messageId!)) {
+      seen.add(c.messageId!);
+      ids.push(c.messageId!);
+    }
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("text-end message-id rotation (issue #836)", () => {
+  describe.each([
+    ["local", makeLocalMastraAgent],
+    ["remote", makeRemoteMastraAgent],
+  ])("%s agent", (_label, makeAgent) => {
+    it("text before and after a tool call get different messageIds", async () => {
+      // Scenario: text → tool-call → tool-result → text → finish
+      // Before the fix, both text segments shared one messageId.
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("Before tool "),
+          toolCall("tc-1", "get_weather", { city: "NYC" }),
+          toolResult("tc-1", { temp: 72 }),
+          textDelta("After tool"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      const ids = uniqueMessageIds(chunks);
+
+      expect(chunks).toHaveLength(2);
+      expect(ids).toHaveLength(2);
+      expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it("consecutive text-deltas within a single segment share one messageId", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("Hello "),
+          textDelta("world"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      const ids = uniqueMessageIds(chunks);
+
+      expect(chunks).toHaveLength(2);
+      expect(ids).toHaveLength(1);
+    });
+
+    it("three text segments separated by tool calls get three distinct messageIds", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("Segment 1"),
+          toolCall("tc-1", "tool_a"),
+          toolResult("tc-1", "result_a"),
+          textDelta("Segment 2"),
+          toolCall("tc-2", "tool_b"),
+          toolResult("tc-2", "result_b"),
+          textDelta("Segment 3"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      const ids = uniqueMessageIds(chunks);
+
+      expect(chunks).toHaveLength(3);
+      expect(ids).toHaveLength(3);
+      // All three IDs must be distinct
+      expect(new Set(ids).size).toBe(3);
+    });
+
+    it("tool call parentMessageId matches the preceding text segment", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("Let me check"),
+          toolCall("tc-1", "search", { q: "test" }),
+          toolResult("tc-1", "found"),
+          textDelta("Here are the results"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const firstTextChunk = events.find(
+        (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+      ) as TextMessageChunkEvent;
+      const toolStart = events.find(
+        (e) => e.type === EventType.TOOL_CALL_START,
+      ) as ToolCallStartEvent;
+
+      // The tool call's parentMessageId should reference the preceding text
+      expect(toolStart.parentMessageId).toBe(firstTextChunk.messageId);
+    });
+
+    it("tool-only run (no text) completes without errors", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          toolCall("tc-1", "do_something"),
+          toolResult("tc-1", "done"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      expect(chunks).toHaveLength(0);
+      expect(events[0].type).toBe(EventType.RUN_STARTED);
+      expect(events[events.length - 1].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("step-finish between steps rotates messageId correctly", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("Step 1 text"),
+          toolCall("tc-1", "tool_a"),
+          stepFinish(),
+          toolResult("tc-1", "result"),
+          textDelta("Step 2 text"),
+          stepFinish(),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      const ids = uniqueMessageIds(chunks);
+
+      expect(chunks).toHaveLength(2);
+      expect(ids).toHaveLength(2);
+      expect(ids[0]).not.toBe(ids[1]);
+    });
+
+    it("text → tool-call (no finish between) rotates messageId before tool events", async () => {
+      // This is the exact scenario from issue #836: no step-finish between
+      // text and tool-call within the same step.
+      const agent = makeAgent({
+        streamChunks: [
+          textDelta("I will look that up"),
+          toolCall("tc-1", "lookup"),
+          toolResult("tc-1", { data: "found" }),
+          textDelta("Found it!"),
+          finish(),
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput({
+        messages: [{ id: "1", role: "user", content: "Hi" }],
+      }));
+
+      const chunks = textChunks(events);
+      const ids = uniqueMessageIds(chunks);
+
+      expect(ids).toHaveLength(2);
+      expect(ids[0]).not.toBe(ids[1]);
+
+      // Verify the second text segment uses a NEW messageId, not the first one
+      const secondChunk = chunks[1];
+      expect(secondChunk.messageId).toBe(ids[1]);
+      expect(secondChunk.delta).toBe("Found it!");
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -441,10 +441,38 @@ export class MastraAgent extends AbstractAgent {
       args: any;
     } | null = null;
 
+    // Tracks whether we are inside an active text segment. Used to detect
+    // text-segment boundaries so that messageId is rotated when a text
+    // segment ends (i.e., when a non-text event like tool-call arrives),
+    // not just when the entire step/run finishes.
+    let inTextSegment = false;
+
+    // Deferred rotation flag. When a text segment closes (e.g. because a
+    // tool-call arrives), we mark that a messageId rotation is needed but
+    // delay the actual rotation until the *next* text segment starts.
+    // This ensures that tool-call events emitted between text segments
+    // still reference the messageId of the preceding text via
+    // parentMessageId (which reads getMessageId() at emit time).
+    let needsMessageIdRotation = false;
+
     const flush = () => {
       if (pendingToolCall) {
         callbacks.onToolCallPart?.(pendingToolCall);
         pendingToolCall = null;
+      }
+    };
+
+    const closeTextSegment = () => {
+      if (inTextSegment) {
+        inTextSegment = false;
+        needsMessageIdRotation = true;
+      }
+    };
+
+    const rotateMessageIdIfNeeded = () => {
+      if (needsMessageIdRotation) {
+        callbacks.onFinishMessagePart?.();
+        needsMessageIdRotation = false;
       }
     };
 
@@ -460,10 +488,13 @@ export class MastraAgent extends AbstractAgent {
       switch (chunk.type) {
         case "text-delta": {
           flush();
+          rotateMessageIdIfNeeded();
+          inTextSegment = true;
           callbacks.onTextPart?.(chunk.payload.text);
           break;
         }
         case "tool-call": {
+          closeTextSegment();
           flush();
           pendingToolCall = {
             toolCallId: chunk.payload.toolCallId,
@@ -473,6 +504,7 @@ export class MastraAgent extends AbstractAgent {
           break;
         }
         case "tool-result": {
+          closeTextSegment();
           flush();
           callbacks.onToolResultPart?.({
             toolCallId: chunk.payload.toolCallId,
@@ -486,6 +518,7 @@ export class MastraAgent extends AbstractAgent {
           return true;
         }
         case "tool-call-suspended": {
+          closeTextSegment();
           // Always discard the pending tool-call: if it matches, the tool
           // was suspended before execution; if it doesn't match, the pending
           // call is orphaned (never executed) so emitting TOOL_CALL_START/
@@ -508,13 +541,16 @@ export class MastraAgent extends AbstractAgent {
           });
           break;
         }
-        // Both "finish" and "step-finish" flush any pending tool call and rotate
-        // the messageId so the next step's text gets a fresh ID. When a stream
-        // ends with step-finish followed by finish, onFinishMessagePart fires
-        // twice — the second rotation produces an unused messageId, which is harmless.
+        // "finish" and "step-finish" close any open text segment and flush
+        // pending tool calls. After flushing (so tool events still reference
+        // the current messageId), we unconditionally rotate so the next
+        // step/run gets a fresh messageId. This also clears any deferred
+        // rotation from closeTextSegment.
         case "finish":
         case "step-finish": {
+          closeTextSegment();
           flush();
+          needsMessageIdRotation = false;
           callbacks.onFinishMessagePart?.();
           break;
         }
@@ -532,7 +568,15 @@ export class MastraAgent extends AbstractAgent {
       return false;
     };
 
-    return { handleChunk, flush };
+    // finalize: called at end-of-stream to close any open text segment,
+    // flush any pending tool call, and apply any deferred rotation.
+    const finalize = () => {
+      closeTextSegment();
+      flush();
+      rotateMessageIdIfNeeded();
+    };
+
+    return { handleChunk, finalize };
   }
 
   /**
@@ -543,11 +587,11 @@ export class MastraAgent extends AbstractAgent {
     stream: AsyncIterable<any>,
     callbacks: MastraAgentStreamOptions,
   ): Promise<boolean> {
-    const { handleChunk, flush } = this.createChunkProcessor(callbacks);
+    const { handleChunk, finalize } = this.createChunkProcessor(callbacks);
     for await (const chunk of stream) {
       if (handleChunk(chunk)) return true;
     }
-    flush();
+    finalize();
     return false;
   }
 
@@ -632,7 +676,7 @@ export class MastraAgent extends AbstractAgent {
         // Remote agents use processDataStream (callback-based) — share
         // chunk handling logic via createChunkProcessor.
         if (response && typeof response.processDataStream === "function") {
-          const { handleChunk, flush } = this.createChunkProcessor({
+          const { handleChunk, finalize } = this.createChunkProcessor({
             onTextPart,
             onFinishMessagePart,
             onToolCallPart,
@@ -647,7 +691,7 @@ export class MastraAgent extends AbstractAgent {
               if (handleChunk(chunk)) stopped = true;
             },
           });
-          if (!stopped) flush();
+          if (!stopped) finalize();
           if (!stopped) await onRunFinished?.();
         } else {
           throw new Error("Invalid response from remote agent");


### PR DESCRIPTION
## Problem

Fixes #836 — the Mastra adapter merges multiple text messages into one because `messageId` only rotates on `finish`/`step-finish` events, not when a text segment actually ends (e.g., when a tool-call arrives between two text segments).

A stream like:
```
text-delta("Hello") → tool-call → tool-result → text-delta("World") → finish
```
emits both text chunks with the **same** `messageId`, causing clients to merge them into a single message.

## Root Cause

`onFinishMessagePart` (which calls `setMessageId(randomUUID())`) was only invoked on `finish`/`step-finish` events inside `createChunkProcessor`. There was no text-segment boundary tracking.

## Fix

Added **text-segment state tracking** with deferred rotation in `createChunkProcessor`:

- `inTextSegment` — tracks whether we're inside an active text segment
- `needsMessageIdRotation` — deferred rotation flag set when a text segment closes
- `closeTextSegment()` — marks the end of a text segment (defers rotation)
- `rotateMessageIdIfNeeded()` — applies deferred rotation when the next text segment starts

The rotation is **deferred** (not immediate) so that tool-call events emitted between text segments still reference the correct `parentMessageId` of the preceding text segment.

Text segment boundaries are detected on: `tool-call`, `tool-result`, `tool-call-suspended`, `finish`, `step-finish`.

## Tests

Added 14 regression tests (7 scenarios × 2 agent types: local + remote):
1. Text before/after tool call get different messageIds
2. Consecutive text-deltas within one segment share the same messageId
3. Three text segments separated by tool calls get three distinct IDs
4. Tool call `parentMessageId` matches the preceding text segment
5. Tool-only run (no text) completes without errors
6. `step-finish` between steps rotates messageId correctly
7. Exact #836 scenario: `text → tool-call (no finish between) → text`

All 95 tests pass (81 existing + 14 new).