### PR TITLE
fix(langgraph): filter MESSAGES_SNAPSHOT by registered tool names, not message shape

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "sdks/python/**"
+      - "integrations/langgraph/python/**"
       - ".github/workflows/unit-python-sdk.yml"
   pull_request:
     branches: [main]
     paths:
       - "sdks/python/**"
+      - "integrations/langgraph/python/**"
       - ".github/workflows/unit-python-sdk.yml"
 
 jobs:
@@ -38,4 +40,31 @@ jobs:
 
       - name: Run tests
         working-directory: sdks/python
+        run: uv run python -m unittest discover tests -v
+
+  langgraph-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: ">=0.8.0"
+
+      - name: Load cached venv
+        id: cached-uv-dependencies
+        uses: actions/cache@v4
+        with:
+          path: integrations/langgraph/python/.venv
+          key: venv-${{ runner.os }}-langgraph-${{ hashFiles('integrations/langgraph/python/uv.lock') }}
+
+      - name: Install dependencies
+        working-directory: integrations/langgraph/python
+        run: uv sync
+
+      - name: Run tests
+        working-directory: integrations/langgraph/python
         run: uv run python -m unittest discover tests -v

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1200,6 +1200,33 @@ class LangGraphAgent:
 
         return kwargs
 
+    @staticmethod
+    def _is_structured_output_message(message):
+        """Identify AIMessages produced by internal LLM calls that never commit
+        to the state reducer's `messages` channel — most commonly
+        `.with_structured_output(Schema)` and router/classifier chains.
+
+        These messages share a signature: empty/absent textual content plus a
+        tool_calls payload whose "name" is a Pydantic schema rather than a
+        registered agent tool. The LangChain callback system does not expose
+        the `ls_structured_output_format` invocation marker on
+        `on_chat_model_end` events (it only lives on `on_chat_model_start`
+        `invocation_params`), so shape-based detection at the snapshot-merge
+        site is the reliable signal.
+
+        Real conversational subgraph outputs (the case PR #1426 protects)
+        always carry non-empty textual content, so they pass through. Real
+        agentic tool-call AIMessages with empty content commit to the
+        reducer's `messages` channel and therefore arrive via the checkpoint
+        path, not `streamed_messages`, so they are unaffected by this filter.
+        """
+        if not isinstance(message, AIMessage):
+            return False
+        content = getattr(message, "content", None)
+        content_is_empty = content is None or content == "" or content == []
+        tool_calls = getattr(message, "tool_calls", None) or []
+        return content_is_empty and len(tool_calls) > 0
+
     async def get_state_and_messages_snapshots(self, config):
         state = await self.graph.aget_state(config)
         state_values = state.values if state.values is not None else state
@@ -1211,7 +1238,12 @@ class LangGraphAgent:
         streamed_messages = self.active_run.get("streamed_messages", [])
         if streamed_messages:
             checkpoint_ids = {getattr(m, "id", None) for m in checkpoint_messages} - {None}
-            extra = [m for m in streamed_messages if getattr(m, "id", None) and getattr(m, "id", None) not in checkpoint_ids]
+            extra = [
+                m for m in streamed_messages
+                if getattr(m, "id", None)
+                and getattr(m, "id", None) not in checkpoint_ids
+                and not self._is_structured_output_message(m)
+            ]
             checkpoint_messages = checkpoint_messages + extra
         snapshot_messages = self._filter_orphan_tool_messages(checkpoint_messages)
         yield self._dispatch_event(

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -166,6 +166,7 @@ class LangGraphAgent:
             "model_made_tool_call": False,
             "state_reliable": True,
             "streamed_messages": [],
+            "registered_tool_names": self._extract_registered_tool_names(input),
         }
         self.active_run = INITIAL_ACTIVE_RUN
 
@@ -1201,31 +1202,85 @@ class LangGraphAgent:
         return kwargs
 
     @staticmethod
-    def _is_structured_output_message(message):
-        """Identify AIMessages produced by internal LLM calls that never commit
-        to the state reducer's `messages` channel — most commonly
-        `.with_structured_output(Schema)` and router/classifier chains.
+    def _extract_registered_tool_names(input: RunAgentInput) -> set:
+        """Collect the names of tools the caller registered for this run.
 
