### PR TITLE
fix: propagate conversation_manager to per-thread StrandsAgent instances (#1471)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -71,6 +71,8 @@ class StrandsAgent:
             self._agent_kwargs["agent_id"] = agent.agent_id
         if hasattr(agent, "state") and agent.state is not None:
             self._agent_kwargs["state"] = agent.state.get()
+        if hasattr(agent, "conversation_manager") and agent.conversation_manager is not None:
+            self._agent_kwargs["conversation_manager"] = agent.conversation_manager
 
         self.name = name
         self.description = description


### PR DESCRIPTION
Closes #1471

`StrandsAgent.__init__` extracted various attributes from the template agent into `_agent_kwargs` but missed `conversation_manager`. This caused per-thread agents to have no conversation manager, leading to unbounded message accumulation and `ContextWindowOverflowException`. Now extracts and propagates `conversation_manager` alongside the other attributes.