### PR TITLE
fix(aws-strands): Fixed context propogation in frontend tools for HITL

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -400,7 +400,19 @@ class StrandsAgent:
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
                         if tool_name and tool_name in frontend_tool_names:
-                            user_message = f"{tool_name} executed successfully with no return value."
+                            if isinstance(msg.content, str):
+                                result_text = msg.content
+                            if result_text:
+                                user_message = (
+                                    f"Frontend tool '{tool_name}' returned: {result_text}\n"
+                                    "Use this tool result as authoritative context. "
+                                    "If this indicates denial/rejection, do not execute downstream tools."
+                                )
+                            else:
+                                user_message = (
+                                    f"Frontend tool '{tool_name}' returned no content.\n"
+                                    "Ask user how else you can be of assistance"
+                                )
                         break
             elif input_data.messages:
                 for msg in reversed(input_data.messages):


### PR DESCRIPTION
## Summary

In AWS Strands when we use useHumanInTheLoop, the 'respond' tool message from the frontend sent to AG-UI/Agent is not taken as context and the agent responds to any 'respond' tool message workflow as 'Successfully executed' even if user clicks on Deny for execution. Its hardcoded and fixed. The changes made send frontend result context to the agent so the agent responds appropriately and dynamically for tool message results sent from UI. 

## What changed
- Removed the hardcoded statement ``` f"{tool_name} executed successfully with no return value." ```
- Added an if else condition to cater to frontend tool message results 

Related CopilotKit issues:
- #1557