### PR TITLE
fix: parse Bedrock Converse reasoning_content block format (#1361)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -311,6 +311,19 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
                 index=block.get("index", 0)
             )
 
+        # AWS Bedrock Converse format: { type: "reasoning_content", reasoning_content: { text: "...", signature: "..." } }
+        if block_type == "reasoning_content" and isinstance(block.get("reasoning_content"), dict):
+            rc = block["reasoning_content"]
+            if rc.get("text"):
+                result = LangGraphReasoning(
+                    text=rc["text"],
+                    type="text",
+                    index=block.get("index", 0),
+                )
+                if rc.get("signature"):
+                    result["signature"] = rc["signature"]
+                return result
+
         # OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
         if block_type == "reasoning" and block.get("summary"):
             summaries = block["summary"]


### PR DESCRIPTION
Closes #1361

`resolve_reasoning_content` did not handle the AWS Bedrock Converse API format where reasoning is emitted as `{ type: "reasoning_content", reasoning_content: { text: "...", signature: "..." } }`. Added a handler for this block type, including signature extraction for extended thinking.