### PR TITLE
ci(release): fix nx release graph init by adding release.projects allowlist

### DIFF
--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           reporter: github-check
           level: error
-          fail_on_error: true
+          fail_level: error
           actionlint_flags: >-
             .github/workflows/prepare-release.yml
             .github/workflows/publish-release.yml

--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -17,6 +17,7 @@ on:
       - ".github/workflows/prerelease.yml"
       - ".github/workflows/lint-release-workflows.yml"
       - "scripts/release/**"
+      - "nx.json"
   pull_request:
     paths:
       - ".github/workflows/prepare-release.yml"
@@ -24,6 +25,7 @@ on:
       - ".github/workflows/prerelease.yml"
       - ".github/workflows/lint-release-workflows.yml"
       - "scripts/release/**"
+      - "nx.json"
 
 jobs:
   actionlint:
@@ -58,3 +60,14 @@ jobs:
             exit 0
           fi
           shellcheck --severity=warning "${files[@]}"
+
+  release-allowlist-sync:
+    # Verifies nx.json's release.projects matches release.config.json's
+    # TypeScript package allowlist. Drift between these two lists causes
+    # nx release publish to either fail (extra project without versionActions)
+    # or silently skip a package (missing from nx.json).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify nx.json and release.config.json are in sync
+        run: bash scripts/release/verify-nx-release-allowlist.sh

--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,29 @@
   "useDaemonProcess": true,
   "parallel": 30,
   "defaultBase": "main",
+  "release": {
+    "projects": [
+      "@ag-ui/core",
+      "@ag-ui/client",
+      "@ag-ui/encoder",
+      "@ag-ui/proto",
+      "create-ag-ui-app",
+      "@ag-ui/a2a",
+      "@ag-ui/ag2",
+      "@ag-ui/agno",
+      "@ag-ui/claude-agent-sdk",
+      "@ag-ui/crewai",
+      "@ag-ui/langchain",
+      "@ag-ui/langgraph",
+      "@ag-ui/llamaindex",
+      "@ag-ui/mastra",
+      "@ag-ui/pydantic-ai",
+      "@ag-ui/spring-ai",
+      "@ag-ui/a2a-middleware",
+      "@ag-ui/a2ui-middleware",
+      "@ag-ui/mcp-apps-middleware"
+    ]
+  },
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
     "production": [

--- a/scripts/release/verify-nx-release-allowlist.sh
+++ b/scripts/release/verify-nx-release-allowlist.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# scripts/release/verify-nx-release-allowlist.sh
+#
+# Verifies nx.json's `release.projects` matches the set of TypeScript
+# packages enrolled in scripts/release/release.config.json.
+#
+# Why this matters: nx release publish initializes a release graph for
+# every project in `release.projects`. If a project is in that list but
+# isn't actually releasable (e.g. a starter template without versionActions),
+# publish fails. Conversely, if a release.config.json package is NOT in
+# nx.json, nx release publish will silently skip it.
+#
+# Both files must list the same TypeScript package names.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG="$REPO_ROOT/scripts/release/release.config.json"
+NX_JSON="$REPO_ROOT/nx.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ERROR: $CONFIG not found" >&2
+  exit 1
+fi
+if [ ! -f "$NX_JSON" ]; then
+  echo "ERROR: $NX_JSON not found" >&2
+  exit 1
+fi
+
+CONFIG_TS=$(jq -r '[.scopes[].packages[] | select(.ecosystem == "typescript") | .name] | sort | .[]' "$CONFIG")
+NX_TS=$(jq -r '.release.projects // [] | sort | .[]' "$NX_JSON")
+
+if [ "$CONFIG_TS" = "$NX_TS" ]; then
+  echo "OK: nx.json release.projects matches release.config.json TypeScript packages"
+  exit 0
+fi
+
+echo "ERROR: nx.json release.projects and release.config.json TypeScript packages are out of sync." >&2
+echo "" >&2
+echo "--- diff (release.config.json vs nx.json) ---" >&2
+diff <(echo "$CONFIG_TS") <(echo "$NX_TS") || true >&2
+echo "" >&2
+echo "Fix: update nx.json's release.projects to match release.config.json's TypeScript package names," >&2
+echo "or vice versa. Both files must agree so nx release publish sees the correct allowlist." >&2
+exit 1


### PR DESCRIPTION
## Summary

Follow-up fix to #1585. The release workflow hit `NX Unable to resolve the default "versionActions" implementation for project "@ag-ui/server-starter-all-features"` on publish. Even when `nx release publish --projects=<list>` is passed, nx still initializes a release graph for *every* workspace package — non-releasable packages like starters fail that init because they don't have a resolvable `versionActions`.

- **Fix:** add `release.projects` to `nx.json` as an explicit allowlist of the 19 TS packages enrolled in `release.config.json`. nx now only considers these in the release graph; starters, in-progress scaffolds, and workspace-only apps are invisible to `nx release`.
- **Drift guard:** new `scripts/release/verify-nx-release-allowlist.sh` compares `nx.json`'s `release.projects` to `release.config.json`'s TypeScript packages and fails CI if they diverge. Wired into `lint-release-workflows.yml` as a new `release-allowlist-sync` job so enrollment in one file without the other is caught on PR.
- **Lint scope extended to nx.json:** `lint-release-workflows.yml` paths filter now includes `nx.json` so changes there trigger the sync check.

## Test plan

- [ ] The new `release-allowlist-sync` job runs green on this PR (allowlists already match)
- [ ] Re-run `release / pre` for `integration-claude-agent-sdk-ts` and confirm `nx release publish` no longer errors on `@ag-ui/server-starter-all-features`
- [ ] Locally: add a dummy TS package to `release.config.json` without updating `nx.json` and confirm the sync check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)