### PR TITLE
fix(adk): work around Runner._resolve_invocation_id override for HITL tool-only submissions

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FIX**: HITL resumption on google-adk >= 1.28 (`_resolve_invocation_id` override) (#1534)
+  - ADK's `Runner._resolve_invocation_id()` (present since ~1.28, behavior visible from 1.30 onward) inspects `new_message`, and when it contains a `FunctionResponse`, forcibly substitutes the caller-supplied `invocation_id` with the one from the matching `FunctionCall` event and routes the run through the resumed-invocation code path.  For standalone `LlmAgent` roots (whose `function_call` events were emitted with `end_of_agent=True`), that path early-returned in `run_async()` — the LLM was never invoked and HITL tool-result submissions produced zero content events.
+  - Feature-detected via `hasattr(Runner, '_resolve_invocation_id')` so the middleware keeps working across the full supported range (`>=1.16,<2.0`).
+  - When the override is present, tool-only submissions now pre-append the `FunctionResponse` as its own session event (tagged with the originating `FunctionCall`'s `invocation_id` for DatabaseSessionService compatibility, #957) and pass a minimal text-only placeholder as `new_message` so `_resolve_invocation_id` short-circuits on the "no function_responses" branch.  Composite-agent HITL resumption continues to pass the stored `invocation_id` via `run_kwargs`.
+  - `test_function_response_has_correct_invocation_id` is now version-aware: it asserts the persisted `invocation_id` matches the originating `FunctionCall` event on ADK >=1.28 and continues to assert the AG-UI `run_id` on older ADK.
+  - New regression suite `tests/test_adk_130_invocation_id_override.py` pins the tool-only HITL flow end-to-end and verifies pre-append doesn't duplicate the persisted `FunctionResponse`.
+
 - **FIX**: Multi-instance session cache hydration in `ADKAgent.run()` (#1484, thanks @deb538)
   - Hydrates the in-memory `_session_lookup_cache` from the database-backed `SessionService` on cache miss, before pending-tool-call detection runs
   - Prevents HITL breakage in load-balanced deployments where requests land on an instance that did not create the session: without hydration, `_has_pending_tool_calls()` returned `False` and user messages were dispatched ahead of pending tool results, causing the LLM to reject the turn

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -23,6 +23,24 @@ from ag_ui.core import (
 
 from google.adk import Runner
 from google.adk.agents import BaseAgent, LlmAgent, RunConfig as ADKRunConfig
+
+# Feature detect ADK's invocation_id override.
+#
+# Runner._resolve_invocation_id() was added somewhere between google-adk 1.24
+# and 1.28 and is present on every version since (including 1.30.0, the release
+# whose failing tests motivated ag-ui-protocol/ag-ui#1534). It inspects
+# new_message and — if it contains a FunctionResponse — forcibly substitutes
+# the caller-supplied invocation_id with the one on the matching FunctionCall
+# event, then routes the run through the resumed-invocation path. For
+# standalone LlmAgent roots that previously emitted end_of_agent=True on the
+# function_call event, that path early-returns without calling the LLM, so
+# HITL resumption silently produces zero content events.
+#
+# When this override is present we reshape the tool-result submission so that
+# new_message does NOT contain a FunctionResponse: the FunctionResponse is
+# pre-appended to the session as its own event, and new_message becomes a
+# minimal placeholder that short-circuits _resolve_invocation_id.
+_ADK_OVERRIDES_INVOCATION_ID = hasattr(Runner, "_resolve_invocation_id")
 from google.adk.agents.run_config import StreamingMode
 from google.adk.agents.llm_agent import InstructionProvider, ToolUnion
 from google.adk.sessions import BaseSessionService, InMemorySessionService
@@ -323,6 +341,30 @@ class ADKAgent:
             return False
 
         return _has_composite_descendant(root)
+
+    @staticmethod
+    def _find_function_call_invocation_id(session, tool_call_id: str) -> Optional[str]:
+        """Find the invocation_id of the event that authored a FunctionCall.
+
+        ADK 1.30+ derives the effective invocation_id for tool-result submissions
+        by looking up the matching FunctionCall event in session history. We read
+        the same attribute here so that any FunctionResponse we pre-append carries
+        a consistent invocation_id with the upstream FunctionCall.
+
+        Returns None if no matching FunctionCall event is found.
+        """
+        events = getattr(session, "events", None) or []
+        for event in events:
+            content = getattr(event, "content", None)
+            parts = getattr(content, "parts", None) if content else None
+            if not parts:
+                continue
+            for part in parts:
+                fc = getattr(part, "function_call", None)
+                fc_id = getattr(fc, "id", None) if fc else None
+                if fc_id and fc_id == tool_call_id:
+                    return getattr(event, "invocation_id", None)
+        return None
 
     @classmethod
     def from_app(
@@ -2081,18 +2123,73 @@ class ADKAgent:
                     )
                     function_response_parts.append(updated_function_response_part)
 
-                # Create function_response_content but DON'T pre-persist to avoid duplicates.
-                # Instead, pass as new_message with explicit invocation_id to control the ID ADK uses.
                 function_response_content = types.Content(parts=function_response_parts, role='user')
-                # Use input.run_id (not stored_invocation_id) as the invocation_id for this tool response
-                # This ensures DatabaseSessionService compatibility
-                tool_response_invocation_id = input.run_id
 
-                # Pass both new_message AND invocation_id to ADK.
-                # This tells ADK: "process this message, but use THIS specific invocation_id"
-                # (rather than auto-generating an e-xxx ID)
-                new_message = function_response_content
-                tool_only_invocation_id = tool_response_invocation_id
+                if _ADK_OVERRIDES_INVOCATION_ID and self._is_adk_resumable():
+                    # ADK with _resolve_invocation_id (~1.28+) routing:
+                    #
+                    # When new_message contains a FunctionResponse, Runner._resolve_invocation_id()
+                    # looks up the matching FunctionCall event in session history and forces the
+                    # invocation_id to that event's invocation_id, sending the run down the
+                    # _setup_context_for_resumed_invocation() path. For standalone LlmAgent roots
+                    # (whose function_call events were emitted with end_of_agent=True), that path
+                    # then early-returns in run_async() because populate_invocation_agent_states()
+                    # sets end_of_agents[agent] = True — so the LLM is never invoked and the run
+                    # emits zero content events (see ag-ui #1534).
+                    #
+                    # To avoid that, we pre-append the FunctionResponse as its own session event
+                    # (mirroring the "tool_results + user_message" branch above) and pass a
+                    # minimal placeholder as new_message that carries NO FunctionResponse. That
+                    # makes _resolve_invocation_id short-circuit on the "no function_responses"
+                    # branch and preserves whatever invocation_id handling run_kwargs already
+                    # encodes (new-invocation path for standalone LlmAgent; resume path with
+                    # stored_invocation_id for composite orchestrators).
+                    first_tool_call_id = active_tool_results[0]['message'].tool_call_id
+                    first_tool_call_id = lro_id_remap.get(first_tool_call_id, first_tool_call_id)
+                    fc_event_invocation_id = self._find_function_call_invocation_id(
+                        session, first_tool_call_id
+                    )
+                    # Prefer the matching FunctionCall event's invocation_id so ADK's own
+                    # persistence/lookup contract stays consistent; fall back through
+                    # stored_invocation_id and input.run_id so DatabaseSessionService still
+                    # receives a non-null value (GitHub #957).
+                    resume_invocation_id = (
+                        fc_event_invocation_id or stored_invocation_id or input.run_id
+                    )
+                    function_response_event = Event(
+                        timestamp=time.time(),
+                        author='user',
+                        content=function_response_content,
+                        invocation_id=resume_invocation_id,
+                    )
+                    logger.debug(
+                        "Pre-appending FunctionResponse for _resolve_invocation_id-capable ADK "
+                        f"tool-only submission with invocation_id={resume_invocation_id}"
+                    )
+                    await self._session_manager._session_service.append_event(
+                        session, function_response_event
+                    )
+
+                    # Placeholder trigger: a single empty text part. _append_new_message_to_session
+                    # requires at least one part, and _get_function_responses_from_content returns
+                    # [] for a text-only Content — which is exactly what we need.
+                    new_message = types.Content(
+                        role='user',
+                        parts=[types.Part(text='')],
+                    )
+                    # Don't force a caller-supplied invocation_id from here. Composite-agent
+                    # resumption still gets stored_invocation_id via the run_kwargs logic below;
+                    # standalone LlmAgents correctly take the new-invocation path.
+                    tool_only_invocation_id = None
+                else:
+                    # ADK without _resolve_invocation_id (<1.28) or non-resumable apps:
+                    # Pass the FunctionResponse as new_message with the AG-UI run_id as the
+                    # invocation_id. Older ADK honors the caller-supplied invocation_id and
+                    # treats every tool submission as a fresh invocation, so the LLM is invoked
+                    # on the updated history. This preserves the #1074 fix (no duplicate
+                    # FunctionResponse events) by avoiding the pre-append.
+                    new_message = function_response_content
+                    tool_only_invocation_id = input.run_id
             else:
                 # No tool results, just use the user message
                 # If user_message is None (e.g., unseen_messages was empty because all were
@@ -2183,13 +2280,18 @@ class ADKAgent:
             # Composite agents (SequentialAgent, LoopAgent) — whether as root or
             # as sub-agents of an LlmAgent root — need it so ADK calls
             # populate_invocation_agent_states() to restore internal state.
-            # For tool responses, we pass tool_only_invocation_id (input.run_id) to ensure
-            # ADK uses the client's run_id instead of auto-generating an e-xxx ID.
+            # For tool responses on ADK < 1.30, we pass tool_only_invocation_id
+            # (input.run_id) so ADK uses the client's run_id instead of
+            # auto-generating an e-xxx ID. On ADK 1.30+, the tool-only branch
+            # above leaves tool_only_invocation_id unset because the runner
+            # forcibly overrides caller-supplied invocation_ids when a
+            # FunctionResponse is present — we work around that by pre-appending
+            # the FunctionResponse and passing a text-only placeholder instead.
             if stored_invocation_id and self._is_adk_resumable() and self._root_agent_needs_invocation_id():
                 run_kwargs["invocation_id"] = stored_invocation_id
                 logger.debug(f"HITL resumption with invocation_id: {stored_invocation_id}")
             elif tool_only_invocation_id and self._is_adk_resumable():
-                # Tool response case: use client's run_id as invocation_id
+                # Tool response case (ADK < 1.30): use client's run_id as invocation_id
                 run_kwargs["invocation_id"] = tool_only_invocation_id
                 logger.debug(f"Tool response with explicit invocation_id: {tool_only_invocation_id}")
 

--- a/integrations/adk-middleware/python/tests/test_adk_130_invocation_id_override.py
+++ b/integrations/adk-middleware/python/tests/test_adk_130_invocation_id_override.py
@@ -1,0 +1,338 @@
+"""Regression tests for google-adk >=1.30 invocation_id override in Runner.
+
+Context: starting with google-adk 1.30.0, Runner._resolve_invocation_id()
+inspects new_message and, if it contains a FunctionResponse, forcibly uses the
+invocation_id of the matching FunctionCall event — sending the run down the
+resumed-invocation code path. For standalone LlmAgent roots that emitted
+end_of_agent=True on the function_call event, that path early-returns without
+invoking the LLM, producing zero content events.
+
+See: ag-ui-protocol/ag-ui#1534
+
+The middleware works around this by pre-appending the FunctionResponse to the
+session and passing a non-FunctionResponse placeholder as new_message, so that
+_resolve_invocation_id short-circuits and the agent is invoked normally.
+
+The tests in this module:
+
+1. Confirm the feature-detection flag `_ADK_OVERRIDES_INVOCATION_ID` matches
+   the installed ADK version.
+2. Drive an end-to-end tool-only HITL submission against a standalone LlmAgent
+   on a resumable App and verify the LLM produces text (the regression the
+   upstream change caused).
+3. Verify that a tool-only submission pre-appends the FunctionResponse exactly
+   once and tags it with the originating FunctionCall's invocation_id (so
+   DatabaseSessionService compatibility survives the new contract).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import pytest
+from typing import List, Optional
+
+from ag_ui.core import (
+    AssistantMessage,
+    BaseEvent,
+    EventType,
+    FunctionCall,
+    RunAgentInput,
+    ToolCall,
+    ToolMessage,
+    Tool as AGUITool,
+    UserMessage,
+)
+from ag_ui_adk import ADKAgent, AGUIToolset
+from ag_ui_adk.adk_agent import _ADK_OVERRIDES_INVOCATION_ID
+from ag_ui_adk.session_manager import SessionManager
+from google.adk import Runner
+from google.adk.agents import Agent
+from google.adk.apps import App, ResumabilityConfig
+
+
+DEFAULT_MODEL = "gemini-2.0-flash"
+
+
+def _collect_text(events: List[BaseEvent]) -> str:
+    buf = ""
+    for e in events:
+        if e.type == EventType.TEXT_MESSAGE_CONTENT:
+            delta = getattr(e, "delta", "") or ""
+            buf += delta
+    return buf
+
+
+def _event_types(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events]
+
+
+def _find_tool_call_id(events: List[BaseEvent]) -> Optional[str]:
+    for e in events:
+        if hasattr(e, "tool_call_id") and e.tool_call_id:
+            return e.tool_call_id
+    return None
+
+
+async def _collect(agent: ADKAgent, input_data: RunAgentInput) -> List[BaseEvent]:
+    events: List[BaseEvent] = []
+    async for event in agent.run(input_data):
+        events.append(event)
+    return events
+
+
+def test_feature_detection_matches_installed_adk_version():
+    """`_ADK_OVERRIDES_INVOCATION_ID` must mirror the real ADK shape."""
+    expected = hasattr(Runner, "_resolve_invocation_id")
+    assert _ADK_OVERRIDES_INVOCATION_ID is expected
+
+
+class TestStandaloneLlmAgentToolOnlyHITL:
+    """End-to-end regression tests for the ADK 1.30+ tool-only submission path.
+
+    Standalone LlmAgent roots were the configuration broken by the 1.30 runner
+    change. The tests here drive the full AG-UI -> ADKAgent -> Runner flow and
+    assert the properties that ag-ui-protocol/ag-ui#1534 regressed on.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_llmock(self, llmock_server):
+        """Ensure LLMock is running when no real API key is set."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest.fixture
+    def check_api_key(self):
+        if not os.getenv("GOOGLE_API_KEY"):
+            pytest.skip("GOOGLE_API_KEY not set - skipping live integration test")
+
+    @pytest.fixture
+    def resumable_standalone_agent(self):
+        agent = Agent(
+            model=DEFAULT_MODEL,
+            name="standalone_hitl_agent",
+            instruction=(
+                "You are a test agent. When asked to check something, call "
+                "check_status. When you receive the tool result, acknowledge it "
+                "briefly in plain text."
+            ),
+            tools=[AGUIToolset()],
+        )
+        app = App(
+            name="test_standalone_1534_app",
+            root_agent=agent,
+            resumability_config=ResumabilityConfig(is_resumable=True),
+        )
+        return ADKAgent.from_app(app, user_id="test_user", use_in_memory_services=True)
+
+    @pytest.mark.asyncio
+    async def test_tool_only_submission_invokes_llm(
+        self, check_api_key, resumable_standalone_agent
+    ):
+        """Tool-only HITL submission must invoke the LLM and emit text events.
+
+        This is the ag-ui-protocol/ag-ui#1534 regression: on ADK 1.30+, the
+        runner forced the resumed-invocation path and early-returned due to
+        end_of_agent=True, so no content was ever produced.
+        """
+        thread_id = f"test_1534_tool_only_{int(time.time())}"
+
+        approve_tool = AGUITool(
+            name="check_status",
+            description="Check the status of something",
+            parameters={"type": "object", "properties": {}},
+        )
+
+        # Turn 1: trigger the tool call
+        events_1 = await _collect(
+            resumable_standalone_agent,
+            RunAgentInput(
+                thread_id=thread_id,
+                run_id="run_probe",
+                messages=[UserMessage(id="m1", role="user", content="Check the status")],
+                tools=[approve_tool],
+                context=[],
+                state={},
+                forwarded_props={},
+            ),
+        )
+        tool_call_id = _find_tool_call_id(events_1)
+        if tool_call_id is None:
+            pytest.skip("Agent did not call the tool - LLM behaviour varied")
+
+        # Turn 2: submit the tool result WITHOUT a trailing user message.
+        # This is the exact path that was broken on 1.30.
+        events_2 = await _collect(
+            resumable_standalone_agent,
+            RunAgentInput(
+                thread_id=thread_id,
+                run_id="run_resume",
+                messages=[
+                    UserMessage(id="m1", role="user", content="Check the status"),
+                    AssistantMessage(
+                        id="m2",
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id=tool_call_id,
+                                function=FunctionCall(
+                                    name="check_status", arguments="{}"
+                                ),
+                            )
+                        ],
+                    ),
+                    ToolMessage(
+                        id="m3",
+                        role="tool",
+                        content='{"status": "ok"}',
+                        tool_call_id=tool_call_id,
+                    ),
+                ],
+                tools=[approve_tool],
+                context=[],
+                state={},
+                forwarded_props={},
+            ),
+        )
+
+        etypes = _event_types(events_2)
+        assert "EventType.RUN_ERROR" not in etypes, f"Got run error: {events_2}"
+        assert _collect_text(events_2), (
+            "REGRESSION (ag-ui#1534): standalone LlmAgent produced no text after "
+            "a tool-only HITL submission. On ADK 1.30+ the middleware must pre-"
+            "append the FunctionResponse and pass a non-FunctionResponse "
+            "placeholder as new_message to keep _resolve_invocation_id a no-op."
+        )
+
+    @pytest.mark.asyncio
+    async def test_tool_only_submission_persists_single_function_response_with_fc_invocation_id(
+        self, check_api_key, resumable_standalone_agent
+    ):
+        """Pre-append path must not duplicate FunctionResponse events.
+
+        On ADK 1.30+, the workaround pre-appends the FunctionResponse AND still
+        hands new_message to the runner. new_message is a placeholder text
+        Content (no FunctionResponse) so the runner's _append_new_message_to_session
+        will NOT persist a second copy. The FunctionResponse we pre-appended must
+        carry the originating FunctionCall event's invocation_id so ADK's
+        persistence contract stays consistent.
+        """
+        thread_id = f"test_1534_fc_inv_id_{int(time.time())}"
+        approve_tool = AGUITool(
+            name="check_status",
+            description="Check status",
+            parameters={"type": "object", "properties": {}},
+        )
+
+        events_1 = await _collect(
+            resumable_standalone_agent,
+            RunAgentInput(
+                thread_id=thread_id,
+                run_id="run_probe",
+                messages=[UserMessage(id="m1", role="user", content="Check the status")],
+                tools=[approve_tool],
+                context=[],
+                state={},
+                forwarded_props={},
+            ),
+        )
+        tool_call_id = _find_tool_call_id(events_1)
+        if tool_call_id is None:
+            pytest.skip("Agent did not call the tool")
+
+        await _collect(
+            resumable_standalone_agent,
+            RunAgentInput(
+                thread_id=thread_id,
+                run_id="run_resume",
+                messages=[
+                    UserMessage(id="m1", role="user", content="Check the status"),
+                    AssistantMessage(
+                        id="m2",
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ToolCall(
+                                id=tool_call_id,
+                                function=FunctionCall(
+                                    name="check_status", arguments="{}"
+                                ),
+                            )
+                        ],
+                    ),
+                    ToolMessage(
+                        id="m3",
+                        role="tool",
+                        content='{"status": "ok"}',
+                        tool_call_id=tool_call_id,
+                    ),
+                ],
+                tools=[approve_tool],
+                context=[],
+                state={},
+                forwarded_props={},
+            ),
+        )
+
+        app_name = resumable_standalone_agent._get_app_name(
+            RunAgentInput(
+                thread_id=thread_id,
+                run_id="run_resume",
+                messages=[],
+                tools=[],
+                context=[],
+                state={},
+                forwarded_props={},
+            )
+        )
+        user_id = "test_user"
+        backend_session_id = resumable_standalone_agent._get_backend_session_id(
+            thread_id, user_id
+        )
+        assert backend_session_id, "Expected a persisted backend session"
+
+        session = await resumable_standalone_agent._session_manager._session_service.get_session(
+            session_id=backend_session_id,
+            app_name=app_name,
+            user_id=user_id,
+        )
+
+        fc_invocation_id = None
+        fr_entries = []
+        for event in session.events:
+            if not event.content or not getattr(event.content, "parts", None):
+                continue
+            for part in event.content.parts:
+                fc = getattr(part, "function_call", None)
+                if fc and getattr(fc, "id", None) == tool_call_id:
+                    fc_invocation_id = getattr(event, "invocation_id", None)
+                fr = getattr(part, "function_response", None)
+                if fr and getattr(fr, "id", None) == tool_call_id:
+                    fr_entries.append(event)
+
+        assert fc_invocation_id is not None, "No FunctionCall event found in session"
+        assert len(fr_entries) == 1, (
+            f"Expected exactly 1 FunctionResponse for tool_call_id={tool_call_id}, "
+            f"found {len(fr_entries)}. Pre-append must not duplicate with ADK's "
+            f"_append_new_message_to_session path."
+        )
+
+        if _ADK_OVERRIDES_INVOCATION_ID:
+            # On ADK >=1.30 the middleware tags the pre-appended FunctionResponse
+            # with the FunctionCall's invocation_id so it matches what ADK itself
+            # would have produced.
+            assert fr_entries[0].invocation_id == fc_invocation_id, (
+                f"FunctionResponse invocation_id should match FunctionCall "
+                f"({fc_invocation_id}), got {fr_entries[0].invocation_id}"
+            )
+        else:
+            # Pre-1.30: middleware hands the AG-UI run_id to ADK, which honors it.
+            assert fr_entries[0].invocation_id == "run_resume", (
+                f"Pre-1.30 behaviour: FunctionResponse invocation_id should be "
+                f"'run_resume', got {fr_entries[0].invocation_id}"
+            )

--- a/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
+++ b/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
@@ -37,6 +37,7 @@ from ag_ui.core import (
     ToolCallEndEvent,
 )
 from ag_ui_adk import ADKAgent, AGUIToolset
+from ag_ui_adk.adk_agent import _ADK_OVERRIDES_INVOCATION_ID
 from ag_ui_adk.session_manager import SessionManager, INVOCATION_ID_STATE_KEY
 from google.adk.agents import Agent
 from google.adk.apps import App, ResumabilityConfig
@@ -288,11 +289,20 @@ class TestLROToolResponseIntegration:
     async def test_function_response_has_correct_invocation_id(
         self, check_api_key, simple_agent
     ):
-        """Integration test: function_response invocation_id matches the run_id.
+        """Integration test: persisted function_response carries a usable invocation_id.
 
-        When tool results are submitted, the persisted function_response event
-        should have invocation_id set to the AG-UI run_id. This is required for
-        DatabaseSessionService compatibility.
+        DatabaseSessionService requires invocation_id to be non-null on every event
+        (GitHub #957). The exact value differs by ADK version:
+
+        - ADK <1.30: the middleware tags the FunctionResponse with the AG-UI run_id
+          and passes it to runner.run_async(); ADK honors that value.
+        - ADK >=1.30: Runner._resolve_invocation_id() forcibly substitutes the
+          invocation_id of the matching FunctionCall event (an ADK-generated
+          ``e-…`` identifier). The middleware pre-appends the FunctionResponse
+          with that same identifier to stay consistent with ADK's contract.
+
+        Either way, the persisted invocation_id must be non-null and must match
+        the FunctionCall event's invocation_id.
         """
         thread_id = f"test_invocation_id_{int(time.time())}"
         expected_run_id = "run_with_tool_result_456"
@@ -372,10 +382,42 @@ class TestLROToolResponseIntegration:
 
             if count > 0:
                 actual_invocation_id = responses[0]['invocation_id']
-                assert actual_invocation_id == expected_run_id, (
-                    f"FunctionResponse invocation_id should be '{expected_run_id}', "
-                    f"got '{actual_invocation_id}'. This breaks DatabaseSessionService."
+                assert actual_invocation_id, (
+                    "FunctionResponse missing invocation_id - breaks DatabaseSessionService"
                 )
+
+                # Find the FunctionCall event's invocation_id so we can compare
+                # against the ground-truth identity that ADK uses.
+                fc_invocation_id = None
+                for event in session.events:
+                    if not event.content or not getattr(event.content, 'parts', None):
+                        continue
+                    for part in event.content.parts:
+                        fc = getattr(part, 'function_call', None)
+                        if fc and getattr(fc, 'id', None) == tool_call_id:
+                            fc_invocation_id = getattr(event, 'invocation_id', None)
+                            break
+                    if fc_invocation_id:
+                        break
+
+                if _ADK_OVERRIDES_INVOCATION_ID:
+                    # ADK >=1.30: the persisted FunctionResponse must carry the same
+                    # invocation_id as the originating FunctionCall event, because
+                    # Runner._resolve_invocation_id() enforces that linkage.
+                    assert fc_invocation_id is not None, (
+                        "Could not locate the FunctionCall event in session — test setup bug"
+                    )
+                    assert actual_invocation_id == fc_invocation_id, (
+                        f"FunctionResponse invocation_id should match FunctionCall "
+                        f"invocation_id '{fc_invocation_id}', got '{actual_invocation_id}'"
+                    )
+                else:
+                    # ADK <1.30: the middleware propagates the AG-UI run_id as the
+                    # invocation_id, which pre-1.30 ADK honors.
+                    assert actual_invocation_id == expected_run_id, (
+                        f"FunctionResponse invocation_id should be '{expected_run_id}', "
+                        f"got '{actual_invocation_id}'. This breaks DatabaseSessionService."
+                    )
 
     @pytest.mark.asyncio
     async def test_tool_result_with_trailing_user_message(


### PR DESCRIPTION
## Summary

Fixes #1534.  Work around ADK's `Runner._resolve_invocation_id()` override so HITL tool-result submissions resume correctly on `google-adk>=1.28` (where the behavior was introduced) through `1.30.0` (the version that motivated the issue).

### Root cause

ADK's `Runner._resolve_invocation_id()` (present since ~1.28) inspects `new_message` and, when it contains a `FunctionResponse`, forcibly substitutes the caller-supplied `invocation_id` with the one on the matching `FunctionCall` event — then routes the run through `_setup_context_for_resumed_invocation()`.  For standalone `LlmAgent` roots (whose `function_call` events were emitted with `end_of_agent=True`), that path early-returns in `run_async()` because `populate_invocation_agent_states()` marks the agent as final, so the LLM is never invoked and tool-only HITL submissions produce zero content events.

### Fix

Feature-detected via `hasattr(Runner, "_resolve_invocation_id")` so the middleware keeps working across the full supported range (`>=1.16,<2.0`).  When the override is present, the tool-only submission path now:

- pre-appends the `FunctionResponse` as its own session event, tagged with the originating `FunctionCall` event's `invocation_id` (preserves DatabaseSessionService compatibility, #957), and
- passes a minimal text-only placeholder `Content(role='user', parts=[Part(text='')])` as `new_message` so `_resolve_invocation_id` short-circuits on the "no function_responses" branch.

Composite-agent HITL resumption continues to pass the stored `invocation_id` via the existing `run_kwargs` logic; standalone `LlmAgent` correctly takes the new-invocation path.

### Test changes

- `test_function_response_has_correct_invocation_id` is now version-aware: on ADK with the override it asserts the persisted `invocation_id` matches the originating `FunctionCall` event; on older ADK it continues to assert the AG-UI `run_id`.
- New suite `tests/test_adk_130_invocation_id_override.py` (3 tests): feature-flag identity, standalone `LlmAgent` tool-only HITL submission produces text events, and pre-append doesn't duplicate the persisted `FunctionResponse`.

### Version matrix (full suite)

| google-adk | Result |
|---|---|
| 1.16.0 (pin floor) | 777 passed, 4 skipped |
| 1.17.0 | 777 passed, 4 skipped |
| 1.18.0 | 777 passed, 4 skipped |
| 1.24.0 | 777 passed, 4 skipped |
| 1.28.1 | 777 passed, 4 skipped |
| 1.29.0 | 777 passed, 4 skipped |
| 1.30.0 (issue target) | 777 passed, 4 skipped |

Branch includes merge of `origin/main` to pick up #1538 (first-turn `TOOL_CALL_*` emission on `google-adk<1.18`); only conflict was CHANGELOG under `[Unreleased]`, both entries retained.

## Test plan

- [x] Full suite passes on each ADK version in the supported range
- [x] New regression suite in `tests/test_adk_130_invocation_id_override.py` pins the fixed behavior end-to-end
- [x] Existing `test_function_response_has_correct_invocation_id` now asserts against ADK's new contract on ≥1.28 and the legacy AG-UI `run_id` contract on older versions
- [x] CHANGELOG entry added under `[Unreleased] / Fixed`

https://claude.ai/code/session_01Jthu7waxKmnUxXwR5DrGdL