### PR TITLE
fix(mastra): sync thread history to CopilotKit and preserve message identity

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -7,6 +7,7 @@ import { MastraAgent } from "../mastra";
 export class FakeMemory {
   threads: Map<string, any> = new Map();
   workingMemoryValue: string | undefined = undefined;
+  recallMessages: any[] = [];
 
   async getThreadById({ threadId }: { threadId: string }) {
     return this.threads.get(threadId) ?? null;
@@ -18,6 +19,10 @@ export class FakeMemory {
 
   async getWorkingMemory(_opts: any): Promise<string | undefined> {
     return this.workingMemoryValue;
+  }
+
+  async recall(_opts: any): Promise<{ messages: any[] }> {
+    return { messages: this.recallMessages };
   }
 }
 

--- a/integrations/mastra/typescript/src/__tests__/mastra-to-agui-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/mastra-to-agui-conversion.test.ts
@@ -1,0 +1,628 @@
+import { convertAGUIMessagesToMastra, convertMastraMessagesToAGUI } from "../utils";
+
+describe("convertMastraMessagesToAGUI", () => {
+  describe("user messages", () => {
+    it("converts text parts to string content", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "Hello world" }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([
+        { id: "msg-1", role: "user", content: "Hello world" },
+      ]);
+    });
+
+    it("joins multiple text parts with newlines", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [
+              { type: "text", text: "First part" },
+              { type: "text", text: "Second part" },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([
+        { id: "msg-1", role: "user", content: "First part\nSecond part" },
+      ]);
+    });
+
+    it("returns empty string for messages with no text parts", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: { format: 2, parts: [] },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([
+        { id: "msg-1", role: "user", content: "" },
+      ]);
+    });
+  });
+
+  describe("assistant messages", () => {
+    it("converts text-only assistant messages", () => {
+      const messages = [
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "I can help you with that." }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: "I can help you with that.",
+          toolCalls: undefined,
+        },
+      ]);
+    });
+
+    it("converts assistant messages with tool invocations (result state)", () => {
+      const messages = [
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              { type: "text", text: "Let me check that." },
+              {
+                type: "tool-invocation",
+                toolCallId: "call-1",
+                toolName: "get_weather",
+                args: { city: "Paris" },
+                state: "result",
+                result: { temperature: 22, unit: "celsius" },
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      // Should produce assistant message + tool result message
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: "msg-2",
+        role: "assistant",
+        content: "Let me check that.",
+      });
+      expect(result[0]).toHaveProperty("toolCalls");
+      expect((result[0] as any).toolCalls[0]).toMatchObject({
+        id: "call-1",
+        type: "function",
+        function: {
+          name: "get_weather",
+          arguments: JSON.stringify({ city: "Paris" }),
+        },
+      });
+      expect(result[1]).toMatchObject({
+        role: "tool",
+        content: JSON.stringify({ temperature: 22, unit: "celsius" }),
+        toolCallId: "call-1",
+      });
+    });
+
+    it("converts tool-call parts (non-invocation format)", () => {
+      const messages = [
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "tool-call",
+                toolCallId: "call-2",
+                toolName: "search",
+                args: { query: "test" },
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: "msg-2",
+        role: "assistant",
+      });
+      expect((result[0] as any).toolCalls[0]).toMatchObject({
+        id: "call-2",
+        type: "function",
+        function: {
+          name: "search",
+          arguments: JSON.stringify({ query: "test" }),
+        },
+      });
+    });
+  });
+
+  describe("system messages", () => {
+    it("skips system messages", () => {
+      const messages = [
+        {
+          id: "msg-sys",
+          role: "system",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "You are a helpful assistant." }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("mixed conversations", () => {
+    it("converts a full conversation with user, assistant, and tool messages", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "What's the weather?" }],
+          },
+        },
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              { type: "text", text: "Checking..." },
+              {
+                type: "tool-invocation",
+                toolCallId: "call-1",
+                toolName: "get_weather",
+                args: { city: "NYC" },
+                state: "result",
+                result: "Sunny, 25°C",
+              },
+            ],
+          },
+        },
+        {
+          id: "msg-3",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "It's sunny and 25°C in NYC." }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toHaveLength(4); // user + assistant+tool + assistant
+      expect(result[0].role).toBe("user");
+      expect(result[1].role).toBe("assistant");
+      expect(result[2].role).toBe("tool");
+      expect(result[3].role).toBe("assistant");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty array for empty input", () => {
+      expect(convertMastraMessagesToAGUI([])).toEqual([]);
+    });
+
+    it("handles missing parts gracefully", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: { format: 2 } as any, // no parts
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toEqual([
+        { id: "msg-1", role: "user", content: "" },
+      ]);
+    });
+
+    it("preserves original message IDs", () => {
+      const messages = [
+        {
+          id: "original-id-123",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "Hello" }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result[0].id).toBe("original-id-123");
+    });
+
+    it("handles tool result as string", () => {
+      const messages = [
+        {
+          id: "msg-2",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "tool-invocation",
+                toolCallId: "call-1",
+                toolName: "get_weather",
+                args: {},
+                state: "result",
+                result: "sunny",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result[1]).toMatchObject({
+        role: "tool",
+        content: "sunny",
+        toolCallId: "call-1",
+      });
+    });
+  });
+
+  describe("multimodal content", () => {
+    it("decodes user image parts (forward-converter shape) back to InputContent", () => {
+      // This is the exact shape `convertAGUIMessagesToMastra` emits for an
+      // AG-UI image: { type: "image", image: "data:<mime>;base64,<raw>" }.
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [
+              { type: "text", text: "Look at this:" },
+              {
+                type: "image",
+                image: "data:image/png;base64,BASE64PNG",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: "msg-1",
+        role: "user",
+        content: [
+          { type: "text", text: "Look at this:" },
+          {
+            type: "image",
+            source: { type: "data", value: "BASE64PNG", mimeType: "image/png" },
+          },
+        ],
+      });
+    });
+
+    it("decodes audio/video/document file parts with data URLs back to raw base64", () => {
+      // Forward-converter shape: { type: "file", mimeType, data: "data:...;base64,<raw>" }
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "file",
+                mimeType: "audio/mp3",
+                data: "data:audio/mp3;base64,AUDIODATA",
+              },
+              {
+                type: "file",
+                mimeType: "video/mp4",
+                data: "data:video/mp4;base64,VIDEODATA",
+              },
+              {
+                type: "file",
+                mimeType: "application/pdf",
+                data: "data:application/pdf;base64,PDFDATA",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result).toHaveLength(1);
+      expect((result[0] as any).content).toEqual([
+        {
+          type: "audio",
+          source: { type: "data", value: "AUDIODATA", mimeType: "audio/mp3" },
+        },
+        {
+          type: "video",
+          source: { type: "data", value: "VIDEODATA", mimeType: "video/mp4" },
+        },
+        {
+          type: "document",
+          source: { type: "data", value: "PDFDATA", mimeType: "application/pdf" },
+        },
+      ]);
+    });
+
+    it("uses url source when file part has a url", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "file",
+                mimeType: "image/jpeg",
+                url: "https://example.com/cat.jpg",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect((result[0] as any).content).toEqual([
+        {
+          type: "image",
+          source: {
+            type: "url",
+            value: "https://example.com/cat.jpg",
+            mimeType: "image/jpeg",
+          },
+        },
+      ]);
+    });
+
+    it("round-trips AG-UI image(data) → Mastra → AG-UI snapshot", () => {
+      const original = [
+        {
+          id: "msg-1",
+          role: "user" as const,
+          content: [
+            { type: "text" as const, text: "Here's an image:" },
+            {
+              type: "image" as const,
+              source: {
+                type: "data" as const,
+                value: "BASE64PNG",
+                mimeType: "image/png",
+              },
+            },
+          ],
+        },
+      ];
+
+      // AG-UI → Mastra CoreMessage
+      const coreMessages = convertAGUIMessagesToMastra(original as any);
+
+      // Simulate storage in Mastra V2 format. Forward converter produced
+      // `{ type: "image", image: "data:image/png;base64,BASE64PNG" }`, and
+      // that's exactly what ends up on the stored MastraDBMessage parts array.
+      const storedContent = coreMessages[0].content;
+      const storedParts = Array.isArray(storedContent) ? storedContent : [];
+      const stored = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: { format: 2, parts: storedParts },
+        },
+      ];
+
+      const snapshot = convertMastraMessagesToAGUI(stored);
+
+      expect(snapshot[0]).toEqual({
+        id: "msg-1",
+        role: "user",
+        content: [
+          { type: "text", text: "Here's an image:" },
+          {
+            type: "image",
+            source: { type: "data", value: "BASE64PNG", mimeType: "image/png" },
+          },
+        ],
+      });
+    });
+
+    it("round-trips AG-UI audio/video/document(data) → Mastra → AG-UI snapshot", () => {
+      const original = [
+        {
+          id: "msg-1",
+          role: "user" as const,
+          content: [
+            {
+              type: "audio" as const,
+              source: {
+                type: "data" as const,
+                value: "AUDIODATA",
+                mimeType: "audio/mp3",
+              },
+            },
+            {
+              type: "video" as const,
+              source: {
+                type: "data" as const,
+                value: "VIDEODATA",
+                mimeType: "video/mp4",
+              },
+            },
+            {
+              type: "document" as const,
+              source: {
+                type: "data" as const,
+                value: "PDFDATA",
+                mimeType: "application/pdf",
+              },
+            },
+          ],
+        },
+      ];
+
+      const coreMessages = convertAGUIMessagesToMastra(original as any);
+      const storedContent = coreMessages[0].content;
+      const storedParts = Array.isArray(storedContent) ? storedContent : [];
+      const stored = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: { format: 2, parts: storedParts },
+        },
+      ];
+
+      const snapshot = convertMastraMessagesToAGUI(stored);
+
+      expect((snapshot[0] as any).content).toEqual([
+        {
+          type: "audio",
+          source: { type: "data", value: "AUDIODATA", mimeType: "audio/mp3" },
+        },
+        {
+          type: "video",
+          source: { type: "data", value: "VIDEODATA", mimeType: "video/mp4" },
+        },
+        {
+          type: "document",
+          source: { type: "data", value: "PDFDATA", mimeType: "application/pdf" },
+        },
+      ]);
+    });
+
+    it("keeps plain string content for text-only user messages", () => {
+      const messages = [
+        {
+          id: "msg-1",
+          role: "user",
+          content: {
+            format: 2,
+            parts: [{ type: "text", text: "just text" }],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result[0]).toEqual({
+        id: "msg-1",
+        role: "user",
+        content: "just text",
+      });
+    });
+  });
+
+  describe("stable IDs", () => {
+    it("produces identical output across repeated calls with the same input", () => {
+      const messages = [
+        {
+          id: "msg-assistant",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              { type: "text", text: "Running tool" },
+              {
+                type: "tool-invocation",
+                toolCallId: "call-abc",
+                toolName: "search",
+                args: { q: "x" },
+                state: "result",
+                result: { hits: 3 },
+              },
+              {
+                type: "tool-invocation",
+                toolCallId: "call-def",
+                toolName: "lookup",
+                args: { id: "42" },
+                state: "result",
+                result: "ok",
+              },
+            ],
+          },
+        },
+      ];
+
+      const first = convertMastraMessagesToAGUI(messages);
+      const second = convertMastraMessagesToAGUI(messages);
+
+      expect(first).toEqual(second);
+    });
+
+    it("derives tool result message IDs from parent message + toolCallId", () => {
+      const messages = [
+        {
+          id: "msg-assistant",
+          role: "assistant",
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: "tool-invocation",
+                toolCallId: "call-abc",
+                toolName: "search",
+                args: {},
+                state: "result",
+                result: "ok",
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = convertMastraMessagesToAGUI(messages);
+
+      expect(result[1]).toMatchObject({
+        id: "msg-assistant:call-abc:result",
+        role: "tool",
+        toolCallId: "call-abc",
+      });
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -10,7 +10,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "Hello world" }]);
+      expect(result).toEqual([{ id: expect.any(String), role: "user", content: "Hello world" }]);
     });
 
     it("converts array content with text parts", () => {
@@ -28,7 +28,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result).toEqual([
-        { role: "user", content: "First part\nSecond part" },
+        { id: expect.any(String), role: "user", content: "First part\nSecond part" },
       ]);
     });
 
