### PR TITLE
Revert PR #1502: wheel file permissions in publish workflow

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -64,14 +64,6 @@ jobs:
           ")
           uv run $TEST_CMD
 
-      - name: Fix source permissions for wheel
-        working-directory: ${{ inputs.package }}
-        run: |
-          # Ensure all source files are readable so the wheel inherits
-          # correct permissions (fixes broken wheels from restrictive umask)
-          find . -type f -exec chmod a+r {} +
-          find . -type d -exec chmod a+rx {} +
-
       - name: Build package
         working-directory: ${{ inputs.package }}
         run: uv build


### PR DESCRIPTION
Reverting — GitHub Actions runners already use umask 022 which makes files world-readable. No evidence of a real permissions problem existed. The existing 'Verify wheel permissions' step downstream would catch issues if they occurred.