### PR TITLE
fix(langgraph): emit post-run MESSAGES_SNAPSHOT from checkpoint only for non-subgraph runs

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "sdks/python/**"
+      - "integrations/langgraph/python/**"
       - ".github/workflows/unit-python-sdk.yml"
   pull_request:
     branches: [main]
     paths:
       - "sdks/python/**"
+      - "integrations/langgraph/python/**"
       - ".github/workflows/unit-python-sdk.yml"
 
 jobs:
@@ -38,4 +40,31 @@ jobs:
 
       - name: Run tests
         working-directory: sdks/python
+        run: uv run python -m unittest discover tests -v
+
+  langgraph-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: ">=0.8.0"
+
+      - name: Load cached venv
+        id: cached-uv-dependencies
+        uses: actions/cache@v4
+        with:
+          path: integrations/langgraph/python/.venv
+          key: venv-${{ runner.os }}-langgraph-${{ hashFiles('integrations/langgraph/python/uv.lock') }}
+
+      - name: Install dependencies
+        working-directory: integrations/langgraph/python
+        run: uv sync
+
+      - name: Run tests
+        working-directory: integrations/langgraph/python
         run: uv run python -m unittest discover tests -v

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -166,6 +166,7 @@ class LangGraphAgent:
             "model_made_tool_call": False,
             "state_reliable": True,
             "streamed_messages": [],
+            "any_mid_stream_merge_fired": False,
         }
         self.active_run = INITIAL_ACTIVE_RUN
 
@@ -233,7 +234,12 @@ class LangGraphAgent:
 
                 if is_subgraph_stream and current_subgraph != self.current_subgraph:
                     self.current_subgraph = current_subgraph
-                    # Every time a subgraph changes, we need to update the state and messages snapshots
+                    # Every time a subgraph changes, we need to update the state and messages snapshots.
+                    # Record that a mid-stream merge fired: the post-run
+                    # snapshot must preserve these streamed_messages
+                    # (delivered to the client here) rather than wiping
+                    # them with a checkpoint-only final snapshot.
+                    self.active_run["any_mid_stream_merge_fired"] = True
                     async for ev in self.get_state_and_messages_snapshots(config):
                         yield ev
 
@@ -361,7 +367,30 @@ class LangGraphAgent:
                 for ev in self.handle_node_change(node_name):
                     yield ev
 
-            async for ev in self.get_state_and_messages_snapshots(config):
+            # Post-run MESSAGES_SNAPSHOT semantics:
+            #
+            # - Non-subgraph runs (supervisor flow never fired a
+            #   mid-stream boundary snapshot): the checkpoint is the
+            #   authoritative final state. Do NOT merge in
+            #   ``streamed_messages`` — they include transient LLM
+            #   outputs (``.with_structured_output()`` / router /
+            #   classifier calls) that never committed, and their
+            #   presence here shows up as duplicate / empty assistant
+            #   bubbles in the final snapshot.
+            #
+            # - Subgraph runs (at least one subgraph-boundary snapshot
+            #   already fired): keep the ``streamed_messages`` merge.
+            #   Subgraph messages are delivered to the client via the
+            #   mid-stream snapshots and must remain visible in the
+            #   final snapshot; the parent graph often returns
+            #   ``Command(goto=...)`` without folding them into state,
+            #   so the checkpoint alone is incomplete.
+            any_mid_stream_merge_fired = self.active_run.get(
+                "any_mid_stream_merge_fired", False
+            )
+            async for ev in self.get_state_and_messages_snapshots(
+                config, merge_streamed_messages=any_mid_stream_merge_fired
+            ):
                 yield ev
 
             for ev in self.handle_node_change(None):
@@ -1200,7 +1229,28 @@ class LangGraphAgent:
 
         return kwargs
 
