### PR TITLE
fix: A2UI middleware v0.9 inline catalog schema format

### DIFF
--- a/middlewares/a2ui-middleware/package.json
+++ b/middlewares/a2ui-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ag-ui/a2ui-middleware",
   "author": "Markus Ecker",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },

--- a/middlewares/a2ui-middleware/src/index.ts
+++ b/middlewares/a2ui-middleware/src/index.ts
@@ -41,7 +41,7 @@ export const A2UIActivityType = "a2ui-surface";
  * The LangGraph connector uses this to extract the schema from context and inject it
  * into the agent's key/value state instead of the system prompt.
  */
-export const A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema — available components for generating UI surfaces. Use these component names and props when creating A2UI operations.";
+export const A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema — available components for generating UI surfaces. Use these component names and properties when creating A2UI operations.";
 
 /**
  * Extract EventWithState type from Middleware.runNextWithState return type
@@ -103,7 +103,14 @@ export class A2UIMiddleware extends Middleware {
    * the server-side schema replaces it.
    */
   private injectSchemaContext(input: RunAgentInput): RunAgentInput {
-    if (!this.config.schema || this.config.schema.length === 0) {
+    if (!this.config.schema) {
+      return input;
+    }
+    // Empty check: array → length, inline catalog → no components
+    const isEmpty = Array.isArray(this.config.schema)
+      ? this.config.schema.length === 0
+      : Object.keys(this.config.schema.components ?? {}).length === 0;
+    if (isEmpty) {
       return input;
     }
 

--- a/middlewares/a2ui-middleware/src/types.ts
+++ b/middlewares/a2ui-middleware/src/types.ts
@@ -1,8 +1,19 @@
 /**
- * A2UI component schema definition.
- * Declares which components are available, their props, and slots.
- * This is the contract between the application and the AI agent —
- * the agent can only generate UI using components defined here.
+ * A2UI v0.9 inline catalog schema.
+ * Matches the structure defined by the A2UI specification (basic_catalog.json).
+ * Components are keyed by name and use standard JSON Schema to describe
+ * their properties in the flat wire format.
+ */
+export interface A2UIInlineCatalogSchema {
+  /** Catalog identifier */
+  catalogId: string;
+  /** Component schemas keyed by component name */
+  components: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * @deprecated Use A2UIInlineCatalogSchema instead.
+ * Legacy component schema definition with { name, props } format.
  */
 export interface A2UIComponentSchema {
   /** Component name (e.g. "TodoCard", "FlightResult") */
@@ -23,8 +34,11 @@ export interface A2UIMiddlewareConfig {
    * Component schema — declares which components are available to agents.
    * When provided, the schema is injected as context into RunAgentInput
    * so agents know what components they can generate.
+   *
+   * Accepts the v0.9 inline catalog format (preferred) or the legacy
+   * array format for backwards compatibility.
    */
-  schema?: A2UIComponentSchema[];
+  schema?: A2UIInlineCatalogSchema | A2UIComponentSchema[];
 
   /**
    * Controls whether the middleware injects an A2UI rendering tool into


### PR DESCRIPTION
## Summary
- Add `A2UIInlineCatalogSchema` type matching the A2UI v0.9 spec format (same structure as `basic_catalog.json`)
- Deprecate legacy `A2UIComponentSchema` (array of `{ name, props }`) which caused LLMs to nest properties under a `"props"` key in their output
- Accept both formats in middleware config for backwards compatibility
- Update context description to say "properties" instead of "props"
- Bump to `0.0.5`

## Context
The old `{ name, props }` schema format confused LLMs into producing invalid A2UI — they would nest component properties inside a `"props"` object instead of using the flat wire format. The new format mirrors the v0.9 spec so the schema structure matches the expected output.

## Test plan
- [x] Tested with ag-ui dojo — A2UI dynamic schema demo works
- [x] Tested with CopilotKit langgraph-starter — sales dashboard renders correctly
- [x] Backwards compatible — middleware still accepts legacy array format

🤖 Generated with [Claude Code](https://claude.com/claude-code)