### PR TITLE
fix: parse DeepSeek reasoning_content from additional_kwargs (#1251)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -337,6 +337,15 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
                 index=data.get("index", 0)
             )
 
+        # DeepSeek / Qwen / xAI format: additional_kwargs.reasoning_content is a string
+        reasoning_content = chunk.additional_kwargs.get("reasoning_content")
+        if reasoning_content and isinstance(reasoning_content, str):
+            return LangGraphReasoning(
+                type="text",
+                text=reasoning_content,
+                index=0,
+            )
+
     return None
 
 


### PR DESCRIPTION
Closes #1251

`resolve_reasoning_content` did not handle the `additional_kwargs.reasoning_content` string format used by DeepSeek, Qwen, xAI, and OpenAI-compatible proxies. Added a check for this format after the existing OpenAI legacy `reasoning.summary` check.