### PR TITLE
fix: crew_exit e2e test fixture matching

### DIFF
--- a/apps/dojo/e2e/aimock-setup.ts
+++ b/apps/dojo/e2e/aimock-setup.ts
@@ -1237,7 +1237,14 @@ export async function setupLLMock(): Promise<void> {
     match: {
       predicate: (req) => {
         const last = req.messages[req.messages.length - 1];
-        return last?.role === "tool";
+        if (last?.role !== "tool") return false;
+        // Don't match CrewAI crew_exit follow-up — it has a dedicated fixture
+        const hasCrewExitTool = req.tools?.some(
+          (t) => t.function.name === "crew_exit",
+        );
+        if (hasCrewExitTool && textOf(last.content) === "Crew exited")
+          return false;
+        return true;
       },
     },
     response: { content: "Done! I've completed that for you." },

--- a/apps/dojo/e2e/tests/crewAITests/crewChatPage.spec.ts
+++ b/apps/dojo/e2e/tests/crewAITests/crewChatPage.spec.ts
@@ -35,22 +35,17 @@ test("[CrewAI] Crew Chat handles follow-up messages (dict state path)", async ({
   await chat.assertAgentReplyVisible(/equals 4/i);
 });
 
-// crew_exit: fixture predicates don't match — ChatWithCrewFlow rebuilds the
-// message array with crew_chat_build_system_message and the aimock tool-result
-// catch-all (prependFixture) fires instead. Needs local aimock journal
-// inspection to understand exact request structure reaching the mock.
-test.fixme(
-  "[CrewAI] Crew Chat handles crew_exit tool call (dict state path)",
-  async ({ page }) => {
-    await page.goto("/crewai/feature/crew_chat");
+test("[CrewAI] Crew Chat handles crew_exit tool call (dict state path)", async ({
+  page,
+}) => {
+  await page.goto("/crewai/feature/crew_chat");
 
-    const chat = new AgenticChatPage(page);
+  const chat = new AgenticChatPage(page);
 
-    await chat.openChat();
-    await expect(chat.agentGreeting).toBeVisible();
+  await chat.openChat();
+  await expect(chat.agentGreeting).toBeVisible();
 
-    await chat.sendMessage("goodbye crew");
-    await chat.assertUserMessageVisible("goodbye crew");
-    await chat.assertAgentReplyVisible(/crew has been shut down/i);
-  },
-);
+  await chat.sendMessage("goodbye crew");
+  await chat.assertUserMessageVisible("goodbye crew");
+  await chat.assertAgentReplyVisible(/crew has been shut down/i);
+});

--- a/integrations/crew-ai/python/ag_ui_crewai/crews.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/crews.py
@@ -125,7 +125,7 @@ class ChatWithCrewFlow(Flow):
                 await copilotkit_exit()
                 self.state["messages"].append({
                     "role": "tool",
-                    "content": "Crew exited",
+                    "content": "Crew exited",  # E2E: aimock-setup.ts matches this exact string
                     "tool_call_id": message["tool_calls"][0]["id"]
                 })
 


### PR DESCRIPTION
## Summary

Un-fixme the crew_exit e2e test by fixing the aimock fixture matching.

## Root Cause

The aimock `prependFixture` tool-result catch-all fires at position 0 in the fixture list. When `ChatWithCrewFlow` processes `crew_exit` and makes a follow-up `acompletion`, the last message is a tool result (`"Crew exited"`), which matched the generic catch-all (`"Done! I've completed that for you."`) instead of our dedicated crew_exit farewell fixture.

## Fix

Exclude CrewAI crew_exit follow-up requests from the tool-result catch-all by checking for the `crew_exit` tool and `"Crew exited"` content in the last message.

## Verification

Tested locally by starting dojo + crew-ai + aimock, sending a request to `/crew_chat` with `"goodbye crew"`, and inspecting the aimock journal. The follow-up now returns `"Goodbye! The crew has been shut down. Have a great day!"` as expected.

## Related

- ag-ui-protocol/ag-ui#1478 (parent PR that added the crew_exit infrastructure)
- CopilotKit/CopilotKit#3749 (RunErrorEvent fix — separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)