### PR TITLE
fix(langgraph): propagate context to copilotkit state

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -101,6 +101,13 @@ logger = logging.getLogger(__name__)
 
 ROOT_SUBGRAPH_NAME = "root"
 
+# Cross-language contract: this string must exactly match
+# A2UI_SCHEMA_CONTEXT_DESCRIPTION in middlewares/a2ui-middleware/src/index.ts.
+A2UI_SCHEMA_CONTEXT_DESCRIPTION = (
+    "A2UI Component Schema \u2014 available components for generating UI surfaces. "
+    "Use these component names and properties when creating A2UI operations."
+)
+
 
 class PreparedStream(TypedDict):
     """Payload returned by prepare_stream / prepare_regenerate_stream.
@@ -820,22 +827,26 @@ class LangGraphAgent:
         # instead of it being dumped into the system prompt with all other context.
         # The remaining (regular) context is written to both state["ag-ui"]["context"]
         # and state["copilotkit"]["context"] — the latter is required because
-        # CopilotKitMiddleware.before_agent() reads context from the copilotkit
-        # state key to build the system prompt.
-        #
-        # Cross-language contract: this string must exactly match
-        # A2UI_SCHEMA_CONTEXT_DESCRIPTION in middlewares/a2ui-middleware/src/index.ts.
-        A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema \u2014 available components for generating UI surfaces. Use these component names and properties when creating A2UI operations."
-
+        # the CopilotKit Python SDK reads context from the copilotkit state key
+        # to build the system prompt.
         all_context = input.context or []
         a2ui_schema_value = None
+        a2ui_match_count = 0
         regular_context = []
         for entry in all_context:
             desc = entry.get("description", "") if isinstance(entry, dict) else getattr(entry, "description", "")
             if desc == A2UI_SCHEMA_CONTEXT_DESCRIPTION:
+                a2ui_match_count += 1
                 a2ui_schema_value = entry.get("value", "") if isinstance(entry, dict) else getattr(entry, "value", "")
             else:
                 regular_context.append(entry)
+
+        if a2ui_match_count > 1:
+            logger.warning(
+                "Found %d context entries matching A2UI_SCHEMA_CONTEXT_DESCRIPTION; "
+                "only the last value will be used as the A2UI schema.",
+                a2ui_match_count,
+            )
 
         if a2ui_schema_value is None and all_context:
             for entry in all_context:
@@ -861,7 +872,7 @@ class LangGraphAgent:
             "tools": unique_tools,
             "ag-ui": ag_ui_state,
             "copilotkit": {
-                **state.get("copilotkit", {}),
+                **(state.get("copilotkit") or {}),
                 "actions": unique_tools,
                 "context": regular_context,
             },

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -818,7 +818,7 @@ class LangGraphAgent:
         # The A2UI schema goes into state["ag-ui"]["a2ui_schema"] so agents
         # can read it directly from state (e.g., for the generate_a2ui tool),
         # instead of it being dumped into the system prompt with all other context.
-        A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema \u2014 available components for generating UI surfaces. Use these component names and props when creating A2UI operations."
+        A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema \u2014 available components for generating UI surfaces. Use these component names and properties when creating A2UI operations."
 
         all_context = input.context or []
         a2ui_schema_value = None
@@ -845,6 +845,7 @@ class LangGraphAgent:
             "copilotkit": {
                 **state.get("copilotkit", {}),
                 "actions": unique_tools,
+                "context": regular_context,
             },
         }
 

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -818,6 +818,13 @@ class LangGraphAgent:
         # The A2UI schema goes into state["ag-ui"]["a2ui_schema"] so agents
         # can read it directly from state (e.g., for the generate_a2ui tool),
         # instead of it being dumped into the system prompt with all other context.
+        # The remaining (regular) context is written to both state["ag-ui"]["context"]
+        # and state["copilotkit"]["context"] — the latter is required because
+        # CopilotKitMiddleware.before_agent() reads context from the copilotkit
+        # state key to build the system prompt.
+        #
+        # Cross-language contract: this string must exactly match
+        # A2UI_SCHEMA_CONTEXT_DESCRIPTION in middlewares/a2ui-middleware/src/index.ts.
         A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema \u2014 available components for generating UI surfaces. Use these component names and properties when creating A2UI operations."
 
         all_context = input.context or []

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -837,6 +837,17 @@ class LangGraphAgent:
             else:
                 regular_context.append(entry)
 
+        if a2ui_schema_value is None and all_context:
+            for entry in all_context:
+                desc = entry.get("description", "") if isinstance(entry, dict) else getattr(entry, "description", "")
+                if "a2ui" in desc.lower():
+                    logger.warning(
+                        "Context entry with A2UI-related description %r did not match "
+                        "A2UI_SCHEMA_CONTEXT_DESCRIPTION. Expected: %r",
+                        desc,
+                        A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+                    )
+
         ag_ui_state: dict = {
             "tools": unique_tools,
             "context": regular_context,

--- a/integrations/langgraph/python/tests/test_merge_state_context.py
+++ b/integrations/langgraph/python/tests/test_merge_state_context.py
@@ -1,0 +1,172 @@
+"""Tests for langgraph_default_merge_state context propagation.
+
+Covers the A2UI schema extraction logic and the dual-write of
+regular_context to both state["ag-ui"]["context"] and
+state["copilotkit"]["context"].
+"""
+
+import logging
+import unittest
+
+from ag_ui.core import Context, RunAgentInput
+
+from tests._helpers import make_agent
+
+
+# Canonical A2UI description — must match the constant in agent.py and
+# middlewares/a2ui-middleware/src/index.ts.
+A2UI_DESC = (
+    "A2UI Component Schema \u2014 available components for generating UI "
+    "surfaces. Use these component names and properties when creating "
+    "A2UI operations."
+)
+
+
+def _make_input(context=None, tools=None):
+    """Build a minimal RunAgentInput with the given context."""
+    return RunAgentInput(
+        thread_id="t-1",
+        run_id="r-1",
+        state={},
+        messages=[],
+        tools=tools or [],
+        context=context or [],
+        forwarded_props={},
+    )
+
+
+class TestContextPropagation(unittest.TestCase):
+    """Verify that regular context lands in both ag-ui and copilotkit state."""
+
+    def test_regular_context_in_both_state_dicts(self):
+        agent = make_agent()
+        ctx = [
+            Context(description="user prefs", value="dark-mode"),
+            Context(description="locale", value="en-US"),
+        ]
+        result = agent.langgraph_default_merge_state({}, [], _make_input(context=ctx))
+
+        self.assertEqual(result["ag-ui"]["context"], ctx)
+        self.assertEqual(result["copilotkit"]["context"], ctx)
+
+    def test_empty_context(self):
+        agent = make_agent()
+        result = agent.langgraph_default_merge_state({}, [], _make_input(context=[]))
+
+        self.assertEqual(result["ag-ui"]["context"], [])
+        self.assertEqual(result["copilotkit"]["context"], [])
+        self.assertNotIn("a2ui_schema", result["ag-ui"])
+
+    def test_none_context(self):
+        agent = make_agent()
+        inp = _make_input()
+        inp.context = None
+        result = agent.langgraph_default_merge_state({}, [], inp)
+
+        self.assertEqual(result["ag-ui"]["context"], [])
+        self.assertEqual(result["copilotkit"]["context"], [])
+
+
+class TestA2UISchemaExtraction(unittest.TestCase):
+    """Verify that the A2UI schema entry is extracted into ag-ui state
+    and excluded from regular context."""
+
+    def test_a2ui_schema_extracted(self):
+        agent = make_agent()
+        a2ui_entry = Context(description=A2UI_DESC, value='{"Button": {}}')
+        regular = Context(description="other", value="val")
+        ctx = [regular, a2ui_entry]
+
+        result = agent.langgraph_default_merge_state({}, [], _make_input(context=ctx))
+
+        self.assertEqual(result["ag-ui"]["a2ui_schema"], '{"Button": {}}')
+        self.assertEqual(result["ag-ui"]["context"], [regular])
+        self.assertEqual(result["copilotkit"]["context"], [regular])
+
+    def test_mismatched_description_stays_in_regular(self):
+        agent = make_agent()
+        wrong = Context(
+            description="A2UI Component Schema \u2014 ...props...",
+            value="schema",
+        )
+        result = agent.langgraph_default_merge_state({}, [], _make_input(context=[wrong]))
+
+        self.assertNotIn("a2ui_schema", result["ag-ui"])
+        self.assertEqual(result["ag-ui"]["context"], [wrong])
+
+    def test_mixed_context_partitioning(self):
+        agent = make_agent()
+        r1 = Context(description="d1", value="v1")
+        r2 = Context(description="d2", value="v2")
+        a2ui = Context(description=A2UI_DESC, value="schema-json")
+        ctx = [r1, a2ui, r2]
+
+        result = agent.langgraph_default_merge_state({}, [], _make_input(context=ctx))
+
+        self.assertEqual(result["ag-ui"]["a2ui_schema"], "schema-json")
+        self.assertEqual(result["ag-ui"]["context"], [r1, r2])
+        self.assertEqual(result["copilotkit"]["context"], [r1, r2])
+
+
+class TestCopilotKitStatePreservation(unittest.TestCase):
+    """Ensure the copilotkit state spread preserves existing keys."""
+
+    def test_existing_keys_preserved(self):
+        agent = make_agent()
+        state = {"copilotkit": {"custom_key": "preserved"}}
+        result = agent.langgraph_default_merge_state(state, [], _make_input())
+
+        self.assertEqual(result["copilotkit"]["custom_key"], "preserved")
+        self.assertEqual(result["copilotkit"]["context"], [])
+        self.assertIn("actions", result["copilotkit"])
+
+    def test_stale_context_overridden(self):
+        agent = make_agent()
+        state = {"copilotkit": {"context": ["stale"]}}
+        fresh = [Context(description="new", value="val")]
+        result = agent.langgraph_default_merge_state(state, [], _make_input(context=fresh))
+
+        self.assertEqual(result["copilotkit"]["context"], fresh)
+
+
+class TestA2UIMismatchWarning(unittest.TestCase):
+    """Verify that a logger warning fires when an A2UI-related context
+    entry doesn't match the expected description string."""
+
+    def test_warning_on_near_miss(self):
+        agent = make_agent()
+        wrong = Context(
+            description="A2UI Component Schema \u2014 old props version",
+            value="schema",
+        )
+        with self.assertLogs("ag_ui_langgraph.agent", level="WARNING") as cm:
+            agent.langgraph_default_merge_state({}, [], _make_input(context=[wrong]))
+
+        self.assertTrue(
+            any("did not match" in msg for msg in cm.output),
+            f"expected mismatch warning, got: {cm.output}",
+        )
+
+    def test_no_warning_when_matched(self):
+        agent = make_agent()
+        correct = Context(description=A2UI_DESC, value="schema")
+        logger = logging.getLogger("ag_ui_langgraph.agent")
+        with self.assertRaises(AssertionError):
+            # assertLogs raises AssertionError when no logs are emitted
+            with self.assertLogs(logger, level="WARNING"):
+                agent.langgraph_default_merge_state(
+                    {}, [], _make_input(context=[correct])
+                )
+
+    def test_no_warning_when_no_a2ui_entries(self):
+        agent = make_agent()
+        regular = Context(description="just regular", value="val")
+        with self.assertRaises(AssertionError):
+            with self.assertLogs("ag_ui_langgraph.agent", level="WARNING"):
+                agent.langgraph_default_merge_state(
+                    {}, [], _make_input(context=[regular])
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_merge_state_context.py
+++ b/integrations/langgraph/python/tests/test_merge_state_context.py
@@ -12,20 +12,14 @@ from pathlib import Path
 
 from ag_ui.core import Context, RunAgentInput
 
+from ag_ui_langgraph.agent import A2UI_SCHEMA_CONTEXT_DESCRIPTION
 from tests._helpers import make_agent
 
 # Resolve repo root relative to this test file:
 # tests/ -> python/ -> langgraph/ -> integrations/ -> repo root
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
-
-# Canonical A2UI description — must match the constant in agent.py and
-# middlewares/a2ui-middleware/src/index.ts.
-A2UI_DESC = (
-    "A2UI Component Schema \u2014 available components for generating UI "
-    "surfaces. Use these component names and properties when creating "
-    "A2UI operations."
-)
+A2UI_DESC = A2UI_SCHEMA_CONTEXT_DESCRIPTION
 
 
 def _make_input(context=None, tools=None):
@@ -63,6 +57,23 @@ class TestContextPropagation(unittest.TestCase):
         self.assertEqual(result["copilotkit"]["context"], [])
         self.assertNotIn("a2ui_schema", result["ag-ui"])
 
+    def test_dict_context_entries_propagated(self):
+        """Verify the dict code path works when context entries bypass
+        Pydantic validation (e.g. raw dicts from deserialized state)."""
+        agent = make_agent()
+        ctx = [
+            {"description": "user prefs", "value": "dark-mode"},
+            {"description": "locale", "value": "en-US"},
+        ]
+        # Pass dicts directly to langgraph_default_merge_state, bypassing
+        # RunAgentInput validation which would coerce dicts to Context objects.
+        inp = _make_input()
+        inp.context = ctx  # type: ignore[assignment]
+        result = agent.langgraph_default_merge_state({}, [], inp)
+
+        self.assertEqual(result["ag-ui"]["context"], ctx)
+        self.assertEqual(result["copilotkit"]["context"], ctx)
+
     def test_none_context(self):
         agent = make_agent()
         inp = _make_input()
@@ -84,6 +95,20 @@ class TestA2UISchemaExtraction(unittest.TestCase):
         ctx = [regular, a2ui_entry]
 
         result = agent.langgraph_default_merge_state({}, [], _make_input(context=ctx))
+
+        self.assertEqual(result["ag-ui"]["a2ui_schema"], '{"Button": {}}')
+        self.assertEqual(result["ag-ui"]["context"], [regular])
+        self.assertEqual(result["copilotkit"]["context"], [regular])
+
+    def test_a2ui_schema_extracted_from_dict_entries(self):
+        """Verify A2UI extraction works when context entries are plain dicts."""
+        agent = make_agent()
+        a2ui_entry = {"description": A2UI_DESC, "value": '{"Button": {}}'}
+        regular = {"description": "other", "value": "val"}
+        inp = _make_input()
+        inp.context = [regular, a2ui_entry]  # type: ignore[assignment]
+
+        result = agent.langgraph_default_merge_state({}, [], inp)
 
         self.assertEqual(result["ag-ui"]["a2ui_schema"], '{"Button": {}}')
         self.assertEqual(result["ag-ui"]["context"], [regular])
@@ -134,6 +159,14 @@ class TestCopilotKitStatePreservation(unittest.TestCase):
 
         self.assertEqual(result["copilotkit"]["context"], fresh)
 
+    def test_none_copilotkit_state_does_not_crash(self):
+        agent = make_agent()
+        state = {"copilotkit": None}
+        result = agent.langgraph_default_merge_state(state, [], _make_input())
+
+        self.assertEqual(result["copilotkit"]["context"], [])
+        self.assertIn("actions", result["copilotkit"])
+
 
 class TestA2UIMismatchWarning(unittest.TestCase):
     """Verify that a logger warning fires when an A2UI-related context
@@ -152,6 +185,24 @@ class TestA2UIMismatchWarning(unittest.TestCase):
             any("did not match" in msg for msg in cm.output),
             f"expected mismatch warning, got: {cm.output}",
         )
+
+    def test_warning_on_duplicate_a2ui_entries(self):
+        agent = make_agent()
+        a2ui_1 = Context(description=A2UI_DESC, value='{"Button": {}}')
+        a2ui_2 = Context(description=A2UI_DESC, value='{"Card": {}}')
+        with self.assertLogs("ag_ui_langgraph.agent", level="WARNING") as cm:
+            result = agent.langgraph_default_merge_state(
+                {}, [], _make_input(context=[a2ui_1, a2ui_2])
+            )
+
+        self.assertTrue(
+            any("Found 2" in msg for msg in cm.output),
+            f"expected duplicate warning, got: {cm.output}",
+        )
+        # Last value wins
+        self.assertEqual(result["ag-ui"]["a2ui_schema"], '{"Card": {}}')
+        self.assertEqual(result["ag-ui"]["context"], [])
+        self.assertEqual(result["copilotkit"]["context"], [])
 
     def test_no_warning_when_matched(self):
         agent = make_agent()
@@ -177,25 +228,13 @@ class TestA2UIMismatchWarning(unittest.TestCase):
 class TestCrossLanguageStringParity(unittest.TestCase):
     """Verify the A2UI description string is identical in the Python
     integration and the TypeScript middleware — the cross-language contract
-    that caused the original bug when the two diverged."""
+    that caused a silent failure when the Python string used "props" while
+    the TypeScript string used "properties", preventing A2UI schema extraction."""
 
-    _PY_PATH = (
-        _REPO_ROOT
-        / "integrations/langgraph/python/ag_ui_langgraph/agent.py"
-    )
     _TS_PATH = (
         _REPO_ROOT
         / "middlewares/a2ui-middleware/src/index.ts"
     )
-
-    @staticmethod
-    def _extract_py_constant(source: str) -> str:
-        match = re.search(
-            r'A2UI_SCHEMA_CONTEXT_DESCRIPTION\s*=\s*"([^"]+)"', source
-        )
-        if not match:
-            raise AssertionError("could not find A2UI_SCHEMA_CONTEXT_DESCRIPTION in Python source")
-        return match.group(1).encode().decode("unicode_escape")
 
     @staticmethod
     def _extract_ts_constant(source: str) -> str:
@@ -207,17 +246,14 @@ class TestCrossLanguageStringParity(unittest.TestCase):
         return match.group(1)
 
     def test_python_and_typescript_strings_match(self):
-        py_src = self._PY_PATH.read_text(encoding="utf-8")
         ts_src = self._TS_PATH.read_text(encoding="utf-8")
-
-        py_val = self._extract_py_constant(py_src)
         ts_val = self._extract_ts_constant(ts_src)
 
         self.assertEqual(
-            py_val,
+            A2UI_DESC,
             ts_val,
             "A2UI_SCHEMA_CONTEXT_DESCRIPTION has diverged between Python and TypeScript. "
-            f"Python: {py_val!r}  TypeScript: {ts_val!r}",
+            f"Python: {A2UI_DESC!r}  TypeScript: {ts_val!r}",
         )
 
 

--- a/integrations/langgraph/python/tests/test_merge_state_context.py
+++ b/integrations/langgraph/python/tests/test_merge_state_context.py
@@ -6,11 +6,17 @@ state["copilotkit"]["context"].
 """
 
 import logging
+import re
 import unittest
+from pathlib import Path
 
 from ag_ui.core import Context, RunAgentInput
 
 from tests._helpers import make_agent
+
+# Resolve repo root relative to this test file:
+# tests/ -> python/ -> langgraph/ -> integrations/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 # Canonical A2UI description — must match the constant in agent.py and
@@ -166,6 +172,53 @@ class TestA2UIMismatchWarning(unittest.TestCase):
                 agent.langgraph_default_merge_state(
                     {}, [], _make_input(context=[regular])
                 )
+
+
+class TestCrossLanguageStringParity(unittest.TestCase):
+    """Verify the A2UI description string is identical in the Python
+    integration and the TypeScript middleware — the cross-language contract
+    that caused the original bug when the two diverged."""
+
+    _PY_PATH = (
+        _REPO_ROOT
+        / "integrations/langgraph/python/ag_ui_langgraph/agent.py"
+    )
+    _TS_PATH = (
+        _REPO_ROOT
+        / "middlewares/a2ui-middleware/src/index.ts"
+    )
+
+    @staticmethod
+    def _extract_py_constant(source: str) -> str:
+        match = re.search(
+            r'A2UI_SCHEMA_CONTEXT_DESCRIPTION\s*=\s*"([^"]+)"', source
+        )
+        if not match:
+            raise AssertionError("could not find A2UI_SCHEMA_CONTEXT_DESCRIPTION in Python source")
+        return match.group(1).encode().decode("unicode_escape")
+
+    @staticmethod
+    def _extract_ts_constant(source: str) -> str:
+        match = re.search(
+            r'A2UI_SCHEMA_CONTEXT_DESCRIPTION\s*=\s*"([^"]+)"', source
+        )
+        if not match:
+            raise AssertionError("could not find A2UI_SCHEMA_CONTEXT_DESCRIPTION in TypeScript source")
+        return match.group(1)
+
+    def test_python_and_typescript_strings_match(self):
+        py_src = self._PY_PATH.read_text(encoding="utf-8")
+        ts_src = self._TS_PATH.read_text(encoding="utf-8")
+
+        py_val = self._extract_py_constant(py_src)
+        ts_val = self._extract_ts_constant(ts_src)
+
+        self.assertEqual(
+            py_val,
+            ts_val,
+            "A2UI_SCHEMA_CONTEXT_DESCRIPTION has diverged between Python and TypeScript. "
+            f"Python: {py_val!r}  TypeScript: {ts_val!r}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `langgraph_default_merge_state()` writes context to `state["ag-ui"]["context"]` but never to `state["copilotkit"]["context"]`, causing `CopilotKitMiddleware.before_agent()` to always see empty context
- A2UI schema description string used "props" instead of "properties", mismatching the TS middleware's canonical string — so the schema was never extracted into `state["ag-ui"]["a2ui_schema"]`

## Reproduction

Any Python LangGraph agent using `CopilotKitMiddleware()` with a tool that reads `runtime.state["copilotkit"]["context"]` gets an empty list. This breaks the dynamic A2UI generation pattern where the secondary LLM needs the catalog schema from the frontend.

## Fix

1. Add `"context": regular_context` to the `copilotkit` state dict in `langgraph_default_merge_state()`
2. Fix description string: "props" → "properties" to match TS middleware

## Test plan

- [x] Verified with apartment finder demo: `context_entries` goes from 0 to populated after fix
- [ ] Existing tests should still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)