### PR TITLE
Fix/state streaming lg js

### DIFF
--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -543,7 +543,10 @@ export class LangGraphAgent extends AbstractAgent {
         }
 
         if (streamResponseChunk.event === "values") {
-          latestStateValues = chunk.data;
+          latestStateValues = {
+            ...latestStateValues,
+            ...chunk.data,
+          };
           continue;
         } else if (subgraphsStreamEnabled && chunk.event.startsWith("values|")) {
           latestStateValues = {
@@ -594,6 +597,31 @@ export class LangGraphAgent extends AbstractAgent {
           shouldExit ||
           (eventType === LangGraphEventTypes.OnCustomEvent &&
             chunkData.name === CustomEventNames.Exit);
+
+        // Parity with Python reader (langgraph_agent.py:447): update local state
+        // cache from on_chain_end outputs so state stays fresh across node boundaries
+        // without relying on a `values` stream chunk after every step.
+        // LangGraph JS doesn't emit `values` chunks with the latest state between
+        // tool execution and run end, so without this update, intermediate
+        // STATE_SNAPSHOTs go stale after a tool Command updates state.
+        if (eventType === LangGraphEventTypes.OnChainEnd && chunkData.data?.output != null) {
+          const output: any = chunkData.data.output;
+          if (typeof output === "object" && !Array.isArray(output)) {
+            latestStateValues = { ...latestStateValues, ...output };
+          } else if (Array.isArray(output)) {
+            for (const item of output) {
+              if (
+                item &&
+                typeof item === "object" &&
+                (item as any).lg_name === "Command" &&
+                (item as any).update &&
+                typeof (item as any).update === "object"
+              ) {
+                latestStateValues = { ...latestStateValues, ...(item as any).update };
+              }
+            }
+          }
+        }
 
         if (eventType === LangGraphEventTypes.OnChainEnd && this.activeRun!.nodeName === currentNodeName) {
           this.activeRun!.exitingNode = true;

--- a/integrations/langgraph/typescript/src/middlewares/state-streaming.ts
+++ b/integrations/langgraph/typescript/src/middlewares/state-streaming.ts
@@ -62,7 +62,26 @@ export const stateStreamingMiddleware = (...items: StateItem[]) => {
       const modelWithState = request.model.withConfig({
         metadata: { predict_state: predictState },
       });
-      return handler({ ...request, model: modelWithState });
+
+      const m = request.model as any;
+      const proto = Object.getPrototypeOf(m);
+      const origCombine = proto._combineCallOptions;
+      if (origCombine) {
+        proto._combineCallOptions = function (options: any) {
+          const combined = origCombine.call(this, options);
+          combined.metadata = {
+            ...(this.defaultOptions?.metadata ?? {}),
+            ...(options?.metadata ?? {}),
+            predict_state: predictState,
+          };
+          return combined;
+        };
+      }
+      try {
+        return await handler({ ...request, model: modelWithState });
+      } finally {
+        if (origCombine) proto._combineCallOptions = origCombine;
+      }
     },
   });
 };


### PR DESCRIPTION
This PR fixes 2 main issues:
1. state streaming: with prebuilt agents (main agents used today), you can specify model in 2 ways:

External: model: new ChatOpenAI(...)
String: model: 'gpt-5.4' 

When external model is specified, out StateStreamingMiddleware doesn't work, because it work on adding metadata to events (appends something to model config) and external config would override what we append

2. Once the above works, there's a gap between the time state has streamed from the tool call, and getting the state snapshot that includes the emitted state.