### PR TITLE
feat(client): compact state snapshots and deltas per run

### DIFF
--- a/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
+++ b/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
@@ -6,6 +6,8 @@ import {
   ToolCallStartEvent,
   ToolCallArgsEvent,
   CustomEvent,
+  StateSnapshotEvent,
+  StateDeltaEvent,
 } from "@ag-ui/core";
 
 describe("Event Compaction", () => {
@@ -289,6 +291,267 @@ describe("Event Compaction", () => {
       expect(compacted[4].type).toBe(EventType.TOOL_CALL_ARGS);
       expect((compacted[4] as ToolCallArgsEvent).delta).toBe('{"q": "test"}');
       expect(compacted[5].type).toBe(EventType.TOOL_CALL_END);
+    });
+  });
+
+  describe("State Compaction", () => {
+    it("should compact multiple state snapshots into one per run", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 1 } },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 2 } },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 3 } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ count: 3 });
+      expect(compacted[2].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should compact snapshot + deltas into a single snapshot", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 0, name: "test" } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/count", value: 1 }] },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/count", value: 2 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ count: 2, name: "test" });
+      expect(compacted[2].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should compact deltas-only into a single snapshot (starting from empty)", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/foo", value: "bar" }] },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/baz", value: 42 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ foo: "bar", baz: 42 });
+      expect(compacted[2].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should handle snapshot followed by delta that overwrites it", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { a: 1, b: 2 } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "remove", path: "/b" }] },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/c", value: 3 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ a: 1, c: 3 });
+    });
+
+    it("should handle multiple runs independently", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { step: 1 } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/step", value: 2 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { step: 10 } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/step", value: 20 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(6);
+      // Run 1
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ step: 2 });
+      expect(compacted[2].type).toBe(EventType.RUN_FINISHED);
+      // Run 2
+      expect(compacted[3].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[4].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[4] as StateSnapshotEvent).snapshot).toEqual({ step: 20 });
+      expect(compacted[5].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should not emit state snapshot when no state events in run", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.TEXT_MESSAGE_START, messageId: "msg1", role: "assistant" },
+        { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg1", delta: "Hello" },
+        { type: EventType.TEXT_MESSAGE_END, messageId: "msg1" },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(5);
+      expect(compacted.filter((e) => e.type === EventType.STATE_SNAPSHOT)).toHaveLength(0);
+    });
+
+    it("should handle state events outside of runs", () => {
+      const events = [
+        { type: EventType.STATE_SNAPSHOT, snapshot: { x: 1 } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/x", value: 2 }] },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(1);
+      expect(compacted[0].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[0] as StateSnapshotEvent).snapshot).toEqual({ x: 2 });
+    });
+
+    it("should handle snapshot after deltas within a run (snapshot resets state)", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/old", value: true }] },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { fresh: true } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/extra", value: 1 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ fresh: true, extra: 1 });
+    });
+
+    it("should preserve non-state events alongside state compaction", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 0 } },
+        { type: EventType.TEXT_MESSAGE_START, messageId: "msg1", role: "assistant" },
+        { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg1", delta: "Hi" },
+        { type: EventType.TEXT_MESSAGE_END, messageId: "msg1" },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/count", value: 1 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(6);
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      // Text message events
+      expect(compacted[1].type).toBe(EventType.TEXT_MESSAGE_START);
+      expect(compacted[2].type).toBe(EventType.TEXT_MESSAGE_CONTENT);
+      expect(compacted[3].type).toBe(EventType.TEXT_MESSAGE_END);
+      // Compacted state before RUN_FINISHED
+      expect(compacted[4].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[4] as StateSnapshotEvent).snapshot).toEqual({ count: 1 });
+      expect(compacted[5].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should flush state events before RUN_STARTED when they precede any run", () => {
+      const events = [
+        { type: EventType.STATE_SNAPSHOT, snapshot: { preRun: true } },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { inRun: true } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(4);
+      expect(compacted[0].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[0] as StateSnapshotEvent).snapshot).toEqual({ preRun: true });
+      expect(compacted[1].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[2].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[2] as StateSnapshotEvent).snapshot).toEqual({ inRun: true });
+      expect(compacted[3].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should flush state events between runs", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { run: 1 } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { between: true } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/extra", value: 1 }] },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { run: 2 } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(7);
+      // Run 1
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ run: 1 });
+      expect(compacted[2].type).toBe(EventType.RUN_FINISHED);
+      // Between runs — flushed before RUN_STARTED
+      expect(compacted[3].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[3] as StateSnapshotEvent).snapshot).toEqual({ between: true, extra: 1 });
+      // Run 2
+      expect(compacted[4].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[5].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[5] as StateSnapshotEvent).snapshot).toEqual({ run: 2 });
+      expect(compacted[6].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("should flush state on RUN_ERROR", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 0 } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "replace", path: "/count", value: 5 }] },
+        { type: EventType.RUN_ERROR, threadId: "t1", runId: "r1", message: "something failed" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect(compacted[0].type).toBe(EventType.RUN_STARTED);
+      expect(compacted[1].type).toBe(EventType.STATE_SNAPSHOT);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({ count: 5 });
+      expect(compacted[2].type).toBe(EventType.RUN_ERROR);
+    });
+
+    it("should handle complex nested state with JSON patch operations", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        {
+          type: EventType.STATE_SNAPSHOT,
+          snapshot: { users: [{ name: "Alice", age: 30 }], settings: { theme: "dark" } },
+        },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "add", path: "/users/-", value: { name: "Bob", age: 25 } }],
+        },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "replace", path: "/settings/theme", value: "light" }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(3);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({
+        users: [
+          { name: "Alice", age: 30 },
+          { name: "Bob", age: 25 },
+        ],
+        settings: { theme: "light" },
+      });
     });
   });
 });

