### PR TITLE
ci(release): scope build/test and restructure release scopes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,26 +14,29 @@ on:
         required: true
         type: choice
         options:
-          - a2a
-          - a2a-middleware
-          - a2ui-middleware
-          - adk-middleware
-          - ag2
-          - agent-spec
-          - agno
-          - aws-strands
-          - claude-agent-sdk
-          - crewai
-          - langchain
-          - langgraph
-          - langroid
-          - llama-index
-          - mastra
-          - mcp-apps-middleware
-          - pydantic-ai
-          - py-sdk
-          - spring-ai
-          - ts-sdk
+          - integration-a2a
+          - integration-adk
+          - integration-ag2
+          - integration-agent-spec
+          - integration-agno
+          - integration-aws-strands
+          - integration-claude-agent-sdk-py
+          - integration-claude-agent-sdk-ts
+          - integration-crewai-py
+          - integration-crewai-ts
+          - integration-langchain
+          - integration-langgraph-py
+          - integration-langgraph-ts
+          - integration-langroid
+          - integration-llama-index
+          - integration-mastra
+          - integration-pydantic-ai
+          - integration-spring-ai
+          - middleware-a2a
+          - middleware-a2ui
+          - middleware-mcp-apps
+          - sdk-py
+          - sdk-ts
       bump:
         description: "Version bump level"
         required: true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,26 +12,29 @@ on:
         required: true
         type: choice
         options:
-          - a2a
-          - a2a-middleware
-          - a2ui-middleware
-          - adk-middleware
-          - ag2
-          - agent-spec
-          - agno
-          - aws-strands
-          - claude-agent-sdk
-          - crewai
-          - langchain
-          - langgraph
-          - langroid
-          - llama-index
-          - mastra
-          - mcp-apps-middleware
-          - pydantic-ai
-          - py-sdk
-          - spring-ai
-          - ts-sdk
+          - integration-a2a
+          - integration-adk
+          - integration-ag2
+          - integration-agent-spec
+          - integration-agno
+          - integration-aws-strands
+          - integration-claude-agent-sdk-py
+          - integration-claude-agent-sdk-ts
+          - integration-crewai-py
+          - integration-crewai-ts
+          - integration-langchain
+          - integration-langgraph-py
+          - integration-langgraph-ts
+          - integration-langroid
+          - integration-llama-index
+          - integration-mastra
+          - integration-pydantic-ai
+          - integration-spring-ai
+          - middleware-a2a
+          - middleware-a2ui
+          - middleware-mcp-apps
+          - sdk-py
+          - sdk-ts
       suffix:
         description: "Version suffix (e.g. 'fix-user-issue'). Leave blank for timestamp."
         required: false
@@ -121,25 +124,35 @@ jobs:
             jq -r '.packages[] | "- **\(.name)**: \(.oldVersion) → \(.newVersion)"' /tmp/bump-result.json
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build TypeScript packages
-        run: pnpm run build
+      - name: Extract TypeScript projects in scope
+        id: ts
+        run: |
+          PROJECTS=$(jq -r '[.packages[] | select(.ecosystem == "typescript") | .name] | join(",")' /tmp/bump-result.json)
+          COUNT=$(jq '[.packages[] | select(.ecosystem == "typescript")] | length' /tmp/bump-result.json)
+          echo "projects=$PROJECTS" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "TypeScript projects in scope: $PROJECTS"
+          else
+            echo "No TypeScript projects in scope — build/test/publish will be skipped"
+          fi
 
-      - name: Test TypeScript packages
-        run: pnpm run test
+      - name: Build TypeScript packages in scope
+        if: steps.ts.outputs.count != '0'
+        run: npx nx run-many -t build --projects="${{ steps.ts.outputs.projects }}"
+
+      - name: Test TypeScript packages in scope
+        if: steps.ts.outputs.count != '0'
+        run: npx nx run-many -t test --projects="${{ steps.ts.outputs.projects }}"
 
       - name: Publish TypeScript packages
-        if: inputs.dry_run != true
+        if: steps.ts.outputs.count != '0' && inputs.dry_run != true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          TS_PACKAGES=$(jq -c '[.packages[] | select(.ecosystem == "typescript")]' /tmp/bump-result.json)
-          TS_COUNT=$(echo "$TS_PACKAGES" | jq 'length')
-          if [ "$TS_COUNT" -gt 0 ]; then
-            PROJECTS=$(echo "$TS_PACKAGES" | jq -r '[.[].name] | join(",")')
-            echo "Publishing TypeScript canary: $PROJECTS"
-            npx nx release publish --projects="$PROJECTS" --tag canary
-          fi
+          echo "Publishing TypeScript canary: ${{ steps.ts.outputs.projects }}"
+          npx nx release publish --projects="${{ steps.ts.outputs.projects }}" --tag canary
 
       - name: Publish Python packages
         if: inputs.dry_run != true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -142,13 +142,23 @@ jobs:
             echo "No version changes detected — nothing to publish."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build TypeScript packages