-        These messages share a signature: empty/absent textual content plus a
-        tool_calls payload whose "name" is a Pydantic schema rather than a
-        registered agent tool. The LangChain callback system does not expose
-        the `ls_structured_output_format` invocation marker on
-        `on_chat_model_end` events (it only lives on `on_chat_model_start`
-        `invocation_params`), so shape-based detection at the snapshot-merge
-        site is the reliable signal.
+        These are the agent-level tools declared on ``RunAgentInput.tools``:
+        the ones whose calls should surface to the user. Any tool_call
+        naming something outside this set is, by construction, an
+        LLM-internal invocation (e.g. a Pydantic schema passed to
+        ``.with_structured_output``) that the caller never declared as a
+        user-visible tool."""
+        names: set = set()
+        tools = getattr(input, "tools", None) or []
+        for tool in tools:
+            name = None
+            if isinstance(tool, dict):
+                name = tool.get("name")
+            else:
+                name = getattr(tool, "name", None)
+            if isinstance(name, str) and name:
+                names.add(name)
+        return names
 
-        Real conversational subgraph outputs (the case PR #1426 protects)
-        always carry non-empty textual content, so they pass through. Real
-        agentic tool-call AIMessages with empty content commit to the
-        reducer's `messages` channel and therefore arrive via the checkpoint
-        path, not `streamed_messages`, so they are unaffected by this filter.
+    @staticmethod
+    def _ai_message_content_is_empty(content: Any) -> bool:
+        """Treat an ``AIMessage.content`` as empty when it carries no
+        user-visible text. Scalar ``None``/``""`` are trivially empty; a
+        list is empty when every block is a dict lacking a non-empty
+        ``text`` field with ``type == "text"`` (tool_use, thinking, and
+        other non-textual blocks count as "no text")."""
+        if content is None or content == "":
+            return True
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text" and block.get("text"):
+                        return False
+                elif isinstance(block, str):
+                    if block:
+                        return False
+                else:
+                    return False
+            return True
+        return False
+
+    @classmethod
+    def _is_structured_output_message(
+        cls, message: BaseMessage, registered_tool_names: set
+    ) -> bool:
+        """Classify an ``AIMessage`` as an LLM-internal call that must
+        never reach ``MESSAGES_SNAPSHOT``.
+
+        Returns True iff the message is an ``AIMessage`` whose textual
+        content is empty, carries tool_calls, and none of those
+        tool_calls name a tool registered for the current run. The
+        registry check is the load-bearing signal: any tool_call whose
+        name matches a caller-registered tool is user-facing by
+        definition and is preserved, even on an empty-content turn.
+
+        Args:
+            message: The candidate message to classify.
+            registered_tool_names: The set of tool names declared on
+                this run's input.
+
+        Returns:
+            True when the message is a structured-output / internal LLM
+            call and should be dropped from the snapshot payload; False
+            otherwise.
         """
         if not isinstance(message, AIMessage):
             return False
-        content = getattr(message, "content", None)
-        content_is_empty = content is None or content == "" or content == []
-        tool_calls = getattr(message, "tool_calls", None) or []
-        return content_is_empty and len(tool_calls) > 0
+        if not cls._ai_message_content_is_empty(message.content):
+            return False
+        tool_calls = message.tool_calls or []
+        if not tool_calls:
+            return False
+        for tc in tool_calls:
+            name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+            if name and name in registered_tool_names:
+                return False
+        return True
 
     async def get_state_and_messages_snapshots(self, config):
         state = await self.graph.aget_state(config)
@@ -1237,13 +1292,24 @@ class LangGraphAgent:
         checkpoint_messages = state_values.get("messages", [])
         streamed_messages = self.active_run.get("streamed_messages", [])
         if streamed_messages:
+            registered_tool_names = self.active_run.get("registered_tool_names") or set()
             checkpoint_ids = {getattr(m, "id", None) for m in checkpoint_messages} - {None}
-            extra = [
-                m for m in streamed_messages
-                if getattr(m, "id", None)
-                and getattr(m, "id", None) not in checkpoint_ids
-                and not self._is_structured_output_message(m)
-            ]
+            extra = []
+            for m in streamed_messages:
+                mid = getattr(m, "id", None)
+                if not mid or mid in checkpoint_ids:
+                    continue
+                if self._is_structured_output_message(m, registered_tool_names):
+                    tool_call_names = [
+                        tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+                        for tc in (getattr(m, "tool_calls", None) or [])
+                    ]
+                    logger.debug(
+                        "Dropping structured-output AIMessage from MESSAGES_SNAPSHOT (id=%s, tool_calls=%s)",
+                        mid, tool_call_names,
+                    )
+                    continue
+                extra.append(m)
             checkpoint_messages = checkpoint_messages + extra
         snapshot_messages = self._filter_orphan_tool_messages(checkpoint_messages)
         yield self._dispatch_event(

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -52,6 +52,7 @@ RunMetadata = TypedDict("RunMetadata", {
     "has_function_streaming": NotRequired[bool],
     "model_made_tool_call": NotRequired[bool],
     "state_reliable": NotRequired[bool],
+    "registered_tool_names": NotRequired[set],
 })
 
 MessagesInProgressRecord = Dict[str, Optional[MessageInProgress]]

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -24,8 +24,6 @@ test = "python -m unittest discover tests"
 [dependency-groups]
 dev = [
     "fastapi>=0.115.12",
-    "pytest>=9.0.3",
-    "pytest-asyncio>=1.3.0",
 ]
 
 [build-system]

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -24,6 +24,8 @@ test = "python -m unittest discover tests"
 [dependency-groups]
 dev = [
     "fastapi>=0.115.12",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [build-system]

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "ag-ui-protocol>=0.1.10",
+    "ag-ui-protocol>=0.1.15",
     "langchain>=1.2.0",
     "langchain-core>=0.3.0",
     "langgraph>=0.3.25,<2",

--- a/integrations/langgraph/python/tests/_helpers.py
+++ b/integrations/langgraph/python/tests/_helpers.py
@@ -1,0 +1,88 @@
+"""Shared test helpers for ag-ui-langgraph integration tests.
+
+These helpers build lightweight ``LangGraphAgent`` fixtures backed by
+``MagicMock``/``AsyncMock`` stand-ins so tests can exercise agent logic in
+isolation, without spinning up a real graph or hitting any network.
+"""
+
+from typing import Any, Iterable, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+from langgraph.graph.state import CompiledStateGraph
+
+from ag_ui.core import EventType
+from ag_ui_langgraph.agent import LangGraphAgent
+
+
+def make_agent(subgraph_names: Optional[Iterable[str]] = None) -> LangGraphAgent:
+    """Return a ``LangGraphAgent`` whose graph is a mock with the given
+    subgraph nodes. Every listed name becomes a node whose ``bound``
+    attribute is itself a ``CompiledStateGraph`` mock, which is how the
+    agent detects subgraphs at construction time."""
+    graph = MagicMock(spec=CompiledStateGraph)
+    graph.config_specs = []
+    nodes = {}
+    for name in (subgraph_names or []):
+        node = MagicMock()
+        node.bound = MagicMock(spec=CompiledStateGraph)
+        nodes[name] = node
+    graph.nodes = nodes
+    return LangGraphAgent(name="test", graph=graph)
+
+
+def _record_dispatch(agent: LangGraphAgent):
+    """Replace ``agent._dispatch_event`` with a recording function.
+
+    The installed function appends every dispatched event to
+    ``agent.dispatched`` and returns the event unchanged so the rest of
+    the agent's control flow (which expects the return value) still
+    works. Using a named function instead of a lambda keeps tracebacks
+    readable and makes the side effect explicit."""
+    agent.dispatched = []
+
+    def _dispatch(event):
+        agent.dispatched.append(event)
+        return event
+
+    agent._dispatch_event = _dispatch
+    return agent
+
+
+def make_configured_agent(
+    checkpoint_messages: List[Any],
+    streamed_messages: Optional[List[Any]] = None,
+    subgraph_names: Optional[Iterable[str]] = None,
+    registered_tool_names: Optional[Iterable[str]] = None,
+) -> LangGraphAgent:
+    """Build an agent with a mocked checkpoint and a recording dispatcher.
+
+    The mocked ``graph.aget_state`` returns a state whose ``.values``
+    carries ``checkpoint_messages`` under the ``messages`` key.
+    ``streamed_messages`` is placed on ``active_run`` so the merge path in
+    ``get_state_and_messages_snapshots`` can observe it. When
+    ``registered_tool_names`` is provided, it becomes the set used by the
+    structured-output filter to distinguish user-facing tool calls from
+    internal schema invocations."""
+    agent = make_agent(list(subgraph_names) if subgraph_names else ["hotels_agent"])
+    agent.active_run = {
+        "id": "run-1",
+        "streamed_messages": list(streamed_messages or []),
+        "registered_tool_names": set(registered_tool_names or []),
+    }
+    _record_dispatch(agent)
+    agent.get_state_snapshot = MagicMock(return_value={})
+    state = MagicMock()
+    state.values = {"messages": checkpoint_messages}
+    agent.graph.aget_state = AsyncMock(return_value=state)
+    return agent
+
+
+def snapshot_event(dispatched: List[Any]):
+    """Return the first ``MESSAGES_SNAPSHOT`` event in a dispatched list.
+
+    Raises ``StopIteration`` if no snapshot was dispatched — callers use
+    this as an assertion that the snapshot was emitted."""
+    return next(
+        e for e in dispatched
+        if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT
+    )

--- a/integrations/langgraph/python/tests/test_make_json_safe.py
+++ b/integrations/langgraph/python/tests/test_make_json_safe.py
@@ -1,11 +1,10 @@
 """Tests for make_json_safe function."""
 import json
 import threading
+import unittest
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-
-import pytest
 
 from ag_ui_langgraph.utils import make_json_safe, json_safe_stringify
 
@@ -37,7 +36,7 @@ class DataclassWithRuntimeConfig:
     config: Any = None   # LangGraph-injected, not serializable
 
 
-class TestMakeJsonSafe:
+class TestMakeJsonSafe(unittest.TestCase):
     """Tests for make_json_safe function."""
 
     def test_primitives(self):

--- a/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
+++ b/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
@@ -1,0 +1,296 @@
+"""
+Tests for the regression introduced by PR #1426 (commit 24aa9af, shipped in
+ag-ui-langgraph 0.0.30): internal LLM invocations — most notably
+`.with_structured_output()` calls made inside a graph node — fire
+`on_chat_model_end`, get appended to `active_run['streamed_messages']`, and
+then leak into the MESSAGES_SNAPSHOT payload even though they were never
+committed to the state reducer's `messages` channel.
+
+Symptom seen by the customer: an empty assistant bubble appears in the UI
+after any node that internally uses `.with_structured_output(Schema)` for
+routing / classification / extraction.
+
+These tests exercise `LangGraphAgent.get_state_and_messages_snapshots`, which
+is the exact site where `streamed_messages` are merged into the snapshot
+payload (agent.py lines ~1210-1215 at the time of writing).
+
+Expected status on current main (bug present):
+  a) test_structured_output_call_excluded_from_snapshot      -> FAIL
+  b) test_router_llm_call_excluded_from_snapshot             -> FAIL
+  c) test_subgraph_uncommitted_message_still_appended        -> PASS (protects
+     the PR #1426 behavior; duplicates
+     test_subgraph_streaming.py::TestGetStateAndMessagesSnapshots::
+     test_uncommitted_streamed_message_appended_after_checkpoint)
+  d) test_empty_content_structured_output_not_emitted        -> FAIL
+
+After the fix, all four must pass.
+
+Fake models only — no external API calls.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph.state import CompiledStateGraph
+
+from ag_ui_langgraph.agent import LangGraphAgent
+from ag_ui.core import EventType
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror style from test_subgraph_streaming.py)
+# ---------------------------------------------------------------------------
+
+def _make_agent(subgraph_names=None):
+    graph = MagicMock(spec=CompiledStateGraph)
+    graph.config_specs = []
+    nodes = {}
+    for name in (subgraph_names or []):
+        node = MagicMock()
+        node.bound = MagicMock(spec=CompiledStateGraph)
+        nodes[name] = node
+    graph.nodes = nodes
+    return LangGraphAgent(name="test", graph=graph)
+
+
+def _event_types(events):
+    types = []
+    for ev in events:
+        t = getattr(ev, "type", None)
+        if t is not None:
+            types.append(t.value if hasattr(t, "value") else str(t))
+    return types
+
+
+def _make_configured_agent(checkpoint_messages, streamed_messages=None):
+    """Build an agent with a mocked checkpoint and pre-populated streamed_messages."""
+    agent = _make_agent(["some_subgraph"])
+    agent.active_run = {"id": "run-1", "streamed_messages": streamed_messages or []}
+    agent.dispatched = []
+    agent._dispatch_event = lambda ev: agent.dispatched.append(ev) or ev
+    agent.get_state_snapshot = MagicMock(return_value={})
+    state = MagicMock()
+    state.values = {"messages": checkpoint_messages}
+    agent.graph.aget_state = AsyncMock(return_value=state)
+    return agent
+
+
+def _structured_output_ai_message(
+    schema_name="Classification",
+    id_="struct-call-1",
+    call_id="call_struct_1",
+    args=None,
+):
+    """Build the AIMessage that `.with_structured_output(Schema)` actually
+    emits: empty `content`, single tool_call carrying the schema."""
+    return AIMessage(
+        id=id_,
+        content="",
+        tool_calls=[
+            {
+                "name": schema_name,
+                "args": args or {"category": "greeting", "confidence": 0.9},
+                "id": call_id,
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def _snapshot_event(dispatched):
+    return next(
+        e for e in dispatched
+        if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Structured output call must not leak into MESSAGES_SNAPSHOT
+# ---------------------------------------------------------------------------
+
+class TestStructuredOutputExcluded(unittest.IsolatedAsyncioTestCase):
+    """An LLM call made via `.with_structured_output(Pydantic)` fires
+    on_chat_model_end with a BaseMessage output. The current buggy code path
+    appends it into streamed_messages, and because its id is not in the
+    checkpoint, it leaks into the snapshot as an empty assistant bubble.
+    """
+
+    async def test_structured_output_call_excluded_from_snapshot(self):
+        user = HumanMessage(content="hi there", id="u1")
+        assistant = AIMessage(content="Hello!", id="a1")
+        # This is the "bad" message: the internal schema-extraction call.
+        structured = _structured_output_ai_message(
+            schema_name="RouterSchema",
+            id_="routing-internal-1",
+            call_id="call_routing_1",
+            args={"intent": "greeting", "confidence": 0.99},
+        )
+
+        agent = _make_configured_agent(
+            checkpoint_messages=[user, assistant],
+            streamed_messages=[structured],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = _snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertNotIn(
+            "routing-internal-1", ids,
+            "Structured-output internal LLM call must not appear in MESSAGES_SNAPSHOT "
+            "(it never committed to the state reducer's `messages` channel).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Router / classifier LLM calls must not leak
+# ---------------------------------------------------------------------------
+
+class TestRouterLLMCallExcluded(unittest.IsolatedAsyncioTestCase):
+    """A node that uses an internal LLM for routing (e.g. a classifier chain,
+    an extraction chain, or any LangChain-internal model call not wired to
+    the state reducer's `messages` channel) should not surface in the
+    snapshot."""
+
+    async def test_router_llm_call_excluded_from_snapshot(self):
+        user = HumanMessage(content="what's the weather?", id="u1")
+        final = AIMessage(content="It's sunny.", id="a1")
+        # Pretend a router node invoked an LLM internally; its output came
+        # back on on_chat_model_end but the node returned without writing it
+        # to the `messages` channel.
+        router_internal = AIMessage(
+            id="router-internal-1",
+            content="",
+            tool_calls=[
+                {
+                    "name": "RouteSchema",
+                    "args": {"route": "weather_agent"},
+                    "id": "call_router_1",
+                    "type": "tool_call",
+                }
+            ],
+        )
+
+        agent = _make_configured_agent(
+            checkpoint_messages=[user, final],
+            streamed_messages=[router_internal],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = _snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertNotIn(
+            "router-internal-1", ids,
+            "Router/classifier internal LLM call must not appear in snapshot; "
+            "it was never committed to the reducer's `messages` channel.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (c) Subgraph uncommitted-message behavior (PR #1426) must be preserved
+# ---------------------------------------------------------------------------
+
+class TestSubgraphUncommittedMessageStillAppended(unittest.IsolatedAsyncioTestCase):
+    """This test protects the legit behavior fixed in PR #1426:
+    when a subgraph produces a *real* conversational message before the
+    parent checkpoint has committed it, a mid-stream snapshot must still
+    include that message so the client sees it in the correct order.
+
+    NOTE: this duplicates the intent of
+    tests/test_subgraph_streaming.py::TestGetStateAndMessagesSnapshots::
+      test_uncommitted_streamed_message_appended_after_checkpoint
+    and is included here so the two behaviors — "include real uncommitted
+    msgs" vs. "exclude structured-output msgs" — sit side by side as a
+    regression contract around the upcoming filter.
+    """
+
+    async def test_subgraph_uncommitted_message_still_appended(self):
+        user = HumanMessage(content="AMS to SF", id="u1")
+        flights = AIMessage(content="Booked KLM", id="f1")
+        # A real assistant message produced inside a subgraph, not yet
+        # committed to the parent checkpoint.
+        hotels_uncommitted = AIMessage(content="Booked Hotel Zoe", id="h-uncommitted-1")
+
+        agent = _make_configured_agent(
+            checkpoint_messages=[user, flights],
+            streamed_messages=[hotels_uncommitted],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = _snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn(
+            "h-uncommitted-1", ids,
+            "Real uncommitted subgraph message MUST remain in the snapshot "
+            "— this is the PR #1426 behavior the fix must preserve.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (d) Empty-content structured output — the customer's exact symptom
+# ---------------------------------------------------------------------------
+
+class TestEmptyContentStructuredOutputNotEmitted(unittest.IsolatedAsyncioTestCase):
+    """The specific symptom reported: `.with_structured_output()` returns an
+    AIMessage with `content=""` (pure tool_calls for the Pydantic schema).
+    The current code path passes it through to the snapshot, which the
+    frontend renders as an empty assistant bubble.
+
+    This test codifies the user-visible contract: no empty-content
+    structured-output BaseMessage may reach the MESSAGES_SNAPSHOT.
+    """
+
+    async def test_empty_content_structured_output_not_emitted(self):
+        user = HumanMessage(content="extract entities from: Paris", id="u1")
+        final = AIMessage(content="Found: Paris (city).", id="a1")
+        # Multiple structured-output internal calls — all should be excluded.
+        extract1 = _structured_output_ai_message(
+            schema_name="EntityExtraction",
+            id_="extract-internal-1",
+            call_id="call_extract_1",
+            args={"entities": [{"text": "Paris", "type": "city"}]},
+        )
+        extract2 = _structured_output_ai_message(
+            schema_name="Sentiment",
+            id_="extract-internal-2",
+            call_id="call_sentiment_1",
+            args={"sentiment": "neutral", "score": 0.0},
+        )
+
+        agent = _make_configured_agent(
+            checkpoint_messages=[user, final],
+            streamed_messages=[extract1, extract2],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = _snapshot_event(agent.dispatched)
+
+        # Neither internal structured-output message should appear.
+        ids = [m.id for m in snap.messages]
+        self.assertNotIn("extract-internal-1", ids)
+        self.assertNotIn("extract-internal-2", ids)
+
+        # Stronger: no empty-content assistant message should be emitted at
+        # all (this is the user-visible "empty bubble" symptom).
+        for m in snap.messages:
+            content = getattr(m, "content", None)
+            role = getattr(m, "role", None)
+            if role == "assistant" and (content == "" or content is None):
+                tool_calls = getattr(m, "tool_calls", None) or []
+                self.fail(
+                    f"Empty-content assistant message leaked into snapshot: "
+                    f"id={getattr(m, 'id', None)!r}, tool_calls={tool_calls!r}. "
+                    "This is the exact 'empty bubble' symptom reported by the customer."
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
+++ b/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
@@ -1,79 +1,26 @@
-"""
-Tests for the regression introduced by PR #1426 (commit 24aa9af, shipped in
-ag-ui-langgraph 0.0.30): internal LLM invocations — most notably
-`.with_structured_output()` calls made inside a graph node — fire
-`on_chat_model_end`, get appended to `active_run['streamed_messages']`, and
-then leak into the MESSAGES_SNAPSHOT payload even though they were never
-committed to the state reducer's `messages` channel.
+"""Tests for the MESSAGES_SNAPSHOT filter that drops LLM-internal
+structured-output / router / classifier calls while preserving every
+message the caller's registered tools or state reducer produced.
 
-Symptom seen by the customer: an empty assistant bubble appears in the UI
-after any node that internally uses `.with_structured_output(Schema)` for
-routing / classification / extraction.
-
-These tests exercise `LangGraphAgent.get_state_and_messages_snapshots`, which
-is the exact site where `streamed_messages` are merged into the snapshot
-payload (agent.py lines ~1210-1215 at the time of writing).
-
-Expected status on current main (bug present):
-  a) test_structured_output_call_excluded_from_snapshot      -> FAIL
-  b) test_router_llm_call_excluded_from_snapshot             -> FAIL
-  c) test_subgraph_uncommitted_message_still_appended        -> PASS (protects
-     the PR #1426 behavior; duplicates
-     test_subgraph_streaming.py::TestGetStateAndMessagesSnapshots::
-     test_uncommitted_streamed_message_appended_after_checkpoint)
-  d) test_empty_content_structured_output_not_emitted        -> FAIL
-
-After the fix, all four must pass.
-
-Fake models only — no external API calls.
+Contract under test:
+    A streamed AIMessage whose textual content is empty AND whose
+    tool_calls all name something OTHER than a tool registered on the
+    current run is classified as an internal LLM call and must not
+    appear in ``MESSAGES_SNAPSHOT``. Every other message — including
+    real agentic tool-call AIMessages whose tool_calls name a
+    registered tool — flows through unchanged.
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.graph.state import CompiledStateGraph
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from ag_ui_langgraph.agent import LangGraphAgent
 from ag_ui.core import EventType
+from ag_ui_langgraph.agent import LangGraphAgent
 
-
-# ---------------------------------------------------------------------------
-# Helpers (mirror style from test_subgraph_streaming.py)
-# ---------------------------------------------------------------------------
-
-def _make_agent(subgraph_names=None):
-    graph = MagicMock(spec=CompiledStateGraph)
-    graph.config_specs = []
-    nodes = {}
-    for name in (subgraph_names or []):
-        node = MagicMock()
-        node.bound = MagicMock(spec=CompiledStateGraph)
-        nodes[name] = node
-    graph.nodes = nodes
-    return LangGraphAgent(name="test", graph=graph)
-
-
-def _event_types(events):
-    types = []
-    for ev in events:
-        t = getattr(ev, "type", None)
-        if t is not None:
-            types.append(t.value if hasattr(t, "value") else str(t))
-    return types
-
-
-def _make_configured_agent(checkpoint_messages, streamed_messages=None):
-    """Build an agent with a mocked checkpoint and pre-populated streamed_messages."""
-    agent = _make_agent(["some_subgraph"])
-    agent.active_run = {"id": "run-1", "streamed_messages": streamed_messages or []}
-    agent.dispatched = []
-    agent._dispatch_event = lambda ev: agent.dispatched.append(ev) or ev
-    agent.get_state_snapshot = MagicMock(return_value={})
-    state = MagicMock()
-    state.values = {"messages": checkpoint_messages}
-    agent.graph.aget_state = AsyncMock(return_value=state)
-    return agent
+from tests._helpers import make_agent, make_configured_agent, snapshot_event
 
 
 def _structured_output_ai_message(
@@ -82,8 +29,9 @@ def _structured_output_ai_message(
     call_id="call_struct_1",
     args=None,
 ):
-    """Build the AIMessage that `.with_structured_output(Schema)` actually
-    emits: empty `content`, single tool_call carrying the schema."""
+    """Build the AIMessage that ``.with_structured_output(Schema)``
+    emits: empty content and a single tool_call carrying the schema
+    name rather than a registered tool name."""
     return AIMessage(
         id=id_,
         content="",
@@ -98,28 +46,14 @@ def _structured_output_ai_message(
     )
 
 
-def _snapshot_event(dispatched):
-    return next(
-        e for e in dispatched
-        if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT
-    )
-
-
-# ---------------------------------------------------------------------------
-# (a) Structured output call must not leak into MESSAGES_SNAPSHOT
-# ---------------------------------------------------------------------------
-
 class TestStructuredOutputExcluded(unittest.IsolatedAsyncioTestCase):
-    """An LLM call made via `.with_structured_output(Pydantic)` fires
-    on_chat_model_end with a BaseMessage output. The current buggy code path
-    appends it into streamed_messages, and because its id is not in the
-    checkpoint, it leaks into the snapshot as an empty assistant bubble.
-    """
+    """Structured-output schema invocations must not leak into the
+    snapshot even when their empty-content / tool_calls shape would
+    otherwise match a real tool-call turn."""
 
     async def test_structured_output_call_excluded_from_snapshot(self):
         user = HumanMessage(content="hi there", id="u1")
         assistant = AIMessage(content="Hello!", id="a1")
-        # This is the "bad" message: the internal schema-extraction call.
         structured = _structured_output_ai_message(
             schema_name="RouterSchema",
             id_="routing-internal-1",
@@ -127,39 +61,33 @@ class TestStructuredOutputExcluded(unittest.IsolatedAsyncioTestCase):
             args={"intent": "greeting", "confidence": 0.99},
         )
 
-        agent = _make_configured_agent(
+        agent = make_configured_agent(
             checkpoint_messages=[user, assistant],
             streamed_messages=[structured],
+            registered_tool_names=["search_flights"],
         )
 
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
 
-        snap = _snapshot_event(agent.dispatched)
+        snap = snapshot_event(agent.dispatched)
         ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
         self.assertNotIn(
             "routing-internal-1", ids,
-            "Structured-output internal LLM call must not appear in MESSAGES_SNAPSHOT "
-            "(it never committed to the state reducer's `messages` channel).",
+            "Structured-output invocation must not appear in MESSAGES_SNAPSHOT.",
         )
 
 
-# ---------------------------------------------------------------------------
-# (b) Router / classifier LLM calls must not leak
-# ---------------------------------------------------------------------------
-
 class TestRouterLLMCallExcluded(unittest.IsolatedAsyncioTestCase):
-    """A node that uses an internal LLM for routing (e.g. a classifier chain,
-    an extraction chain, or any LangChain-internal model call not wired to
-    the state reducer's `messages` channel) should not surface in the
-    snapshot."""
+    """Router / classifier LLM calls that emit an AIMessage carrying a
+    schema-named tool_call but no registered-tool name must be
+    filtered."""
 
     async def test_router_llm_call_excluded_from_snapshot(self):
         user = HumanMessage(content="what's the weather?", id="u1")
         final = AIMessage(content="It's sunny.", id="a1")
-        # Pretend a router node invoked an LLM internally; its output came
-        # back on on_chat_model_end but the node returned without writing it
-        # to the `messages` channel.
         router_internal = AIMessage(
             id="router-internal-1",
             content="",
@@ -173,49 +101,37 @@ class TestRouterLLMCallExcluded(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
-        agent = _make_configured_agent(
+        agent = make_configured_agent(
             checkpoint_messages=[user, final],
             streamed_messages=[router_internal],
+            registered_tool_names=["get_weather"],
         )
 
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
 
-        snap = _snapshot_event(agent.dispatched)
+        snap = snapshot_event(agent.dispatched)
         ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
         self.assertNotIn(
             "router-internal-1", ids,
-            "Router/classifier internal LLM call must not appear in snapshot; "
-            "it was never committed to the reducer's `messages` channel.",
+            "Router/classifier internal LLM call must not appear in snapshot.",
         )
 
 
-# ---------------------------------------------------------------------------
-# (c) Subgraph uncommitted-message behavior (PR #1426) must be preserved
-# ---------------------------------------------------------------------------
-
 class TestSubgraphUncommittedMessageStillAppended(unittest.IsolatedAsyncioTestCase):
-    """This test protects the legit behavior fixed in PR #1426:
-    when a subgraph produces a *real* conversational message before the
-    parent checkpoint has committed it, a mid-stream snapshot must still
-    include that message so the client sees it in the correct order.
-
-    NOTE: this duplicates the intent of
-    tests/test_subgraph_streaming.py::TestGetStateAndMessagesSnapshots::
-      test_uncommitted_streamed_message_appended_after_checkpoint
-    and is included here so the two behaviors — "include real uncommitted
-    msgs" vs. "exclude structured-output msgs" — sit side by side as a
-    regression contract around the upcoming filter.
-    """
+    """Real conversational subgraph messages produced before the parent
+    checkpoint commits them must still surface in the mid-stream
+    snapshot — the regression fix from the earlier subgraph streaming
+    work must be preserved."""
 
     async def test_subgraph_uncommitted_message_still_appended(self):
         user = HumanMessage(content="AMS to SF", id="u1")
         flights = AIMessage(content="Booked KLM", id="f1")
-        # A real assistant message produced inside a subgraph, not yet
-        # committed to the parent checkpoint.
         hotels_uncommitted = AIMessage(content="Booked Hotel Zoe", id="h-uncommitted-1")
 
-        agent = _make_configured_agent(
+        agent = make_configured_agent(
             checkpoint_messages=[user, flights],
             streamed_messages=[hotels_uncommitted],
         )
@@ -223,33 +139,21 @@ class TestSubgraphUncommittedMessageStillAppended(unittest.IsolatedAsyncioTestCa
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
 
-        snap = _snapshot_event(agent.dispatched)
+        snap = snapshot_event(agent.dispatched)
         ids = [m.id for m in snap.messages]
-        self.assertIn(
-            "h-uncommitted-1", ids,
-            "Real uncommitted subgraph message MUST remain in the snapshot "
-            "— this is the PR #1426 behavior the fix must preserve.",
-        )
+        self.assertIn("h-uncommitted-1", ids)
 
 
-# ---------------------------------------------------------------------------
-# (d) Empty-content structured output — the customer's exact symptom
-# ---------------------------------------------------------------------------
-
-class TestEmptyContentStructuredOutputNotEmitted(unittest.IsolatedAsyncioTestCase):
-    """The specific symptom reported: `.with_structured_output()` returns an
-    AIMessage with `content=""` (pure tool_calls for the Pydantic schema).
-    The current code path passes it through to the snapshot, which the
-    frontend renders as an empty assistant bubble.
-
-    This test codifies the user-visible contract: no empty-content
-    structured-output BaseMessage may reach the MESSAGES_SNAPSHOT.
-    """
+class TestEmptyContentAssistantNeverLeaks(unittest.IsolatedAsyncioTestCase):
+    """No empty-content assistant bubble may reach the snapshot via the
+    structured-output path. Uses a mixed fixture so the guard does not
+    pass by coincidence: a real non-empty assistant message sits
+    alongside the structured-output message, and only the structured
+    one is filtered."""
 
     async def test_empty_content_structured_output_not_emitted(self):
         user = HumanMessage(content="extract entities from: Paris", id="u1")
         final = AIMessage(content="Found: Paris (city).", id="a1")
-        # Multiple structured-output internal calls — all should be excluded.
         extract1 = _structured_output_ai_message(
             schema_name="EntityExtraction",
             id_="extract-internal-1",
@@ -263,33 +167,394 @@ class TestEmptyContentStructuredOutputNotEmitted(unittest.IsolatedAsyncioTestCas
             args={"sentiment": "neutral", "score": 0.0},
         )
 
-        agent = _make_configured_agent(
+        agent = make_configured_agent(
             checkpoint_messages=[user, final],
             streamed_messages=[extract1, extract2],
+            registered_tool_names=["lookup_city"],
         )
 
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
 
-        snap = _snapshot_event(agent.dispatched)
-
-        # Neither internal structured-output message should appear.
+        snap = snapshot_event(agent.dispatched)
         ids = [m.id for m in snap.messages]
         self.assertNotIn("extract-internal-1", ids)
         self.assertNotIn("extract-internal-2", ids)
 
-        # Stronger: no empty-content assistant message should be emitted at
-        # all (this is the user-visible "empty bubble" symptom).
         for m in snap.messages:
             content = getattr(m, "content", None)
             role = getattr(m, "role", None)
-            if role == "assistant" and (content == "" or content is None):
-                tool_calls = getattr(m, "tool_calls", None) or []
-                self.fail(
+            if role == "assistant":
+                self.assertFalse(
+                    content == "" or content is None,
                     f"Empty-content assistant message leaked into snapshot: "
-                    f"id={getattr(m, 'id', None)!r}, tool_calls={tool_calls!r}. "
-                    "This is the exact 'empty bubble' symptom reported by the customer."
+                    f"id={getattr(m, 'id', None)!r}",
                 )
+
+    async def test_structured_output_beside_real_assistant(self):
+        """A real non-empty assistant message co-existing in the stream
+        with a structured-output message must survive — only the
+        structured one is dropped."""
+        user = HumanMessage(content="what's up?", id="u1")
+        real_assistant = AIMessage(
+            content="Here's the summary you asked for.",
+            id="real-assistant-1",
+        )
+        structured = _structured_output_ai_message(
+            schema_name="SummarySchema",
+            id_="structured-1",
+            call_id="call_schema_1",
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user],
+            streamed_messages=[real_assistant, structured],
+            registered_tool_names=["summarize"],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("real-assistant-1", ids)
+        self.assertNotIn("structured-1", ids)
+
+        for m in snap.messages:
+            role = getattr(m, "role", None)
+            content = getattr(m, "content", None)
+            if role == "assistant":
+                self.assertFalse(
+                    content == "" or content is None,
+                    "No assistant message in the snapshot may have empty content.",
+                )
+
+
+class TestFilterClassifierBoundaryCoverage(unittest.TestCase):
+    """Direct coverage of ``_is_structured_output_message`` across the
+    boundary conditions that matter in production streams: empty-string
+    vs. list content, Anthropic tool_use blocks, mixed text/tool_use
+    lists, and non-AIMessage types that must never be classified."""
+
+    def test_empty_string_content_with_registered_tool_not_filtered(self):
+        msg = AIMessage(
+            id="real-tc-1",
+            content="",
+            tool_calls=[{
+                "name": "search_flights",
+                "args": {"origin": "AMS"},
+                "id": "call_real_1",
+                "type": "tool_call",
+            }],
+        )
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_empty_string_content_with_unregistered_tool_filtered(self):
+        msg = AIMessage(
+            id="schema-1",
+            content="",
+            tool_calls=[{
+                "name": "ClassificationSchema",
+                "args": {},
+                "id": "call_schema_1",
+                "type": "tool_call",
+            }],
+        )
+        self.assertTrue(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_anthropic_tool_use_only_list_content_filtered(self):
+        msg = AIMessage(
+            id="schema-anth-1",
+            content=[{
+                "type": "tool_use",
+                "id": "call_schema_anth_1",
+                "name": "Schema",
+                "input": {},
+            }],
+            tool_calls=[{
+                "name": "Schema",
+                "args": {},
+                "id": "call_schema_anth_1",
+                "type": "tool_call",
+            }],
+        )
+        self.assertTrue(
+            LangGraphAgent._is_structured_output_message(msg, {"book_flight"}),
+        )
+
+    def test_text_block_with_empty_text_filtered_when_tool_unregistered(self):
+        msg = AIMessage(
+            id="schema-empty-text-1",
+            content=[{"type": "text", "text": ""}],
+            tool_calls=[{
+                "name": "Schema",
+                "args": {},
+                "id": "call_empty_text_1",
+                "type": "tool_call",
+            }],
+        )
+        self.assertTrue(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_text_block_with_real_text_never_filtered(self):
+        msg = AIMessage(
+            id="real-text-1",
+            content=[{"type": "text", "text": "here is an answer"}],
+            tool_calls=[{
+                "name": "AnythingSchema",
+                "args": {},
+                "id": "call_real_text_1",
+                "type": "tool_call",
+            }],
+        )
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, set()),
+        )
+
+    def test_human_message_never_classified(self):
+        msg = HumanMessage(id="human-empty-1", content="")
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_tool_message_never_classified(self):
+        msg = ToolMessage(id="tool-empty-1", content="", tool_call_id="call_x")
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_ai_message_no_tool_calls_not_filtered(self):
+        msg = AIMessage(id="empty-no-tc-1", content="", tool_calls=[])
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+    def test_mixed_tool_calls_any_registered_name_preserves_message(self):
+        msg = AIMessage(
+            id="mixed-tc-1",
+            content="",
+            tool_calls=[
+                {"name": "InternalSchema", "args": {}, "id": "c1", "type": "tool_call"},
+                {"name": "search_flights", "args": {}, "id": "c2", "type": "tool_call"},
+            ],
+        )
+        self.assertFalse(
+            LangGraphAgent._is_structured_output_message(msg, {"search_flights"}),
+        )
+
+
+class TestMixedStreamedMessages(unittest.IsolatedAsyncioTestCase):
+    """One structured-output message and one real uncommitted
+    tool-call must each take the correct path through the filter."""
+
+    async def test_structured_filtered_real_tool_call_preserved(self):
+        user = HumanMessage(content="book flight", id="u1")
+        checkpoint_assistant = AIMessage(content="let me book", id="a1")
+        real_tool_call = AIMessage(
+            id="real-tc-1",
+            content="",
+            tool_calls=[{
+                "name": "search_flights",
+                "args": {"origin": "AMS", "dest": "SFO"},
+                "id": "call_real_1",
+                "type": "tool_call",
+            }],
+        )
+        structured = _structured_output_ai_message(
+            schema_name="RouterSchema",
+            id_="structured-1",
+            call_id="call_schema_1",
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user, checkpoint_assistant],
+            streamed_messages=[real_tool_call, structured],
+            registered_tool_names=["search_flights"],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("real-tc-1", ids)
+        self.assertNotIn("structured-1", ids)
+
+
+class TestExtractRegisteredToolNames(unittest.TestCase):
+    """``_extract_registered_tool_names`` pulls names from both dict
+    and object tools, skips entries without a name, and deduplicates."""
+
+    def test_mixed_dict_and_object_tools(self):
+        class _ToolObj:
+            def __init__(self, name):
+                self.name = name
+
+        input = SimpleNamespace(
+            tools=[
+                {"name": "search_flights"},
+                _ToolObj("book_hotel"),
+                {"description": "no-name"},
+                None,
+                {"name": "search_flights"},
+            ]
+        )
+        names = LangGraphAgent._extract_registered_tool_names(input)
+        self.assertEqual(names, {"search_flights", "book_hotel"})
+
+    def test_no_tools_returns_empty_set(self):
+        input = SimpleNamespace(tools=None)
+        self.assertEqual(LangGraphAgent._extract_registered_tool_names(input), set())
+
+    def test_missing_tools_attribute_returns_empty_set(self):
+        input = SimpleNamespace()
+        self.assertEqual(LangGraphAgent._extract_registered_tool_names(input), set())
+
+
+class TestHandleStreamEventsFiltering(unittest.IsolatedAsyncioTestCase):
+    """End-to-end through ``_handle_stream_events``: feed an
+    ``OnChatModelEnd`` carrying a structured-output AIMessage, then
+    trigger a final snapshot, and assert the emitted MESSAGES_SNAPSHOT
+    excludes the structured message."""
+
+    async def test_structured_output_excluded_from_end_of_run_snapshot(self):
+        agent = make_agent(["hotels_agent"])
+
+        structured = _structured_output_ai_message(
+            schema_name="RouteSchema",
+            id_="structured-integration-1",
+            call_id="call_struct_int_1",
+        )
+
+        user = HumanMessage(content="hi", id="u1")
+        final_assistant = AIMessage(content="done", id="a1")
+
+        final_state = MagicMock()
+        final_state.values = {"messages": [user, final_assistant]}
+        final_state.tasks = []
+        final_state.next = []
+        final_state.metadata = {"writes": {}}
+
+        run_input = MagicMock()
+        run_input.run_id = "run-1"
+        run_input.thread_id = "thread-1"
+        run_input.messages = []
+        run_input.forwarded_props = {}
+        run_input.tools = [{"name": "book_flight"}]
+
+        async def fake_prepare(*args, **kwargs):
+            agent.active_run["schema_keys"] = {
+                "input": ["messages"], "output": ["messages"],
+                "config": [], "context": [],
+            }
+
+            async def gen():
+                yield {
+                    "event": "on_chat_model_end",
+                    "name": "classifier",
+                    "data": {"output": structured},
+                    "metadata": {
+                        "langgraph_node": "classifier",
+                        "langgraph_checkpoint_ns": "",
+                    },
+                    "run_id": "run-1",
+                }
+
+            return {
+                "stream": gen(),
+                "state": MagicMock(values={"messages": []}),
+                "config": {"configurable": {"thread_id": "thread-1"}},
+            }
+
+        agent.graph.aget_state = AsyncMock(return_value=final_state)
+        agent.prepare_stream = fake_prepare
+
+        collected = []
+        async for ev in agent._handle_stream_events(run_input):
+            collected.append(ev)
+
+        snapshots = [e for e in collected if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT]
+        self.assertGreaterEqual(len(snapshots), 1)
+        final_snap = snapshots[-1]
+        ids = [m.id for m in final_snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
+        self.assertNotIn("structured-integration-1", ids)
+
+    async def test_real_tool_call_preserved_in_end_of_run_snapshot(self):
+        """Mirror of the above with a REAL tool-call AIMessage whose
+        name is registered. It must survive to the final snapshot even
+        if the checkpoint has not yet caught up."""
+        agent = make_agent(["hotels_agent"])
+
+        real_tool_call = AIMessage(
+            id="real-tc-integration-1",
+            content="",
+            tool_calls=[{
+                "name": "book_flight",
+                "args": {"origin": "AMS", "dest": "SFO"},
+                "id": "call_real_int_1",
+                "type": "tool_call",
+            }],
+        )
+
+        user = HumanMessage(content="book AMS->SFO", id="u1")
+
+        # The checkpoint has not yet committed the tool-call turn.
+        final_state = MagicMock()
+        final_state.values = {"messages": [user]}
+        final_state.tasks = []
+        final_state.next = []
+        final_state.metadata = {"writes": {}}
+
+        run_input = MagicMock()
+        run_input.run_id = "run-1"
+        run_input.thread_id = "thread-1"
+        run_input.messages = []
+        run_input.forwarded_props = {}
+        run_input.tools = [{"name": "book_flight"}]
+
+        async def fake_prepare(*args, **kwargs):
+            agent.active_run["schema_keys"] = {
+                "input": ["messages"], "output": ["messages"],
+                "config": [], "context": [],
+            }
+
+            async def gen():
+                yield {
+                    "event": "on_chat_model_end",
+                    "name": "planner",
+                    "data": {"output": real_tool_call},
+                    "metadata": {
+                        "langgraph_node": "planner",
+                        "langgraph_checkpoint_ns": "",
+                    },
+                    "run_id": "run-1",
+                }
+
+            return {
+                "stream": gen(),
+                "state": MagicMock(values={"messages": []}),
+                "config": {"configurable": {"thread_id": "thread-1"}},
+            }
+
+        agent.graph.aget_state = AsyncMock(return_value=final_state)
+        agent.prepare_stream = fake_prepare
+
+        collected = []
+        async for ev in agent._handle_stream_events(run_input):
+            collected.append(ev)
+
+        snapshots = [e for e in collected if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT]
+        self.assertGreaterEqual(len(snapshots), 1)
+        final_snap = snapshots[-1]
+        ids = [m.id for m in final_snap.messages]
+        self.assertIn("real-tc-integration-1", ids)
 
 
 if __name__ == "__main__":

--- a/integrations/langgraph/python/tests/test_subgraph_streaming.py
+++ b/integrations/langgraph/python/tests/test_subgraph_streaming.py
@@ -15,27 +15,11 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.graph.state import CompiledStateGraph
 
-from ag_ui_langgraph.agent import LangGraphAgent, ROOT_SUBGRAPH_NAME
+from ag_ui_langgraph.agent import ROOT_SUBGRAPH_NAME
 from ag_ui.core import EventType
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_agent(subgraph_names=None):
-    """Return a LangGraphAgent with mocked CompiledStateGraph subgraph nodes."""
-    graph = MagicMock(spec=CompiledStateGraph)
-    graph.config_specs = []
-    nodes = {}
-    for name in (subgraph_names or []):
-        node = MagicMock()
-        node.bound = MagicMock(spec=CompiledStateGraph)
-        nodes[name] = node
-    graph.nodes = nodes
-    return LangGraphAgent(name="test", graph=graph)
+from tests._helpers import make_agent as _make_agent, make_configured_agent
 
 
 def _event_types(events):
@@ -112,25 +96,14 @@ class TestSubgraphDetection(unittest.TestCase):
 
 class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
 
-    def _make_agent(self, checkpoint_messages, streamed_messages=None):
-        agent = _make_agent(["hotels_agent"])
-        agent.active_run = {"id": "run-1", "streamed_messages": streamed_messages or []}
-        agent.dispatched = []
-        agent._dispatch_event = lambda ev: agent.dispatched.append(ev) or ev
-        agent.get_state_snapshot = MagicMock(return_value={})
-        state = MagicMock()
-        state.values = {"messages": checkpoint_messages}
-        agent.graph.aget_state = AsyncMock(return_value=state)
-        return agent
-
     async def test_dispatches_state_snapshot(self):
-        agent = self._make_agent([HumanMessage(content="hi", id="u1")])
+        agent = make_configured_agent([HumanMessage(content="hi", id="u1")])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         self.assertIn("STATE_SNAPSHOT", _event_types(agent.dispatched))
 
     async def test_dispatches_messages_snapshot(self):
-        agent = self._make_agent([HumanMessage(content="hi", id="u1")])
+        agent = make_configured_agent([HumanMessage(content="hi", id="u1")])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         self.assertIn("MESSAGES_SNAPSHOT", _event_types(agent.dispatched))
@@ -140,7 +113,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         user = HumanMessage(content="AMS to SF", id="u1")
         flights = AIMessage(content="Booked KLM", id="f1")
         hotels = AIMessage(content="Booked Hotel Zoe", id="h1")
-        agent = self._make_agent([user, flights, hotels])
+        agent = make_configured_agent([user, flights, hotels])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)
@@ -153,7 +126,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         user = HumanMessage(content="hi", id="u1")
         flights = AIMessage(content="Booked KLM", id="f1")
         supervisor_routing = AIMessage(content="routing", id="sup1")
-        agent = self._make_agent([user, flights], streamed_messages=[supervisor_routing])
+        agent = make_configured_agent([user, flights], streamed_messages=[supervisor_routing])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)
@@ -165,7 +138,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         """A streamed message whose ID is already in the checkpoint appears only once."""
         user = HumanMessage(content="hi", id="u1")
         exp = AIMessage(content="activities", id="exp1")
-        agent = self._make_agent([user, exp], streamed_messages=[exp])
+        agent = make_configured_agent([user, exp], streamed_messages=[exp])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -26,7 +26,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", specifier = ">=0.1.10" },
+    { name = "ag-ui-protocol", specifier = ">=0.1.15" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.12" },
     { name = "langchain", specifier = ">=1.2.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
@@ -40,14 +40,14 @@ dev = [{ name = "fastapi", specifier = ">=0.115.12" }]
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.11"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/c1/33ab11dc829c6c28d0d346988b2f394aa632d3ad63d1d2eb5f16eccd769b/ag_ui_protocol-0.1.11.tar.gz", hash = "sha256:b336dfebb5751e9cc2c676a3008a4bce4819004e6f6f8cba73169823564472ae", size = 6249, upload-time = "2026-02-11T12:41:36.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/83/5c6f4cb24d27d9cbe0c31ba2f3b4d1ff42bc6f87ba9facfa9e9d44046c6b/ag_ui_protocol-0.1.11-py3-none-any.whl", hash = "sha256:b0cc25570462a8eba8e57a098e0a2d6892a1f571a7bea7da2d4b60efd5d66789", size = 8392, upload-time = "2026-02-11T12:41:35.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
 ]
 
 [[package]]

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -22,8 +22,6 @@ fastapi = [
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -38,11 +36,7 @@ requires-dist = [
 provides-extras = ["fastapi"]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-]
+dev = [{ name = "fastapi", specifier = ">=0.115.12" }]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -86,15 +80,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -180,15 +165,6 @@ wheels = [
 ]
 
 [[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -260,15 +236,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
-name = "iniconfig"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -520,15 +487,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -634,47 +592,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pytest"
-version = "9.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -767,42 +684,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
-    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10, <3.14"
 
 [[package]]
 name = "ag-ui-langgraph"
-version = "0.0.29"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -22,6 +22,8 @@ fastapi = [
 [package.dev-dependencies]
 dev = [
     { name = "fastapi" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -36,7 +38,11 @@ requires-dist = [
 provides-extras = ["fastapi"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "fastapi", specifier = ">=0.115.12" }]
+dev = [
+    { name = "fastapi", specifier = ">=0.115.12" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -80,6 +86,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -165,6 +180,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -236,6 +260,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -487,6 +520,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -592,6 +634,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +767,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes a regression in `ag-ui-langgraph` between **0.0.21 → 0.0.30** where `MESSAGES_SNAPSHOT` emits duplicate / empty assistant messages, causing repeated feedback UI triggers on a single response.

Tracked as `FOR-91`. Reported as blocking a customer release.

## Root cause

PR #1426 (commit `24aa9af`, shipped in 0.0.30) added a `streamed_messages` collection that captures every `on_chat_model_end` output unconditionally. This sweeps in `.with_structured_output(Schema)` calls, router/classifier chains, and any other internal LangChain model invocation — even though these never commit to the state reducer's `messages` channel. They then get re-added to the snapshot as "extra" messages, producing empty bubbles on the frontend.

PR #1426's intent (surface subgraph messages before the parent checkpoint commits them) is correct and must be preserved.

## Approach

Classify messages by **registered-tool membership**, not shape:

- `_extract_registered_tool_names` — pulls the set of tool names declared on the current `RunAgentInput.tools` into `active_run["registered_tool_names"]` at run start.
- `_ai_message_content_is_empty` — type-aware emptiness predicate. Handles `None`, `""`, `[]`, and Anthropic-style content-block lists (`[{"type": "tool_use", …}]`, `[{"type": "text", "text": ""}]`).
- `_is_structured_output_message` — an AIMessage is filtered iff content is empty AND it has tool_calls AND **none** of those tool_calls name a registered tool. Any tool_call matching a caller-registered tool preserves the message — this is what keeps real agentic tool-call turns alive across the mid-stream subgraph-boundary snapshot where the parent checkpoint may not yet carry them.

The filter runs only over `extra` (streamed-not-in-checkpoint). Drops are logged at the snapshot-merge site for observability.

## What changed

- `ag_ui_langgraph/agent.py` — filter + registered-tool plumbing, drop logging
- `ag_ui_langgraph/types.py` — `RunMetadata.registered_tool_names`
- `tests/_helpers.py` (new) — shared fixtures lifted from `test_subgraph_streaming.py`
- `tests/test_messages_snapshot_filtering.py` (new) — 16 tests: boundary matrix for the classifier, 2 end-to-end via `_handle_stream_events`, protects PR #1426's subgraph behavior
- `tests/test_subgraph_streaming.py` — refactored to consume shared helpers
- `tests/test_make_json_safe.py` — converted to `unittest.TestCase` so `unittest discover` sees it
- `pyproject.toml` / `uv.lock` — drop unused `pytest` / `pytest-asyncio` dev deps; remove unused `import pytest` from `test_make_json_safe.py`
- `.github/workflows/unit-python-sdk.yml` — add `langgraph-python` job (previously this package had no PR-path CI coverage)

## Test plan

- [x] `uv run python -m unittest discover tests` — 125/125 pass in the worktree
- [x] Existing `test_subgraph_streaming.py` unchanged behaviorally, 20/20 pass after helper extraction
- [x] New boundary-coverage matrix for classifier (Anthropic list content, mixed list blocks, HumanMessage / ToolMessage negatives, empty content + empty tool_calls, mixed registered+unregistered tool_calls)
- [ ] CI workflow smoke-tests (first time `integrations/langgraph/python/**` actually triggers unit CI)
- [ ] Paul Fisher's team validates the fix against their reproducer

## Notes

- Follow-up PR stacked on this branch will address pre-existing typing gaps surfaced while reviewing (`RunMetadata` drift, `active_run` None-check discipline, bare `except Exception: raise`, `_dispatch_event` return-type annotation, `get_schema_keys` broad exception swallow).
- Customer workaround (local checkpoint re-read on `MESSAGES_SNAPSHOT`) can be removed after adopting this.