### PR TITLE
fix(dojo): repoint stale ADK/Pydantic/Open Agent Spec URLs

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -426,11 +426,11 @@ projects:
       - key: CREW_AI_URL
         value: https://ag-ui-dojo-crewai.onrender.com
       - key: AGENT_SPEC_URL
-        value: https://ag-ui-dojo-open-agent-spec.onrender.com
+        value: https://ag-ui-p7fw.onrender.com
       - key: PYDANTIC_AI_URL
-        value: https://ag-ui-dojo-pydantic-ai.onrender.com
+        value: https://pydantic-ai.onrender.com
       - key: ADK_MIDDLEWARE_URL
-        value: https://ag-ui-adk.onrender.com
+        value: https://ag-ui.onrender.com
       - key: AGENT_FRAMEWORK_PYTHON_URL
         value: https://ag-ui-dojo-maf-python.onrender.com
       - key: AGENT_FRAMEWORK_DOTNET_URL


### PR DESCRIPTION
## Summary

Three of the dojo's integration env vars in `render.yaml` pointed at Render hostnames that no longer have running services — the edge returns `x-render-routing: no-server`. The actual deployments live under different hostnames, so the dojo chats for **Google ADK**, **Pydantic AI**, and **Open Agent Spec (Oracle LangGraph)** produced empty responses (HTTP 404 → no SSE events → blank chat bubble).

| Env var | Old (dead) | New (live) |
|---|---|---|
| `ADK_MIDDLEWARE_URL` | `ag-ui-adk.onrender.com` | `ag-ui.onrender.com` |
| `PYDANTIC_AI_URL` | `ag-ui-dojo-pydantic-ai.onrender.com` | `pydantic-ai.onrender.com` |
| `AGENT_SPEC_URL` | `ag-ui-dojo-open-agent-spec.onrender.com` | `ag-ui-p7fw.onrender.com` |

## How verified

Confirmed via direct curl against the new URLs:
- **Pydantic AI** streams `RUN_STARTED` → `TEXT_MESSAGE_CONTENT` deltas cleanly.
- **Open Agent Spec** at `/langgraph/agentic_chat` streams full responses.
- **ADK** at `/chat/` reaches the model (currently throwing a Vertex AI 429 quota error, separate concern).

## Important: env vars also need updating in the Render dashboard

`render.yaml` is the source-of-truth manifest, but the running dojo service has its env vars set live in the dashboard. Merging this PR alone does not change production behavior — the same three values need to be updated on the `ag-ui-dojo-app` service in Render, or a `render blueprint apply` run.

## Out of scope (related but separate)

The investigation also surfaced these issues, **not** addressed here:
- A2A buildings_management is also `no-server` — needs its real URL
- ADK `GOOGLE_API_KEY` is hitting Vertex AI quota (429)
- CrewAI `OPENAI_API_KEY` is invalid (`AGUI_CREWAI_FLOW_ERROR_AUTHENTICATIONERROR`)
- Claude Agent SDK (TS + Python) `ANTHROPIC_API_KEY` has $0 credit balance
- Claude Agent SDK Python silently swallows the billing error instead of emitting `RUN_ERROR` like the TypeScript adapter does — worth a follow-up

## Test plan

- [ ] Update env vars in Render dashboard on `ag-ui-dojo-app` to match this PR
- [ ] Open the Dojo, pick **Google ADK** → agentic_chat → message streams (or 429 if quota issue persists)
- [ ] Open the Dojo, pick **Pydantic AI** → agentic_chat → message streams
- [ ] Open the Dojo, pick **Open Agent Spec (LangGraph)** → agentic_chat → message streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)