### PR TITLE
chore(kotlin): upgrade Ktor from 3.1.3 to 3.2.4

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade Ktor from 3.1.3 to 3.2.4 (latest compatible with Kotlin 2.1.x)
 
+### Fixed
+- Repair chatapp-swiftui XCFramework build: remove stale composite-build substitution for deleted kotlin-a2ui module, add missing a2ui-4k catalog entry, and align kotlinx-datetime on the 0.7.1-0.6.x-compat artifact for iOS compatibility
+
 ### Examples
 - Update a2ui-4k dependency from 0.8.0 to 0.8.1 in chatapp examples
 - Remove unnecessary core library desugaring from chatapp-shared (minSdk is 26)

--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgrade Ktor from 3.1.3 to 3.2.4 (latest compatible with Kotlin 2.1.x)
+
 ### Examples
 - Update a2ui-4k dependency from 0.8.0 to 0.8.1 in chatapp examples
 - Remove unnecessary core library desugaring from chatapp-shared (minSdk is 26)

--- a/sdks/community/kotlin/build.gradle.kts
+++ b/sdks/community/kotlin/build.gradle.kts
@@ -85,10 +85,10 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Ktor for networking
-                implementation("io.ktor:ktor-client-core:3.1.3")
-                implementation("io.ktor:ktor-client-content-negotiation:3.1.3")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.3")
-                implementation("io.ktor:ktor-client-logging:3.1.3")
+                implementation("io.ktor:ktor-client-core:3.2.4")
+                implementation("io.ktor:ktor-client-content-negotiation:3.2.4")
+                implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.4")
+                implementation("io.ktor:ktor-client-logging:3.2.4")
                 
                 // Kotlinx libraries
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
@@ -104,13 +104,13 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
-                implementation("io.ktor:ktor-client-mock:3.1.3")
+                implementation("io.ktor:ktor-client-mock:3.2.4")
             }
         }
         
         val androidMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-android:3.1.3")
+                implementation("io.ktor:ktor-client-android:3.2.4")
                 implementation("org.slf4j:slf4j-android:1.7.36")
             }
         }
@@ -125,13 +125,13 @@ kotlin {
             iosSimulatorArm64Main.dependsOn(this)
             
             dependencies {
-                implementation("io.ktor:ktor-client-darwin:3.1.3")
+                implementation("io.ktor:ktor-client-darwin:3.2.4")
             }
         }
         
         val jvmMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-java:3.1.3")
+                implementation("io.ktor:ktor-client-java:3.2.4")
                 implementation("org.slf4j:slf4j-simple:2.0.9")
             }
         }

--- a/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kotlin = "2.1.20"
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"
 kotlinx-coroutines = "1.10.2"
-kotlinx-datetime = "0.6.2"
+kotlinx-datetime = "0.7.1-0.6.x-compat"
 android-gradle = "8.12.0"
 kotlin-logging = "3.0.5"
 logback-android = "3.0.0"
@@ -30,7 +30,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version.ref 
 agui-client = { module = "com.ag-ui.community:kotlin-client", version.ref = "agui-core" }
 agui-core = { module = "com.ag-ui.community:kotlin-core", version.ref = "agui-core" }
 agui-tools = { module = "com.ag-ui.community:kotlin-tools", version.ref = "agui-core" }
-agui-a2ui = { module = "com.ag-ui.community:kotlin-a2ui", version.ref = "agui-core" }
+a2ui4k = { module = "com.contextable:a2ui-4k", version = "0.8.1" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 core = { module = "androidx.test:core", version.ref = "core" }

--- a/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
@@ -12,7 +12,6 @@ includeBuild("../../library") {
         substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
         substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
         substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
-        substitute(module("com.ag-ui.community:kotlin-a2ui")).using(project(":kotlin-a2ui"))
     }
 }
 

--- a/sdks/community/kotlin/library/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/library/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ core-ktx = "1.16.0"
 kotlin = "2.1.20"
 kotlin-json-patch = "1.0.0"
 #Downgrading to avoid an R8 error
-ktor = "3.1.3"
+ktor = "3.2.4"
 kotlinx-serialization = "1.8.1"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"


### PR DESCRIPTION
## Summary
- Upgrade Ktor from 3.1.3 to 3.2.4 in the Kotlin community SDK (both version catalog and legacy root build.gradle.kts)
- 3.2.4 is the latest Ktor version compatible with the project's Kotlin 2.1.20 compiler (3.3+ needs Kotlin 2.2+, 3.4+ needs Kotlin 2.3+)
- Add changelog entry to the Unreleased section

## Context
An OWASP dependency-check scan found that all runtime dependencies in the Kotlin SDK are clean — the flagged Netty/gRPC/protobuf CVEs are exclusively in build-time tooling (Dokka, JReleaser). This Ktor bump is a general maintenance upgrade, not a CVE fix.

## Test plan
- [x] All three library modules (core, client, tools) compile cleanly with Ktor 3.2.4
- [x] All JVM tests pass (kotlin-core, kotlin-client, kotlin-tools)
- [x] Verify Android build succeeds in CI (R8 compatibility — the original 3.1.3 pin was to avoid an R8 error)
- [x] Verify iOS targets compile in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)