--- a/sdks/typescript/packages/client/src/compact/compact.ts
+++ b/sdks/typescript/packages/client/src/compact/compact.ts
@@ -7,12 +7,18 @@ import {
   ToolCallStartEvent,
   ToolCallArgsEvent,
   ToolCallEndEvent,
+  StateSnapshotEvent,
+  StateDeltaEvent,
 } from "@ag-ui/core";
+import * as jsonpatch from "fast-json-patch";
+import { structuredClone_ } from "../utils";
 
 /**
  * Compacts streaming events by consolidating multiple deltas into single events.
  * For text messages: multiple content deltas become one concatenated delta.
  * For tool calls: multiple args deltas become one concatenated delta.
+ * For state: all STATE_SNAPSHOT and STATE_DELTA events within a run are compacted
+ *   into a single STATE_SNAPSHOT representing the final state.
  * Events between related streaming events are reordered to keep streaming events together.
  *
  * @param events - Array of events to compact
@@ -38,6 +44,9 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       otherEvents: BaseEvent[];
     }
   >();
+
+  // State compaction: collects state events, flushed at RUN_STARTED (pre-run/inter-run), RUN_FINISHED/RUN_ERROR (in-run), and at end (trailing)
+  let stateEvents: (StateSnapshotEvent | StateDeltaEvent)[] = [];
 
   for (const event of events) {
     // Handle text message streaming events
@@ -127,6 +136,25 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       // Flush this tool call's events
       flushToolCall(toolCallId, pending, compacted);
       pendingToolCalls.delete(toolCallId);
+    } else if (event.type === EventType.RUN_STARTED) {
+      // Flush any pre-run state events before starting a new run
+      flushState(stateEvents, compacted);
+      stateEvents = [];
+      compacted.push(event);
+    } else if (
+      event.type === EventType.RUN_FINISHED ||
+      event.type === EventType.RUN_ERROR
+    ) {
+      // Flush compacted state into output before the run boundary event
+      flushState(stateEvents, compacted);
+      stateEvents = [];
+      compacted.push(event);
+    } else if (
+      event.type === EventType.STATE_SNAPSHOT ||
+      event.type === EventType.STATE_DELTA
+    ) {
+      // Collect state events for compaction
+      stateEvents.push(event as StateSnapshotEvent | StateDeltaEvent);
     } else {
       // For non-streaming events, check if we're in the middle of any streaming sequences
       let addedToBuffer = false;
@@ -169,6 +197,9 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
   for (const [toolCallId, pending] of pendingToolCalls) {
     flushToolCall(toolCallId, pending, compacted);
   }
+
+  // Flush any remaining state events (incomplete run or events outside runs)
+  flushState(stateEvents, compacted);
 
   return compacted;
 }
@@ -249,4 +280,31 @@ function flushToolCall(
   for (const otherEvent of pending.otherEvents) {
     compacted.push(otherEvent);
   }
+}
+
+function flushState(
+  stateEvents: (StateSnapshotEvent | StateDeltaEvent)[],
+  compacted: BaseEvent[],
+): void {
+  if (stateEvents.length === 0) {
+    return;
+  }
+
+  let state: any = {};
+
+  for (const event of stateEvents) {
+    if (event.type === EventType.STATE_SNAPSHOT) {
+      state = structuredClone_(event.snapshot);
+    } else {
+      const result = jsonpatch.applyPatch(state, structuredClone_(event.delta), true, false);
+      state = result.newDocument;
+    }
+  }
+
+  const compactedSnapshot: StateSnapshotEvent = {
+    type: EventType.STATE_SNAPSHOT,
+    snapshot: state,
+  };
+
+  compacted.push(compactedSnapshot);
 }


### PR DESCRIPTION
## Summary
- Adds state compaction to `compactEvents` in `@ag-ui/client`: all `STATE_SNAPSHOT` and `STATE_DELTA` events within a run are resolved into a single `STATE_SNAPSHOT` representing the final computed state
- Deltas applied via `fast-json-patch` (RFC 6902), with `structuredClone_` polyfill for defensive copying
- State flushed at three boundaries: `RUN_STARTED` (pre-run/inter-run events), `RUN_FINISHED`/`RUN_ERROR` (in-run events), and end-of-stream (trailing events outside runs)
- 13 new test cases covering: snapshot-only, delta-only, snapshot+delta, snapshot-resets-state, multi-run independence, no-state runs, state outside runs, pre-run flush, between-run flush, RUN_ERROR flush, mixed event types, and complex nested JSON patch operations

## Test plan
- [x] `npx nx run @ag-ui/client:test` — 465 tests pass (51 files, 0 failures)
- [x] `npx nx run @ag-ui/client:build` — builds successfully
- [ ] Verify no regressions in downstream consumers of `compactEvents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)