### PR TITLE
fix: iterate all tasks for interrupts in parallel tool calls (#1409)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -102,6 +102,18 @@ logger = logging.getLogger(__name__)
 
 ROOT_SUBGRAPH_NAME = "root"
 
+
+def collect_interrupts(tasks):
+    """Flatten interrupts across every task in the sequence.
+
+    When a LangGraph agent fires multiple parallel tool calls and one of them
+    hits ``interrupt()``, the interrupt may land on ``tasks[1]`` or later
+    rather than ``tasks[0]``. Historical code only checked ``tasks[0]``,
+    silently losing interrupts on any other task (#1409). Iterate all tasks
+    so every active interrupt is surfaced.
+    """
+    return [i for t in (tasks or []) for i in t.interrupts]
+
 class LangGraphAgent:
     def __init__(self, *, name: str, graph: CompiledStateGraph, description: Optional[str] = None, config:  Union[Optional[RunnableConfig], dict] = None):
         self.name = name
@@ -338,7 +350,7 @@ class LangGraphAgent:
             state = await self.graph.aget_state(config)
 
             tasks = state.tasks if len(state.tasks) > 0 else None
-            interrupts = [i for t in (tasks or []) for i in t.interrupts]
+            interrupts = collect_interrupts(tasks)
 
             writes = state.metadata.get("writes", {}) or {}
             node_name = self.active_run["node_name"] if interrupts else next(iter(writes), None)
@@ -386,7 +398,7 @@ class LangGraphAgent:
         state = self.langgraph_default_merge_state(state_input, langchain_messages, input)
         self.active_run["current_graph_state"].update(state)
         config["configurable"]["thread_id"] = thread_id
-        interrupts = [i for t in (agent_state.tasks or []) for i in t.interrupts]
+        interrupts = collect_interrupts(agent_state.tasks)
         has_active_interrupts = len(interrupts) > 0
         resume_input = forwarded_props.get('command', {}).get('resume', None)
 

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -338,7 +338,7 @@ class LangGraphAgent:
             state = await self.graph.aget_state(config)
 
             tasks = state.tasks if len(state.tasks) > 0 else None
-            interrupts = tasks[0].interrupts if tasks else []
+            interrupts = [i for t in (tasks or []) for i in t.interrupts]
 
             writes = state.metadata.get("writes", {}) or {}
             node_name = self.active_run["node_name"] if interrupts else next(iter(writes), None)
@@ -386,7 +386,7 @@ class LangGraphAgent:
         state = self.langgraph_default_merge_state(state_input, langchain_messages, input)
         self.active_run["current_graph_state"].update(state)
         config["configurable"]["thread_id"] = thread_id
-        interrupts = agent_state.tasks[0].interrupts if agent_state.tasks and len(agent_state.tasks) > 0 else []
+        interrupts = [i for t in (agent_state.tasks or []) for i in t.interrupts]
         has_active_interrupts = len(interrupts) > 0
         resume_input = forwarded_props.get('command', {}).get('resume', None)
 

--- a/integrations/langgraph/python/tests/test_collect_interrupts.py
+++ b/integrations/langgraph/python/tests/test_collect_interrupts.py
@@ -1,0 +1,54 @@
+"""Tests for collect_interrupts — the parallel-task interrupt helper (#1409).
+
+The regression: historical code read ``tasks[0].interrupts`` and discarded
+any interrupt on ``tasks[1]`` or later. collect_interrupts must iterate
+every task so parallel-tool-call interrupts are never silently lost.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from ag_ui_langgraph.agent import collect_interrupts
+
+
+def _task(*interrupts):
+    """A stand-in for PregelTask — only ``.interrupts`` is read."""
+    return SimpleNamespace(interrupts=list(interrupts))
+
+
+class TestCollectInterrupts(unittest.TestCase):
+    def test_returns_empty_list_for_none(self):
+        self.assertEqual(collect_interrupts(None), [])
+
+    def test_returns_empty_list_for_empty_tasks(self):
+        self.assertEqual(collect_interrupts([]), [])
+
+    def test_returns_empty_when_no_task_has_interrupts(self):
+        self.assertEqual(collect_interrupts([_task(), _task()]), [])
+
+    def test_collects_interrupts_from_first_task(self):
+        self.assertEqual(
+            collect_interrupts([_task("a"), _task()]),
+            ["a"],
+        )
+
+    def test_collects_interrupts_from_a_later_task(self):
+        """The #1409 regression: old code only looked at tasks[0]."""
+        self.assertEqual(
+            collect_interrupts([_task(), _task("b"), _task()]),
+            ["b"],
+        )
+
+    def test_collects_interrupts_across_every_task_in_order(self):
+        self.assertEqual(
+            collect_interrupts([
+                _task("a", "b"),
+                _task(),
+                _task("c"),
+            ]),
+            ["a", "b", "c"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1409

When a LangGraph agent calls multiple tools in parallel and one triggers `interrupt()`, the interrupt may be on `tasks[1]` or later. Both locations that checked interrupts only examined `tasks[0]`, causing interrupts on other tasks to be silently missed. Now iterates all tasks to collect interrupts.