### PR TITLE
fix(ci): add tsx to root devDependencies so release workflows can run

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nx": "^22.4.5",
     "prettier": "^3.5.3",
     "semver": "^7.7.3",
+    "tsx": "^4.20.6",
     "typescript": "5.8.2"
   },
   "packageManager": "pnpm@10.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       semver:
         specifier: ^7.7.3
         version: 7.7.3
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
       typescript:
         specifier: 5.8.2
         version: 5.8.2


### PR DESCRIPTION
## Summary

The new `release / pre` workflow (added in #1487) [failed on its first run](https://github.com/ag-ui-protocol/ag-ui/actions/runs/24897208075/job/72905125395) with a silent `exit 254` from the **Compute prerelease version and bump** step. Root cause: `tsx` is not declared at the repo root, so `pnpm tsx scripts/release/prepare-release.ts …` falls through to pnpm's recursive exec and fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "tsx" not found`. pnpm writes that error to **stdout**, which the workflow captures into `RESULT=$(pnpm tsx …)` — leaving zero trace in the CI log and zero stderr to diagnose from.

This PR adds `tsx@^4.20.6` (same minor as `integrations/claude-agent-sdk/typescript`) to root `devDependencies`.

## Verified locally

```
$ pnpm tsx scripts/release/prepare-release.ts --scope claude-agent-sdk --bump prerelease --preid "canary.$(date +%s)" --dry-run
[claude-agent-sdk] ag-ui-claude-sdk: 0.1.0 -> 0.1.1.dev1777048183
{ "scope": "claude-agent-sdk", "packages": [ … ] }
EXIT: 0
```

Also verified for `--scope ts-sdk` — produces valid semver `0.0.53-canary.first-pass.0`.

## Follow-ups not in this PR

1. **Non-numeric suffix breaks Python PEP 440.** Running the workflow with `suffix: first-pass` on a Python scope produces `0.1.1.devfirst-pass` — invalid per PEP 440 (`.devN` requires numeric `N`), so PyPI publish will reject it. Fix should live in [`scripts/release/prepare-release.ts`](https://github.com/ag-ui-protocol/ag-ui/blob/main/scripts/release/prepare-release.ts) `bumpPythonVersion` — sanitize/hash non-numeric suffixes when falling through to `.devN`.
2. **Stderr-swallow in workflow.** `RESULT=$(pnpm tsx …)` hides errors from the step log. Recommend piping stdout straight to the file instead:
   ```bash
   pnpm tsx scripts/release/prepare-release.ts … > /tmp/bump-result.json
   ```
   The script already uses `console.error` for progress/errors and `console.log` only for the JSON payload, so this works cleanly and future failures will be visible.

## Test plan

- [ ] Merge and re-run `release / pre` with `scope: claude-agent-sdk`, leaving `suffix` blank (timestamp → valid `.devN`), `dry_run: true`.
- [ ] Confirm the **Compute prerelease version and bump** step succeeds and the step summary shows the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)