### PR TITLE
Add credentials config option to HttpAgent

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/http.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/http.test.ts
@@ -236,4 +236,73 @@ describe("HttpAgent", () => {
       signal: expect.any(AbortSignal),
     });
   });
+
+  describe("credentials option (#323)", () => {
+    function minimalInput(agent: HttpAgent) {
+      return {
+        threadId: agent.threadId,
+        runId: "mock-run-id",
+        tools: [],
+        context: [],
+        forwardedProps: {},
+        state: agent.state,
+        messages: agent.messages,
+      };
+    }
+
+    it("forwards a configured credentials value to runHttpRequest", () => {
+      (runHttpRequest as Mock).mockReturnValue(of());
+
+      const agent = new HttpAgent({
+        url: "https://api.example.com/v1/chat",
+        credentials: "include",
+      });
+
+      agent.run(minimalInput(agent));
+
+      expect(runHttpRequest).toHaveBeenCalledWith(
+        "https://api.example.com/v1/chat",
+        expect.objectContaining({ credentials: "include" }),
+      );
+    });
+
+    it("omits credentials when the option is not set", () => {
+      (runHttpRequest as Mock).mockReturnValue(of());
+
+      const agent = new HttpAgent({ url: "https://api.example.com/v1/chat" });
+
+      agent.run(minimalInput(agent));
+
+      // `credentials: undefined` flows through; fetch treats that the same as
+      // omitting the key entirely, so the browser uses its default mode.
+      const [, init] = (runHttpRequest as Mock).mock.calls[0];
+      expect(init.credentials).toBeUndefined();
+    });
+
+    it("stores the credentials option on the instance", () => {
+      const agent = new HttpAgent({
+        url: "https://api.example.com/v1/chat",
+        credentials: "same-origin",
+      });
+      expect(agent.credentials).toBe("same-origin");
+    });
+
+    it("preserves credentials through clone()", () => {
+      const agent = new HttpAgent({
+        url: "https://api.example.com/v1/chat",
+        credentials: "include",
+      });
+
+      const cloned = agent.clone() as HttpAgent;
+
+      expect(cloned.credentials).toBe("include");
+      // The clone must carry credentials through to its own request too.
+      (runHttpRequest as Mock).mockReturnValue(of());
+      cloned.run(minimalInput(cloned));
+      expect(runHttpRequest).toHaveBeenLastCalledWith(
+        "https://api.example.com/v1/chat",
+        expect.objectContaining({ credentials: "include" }),
+      );
+    });
+  });
 });

--- a/sdks/typescript/packages/client/src/agent/http.ts
+++ b/sdks/typescript/packages/client/src/agent/http.ts
@@ -14,6 +14,7 @@ interface RunHttpAgentConfig extends RunAgentParameters {
 export class HttpAgent extends AbstractAgent {
   public url: string;
   public headers: Record<string, string>;
+  public credentials?: RequestCredentials;
   public abortController: AbortController = new AbortController();
 
   /**
@@ -32,6 +33,7 @@ export class HttpAgent extends AbstractAgent {
       },
       body: JSON.stringify(input),
       signal: this.abortController.signal,
+      credentials: this.credentials,
     };
   }
 
@@ -52,6 +54,7 @@ export class HttpAgent extends AbstractAgent {
     super(config);
     this.url = config.url;
     this.headers = structuredClone_(config.headers ?? {});
+    this.credentials = config.credentials;
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
@@ -63,6 +66,7 @@ export class HttpAgent extends AbstractAgent {
     const cloned = super.clone() as HttpAgent;
     cloned.url = this.url;
     cloned.headers = structuredClone_(this.headers ?? {});
+    cloned.credentials = this.credentials;
 
     const newController = new AbortController();
     const originalSignal = this.abortController.signal as AbortSignal & { reason?: unknown };

--- a/sdks/typescript/packages/client/src/agent/types.ts
+++ b/sdks/typescript/packages/client/src/agent/types.ts
@@ -42,6 +42,7 @@ export interface AgentConfig {
 export interface HttpAgentConfig extends AgentConfig {
   url: string;
   headers?: Record<string, string>;
+  credentials?: RequestCredentials;
 }
 
 export type RunAgentParameters = Partial<


### PR DESCRIPTION
## Summary
- Adds optional `credentials` property to `HttpAgentConfig` for controlling `fetch` credential mode
- Passes the configured `credentials` through to `requestInit()`, enabling `credentials: "include"` for cross-origin cookie support
- Properly propagates credentials through constructor and `clone()`

Fixes #323

## Test plan
- [x] All 441 existing client tests pass
- [ ] Verify `HttpAgent({ url, credentials: "include" })` sends cookies cross-origin