### PR TITLE
fix(adk-middleware): pre-yield pending tool-call registration + ADK >=1.30 test gating (#1581)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FIX**: Race in multi-instance HITL pending tool-call registration (#1581)
+  - In multi-pod deployments sharing a Redis-backed `SessionService`, HITL tool results were silently dropped because `_start_new_execution` registered each pending tool-call ID in the session store *after* the streaming loop exited — i.e. after `ToolCallEndEvent` (and `RUN_FINISHED`) had already been delivered to the client.  A continuation request load-balanced to a different pod observed an empty `pending_tool_calls` list and failed to resume the agent.
+  - `_add_pending_tool_call_with_context` now runs inside the streaming loop, before `yield event`, when a `ToolCallEndEvent` is observed.  For backend ADK tools that complete in the same stream, the just-registered ID is removed via `_remove_pending_tool_call` when the corresponding `ToolCallResultEvent` is seen, preserving prior semantics.
+  - Adds two regression tests in `test_multi_instance_hitl.py` covering the ordering invariant and the backend-tool cleanup path.
+
+- **FIX**: Gate ADK >=1.30-only tests so they skip cleanly on supported older ADK versions
+  - Three tests in `test_lro_tool_response_persistence.py` and one in `test_adk_130_invocation_id_override.py` assert behaviour produced by the ADK >=1.30 pre-append workaround in `adk_agent.py` (guarded by `_ADK_OVERRIDES_INVOCATION_ID`).  On ADK <1.30 the workaround is intentionally a no-op, so these tests previously failed on the lower end of the `>=1.16,<2.0` supported range.
+  - Each of the four tests now carries `@pytest.mark.skipif(not _ADK_OVERRIDES_INVOCATION_ID, ...)` and skips with an explicit reason on <1.30; on >=1.30 they continue to run unchanged.  The version-aware `test_function_response_has_correct_invocation_id` and the meta-test `test_feature_detection_matches_installed_adk_version` are intentionally left un-gated.
+
 - **FIX**: `temp:`-prefixed state from `extract_state_from_request` now reaches `tool_context.state` (#1571)
   - ADK's session services (`DatabaseSessionService`, `InMemorySessionService`, `VertexAiSessionService`) strip `temp:` keys before persisting, so request-scoped values (e.g. bearer tokens) returned by `extract_state_from_request` were silently dropped before the Runner fetched the session for an invocation
   - The session service is now transparently wrapped by `RequestStateSessionService`, which holds pending `temp:` state in memory keyed by `(app_name, user_id, session_id)` and merges it into the session that ADK's Runner loads at invocation time — so `temp:` keys are visible to tools during the run while still not being persisted

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1657,39 +1657,43 @@ class ADKAgent:
             
             # Stream events and track tool calls
             logger.debug(f"Starting to stream events for execution {execution.thread_id}")
-            has_tool_calls = False
-            tool_call_ids = []
+            app_name = self._get_app_name(input)
+            tool_call_ids: List[str] = []
 
             logger.debug(f"About to iterate over _stream_events for execution {execution.thread_id}")
             async for event in self._stream_events(execution):
-                # Track tool calls for HITL scenarios
+                # Register HITL tool calls in the backend session store BEFORE
+                # yielding ToolCallEndEvent. Otherwise a horizontally-scaled
+                # deployment can race: the client receives the event, posts the
+                # tool result to a different pod, and that pod sees an empty
+                # pending_tool_calls list because this pod hasn't written yet.
+                # See issue #1581.
                 if isinstance(event, ToolCallEndEvent):
                     logger.info(f"Detected ToolCallEndEvent with id: {event.tool_call_id}")
-                    has_tool_calls = True
                     tool_call_ids.append(event.tool_call_id)
+                    await self._add_pending_tool_call_with_context(
+                        execution.thread_id, event.tool_call_id, app_name, user_id
+                    )
 
-                # backend tools will always emit ToolCallResultEvent
-                # If it is a backend tool then we don't need to add the tool_id in pending_tools
+                # Backend tools complete within the same stream and emit a
+                # ToolCallResultEvent — no client continuation is expected, so
+                # remove the just-registered ID from the pending list before
+                # yielding the result.
                 if isinstance(event, ToolCallResultEvent) and event.tool_call_id in tool_call_ids:
                     logger.info(f"Detected ToolCallResultEvent with id: {event.tool_call_id}")
                     tool_call_ids.remove(event.tool_call_id)
+                    await self._remove_pending_tool_call(
+                        execution.thread_id, event.tool_call_id, user_id
+                    )
                     # Mark tool_call_id as processed so replay will skip it (fixes #437 replay bug)
                     self._session_manager.mark_messages_processed(
-                        self._get_app_name(input), execution.thread_id, [event.tool_call_id]
+                        app_name, execution.thread_id, [event.tool_call_id]
                     )
 
                 logger.debug(f"Yielding event: {type(event).__name__}")
                 yield event
 
             logger.debug(f"Finished iterating over _stream_events for execution {execution.thread_id}")
-
-            # If we found tool calls, add them to session state BEFORE cleanup
-            if has_tool_calls:
-                app_name = self._get_app_name(input)
-                for tool_call_id in tool_call_ids:
-                    await self._add_pending_tool_call_with_context(
-                        execution.thread_id, tool_call_id, app_name, user_id
-                    )
             logger.debug(f"Finished streaming events for execution {execution.thread_id}")
 
             # Emit RUN_FINISHED

--- a/integrations/adk-middleware/python/tests/test_adk_130_invocation_id_override.py
+++ b/integrations/adk-middleware/python/tests/test_adk_130_invocation_id_override.py
@@ -210,6 +210,10 @@ class TestStandaloneLlmAgentToolOnlyHITL:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not _ADK_OVERRIDES_INVOCATION_ID,
+        reason="FunctionCall lookup in session relies on the ADK >=1.30 pre-append workaround",
+    )
     async def test_tool_only_submission_persists_single_function_response_with_fc_invocation_id(
         self, check_api_key, resumable_standalone_agent
     ):

--- a/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
+++ b/integrations/adk-middleware/python/tests/test_lro_tool_response_persistence.py
@@ -166,6 +166,10 @@ class TestLROToolResponseIntegration:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not _ADK_OVERRIDES_INVOCATION_ID,
+        reason="Single-FunctionResponse persistence guarantee depends on the ADK >=1.30 pre-append workaround",
+    )
     async def test_tool_result_persists_single_function_response(
         self, check_api_key, simple_agent
     ):
