### PR TITLE
fix(adk-middleware): preserve `temp:` state from `extract_state_from_request`

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FIX**: `temp:`-prefixed state from `extract_state_from_request` now reaches `tool_context.state` (#1571)
+  - ADK's session services (`DatabaseSessionService`, `InMemorySessionService`, `VertexAiSessionService`) strip `temp:` keys before persisting, so request-scoped values (e.g. bearer tokens) returned by `extract_state_from_request` were silently dropped before the Runner fetched the session for an invocation
+  - The session service is now transparently wrapped by `RequestStateSessionService`, which holds pending `temp:` state in memory keyed by `(app_name, user_id, session_id)` and merges it into the session that ADK's Runner loads at invocation time — so `temp:` keys are visible to tools during the run while still not being persisted
+  - Pending state is cleared in the `finally` block of `_run_adk_in_background` so a later run on the same session cannot inherit a stale value (e.g. a rotated token)
+  - `temp:` keys extracted from the request are also filtered out of the end-of-run `STATE_SNAPSHOT` so ephemeral server-side state never leaks to clients
+  - Purely additive for callers: non-`temp:` keys flow through the existing persistence path unchanged; ADK-native `output_key="temp:foo"` flows (e.g. `SequentialAgent` passing data between sub-agents) continue to work; the wrapper is a transparent `BaseSessionService` proxy (unwrap via `.inner` if ever needed)
+  - New tests: `tests/test_temp_state_extraction.py` (10 tests) covering the wrapper, the `ADKAgent` wiring, and an end-to-end flow that asserts `temp:` visibility in `tool_context.state`, non-persistence to session storage, and non-leakage into `STATE_SNAPSHOT`
+
 - **FIX**: First-turn HITL `TOOL_CALL_*` emission on `google-adk` <1.18 (#1536)
   - `EventTranslator.translate_lro_function_calls` previously suppressed emission for client-tool names in resumable mode, relying on `ClientProxyTool` as the sole emitter
   - On `google-adk` 1.16/1.17 the runner's resumable flow returns before invoking LRO tools on the first turn (`base_llm_flow.py` pause-early-return), so the proxy never ran and the trio was never emitted — the first HITL turn produced no `TOOL_CALL_START/ARGS/END`

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -2565,6 +2565,15 @@ class ADKAgent:
             # moving states snapshot events after the text event clousure to avoid this error https://github.com/Contextable/ag-ui/issues/28
             final_state = await self._session_manager.get_session_state(backend_session_id, app_name, user_id)
 
+            # `temp:` keys are ephemeral invocation state (see issue #1571) —
+            # they're visible to tools during the run but must not leak into
+            # the client-facing STATE_SNAPSHOT.
+            if final_state:
+                final_state = {
+                    k: v for k, v in final_state.items()
+                    if not (isinstance(k, str) and k.startswith(_ADKState.TEMP_PREFIX))
+                }
+
             # Merge accumulated predictive state from all ClientProxyToolset instances
             # This ensures values set during HITL tool calls survive the final STATE_SNAPSHOT
             accumulated_predict_state = {}

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -45,6 +45,7 @@ from google.adk.agents.run_config import StreamingMode
 from google.adk.agents.llm_agent import InstructionProvider, ToolUnion
 from google.adk.sessions import BaseSessionService, InMemorySessionService
 from google.adk.sessions.session import Event
+from google.adk.sessions.state import State as _ADKState
 from google.adk.artifacts import BaseArtifactService, InMemoryArtifactService
 from google.adk.memory import BaseMemoryService, InMemoryMemoryService
 from google.adk.auth.credential_service.base_credential_service import BaseCredentialService
@@ -71,6 +72,7 @@ _INTERNAL_STATE_KEYS = frozenset({
 from .execution_state import ExecutionState
 from .client_proxy_toolset import ClientProxyToolset
 from .config import PredictStateMapping
+from .request_state_service import RequestStateSessionService
 from .utils.converters import convert_message_content_to_parts
 
 import logging
@@ -228,7 +230,13 @@ class ADKAgent:
         # Use provided session service or create default based on use_in_memory_services
         if session_service is None:
             session_service = InMemorySessionService()  # Default for both dev and production
-            
+
+        # Wrap the session service so we can inject `temp:`-prefixed state into
+        # the session that ADK's Runner fetches at invocation time. See
+        # https://github.com/ag-ui-protocol/ag-ui/issues/1571 for context.
+        if not isinstance(session_service, RequestStateSessionService):
+            session_service = RequestStateSessionService(session_service)
+
         self._session_manager = SessionManager.get_instance(
             session_service=session_service,
             memory_service=self._memory_service,  # Pass memory service for automatic session memory
@@ -240,7 +248,16 @@ class ADKAgent:
             use_thread_id_as_session_id=use_thread_id_as_session_id,
             hitl_max_wait_seconds=hitl_max_wait_seconds,
         )
-        
+
+        # Reach through the singleton so every ADKAgent sharing this process
+        # writes pending `temp:` state onto whatever wrapper the singleton
+        # actually holds (the singleton ignores later session_service args).
+        active_service = self._session_manager._session_service
+        if not isinstance(active_service, RequestStateSessionService):
+            active_service = RequestStateSessionService(active_service)
+            self._session_manager._session_service = active_service
+        self._request_state_service: RequestStateSessionService = active_service
+
         # Tool execution tracking — keyed by (thread_id, user_id) to avoid cross-user collisions
         self._active_executions: Dict[Tuple[str, str], ExecutionState] = {}
         self._execution_timeout = execution_timeout_seconds
@@ -1913,6 +1930,7 @@ class ADKAgent:
             event_queue: Queue for emitting events
         """
         runner: Optional[Runner] = None
+        backend_session_id: Optional[str] = None
         logger.debug(f"[BG_EXEC] _run_adk_in_background called for thread={input.thread_id}")
         logger.debug(f"[BG_EXEC]   tool_results={len(tool_results) if tool_results else 0}, message_batch={len(message_batch) if message_batch else 0}")
         try:
@@ -1938,20 +1956,45 @@ class ADKAgent:
             # See: https://github.com/ag-ui-protocol/ag-ui/issues/1168
             for key in _INTERNAL_STATE_KEYS:
                 state_with_context.pop(key, None)
+
+            # Split `temp:`-prefixed keys from the persisted state. Every stock
+            # ADK session service strips `temp:` keys before writing, so if we
+            # passed them through the normal persistence path they would not
+            # reach `tool_context.state` at tool-invocation time. The wrapper
+            # registered on the session service (RequestStateSessionService)
+            # re-injects them when the Runner fetches the session.
+            # See: https://github.com/ag-ui-protocol/ag-ui/issues/1571
+            temp_state: Dict[str, Any] = {}
+            persistent_state: Dict[str, Any] = {}
+            for k, v in state_with_context.items():
+                if isinstance(k, str) and k.startswith(_ADKState.TEMP_PREFIX):
+                    temp_state[k] = v
+                else:
+                    persistent_state[k] = v
             if input.context:
-                state_with_context[CONTEXT_STATE_KEY] = [
+                persistent_state[CONTEXT_STATE_KEY] = [
                     {"description": ctx.description, "value": ctx.value}
                     for ctx in input.context
                 ]
 
             # Ensure session exists and get backend session_id
             session, backend_session_id = await self._ensure_session_exists(
-                app_name, user_id, input.thread_id, state_with_context
+                app_name, user_id, input.thread_id, persistent_state
+            )
+
+            # Register any `temp:` state so it gets merged into the session
+            # that ADK's Runner fetches for this invocation. Cleared in the
+            # finally-block below regardless of success / failure.
+            self._request_state_service.set_pending_temp_state(
+                app_name=app_name,
+                user_id=user_id,
+                session_id=backend_session_id,
+                temp_state=temp_state,
             )
 
             # this will always update the backend states with the frontend states
             # Recipe Demo Example: if there is a state "salt" in the ingredients state and in frontend user remove this salt state using UI from the ingredients list then our backend should also update these state changes as well to sync both the states
-            await self._session_manager.update_session_state(backend_session_id, app_name, user_id, state_with_context)
+            await self._session_manager.update_session_state(backend_session_id, app_name, user_id, persistent_state)
 
             # Refresh session to get updated last_update_time after state update
             # This prevents "stale session" errors when using DatabaseSessionService
@@ -2612,6 +2655,16 @@ class ADKAgent:
                             input.thread_id,
                             close_error,
                         )
+
+            # Drop any pending per-invocation `temp:` state so a later run on
+            # the same session does not inherit stale values (e.g. a rotated
+            # bearer token).
+            if backend_session_id is not None:
+                self._request_state_service.clear_pending_temp_state(
+                    app_name=app_name,
+                    user_id=user_id,
+                    session_id=backend_session_id,
+                )
     
     async def _cleanup_stale_executions(self):
         """Clean up stale executions."""

--- a/integrations/adk-middleware/python/src/ag_ui_adk/request_state_service.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/request_state_service.py
@@ -1,0 +1,146 @@
+# src/ag_ui_adk/request_state_service.py
+
+"""Session service wrapper that injects per-invocation ``temp:`` state.
+
+ADK's :class:`Runner` fetches sessions fresh via ``session_service.get_session``
+at the start of each invocation. Because every stock session service strips
+``temp:``-prefixed keys before persisting them (see
+``BaseSessionService._apply_temp_state`` / ``_trim_temp_delta_state``),
+``temp:`` state produced *outside* an invocation — for example by the
+``extract_state_from_request`` hook on the FastAPI endpoint — cannot reach
+``tool_context.state`` through the normal ``append_event`` path.
+
+This wrapper sits in front of the user-supplied session service and merges
+pending ``temp:`` state into the session returned by ``get_session`` for a
+specific ``(app_name, user_id, session_id)`` triple. All other calls are
+forwarded verbatim, so the wrapper is transparent when no pending state is
+registered.
+
+See https://github.com/ag-ui-protocol/ag-ui/issues/1571.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from google.adk.events import Event
+from google.adk.sessions.base_session_service import (
+    BaseSessionService,
+    GetSessionConfig,
+    ListSessionsResponse,
+)
+from google.adk.sessions.session import Session
+
+
+_PendingKey = Tuple[str, str, str]  # (app_name, user_id, session_id)
+
+
+class RequestStateSessionService(BaseSessionService):
+    """Transparently proxies a session service, injecting pending ``temp:`` state.
+
+    The wrapper holds an in-memory mapping from
+    ``(app_name, user_id, session_id)`` to a dict of ``temp:``-prefixed keys.
+    On every call to :meth:`get_session`, the wrapper delegates to the inner
+    service and, if any pending state is registered for that triple, merges it
+    into ``session.state`` before returning. The pending entry is *not* cleared
+    automatically — callers must call :meth:`clear_pending_temp_state` once the
+    invocation has finished so later invocations do not inherit stale values.
+    """
+
+    def __init__(self, inner: BaseSessionService) -> None:
+        self._inner = inner
+        self._pending_temp_state: Dict[_PendingKey, Dict[str, Any]] = {}
+
+    @property
+    def inner(self) -> BaseSessionService:
+        """The wrapped session service."""
+        return self._inner
+
+    def set_pending_temp_state(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        temp_state: Optional[Dict[str, Any]],
+    ) -> None:
+        """Register ``temp:`` state to inject on the next ``get_session`` call.
+
+        Passing an empty dict or ``None`` removes any existing pending state
+        for the triple.
+        """
+        key = (app_name, user_id, session_id)
+        if temp_state:
+            self._pending_temp_state[key] = dict(temp_state)
+        else:
+            self._pending_temp_state.pop(key, None)
+
+    def clear_pending_temp_state(
+        self, *, app_name: str, user_id: str, session_id: str
+    ) -> None:
+        """Remove any pending ``temp:`` state for the given triple."""
+        self._pending_temp_state.pop((app_name, user_id, session_id), None)
+
+    def _inject(self, session: Optional[Session], key: _PendingKey) -> Optional[Session]:
+        if session is None:
+            return None
+        temp_state = self._pending_temp_state.get(key)
+        if not temp_state:
+            return session
+        for k, v in temp_state.items():
+            session.state[k] = v
+        return session
+
+    # ------------------------------------------------------------------
+    # BaseSessionService interface — delegate to the inner implementation
+    # ------------------------------------------------------------------
+
+    async def create_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        state: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+    ) -> Session:
+        session = await self._inner.create_session(
+            app_name=app_name,
+            user_id=user_id,
+            state=state,
+            session_id=session_id,
+        )
+        if session is not None:
+            self._inject(session, (app_name, user_id, session.id))
+        return session
+
+    async def get_session(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        session_id: str,
+        config: Optional[GetSessionConfig] = None,
+    ) -> Optional[Session]:
+        session = await self._inner.get_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+            config=config,
+        )
+        return self._inject(session, (app_name, user_id, session_id))
+
+    async def list_sessions(
+        self, *, app_name: str, user_id: Optional[str] = None
+    ) -> ListSessionsResponse:
+        return await self._inner.list_sessions(app_name=app_name, user_id=user_id)
+
+    async def delete_session(
+        self, *, app_name: str, user_id: str, session_id: str
+    ) -> None:
+        self._pending_temp_state.pop((app_name, user_id, session_id), None)
+        await self._inner.delete_session(
+            app_name=app_name, user_id=user_id, session_id=session_id
+        )
+
+    async def append_event(self, session: Session, event: Event) -> Event:
+        return await self._inner.append_event(session=session, event=event)

--- a/integrations/adk-middleware/python/tests/llmock/fixtures/temp_state.json
+++ b/integrations/adk-middleware/python/tests/llmock/fixtures/temp_state.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "read the temp token" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "check_temp_state_tool",
+            "arguments": "{}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
+++ b/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
@@ -319,6 +319,16 @@ class TestTempStateReachesToolContext:
             stored.sessions[0].id,
         ) not in adk_agent._request_state_service._pending_temp_state
 
+        # STATE_SNAPSHOT events sent to the client must not expose `temp:`
+        # keys — they're server-side ephemeral state.
+        snapshot_events = [e for e in events if str(e.type) == "EventType.STATE_SNAPSHOT"]
+        assert snapshot_events, "Expected at least one STATE_SNAPSHOT event"
+        for snap in snapshot_events:
+            assert not any(
+                isinstance(k, str) and k.startswith(ADKState.TEMP_PREFIX)
+                for k in snap.snapshot.keys()
+            ), f"temp: keys leaked into STATE_SNAPSHOT: {list(snap.snapshot.keys())}"
+
         await adk_agent.close()
 
     @pytest.mark.asyncio

--- a/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
+++ b/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python
+"""Tests for `temp:`-prefixed state extracted from the incoming request.
+
+Regression tests for https://github.com/ag-ui-protocol/ag-ui/issues/1571 —
+``extract_state_from_request`` used to lose ``temp:`` state because every stock
+ADK session service strips ``temp:`` keys on persistence. These tests verify
+that ``temp:`` state now reaches ``tool_context.state`` during the invocation
+while still being excluded from the persistent session state.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import pytest
+
+from ag_ui.core import (
+    BaseEvent,
+    Context,
+    EventType,
+    RunAgentInput,
+    UserMessage,
+)
+from ag_ui_adk import ADKAgent, SessionManager
+from ag_ui_adk.request_state_service import RequestStateSessionService
+from google.adk.agents import LlmAgent
+from google.adk.sessions import InMemorySessionService
+from google.adk.sessions.state import State as ADKState
+from google.adk.tools import ToolContext
+
+
+DEFAULT_MODEL = "gemini-2.0-flash"
+
+
+async def _collect(agent: ADKAgent, run_input: RunAgentInput) -> List[BaseEvent]:
+    events: List[BaseEvent] = []
+    async for event in agent.run(run_input):
+        events.append(event)
+    return events
+
+
+def _event_types(events: List[BaseEvent]) -> List[str]:
+    return [str(e.type) for e in events]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for RequestStateSessionService
+# ---------------------------------------------------------------------------
+
+
+class TestRequestStateSessionService:
+    """The wrapper merges pending ``temp:`` state into ``get_session`` results."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest.mark.asyncio
+    async def test_pending_state_injected_on_get_session(self):
+        inner = InMemorySessionService()
+        wrapper = RequestStateSessionService(inner)
+
+        session = await inner.create_session(
+            app_name="app", user_id="user", session_id="sess1"
+        )
+
+        wrapper.set_pending_temp_state(
+            app_name="app",
+            user_id="user",
+            session_id=session.id,
+            temp_state={"temp:token": "abc", "temp:trace": "xyz"},
+        )
+
+        fetched = await wrapper.get_session(
+            app_name="app", user_id="user", session_id=session.id
+        )
+
+        assert fetched is not None
+        assert fetched.state["temp:token"] == "abc"
+        assert fetched.state["temp:trace"] == "xyz"
+
+    @pytest.mark.asyncio
+    async def test_temp_state_not_persisted_to_inner(self):
+        """Pending state lives only on the returned copy; storage is untouched."""
+        inner = InMemorySessionService()
+        wrapper = RequestStateSessionService(inner)
+
+        session = await inner.create_session(
+            app_name="app", user_id="user", session_id="sess1"
+        )
+        wrapper.set_pending_temp_state(
+            app_name="app",
+            user_id="user",
+            session_id=session.id,
+            temp_state={"temp:token": "abc"},
+        )
+
+        # First fetch sees the injected value.
+        first = await wrapper.get_session(
+            app_name="app", user_id="user", session_id=session.id
+        )
+        assert first.state["temp:token"] == "abc"
+
+        # Clear the pending state; subsequent fetches must not see it, and the
+        # inner service's storage must not have been mutated.
+        wrapper.clear_pending_temp_state(
+            app_name="app", user_id="user", session_id=session.id
+        )
+
+        second = await wrapper.get_session(
+            app_name="app", user_id="user", session_id=session.id
+        )
+        assert "temp:token" not in second.state
+
+        raw = await inner.get_session(
+            app_name="app", user_id="user", session_id=session.id
+        )
+        assert "temp:token" not in raw.state
+
+    @pytest.mark.asyncio
+    async def test_pending_state_scoped_to_session_triple(self):
+        inner = InMemorySessionService()
+        wrapper = RequestStateSessionService(inner)
+
+        await inner.create_session(app_name="app", user_id="u1", session_id="a")
+        await inner.create_session(app_name="app", user_id="u2", session_id="b")
+
+        wrapper.set_pending_temp_state(
+            app_name="app",
+            user_id="u1",
+            session_id="a",
+            temp_state={"temp:token": "for-u1"},
+        )
+
+        other = await wrapper.get_session(app_name="app", user_id="u2", session_id="b")
+        assert "temp:token" not in other.state
+
+        mine = await wrapper.get_session(app_name="app", user_id="u1", session_id="a")
+        assert mine.state["temp:token"] == "for-u1"
+
+    @pytest.mark.asyncio
+    async def test_empty_or_none_removes_pending(self):
+        inner = InMemorySessionService()
+        wrapper = RequestStateSessionService(inner)
+        await inner.create_session(app_name="app", user_id="u", session_id="s")
+
+        wrapper.set_pending_temp_state(
+            app_name="app", user_id="u", session_id="s",
+            temp_state={"temp:token": "t"},
+        )
+        wrapper.set_pending_temp_state(
+            app_name="app", user_id="u", session_id="s", temp_state=None,
+        )
+
+        fetched = await wrapper.get_session(app_name="app", user_id="u", session_id="s")
+        assert "temp:token" not in fetched.state
+
+    @pytest.mark.asyncio
+    async def test_delete_session_clears_pending(self):
+        inner = InMemorySessionService()
+        wrapper = RequestStateSessionService(inner)
+        await inner.create_session(app_name="app", user_id="u", session_id="s")
+
+        wrapper.set_pending_temp_state(
+            app_name="app", user_id="u", session_id="s",
+            temp_state={"temp:token": "t"},
+        )
+        await wrapper.delete_session(app_name="app", user_id="u", session_id="s")
+
+        # Re-create the session; pending state should be gone.
+        await inner.create_session(app_name="app", user_id="u", session_id="s")
+        fetched = await wrapper.get_session(app_name="app", user_id="u", session_id="s")
+        assert "temp:token" not in fetched.state
+
+
+# ---------------------------------------------------------------------------
+# ADKAgent wiring: the session service is auto-wrapped at construction time.
+# ---------------------------------------------------------------------------
+
+
+class TestADKAgentWrapsSessionService:
+    """ADKAgent must always expose a RequestStateSessionService internally."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    def _make_agent(self, *, session_service=None) -> ADKAgent:
+        adk = LlmAgent(name="stub", model=DEFAULT_MODEL, instruction="hi")
+        return ADKAgent(
+            adk_agent=adk,
+            app_name="test_app",
+            user_id="test_user",
+            session_service=session_service,
+            use_in_memory_services=True,
+        )
+
+    def test_default_service_is_wrapped(self):
+        agent = self._make_agent()
+        assert isinstance(agent._request_state_service, RequestStateSessionService)
+        assert agent._session_manager._session_service is agent._request_state_service
+
+    def test_user_supplied_service_is_wrapped(self):
+        supplied = InMemorySessionService()
+        agent = self._make_agent(session_service=supplied)
+        assert isinstance(agent._request_state_service, RequestStateSessionService)
+        assert agent._request_state_service.inner is supplied
+
+    def test_already_wrapped_service_is_reused(self):
+        supplied = RequestStateSessionService(InMemorySessionService())
+        agent = self._make_agent(session_service=supplied)
+        assert agent._request_state_service is supplied
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: `temp:` state extracted from the request reaches the tool and
+# is not persisted to the session after the run completes.
+# ---------------------------------------------------------------------------
+
+
+class TestTempStateReachesToolContext:
+    """End-to-end verification using a real ADK LlmAgent + llmock fixture."""
+
+    @pytest.fixture(autouse=True)
+    def setup_llmock(self, llmock_server):
+        """Ensure the LLMock server is running."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest.mark.asyncio
+    async def test_temp_state_visible_in_tool_context(self):
+        observed_state: Dict[str, Any] = {}
+
+        def check_temp_state_tool(tool_context: ToolContext) -> str:
+            """Snapshot ``tool_context.state`` so the test can inspect it."""
+            observed_state.update(tool_context.state.to_dict())
+            return "ok"
+
+        llm_agent = LlmAgent(
+            name="temp_state_agent",
+            model=DEFAULT_MODEL,
+            instruction=(
+                "You have a tool called check_temp_state_tool. Always call it "
+                "when the user asks you to."
+            ),
+            tools=[check_temp_state_tool],
+        )
+
+        session_service = InMemorySessionService()
+        adk_agent = ADKAgent(
+            adk_agent=llm_agent,
+            app_name="temp_state_app",
+            user_id="temp_state_user",
+            session_service=session_service,
+        )
+
+        run_input = RunAgentInput(
+            thread_id="temp_state_thread",
+            run_id="run_1",
+            messages=[
+                UserMessage(id="msg_1", role="user", content="read the temp token"),
+            ],
+            context=[Context(description="env", value="prod")],
+            state={
+                "temp:token": "bearer-xyz",
+                "non_temp_key": "persisted-value",
+            },
+            tools=[],
+            forwarded_props={},
+        )
+
+        events = await _collect(adk_agent, run_input)
+        types = _event_types(events)
+
+        assert "EventType.RUN_STARTED" in types
+        assert "EventType.RUN_FINISHED" in types
+        assert "EventType.RUN_ERROR" not in types
+
+        # Tool must have been invoked (the mock LLM's tool-call fixture fired).
+        assert observed_state, "Tool was not invoked — llmock fixture mismatch?"
+
+        # Temp state extracted from the request is visible to the tool.
+        assert observed_state.get("temp:token") == "bearer-xyz"
+        # Persistent state is also visible.
+        assert observed_state.get("non_temp_key") == "persisted-value"
+
+        # After the run, `temp:` keys must NOT be persisted to session storage.
+        # Read through the raw service, bypassing the wrapper, so we see what
+        # was actually written.
+        stored = await session_service.list_sessions(
+            app_name="temp_state_app", user_id="temp_state_user"
+        )
+        assert len(stored.sessions) == 1
+        raw_session = await session_service.get_session(
+            app_name="temp_state_app",
+            user_id="temp_state_user",
+            session_id=stored.sessions[0].id,
+        )
+        assert raw_session is not None
+        assert not any(
+            k.startswith(ADKState.TEMP_PREFIX) for k in raw_session.state.keys()
+        ), f"temp: keys were persisted: {list(raw_session.state)}"
+        # Non-temp keys are persisted.
+        assert raw_session.state.get("non_temp_key") == "persisted-value"
+
+        # The wrapper cleared pending temp state after the run finished.
+        assert (
+            "temp_state_app",
+            "temp_state_user",
+            stored.sessions[0].id,
+        ) not in adk_agent._request_state_service._pending_temp_state
+
+        await adk_agent.close()
+
+    @pytest.mark.asyncio
+    async def test_temp_state_absent_when_request_has_none(self):
+        """Requests without temp state must still work unchanged."""
+        observed_state: Dict[str, Any] = {}
+
+        def check_temp_state_tool(tool_context: ToolContext) -> str:
+            observed_state.update(tool_context.state.to_dict())
+            return "ok"
+
+        llm_agent = LlmAgent(
+            name="temp_state_agent_2",
+            model=DEFAULT_MODEL,
+            instruction="Always call the tool.",
+            tools=[check_temp_state_tool],
+        )
+
+        adk_agent = ADKAgent(
+            adk_agent=llm_agent,
+            app_name="temp_state_app_2",
+            user_id="u2",
+            use_in_memory_services=True,
+        )
+
+        run_input = RunAgentInput(
+            thread_id="t2",
+            run_id="r2",
+            messages=[UserMessage(id="m1", role="user", content="read the temp token")],
+            context=[],
+            state={"plain_key": "plain_value"},
+            tools=[],
+            forwarded_props={},
+        )
+
+        events = await _collect(adk_agent, run_input)
+        assert "EventType.RUN_ERROR" not in _event_types(events)
+        # No temp keys should be observed.
+        assert not any(
+            k.startswith(ADKState.TEMP_PREFIX) for k in observed_state.keys()
+        )
+        assert observed_state.get("plain_key") == "plain_value"
+
+        await adk_agent.close()


### PR DESCRIPTION
## Summary

Fixes #1571. `temp:`-prefixed values returned from `extract_state_from_request` (e.g. a bearer token pulled from the `Authorization` header) were silently dropped and never reached `tool_context.state`.

### Root cause

Every stock ADK session service (`DatabaseSessionService`, `InMemorySessionService`, `VertexAiSessionService`) strips `temp:` keys from the state delta before persisting — that's the intended ADK semantic. The middleware was routing the extracted request state straight through `update_session_state` → `append_event`, so by the time the Runner fetched the session for the invocation, the `temp:` keys were gone.

### Fix

- Introduce `RequestStateSessionService` — a transparent `BaseSessionService` proxy that holds pending `temp:` state keyed by `(app_name, user_id, session_id)` and merges it into the session returned by `get_session`. All other calls delegate to the inner service verbatim.
- In `_run_adk_in_background`, split `input.state` into `persistent_state` (flows through the existing persistence path, unchanged) and `temp_state` (registered on the wrapper). The wrapper injects `temp:` keys onto the session ADK's Runner loads at invocation time, so tools see them via `tool_context.state`.
- Clear the pending state in the `finally` block so a later run on the same session can't inherit a rotated token or other stale values.
- Strip `temp:` keys from the end-of-run `STATE_SNAPSHOT` so ephemeral server-side state never leaks to clients.

### Backwards compatibility

Purely additive — no user-visible API changes:

| Scenario | Before | After |
|---|---|---|
| Non-`temp:` keys from `extract_state_from_request` | Persisted, visible to tools, in STATE_SNAPSHOT | Identical |
| `temp:` keys from `extract_state_from_request` | Silently dropped (the bug) | Visible to tools; not persisted; not in STATE_SNAPSHOT |
| ADK-native `output_key="temp:foo"` flows | Worked | Unchanged |
| User-supplied `session_service` | Used directly | Auto-wrapped in a transparent proxy (unwrap via `.inner`) |

## Test plan

- [x] 10 new tests in `tests/test_temp_state_extraction.py`
  - `TestRequestStateSessionService` (5): injection on `get_session`, non-persistence to inner storage, `(app, user, session)` isolation, removal on empty/None, cleanup on `delete_session`
  - `TestADKAgentWrapsSessionService` (3): default service wrapped, user-supplied service wrapped, already-wrapped service reused
  - `TestTempStateReachesToolContext` (2): end-to-end with a real `LlmAgent` + llmock fixture — asserts `temp:token` is visible to the tool, is **not** in the raw session state after the run, pending state is cleared, and `temp:` keys do not appear in any `STATE_SNAPSHOT` event
- [x] Full suite: 787 passed, 4 skipped (Vertex live tests), no regressions

https://claude.ai/code/session_01LRAH21kUT1d3B3bmAfVAYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRAH21kUT1d3B3bmAfVAYs)_