@@ -39,7 +39,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "" }]);
+      expect(result).toEqual([{ id: expect.any(String), role: "user", content: "" }]);
     });
 
     it("preserves non-text parts as structured content", () => {
@@ -61,6 +61,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             { type: "text", text: "Keep this" },
@@ -85,7 +86,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "hello\nworld" }]);
+      expect(result).toEqual([{ id: expect.any(String), role: "user", content: "hello\nworld" }]);
     });
   });
 
@@ -111,6 +112,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             { type: "image", image: "https://example.com/photo.jpg" },
@@ -141,6 +143,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             { type: "image", image: "data:image/png;base64,abc123" },
@@ -171,6 +174,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             {
@@ -205,6 +209,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             {
@@ -232,7 +237,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result).toEqual([
-        { role: "user", content: "Hello\nWorld" },
+        { id: expect.any(String), role: "user", content: "Hello\nWorld" },
       ]);
     });
 
@@ -244,7 +249,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result).toEqual([
-        { role: "user", content: "Just a string" },
+        { id: expect.any(String), role: "user", content: "Just a string" },
       ]);
     });
 
@@ -295,6 +300,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "user",
           content: [
             { type: "text", text: "Look at this image:" },
@@ -316,6 +322,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "assistant",
           content: [{ type: "text", text: "I can help with that" }],
         },