@@ -420,6 +424,10 @@ class TestLROToolResponseIntegration:
                     )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not _ADK_OVERRIDES_INVOCATION_ID,
+        reason="Single-FunctionResponse persistence guarantee depends on the ADK >=1.30 pre-append workaround",
+    )
     async def test_tool_result_with_trailing_user_message(
         self, check_api_key, simple_agent
     ):
@@ -554,6 +562,10 @@ class TestHITLResumptionIntegration:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not _ADK_OVERRIDES_INVOCATION_ID,
+        reason="HITL resumption FunctionResponse persistence depends on the ADK >=1.30 pre-append workaround",
+    )
     async def test_hitl_resumption_preserves_invocation_context(
         self, check_api_key, hitl_agent
     ):

--- a/integrations/adk-middleware/python/tests/test_multi_instance_hitl.py
+++ b/integrations/adk-middleware/python/tests/test_multi_instance_hitl.py
@@ -16,6 +16,7 @@ from ag_ui.core import (
     RunAgentInput, UserMessage, AssistantMessage, ToolMessage,
     ToolCall, FunctionCall, Tool as AGUITool,
     ToolCallStartEvent, ToolCallArgsEvent, ToolCallEndEvent,
+    ToolCallResultEvent,
     EventType, RunErrorEvent,
 )
 from google.adk.agents import LlmAgent
@@ -244,6 +245,129 @@ class TestMultiInstanceHITL:
         cached_b = instance_b._session_lookup_cache.get((thread_id, "test_user"))
         assert cached_b is not None
         assert cached_b[0] == session_id_a, "Instance B should find Instance A's session"
