### PR TITLE
Move @ag-ui/core to peerDependencies in @ag-ui/client

### DIFF
--- a/sdks/typescript/packages/client/package.json
+++ b/sdks/typescript/packages/client/package.json
@@ -27,7 +27,6 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/core": "workspace:*",
     "@ag-ui/encoder": "workspace:*",
     "@ag-ui/proto": "workspace:*",
     "@types/uuid": "^10.0.0",
@@ -53,5 +52,8 @@
       "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "@ag-ui/core": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary
- Moves `@ag-ui/core` from `dependencies` to `peerDependencies` in `@ag-ui/client`
- Prevents type mismatch when consumers also depend on `@ag-ui/core` directly (e.g. `AbstractAgent` from bundled copy differs from consumer's copy)

Fixes #1176

## Test plan
- [x] All 441 client tests pass
- [x] `pnpm install` succeeds in the monorepo (workspace resolution still works)
- [ ] Verify downstream consumers no longer see `AbstractAgent` type mismatch