### PR TITLE
fix(aws-strands): forward all template kwargs to per-thread agents via signature introspection

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -4,12 +4,44 @@ Translates Strands streaming events into the AG-UI event protocol.
 """
 
 import base64
+import inspect
 import json
 import logging
 import uuid
 from typing import Any, AsyncIterator, Dict, List
 
 from strands import Agent as StrandsAgentCore
+
+# Params handled explicitly by StrandsAgent — excluded from auto-forwarding.
+# "messages" is excluded: per-thread agents start with no history;
+# AG-UI injects messages at runtime via RunAgentInput.
+# "hooks" is excluded: Agent stores hooks as a HookRegistry after init, not
+# the original list the constructor expects — forwarding it causes a TypeError.
+_AGUI_EXPLICIT_PARAMS = {"self", "model", "system_prompt", "tools", "messages", "hooks"}
+
+
+def _extract_agent_kwargs(agent: StrandsAgentCore) -> dict:
+    """Build kwargs for StrandsAgentCore by introspecting its constructor signature.
+
+    Forward-compatible: new Strands parameters are picked up automatically
+    without changes here, as long as they are stored as same-named instance
+    attributes (the same assumption the manual approach made).
+    """
+    kwargs = {}
+    for name in inspect.signature(StrandsAgentCore.__init__).parameters:
+        if name in _AGUI_EXPLICIT_PARAMS:
+            continue
+        if not hasattr(agent, name):
+            continue
+        value = getattr(agent, name)
+        if value is None:
+            continue
+        # state is an AgentState container; extract the underlying plain dict
+        if name == "state" and hasattr(value, "get"):
+            value = value.get()
+        kwargs[name] = value
+    return kwargs
+
 
 logger = logging.getLogger(__name__)
 from ag_ui.core import (
@@ -69,19 +101,7 @@ class StrandsAgent:
             if hasattr(agent, "tool_registry")
             else []
         )
-        self._agent_kwargs = {
-            "record_direct_tool_call": agent.record_direct_tool_call
-            if hasattr(agent, "record_direct_tool_call")
-            else True,
-        }
-        if hasattr(agent, "trace_attributes") and agent.trace_attributes:
-            self._agent_kwargs["trace_attributes"] = agent.trace_attributes
-        if hasattr(agent, "agent_id") and agent.agent_id:
-            self._agent_kwargs["agent_id"] = agent.agent_id
-        if hasattr(agent, "state") and agent.state is not None:
-            self._agent_kwargs["state"] = agent.state.get()
-        if hasattr(agent, "conversation_manager") and agent.conversation_manager is not None:
-            self._agent_kwargs["conversation_manager"] = agent.conversation_manager
+        self._agent_kwargs = _extract_agent_kwargs(agent)
 
         self.name = name
         self.description = description

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -1,13 +1,4 @@
-"""Tests for StrandsAgent template kwarg propagation to new thread instances.
-
-StrandsAgent.__init__ currently captures only four attributes from the template
-agent (model, system_prompt, tools, record_direct_tool_call).  All other
-constructor parameters — trace_attributes, agent_id, conversation_manager,
-state — are silently discarded, so every new thread starts with default values
-regardless of what was configured on the template.
-
-Each test below is written to FAIL with the current code and PASS after the fix.
-"""
+"""Tests for StrandsAgent template kwarg propagation to new thread instances."""
 
 from __future__ import annotations
 
@@ -18,7 +9,6 @@ from strands import Agent
 from strands.tools.registry import ToolRegistry
 
 from ag_ui_strands.agent import StrandsAgent
-from ag_ui_strands.config import StrandsAgentConfig
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +16,9 @@ from ag_ui_strands.config import StrandsAgentConfig
 # ---------------------------------------------------------------------------
 
 def _mock_model():
-    return MagicMock()
+    m = MagicMock()
+    m.stateful = False  # prevent Strands from rejecting conversation_manager
+    return m
 
 
 def _run_input(thread_id: str = "t1"):
@@ -55,93 +47,72 @@ class _CapturingCore:
 
 
 async def _trigger_thread_creation(ag: StrandsAgent, thread_id: str) -> "_CapturingCore":
-    """Run the agent far enough to create the thread instance, then return it."""
     inp = _run_input(thread_id)
     async for _ in ag.run(inp):
-        break  # one event is enough; thread is created before any yield
+        break
     return ag._agents_by_thread[thread_id]
 
 
 # ---------------------------------------------------------------------------
-# Static tests — check _agent_kwargs at construction time (no async needed)
+# Tests
 # ---------------------------------------------------------------------------
+
+def _make_template():
+    """One Agent with every hardcoded kwarg set to a non-default value."""
+    conversation_manager = MagicMock()
+    template = Agent(
+        model=_mock_model(),
+        trace_attributes={"env": "prod"},
+        agent_id="my-agent-id",
+        state={"count": 0},
+        conversation_manager=conversation_manager,
+    )
+    return template, conversation_manager
+
+
+class TestExcludedParams:
+    """Params that must never appear in _agent_kwargs or be forwarded to new threads."""
+
+    @pytest.mark.asyncio
+    async def test_excluded_params_not_forwarded(self):
+        from ag_ui_strands.agent import _AGUI_EXPLICIT_PARAMS
+
+        template = Agent(model=_mock_model(), hooks=[MagicMock()])
+        ag = StrandsAgent(template, name="test")
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            instance = await _trigger_thread_creation(ag, "excluded-thread")
+
+        for param in _AGUI_EXPLICIT_PARAMS - {"self"}:
+            assert param not in ag._agent_kwargs, f"{param} should not be in _agent_kwargs"
+
 
 class TestTemplateKwargsCapture:
-    """StrandsAgent.__init__ must capture all relevant template attributes."""
+    """All hardcoded template attributes must appear in _agent_kwargs after __init__."""
 
-    def test_trace_attributes_captured(self):
-        """trace_attributes from the template must appear in _agent_kwargs."""
-        template = Agent(model=_mock_model(), trace_attributes={"env": "prod"})
+    def test_all_hardcoded_kwargs_captured(self):
+        template, conversation_manager = _make_template()
         ag = StrandsAgent(template, name="test")
 
-        assert "trace_attributes" in ag._agent_kwargs, (
-            "trace_attributes not captured — new threads will lose observability config"
-        )
-        assert ag._agent_kwargs["trace_attributes"] == {"env": "prod"}
+        assert ag._agent_kwargs.get("trace_attributes") == {"env": "prod"}
+        assert ag._agent_kwargs.get("agent_id") == "my-agent-id"
+        assert "state" in ag._agent_kwargs
+        assert ag._agent_kwargs.get("conversation_manager") is conversation_manager
 
-    def test_agent_id_captured(self):
-        """agent_id from the template must appear in _agent_kwargs."""
-        template = Agent(model=_mock_model(), agent_id="my-agent-id")
-        ag = StrandsAgent(template, name="test")
-
-        assert "agent_id" in ag._agent_kwargs, (
-            "agent_id not captured — new threads will get the default 'default' id"
-        )
-        assert ag._agent_kwargs["agent_id"] == "my-agent-id"
-
-    def test_initial_state_captured(self):
-        """Initial state from the template must be preserved for new threads."""
-        template = Agent(model=_mock_model(), state={"greeting": "hello", "count": 0})
-        ag = StrandsAgent(template, name="test")
-
-        assert "state" in ag._agent_kwargs, (
-            "state not captured — new threads always start with empty state"
-        )
-
-
-# ---------------------------------------------------------------------------
-# Runtime tests — confirm new thread instances are created with the right kwargs
-# ---------------------------------------------------------------------------
 
 class TestNewThreadUsesTemplateKwargs:
-    """When StrandsAgentCore is instantiated for a new thread it must receive
-    all template kwargs, not just the four currently hard-coded ones."""
+    """New per-thread StrandsAgentCore instances must receive all hardcoded template kwargs."""
 
     @pytest.mark.asyncio
-    async def test_new_thread_receives_trace_attributes(self):
-        """New thread instance must be constructed with the template trace_attributes."""
-        template = Agent(model=_mock_model(), trace_attributes={"env": "prod"})
+    async def test_all_hardcoded_kwargs_forwarded_to_new_thread(self):
+        template, conversation_manager = _make_template()
         ag = StrandsAgent(template, name="test")
 
         with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
-            instance = await _trigger_thread_creation(ag, "trace-thread")
+            instance = await _trigger_thread_creation(ag, "thread-1")
 
-        assert instance.init_kwargs.get("trace_attributes") == {"env": "prod"}, (
-            f"trace_attributes not passed to new thread. Got: {instance.init_kwargs}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_new_thread_receives_agent_id(self):
-        """New thread instance must be constructed with the template agent_id."""
-        template = Agent(model=_mock_model(), agent_id="my-agent-id")
-        ag = StrandsAgent(template, name="test")
-
-        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
-            instance = await _trigger_thread_creation(ag, "id-thread")
-
-        assert instance.init_kwargs.get("agent_id") == "my-agent-id", (
-            f"agent_id not passed to new thread. Got: {instance.init_kwargs}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_new_thread_receives_initial_state(self):
-        """New thread instance must be constructed with the template initial state."""
-        template = Agent(model=_mock_model(), state={"greeting": "hello"})
-        ag = StrandsAgent(template, name="test")
-
-        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
-            instance = await _trigger_thread_creation(ag, "state-thread")
-
-        assert "state" in instance.init_kwargs, (
-            f"state not passed to new thread. Got: {instance.init_kwargs}"
-        )
+        kwargs = instance.init_kwargs
+        assert kwargs.get("trace_attributes") == {"env": "prod"}, f"got: {kwargs}"
+        assert kwargs.get("agent_id") == "my-agent-id", f"got: {kwargs}"
+        assert "state" in kwargs, f"got: {kwargs}"
+        assert kwargs.get("conversation_manager") is conversation_manager, f"got: {kwargs}"


### PR DESCRIPTION
There has been several AWS strands properties that we were not supporting. The latest one mentioned in the issue below (session manager).
This PR, in order to fix the latest one, reads dynamically all the options and assigns, so basically enabling these properties forwards compatible

Fixes https://github.com/ag-ui-protocol/ag-ui/issues/807