### PR TITLE
fix: reuse stable message_id across run to prevent split messages (#1317)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -183,6 +183,8 @@ class LangGraphAgent:
             "has_function_streaming": False,
             "model_made_tool_call": False,
             "state_reliable": True,
+            "stable_message_id": None,
+            "paused_text_message_id": None,
         }
         self.active_run = INITIAL_ACTIVE_RUN
         try:
@@ -429,6 +431,30 @@ class LangGraphAgent:
             yield self._dispatch_event(
                 RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["id"])
             )
+        except Exception:
+            # Clean up any open text message before propagating the error
+            if self.active_run:
+                mip = self.get_message_in_progress(self.active_run["id"])
+                if mip and mip.get("id") and not mip.get("tool_call_id"):
+                    yield self._dispatch_event(
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=mip["id"],
+                            raw_event={},
+                        )
+                    )
+                    self.messages_in_process[self.active_run["id"]] = None
+                elif self.active_run.get("paused_text_message_id"):
+                    paused_id = self.active_run["paused_text_message_id"]
+                    yield self._dispatch_event(
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=paused_id,
+                            raw_event={},
+                        )
+                    )
+                    self.active_run["paused_text_message_id"] = None
+            raise
         finally:
             self.active_run = None
 
@@ -931,7 +957,18 @@ class LangGraphAgent:
             # during tool-call / structured-output transitions, and the
             # truthy check would misclassify it as an end-event.
             is_message_content_event = tool_call_data is None and message_content is not None
-            is_message_end_event = has_current_stream and not current_stream.get("tool_call_id") and not is_message_content_event
+            is_message_end_event = (
+                has_current_stream
+                and not current_stream.get("tool_call_id")
+                and not is_message_content_event
+                and tool_call_data is None
+            )
+            is_message_pause_event = (
+                has_current_stream
+                and not current_stream.get("tool_call_id")
+                and not is_message_content_event
+                and tool_call_data is not None
+            )
 
             if reasoning_data:
                 for event_str in self.handle_reasoning_event(reasoning_data):
@@ -995,10 +1032,21 @@ class LangGraphAgent:
                 return
 
 
+            if is_message_pause_event:
+                # Tool calls starting while text in progress — pause without ending
+                self.active_run["paused_text_message_id"] = current_stream.get("id")
+                self.messages_in_process[self.active_run["id"]] = None
+                # Re-derive: message_in_progress is now cleared, so tool call start can proceed
+                is_tool_call_start_event = bool(tool_call_data and tool_call_data.get("name"))
+                if is_tool_call_start_event:
+                    self.active_run["has_function_streaming"] = True
+
             if is_message_end_event:
-                yield self._dispatch_event(
-                    TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=current_stream["id"], raw_event=event)
-                )
+                # Defer TextMessageEnd to on_chat_model_end — an empty chunk
+                # during streaming doesn't guarantee the run is complete (tool
+                # calls may follow). Pause the message so on_chat_model_end
+                # can close it.
+                self.active_run["paused_text_message_id"] = current_stream.get("id")
                 self.messages_in_process[self.active_run["id"]] = None
                 return
 
@@ -1041,22 +1089,42 @@ class LangGraphAgent:
                     return
 
                 if bool(current_stream and current_stream.get("id")) == False:
-                    yield self._dispatch_event(
-                        TextMessageStartEvent(
-                            type=EventType.TEXT_MESSAGE_START,
-                            role="assistant",
-                            message_id=chunk_id,
-                            raw_event=event,
+                    paused_id = self.active_run.get("paused_text_message_id")
+                    if paused_id:
+                        # Resuming text after tool calls — reuse paused message.
+                        # Don't emit TextMessageStart (message was never ended, so client still considers it active).
+                        msg_id = paused_id
+                        self.active_run["paused_text_message_id"] = None
+                        self.set_message_in_progress(
+                            self.active_run["id"],
+                            MessageInProgress(
+                                id=msg_id,
+                                tool_call_id=None,
+                                tool_call_name=None
+                            )
                         )
-                    )
-                    self.set_message_in_progress(
-                        self.active_run["id"],
-                        MessageInProgress(
-                            id=chunk_id,
-                            tool_call_id=None,
-                            tool_call_name=None
+                    else:
+                        # First text in the run — emit TextMessageStart.
+                        # Cache the id on active_run so subsequent chunks reuse it.
+                        if not self.active_run.get("stable_message_id"):
+                            self.active_run["stable_message_id"] = chunk_id
+                        msg_id = self.active_run["stable_message_id"]
+                        yield self._dispatch_event(
+                            TextMessageStartEvent(
+                                type=EventType.TEXT_MESSAGE_START,
+                                role="assistant",
+                                message_id=msg_id,
+                                raw_event=event,
+                            )
                         )
-                    )
+                        self.set_message_in_progress(
+                            self.active_run["id"],
+                            MessageInProgress(
+                                id=msg_id,
+                                tool_call_id=None,
+                                tool_call_name=None
+                            )
+                        )
                     current_stream = self.get_message_in_progress(self.active_run["id"])
 
                 yield self._dispatch_event(
@@ -1083,7 +1151,21 @@ class LangGraphAgent:
                 )
                 if resolved:
                     self.messages_in_process[self.active_run["id"]] = None
+                    self.active_run["stable_message_id"] = None
                 yield resolved
+            else:
+                # Handle paused text messages that were never resumed
+                paused_id = self.active_run.get("paused_text_message_id")
+                if paused_id:
+                    yield self._dispatch_event(
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=paused_id,
+                            raw_event=event,
+                        )
+                    )
+                    self.active_run["paused_text_message_id"] = None
+                    self.active_run["stable_message_id"] = None
 
         elif event_type == LangGraphEventTypes.OnCustomEvent:
             if event["name"] == CustomEventNames.ManuallyEmitMessage:

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -62,6 +62,9 @@ RunMetadata = TypedDict("RunMetadata", {
     "manually_emitted_state": NotRequired[Optional[State]],
     # Reasoning / thinking
     "reasoning_process": NotRequired[Optional[ThinkingProcess]],
+    # Stable message IDs for pause/resume flows
+    "stable_message_id": NotRequired[Optional[str]],
+    "paused_text_message_id": NotRequired[Optional[str]],
 })
 
 MessagesInProgressRecord = Dict[str, Optional[MessageInProgress]]

--- a/integrations/langgraph/python/tests/test_message_pause.py
+++ b/integrations/langgraph/python/tests/test_message_pause.py
@@ -1,0 +1,425 @@
+"""Tests for message pause/resume bug fixes.
+
+Each fix has a RED test (demonstrates the bug) and a GREEN test (verifies the fix).
+Since the fixes are already applied, the RED tests verify the bug *would* have occurred
+by testing the underlying conditions, while GREEN tests verify correct behavior.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+from typing import Optional
+
+from ag_ui.core import EventType
+
+from ag_ui_langgraph import LangGraphAgent
+from ag_ui_langgraph.types import MessageInProgress
+
+
+def _make_agent() -> LangGraphAgent:
+    """Create a minimal LangGraphAgent for unit testing."""
+    graph = MagicMock()
+    graph.config_specs = []
+    agent = LangGraphAgent(name="test", graph=graph)
+    agent.active_run = {
+        "id": "run-1",
+        "thread_id": "thread-1",
+        "reasoning_process": None,
+        "node_name": None,
+        "has_function_streaming": False,
+        "model_made_tool_call": False,
+        "state_reliable": True,
+        "stable_message_id": None,
+        "paused_text_message_id": None,
+    }
+    return agent
+
+
+def _make_chunk(content=None, tool_call_chunks=None, chunk_id="chunk-1", finish_reason=None):
+    """Create a mock AIMessageChunk."""
+    chunk = MagicMock()
+    chunk.id = chunk_id
+    chunk.content = content if content is not None else ""
+    chunk.tool_call_chunks = tool_call_chunks or []
+    chunk.response_metadata = {}
+    # Prevent resolve_reasoning_content / resolve_encrypted_reasoning_content
+    # from finding spurious reasoning data in mock attributes.
+    chunk.additional_kwargs = {}
+    if finish_reason:
+        chunk.response_metadata["finish_reason"] = finish_reason
+    return chunk
+
+
+def _make_stream_event(chunk, metadata=None):
+    """Create a synthetic on_chat_model_stream event."""
+    return {
+        "event": "on_chat_model_stream",
+        "data": {"chunk": chunk},
+        "metadata": metadata or {},
+        "run_id": "run-1",
+    }
+
+
+def _make_model_end_event(output_msg=None):
+    """Create a synthetic on_chat_model_end event."""
+    return {
+        "event": "on_chat_model_end",
+        "data": {"output": output_msg},
+        "metadata": {},
+        "run_id": "run-1",
+    }
+
+
+async def _collect_events(async_gen):
+    """Collect all events from an async generator."""
+    events = []
+    async for ev in async_gen:
+        events.append(ev)
+    return events
+
+
+class TestFix1_SetMessageInProgressNone(unittest.TestCase):
+    """Fix 1: set_message_in_progress(None) crashes on **None."""
+
+    def test_red_set_message_in_progress_with_none_crashes(self):
+        """Demonstrate that set_message_in_progress(run_id, None) would crash."""
+        agent = _make_agent()
+        # set_message_in_progress does **data which crashes on None
+        with self.assertRaises(TypeError):
+            agent.set_message_in_progress("run-1", None)
+
+    def test_green_direct_assignment_clears_safely(self):
+        """The fix uses direct assignment instead of set_message_in_progress."""
+        agent = _make_agent()
+        # Set up a message in progress first
+        agent.set_message_in_progress("run-1", MessageInProgress(
+            id="msg-1", tool_call_id=None, tool_call_name=None
+        ))
+        self.assertIsNotNone(agent.get_message_in_progress("run-1"))
+
+        # The fix: direct assignment works with None
+        agent.messages_in_process["run-1"] = None
+        self.assertIsNone(agent.get_message_in_progress("run-1"))
+
+
+class TestFix2_ToolCallStartAfterPause(unittest.IsolatedAsyncioTestCase):
+    """Fix 2: Tool call start dropped after pause because is_tool_call_start_event
+    was pre-computed with has_current_stream=True (so it was False)."""
+
+    async def test_red_tool_call_start_flag_stale_after_pause(self):
+        """Show that pre-computed is_tool_call_start_event is False when
+        has_current_stream was True at computation time."""
+        # This simulates the pre-fix logic
+        has_current_stream = True  # Text message was in progress
+        tool_call_data = {"name": "search", "id": "tc-1", "args": ""}
+
+        # Pre-fix: flag computed once with has_current_stream=True
+        is_tool_call_start_event = not has_current_stream and tool_call_data and tool_call_data.get("name")
+        self.assertFalse(is_tool_call_start_event, "Pre-fix: tool call start is incorrectly False")
+
+    async def test_green_tool_call_start_re_derived_after_pause(self):
+        """After the pause handler clears message_in_progress, re-derive the flag."""
+        agent = _make_agent()
+
+        # Set up: text message in progress
+        agent.set_message_in_progress("run-1", MessageInProgress(
+            id="msg-1", tool_call_id=None, tool_call_name=None
+        ))
+
+        # Create a stream event with a tool call chunk (triggers pause then tool call start)
+        tool_call_chunk = MagicMock()
+        tool_call_chunk.get = lambda k, d=None: {"name": "search", "id": "tc-1", "args": ""}.get(k, d)
+        tool_call_chunk.__getitem__ = lambda self_tc, k: {"name": "search", "id": "tc-1", "args": ""}[k]
+
+        chunk = _make_chunk(
+            content="",
+            tool_call_chunks=[tool_call_chunk],
+        )
+        event = _make_stream_event(chunk, metadata={"emit-messages": True, "emit-tool-calls": True})
+
+        events = await _collect_events(agent._handle_single_event(event, {}))
+
+        # After fix: tool call start event should be emitted
+        tool_call_starts = [e for e in events if hasattr(e, 'type') and e.type == EventType.TOOL_CALL_START]
+        self.assertEqual(len(tool_call_starts), 1, "Tool call start should be emitted after pause")
+        self.assertEqual(tool_call_starts[0].tool_call_name, "search")
+
+
+class TestFix3_PausedMessageOrphanedOnModelEnd(unittest.IsolatedAsyncioTestCase):
+    """Fix 3: Paused text message gets no TextMessageEnd when model ends without
+    resuming text."""
+
+    async def test_red_no_text_end_for_paused_message_without_fix(self):
+        """Demonstrate that without the fix, on_chat_model_end would not emit
+        TextMessageEnd for a paused text message."""
+        agent = _make_agent()
+        agent.active_run["paused_text_message_id"] = "msg-paused"
+        # No message_in_progress (was cleared during pause)
+        agent.messages_in_process["run-1"] = None
+
+        event = _make_model_end_event(output_msg=None)
+
+        # Simulate the OLD handler logic (no paused_id check):
+        # - not isinstance(output_msg, BaseMessage) -> skip streamed_messages append
+        # - get_message_in_progress is None -> skip both branches
+        # Result: no events emitted, paused_text_message_id left dangling
+        old_events = []
+        # The old code had no paused_id cleanup, so events list would be empty
+        # (the two elif branches both require get_message_in_progress to be truthy)
+        mip = agent.get_message_in_progress("run-1")
+        self.assertIsNone(mip, "No message in progress after pause")
+        # Without fix: paused_text_message_id is still set
+        self.assertEqual(agent.active_run["paused_text_message_id"], "msg-paused")
+
+    async def test_green_text_end_emitted_for_paused_on_model_end(self):
+        """With the fix, on_chat_model_end emits TextMessageEnd for paused messages."""
+        agent = _make_agent()
+        agent.active_run["paused_text_message_id"] = "msg-paused"
+        agent.messages_in_process["run-1"] = None
+
+        event = _make_model_end_event(output_msg=None)
+
+        events = await _collect_events(agent._handle_single_event(event, {}))
+
+        text_ends = [e for e in events if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+        self.assertEqual(len(text_ends), 1, "Should emit TextMessageEnd for paused message")
+        self.assertEqual(text_ends[0].message_id, "msg-paused")
+        # paused_text_message_id should be cleared
+        self.assertIsNone(agent.active_run["paused_text_message_id"])
+
+
+class TestFix4_PausedMessageOrphanedOnError(unittest.IsolatedAsyncioTestCase):
+    """Fix 4: Stream error while message is paused leaves it orphaned."""
+
+    async def test_red_no_cleanup_on_error_without_fix(self):
+        """Without the fix, an exception in the stream leaves paused messages orphaned."""
+        agent = _make_agent()
+        agent.active_run["paused_text_message_id"] = "msg-paused"
+
+        # The old except handler was just `raise` - no cleanup
+        # Verify the paused state exists and would be orphaned
+        self.assertEqual(agent.active_run["paused_text_message_id"], "msg-paused")
+
+    async def test_green_cleanup_on_error(self):
+        """With the fix, the exception handler emits TextMessageEnd before re-raising."""
+        agent = _make_agent()
+        agent.active_run["paused_text_message_id"] = "msg-paused"
+
+        # We need to test _handle_stream_events exception handler.
+        # Instead of mocking the full stream pipeline, test the cleanup logic directly
+        # by simulating what the fixed except block does.
+
+        # The fix checks for paused_text_message_id and emits TextMessageEnd
+        paused_id = agent.active_run.get("paused_text_message_id")
+        self.assertIsNotNone(paused_id)
+
+        # Simulate the cleanup the fixed except block performs
+        event = agent._dispatch_event(
+            __import__('ag_ui.core', fromlist=['TextMessageEndEvent']).TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=paused_id,
+                raw_event={},
+            )
+        )
+        agent.active_run["paused_text_message_id"] = None
+
+        self.assertEqual(event.type, EventType.TEXT_MESSAGE_END)
+        self.assertEqual(event.message_id, "msg-paused")
+        self.assertIsNone(agent.active_run["paused_text_message_id"])
+
+    async def test_green_error_handler_in_stream_context(self):
+        """Integration test: verify the except block in _handle_stream_events
+        yields TextMessageEnd before re-raising when paused_text_message_id is set."""
+        from unittest.mock import AsyncMock, patch
+
+        agent = _make_agent()
+
+        # Create a mock input
+        mock_input = MagicMock()
+        mock_input.thread_id = "thread-1"
+        mock_input.run_id = "run-1"
+        mock_input.messages = []
+        mock_input.state = {}
+        mock_input.forwarded_props = {}
+        mock_input.copy = MagicMock(return_value=mock_input)
+
+        # Mock prepare_stream to set up paused state and return a failing stream
+        async def failing_stream():
+            # Set up paused state as if text was paused
+            agent.active_run["paused_text_message_id"] = "msg-paused"
+            raise RuntimeError("Stream connection lost")
+            yield  # make it a generator  # noqa: unreachable
+
+        mock_state = MagicMock()
+        mock_state.tasks = []
+        mock_state.values = {"messages": []}
+
+        async def mock_prepare_stream(input, agent_state, config):
+            return {
+                "state": {},
+                "stream": failing_stream(),
+                "config": {},
+            }
+
+        with patch.object(agent, 'prepare_stream', side_effect=mock_prepare_stream):
+            with patch.object(agent.graph, 'aget_state', new_callable=AsyncMock, return_value=mock_state):
+                events = []
+                error_raised = False
+                try:
+                    async for ev in agent._handle_stream_events(mock_input):
+                        events.append(ev)
+                except RuntimeError as e:
+                    error_raised = True
+                    self.assertEqual(str(e), "Stream connection lost")
+
+                self.assertTrue(error_raised, "RuntimeError should propagate")
+
+                # Check that TextMessageEnd was yielded for the paused message
+                text_ends = [e for e in events
+                             if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+                self.assertEqual(len(text_ends), 1,
+                                 "TextMessageEnd should be emitted for paused message on error")
+                self.assertEqual(text_ends[0].message_id, "msg-paused")
+
+
+class TestFix5_DeferredTextMessageEnd(unittest.IsolatedAsyncioTestCase):
+    """Fix 5: Empty chunk between text and tool call causes premature TextMessageEnd.
+
+    Some models (DeepSeek, Qwen) send an empty chunk (no content, no tool_call_chunks)
+    between text output and tool call initiation. Previously this triggered
+    isMessageEndEvent and emitted TextMessageEnd prematurely. Now we defer
+    TextMessageEnd to on_chat_model_end.
+    """
+
+    async def test_red_empty_chunk_causes_premature_end(self):
+        """Demonstrate that an empty chunk between text and tool call
+        would have caused premature TextMessageEnd under the old logic."""
+        # Under the old logic, isMessageEndEvent fires when:
+        # - has_current_stream = True (text in progress)
+        # - tool_call_data is None (no tool call chunks)
+        # - is_message_content_event = False (empty content)
+        has_current_stream = True
+        tool_call_data = None
+        is_message_content_event = False
+
+        # Old isMessageEndEvent computation (before adding toolCallData check):
+        old_is_message_end_event = (
+            has_current_stream
+            and not is_message_content_event
+            and tool_call_data is None
+        )
+        self.assertTrue(old_is_message_end_event,
+                        "Old logic would trigger TextMessageEnd on empty chunk")
+
+    async def test_green_empty_chunk_does_not_emit_text_end(self):
+        """With the fix, an empty chunk while text is in progress does not
+        emit a premature TextMessageEnd. Under the current empty-delta
+        handling on main (resolve_message_content preserves ""), the empty
+        delta is swallowed as a legitimate content chunk and the message
+        remains in progress — TextMessageEnd is deferred to on_chat_model_end
+        or to a subsequent tool-call chunk (which triggers the pause path)."""
+        agent = _make_agent()
+
+        # Set up: text message in progress
+        agent.set_message_in_progress("run-1", MessageInProgress(
+            id="msg-1", tool_call_id=None, tool_call_name=None
+        ))
+
+        # Empty chunk — no content, no tool calls
+        chunk = _make_chunk(content="", tool_call_chunks=[], chunk_id="msg-1")
+        event = _make_stream_event(chunk, metadata={"emit-messages": True})
+
+        events = await _collect_events(agent._handle_single_event(event, {}))
+
+        # No TextMessageEnd should be emitted
+        text_ends = [e for e in events if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+        self.assertEqual(len(text_ends), 0,
+                         "Empty chunk should not emit premature TextMessageEnd")
+
+        # messagesInProcess should still be tracking the open text message —
+        # the empty delta is valid content, not an end-of-message signal.
+        self.assertIsNotNone(agent.get_message_in_progress("run-1"))
+        self.assertEqual(agent.get_message_in_progress("run-1")["id"], "msg-1")
+
+    async def test_green_empty_chunk_then_tool_then_text_then_model_end(self):
+        """Full sequence: text -> empty chunk -> tool call -> text resume -> model end.
+        TextMessageEnd fires exactly once at the end."""
+        agent = _make_agent()
+
+        # 1. Text content arrives
+        chunk1 = _make_chunk(content="Let me search", chunk_id="msg-1")
+        event1 = _make_stream_event(chunk1, metadata={"emit-messages": True, "emit-tool-calls": True})
+        events = await _collect_events(agent._handle_single_event(event1, {}))
+
+        text_starts = [e for e in events if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_START]
+        self.assertEqual(len(text_starts), 1)
+
+        # 2. Empty chunk (gap between text and tool call)
+        chunk2 = _make_chunk(content="", tool_call_chunks=[], chunk_id="msg-1")
+        event2 = _make_stream_event(chunk2, metadata={"emit-messages": True, "emit-tool-calls": True})
+        events2 = await _collect_events(agent._handle_single_event(event2, {}))
+
+        # No TextMessageEnd yet
+        text_ends = [e for e in events2 if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+        self.assertEqual(len(text_ends), 0, "No premature TextMessageEnd after empty chunk")
+
+        # 3. Tool call arrives
+        tc_chunk = MagicMock()
+        tc_chunk.get = lambda k, d=None: {"name": "search", "id": "tc-1", "args": ""}.get(k, d)
+        tc_chunk.__getitem__ = lambda self_tc, k: {"name": "search", "id": "tc-1", "args": ""}[k]
+        chunk3 = _make_chunk(content="", tool_call_chunks=[tc_chunk], chunk_id="msg-1")
+        event3 = _make_stream_event(chunk3, metadata={"emit-messages": True, "emit-tool-calls": True})
+        events3 = await _collect_events(agent._handle_single_event(event3, {}))
+
+        tool_starts = [e for e in events3 if hasattr(e, 'type') and e.type == EventType.TOOL_CALL_START]
+        self.assertEqual(len(tool_starts), 1)
+
+        # 4. Tool call ends
+        chunk4 = _make_chunk(content="", tool_call_chunks=[], chunk_id="msg-1")
+        # Simulate tool call in progress
+        agent.set_message_in_progress("run-1", MessageInProgress(
+            id="msg-1", tool_call_id="tc-1", tool_call_name="search"
+        ))
+        event4 = _make_stream_event(chunk4, metadata={"emit-messages": True, "emit-tool-calls": True})
+        events4 = await _collect_events(agent._handle_single_event(event4, {}))
+
+        tool_ends = [e for e in events4 if hasattr(e, 'type') and e.type == EventType.TOOL_CALL_END]
+        self.assertEqual(len(tool_ends), 1)
+
+        # 5. Text resumes
+        chunk5 = _make_chunk(content="Here are results", chunk_id="msg-1")
+        event5 = _make_stream_event(chunk5, metadata={"emit-messages": True, "emit-tool-calls": True})
+        events5 = await _collect_events(agent._handle_single_event(event5, {}))
+
+        # Should NOT have a new TextMessageStart (resumed, not new)
+        new_starts = [e for e in events5 if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_START]
+        self.assertEqual(len(new_starts), 0, "Resumed text should not emit new TextMessageStart")
+
+        # 6. Model ends
+        event6 = _make_model_end_event(output_msg=None)
+        events6 = await _collect_events(agent._handle_single_event(event6, {}))
+
+        # Now TextMessageEnd should fire
+        all_text_ends = [e for e in events6 if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+        self.assertEqual(len(all_text_ends), 1, "TextMessageEnd should fire on model end")
+        self.assertEqual(all_text_ends[0].message_id, "msg-1")
+
+    async def test_green_text_then_model_end_no_empty_chunk(self):
+        """Text content followed directly by model end (no empty chunk) still works."""
+        agent = _make_agent()
+
+        # 1. Text content
+        chunk = _make_chunk(content="Hello world", chunk_id="msg-1")
+        event = _make_stream_event(chunk, metadata={"emit-messages": True})
+        await _collect_events(agent._handle_single_event(event, {}))
+
+        # 2. Model ends (text still in messagesInProcess)
+        event2 = _make_model_end_event(output_msg=None)
+        events2 = await _collect_events(agent._handle_single_event(event2, {}))
+
+        text_ends = [e for e in events2 if hasattr(e, 'type') and e.type == EventType.TEXT_MESSAGE_END]
+        self.assertEqual(len(text_ends), 1)
+        self.assertEqual(text_ends[0].message_id, "msg-1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -206,6 +206,8 @@ export class LangGraphAgent extends AbstractAgent {
       threadId: input.threadId,
       hasFunctionStreaming: false,
       modelMadeToolCall: false,
+      pausedTextMessageId: null,
+      stableMessageId: null,
     };
     // Reset per-run flags
     this.cancelRequested = false;
@@ -683,6 +685,26 @@ export class LangGraphAgent extends AbstractAgent {
       this.activeRun = undefined;
       return subscriber.complete();
     } catch (e) {
+      // Clean up any open text message before propagating error
+      const mip = this.getMessageInProgress(this.activeRun?.id ?? "");
+      if (mip?.id && !mip.toolCallId) {
+        this.dispatchEvent({
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: mip.id,
+          rawEvent: {},
+        });
+        this.messagesInProcess[this.activeRun!.id] = null;
+      } else {
+        const pausedId = this.activeRun?.pausedTextMessageId;
+        if (pausedId) {
+          this.dispatchEvent({
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: pausedId,
+            rawEvent: {},
+          });
+          this.activeRun!.pausedTextMessageId = null;
+        }
+      }
       return subscriber.error(e);
     }
   }
@@ -729,7 +751,7 @@ export class LangGraphAgent extends AbstractAgent {
           (predictStateTool: PredictStateTool) => predictStateTool.tool === toolCallData?.name,
         );
 
-        const isToolCallStartEvent = !hasCurrentStream && toolCallData?.name;
+        let isToolCallStartEvent = !hasCurrentStream && toolCallData?.name;
         const isToolCallArgsEvent =
           hasCurrentStream && currentStream?.toolCallId && toolCallData?.args;
         const isToolCallEndEvent = hasCurrentStream && currentStream?.toolCallId && !toolCallData;
@@ -743,8 +765,18 @@ export class LangGraphAgent extends AbstractAgent {
         const messageContent = resolveMessageContent(event.data.chunk.content);
         const isMessageContentEvent = Boolean(!toolCallData && messageContent);
 
+        // Empty chunk with no tool call data — defer end to OnChatModelEnd
         const isMessageEndEvent =
-          hasCurrentStream && !currentStream?.toolCallId && !isMessageContentEvent;
+          hasCurrentStream &&
+          !currentStream?.toolCallId &&
+          !isMessageContentEvent &&
+          !toolCallData;
+        // Text message pauses when tool calls start while text is in progress
+        const isMessagePauseEvent =
+          hasCurrentStream &&
+          !currentStream?.toolCallId &&
+          !isMessageContentEvent &&
+          !!toolCallData;
 
         if (reasoningData) {
           this.handleReasoningEvent(reasoningData);
@@ -804,15 +836,24 @@ export class LangGraphAgent extends AbstractAgent {
           break;
         }
 
-        if (isMessageEndEvent) {
-          const resolved = this.dispatchEvent({
-            type: EventType.TEXT_MESSAGE_END,
-            messageId: currentStream!.id,
-            rawEvent: event,
-          });
-          if (resolved) {
-            this.messagesInProcess[this.activeRun!.id] = null;
+        if (isMessagePauseEvent) {
+          // Tool calls starting while text in progress — pause without ending
+          this.activeRun!.pausedTextMessageId = currentStream?.id ?? null;
+          this.messagesInProcess[this.activeRun!.id] = null;
+          // Re-derive: messagesInProcess cleared, tool call start can now proceed
+          isToolCallStartEvent = !!toolCallData?.name;
+          if (isToolCallStartEvent) {
+            this.activeRun!.hasFunctionStreaming = true;
           }
+          // Don't break — fall through to tool call start handler
+        }
+
+        if (isMessageEndEvent) {
+          // Defer TextMessageEnd to OnChatModelEnd — an empty chunk during
+          // streaming doesn't guarantee the run is complete (tool calls may
+          // follow). Pause the message so OnChatModelEnd can close it.
+          this.activeRun!.pausedTextMessageId = currentStream?.id ?? null;
+          this.messagesInProcess[this.activeRun!.id] = null;
           break;
         }
 
@@ -850,17 +891,35 @@ export class LangGraphAgent extends AbstractAgent {
         if (isMessageContentEvent && shouldEmitMessages) {
           // No existing message yet, also init the message
           if (!currentStream) {
-            this.dispatchEvent({
-              type: EventType.TEXT_MESSAGE_START,
-              role: "assistant",
-              messageId: event.data.chunk.id,
-              rawEvent: event,
-            });
-            this.setMessageInProgress(this.activeRun!.id, {
-              id: event.data.chunk.id,
-              toolCallId: null,
-              toolCallName: null,
-            });
+            const pausedId = this.activeRun?.pausedTextMessageId;
+            if (pausedId) {
+              // Resuming text after tool calls — reuse the paused message_id
+              // Don't emit TextMessageStart (message is still active in client)
+              this.activeRun!.pausedTextMessageId = null;
+              this.setMessageInProgress(this.activeRun!.id, {
+                id: pausedId,
+                toolCallId: null,
+                toolCallName: null,
+              });
+            } else {
+              // Cache the first chunk's message ID and reuse it for stability
+              if (!this.activeRun!.stableMessageId) {
+                this.activeRun!.stableMessageId = event.data.chunk.id;
+              }
+              const messageId = this.activeRun!.stableMessageId!;
+              // First text in the run — emit TextMessageStart
+              this.dispatchEvent({
+                type: EventType.TEXT_MESSAGE_START,
+                role: "assistant",
+                messageId,
+                rawEvent: event,
+              });
+              this.setMessageInProgress(this.activeRun!.id, {
+                id: messageId,
+                toolCallId: null,
+                toolCallName: null,
+              });
+            }
             currentStream = this.getMessageInProgress(this.activeRun!.id);
           }
 
@@ -894,8 +953,20 @@ export class LangGraphAgent extends AbstractAgent {
           });
           if (resolved) {
             this.messagesInProcess[this.activeRun!.id] = null;
+            this.activeRun!.stableMessageId = null;
           }
           break;
+        }
+        // Handle paused text messages that were never resumed
+        const pausedId = this.activeRun?.pausedTextMessageId;
+        if (pausedId) {
+          this.dispatchEvent({
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: pausedId,
+            rawEvent: event,
+          });
+          this.activeRun!.pausedTextMessageId = null;
+          this.activeRun!.stableMessageId = null;
         }
         break;
       case LangGraphEventTypes.OnCustomEvent:
@@ -1085,6 +1156,10 @@ export class LangGraphAgent extends AbstractAgent {
     if (toolCallChunks?.length > 0) {
       const tc = toolCallChunks[0];
       if (tc.name) {
+        // NOTE: messages-tuple mode still uses end-not-pause when tool calls start
+        // during text streaming. The pause/resume pattern is only implemented in
+        // the events-mode path (handleSingleEvent). This is acceptable because
+        // messages-tuple is a fallback used only when eventsStreamActive is false.
         // End any text message in progress
         if (currentStream?.id && !currentStream?.toolCallId) {
           this.dispatchEvent({

--- a/integrations/langgraph/typescript/src/messages-tuple.test.ts
+++ b/integrations/langgraph/typescript/src/messages-tuple.test.ts
@@ -14,7 +14,7 @@ import { EventType } from "@ag-ui/client";
 function createAgent() {
   const agent = new LangGraphAgent({
     graphId: "test-graph",
-    url: "http://localhost:8000",
+    deploymentUrl: "http://localhost:8000",
   });
 
   // Wire up a mock subscriber and activeRun so dispatchEvent works
@@ -70,7 +70,12 @@ describe("messages-tuple stream mode", () => {
 
       // Now a messages-tuple array should be skipped
       agent.handleSingleEvent([
-        { type: "AIMessageChunk", id: "msg-1", content: "Hello", response_metadata: {} },
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          response_metadata: {},
+        },
         {},
       ]);
 
@@ -93,7 +98,9 @@ describe("messages-tuple stream mode", () => {
         },
       });
 
-      expect(events.some((e) => e.type === EventType.TEXT_MESSAGE_START)).toBe(true);
+      expect(events.some((e) => e.type === EventType.TEXT_MESSAGE_START)).toBe(
+        true,
+      );
     });
   });
 
@@ -129,12 +136,22 @@ describe("messages-tuple stream mode", () => {
 
       // First chunk starts the message
       agent.handleSingleEvent([
-        { type: "AIMessageChunk", id: "msg-1", content: "Hello", response_metadata: {} },
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          response_metadata: {},
+        },
         {},
       ]);
       // Second chunk continues
       agent.handleSingleEvent([
-        { type: "AIMessageChunk", id: "msg-1", content: " world", response_metadata: {} },
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: " world",
+          response_metadata: {},
+        },
         {},
       ]);
 
@@ -149,7 +166,12 @@ describe("messages-tuple stream mode", () => {
       const { agent, events } = createAgent();
 
       agent.handleSingleEvent([
-        { type: "AIMessageChunk", id: "msg-1", content: "Hello", response_metadata: {} },
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Hello",
+          response_metadata: {},
+        },
         {},
       ]);
       agent.handleSingleEvent([
@@ -162,7 +184,9 @@ describe("messages-tuple stream mode", () => {
         {},
       ]);
 
-      const endEvents = events.filter((e) => e.type === EventType.TEXT_MESSAGE_END);
+      const endEvents = events.filter(
+        (e) => e.type === EventType.TEXT_MESSAGE_END,
+      );
       expect(endEvents).toHaveLength(1);
       expect(endEvents[0].messageId).toBe("msg-1");
     });
@@ -232,7 +256,9 @@ describe("messages-tuple stream mode", () => {
         {},
       ]);
 
-      const endEvents = events.filter((e) => e.type === EventType.TOOL_CALL_END);
+      const endEvents = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_END,
+      );
       expect(endEvents).toHaveLength(1);
       expect(endEvents[0].toolCallId).toBe("tc-1");
     });
@@ -290,7 +316,12 @@ describe("messages-tuple stream mode", () => {
 
       // Start text
       agent.handleSingleEvent([
-        { type: "AIMessageChunk", id: "msg-1", content: "Let me search", response_metadata: {} },
+        {
+          type: "AIMessageChunk",
+          id: "msg-1",
+          content: "Let me search",
+          response_metadata: {},
+        },
         {},
       ]);
 
@@ -307,7 +338,9 @@ describe("messages-tuple stream mode", () => {
       ]);
 
       const textEnd = events.find((e) => e.type === EventType.TEXT_MESSAGE_END);
-      const toolStart = events.find((e) => e.type === EventType.TOOL_CALL_START);
+      const toolStart = events.find(
+        (e) => e.type === EventType.TOOL_CALL_START,
+      );
       expect(textEnd).toBeDefined();
       expect(toolStart).toBeDefined();
 

--- a/integrations/langgraph/typescript/src/pause-resume.test.ts
+++ b/integrations/langgraph/typescript/src/pause-resume.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for text pause/resume, tool call after pause, orphaned pause cleanup,
+ * and stable message ID reuse.
+ */
+
+import { describe, it, expect } from "vitest";
+import { LangGraphAgent } from "./agent";
+import { EventType } from "@ag-ui/client";
+import { LangGraphEventTypes } from "./types";
+
+// Minimal config to construct the agent with pausedTextMessageId support
+function createAgent() {
+  const agent = new LangGraphAgent({
+    graphId: "test-graph",
+    deploymentUrl: "http://localhost:8000",
+  });
+
+  const events: any[] = [];
+  (agent as any).subscriber = { next: (e: any) => events.push(e) };
+  (agent as any).activeRun = {
+    id: "run-1",
+    threadId: "thread-1",
+    hasFunctionStreaming: false,
+    pausedTextMessageId: null,
+    stableMessageId: null,
+  };
+  (agent as any).messagesInProcess = {};
+
+  return { agent, events };
+}
+
+function chatModelStreamEvent(
+  chunkId: string,
+  content: string | any[],
+  toolCallChunks?: any[],
+  finishReason?: string | null,
+  metadata?: Record<string, any>,
+) {
+  return {
+    event: LangGraphEventTypes.OnChatModelStream,
+    metadata: {
+      "emit-messages": true,
+      "emit-tool-calls": true,
+      ...(metadata ?? {}),
+    },
+    data: {
+      chunk: {
+        id: chunkId,
+        content,
+        tool_call_chunks: toolCallChunks,
+        response_metadata: finishReason ? { finish_reason: finishReason } : {},
+      },
+    },
+  };
+}
+
+function chatModelEndEvent(outputId?: string) {
+  return {
+    event: LangGraphEventTypes.OnChatModelEnd,
+    data: outputId
+      ? { output: { id: outputId, type: "ai" } }
+      : { output: null },
+  };
+}
+
+describe("pause/resume and tool call after pause", () => {
+  it("text -> tool -> text produces correct event sequence without premature TextMessageEnd", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content arrives
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "Let me look that up"),
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe(EventType.TEXT_MESSAGE_START);
+    expect(events[0].messageId).toBe("msg-1");
+    expect(events[1].type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+
+    // 2. Tool call arrives while text is in progress -> pause + tool call start
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "search", args: "" },
+      ]),
+    );
+
+    // Should NOT have a TEXT_MESSAGE_END — message is paused, not ended
+    const prematureEnd = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(prematureEnd).toHaveLength(0);
+
+    // Should have TOOL_CALL_START
+    const toolStart = events.filter(
+      (e) => e.type === EventType.TOOL_CALL_START,
+    );
+    expect(toolStart).toHaveLength(1);
+    expect(toolStart[0].toolCallName).toBe("search");
+
+    // 3. Tool call args
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [{ args: '{"q":"test"}' }]),
+    );
+    expect(events.some((e) => e.type === EventType.TOOL_CALL_ARGS)).toBe(true);
+
+    // 4. Tool call ends (no tool_call_chunks)
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    const toolEnd = events.filter((e) => e.type === EventType.TOOL_CALL_END);
+    expect(toolEnd).toHaveLength(1);
+
+    // 5. New text arrives — should resume paused message, not start new one
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "Here are the results"),
+    );
+
+    // Should still only have 1 TEXT_MESSAGE_START total (no second start)
+    const textStarts = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_START,
+    );
+    expect(textStarts).toHaveLength(1);
+
+    // The resumed text content should use the original paused message ID
+    const textContents = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    const lastContent = textContents[textContents.length - 1];
+    expect(lastContent.messageId).toBe("msg-1");
+
+    // 6. Model ends — should emit exactly one TextMessageEnd for the full message
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(1);
+    expect(textEnds[0].messageId).toBe("msg-1");
+  });
+
+  it("tool call start is not dropped after pause clears messagesInProcess", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content arrives
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Thinking..."));
+
+    // 2. Tool call arrives while text is in progress
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "lookup", args: "" },
+      ]),
+    );
+
+    // The tool call start MUST be emitted despite the pause clearing messagesInProcess
+    const toolStarts = events.filter(
+      (e) => e.type === EventType.TOOL_CALL_START,
+    );
+    expect(toolStarts).toHaveLength(1);
+    expect(toolStarts[0].toolCallId).toBe("tc-1");
+    expect(toolStarts[0].toolCallName).toBe("lookup");
+  });
+});
+
+describe("paused message orphaned on model end", () => {
+  it("text -> tool -> model_end produces TextMessageEnd for paused message", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content starts
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Let me check"));
+
+    // 2. Tool call pauses the text
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "search", args: "" },
+      ]),
+    );
+
+    // 3. Tool call ends
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // 4. Model ends without resuming text
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    // The paused text message should get a TEXT_MESSAGE_END
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(1);
+    expect(textEnds[0].messageId).toBe("msg-1");
+  });
+
+  it("model end without paused message does not emit spurious TextMessageEnd", () => {
+    const { agent, events } = createAgent();
+
+    // Just a tool call, no text pause
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "search", args: "" },
+      ]),
+    );
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [{ args: '{"q":"test"}' }]),
+    );
+    // Tool call end
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // Model end
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    // TOOL_CALL_END emitted, but no TEXT_MESSAGE_END
+    const toolEnds = events.filter((e) => e.type === EventType.TOOL_CALL_END);
+    expect(toolEnds).toHaveLength(1);
+
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(0);
+  });
+});
+
+describe("stable message ID reuse across chunks", () => {
+  it("uses the first chunk message ID for all subsequent text messages", () => {
+    const { agent, events } = createAgent();
+
+    // First chunk with id "msg-1"
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Hello"));
+
+    expect(events[0].type).toBe(EventType.TEXT_MESSAGE_START);
+    expect(events[0].messageId).toBe("msg-1");
+
+    // Second chunk — different id from platform ("msg-1-chunk-2") but should reuse msg-1
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1-chunk-2", " world"));
+
+    // The content should still reference msg-1
+    const contentEvents = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    expect(contentEvents).toHaveLength(2);
+    expect(contentEvents[1].messageId).toBe("msg-1");
+  });
+
+  it("stable message ID resets after model end, new model turn gets fresh ID", () => {
+    const { agent, events } = createAgent();
+
+    // Text starts with id "msg-1"
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Searching..."));
+
+    // Tool call pauses text
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "search", args: "" },
+      ]),
+    );
+
+    // Tool call ends
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // Text resumes — paused ID takes priority for this continuation
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Results found"));
+
+    // Model ends — stableMessageId is cleared
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    // New model turn with different platform ID
+    agent.handleSingleEvent(chatModelStreamEvent("msg-2", "More info"));
+
+    // stableMessageId was reset on model end, so second turn uses fresh ID
+    const textStarts = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_START,
+    );
+    // Two starts: first from model turn 1, second from model turn 2
+    expect(textStarts).toHaveLength(2);
+    expect(textStarts[0].messageId).toBe("msg-1");
+    expect(textStarts[1].messageId).toBe("msg-2"); // fresh ID for new turn
+  });
+});
+
+describe("deferred TextMessageEnd — empty chunk before tool call", () => {
+  it("empty chunk between text and tool call does not emit premature TextMessageEnd", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content arrives
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "Let me search for that"),
+    );
+    expect(
+      events.filter((e) => e.type === EventType.TEXT_MESSAGE_START),
+    ).toHaveLength(1);
+
+    // 2. Empty chunk arrives (no content, no tool calls) — some models emit this
+    //    between text output and tool call initiation
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // TextMessageEnd must NOT fire here — the run may not be complete
+    expect(
+      events.filter((e) => e.type === EventType.TEXT_MESSAGE_END),
+    ).toHaveLength(0);
+
+    // 3. Tool call arrives
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "", [
+        { id: "tc-1", name: "search", args: "" },
+      ]),
+    );
+
+    // Tool call start should still work
+    const toolStarts = events.filter(
+      (e) => e.type === EventType.TOOL_CALL_START,
+    );
+    expect(toolStarts).toHaveLength(1);
+
+    // Still no TextMessageEnd
+    expect(
+      events.filter((e) => e.type === EventType.TEXT_MESSAGE_END),
+    ).toHaveLength(0);
+
+    // 4. Tool call ends
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // 5. More text arrives
+    agent.handleSingleEvent(
+      chatModelStreamEvent("msg-1", "Here are the results"),
+    );
+
+    // Only 1 TextMessageStart total (resumed, not new)
+    expect(
+      events.filter((e) => e.type === EventType.TEXT_MESSAGE_START),
+    ).toHaveLength(1);
+
+    // 6. Model ends — now TextMessageEnd should fire exactly once
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(1);
+    expect(textEnds[0].messageId).toBe("msg-1");
+  });
+
+  it("text followed by model end (no tool calls) still emits TextMessageEnd", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Hello world"));
+
+    // 2. Model ends normally
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(1);
+    expect(textEnds[0].messageId).toBe("msg-1");
+  });
+
+  it("empty chunk then model end (simple case) still emits TextMessageEnd", () => {
+    const { agent, events } = createAgent();
+
+    // 1. Text content
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "Thinking..."));
+
+    // 2. Empty chunk
+    agent.handleSingleEvent(chatModelStreamEvent("msg-1", "", undefined));
+
+    // No TextMessageEnd yet (deferred)
+    expect(
+      events.filter((e) => e.type === EventType.TEXT_MESSAGE_END),
+    ).toHaveLength(0);
+
+    // 3. Model ends
+    agent.handleSingleEvent(chatModelEndEvent("msg-1"));
+
+    // Now TextMessageEnd fires
+    const textEnds = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_END,
+    );
+    expect(textEnds).toHaveLength(1);
+    expect(textEnds[0].messageId).toBe("msg-1");
+  });
+});
+
+describe("pausedTextMessageId initialization", () => {
+  it("activeRun initializes with pausedTextMessageId null", () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+
+    // Simulate what runAgentStream does
+    (agent as any).activeRun = {
+      id: "run-1",
+      threadId: "thread-1",
+      hasFunctionStreaming: false,
+      pausedTextMessageId: null,
+      stableMessageId: null,
+    };
+
+    expect((agent as any).activeRun.pausedTextMessageId).toBeNull();
+    expect((agent as any).activeRun.stableMessageId).toBeNull();
+  });
+});

--- a/integrations/langgraph/typescript/src/types.ts
+++ b/integrations/langgraph/typescript/src/types.ts
@@ -1,4 +1,7 @@
-import { AssistantGraph, Message as LangGraphMessage } from "@langchain/langgraph-sdk";
+import {
+  AssistantGraph,
+  Message as LangGraphMessage,
+} from "@langchain/langgraph-sdk";
 import { MessageType } from "@langchain/core/messages";
 import { RunAgentInput } from "@ag-ui/core";
 
@@ -23,8 +26,8 @@ export type LangGraphToolWithName = {
     name: string;
     description: string;
     parameters: any;
-  },
-}
+  };
+};
 
 export type State<TDefinedState = Record<string, any>> = {
   [k in keyof TDefinedState]: TDefinedState[k] | null;
@@ -32,10 +35,10 @@ export type State<TDefinedState = Record<string, any>> = {
 export interface StateEnrichment {
   messages: LangGraphMessage[];
   tools: LangGraphToolWithName[];
-  'ag-ui': {
+  "ag-ui": {
     tools: LangGraphToolWithName[];
-    context: RunAgentInput['context']
-  }
+    context: RunAgentInput["context"];
+  };
 }
 
 export type SchemaKeys = {
@@ -53,10 +56,10 @@ export type MessageInProgress = {
 
 export type ReasoningInProgress = {
   index: number;
-  type?: LangGraphReasoning['type'];
+  type?: LangGraphReasoning["type"];
   messageId: string;
   signature?: string;
-}
+};
 
 export interface RunMetadata {
   id: string;
@@ -66,7 +69,7 @@ export interface RunMetadata {
   exitingNode?: boolean;
   manuallyEmittedState?: State | null;
   threadId?: string;
-  graphInfo?: AssistantGraph
+  graphInfo?: AssistantGraph;
   hasFunctionStreaming?: boolean;
   // True once the platform-assigned run id is known (set from stream metadata)
   serverRunIdKnown?: boolean;
@@ -75,6 +78,10 @@ export interface RunMetadata {
   // execution; cleared in OnToolEnd/OnToolError. While set, STATE_SNAPSHOT
   // emission is suppressed so optimistic UI state is not overwritten.
   modelMadeToolCall?: boolean;
+  // Message ID saved when text is paused for tool calls (not ended)
+  pausedTextMessageId?: string | null;
+  // Stable message ID cached from first text chunk, reused across chunks
+  stableMessageId?: string | null;
 }
 
 export type MessagesInProgressRecord = Record<string, MessageInProgress | null>;
@@ -107,7 +114,8 @@ interface LangGraphPlatformResultMessage extends BaseLangGraphPlatformMessage {
   name: string;
 }
 
-interface LangGraphPlatformActionExecutionMessage extends BaseLangGraphPlatformMessage {
+interface LangGraphPlatformActionExecutionMessage
+  extends BaseLangGraphPlatformMessage {
   tool_calls: ToolCall[];
 }
 
@@ -130,7 +138,7 @@ export interface PredictStateTool {
 }
 
 export interface LangGraphReasoning {
-  type: 'text';
+  type: "text";
   text: string;
   index: number;
   signature?: string;


### PR DESCRIPTION
## Summary

Each `on_chat_model_stream` chunk carries a new `chunk.id`, so when the model does tool calls and then continues with text, a new `TextMessageStart` was emitted with a different `message_id`. This caused the frontend to render multiple message bubbles for a single response.

**Fix:** Generates a stable `message_id` on the first text chunk and reuses it for all subsequent text message events in the same run. The client handles ID reuse gracefully — `TextMessageStart` with an existing ID is a no-op, `TextMessageContent` appends correctly.

**TODO:** `TextMessageEnd` currently fires after the first text segment (before tool calls). After tool calls, the second text segment streams in but there's no second `TextMessageEnd`, so `onNewMessage` fires with content from the first segment only. Fix: defer `TextMessageEnd` until the run is truly complete — isolated to `ag_ui_langgraph/agent.py`, no protocol changes needed.

Closes #1317

## Test plan

- [ ] Verify single message bubble when model does text → tool call → text
- [ ] Verify `onNewMessage` callback fires with complete content (not just first segment)
- [ ] Add tests for stable ID reuse across tool-call interruptions
- [ ] Add test for deferred `TextMessageEnd` timing