+      - name: Extract TypeScript project names
         if: steps.detect_ts.outputs.count != '0'
-        run: pnpm run build
+        id: ts_projects
+        env:
+          TS_PACKAGES: ${{ steps.detect_ts.outputs.packages }}
+        run: |
+          PROJECTS=$(echo "$TS_PACKAGES" | jq -r '[.[].name] | join(",")')
+          echo "projects=$PROJECTS" >> "$GITHUB_OUTPUT"
+          echo "Scoped build/test to TypeScript projects: $PROJECTS"
 
-      - name: Test TypeScript packages
+      - name: Build TypeScript packages in scope
         if: steps.detect_ts.outputs.count != '0'
-        run: pnpm run test
+        run: npx nx run-many -t build --projects="${{ steps.ts_projects.outputs.projects }}"
+
+      - name: Test TypeScript packages in scope
+        if: steps.detect_ts.outputs.count != '0'
+        run: npx nx run-many -t test --projects="${{ steps.ts_projects.outputs.projects }}"
 
       - name: Group TypeScript packages by dist-tag
         if: steps.detect_ts.outputs.count != '0'

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -1,7 +1,7 @@
 {
   "prereleaseTag": "canary",
   "scopes": {
-    "ts-sdk": {
+    "sdk-ts": {
       "description": "TypeScript SDK core packages",
       "sharedVersion": true,
       "versionSource": "sdks/typescript/packages/core/package.json",
@@ -13,139 +13,158 @@
         { "name": "create-ag-ui-app", "path": "sdks/typescript/packages/cli", "ecosystem": "typescript" }
       ]
     },
-    "py-sdk": {
+    "sdk-py": {
       "description": "Python SDK",
       "sharedVersion": false,
       "packages": [
         { "name": "ag-ui-protocol", "path": "sdks/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "a2a": {
-      "description": "A2A integration",
+    "integration-a2a": {
+      "description": "A2A integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/a2a", "path": "integrations/a2a/typescript", "ecosystem": "typescript" }
       ]
     },
-    "adk-middleware": {
+    "integration-adk": {
       "description": "ADK Middleware integration (Python)",
       "sharedVersion": false,
       "packages": [
         { "name": "ag_ui_adk", "path": "integrations/adk-middleware/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "ag2": {
-      "description": "AG2 integration",
+    "integration-ag2": {
+      "description": "AG2 integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/ag2", "path": "integrations/ag2/typescript", "ecosystem": "typescript" }
       ]
     },
-    "agent-spec": {
+    "integration-agent-spec": {
       "description": "Agent Spec integration (Python)",
       "sharedVersion": false,
       "packages": [
         { "name": "ag-ui-agent-spec", "path": "integrations/agent-spec/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "agno": {
-      "description": "Agno integration",
+    "integration-agno": {
+      "description": "Agno integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/agno", "path": "integrations/agno/typescript", "ecosystem": "typescript" }
       ]
     },
-    "aws-strands": {
+    "integration-aws-strands": {
       "description": "AWS Strands integration (Python)",
       "sharedVersion": false,
       "packages": [
         { "name": "ag_ui_strands", "path": "integrations/aws-strands/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "claude-agent-sdk": {
+    "integration-claude-agent-sdk-ts": {
+      "description": "Claude Agent SDK integration (TypeScript)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "@ag-ui/claude-agent-sdk", "path": "integrations/claude-agent-sdk/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "integration-claude-agent-sdk-py": {
       "description": "Claude Agent SDK integration (Python)",
       "sharedVersion": false,
       "packages": [
         { "name": "ag-ui-claude-sdk", "path": "integrations/claude-agent-sdk/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "crewai": {
-      "description": "CrewAI integration (TS + Python)",
+    "integration-crewai-ts": {
+      "description": "CrewAI integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
-        { "name": "@ag-ui/crewai", "path": "integrations/crew-ai/typescript", "ecosystem": "typescript" },
+        { "name": "@ag-ui/crewai", "path": "integrations/crew-ai/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "integration-crewai-py": {
+      "description": "CrewAI integration (Python)",
+      "sharedVersion": false,
+      "packages": [
         { "name": "ag-ui-crewai", "path": "integrations/crew-ai/python", "ecosystem": "python", "buildSystem": "poetry" }
       ]
     },
-    "langchain": {
-      "description": "LangChain integration",
+    "integration-langchain": {
+      "description": "LangChain integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/langchain", "path": "integrations/langchain/typescript", "ecosystem": "typescript" }
       ]
     },
-    "langgraph": {
-      "description": "LangGraph integration (TS + Python)",
+    "integration-langgraph-ts": {
+      "description": "LangGraph integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
-        { "name": "@ag-ui/langgraph", "path": "integrations/langgraph/typescript", "ecosystem": "typescript" },
+        { "name": "@ag-ui/langgraph", "path": "integrations/langgraph/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "integration-langgraph-py": {
+      "description": "LangGraph integration (Python)",
+      "sharedVersion": false,
+      "packages": [
         { "name": "ag-ui-langgraph", "path": "integrations/langgraph/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "langroid": {
+    "integration-langroid": {
       "description": "Langroid integration (Python)",
       "sharedVersion": false,
       "packages": [
         { "name": "ag_ui_langroid", "path": "integrations/langroid/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
-    "llama-index": {
-      "description": "Llama Index integration",
+    "integration-llama-index": {
+      "description": "Llama Index integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/llamaindex", "path": "integrations/llama-index/typescript", "ecosystem": "typescript" }
       ]
     },
-    "mastra": {
-      "description": "Mastra integration",
+    "integration-mastra": {
+      "description": "Mastra integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/mastra", "path": "integrations/mastra/typescript", "ecosystem": "typescript" }
       ]
     },
-    "pydantic-ai": {
-      "description": "Pydantic AI integration",
+    "integration-pydantic-ai": {
+      "description": "Pydantic AI integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/pydantic-ai", "path": "integrations/pydantic-ai/typescript", "ecosystem": "typescript" }
       ]
     },
-    "a2a-middleware": {
-      "description": "A2A Middleware",
+    "integration-spring-ai": {
+      "description": "Spring AI integration (community, TypeScript)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "@ag-ui/spring-ai", "path": "integrations/community/spring-ai/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "middleware-a2a": {
+      "description": "A2A Middleware (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/a2a-middleware", "path": "middlewares/a2a-middleware", "ecosystem": "typescript" }
       ]
     },
-    "a2ui-middleware": {
-      "description": "A2UI Middleware",
+    "middleware-a2ui": {
+      "description": "A2UI Middleware (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/a2ui-middleware", "path": "middlewares/a2ui-middleware", "ecosystem": "typescript" }
       ]
     },
-    "mcp-apps-middleware": {
-      "description": "MCP Apps Middleware",
+    "middleware-mcp-apps": {
+      "description": "MCP Apps Middleware (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/mcp-apps-middleware", "path": "middlewares/mcp-apps-middleware", "ecosystem": "typescript" }
-      ]
-    },
-    "spring-ai": {
-      "description": "Spring AI integration (community)",
-      "sharedVersion": false,
-      "packages": [
-        { "name": "@ag-ui/spring-ai", "path": "integrations/community/spring-ai/typescript", "ecosystem": "typescript" }
       ]
     }
   }


### PR DESCRIPTION
## Summary

- **Scope build/test to what's actually being released.** Previously, every release (even releasing a single integration) ran `pnpm run build` + `pnpm run test` across the *entire* workspace via `nx run-many -t build/test`. Now both `prerelease` and `publish-release` workflows read the set of packages being released and pass `--projects=<list>` to `nx run-many` — nx's task graph pulls in upstream deps automatically, so `integration-mastra` builds mastra + core/client/encoder/proto, not the whole repo.
- **Python-only releases skip TypeScript build/test entirely.** `prerelease.yml` gates the TS build/test/publish steps on `steps.ts.outputs.count != '0'`. `publish-release.yml` already had the Python-only skip via `steps.detect_ts.outputs.count != '0'`; the new scoping step is also gated by it.
- **Restructured release scopes with a category-prefix convention.** Scopes now make ecosystem obvious at the name level:
  - `sdk-ts`, `sdk-py` (was `ts-sdk`, `py-sdk`)
  - `middleware-{name}` — for middlewares under `middlewares/` (all TS-only, no suffix needed)
  - `integration-{name}` — single-language integrations
  - `integration-{name}-{ts,py}` — dual-language integrations where disambiguation is needed (langgraph, crewai, claude-agent-sdk)
- **Split bundled scopes.** `crewai` and `langgraph` previously bundled their TS and Python packages into one scope — they're now released independently as `integration-{name}-ts` / `integration-{name}-py`.
- **Enrolled `@ag-ui/claude-agent-sdk`.** The TS package at [integrations/claude-agent-sdk/typescript](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-agent-sdk/typescript) was never in `release.config.json`, so `detect-ts-version-changes.sh` silently excluded it. Added as `integration-claude-agent-sdk-ts`.

**Breaking change for `workflow_dispatch` users:** scope choice names all changed (e.g. `mastra` → `integration-mastra`, `langgraph` → `integration-langgraph-ts` / `integration-langgraph-py`). Any bookmarked run URLs will need the new names.

## Test plan

- [ ] Dry-run `release / pre` with `integration-mastra` scope — confirm only mastra + its TS deps build (not the whole workspace), Python build/test step does not run
- [ ] Dry-run `release / pre` with `integration-adk` scope — confirm TS build/test/publish steps are skipped entirely (Python-only)
- [ ] Dry-run `release / pre` with `sdk-ts` scope — confirm the 5 shared-version core packages build and test
- [ ] Dry-run `release / create-pr` with `integration-langgraph-ts` scope — confirm version bumps only the TS package, not the Python one (validating the split)
- [ ] Verify `release / publish` on a merged release PR still detects + publishes correctly (detection is unchanged; scoping only affects the build/test step that runs before publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)