### PR TITLE
fix: fix state not streaming when tools execute after one another

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/middlewares/state_streaming.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/middlewares/state_streaming.py
@@ -37,7 +37,13 @@ class StateStreamingMiddleware(AgentMiddleware):
         producing a duplicate stream.
         """
         msgs = request.messages
-        return not (msgs and isinstance(msgs[-1], ToolMessage))
+        if not (msgs and isinstance(msgs[-1], ToolMessage)):
+            return True
+        # Only suppress if the last tool is one we're actually tracking
+        # (prevents duplicate stream if the same tool is called again)
+        last_tool_name = getattr(msgs[-1], 'name', None)
+        tracked_tools = {item["tool"] for item in self._emit_intermediate_state}
+        return last_tool_name not in tracked_tools
 
     def wrap_model_call(
         self,

--- a/integrations/langgraph/python/tests/test_state_streaming_middleware.py
+++ b/integrations/langgraph/python/tests/test_state_streaming_middleware.py
@@ -51,10 +51,17 @@ class TestIsPreToolCall(unittest.TestCase):
         req = _make_request([HumanMessage(content="hi"), AIMessage(content="sure")])
         self.assertTrue(self.middleware._is_pre_tool_call(req))
 
-    def test_tool_message_last_is_not_pre_tool_call(self):
-        tool_msg = ToolMessage(content="result", tool_call_id="tc1")
+    def test_tracked_tool_message_last_suppresses_inject(self):
+        """A ToolMessage from a tracked tool should suppress injection."""
+        tool_msg = ToolMessage(content="result", tool_call_id="tc1", name="write_recipe")
         req = _make_request([HumanMessage(content="go"), tool_msg])
         self.assertFalse(self.middleware._is_pre_tool_call(req))
+
+    def test_untracked_tool_message_last_is_pre_tool_call(self):
+        """A ToolMessage from an untracked tool (e.g. open_canvas) should still inject."""
+        tool_msg = ToolMessage(content="Canvas is now open.", tool_call_id="tc1", name="open_canvas")
+        req = _make_request([HumanMessage(content="go"), tool_msg])
+        self.assertTrue(self.middleware._is_pre_tool_call(req))
 
 
 class TestWrapModelCall(unittest.TestCase):
@@ -192,11 +199,11 @@ class TestWrapModelCallConfigInjection(unittest.TestCase):
         tools = [p["tool"] for p in captured["meta"]["predict_state"]]
         self.assertIn("write_recipe", tools)
 
-    def test_predict_state_not_injected_post_tool_call(self):
-        """predict_state metadata is NOT set when last message is a ToolMessage."""
+    def test_predict_state_not_injected_post_tracked_tool_call(self):
+        """predict_state metadata is NOT set when last message is a tracked ToolMessage."""
         middleware = self._make_middleware()
         req = MagicMock()
-        req.messages = [ToolMessage(content="result", tool_call_id="tc1")]
+        req.messages = [ToolMessage(content="result", tool_call_id="tc1", name="write_recipe")]
 
         captured = {}
         def handler(request):
@@ -224,11 +231,26 @@ class TestWrapModelCallConfigInjection(unittest.TestCase):
         tools = [p["tool"] for p in captured["meta"]["predict_state"]]
         self.assertIn("write_recipe", tools)
 
-    def test_predict_state_not_injected_async_post_tool_call(self):
-        """Async: predict_state metadata is NOT set when last message is a ToolMessage."""
+    def test_predict_state_injected_after_untracked_tool_call(self):
+        """predict_state IS injected when last ToolMessage is from an untracked tool."""
         middleware = self._make_middleware()
         req = MagicMock()
-        req.messages = [ToolMessage(content="result", tool_call_id="tc1")]
+        req.messages = [ToolMessage(content="Canvas is now open.", tool_call_id="tc1", name="open_canvas")]
+
+        captured = {}
+        def handler(request):
+            captured["meta"] = (var_child_runnable_config.get() or {}).get("metadata", {})
+            return MagicMock()
+
+        middleware.wrap_model_call(req, handler)
+
+        self.assertIn("predict_state", captured["meta"])
+
+    def test_predict_state_not_injected_async_post_tracked_tool_call(self):
+        """Async: predict_state metadata is NOT set when last message is a tracked ToolMessage."""
+        middleware = self._make_middleware()
+        req = MagicMock()
+        req.messages = [ToolMessage(content="result", tool_call_id="tc1", name="write_recipe")]
 
         captured = {}
         async def handler(request):

--- a/integrations/langgraph/typescript/src/middlewares/index.ts
+++ b/integrations/langgraph/typescript/src/middlewares/index.ts
@@ -1,1 +1,1 @@
-export * from './state-streaming'
+export * from "./state-streaming";

--- a/integrations/langgraph/typescript/src/middlewares/state-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/middlewares/state-streaming.test.ts
@@ -16,7 +16,12 @@ vi.mock("langchain", () => ({
 }));
 
 import { stateStreamingMiddleware, stateItem } from "./state-streaming";
-import { BaseMessage, HumanMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+import {
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import { ModelRequest } from "langchain";
 
 /** Minimal mock of request.model — only withConfig is exercised. */
@@ -47,7 +52,13 @@ function makeRequest(messages: BaseMessage[]) {
 }
 
 describe("stateStreamingMiddleware", () => {
-  const items = [stateItem({ stateKey: "recipe", tool: "write_recipe", toolArgument: "draft" })];
+  const items = [
+    stateItem({
+      stateKey: "recipe",
+      tool: "write_recipe",
+      toolArgument: "draft",
+    }),
+  ];
 
   describe("wrapModelCall — isPreToolCall logic", () => {
     it("injects predict_state metadata when messages array is empty", async () => {
@@ -60,11 +71,21 @@ describe("stateStreamingMiddleware", () => {
       expect(model.withConfig).toHaveBeenCalledOnce();
       expect(model.withConfig).toHaveBeenCalledWith({
         metadata: {
-          predict_state: [{ state_key: "recipe", tool: "write_recipe", tool_argument: "draft" }],
+          predict_state: [
+            {
+              state_key: "recipe",
+              tool: "write_recipe",
+              tool_argument: "draft",
+            },
+          ],
         },
       });
       // handler receives a request with the enriched model
-      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ model: expect.objectContaining({ _isModelWithConfig: true }) }));
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({ _isModelWithConfig: true }),
+        }),
+      );
     });
 
     it("injects predict_state metadata when last message is not a ToolMessage", async () => {
@@ -77,25 +98,60 @@ describe("stateStreamingMiddleware", () => {
       expect(model.withConfig).toHaveBeenCalledOnce();
     });
 
-    it("passes through without injecting when last message is a ToolMessage", async () => {
+    it("suppresses injection when last message is a ToolMessage for a tracked tool", async () => {
       const middleware = stateStreamingMiddleware(...items);
-      const toolMsg = new ToolMessage({ content: "result", tool_call_id: "tc1" });
-      const { request, model } = makeRequest([new HumanMessage("call it"), toolMsg]);
+      const toolMsg = new ToolMessage({
+        content: "result",
+        tool_call_id: "tc1",
+        name: "write_recipe",
+      });
+      const { request, model } = makeRequest([
+        new HumanMessage("call it"),
+        toolMsg,
+      ]);
       const handler = vi.fn().mockResolvedValue({ content: "ok" });
 
       await middleware.wrapModelCall!(request, handler);
 
-      // model.withConfig must NOT have been called — request passes through unchanged
+      // model.withConfig must NOT have been called — tracked tool suppresses
       expect(model.withConfig).not.toHaveBeenCalled();
       expect(handler).toHaveBeenCalledWith(request);
+    });
+
+    it("injects when last message is a ToolMessage for an untracked tool", async () => {
+      const middleware = stateStreamingMiddleware(...items);
+      // open_canvas is not in the tracked items list
+      const toolMsg = new ToolMessage({
+        content: "Canvas is now open.",
+        tool_call_id: "tc2",
+        name: "open_canvas",
+      });
+      const { request, model } = makeRequest([
+        new HumanMessage("call it"),
+        toolMsg,
+      ]);
+      const handler = vi.fn().mockResolvedValue({ content: "ok" });
+
+      await middleware.wrapModelCall!(request, handler);
+
+      // untracked tool — predict_state should be injected so manage_todos can stream
+      expect(model.withConfig).toHaveBeenCalledOnce();
     });
   });
 
   describe("predict_state payload shape", () => {
     it("maps StateItem camelCase fields to snake_case in predict_state", async () => {
       const middleware = stateStreamingMiddleware(
-        stateItem({ stateKey: "myState", tool: "my_tool", toolArgument: "my_arg" }),
-        stateItem({ stateKey: "otherState", tool: "other_tool", toolArgument: "other_arg" }),
+        stateItem({
+          stateKey: "myState",
+          tool: "my_tool",
+          toolArgument: "my_arg",
+        }),
+        stateItem({
+          stateKey: "otherState",
+          tool: "other_tool",
+          toolArgument: "other_arg",
+        }),
       );
       const { request, model } = makeRequest([new HumanMessage("go")]);
       const handler = vi.fn().mockResolvedValue({ content: "ok" });
@@ -106,7 +162,11 @@ describe("stateStreamingMiddleware", () => {
         metadata: {
           predict_state: [
             { state_key: "myState", tool: "my_tool", tool_argument: "my_arg" },
-            { state_key: "otherState", tool: "other_tool", tool_argument: "other_arg" },
+            {
+              state_key: "otherState",
+              tool: "other_tool",
+              tool_argument: "other_arg",
+            },
           ],
         },
       });
@@ -188,10 +248,10 @@ describe("stateStreamingMiddleware", () => {
       const shouldEmit = (exitingNode: boolean, hasPredictState: boolean) =>
         !(exitingNode && hasPredictState);
 
-      expect(shouldEmit(true, true)).toBe(false);   // suppressed ✓
-      expect(shouldEmit(true, false)).toBe(true);   // not suppressed
-      expect(shouldEmit(false, true)).toBe(true);   // not suppressed
-      expect(shouldEmit(false, false)).toBe(true);  // not suppressed
+      expect(shouldEmit(true, true)).toBe(false); // suppressed ✓
+      expect(shouldEmit(true, false)).toBe(true); // not suppressed
+      expect(shouldEmit(false, true)).toBe(true); // not suppressed
+      expect(shouldEmit(false, false)).toBe(true); // not suppressed
     });
   });
 });

--- a/integrations/langgraph/typescript/src/middlewares/state-streaming.ts
+++ b/integrations/langgraph/typescript/src/middlewares/state-streaming.ts
@@ -34,17 +34,23 @@ export const stateStreamingMiddleware = (...items: StateItem[]) => {
     tool_argument: i.toolArgument,
   }));
 
+  const trackedTools = new Set(items.map((i) => i.tool));
+
   /**
-   * Return true if this model call may generate the initial tool call.
-   * When the last message is a ToolMessage the tool has already run and
-   * the model is being called for a follow-up response. Injecting
-   * predict_state in that case would re-trigger streaming if the model
-   * decides to call the same tool again, producing a duplicate stream.
+   * Return true if intermediate state should be injected for this model call.
+   *
+   * Suppress only when the last tool that ran is one we track. If we injected
+   * again after a tracked tool, predict_state would stream a second time for
+   * that same tool on its next invocation — a true duplicate stream. Untracked
+   * tools (e.g. open_canvas) are safe to inject after because the next call
+   * may need to stream a tracked tool.
    */
   const isPreToolCall = (request: { messages?: BaseMessage[] }): boolean => {
     const msgs = request?.messages ?? [];
     if (msgs.length === 0) return true;
-    return !(msgs[msgs.length - 1] instanceof ToolMessage);
+    const last = msgs[msgs.length - 1];
+    if (!(last instanceof ToolMessage)) return true;
+    return !trackedTools.has(last.name ?? "");
   };
 
   return createMiddleware({


### PR DESCRIPTION
When an untracked tool* ran before a tracked one*, the middleware would suppress predict_state injection for the subsequent model call, causing the tracked tool's state to never stream. The  
fix makes suppression conditional: only suppress injection when the last tool that ran is itself tracked, so untracked tools no longer block the next tracked tool from streaming.

* tracked = tool that was passed as an item to the middleware to be streamed 