-    async def get_state_and_messages_snapshots(self, config):
+    async def get_state_and_messages_snapshots(self, config, merge_streamed_messages: bool = True):
+        """Emit STATE_SNAPSHOT + MESSAGES_SNAPSHOT for the current checkpoint.
+
+        ``merge_streamed_messages`` controls whether uncommitted messages
+        accumulated in ``active_run["streamed_messages"]`` are appended to
+        the checkpoint's message list before emitting MESSAGES_SNAPSHOT.
+
+        Mid-stream callers (subgraph-boundary transitions) pass ``True``
+        (the default) so in-flight subgraph messages surface before their
+        parent commits — this is the PR #1426 subgraph-lag fix.
+
+        The post-run caller passes ``True`` only when at least one
+        mid-stream merge already fired (``any_mid_stream_merge_fired``),
+        i.e. a subgraph handoff delivered ``streamed_messages`` to the
+        client that the parent graph never committed to state; the final
+        snapshot must preserve them. Otherwise the post-run caller
+        passes ``False`` so the final snapshot is emitted from the
+        checkpoint alone — dropping transient/intermediate LLM outputs
+        (e.g. ``.with_structured_output()`` / router / classifier calls)
+        that never committed and would otherwise appear as duplicate /
+        empty assistant bubbles.
+        """
         state = await self.graph.aget_state(config)
         state_values = state.values if state.values is not None else state
         yield self._dispatch_event(
@@ -1208,11 +1258,12 @@ class LangGraphAgent:
         )
 
         checkpoint_messages = state_values.get("messages", [])