+
+    @pytest.mark.asyncio
+    async def test_pending_tool_call_registered_before_tool_call_end_event_yielded(
+        self, instance_a, sample_tool,
+    ):
+        """Regression test for #1581.
+
+        The pending tool call ID must be persisted to the shared session store
+        the moment a `ToolCallEndEvent` is delivered to the consumer. Otherwise
+        a continuation request routed to another pod will see an empty
+        pending_tool_calls list and silently drop the tool result.
+
+        We verify via ``instance_a._has_pending_tool_calls`` (warm cache),
+        which reads through to the shared session service — proving the write
+        has reached the backing store before the event reached the consumer.
+        """
+        thread_id = "race_condition_thread"
+        tool_call_id = "tool_call_race_xyz"
+
+        await instance_a._ensure_session_exists(
+            app_name="test_app", user_id="test_user",
+            thread_id=thread_id, initial_state={},
+        )
+
+        input_a = RunAgentInput(
+            thread_id=thread_id,
+            run_id="run_race",
+            messages=[UserMessage(id="msg_1", role="user", content="Plan something")],
+            tools=[sample_tool],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        async def mock_run_a(*args, **kwargs):
+            eq = kwargs["event_queue"]
+            await eq.put(ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=tool_call_id,
+                tool_call_name="approve_plan",
+            ))
+            await eq.put(ToolCallArgsEvent(
+                type=EventType.TOOL_CALL_ARGS,
+                tool_call_id=tool_call_id,
+                delta="{}",
+            ))
+            await eq.put(ToolCallEndEvent(
+                type=EventType.TOOL_CALL_END,
+                tool_call_id=tool_call_id,
+            ))
+            await eq.put(None)
+
+        observed_end = False
+        with patch.object(instance_a, "_run_adk_in_background", side_effect=mock_run_a):
+            async for event in instance_a.run(input_a):
+                if isinstance(event, ToolCallEndEvent):
+                    observed_end = True
+                    assert await instance_a._has_pending_tool_calls(
+                        thread_id, "test_user"
+                    ), (
+                        "pending_tool_calls must be persisted before "
+                        "ToolCallEndEvent is yielded (issue #1581)"
+                    )
+
+        assert observed_end, "Test setup error: never observed ToolCallEndEvent"
+
+    @pytest.mark.asyncio
+    async def test_backend_tool_result_clears_pending_before_stream_ends(
+        self, instance_a, sample_tool,
+    ):
+        """Backend ADK tools complete in-stream and must not leave a stale
+        entry in pending_tool_calls. The just-registered ID is removed when
+        the corresponding ToolCallResultEvent is observed.
+        """
+        thread_id = "backend_tool_thread"
+        tool_call_id = "tool_call_backend_456"
+
+        await instance_a._ensure_session_exists(
+            app_name="test_app", user_id="test_user",
+            thread_id=thread_id, initial_state={},
+        )
+
+        input_a = RunAgentInput(
+            thread_id=thread_id,
+            run_id="run_backend",
+            messages=[UserMessage(id="msg_1", role="user", content="Do a backend thing")],
+            tools=[sample_tool],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        async def mock_run_backend_tool(*args, **kwargs):
+            eq = kwargs["event_queue"]
+            await eq.put(ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=tool_call_id,
+                tool_call_name="server_side_tool",
+            ))
+            await eq.put(ToolCallArgsEvent(
+                type=EventType.TOOL_CALL_ARGS,
+                tool_call_id=tool_call_id,
+                delta="{}",
+            ))
+            await eq.put(ToolCallEndEvent(
+                type=EventType.TOOL_CALL_END,
+                tool_call_id=tool_call_id,
+            ))
+            await eq.put(ToolCallResultEvent(
+                type=EventType.TOOL_CALL_RESULT,
+                message_id="msg_result",
+                tool_call_id=tool_call_id,
+                content='{"ok": true}',
+            ))
+            await eq.put(None)
+
+        with patch.object(instance_a, "_run_adk_in_background", side_effect=mock_run_backend_tool):
+            async for _ in instance_a.run(input_a):
+                pass
+
+        assert not await instance_a._has_pending_tool_calls(thread_id, "test_user"), (
+            "Backend tool result should clear the pending tool call entry"
+        )
 
     @pytest.mark.asyncio
     async def test_independent_caches_shared_session_service(


### PR DESCRIPTION
## Summary

- **Multi-instance HITL fix (#1581)**: Pre-existing on this branch as 790798d8. In multi-pod deployments sharing a Redis-backed `SessionService`, HITL tool results were silently dropped because `_start_new_execution` registered each pending tool-call ID *after* the streaming loop exited — i.e. after `ToolCallEndEvent` and `RUN_FINISHED` had already been delivered.  A continuation request load-balanced to a different pod observed an empty `pending_tool_calls` list and failed to resume the agent. `_add_pending_tool_call_with_context` now runs inside the streaming loop, before the `yield`, when a `ToolCallEndEvent` is observed; backend ADK tools that complete in-stream still get the just-registered ID removed when the corresponding `ToolCallResultEvent` is seen, preserving prior semantics. Two regression tests added in `test_multi_instance_hitl.py`.

- **ADK >=1.30 test gating**: Three tests in `test_lro_tool_response_persistence.py` and one in `test_adk_130_invocation_id_override.py` assert behaviour produced by the ADK >=1.30 pre-append workaround in `adk_agent.py` (guarded by `_ADK_OVERRIDES_INVOCATION_ID`). On ADK <1.30 the workaround is intentionally a no-op, so these tests previously failed against the lower end of the supported `>=1.16,<2.0` range — and the lockfile resolves to 1.26.0 today, so a fresh `uv sync` reproduces this. Each affected test now carries `@pytest.mark.skipif(not _ADK_OVERRIDES_INVOCATION_ID, ...)` with an explicit reason. The version-aware `test_function_response_has_correct_invocation_id` and the meta-test `test_feature_detection_matches_installed_adk_version` are intentionally left un-gated.

- **CHANGELOG**: adds entries under `[Unreleased] → Fixed` for both the #1581 fix and the gating change.

## Test plan

- [x] `uv run pytest tests/test_multi_instance_hitl.py` on the lockfile version (ADK 1.26.0): 5 passed
- [x] Targeted run on **ADK 1.30.0**: all 7 previously-failing tests pass
- [x] Targeted run on **ADK 1.26.0**: 3 pass, 4 skip with explicit reasons (no failures)
- [x] Full suite on **ADK 1.31.1** (latest within the constraint range): 786 passed, 5 skipped (Vertex live), 0 unrelated regressions (two tests flaked under `-n auto` parallel mode but both pass in isolation — `test_reasoning_events_structure` and `test_mixed_text_and_image_color_stripes`, both real-LLM behaviour-variance flakes unrelated to this PR)

The lockfile (`uv.lock`) is intentionally untouched — keeping scope tight to the #1581 fix + gating; raising the lockfile to 1.31.1 also bumps `google-cloud-aiplatform` and `google-genai` transitively, which deserves a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)