@@ -345,6 +352,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "assistant",
           content: [
             {
@@ -381,6 +389,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: expect.any(String),
           role: "assistant",
           content: [
             { type: "text", text: "Let me check" },
@@ -457,6 +466,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result[1]).toEqual({
+        id: expect.any(String),
         role: "tool",
         content: [
           {
@@ -482,6 +492,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result[0]).toEqual({
+        id: expect.any(String),
         role: "tool",
         content: [
           {
@@ -538,6 +549,38 @@ describe("convertAGUIMessagesToMastra", () => {
 
     it("returns empty array for empty messages", () => {
       expect(convertAGUIMessagesToMastra([])).toEqual([]);
+    });
+  });
+
+  describe("id preservation", () => {
+    it("preserves AG-UI message ids on CoreMessage output so Mastra dedupes", () => {
+      const messages: Message[] = [
+        { id: "msg-user-1", role: "user", content: "hi" },
+        {
+          id: "msg-assistant-1",
+          role: "assistant",
+          content: "hello",
+          toolCalls: [
+            {
+              id: "tc-1",
+              type: "function",
+              function: { name: "f", arguments: "{}" },
+            },
+          ],
+        },
+        {
+          id: "msg-tool-1",
+          role: "tool",
+          content: "done",
+          toolCallId: "tc-1",
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect((result[0] as any).id).toBe("msg-user-1");
+      expect((result[1] as any).id).toBe("msg-assistant-1");
+      expect((result[2] as any).id).toBe("msg-tool-1");
     });
   });
 });

--- a/integrations/mastra/typescript/src/__tests__/messages-snapshot.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/messages-snapshot.test.ts
@@ -1,0 +1,226 @@
+import { EventType } from "@ag-ui/client";
+import {
+  FakeMemory,
+  makeLocalMastraAgent,
+  makeRemoteMastraAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+
+const SIMPLE_STREAM_CHUNKS = [
+  { type: "text-delta", payload: { text: "Hello" } },
+  { type: "finish", payload: {} },
+];
+
+describe("MESSAGES_SNAPSHOT emission", () => {
+  it("emits MESSAGES_SNAPSHOT before RUN_FINISHED when memory has messages", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      },
+      {
+        id: "msg-2",
+        role: "assistant",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hi there!" }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.MESSAGES_SNAPSHOT);
+
+    // MESSAGES_SNAPSHOT should come before RUN_FINISHED
+    const snapshotIdx = types.indexOf(EventType.MESSAGES_SNAPSHOT);
+    const finishedIdx = types.indexOf(EventType.RUN_FINISHED);
+    expect(snapshotIdx).toBeLessThan(finishedIdx);
+
+    // Verify the snapshot content
+    const snapshot = events.find((e) => e.type === EventType.MESSAGES_SNAPSHOT) as any;
+    expect(snapshot.messages).toHaveLength(2);
+    expect(snapshot.messages[0]).toMatchObject({
+      id: "msg-1",
+      role: "user",
+      content: "Hello",
+    });
+    expect(snapshot.messages[1]).toMatchObject({
+      id: "msg-2",
+      role: "assistant",
+      content: "Hi there!",
+    });
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT when memory has no messages", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT when recalled history is system-only", async () => {
+    // System messages are intentionally dropped by convertMastraMessagesToAGUI,
+    // which would leave an empty AG-UI snapshot. Emitting that would wipe
+    // client-side conversation state.
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "sys-1",
+        role: "system",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "You are a helpful assistant." }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT for remote agents", async () => {
+    const agent = makeRemoteMastraAgent({
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("emits MESSAGES_SNAPSHOT after STATE_SNAPSHOT (working memory)", async () => {
+    const memory = new FakeMemory();
+    memory.workingMemoryValue = JSON.stringify({ key: "value" });
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    const stateIdx = types.indexOf(EventType.STATE_SNAPSHOT);
+    const msgsIdx = types.indexOf(EventType.MESSAGES_SNAPSHOT);
+    const finishedIdx = types.indexOf(EventType.RUN_FINISHED);
+
+    expect(stateIdx).toBeGreaterThan(-1);
+    expect(msgsIdx).toBeGreaterThan(-1);
+    expect(stateIdx).toBeLessThan(msgsIdx);
+    expect(msgsIdx).toBeLessThan(finishedIdx);
+  });
+
+  it("still emits RUN_FINISHED if messages snapshot fails", async () => {
+    const memory = new FakeMemory();
+    // Override recall to throw
+    memory.recall = async () => {
+      throw new Error("DB connection failed");
+    };
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    // Should not throw — best-effort
+    const events = await collectEvents(agent, makeInput());
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("includes tool call messages in the snapshot", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "What's the weather?" }],
+        },
+      },
+      {
+        id: "msg-2",
+        role: "assistant",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [
+            { type: "text", text: "Let me check." },
+            {
+              type: "tool-invocation",
+              toolCallId: "call-1",
+              toolName: "get_weather",
+              args: { city: "NYC" },
+              state: "result",
+              result: "Sunny, 25°C",
+            },
+          ],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const snapshot = events.find((e) => e.type === EventType.MESSAGES_SNAPSHOT) as any;
+    expect(snapshot).toBeDefined();
+    // user + assistant + tool = 3 messages
+    expect(snapshot.messages).toHaveLength(3);
+    expect(snapshot.messages[0].role).toBe("user");
+    expect(snapshot.messages[1].role).toBe("assistant");
+    expect(snapshot.messages[2].role).toBe("tool");
+    expect(snapshot.messages[2].toolCallId).toBe("call-1");
+  });
+});

--- a/integrations/mastra/typescript/src/__tests__/messages-snapshot.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/messages-snapshot.test.ts
@@ -1,0 +1,308 @@
+import { EventType } from "@ag-ui/client";
+import {
+  FakeMemory,
+  makeLocalMastraAgent,
+  makeRemoteMastraAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+
+const SIMPLE_STREAM_CHUNKS = [
+  { type: "text-delta", payload: { text: "Hello" } },
+  { type: "finish", payload: {} },
+];
+
+describe("MESSAGES_SNAPSHOT emission", () => {
+  it("emits MESSAGES_SNAPSHOT before RUN_FINISHED when memory has messages", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      },
+      {
+        id: "msg-2",
+        role: "assistant",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hi there!" }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.MESSAGES_SNAPSHOT);
+
+    // MESSAGES_SNAPSHOT should come before RUN_FINISHED
+    const snapshotIdx = types.indexOf(EventType.MESSAGES_SNAPSHOT);
+    const finishedIdx = types.indexOf(EventType.RUN_FINISHED);
+    expect(snapshotIdx).toBeLessThan(finishedIdx);
+
+    // Verify the snapshot content
+    const snapshot = events.find((e) => e.type === EventType.MESSAGES_SNAPSHOT) as any;
+    expect(snapshot.messages).toHaveLength(2);
+    expect(snapshot.messages[0]).toMatchObject({
+      id: "msg-1",
+      role: "user",
+      content: "Hello",
+    });
+    expect(snapshot.messages[1]).toMatchObject({
+      id: "msg-2",
+      role: "assistant",
+      content: "Hi there!",
+    });
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT when memory has no messages", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT when recalled history is system-only", async () => {
+    // System messages are intentionally dropped by convertMastraMessagesToAGUI,
+    // which would leave an empty AG-UI snapshot. Emitting that would wipe
+    // client-side conversation state.
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "sys-1",
+        role: "system",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "You are a helpful assistant." }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("does not emit MESSAGES_SNAPSHOT for remote agents", async () => {
+    const agent = makeRemoteMastraAgent({
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("emits MESSAGES_SNAPSHOT after STATE_SNAPSHOT (working memory)", async () => {
+    const memory = new FakeMemory();
+    memory.workingMemoryValue = JSON.stringify({ key: "value" });
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const types = events.map((e) => e.type);
+    const stateIdx = types.indexOf(EventType.STATE_SNAPSHOT);
+    const msgsIdx = types.indexOf(EventType.MESSAGES_SNAPSHOT);
+    const finishedIdx = types.indexOf(EventType.RUN_FINISHED);
+
+    expect(stateIdx).toBeGreaterThan(-1);
+    expect(msgsIdx).toBeGreaterThan(-1);
+    expect(stateIdx).toBeLessThan(msgsIdx);
+    expect(msgsIdx).toBeLessThan(finishedIdx);
+  });
+
+  it("still emits RUN_FINISHED if messages snapshot fails", async () => {
+    const memory = new FakeMemory();
+    // Override recall to throw
+    memory.recall = async () => {
+      throw new Error("DB connection failed");
+    };
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    // Should not throw — best-effort
+    const events = await collectEvents(agent, makeInput());
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("suppresses MESSAGES_SNAPSHOT when a client tool call is streamed (HITL)", async () => {
+    // A client/frontend tool (e.g. CopilotKit generate_task_steps) renders on
+    // the client keyed to the streamed tool-call id. The authoritative snapshot
+    // from recall() carries Mastra's stored id, which won't match, so replacing
+    // the client's message list would orphan the in-flight HITL render. Suppress.
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: { format: 2, parts: [{ type: "text", text: "Plan it." }] },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: [
+        {
+          type: "tool-call",
+          payload: {
+            toolCallId: "client-1",
+            toolName: "generate_task_steps",
+            args: { steps: [] },
+          },
+        },
+        { type: "finish", payload: {} },
+      ],
+    });
+
+    const events = await collectEvents(agent, makeInput());
+    const types = events.map((e) => e.type);
+
+    // Tool call was emitted, but the snapshot is gated off because it never resolved.
+    expect(types).toContain(EventType.TOOL_CALL_START);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("suppresses MESSAGES_SNAPSHOT for a backend tool call even when it resolves in-run", async () => {
+    // The bridge streams the tool call under the provider id (e.g. OpenAI
+    // `call_…`), but the recall()-sourced snapshot carries Mastra's stored id.
+    // Replacing the client's message list with mismatched ids orphans the
+    // frontend's rendered tool card. Until streamed ids == stored ids, any
+    // tool-call turn must suppress the snapshot — not just pending client tools.
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: { format: 2, parts: [{ type: "text", text: "Weather?" }] },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: [
+        {
+          type: "tool-call",
+          payload: {
+            toolCallId: "srv-1",
+            toolName: "get_weather",
+            args: { city: "NYC" },
+          },
+        },
+        {
+          type: "tool-result",
+          payload: { toolCallId: "srv-1", result: "Sunny" },
+        },
+        { type: "finish", payload: {} },
+      ],
+    });
+
+    const events = await collectEvents(agent, makeInput());
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain(EventType.TOOL_CALL_RESULT);
+    expect(types).not.toContain(EventType.MESSAGES_SNAPSHOT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("includes tool call messages in the snapshot", async () => {
+    const memory = new FakeMemory();
+    memory.recallMessages = [
+      {
+        id: "msg-1",
+        role: "user",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [{ type: "text", text: "What's the weather?" }],
+        },
+      },
+      {
+        id: "msg-2",
+        role: "assistant",
+        createdAt: new Date(),
+        content: {
+          format: 2,
+          parts: [
+            { type: "text", text: "Let me check." },
+            {
+              type: "tool-invocation",
+              toolCallId: "call-1",
+              toolName: "get_weather",
+              args: { city: "NYC" },
+              state: "result",
+              result: "Sunny, 25°C",
+            },
+          ],
+        },
+      },
+    ];
+
+    const agent = makeLocalMastraAgent({
+      memory,
+      streamChunks: SIMPLE_STREAM_CHUNKS,
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const snapshot = events.find((e) => e.type === EventType.MESSAGES_SNAPSHOT) as any;
+    expect(snapshot).toBeDefined();
+    // user + assistant + tool = 3 messages
+    expect(snapshot.messages).toHaveLength(3);
+    expect(snapshot.messages[0].role).toBe("user");
+    expect(snapshot.messages[1].role).toBe("assistant");
+    expect(snapshot.messages[2].role).toBe("tool");
+    expect(snapshot.messages[2].toolCallId).toBe("call-1");
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -2,6 +2,7 @@ import type {
   AgentConfig,
   BaseEvent,
   CustomEvent,
+  MessagesSnapshotEvent,
   ReasoningStartEvent,
   ReasoningMessageStartEvent,
   ReasoningMessageContentEvent,
@@ -26,6 +27,7 @@ import { Observable } from "rxjs";
 import type { MastraClient } from "@mastra/client-js";
 import {
   convertAGUIMessagesToMastra,
+  convertMastraMessagesToAGUI,
   GetLocalAgentsOptions,
   getLocalAgents,
   getRemoteAgents,
@@ -106,6 +108,7 @@ export class MastraAgent extends AbstractAgent {
         // Close the run cleanly without calling resumeStream.
         if (forwardedCommand?.resume === false && forwardedCommand?.interruptEvent) {
           await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+          await this.emitMessagesSnapshot(subscriber, input.threadId);
           subscriber.next({
             type: EventType.RUN_FINISHED,
             threadId: input.threadId,
@@ -189,6 +192,7 @@ export class MastraAgent extends AbstractAgent {
 
             if (!hadError) {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+              await this.emitMessagesSnapshot(subscriber, input.threadId);
               subscriber.next({
                 type: EventType.RUN_FINISHED,
                 threadId: input.threadId,
@@ -274,6 +278,7 @@ export class MastraAgent extends AbstractAgent {
             },
             onRunFinished: async () => {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+              await this.emitMessagesSnapshot(subscriber, input.threadId);
               subscriber.next({
                 type: EventType.RUN_FINISHED,
                 threadId: input.threadId,
@@ -353,6 +358,54 @@ export class MastraAgent extends AbstractAgent {
     } catch (error) {
       console.warn(
         `[MastraAgent] Failed to emit working memory snapshot for thread ${threadId}:`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Fetches conversation history from a local agent's memory and emits a
+   * MESSAGES_SNAPSHOT event so frontends (e.g. CopilotKit) can synchronize
+   * thread state without re-sending all messages.
+   *
+   * Best-effort: logs a warning and returns gracefully on failure so callers
+   * can proceed with RUN_FINISHED even when the snapshot could not be delivered.
+   */
+  private async emitMessagesSnapshot(
+    subscriber: { next: (event: BaseEvent) => void },
+    threadId: string,
+  ): Promise<boolean> {
+    if (!this.isLocalMastraAgent(this.agent)) return true;
+    try {
+      const memory = await this.agent.getMemory({
+        requestContext: this.requestContext,
+      });
+      if (memory) {
+        const { messages } = await memory.recall({
+          threadId,
+          resourceId: this.resourceId,
+          perPage: false,
+        });
+
+        if (messages && messages.length > 0) {
+          const aguiMessages = convertMastraMessagesToAGUI(messages);
+          // Guard against emitting an empty snapshot when all recalled
+          // messages were filtered out (e.g. system-only history).
+          // MESSAGES_SNAPSHOT is authoritative on the client, so an empty
+          // array would clear visible conversation state.
+          if (aguiMessages.length > 0) {
+            subscriber.next({
+              type: EventType.MESSAGES_SNAPSHOT,
+              messages: aguiMessages,
+            } as MessagesSnapshotEvent);
+          }
+        }
+      }
+      return true;
+    } catch (error) {
+      console.warn(
+        `[MastraAgent] Failed to emit messages snapshot for thread ${threadId}:`,
         error,
       );
       return false;
@@ -663,6 +716,11 @@ export class MastraAgent extends AbstractAgent {
     const convertedMessages = convertAGUIMessagesToMastra(messages);
     this.requestContext?.set("ag-ui", { context: inputContext });
     const requestContext = this.requestContext;
+
+    // Message IDs are preserved by convertAGUIMessagesToMastra, so Mastra's
+    // MessageHistory processor dedupes input against stored messages by ID
+    // and storage.saveMessages upserts by ID. We forward everything
+    // CopilotKit sends and let Mastra handle deduplication.
 
     if (this.isLocalMastraAgent(this.agent)) {
       try {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -2,6 +2,7 @@ import type {
   AgentConfig,
   BaseEvent,
   CustomEvent,
+  MessagesSnapshotEvent,
   ReasoningStartEvent,
   ReasoningMessageStartEvent,
   ReasoningMessageContentEvent,
@@ -26,6 +27,7 @@ import { Observable } from "rxjs";
 import type { MastraClient } from "@mastra/client-js";
 import {
   convertAGUIMessagesToMastra,
+  convertMastraMessagesToAGUI,
   GetLocalAgentsOptions,
   getLocalAgents,
   getRemoteAgents,
@@ -92,6 +94,22 @@ export class MastraAgent extends AbstractAgent {
   run(input: RunAgentInput): Observable<BaseEvent> {
     let messageId = randomUUID();
 
+    // True once any tool call is streamed this run. We then suppress the
+    // end-of-run MESSAGES_SNAPSHOT, because the bridge streams tool calls under
+    // the model/provider id (e.g. OpenAI `call_…`) while Mastra persists them
+    // under a different stored id. The snapshot is sourced from memory.recall()
+    // and is authoritative — replacing the client's message list — so its
+    // mismatched ids orphan whatever the frontend rendered against the streamed
+    // id (a HITL plan, a backend-tool card), wiping the UI. Until streamed ids
+    // match stored ids, only pure-text turns can safely emit the snapshot.
+    // Mirrors LangGraph's snapshot suppression "while a message is in progress".
+    // NOTE: this still cannot protect a *prior* turn's tool render from a later
+    // text turn's snapshot — full safety needs streamed==stored id alignment.
+    let toolCallStreamedThisRun = false;
+    const markToolCallStreamed = () => {
+      toolCallStreamedThisRun = true;
+    };
+
     return new Observable<BaseEvent>((subscriber) => {
       const run = async () => {
         const runStartedEvent: RunStartedEvent = {
@@ -114,6 +132,7 @@ export class MastraAgent extends AbstractAgent {
           forwardedCommand?.interruptEvent
         ) {
           await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+          await this.emitMessagesSnapshot(subscriber, input.threadId);
           subscriber.next({
             type: EventType.RUN_FINISHED,
             threadId: input.threadId,
@@ -205,6 +224,7 @@ export class MastraAgent extends AbstractAgent {
                 messageId = id;
               },
               input.runId,
+              markToolCallStreamed,
             );
             const hadError = await this.processFullStream(response.fullStream, {
               ...callbacks,
@@ -215,6 +235,9 @@ export class MastraAgent extends AbstractAgent {
 
             if (!hadError) {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+              if (!toolCallStreamedThisRun) {
+                await this.emitMessagesSnapshot(subscriber, input.threadId);
+              }
               subscriber.next({
                 type: EventType.RUN_FINISHED,
                 threadId: input.threadId,
@@ -311,6 +334,7 @@ export class MastraAgent extends AbstractAgent {
               messageId = id;
             },
             input.runId,
+            markToolCallStreamed,
           );
 
           await this.streamMastraAgent(input, {
@@ -320,6 +344,9 @@ export class MastraAgent extends AbstractAgent {
             },
             onRunFinished: async () => {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
+              if (!toolCallStreamedThisRun) {
+                await this.emitMessagesSnapshot(subscriber, input.threadId);
+              }
               subscriber.next({
                 type: EventType.RUN_FINISHED,
                 threadId: input.threadId,
@@ -406,6 +433,54 @@ export class MastraAgent extends AbstractAgent {
   }
 
   /**
+   * Fetches conversation history from a local agent's memory and emits a
+   * MESSAGES_SNAPSHOT event so frontends (e.g. CopilotKit) can synchronize
+   * thread state without re-sending all messages.
+   *
+   * Best-effort: logs a warning and returns gracefully on failure so callers
+   * can proceed with RUN_FINISHED even when the snapshot could not be delivered.
+   */
+  private async emitMessagesSnapshot(
+    subscriber: { next: (event: BaseEvent) => void },
+    threadId: string,
+  ): Promise<boolean> {
+    if (!this.isLocalMastraAgent(this.agent)) return true;
+    try {
+      const memory = await this.agent.getMemory({
+        requestContext: this.requestContext,
+      });
+      if (memory) {
+        const { messages } = await memory.recall({
+          threadId,
+          resourceId: this.resourceId ?? threadId,
+          perPage: false,
+        });
+
+        if (messages && messages.length > 0) {
+          const aguiMessages = convertMastraMessagesToAGUI(messages);
+          // Guard against emitting an empty snapshot when all recalled
+          // messages were filtered out (e.g. system-only history).
+          // MESSAGES_SNAPSHOT is authoritative on the client, so an empty
+          // array would clear visible conversation state.
+          if (aguiMessages.length > 0) {
+            subscriber.next({
+              type: EventType.MESSAGES_SNAPSHOT,
+              messages: aguiMessages,
+            } as MessagesSnapshotEvent);
+          }
+        }
+      }
+      return true;
+    } catch (error) {
+      console.warn(
+        `[MastraAgent] Failed to emit messages snapshot for thread ${threadId}:`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
    * Creates the callback set used by processFullStream to emit AG-UI events.
    * messageId is accessed/mutated via getter/setter closures so that when
    * onFinishMessagePart replaces the ID with a new UUID, subsequent callbacks
@@ -416,6 +491,7 @@ export class MastraAgent extends AbstractAgent {
     getMessageId: () => string,
     setMessageId: (id: string) => void,
     runId: string,
+    onToolCallStreamed: () => void,
   ): Omit<MastraAgentStreamOptions, "onError" | "onRunFinished"> {
     let reasoningMessageId: string | null = null;
     let isReasoning = false;
@@ -477,6 +553,10 @@ export class MastraAgent extends AbstractAgent {
       },
       onToolCallPart: (streamPart) => {
         closeReasoning();
+        // Any tool call this run gates the end-of-run MESSAGES_SNAPSHOT (see
+        // run()): the snapshot's stored ids won't match this streamed id, so
+        // emitting it would orphan the frontend's tool render.
+        onToolCallStreamed();
         subscriber.next({
           type: EventType.TOOL_CALL_START,
           parentMessageId: getMessageId(),
@@ -709,6 +789,11 @@ export class MastraAgent extends AbstractAgent {
     const convertedMessages = convertAGUIMessagesToMastra(messages);
     this.requestContext?.set("ag-ui", { context: inputContext });
     const requestContext = this.requestContext;
+
+    // Message IDs are preserved by convertAGUIMessagesToMastra, so Mastra's
+    // MessageHistory processor dedupes input against stored messages by ID
+    // and storage.saveMessages upserts by ID. We forward everything
+    // CopilotKit sends and let Mastra handle deduplication.
 
     if (this.isLocalMastraAgent(this.agent)) {
       try {

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -1,5 +1,5 @@
 import type { InputContent, InputContentDataSource, InputContentUrlSource, Message } from "@ag-ui/client";
-import { AbstractAgent } from "@ag-ui/client";
+import { AbstractAgent, randomUUID } from "@ag-ui/client";
 import { MastraClient } from "@mastra/client-js";
 import type { Mastra } from "@mastra/core";
 import type { CoreMessage } from "@mastra/core/llm";
@@ -105,6 +105,14 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
 };
 
 export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] {
+  // Preserve AG-UI message IDs on the CoreMessage objects. Although CoreMessage
+  // does not officially type an `id` field, Mastra's AIV4Adapter.fromCoreMessage
+  // reads `id` when present (see @mastra/core AIV4Adapter.fromCoreMessage).
+  // Preserving IDs enables Mastra's MessageHistory processor to deduplicate:
+  //   - processInput filters historical messages whose IDs match the input IDs
+  //   - storage.saveMessages upserts by ID, so re-sent history won't duplicate
+  // Without this, CopilotKit re-sending the full thread on every turn causes
+  // message duplication in Mastra-backed storage.
   const result: CoreMessage[] = [];
 
   for (const message of messages) {
@@ -123,15 +131,17 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
         });
       }
       result.push({
+        id: message.id,
         role: "assistant",
         content: parts,
-      });
+      } as CoreMessage);
     } else if (message.role === "user") {
       const userContent = toMastraContent(message.content);
       result.push({
+        id: message.id,
         role: "user",
         content: userContent,
-      });
+      } as CoreMessage);
     } else if (message.role === "tool") {
       let toolName = "unknown";
       for (const msg of messages) {
@@ -145,6 +155,7 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
         }
       }
       result.push({
+        id: message.id,
         role: "tool",
         content: [
           {
@@ -154,8 +165,199 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
             result: message.content,
           },
         ],
-      });
+      } as CoreMessage);
     }
+  }
+
+  return result;
+}
+
+/**
+ * Converts Mastra MastraDBMessage[] (V2 format) to AG-UI Message[] format.
+ * Used to emit MESSAGES_SNAPSHOT events so frontends (e.g. CopilotKit) can
+ * synchronize thread history without re-sending all messages.
+ *
+ * MastraDBMessage uses a V2 parts-based format:
+ *   { id, role, content: { format: 2, parts: [...] } }
+ *
+ * Each part has a `type` (e.g. "text", "tool-invocation") with type-specific fields.
+ */
+/**
+ * Parse a string payload that may be either a `data:<mime>;base64,<raw>` URL
+ * or a plain URL into an AG-UI content source. The forward converter
+ * (`toMastraContent` / `mediaSourceToUrl`) always produces a data URL for
+ * `type: "data"` sources and a plain URL for `type: "url"` sources, so we
+ * reverse that here to recover the original shape. `mimeTypeHint` is used
+ * when the payload is a plain URL (no mime embedded).
+ */
+function parseMediaSource(
+  value: string,
+  mimeTypeHint?: string,
+): InputContentDataSource | InputContentUrlSource {
+  const dataUrlMatch = /^data:([^;,]+)(?:;([^,]+))?,(.*)$/.exec(value);
+  if (dataUrlMatch) {
+    const [, mime, encoding, payload] = dataUrlMatch;
+    // Only base64 data URLs round-trip cleanly to AG-UI's { type: "data" }
+    // shape (which expects raw base64). Anything else, hand back as a url.
+    if (encoding === "base64") {
+      return { type: "data", value: payload, mimeType: mime };
+    }
+    return { type: "url", value, mimeType: mime };
+  }
+  return {
+    type: "url",
+    value,
+    mimeType: mimeTypeHint ?? "application/octet-stream",
+  };
+}
+
+/**
+ * Map a Mastra V2 media part back to an AG-UI InputContent entry.
+ *
+ * Handles both shapes emitted by the forward converter (`toMastraContent`):
+ *   - `{ type: "image", image: <data-url | url> }`
+ *   - `{ type: "file", mimeType, data: <data-url | url> | url: <url> }`
+ *
+ * Returns null when the part can't be represented.
+ */
+function mediaPartToAGUIInputContent(part: {
+  type?: string;
+  mimeType?: string;
+  data?: string;
+  url?: string;
+  image?: string;
+}): InputContent | null {
+  if (part.type === "image") {
+    // Forward converter emits `{ type: "image", image: <url-or-data-url> }`.
+    // The mime type for plain URLs isn't recoverable, so default to image/*.
+    const raw = part.image;
+    if (!raw) return null;
+    const source = parseMediaSource(raw, "image/*");
+    return { type: "image", source };
+  }
+
+  if (part.type === "file") {
+    const hintedMime = part.mimeType ?? "application/octet-stream";
+    let source: InputContentDataSource | InputContentUrlSource | null = null;
+    if (part.data) {
+      source = parseMediaSource(part.data, hintedMime);
+      // If the hinted mime conflicts with a decoded data-URL mime, trust the
+      // hint from the part (it's authoritative in storage).
+      if (source.type === "data" && part.mimeType) {
+        source = { ...source, mimeType: part.mimeType };
+      }
+    } else if (part.url) {
+      source = { type: "url", value: part.url, mimeType: hintedMime };
+    }
+    if (!source) return null;
+
+    const mime = source.mimeType ?? hintedMime;
+    if (mime.startsWith("image/")) return { type: "image", source };
+    if (mime.startsWith("audio/")) return { type: "audio", source };
+    if (mime.startsWith("video/")) return { type: "video", source };
+    return { type: "document", source };
+  }
+
+  return null;
+}
+
+export function convertMastraMessagesToAGUI(messages: { id: string; role: string; content: { parts?: any[] } }[]): Message[] {
+  const result: Message[] = [];
+
+  for (const message of messages) {
+    const parts = message.content?.parts ?? [];
+
+    if (message.role === "user") {
+      // Preserve multimodal content. Use a string when the message is text-only
+      // (backwards-compat with AG-UI clients that expect string content), and
+      // an InputContent[] when any non-text part is present.
+      const inputContent: InputContent[] = [];
+      for (const part of parts) {
+        if (part.type === "text") {
+          if (part.text) inputContent.push({ type: "text", text: part.text });
+        } else if (part.type === "file" || part.type === "image") {
+          const mapped = mediaPartToAGUIInputContent(part);
+          if (mapped) inputContent.push(mapped);
+        }
+      }
+
+      const hasNonText = inputContent.some((c) => c.type !== "text");
+      if (hasNonText) {
+        result.push({
+          id: message.id,
+          role: "user",
+          content: inputContent,
+        } as Message);
+      } else {
+        const text = inputContent
+          .filter((c): c is Extract<InputContent, { type: "text" }> => c.type === "text")
+          .map((c) => c.text)
+          .join("\n");
+        result.push({
+          id: message.id,
+          role: "user",
+          content: text,
+        } as Message);
+      }
+    } else if (message.role === "assistant") {
+      // AG-UI AssistantMessage.content is `string | undefined`, so non-text
+      // assistant parts (file/reasoning/etc.) cannot be faithfully represented
+      // and are intentionally skipped. Text parts are concatenated in order.
+      const textSegments: string[] = [];
+      const toolCalls: Array<{
+        id: string;
+        type: "function";
+        function: { name: string; arguments: string };
+      }> = [];
+      const toolResults: Array<{ toolCallId: string; result: any }> = [];
+
+      for (const part of parts) {
+        if (part.type === "text") {
+          if (part.text) textSegments.push(part.text);
+        } else if (part.type === "tool-invocation" || part.type === "tool-call") {
+          const toolCallId = part.toolCallId ?? part.id ?? randomUUID();
+          const toolName = part.toolName ?? part.name ?? "unknown";
+          const args = part.args ?? {};
+          toolCalls.push({
+            id: toolCallId,
+            type: "function",
+            function: {
+              name: toolName,
+              arguments: typeof args === "string" ? args : JSON.stringify(args),
+            },
+          });
+          if (part.type === "tool-invocation" && part.state === "result" && part.result !== undefined) {
+            toolResults.push({
+              toolCallId,
+              result: part.result,
+            });
+          }
+        }
+      }
+
+      const textContent = textSegments.join("");
+      if (textContent || toolCalls.length > 0) {
+        result.push({
+          id: message.id,
+          role: "assistant",
+          content: textContent || undefined,
+          toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        } as Message);
+      }
+
+      // Push tool result messages after the assistant message with stable IDs
+      // derived from the parent message + tool call, so repeated snapshots
+      // don't produce new IDs for the same logical tool result.
+      for (const tr of toolResults) {
+        result.push({
+          id: `${message.id}:${tr.toolCallId}:result`,
+          role: "tool",
+          content: typeof tr.result === "string" ? tr.result : JSON.stringify(tr.result),
+          toolCallId: tr.toolCallId,
+        } as Message);
+      }
+    }
+    // System messages are skipped — AG-UI MESSAGES_SNAPSHOT only needs user/assistant/tool
   }
 
   return result;

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -1,5 +1,5 @@
 import type { InputContent, InputContentDataSource, InputContentUrlSource, Message } from "@ag-ui/client";
-import { AbstractAgent } from "@ag-ui/client";
+import { AbstractAgent, randomUUID } from "@ag-ui/client";
 import { MastraClient } from "@mastra/client-js";
 import type { Mastra } from "@mastra/core";
 import type { CoreMessage } from "@mastra/core/llm";
@@ -102,6 +102,13 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
 };
 
 export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWithId[] {
+  // Preserve AG-UI message IDs on the CoreMessage objects (see CoreMessageWithId).
+  // Mastra's AIV4Adapter.fromCoreMessage reads `id` when present, which enables
+  // Mastra's MessageHistory processor to deduplicate re-sent history:
+  //   - processInput filters historical messages whose IDs match the input IDs
+  //   - storage.saveMessages upserts by ID, so re-sent history won't duplicate
+  // The `id` key is omitted when undefined so it doesn't defeat Mastra's
+  // `"id" in message` check.
   const result: CoreMessageWithId[] = [];
 
   for (const message of messages) {
@@ -123,14 +130,14 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWit
         ...(message.id !== undefined ? { id: message.id } : {}),
         role: "assistant",
         content: parts,
-      });
+      } as CoreMessage);
     } else if (message.role === "user") {
       const userContent = toMastraContent(message.content);
       result.push({
         ...(message.id !== undefined ? { id: message.id } : {}),
         role: "user",
         content: userContent,
-      });
+      } as CoreMessage);
     } else if (message.role === "tool") {
       let toolName = "unknown";
       for (const msg of messages) {
@@ -154,8 +161,199 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWit
             result: message.content,
           },
         ],
-      });
+      } as CoreMessage);
     }
+  }
+
+  return result;
+}
+
+/**
+ * Converts Mastra MastraDBMessage[] (V2 format) to AG-UI Message[] format.
+ * Used to emit MESSAGES_SNAPSHOT events so frontends (e.g. CopilotKit) can
+ * synchronize thread history without re-sending all messages.
+ *
+ * MastraDBMessage uses a V2 parts-based format:
+ *   { id, role, content: { format: 2, parts: [...] } }
+ *
+ * Each part has a `type` (e.g. "text", "tool-invocation") with type-specific fields.
+ */
+/**
+ * Parse a string payload that may be either a `data:<mime>;base64,<raw>` URL
+ * or a plain URL into an AG-UI content source. The forward converter
+ * (`toMastraContent` / `mediaSourceToUrl`) always produces a data URL for
+ * `type: "data"` sources and a plain URL for `type: "url"` sources, so we
+ * reverse that here to recover the original shape. `mimeTypeHint` is used
+ * when the payload is a plain URL (no mime embedded).
+ */
+function parseMediaSource(
+  value: string,
+  mimeTypeHint?: string,
+): InputContentDataSource | InputContentUrlSource {
+  const dataUrlMatch = /^data:([^;,]+)(?:;([^,]+))?,(.*)$/.exec(value);
+  if (dataUrlMatch) {
+    const [, mime, encoding, payload] = dataUrlMatch;
+    // Only base64 data URLs round-trip cleanly to AG-UI's { type: "data" }
+    // shape (which expects raw base64). Anything else, hand back as a url.
+    if (encoding === "base64") {
+      return { type: "data", value: payload, mimeType: mime };
+    }
+    return { type: "url", value, mimeType: mime };
+  }
+  return {
+    type: "url",
+    value,
+    mimeType: mimeTypeHint ?? "application/octet-stream",
+  };
+}
+
+/**
+ * Map a Mastra V2 media part back to an AG-UI InputContent entry.
+ *
+ * Handles both shapes emitted by the forward converter (`toMastraContent`):
+ *   - `{ type: "image", image: <data-url | url> }`
+ *   - `{ type: "file", mimeType, data: <data-url | url> | url: <url> }`
+ *
+ * Returns null when the part can't be represented.
+ */
+function mediaPartToAGUIInputContent(part: {
+  type?: string;
+  mimeType?: string;
+  data?: string;
+  url?: string;
+  image?: string;
+}): InputContent | null {
+  if (part.type === "image") {
+    // Forward converter emits `{ type: "image", image: <url-or-data-url> }`.
+    // The mime type for plain URLs isn't recoverable, so default to image/*.
+    const raw = part.image;
+    if (!raw) return null;
+    const source = parseMediaSource(raw, "image/*");
+    return { type: "image", source };
+  }
+
+  if (part.type === "file") {
+    const hintedMime = part.mimeType ?? "application/octet-stream";
+    let source: InputContentDataSource | InputContentUrlSource | null = null;
+    if (part.data) {
+      source = parseMediaSource(part.data, hintedMime);
+      // If the hinted mime conflicts with a decoded data-URL mime, trust the
+      // hint from the part (it's authoritative in storage).
+      if (source.type === "data" && part.mimeType) {
+        source = { ...source, mimeType: part.mimeType };
+      }
+    } else if (part.url) {
+      source = { type: "url", value: part.url, mimeType: hintedMime };
+    }
+    if (!source) return null;
+
+    const mime = source.mimeType ?? hintedMime;
+    if (mime.startsWith("image/")) return { type: "image", source };
+    if (mime.startsWith("audio/")) return { type: "audio", source };
+    if (mime.startsWith("video/")) return { type: "video", source };
+    return { type: "document", source };
+  }
+
+  return null;
+}
+
+export function convertMastraMessagesToAGUI(messages: { id: string; role: string; content: { parts?: any[] } }[]): Message[] {
+  const result: Message[] = [];
+
+  for (const message of messages) {
+    const parts = message.content?.parts ?? [];
+
+    if (message.role === "user") {
+      // Preserve multimodal content. Use a string when the message is text-only
+      // (backwards-compat with AG-UI clients that expect string content), and
+      // an InputContent[] when any non-text part is present.
+      const inputContent: InputContent[] = [];
+      for (const part of parts) {
+        if (part.type === "text") {
+          if (part.text) inputContent.push({ type: "text", text: part.text });
+        } else if (part.type === "file" || part.type === "image") {
+          const mapped = mediaPartToAGUIInputContent(part);
+          if (mapped) inputContent.push(mapped);
+        }
+      }
+
+      const hasNonText = inputContent.some((c) => c.type !== "text");
+      if (hasNonText) {
+        result.push({
+          id: message.id,
+          role: "user",
+          content: inputContent,
+        } as Message);
+      } else {
+        const text = inputContent
+          .filter((c): c is Extract<InputContent, { type: "text" }> => c.type === "text")
+          .map((c) => c.text)
+          .join("\n");
+        result.push({
+          id: message.id,
+          role: "user",
+          content: text,
+        } as Message);
+      }
+    } else if (message.role === "assistant") {
+      // AG-UI AssistantMessage.content is `string | undefined`, so non-text
+      // assistant parts (file/reasoning/etc.) cannot be faithfully represented
+      // and are intentionally skipped. Text parts are concatenated in order.
+      const textSegments: string[] = [];
+      const toolCalls: Array<{
+        id: string;
+        type: "function";
+        function: { name: string; arguments: string };
+      }> = [];
+      const toolResults: Array<{ toolCallId: string; result: any }> = [];
+
+      for (const part of parts) {
+        if (part.type === "text") {
+          if (part.text) textSegments.push(part.text);
+        } else if (part.type === "tool-invocation" || part.type === "tool-call") {
+          const toolCallId = part.toolCallId ?? part.id ?? randomUUID();
+          const toolName = part.toolName ?? part.name ?? "unknown";
+          const args = part.args ?? {};
+          toolCalls.push({
+            id: toolCallId,
+            type: "function",
+            function: {
+              name: toolName,
+              arguments: typeof args === "string" ? args : JSON.stringify(args),
+            },
+          });
+          if (part.type === "tool-invocation" && part.state === "result" && part.result !== undefined) {
+            toolResults.push({
+              toolCallId,
+              result: part.result,
+            });
+          }
+        }
+      }
+
+      const textContent = textSegments.join("");
+      if (textContent || toolCalls.length > 0) {
+        result.push({
+          id: message.id,
+          role: "assistant",
+          content: textContent || undefined,
+          toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        } as Message);
+      }
+
+      // Push tool result messages after the assistant message with stable IDs
+      // derived from the parent message + tool call, so repeated snapshots
+      // don't produce new IDs for the same logical tool result.
+      for (const tr of toolResults) {
+        result.push({
+          id: `${message.id}:${tr.toolCallId}:result`,
+          role: "tool",
+          content: typeof tr.result === "string" ? tr.result : JSON.stringify(tr.result),
+          toolCallId: tr.toolCallId,
+        } as Message);
+      }
+    }
+    // System messages are skipped — AG-UI MESSAGES_SNAPSHOT only needs user/assistant/tool
   }
 
   return result;


### PR DESCRIPTION
## Summary

The Mastra AG-UI adapter did not tell the client about the authoritative thread history stored in Mastra memory, and the converter on the way in stripped message IDs. Together this caused every follow-up turn on an existing thread to duplicate previously-persisted messages and left the CopilotKit UI out of sync with what Mastra had on disk.

## What changed

- **Preserve AG-UI message IDs** when converting to Mastra `CoreMessage`, so Mastra's `MessageHistory` processor and storage layer can deduplicate by ID on subsequent turns.
- **Emit `MESSAGES_SNAPSHOT`** before `RUN_FINISHED`, sourced from `memory.recall()`, so the client can reconcile its local history with the server's view of the thread.
- **Add `convertMastraMessagesToAGUI`** with full multimodal support:
  - User image/audio/video/document parts round-trip through AG-UI `InputContent`, decoding base64 data URLs back to raw base64 + mimeType and leaving plain URLs as `url` sources.
  - Tool result messages use a deterministic id of the form `` `${parentMessageId}:${toolCallId}:result` `` so snapshots are stable across repeated emissions.
- **Guard `MESSAGES_SNAPSHOT` emission** on the converted AG-UI message count (not the raw recalled count) so a system-only history does not produce an empty snapshot that would wipe client-side state.

## Test plan

- \`pnpm test\` — 132 tests passing across 7 files.
- \`tsc --noEmit\` — clean.

New tests:

- \`mastra-to-agui-conversion.test.ts\` — text, multimodal round-trips (image/audio/video/document), stable tool-result IDs, snapshot stability.
- \`messages-snapshot.test.ts\` — ordering vs `STATE_SNAPSHOT` and `RUN_FINISHED`, remote-agent and empty-history no-op cases, system-only no-op case, best-effort failure handling, tool-call messages.
- \`message-conversion.test.ts\` — updated expectations for ID preservation.

Related CopilotKit issues:

- CopilotKit/CopilotKit#1969
- CopilotKit/CopilotKit#1881