-        streamed_messages = self.active_run.get("streamed_messages", [])
-        if streamed_messages:
-            checkpoint_ids = {getattr(m, "id", None) for m in checkpoint_messages} - {None}
-            extra = [m for m in streamed_messages if getattr(m, "id", None) and getattr(m, "id", None) not in checkpoint_ids]
-            checkpoint_messages = checkpoint_messages + extra
+        if merge_streamed_messages:
+            streamed_messages = self.active_run.get("streamed_messages", [])
+            if streamed_messages:
+                checkpoint_ids = {getattr(m, "id", None) for m in checkpoint_messages} - {None}
+                extra = [m for m in streamed_messages if getattr(m, "id", None) and getattr(m, "id", None) not in checkpoint_ids]
+                checkpoint_messages = checkpoint_messages + extra
         snapshot_messages = self._filter_orphan_tool_messages(checkpoint_messages)
         yield self._dispatch_event(
             MessagesSnapshotEvent(

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "ag-ui-protocol>=0.1.10",
+    "ag-ui-protocol>=0.1.15",
     "langchain>=1.2.0",
     "langchain-core>=0.3.0",
     "langgraph>=0.3.25,<2",

--- a/integrations/langgraph/python/tests/_helpers.py
+++ b/integrations/langgraph/python/tests/_helpers.py
@@ -1,0 +1,88 @@
+"""Shared test helpers for ag-ui-langgraph integration tests.
+
+These helpers build lightweight ``LangGraphAgent`` fixtures backed by
+``MagicMock``/``AsyncMock`` stand-ins so tests can exercise agent logic in
+isolation, without spinning up a real graph or hitting any network.
+"""
+
+from typing import Any, Iterable, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+from langgraph.graph.state import CompiledStateGraph
+
+from ag_ui.core import EventType
+from ag_ui_langgraph.agent import LangGraphAgent
+
+
+def make_agent(subgraph_names: Optional[Iterable[str]] = None) -> LangGraphAgent:
+    """Return a ``LangGraphAgent`` whose graph is a mock with the given
+    subgraph nodes. Every listed name becomes a node whose ``bound``
+    attribute is itself a ``CompiledStateGraph`` mock, which is how the
+    agent detects subgraphs at construction time."""
+    graph = MagicMock(spec=CompiledStateGraph)
+    graph.config_specs = []
+    nodes = {}
+    for name in (subgraph_names or []):
+        node = MagicMock()
+        node.bound = MagicMock(spec=CompiledStateGraph)
+        nodes[name] = node
+    graph.nodes = nodes
+    return LangGraphAgent(name="test", graph=graph)
+
+
+def _record_dispatch(agent: LangGraphAgent):
+    """Replace ``agent._dispatch_event`` with a recording function.
+
+    The installed function appends every dispatched event to
+    ``agent.dispatched`` and returns the event unchanged so the rest of
+    the agent's control flow (which expects the return value) still
+    works. Using a named function instead of a lambda keeps tracebacks
+    readable and makes the side effect explicit."""
+    agent.dispatched = []
+
+    def _dispatch(event):
+        agent.dispatched.append(event)
+        return event
+
+    agent._dispatch_event = _dispatch
+    return agent
+
+
+def make_configured_agent(
+    checkpoint_messages: List[Any],
+    streamed_messages: Optional[List[Any]] = None,
+    subgraph_names: Optional[Iterable[str]] = None,
+    registered_tool_names: Optional[Iterable[str]] = None,
+) -> LangGraphAgent:
+    """Build an agent with a mocked checkpoint and a recording dispatcher.
+
+    The mocked ``graph.aget_state`` returns a state whose ``.values``
+    carries ``checkpoint_messages`` under the ``messages`` key.
+    ``streamed_messages`` is placed on ``active_run`` so the merge path in
+    ``get_state_and_messages_snapshots`` can observe it. When
+    ``registered_tool_names`` is provided, it becomes the set used by the
+    structured-output filter to distinguish user-facing tool calls from
+    internal schema invocations."""
+    agent = make_agent(list(subgraph_names) if subgraph_names else ["hotels_agent"])
+    agent.active_run = {
+        "id": "run-1",
+        "streamed_messages": list(streamed_messages or []),
+        "registered_tool_names": set(registered_tool_names or []),
+    }
+    _record_dispatch(agent)
+    agent.get_state_snapshot = MagicMock(return_value={})
+    state = MagicMock()
+    state.values = {"messages": checkpoint_messages}
+    agent.graph.aget_state = AsyncMock(return_value=state)
+    return agent
+
+
+def snapshot_event(dispatched: List[Any]):
+    """Return the first ``MESSAGES_SNAPSHOT`` event in a dispatched list.
+
+    Raises ``StopIteration`` if no snapshot was dispatched — callers use
+    this as an assertion that the snapshot was emitted."""
+    return next(
+        e for e in dispatched
+        if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT
+    )

--- a/integrations/langgraph/python/tests/test_make_json_safe.py
+++ b/integrations/langgraph/python/tests/test_make_json_safe.py
@@ -1,11 +1,10 @@
 """Tests for make_json_safe function."""
 import json
 import threading
+import unittest
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-
-import pytest
 
 from ag_ui_langgraph.utils import make_json_safe, json_safe_stringify
 
@@ -37,7 +36,7 @@ class DataclassWithRuntimeConfig:
     config: Any = None   # LangGraph-injected, not serializable
 
 
-class TestMakeJsonSafe:
+class TestMakeJsonSafe(unittest.TestCase):
     """Tests for make_json_safe function."""
 
     def test_primitives(self):

--- a/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
+++ b/integrations/langgraph/python/tests/test_messages_snapshot_filtering.py
@@ -1,0 +1,423 @@
+"""Tests for post-run vs mid-stream MESSAGES_SNAPSHOT semantics.
+
+Contract under test:
+
+    ``get_state_and_messages_snapshots`` takes a
+    ``merge_streamed_messages: bool = True`` parameter.
+
+    Mid-stream (subgraph-boundary transitions) callers pass the default:
+    the emitted MESSAGES_SNAPSHOT is ``checkpoint ++ uncommitted
+    streamed_messages`` so in-flight subgraph output surfaces before its
+    parent commits. This is PR #1426's subgraph-lag fix.
+
+    The post-run caller passes ``False``: the final MESSAGES_SNAPSHOT is
+    the checkpoint alone. This suppresses transient LLM outputs that
+    lived in ``streamed_messages`` but never committed — ``.with_structured_output()``
+    calls, router/classifier turns, supervisor routing bubbles — which
+    otherwise surface as duplicate / empty assistant bubbles in the
+    client.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ag_ui.core import EventType
+
+from tests._helpers import make_agent, make_configured_agent, snapshot_event
+
+
+def _structured_output_ai_message(
+    schema_name="Classification",
+    id_="struct-call-1",
+    call_id="call_struct_1",
+    args=None,
+):
+    """Build the AIMessage that ``.with_structured_output(Schema)``
+    emits: empty content and a single tool_call carrying the schema
+    name rather than a user-facing tool name."""
+    return AIMessage(
+        id=id_,
+        content="",
+        tool_calls=[
+            {
+                "name": schema_name,
+                "args": args or {"category": "greeting", "confidence": 0.9},
+                "id": call_id,
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+class TestPostRunSnapshotUsesCheckpointOnly(unittest.IsolatedAsyncioTestCase):
+    """The post-run MESSAGES_SNAPSHOT must come exclusively from the
+    checkpoint. Anything still sitting in ``streamed_messages`` at
+    end-of-run is, by definition, uncommitted — a transient model
+    output that the graph did not fold into its final state. Including
+    those here is what Paul's upgrade turned up as duplicate / empty
+    assistant bubbles."""
+
+    async def test_post_run_snapshot_uses_checkpoint_only(self):
+        user = HumanMessage(content="hi", id="u1")
+        committed_assistant = AIMessage(content="Hello!", id="a1")
+        uncommitted_streamed = AIMessage(
+            content="intermediate streamed bubble that never committed",
+            id="streamed-extra-1",
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user, committed_assistant],
+            streamed_messages=[uncommitted_streamed],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}, merge_streamed_messages=False):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
+        self.assertNotIn(
+            "streamed-extra-1", ids,
+            "Post-run snapshot must not include uncommitted streamed messages.",
+        )
+
+    async def test_post_run_snapshot_default_false_from_end_of_run(self):
+        """End-to-end: drive ``_handle_stream_events`` through its
+        post-run path and assert the streamed AIMessage captured from
+        ``on_chat_model_end`` does NOT appear in the final
+        MESSAGES_SNAPSHOT. This protects the caller wiring that passes
+        ``merge_streamed_messages=False`` at the post-run call site."""
+        agent = make_agent(["hotels_agent"])
+
+        # A streamed AIMessage that will be appended to
+        # active_run["streamed_messages"] by the on_chat_model_end
+        # handler. The checkpoint below does NOT contain it, so the old
+        # unconditional merge would leak it into the snapshot.
+        streamed_extra = AIMessage(
+            content="uncommitted tail bubble",
+            id="streamed-tail-1",
+        )
+
+        user = HumanMessage(content="hi", id="u1")
+        final_assistant = AIMessage(content="done", id="a1")
+
+        final_state = MagicMock()
+        final_state.values = {"messages": [user, final_assistant]}
+        final_state.tasks = []
+        final_state.next = []
+        final_state.metadata = {"writes": {}}
+
+        run_input = MagicMock()
+        run_input.run_id = "run-1"
+        run_input.thread_id = "thread-1"
+        run_input.messages = []
+        run_input.forwarded_props = {}
+        run_input.tools = []
+
+        async def fake_prepare(*args, **kwargs):
+            agent.active_run["schema_keys"] = {
+                "input": ["messages"], "output": ["messages"],
+                "config": [], "context": [],
+            }
+
+            async def gen():
+                yield {
+                    "event": "on_chat_model_end",
+                    "name": "planner",
+                    "data": {"output": streamed_extra},
+                    "metadata": {
+                        "langgraph_node": "planner",
+                        "langgraph_checkpoint_ns": "",
+                    },
+                    "run_id": "run-1",
+                }
+
+            return {
+                "stream": gen(),
+                "state": MagicMock(values={"messages": []}),
+                "config": {"configurable": {"thread_id": "thread-1"}},
+            }
+
+        agent.graph.aget_state = AsyncMock(return_value=final_state)
+        agent.prepare_stream = fake_prepare
+
+        collected = []
+        async for ev in agent._handle_stream_events(run_input):
+            collected.append(ev)
+
+        snapshots = [e for e in collected if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT]
+        self.assertGreaterEqual(len(snapshots), 1)
+        final_snap = snapshots[-1]
+        ids = [m.id for m in final_snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
+        self.assertNotIn(
+            "streamed-tail-1", ids,
+            "End-of-run snapshot must not leak uncommitted streamed messages.",
+        )
+
+
+class TestPostRunPreservesStreamedAfterMidStreamMerge(unittest.IsolatedAsyncioTestCase):
+    """When a mid-stream subgraph-boundary snapshot fired during the
+    run, streamed_messages were already delivered to the client through
+    that snapshot. The post-run final snapshot must not wipe them: it
+    continues to merge streamed_messages so the client's message list
+    stays consistent. This is the dojo subgraphs / travel-agent
+    scenario where the supervisor's routing AIMessage is only ever in
+    ``streamed_messages`` (supervisor returns ``Command(goto=...)``
+    without an ``update``) yet must survive to the final snapshot."""
+
+    async def test_post_run_preserves_streamed_when_mid_stream_merge_fired(self):
+        agent = make_agent(["flights_agent"])
+
+        supervisor_routing_msg = AIMessage(
+            content="",
+            id="supervisor-route-1",
+            tool_calls=[
+                {
+                    "name": "SupervisorResponseFormatter",
+                    "args": {
+                        "answer": "Handing off to flights.",
+                        "next_agent": "flights_agent",
+                    },
+                    "id": "call_sup_1",
+                    "type": "tool_call",
+                }
+            ],
+        )
+
+        user = HumanMessage(content="plan my trip", id="u1")
+        # The checkpoint never commits the supervisor's routing
+        # AIMessage — supervisor returned Command(goto=...) without an
+        # update. The final state below reflects that.
+        final_state = MagicMock()
+        final_state.values = {"messages": [user]}
+        final_state.tasks = []
+        final_state.next = []
+        final_state.metadata = {"writes": {}}
+
+        run_input = MagicMock()
+        run_input.run_id = "run-1"
+        run_input.thread_id = "thread-1"
+        run_input.messages = []
+        run_input.forwarded_props = {}
+        run_input.tools = []
+
+        async def fake_prepare(*args, **kwargs):
+            agent.active_run["schema_keys"] = {
+                "input": ["messages"], "output": ["messages"],
+                "config": [], "context": [],
+            }
+
+            async def gen():
+                # The supervisor's LLM end-of-stream lands in
+                # streamed_messages.
+                yield {
+                    "event": "on_chat_model_end",
+                    "name": "supervisor",
+                    "data": {"output": supervisor_routing_msg},
+                    "metadata": {
+                        "langgraph_node": "supervisor",
+                        "langgraph_checkpoint_ns": "",
+                    },
+                    "run_id": "run-1",
+                }
+                # Then the flights_agent subgraph starts — ns change
+                # triggers the mid-stream boundary snapshot.
+                yield {
+                    "event": "on_chain_start",
+                    "name": "flights_agent",
+                    "data": {},
+                    "metadata": {
+                        "langgraph_node": "flights_agent",
+                        "langgraph_checkpoint_ns": "flights_agent:abc",
+                    },
+                    "run_id": "run-1",
+                }
+
+            return {
+                "stream": gen(),
+                "state": MagicMock(values={"messages": []}),
+                "config": {"configurable": {"thread_id": "thread-1"}},
+            }
+
+        agent.graph.aget_state = AsyncMock(return_value=final_state)
+        agent.prepare_stream = fake_prepare
+
+        collected = []
+        async for ev in agent._handle_stream_events(run_input):
+            collected.append(ev)
+
+        snapshots = [e for e in collected if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT]
+        # At minimum: mid-stream at subgraph boundary + post-run.
+        self.assertGreaterEqual(len(snapshots), 2)
+        final_snap = snapshots[-1]
+        ids = [m.id for m in final_snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn(
+            "supervisor-route-1", ids,
+            "Post-run snapshot must preserve supervisor routing AIMessage "
+            "delivered through the mid-stream subgraph-boundary merge.",
+        )
+
+
+class TestMidStreamSubgraphBoundaryMergesStreamed(unittest.IsolatedAsyncioTestCase):
+    """The mid-stream call path — invoked on every subgraph →
+    root/parent transition — must still merge ``streamed_messages`` on
+    top of the checkpoint. This is the exact window PR #1426 closed:
+    between the subgraph producing its output and the parent graph
+    committing it, the client would otherwise lose the subgraph's
+    visible message."""
+
+    async def test_mid_stream_subgraph_boundary_merges_streamed(self):
+        user = HumanMessage(content="AMS to SF", id="u1")
+        flights = AIMessage(content="Booked KLM", id="f1")
+        hotels_uncommitted = AIMessage(content="Booked Hotel Zoe", id="h-uncommitted-1")
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user, flights],
+            streamed_messages=[hotels_uncommitted],
+        )
+
+        # Default merge_streamed_messages=True — mid-stream semantics.
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("f1", ids)
+        self.assertIn(
+            "h-uncommitted-1", ids,
+            "Mid-stream snapshot must include uncommitted subgraph messages.",
+        )
+        self.assertGreater(ids.index("h-uncommitted-1"), ids.index("f1"))
+
+
+class TestSupervisorBindToolsMessageSurvivesMidStream(unittest.IsolatedAsyncioTestCase):
+    """Regression guard against the dojo subgraphs / travel-agent
+    failure. A supervisor AIMessage produced by
+    ``model.bind_tools([SupervisorResponseFormatter])`` has empty
+    textual content and a tool_call naming a Pydantic schema, not a
+    user-registered tool. The content the user sees lives in
+    ``tool_call.args["answer"]``; the message itself flows through
+    ``streamed_messages`` because the supervisor only commits a new
+    AIMessage(content=args["answer"]) when routing to END.
+
+    The earlier registry-based filter mistook this for a
+    .with_structured_output() call and dropped it, breaking subgraph
+    flow. Under the new semantics the mid-stream merge is
+    shape-agnostic: it includes every uncommitted streamed message."""
+
+    async def test_supervisor_bind_tools_message_survives_mid_stream(self):
+        user = HumanMessage(content="plan my trip", id="u1")
+        supervisor_bind_tools_msg = AIMessage(
+            id="supervisor-bind-1",
+            content="",
+            tool_calls=[
+                {
+                    "name": "SupervisorResponseFormatter",
+                    "args": {
+                        "answer": "I'll hand you off to the flights agent.",
+                        "next": "flights_agent",
+                    },
+                    "id": "call_supervisor_1",
+                    "type": "tool_call",
+                }
+            ],
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user],
+            streamed_messages=[supervisor_bind_tools_msg],
+            # Intentionally none of these tools name
+            # SupervisorResponseFormatter — this is exactly the shape the
+            # old registry-based filter rejected.
+            registered_tool_names=["search_flights", "book_hotel"],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn(
+            "supervisor-bind-1", ids,
+            "Supervisor bind_tools AIMessage must survive the mid-stream "
+            "snapshot merge — dropping it breaks subgraph routing.",
+        )
+
+
+class TestStructuredOutputCallExcludedFromPostRunSnapshot(unittest.IsolatedAsyncioTestCase):
+    """The Paul regression case: a ``.with_structured_output()`` call
+    emits an AIMessage with empty content + a Pydantic-schema tool_call.
+    It lands in ``streamed_messages`` via on_chat_model_end but the
+    graph never folds it into state. At end-of-run it must NOT appear
+    in MESSAGES_SNAPSHOT."""
+
+    async def test_structured_output_call_excluded_from_post_run_snapshot(self):
+        user = HumanMessage(content="classify this", id="u1")
+        final_assistant = AIMessage(content="it's a greeting", id="a1")
+        structured = _structured_output_ai_message(
+            schema_name="Classification",
+            id_="structured-leak-1",
+            call_id="call_structured_1",
+            args={"category": "greeting"},
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user, final_assistant],
+            streamed_messages=[structured],
+        )
+
+        # Post-run semantics.
+        async for _ in agent.get_state_and_messages_snapshots({}, merge_streamed_messages=False):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("u1", ids)
+        self.assertIn("a1", ids)
+        self.assertNotIn(
+            "structured-leak-1", ids,
+            "A .with_structured_output() AIMessage that never committed "
+            "must not appear in the post-run snapshot.",
+        )
+
+
+class TestStructuredOutputIncludedAtMidStreamSubgraphBoundary(unittest.IsolatedAsyncioTestCase):
+    """Companion to the post-run exclusion test: the new fix is
+    load-bearing on WHICH call path is used, not on message shape. A
+    schema-named tool_call AIMessage that reaches the mid-stream
+    merge — e.g. because the supervisor produced it and the subgraph
+    boundary fired before the supervisor committed — must survive.
+    This is precisely the shape the dojo subgraph flow depends on."""
+
+    async def test_structured_shaped_message_included_mid_stream(self):
+        user = HumanMessage(content="hi", id="u1")
+        streamed = _structured_output_ai_message(
+            schema_name="SupervisorResponseFormatter",
+            id_="shaped-mid-stream-1",
+            call_id="call_shaped_1",
+            args={"answer": "handing off", "next": "flights"},
+        )
+
+        agent = make_configured_agent(
+            checkpoint_messages=[user],
+            streamed_messages=[streamed],
+        )
+
+        async for _ in agent.get_state_and_messages_snapshots({}):
+            pass
+
+        snap = snapshot_event(agent.dispatched)
+        ids = [m.id for m in snap.messages]
+        self.assertIn("shaped-mid-stream-1", ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_subgraph_streaming.py
+++ b/integrations/langgraph/python/tests/test_subgraph_streaming.py
@@ -15,27 +15,11 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.graph.state import CompiledStateGraph
 
-from ag_ui_langgraph.agent import LangGraphAgent, ROOT_SUBGRAPH_NAME
+from ag_ui_langgraph.agent import ROOT_SUBGRAPH_NAME
 from ag_ui.core import EventType
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_agent(subgraph_names=None):
-    """Return a LangGraphAgent with mocked CompiledStateGraph subgraph nodes."""
-    graph = MagicMock(spec=CompiledStateGraph)
-    graph.config_specs = []
-    nodes = {}
-    for name in (subgraph_names or []):
-        node = MagicMock()
-        node.bound = MagicMock(spec=CompiledStateGraph)
-        nodes[name] = node
-    graph.nodes = nodes
-    return LangGraphAgent(name="test", graph=graph)
+from tests._helpers import make_agent as _make_agent, make_configured_agent
 
 
 def _event_types(events):
@@ -112,25 +96,14 @@ class TestSubgraphDetection(unittest.TestCase):
 
 class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
 
-    def _make_agent(self, checkpoint_messages, streamed_messages=None):
-        agent = _make_agent(["hotels_agent"])
-        agent.active_run = {"id": "run-1", "streamed_messages": streamed_messages or []}
-        agent.dispatched = []
-        agent._dispatch_event = lambda ev: agent.dispatched.append(ev) or ev
-        agent.get_state_snapshot = MagicMock(return_value={})
-        state = MagicMock()
-        state.values = {"messages": checkpoint_messages}
-        agent.graph.aget_state = AsyncMock(return_value=state)
-        return agent
-
     async def test_dispatches_state_snapshot(self):
-        agent = self._make_agent([HumanMessage(content="hi", id="u1")])
+        agent = make_configured_agent([HumanMessage(content="hi", id="u1")])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         self.assertIn("STATE_SNAPSHOT", _event_types(agent.dispatched))
 
     async def test_dispatches_messages_snapshot(self):
-        agent = self._make_agent([HumanMessage(content="hi", id="u1")])
+        agent = make_configured_agent([HumanMessage(content="hi", id="u1")])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         self.assertIn("MESSAGES_SNAPSHOT", _event_types(agent.dispatched))
@@ -140,7 +113,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         user = HumanMessage(content="AMS to SF", id="u1")
         flights = AIMessage(content="Booked KLM", id="f1")
         hotels = AIMessage(content="Booked Hotel Zoe", id="h1")
-        agent = self._make_agent([user, flights, hotels])
+        agent = make_configured_agent([user, flights, hotels])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)
@@ -153,7 +126,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         user = HumanMessage(content="hi", id="u1")
         flights = AIMessage(content="Booked KLM", id="f1")
         supervisor_routing = AIMessage(content="routing", id="sup1")
-        agent = self._make_agent([user, flights], streamed_messages=[supervisor_routing])
+        agent = make_configured_agent([user, flights], streamed_messages=[supervisor_routing])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)
@@ -165,7 +138,7 @@ class TestGetStateAndMessagesSnapshots(unittest.IsolatedAsyncioTestCase):
         """A streamed message whose ID is already in the checkpoint appears only once."""
         user = HumanMessage(content="hi", id="u1")
         exp = AIMessage(content="activities", id="exp1")
-        agent = self._make_agent([user, exp], streamed_messages=[exp])
+        agent = make_configured_agent([user, exp], streamed_messages=[exp])
         async for _ in agent.get_state_and_messages_snapshots({}):
             pass
         snap = next(e for e in agent.dispatched if getattr(e, "type", None) == EventType.MESSAGES_SNAPSHOT)

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10, <3.14"
 
 [[package]]
 name = "ag-ui-langgraph"
-version = "0.0.29"
+version = "0.0.33"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -26,7 +26,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", specifier = ">=0.1.10" },
+    { name = "ag-ui-protocol", specifier = ">=0.1.15" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.12" },
     { name = "langchain", specifier = ">=1.2.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
@@ -40,14 +40,14 @@ dev = [{ name = "fastapi", specifier = ">=0.115.12" }]
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.11"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/c1/33ab11dc829c6c28d0d346988b2f394aa632d3ad63d1d2eb5f16eccd769b/ag_ui_protocol-0.1.11.tar.gz", hash = "sha256:b336dfebb5751e9cc2c676a3008a4bce4819004e6f6f8cba73169823564472ae", size = 6249, upload-time = "2026-02-11T12:41:36.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/83/5c6f4cb24d27d9cbe0c31ba2f3b4d1ff42bc6f87ba9facfa9e9d44046c6b/ag_ui_protocol-0.1.11-py3-none-any.whl", hash = "sha256:b0cc25570462a8eba8e57a098e0a2d6892a1f571a7bea7da2d4b60efd5d66789", size = 8392, upload-time = "2026-02-11T12:41:35.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes a regression in `ag-ui-langgraph` between **0.0.21 -> 0.0.30** where `MESSAGES_SNAPSHOT` emits duplicate / empty assistant messages, causing repeated feedback UI triggers on a single response. Tracked as `FOR-91`; reported as blocking a customer release.

## Root cause

PR #1426 (commit `24aa9af`, shipped in 0.0.30) added a `streamed_messages` collection that captures every `on_chat_model_end` output, and merged it into `MESSAGES_SNAPSHOT` at **both** call sites:

- **Mid-stream** (subgraph-boundary transition) — correct. Between a subgraph producing output and its parent committing, the checkpoint trails what the user just saw streamed. This is exactly the window PR #1426 was written to close.
- **Post-run** (after the main `astream_events` loop) — **the bug** for non-subgraph flows. At end-of-run of a plain chat/tool-call graph the checkpoint IS the final authoritative state; merging `streamed_messages` on top re-introduces transient LLM outputs (`.with_structured_output()` calls, router/classifier turns) that never committed. These surface to the client as duplicate / empty assistant messages.

Post-run is NOT a bug in subgraph flows: when a supervisor returns `Command(goto=next_agent)` without an `update={"messages": ...}`, the supervisor's routing AIMessage only ever lives in `streamed_messages`. It was delivered to the client through the mid-stream boundary snapshot; the final snapshot must preserve it or the client's message list gets wiped.

## Approach

Route the post-run merge by subgraph history. `get_state_and_messages_snapshots` now takes `merge_streamed_messages: bool = True`:

- Mid-stream subgraph-boundary callers keep the default (`True`) — PR #1426's subgraph-lag fix is preserved unchanged.
- Mid-stream boundary handler sets `active_run["any_mid_stream_merge_fired"] = True` every time it fires.
- The post-run caller passes that flag: `True` when at least one mid-stream merge already delivered streamed_messages to the client (preserve them — subgraph flow), `False` otherwise (final snapshot is the checkpoint alone — non-subgraph flow, Paul's fix).

No shape-based filtering, no registry of tool names, no classification of AIMessage content. The fix is keyed entirely on call path + subgraph history.

### Why the earlier registry-based approach was dropped

An earlier revision of this PR classified messages by shape (empty content + tool_call naming something outside `RunAgentInput.tools` -> drop). That broke the dojo `langgraph-fastapi` subgraphs / travel-agent flow: its supervisor uses `model.bind_tools([SupervisorResponseFormatter])` where `SupervisorResponseFormatter` is a Pydantic schema, not a user-facing tool — so the supervisor's routing AIMessage (empty `.content`, tool_call naming the schema) was mistakenly classified as an internal call and dropped, killing subgraph handoff. The new fix is shape-agnostic and keyed on call path + subgraph history, so that message survives.

## Commits

1. `test(langgraph): extract shared test helpers` — lifts fixtures out of `test_subgraph_streaming.py` into `tests/_helpers.py` for reuse.
2. `test(langgraph): run test_make_json_safe via unittest discover` — converts to `unittest.TestCase` so the repo-standard runner picks up the 16 JSON-safety tests.
3. `fix(langgraph): emit post-run MESSAGES_SNAPSHOT from checkpoint only for non-subgraph runs` — the narrow fix in `agent.py`.
4. `test(langgraph): cover post-run vs mid-stream snapshot semantics` — new test file covering both call paths, the Paul regression, the subgraph preservation path, and the dojo subgraphs regression guard.
5. `build(langgraph): bump ag-ui-protocol floor to 0.1.15` — `utils.py` imports `ImageInputContent` etc., which need 0.1.15.
6. `ci: run ag-ui-langgraph Python unit tests on integration path changes` — adds a `langgraph-python` job; previously this package had no PR-path CI coverage.

## Test plan

- [x] `uv run python -m unittest discover tests` — 112/112 pass
- [x] Existing `test_subgraph_streaming.py` untouched; mid-stream `streamed_messages` merge is preserved (PR #1426 tests still green)
- [x] New regression guard for the dojo subgraphs / travel-agent supervisor `bind_tools` flow
- [x] Post-run path no longer leaks uncommitted `streamed_messages` in non-subgraph runs (Paul's reproducer case)
- [x] Post-run path preserves streamed_messages in subgraph runs (dojo preservation case)
- [ ] `dojo / langgraph-fastapi` CI check passes
- [ ] Customer validates against their reproducer

## Notes

Stacked follow-up PR addresses pre-existing typing gaps surfaced during review (`RunMetadata` drift, `active_run` None-check discipline, bare `except Exception: raise`, `_dispatch_event` return type, `get_schema_keys` broad exception swallow, `history_config` undefined name).