### PR TITLE
fix(dojo): bump claude-agent-sdk plans + fix A2A buildings URL

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -358,7 +358,7 @@ projects:
       name: ag-ui-dojo-claude-agent-sdk-python
       runtime: python
       repo: https://github.com/ag-ui-protocol/ag-ui
-      plan: starter
+      plan: standard
       scaling:
         minInstances: 1
         maxInstances: 3
@@ -376,7 +376,7 @@ projects:
       name: ag-ui-dojo-claude-agent-sdk-typescript
       runtime: node
       repo: https://github.com/ag-ui-protocol/ag-ui
-      plan: starter
+      plan: standard
       scaling:
         minInstances: 1
         maxInstances: 3

--- a/render.yaml
+++ b/render.yaml
@@ -436,7 +436,7 @@ projects:
       - key: AGENT_FRAMEWORK_DOTNET_URL
         value: https://ag-ui-dojo-maf-dotnet.onrender.com
       - key: A2A_MIDDLEWARE_BUILDINGS_MANAGEMENT_URL
-        value: https://ag-ui-dojo-a2a-middleware-businesses-management.onrender.com
+        value: https://ag-ui-dojo-a2a-middleware-businesses.onrender.com
       - key: A2A_MIDDLEWARE_FINANCE_URL
         value: https://ag-ui-dojo-a2a-middleware-finance.onrender.com
       - key: A2A_MIDDLEWARE_IT_URL


### PR DESCRIPTION
## Summary

Two follow-ups to #1604:

1. **Bump claude-agent-sdk Python and TypeScript services from `starter` (512 MB) to `standard` (2 GB) plan.** Render events for `ag-ui-dojo-claude-agent-sdk-python` show a continuous OOM-recover loop ("Ran out of memory (used over 512MB) while running your code" → "Service recovered" → crash again). The architectural cause is that `ClaudeAgentAdapter` spawns one `ClaudeSDKClient` per thread, which spawns a Claude Code Node.js subprocess (~250–400 MB resident). One active session puts the service over 512 MB; two threads guarantees OOM. The TS variant has the same architecture and same risk. Aligns with `aws-strands-python` which is already on `standard` for the same reason.

2. **Correct the A2A buildings_management URL.** `A2A_MIDDLEWARE_BUILDINGS_MANAGEMENT_URL` pointed at `…a2a-middleware-businesses-management.onrender.com`, but the actual Render service is `…a2a-middleware-businesses.onrender.com` (no `-management` suffix). The wrong hostname returned `x-render-routing: no-server`, which breaks the entire A2A integration because [agents.ts](apps/dojo/src/agents.ts) wires all three sub-agent URLs as required for `A2AMiddlewareAgent`.

## Verification

- A2A buildings (corrected URL): `curl -si https://ag-ui-dojo-a2a-middleware-businesses.onrender.com/` → `HTTP/2 405`, `x-render-origin-server: uvicorn` (alive; 405 because root is POST-only).

## Important

`render.yaml` is the source-of-truth manifest, but the running dojo service has live env vars set in the Render dashboard. Merging this alone does not change production behavior — `A2A_MIDDLEWARE_BUILDINGS_MANAGEMENT_URL` on `ag-ui-dojo-app` needs the same update in the dashboard, and the two Claude SDK services need their plans bumped in the dashboard (or `render blueprint apply`).

## Follow-ups (not in this PR)

- Lower `SessionWorker` TTL from 1800 s → ~120 s in [adapter.py](integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py) so idle Node subprocesses get reaped.
- Cap `max_workers` from 1000 → 10 in the same file; 1000 was unrealistic regardless of plan size.
- CrewAI auth error (`AGUI_CREWAI_FLOW_ERROR_AUTHENTICATIONERROR`) — the `OPENAI_API_KEY` env var on the CrewAI Render service needs rotating; logs confirm the request reaches the service and only fails inside the flow at LLM call time.
- Claude Agent SDK Python silently swallows fatal SDK errors instead of emitting `RUN_ERROR` like the TypeScript adapter does.

## Test plan

- [ ] Update `A2A_MIDDLEWARE_BUILDINGS_MANAGEMENT_URL` env var on `ag-ui-dojo-app` in Render dashboard
- [ ] Bump `ag-ui-dojo-claude-agent-sdk-python` and `ag-ui-dojo-claude-agent-sdk-typescript` to `standard` plan in Render dashboard
- [ ] Open Dojo, pick **A2A** → message streams cleanly
- [ ] Open Dojo, pick **Claude Agent SDK (Python)** → message streams without OOM
- [ ] Open Dojo, pick **Claude Agent SDK (TypeScript)** → message streams (after API credit also resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)