### PR TITLE
Fix Python wheel file permissions in publish workflow

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -64,6 +64,14 @@ jobs:
           ")
           uv run $TEST_CMD
 
+      - name: Fix source permissions for wheel
+        working-directory: ${{ inputs.package }}
+        run: |
+          # Ensure all source files are readable so the wheel inherits
+          # correct permissions (fixes broken wheels from restrictive umask)
+          find . -type f -exec chmod a+r {} +
+          find . -type d -exec chmod a+rx {} +
+
       - name: Build package
         working-directory: ${{ inputs.package }}
         run: uv build


### PR DESCRIPTION
## Summary
- Adds a `chmod` step before `uv build` to ensure all source files are world-readable
- Wheels built under a restrictive umask had files without read permissions, making them uninstallable
- The existing "Verify wheel permissions" step already catches this but doesn't prevent it

Fixes #1341
Fixes #1448

## Test plan
- [ ] Run the publish workflow in dry-run mode and verify the "Verify wheel permissions" step passes
- [ ] Confirm installed wheel files are readable