### PR TITLE
fix(adk-middleware): give ADKAgents with distinct session_services distinct SessionManagers (#1601)

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -101,6 +101,7 @@ class ADKAgent:
 
         # ADK Services
         session_service: Optional[BaseSessionService] = None,
+        session_manager: Optional[SessionManager] = None,
         artifact_service: Optional[BaseArtifactService] = None,
         memory_service: Optional[BaseMemoryService] = None,
         credential_service: Optional[BaseCredentialService] = None,
@@ -143,7 +144,15 @@ class ADKAgent:
             app_name_extractor: Function to extract app name dynamically from input
             user_id: Static user ID for all requests
             user_id_extractor: Function to extract user ID dynamically from input
-            session_service: Session management service (defaults to InMemorySessionService)
+            session_service: Session management service (defaults to InMemorySessionService).
+                When provided, this ADKAgent gets a dedicated SessionManager wrapping
+                the service, so multiple ADKAgents with distinct services no longer
+                collide (see GitHub issue #1601).
+            session_manager: Pre-constructed SessionManager to use. When provided,
+                ``session_service`` and the session-cleanup configuration arguments
+                are ignored (configure the manager directly instead). Useful when
+                multiple ADKAgents should share a manager for consolidated cleanup
+                and per-user session limits.
             artifact_service: File/artifact storage service
             memory_service: Conversation memory and search service (also enables automatic session memory)
             credential_service: Authentication credential storage
@@ -226,32 +235,57 @@ class ADKAgent:
             self._credential_service = credential_service
         
         
-        # Session lifecycle management - use singleton
-        # Use provided session service or create default based on use_in_memory_services
-        if session_service is None:
-            session_service = InMemorySessionService()  # Default for both dev and production
+        # Session lifecycle management. Three construction modes:
+        #   1. session_manager= passed in -> use it as-is (escape hatch for
+        #      callers who want explicit sharing across multiple ADKAgents).
+        #   2. session_service= passed in -> dedicated SessionManager wrapping
+        #      that service. Fixes https://github.com/ag-ui-protocol/ag-ui/issues/1601
+        #      where distinct services were silently collapsed onto the first
+        #      ADKAgent's manager.
+        #   3. Neither -> shared process-wide default. Preserves the historical
+        #      behavior where multiple ADKAgents constructed with no explicit
+        #      service share one manager (and therefore one cleanup loop and
+        #      one set of per-user session limits).
+        if session_manager is not None and session_service is not None:
+            raise ValueError(
+                "Cannot specify both 'session_manager' and 'session_service'. "
+                "Configure the session service via the SessionManager you pass in."
+            )
 
-        # Wrap the session service so we can inject `temp:`-prefixed state into
-        # the session that ADK's Runner fetches at invocation time. See
-        # https://github.com/ag-ui-protocol/ag-ui/issues/1571 for context.
-        if not isinstance(session_service, RequestStateSessionService):
-            session_service = RequestStateSessionService(session_service)
+        if session_manager is not None:
+            self._session_manager = session_manager
+        elif session_service is not None:
+            # Wrap the session service so we can inject `temp:`-prefixed state into
+            # the session that ADK's Runner fetches at invocation time. See
+            # https://github.com/ag-ui-protocol/ag-ui/issues/1571 for context.
+            if not isinstance(session_service, RequestStateSessionService):
+                session_service = RequestStateSessionService(session_service)
+            self._session_manager = SessionManager(
+                session_service=session_service,
+                memory_service=self._memory_service,
+                session_timeout_seconds=session_timeout_seconds,
+                cleanup_interval_seconds=cleanup_interval_seconds,
+                max_sessions_per_user=max_sessions_per_user,
+                delete_session_on_cleanup=delete_session_on_cleanup,
+                save_session_to_memory_on_cleanup=save_session_to_memory_on_cleanup,
+                use_thread_id_as_session_id=use_thread_id_as_session_id,
+                hitl_max_wait_seconds=hitl_max_wait_seconds,
+            )
+        else:
+            self._session_manager = SessionManager.get_default(
+                memory_service=self._memory_service,
+                session_timeout_seconds=session_timeout_seconds,
+                cleanup_interval_seconds=cleanup_interval_seconds,
+                max_sessions_per_user=max_sessions_per_user,
+                delete_session_on_cleanup=delete_session_on_cleanup,
+                save_session_to_memory_on_cleanup=save_session_to_memory_on_cleanup,
+                use_thread_id_as_session_id=use_thread_id_as_session_id,
+                hitl_max_wait_seconds=hitl_max_wait_seconds,
+            )
 
-        self._session_manager = SessionManager.get_instance(
-            session_service=session_service,
-            memory_service=self._memory_service,  # Pass memory service for automatic session memory
-            session_timeout_seconds=session_timeout_seconds,  # 20 minutes default
-            cleanup_interval_seconds=cleanup_interval_seconds,
-            max_sessions_per_user=max_sessions_per_user,
-            delete_session_on_cleanup=delete_session_on_cleanup,
-            save_session_to_memory_on_cleanup=save_session_to_memory_on_cleanup,
-            use_thread_id_as_session_id=use_thread_id_as_session_id,
-            hitl_max_wait_seconds=hitl_max_wait_seconds,
-        )
-
-        # Reach through the singleton so every ADKAgent sharing this process
-        # writes pending `temp:` state onto whatever wrapper the singleton
-        # actually holds (the singleton ignores later session_service args).
+        # The shared default and externally-supplied managers may not yet have
+        # their session service wrapped. Ensure the wrapper is in place so
+        # `temp:` state injection works regardless of construction path.
         active_service = self._session_manager._session_service
         if not isinstance(active_service, RequestStateSessionService):
             active_service = RequestStateSessionService(active_service)
@@ -392,6 +426,7 @@ class ADKAgent:
         user_id_extractor: Optional[Callable[[RunAgentInput], str]] = None,
         # ADK Services (App does NOT contain these - still passed to Runner separately)
         session_service: Optional[BaseSessionService] = None,
+        session_manager: Optional[SessionManager] = None,
         artifact_service: Optional[BaseArtifactService] = None,
         memory_service: Optional[BaseMemoryService] = None,
         credential_service: Optional[BaseCredentialService] = None,
@@ -434,7 +469,11 @@ class ADKAgent:
             app: The ADK App instance containing the root agent and configuration
             user_id: Static user ID for all requests
             user_id_extractor: Function to extract user ID dynamically from input
-            session_service: Session management service (defaults to InMemorySessionService)
+            session_service: Session management service (defaults to InMemorySessionService).
+                See ADKAgent.__init__ for details.
+            session_manager: Pre-constructed SessionManager to use. When provided,
+                ``session_service`` and the session-cleanup configuration arguments
+                are ignored. See ADKAgent.__init__ for details.
             artifact_service: File/artifact storage service
             memory_service: Conversation memory and search service
             credential_service: Authentication credential storage
@@ -481,6 +520,7 @@ class ADKAgent:
             user_id=user_id,
             user_id_extractor=user_id_extractor,
             session_service=session_service,
+            session_manager=session_manager,
             artifact_service=artifact_service,
             memory_service=memory_service,
             credential_service=credential_service,

--- a/integrations/adk-middleware/python/src/ag_ui_adk/session_manager.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/session_manager.py
@@ -19,7 +19,7 @@ INVOCATION_ID_STATE_KEY = "_ag_ui_invocation_id"
 
 class SessionManager:
     """Session manager that wraps ADK's session service.
-    
+
     Adds essential production features:
     - Timeout monitoring based on ADK's lastUpdateTime
     - Cross-user/app session enumeration
@@ -27,17 +27,17 @@ class SessionManager:
     - Automatic cleanup of expired sessions
     - Optional automatic session memory on deletion
     - State management and updates
+
+    Construction model:
+    - ``SessionManager(...)`` builds a regular, isolated instance.
+    - ``SessionManager.get_default(...)`` returns a process-wide shared instance,
+      lazily constructed on first call. ``ADKAgent`` uses this when no explicit
+      session service is supplied, preserving the historical default behavior
+      where multiple agents share one manager.
     """
-    
-    _instance = None
-    _initialized = False
-    
-    def __new__(cls, session_service=None, **kwargs):
-        """Ensure singleton instance."""
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-    
+
+    _default: Optional["SessionManager"] = None
+
     def __init__(
         self,
         session_service=None,
@@ -53,7 +53,7 @@ class SessionManager:
         """Initialize the session manager.
 
         Args:
-            session_service: ADK session service (required on first initialization)
+            session_service: ADK session service (defaults to InMemorySessionService)
             memory_service: Optional ADK memory service for automatic session memory
             session_timeout_seconds: Time before a session is considered expired
             cleanup_interval_seconds: Interval between cleanup cycles
@@ -71,13 +71,10 @@ class SessionManager:
                 pending tool calls are preserved indefinitely. Set this to automatically
                 clean up abandoned HITL sessions after the specified duration.
         """
-        if self._initialized:
-            return
-            
         if session_service is None:
             from google.adk.sessions import InMemorySessionService
             session_service = InMemorySessionService()
-            
+
         self._session_service = session_service
         self._memory_service = memory_service
         self._timeout = session_timeout_seconds
@@ -93,10 +90,9 @@ class SessionManager:
         self._user_sessions: Dict[str, Set[str]] = {}  # user_id -> set of session_keys
         self._processed_message_ids: Dict[str, Set[str]] = {}
         self._hitl_preserved_since: Dict[str, float] = {}  # session_key -> first preservation timestamp
-        
+
         self._cleanup_task: Optional[asyncio.Task] = None
-        self._initialized = True
-        
+
         logger.info(
             f"Initialized SessionManager - "
             f"timeout: {session_timeout_seconds}s, "
@@ -106,24 +102,35 @@ class SessionManager:
             f"thread_id_as_session_id: {use_thread_id_as_session_id}, "
             f"hitl_max_wait: {hitl_max_wait_seconds or 'unlimited'}s"
         )
-    
+
     @classmethod
-    def get_instance(cls, **kwargs):
-        """Get the singleton instance."""
-        return cls(**kwargs)
-    
+    def get_default(cls, **kwargs) -> "SessionManager":
+        """Return the process-wide default SessionManager.
+
+        Constructed lazily on first call. ``kwargs`` are honored only on that
+        first call; subsequent calls return the existing instance regardless
+        of arguments.
+        """
+        if cls._default is None:
+            cls._default = cls(**kwargs)
+        return cls._default
+
     @classmethod
-    def reset_instance(cls):
-        """Reset singleton for testing."""
-        if cls._instance and hasattr(cls._instance, '_cleanup_task'):
-            task = cls._instance._cleanup_task
+    def reset_default(cls):
+        """Reset the process-wide default SessionManager (intended for tests)."""
+        if cls._default is not None:
+            task = cls._default._cleanup_task
             if task:
                 try:
                     task.cancel()
                 except RuntimeError:
                     pass
-        cls._instance = None
-        cls._initialized = False
+        cls._default = None
+
+    # Backward-compatible aliases for callers from before the singleton was
+    # removed. Prefer ``get_default``/``reset_default`` in new code.
+    get_instance = get_default
+    reset_instance = reset_default
     
     async def get_or_create_session(
         self,

--- a/integrations/adk-middleware/python/tests/test_adk_agent.py
+++ b/integrations/adk-middleware/python/tests/test_adk_agent.py
@@ -1078,6 +1078,75 @@ class TestADKAgent:
         assert all(isinstance(t, AGUIToolset) for t in root_agent.sub_agents[0].tools)
 
 
+class TestSessionManagerDispatch:
+    """Regression tests for session_manager / session_service dispatch (issue #1601)."""
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        try:
+            SessionManager.reset_default()
+        except RuntimeError:
+            pass
+        yield
+        try:
+            SessionManager.reset_default()
+        except RuntimeError:
+            pass
+
+    @pytest.fixture
+    def mock_agent(self):
+        agent = Mock(spec=Agent)
+        agent.name = "test_agent"
+        return agent
+
+    def test_distinct_session_services_get_distinct_managers(self, mock_agent):
+        """Two ADKAgents with distinct session_services no longer share a manager (#1601)."""
+        from google.adk.sessions import InMemorySessionService
+        from ag_ui_adk.request_state_service import RequestStateSessionService
+
+        svc1 = InMemorySessionService()
+        svc2 = InMemorySessionService()
+
+        agent1 = ADKAgent(adk_agent=mock_agent, app_name="a", user_id="u", session_service=svc1)
+        agent2 = ADKAgent(adk_agent=mock_agent, app_name="a", user_id="u", session_service=svc2)
+
+        assert agent1._session_manager is not agent2._session_manager
+
+        # The wrapped service inside each manager should point to the caller's service.
+        wrapped1 = agent1._session_manager._session_service
+        wrapped2 = agent2._session_manager._session_service
+        assert isinstance(wrapped1, RequestStateSessionService)
+        assert isinstance(wrapped2, RequestStateSessionService)
+        assert wrapped1.inner is svc1
+        assert wrapped2.inner is svc2
+
+    def test_no_session_service_uses_shared_default(self, mock_agent):
+        """Multiple ADKAgents without explicit services share the process-wide default."""
+        agent1 = ADKAgent(adk_agent=mock_agent, app_name="a", user_id="u")
+        agent2 = ADKAgent(adk_agent=mock_agent, app_name="a", user_id="u")
+        assert agent1._session_manager is agent2._session_manager
+        assert agent1._session_manager is SessionManager.get_default()
+
+    def test_explicit_session_manager_is_used_as_is(self, mock_agent):
+        """A pre-built SessionManager passed in is honored."""
+        manager = SessionManager()
+        agent = ADKAgent(adk_agent=mock_agent, app_name="a", user_id="u", session_manager=manager)
+        assert agent._session_manager is manager
+
+    def test_session_manager_and_session_service_together_raises(self, mock_agent):
+        """Passing both session_manager and session_service is rejected."""
+        from google.adk.sessions import InMemorySessionService
+        manager = SessionManager()
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            ADKAgent(
+                adk_agent=mock_agent,
+                app_name="a",
+                user_id="u",
+                session_manager=manager,
+                session_service=InMemorySessionService(),
+            )
+
+
 class TestThreadIdSessionIdMapping:
     """Test cases for thread_id to session_id mapping and initial state."""
 

--- a/integrations/adk-middleware/python/tests/test_adk_agent.py
+++ b/integrations/adk-middleware/python/tests/test_adk_agent.py
@@ -1146,6 +1146,30 @@ class TestSessionManagerDispatch:
                 session_service=InMemorySessionService(),
             )
 
+    def test_direct_construction_yields_distinct_instances(self):
+        """SessionManager() is no longer a singleton: each call returns a new instance."""
+        m1 = SessionManager()
+        m2 = SessionManager()
+        assert m1 is not m2
+
+    def test_get_default_returns_same_instance_on_repeated_calls(self):
+        """The shared default is sticky once built."""
+        m1 = SessionManager.get_default()
+        m2 = SessionManager.get_default()
+        assert m1 is m2
+
+    def test_reset_default_and_alias_clear_shared_default(self):
+        """reset_default() and the reset_instance alias both let a new default be built."""
+        m1 = SessionManager.get_default()
+        SessionManager.reset_default()
+        m2 = SessionManager.get_default()
+        assert m1 is not m2
+
+        m3 = SessionManager.get_default()
+        SessionManager.reset_instance()  # legacy alias
+        m4 = SessionManager.get_default()
+        assert m3 is not m4
+
 
 class TestThreadIdSessionIdMapping:
     """Test cases for thread_id to session_id mapping and initial state."""

--- a/integrations/adk-middleware/python/tests/test_adk_agent_memory_integration.py
+++ b/integrations/adk-middleware/python/tests/test_adk_agent_memory_integration.py
@@ -91,9 +91,9 @@ class TestADKAgentMemoryIntegration:
 
     def test_adk_agent_passes_memory_service_to_session_manager(self, mock_memory_service, mock_agent):
         """Test that ADKAgent passes memory service to SessionManager."""
-        with patch.object(SessionManager, 'get_instance') as mock_get_instance:
+        with patch.object(SessionManager, 'get_default') as mock_get_default:
             mock_session_manager = Mock()
-            mock_get_instance.return_value = mock_session_manager
+            mock_get_default.return_value = mock_session_manager
 
             adk_agent = ADKAgent(
                 adk_agent=mock_agent,
@@ -103,9 +103,9 @@ class TestADKAgentMemoryIntegration:
                 use_in_memory_services=True
             )
 
-            # Verify SessionManager.get_instance was called with the memory service
-            mock_get_instance.assert_called_once()
-            call_args = mock_get_instance.call_args
+            # Verify SessionManager.get_default was called with the memory service
+            mock_get_default.assert_called_once()
+            call_args = mock_get_default.call_args
             assert call_args[1]['memory_service'] is mock_memory_service
 
     def test_adk_agent_memory_service_sharing_same_instance(self, mock_memory_service, mock_agent):

--- a/integrations/adk-middleware/python/tests/test_from_app_integration.py
+++ b/integrations/adk-middleware/python/tests/test_from_app_integration.py
@@ -32,7 +32,7 @@ def sample_app():
 def reset_session_manager():
     """Reset session manager between tests."""
     yield
-    SessionManager._instance = None
+    SessionManager.reset_default()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #1601. The `SessionManager` was implemented as a strict process-wide singleton: a second `SessionManager.get_instance(session_service=...)` call silently discarded its argument and returned the existing instance, so two `ADKAgent`s constructed with two different session services ended up sharing the first one's. Harmless for `InMemorySessionService` but routed `VertexAiSessionService` traffic to the wrong backend in production.

This PR drops the singleton machinery in favor of a plain class plus an opt-in `SessionManager.get_default()` shared instance. `ADKAgent` dispatches three ways:

- `session_manager=mgr` → use the supplied manager (new escape hatch for callers who want explicit sharing).
- `session_service=svc` → dedicated `SessionManager` wrapping `svc` (fixes the bug).
- neither → `SessionManager.get_default()`, preserving today's effective behavior where multiple no-arg agents share one manager, one cleanup loop, and one set of per-user session limits.

`get_instance` and `reset_instance` remain as deprecated aliases so existing tests and external callers are unaffected.

## Behavior changes worth flagging

For callers that pass an explicit `session_service`, `max_sessions_per_user` and `_processed_message_ids` are now per-agent rather than process-wide. Callers wanting global enforcement across multiple explicit-service agents should construct one `SessionManager` and pass it via the new `session_manager=` parameter.

## Test plan

- [x] Full `adk-middleware` test suite passes (`794 passed, 8 skipped`)
- [x] New `TestSessionManagerDispatch` class covers all three dispatch paths plus the `ValueError` raised when both `session_manager` and `session_service` are supplied
- [x] Extra tests verify `SessionManager()` direct construction yields distinct instances, `get_default()` is sticky, and `reset_default()` (plus its `reset_instance` alias) lets the next `get_default()` rebuild
- [x] Verified live against a deployed Vertex AI Agent Engine in `us-central1`: all 15 tests in `test_vertex_session_service.py` pass — including the 4 normally-skipped `TestVertexSessionServiceLive` cases. Engine was deleted post-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)