### PR TITLE
Revert PR #1499: Bedrock reasoning_content block format

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -311,19 +311,6 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
                 index=block.get("index", 0)
             )
 
-        # AWS Bedrock Converse format: { type: "reasoning_content", reasoning_content: { text: "...", signature: "..." } }
-        if block_type == "reasoning_content" and isinstance(block.get("reasoning_content"), dict):
-            rc = block["reasoning_content"]
-            if rc.get("text"):
-                result = LangGraphReasoning(
-                    text=rc["text"],
-                    type="text",
-                    index=block.get("index", 0),
-                )
-                if rc.get("signature"):
-                    result["signature"] = rc["signature"]
-                return result
-
         # OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
         if block_type == "reasoning" and block.get("summary"):
             summaries = block["summary"]


### PR DESCRIPTION
Reverting — the `{type: 'reasoning_content', reasoning_content: {text: ...}}` block format appears to be hallucinated. LangChain's langchain-aws already converts Bedrock thinking blocks to `{type: 'thinking', thinking: '...'}` which is handled by existing code. This added dead code that gives false confidence.