### PR TITLE
fix(aws-strands): avoid phantom tool-call parents without snapshots

### DIFF
--- a/apps/dojo/e2e/utils/copilot-actions.ts
+++ b/apps/dojo/e2e/utils/copilot-actions.ts
@@ -5,32 +5,58 @@ import { CopilotSelectors } from "./copilot-selectors";
 const LLM_RESPONSE_TIMEOUT = 60_000;
 /** Default timeout for finding a DOM element after response */
 const ELEMENT_TIMEOUT = 10_000;
+/** Brief window to observe a just-started run before treating it as already done. */
+const RUN_START_TIMEOUT = 2_000;
+
+async function waitForNoActiveCopilotRun(
+  page: Page,
+  timeout = LLM_RESPONSE_TIMEOUT,
+) {
+  await page.waitForFunction(
+    () => document.querySelector('[data-copilot-running="true"]') === null,
+    null,
+    { timeout },
+  );
+}
+
+async function waitForCurrentCopilotRunToFinish(
+  page: Page,
+  timeout = LLM_RESPONSE_TIMEOUT,
+) {
+  try {
+    await page.waitForFunction(
+      () => document.querySelector('[data-copilot-running="true"]') !== null,
+      null,
+      { timeout: Math.min(RUN_START_TIMEOUT, timeout) },
+    );
+  } catch {
+    // The response may have completed before Playwright observed running=true.
+  }
+
+  await waitForNoActiveCopilotRun(page, timeout);
+}
+
+async function expectSubmittedUserMessage(
+  page: Page,
+  userMessageIndex: number,
+  message: string,
+) {
+  const submittedMessage =
+    CopilotSelectors.userMessages(page).nth(userMessageIndex);
+  await expect(submittedMessage).toContainText(message, {
+    timeout: ELEMENT_TIMEOUT,
+  });
+}
 
 /**
  * Wait for the LLM SSE stream to finish.
- * Uses the `data-copilot-running` attribute on the chat container —
- * no arbitrary timeouts or loading-indicator polling needed.
+ * Uses the `data-copilot-running` attribute on the chat container.
  */
 export async function awaitLLMResponseDone(
   page: Page,
   timeout = LLM_RESPONSE_TIMEOUT,
 ) {
-  // First wait briefly for the stream to start
-  try {
-    await page.waitForFunction(
-      () => document.querySelector('[data-copilot-running="true"]') !== null,
-      null,
-      { timeout: 3000 },
-    );
-  } catch {
-    // May have already started and finished, continue
-  }
-  // Then wait for the stream to finish
-  await page.waitForFunction(
-    () => document.querySelector('[data-copilot-running="false"]') !== null,
-    null,
-    { timeout },
-  );
+  await waitForCurrentCopilotRunToFinish(page, timeout);
 }
 
 /**
@@ -39,12 +65,28 @@ export async function awaitLLMResponseDone(
  */
 export async function sendChatMessage(page: Page, message: string) {
   const input = CopilotSelectors.chatTextarea(page);
+  const sendButton = CopilotSelectors.sendButton(page);
+  const userMessageCountBefore =
+    await CopilotSelectors.userMessages(page).count();
+
   await input.click();
   await input.fill(message);
-  const sendButton = CopilotSelectors.sendButton(page);
+  await expect(input).toHaveValue(message);
   await expect(sendButton).toBeVisible();
   await expect(sendButton).toBeEnabled();
   await sendButton.click();
+
+  try {
+    await expectSubmittedUserMessage(page, userMessageCountBefore, message);
+  } catch {
+    // If the previous run is still closing, the click can be ignored while the
+    // input keeps the text. Wait for the UI to become idle and submit once.
+    await waitForNoActiveCopilotRun(page);
+    await expect(input).toHaveValue(message);
+    await expect(sendButton).toBeEnabled();
+    await sendButton.click();
+    await expectSubmittedUserMessage(page, userMessageCountBefore, message);
+  }
 }
 
 /**
@@ -77,13 +119,9 @@ export async function sendAndAwaitResponse(
     { timeout },
   );
 
-  // Now wait for the stream to finish — at this point the running state
-  // belongs to the current response, not a stale one.
-  await page.waitForFunction(
-    () => document.querySelector('[data-copilot-running="false"]') !== null,
-    null,
-    { timeout },
-  );
+  // Now wait for the current run to finish. This helper first gives the UI a
+  // chance to report running=true, so a stale idle flag cannot end the wait.
+  await waitForCurrentCopilotRunToFinish(page, timeout);
 }
 
 /**

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -466,6 +466,12 @@ class StrandsAgent:
             # Generate unique message ID
             message_id = str(uuid.uuid4())
             message_started = False
+            # Tracks the id of the most recently emitted text message, persisting
+            # across rotations. Tool calls reference this as parent_message_id so
+            # that back-to-back tool calls (with no text between them) all link
+            # back to the text message that triggered the assistant turn. None
+            # when the run has not produced any text yet.
+            last_emitted_message_id: str | None = None
             tool_calls_seen = {}
             current_state = dict(input_data.state or {})  # Track state for final snapshot
             stop_text_streaming = False
@@ -514,6 +520,7 @@ class StrandsAgent:
                                 role="assistant",
                             )
                             message_started = True
+                            last_emitted_message_id = message_id
 
                         text_chunk = str(event["data"])
                         yield TextMessageContentEvent(
@@ -938,11 +945,15 @@ class StrandsAgent:
                                     logger.debug(
                                         f"Emitting tool call events for {tool_name} (tool_use_id={tool_use_id}, thread_id={input_data.thread_id})"
                                     )
+                                    # parent_message_id references the most recently emitted
+                                    # text message — the assistant content that produced this
+                                    # tool call. None when no text has been emitted in the run
+                                    # yet (per-schema Optional[str]).
                                     yield ToolCallStartEvent(
                                         type=EventType.TOOL_CALL_START,
                                         tool_call_id=tool_use_id,
                                         tool_call_name=tool_name,
-                                        parent_message_id=message_id,
+                                        parent_message_id=last_emitted_message_id,
                                     )
 
                                     if behavior and behavior.args_streamer:

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -332,6 +332,11 @@ class StrandsAgent:
         # would clobber the other.
         self._thread_init_lock = asyncio.Lock()
 
+    def _will_emit_tool_snapshot(self, behavior: Any) -> bool:
+        return self.config.emit_messages_snapshot and not (
+            behavior and behavior.skip_messages_snapshot
+        )
+
     async def run(self, input_data: RunAgentInput) -> AsyncIterator[Any]:
         """Run the Strands agent and yield AG-UI events."""
 
@@ -1296,13 +1301,10 @@ class StrandsAgent:
                                             value=predict_state_payload,
                                         )
 
+                                # Must mirror the later tool snapshot emission condition.
                                 tool_parent_message_id = (
                                     message_id
-                                    if self.config.emit_messages_snapshot
-                                    and not (
-                                        behavior_now
-                                        and behavior_now.skip_messages_snapshot
-                                    )
+                                    if self._will_emit_tool_snapshot(behavior_now)
                                     else last_emitted_text_message_id
                                 )
                                 yield ToolCallStartEvent(
@@ -1441,13 +1443,7 @@ class StrandsAgent:
                                         tool_call_id=tool_use_id,
                                     )
 
-                                    if (
-                                        self.config.emit_messages_snapshot
-                                        and not (
-                                            behavior
-                                            and behavior.skip_messages_snapshot
-                                        )
-                                    ):
+                                    if self._will_emit_tool_snapshot(behavior):
                                         snapshot_messages.append(
                                             AssistantMessage(
                                                 id=message_id,
@@ -1564,13 +1560,10 @@ class StrandsAgent:
                                         message_started = False
                                         message_id = str(uuid.uuid4())
 
+                                    # Must mirror the later tool snapshot emission condition.
                                     tool_parent_message_id = (
                                         message_id
-                                        if self.config.emit_messages_snapshot
-                                        and not (
-                                            behavior
-                                            and behavior.skip_messages_snapshot
-                                        )
+                                        if self._will_emit_tool_snapshot(behavior)
                                         else last_emitted_text_message_id
                                     )
                                     yield ToolCallStartEvent(
@@ -1606,13 +1599,7 @@ class StrandsAgent:
                                         tool_call_id=tool_use_id,
                                     )
 
-                                    if (
-                                        self.config.emit_messages_snapshot
-                                        and not (
-                                            behavior
-                                            and behavior.skip_messages_snapshot
-                                        )
-                                    ):
+                                    if self._will_emit_tool_snapshot(behavior):
                                         snapshot_messages.append(
                                             AssistantMessage(
                                                 id=message_id,

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -729,6 +729,10 @@ class StrandsAgent:
             message_id = str(uuid.uuid4())
             message_started = False
             accumulated_text = ""
+            # Tracks the latest assistant text id that was actually emitted on
+            # the wire. Tool calls use it only when no snapshot will expose the
+            # tool-call AssistantMessage id.
+            last_emitted_text_message_id: str | None = None
             tool_calls_seen = {}
             current_state = dict(input_data.state or {})  # Track state for final snapshot
             stop_text_streaming = False
@@ -821,6 +825,7 @@ class StrandsAgent:
                                 role="assistant",
                             )
                             message_started = True
+                            last_emitted_text_message_id = message_id
 
                         text_chunk = str(event["data"])
                         accumulated_text += text_chunk
@@ -1291,11 +1296,20 @@ class StrandsAgent:
                                             value=predict_state_payload,
                                         )
 
+                                tool_parent_message_id = (
+                                    message_id
+                                    if self.config.emit_messages_snapshot
+                                    and not (
+                                        behavior_now
+                                        and behavior_now.skip_messages_snapshot
+                                    )
+                                    else last_emitted_text_message_id
+                                )
                                 yield ToolCallStartEvent(
                                     type=EventType.TOOL_CALL_START,
                                     tool_call_id=tool_use_id,
                                     tool_call_name=tool_name,
-                                    parent_message_id=message_id,
+                                    parent_message_id=tool_parent_message_id,
                                 )
                                 tool_calls_seen[tool_use_id]["start_emitted"] = True
                         elif tool_name and tool_use_id in tool_calls_seen:
@@ -1550,11 +1564,20 @@ class StrandsAgent:
                                         message_started = False
                                         message_id = str(uuid.uuid4())
 
+                                    tool_parent_message_id = (
+                                        message_id
+                                        if self.config.emit_messages_snapshot
+                                        and not (
+                                            behavior
+                                            and behavior.skip_messages_snapshot
+                                        )
+                                        else last_emitted_text_message_id
+                                    )
                                     yield ToolCallStartEvent(
                                         type=EventType.TOOL_CALL_START,
                                         tool_call_id=tool_use_id,
                                         tool_call_name=tool_name,
-                                        parent_message_id=message_id,
+                                        parent_message_id=tool_parent_message_id,
                                     )
 
                                     try:

--- a/integrations/aws-strands/python/tests/test_tool_call_parent_message_id.py
+++ b/integrations/aws-strands/python/tests/test_tool_call_parent_message_id.py
@@ -1,0 +1,226 @@
+"""Tests for ToolCallStartEvent.parent_message_id correctness (issue #1610).
+
+The adapter previously emitted TOOL_CALL_START with parent_message_id
+pointing at a UUID that had not been emitted to the client — either the
+rotated id reserved for the *next* text segment, or the upfront id from
+run() initialization that was never emitted at all. parent_message_id
+must reference a message the client has already observed, or be None
+when no parent message exists.
+
+These tests pin the post-fix invariant: parent_message_id equals the most
+recently emitted text message id, persisting across back-to-back tool
+calls until a new text segment opens; None when no text has been emitted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ag_ui.core import EventType, RunAgentInput, Tool, UserMessage
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors test_parallel_tool_call_handling.py for consistency)
+# ---------------------------------------------------------------------------
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _build_agent(thread_id: str, stream_events: list) -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=StrandsAgentConfig()
+    )
+
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+
+    async def _stream(_msg: str):
+        for event in stream_events:
+            yield event
+
+    mock_inner.stream_async = _stream
+    agent._agents_by_thread[thread_id] = mock_inner
+    return agent
+
+
+def _run_input(thread_id: str, tools: list | None = None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=tools or [],
+        context=[],
+        forwarded_props={},
+    )
+
+
+async def _collect(agent: StrandsAgent, inp: RunAgentInput) -> list:
+    return [e async for e in agent.run(inp)]
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+THREAD = "parent-msg-id-thread"
+TOOLS = [Tool(name="frontend_tool", description="d", parameters={})]
+
+# Realistic Strands stream: assistant emits some text, then calls a tool.
+STREAM_TEXT_THEN_TOOL = [
+    {"data": "Let me check those tables:"},
+    {"current_tool_use": {"name": "frontend_tool", "toolUseId": "st-1", "input": {}}},
+    {"event": {"contentBlockStop": {}}},
+]
+
+
+async def test_tool_call_parent_id_matches_preceding_text_message():
+    """parent_message_id on TOOL_CALL_START must equal the just-ended text message id.
+
+    The pre-fix adapter rotated message_id *before* emitting the tool call,
+    so parent_message_id pointed at a UUID never seen by the client.
+    """
+    agent = _build_agent(THREAD + "-1", STREAM_TEXT_THEN_TOOL)
+    events = await _collect(agent, _run_input(THREAD + "-1", tools=TOOLS))
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+
+    # Ordering invariant: text message must close before the tool call starts.
+    assert events.index(text_end) < events.index(tool_start), (
+        "TEXT_MESSAGE_END must precede TOOL_CALL_START in the event stream"
+    )
+
+    assert tool_start.parent_message_id == text_end.message_id, (
+        f"parent_message_id={tool_start.parent_message_id!r} should equal the "
+        f"preceding TEXT_MESSAGE_END.message_id={text_end.message_id!r}, but "
+        "instead points at a message that has not been emitted yet."
+    )
+
+
+async def test_tool_call_parent_id_is_an_already_seen_message_id():
+    """parent_message_id must reference a message the client has already observed.
+
+    Stronger framing of the same invariant — any TEXT_MESSAGE_START seen so far
+    is acceptable; what's NOT acceptable is referencing an id that only ever
+    appears later in the stream (or never). None is also acceptable when the
+    tool call has no preceding text message (see test_tool_call_no_preceding_text).
+    """
+    agent = _build_agent(THREAD + "-2", STREAM_TEXT_THEN_TOOL)
+    events = await _collect(agent, _run_input(THREAD + "-2", tools=TOOLS))
+
+    seen_text_message_ids: set[str] = set()
+    asserted_at_least_once = False
+    for event in events:
+        if event.type == EventType.TEXT_MESSAGE_START:
+            seen_text_message_ids.add(event.message_id)
+        elif event.type == EventType.TOOL_CALL_START:
+            asserted_at_least_once = True
+            # parent_message_id is Optional; None is fine, but a non-None value
+            # must always reference a message the client has already started.
+            if event.parent_message_id is not None:
+                assert event.parent_message_id in seen_text_message_ids, (
+                    f"TOOL_CALL_START.parent_message_id={event.parent_message_id!r} "
+                    f"references a message that has not been started yet. Seen so "
+                    f"far: {seen_text_message_ids!r}"
+                )
+    assert asserted_at_least_once, "No TOOL_CALL_START event was emitted"
+
+
+async def test_tool_call_with_no_preceding_text_has_no_parent():
+    """When the tool call comes before any text, parent_message_id must be None.
+
+    The schema declares parent_message_id as Optional[str]. The previous code
+    would set it to the upfront UUID generated when run() began — a UUID that
+    was never emitted as a TEXT_MESSAGE_START to the client. Setting it to
+    None is the only correct value when no parent message exists.
+    """
+    stream = [
+        # Tool call arrives before any text streaming.
+        {"current_tool_use": {"name": "frontend_tool", "toolUseId": "st-1", "input": {}}},
+        {"event": {"contentBlockStop": {}}},
+    ]
+    agent = _build_agent(THREAD + "-no-text", stream)
+    events = await _collect(agent, _run_input(THREAD + "-no-text", tools=TOOLS))
+
+    text_starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    tool_start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+
+    assert len(text_starts) == 0, (
+        f"Stream had no text data; expected 0 TEXT_MESSAGE_START events, "
+        f"got {len(text_starts)}"
+    )
+    assert tool_start.parent_message_id is None, (
+        f"With no preceding text message, parent_message_id should be None, "
+        f"got {tool_start.parent_message_id!r} (a UUID the client has never seen)"
+    )
+
+
+async def test_back_to_back_tool_calls_share_parent_message_id():
+    """Multiple tool calls after one text segment should all reference that text.
+
+    When the LLM emits text and then two consecutive tool calls (no text between
+    them), both tools were "triggered by" the same preceding text message. They
+    must both have parent_message_id pointing at that text — not at phantom
+    UUIDs reserved for never-emitted future text segments.
+    """
+    stream = [
+        {"data": "Calling two tools:"},
+        {"current_tool_use": {"name": "frontend_tool", "toolUseId": "st-a", "input": {}}},
+        {"event": {"contentBlockStop": {}}},  # closes tool A (and ends text)
+        {"current_tool_use": {"name": "frontend_tool", "toolUseId": "st-b", "input": {}}},
+        {"event": {"contentBlockStop": {}}},  # closes tool B (no text in between)
+    ]
+    agent = _build_agent(THREAD + "-btb", stream)
+    events = await _collect(agent, _run_input(THREAD + "-btb", tools=TOOLS))
+
+    text_ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    tool_starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+
+    # Adapter must emit exactly one TEXT_MESSAGE_END for the single text segment.
+    # Otherwise the assertion below would silently encode an adapter assumption.
+    assert len(text_ends) == 1, f"Expected 1 TEXT_MESSAGE_END, got {len(text_ends)}"
+    assert len(tool_starts) == 2, f"Expected 2 TOOL_CALL_START events, got {len(tool_starts)}"
+    for tool_start in tool_starts:
+        assert tool_start.parent_message_id == text_ends[0].message_id, (
+            f"Both tool calls share the same triggering text message "
+            f"({text_ends[0].message_id!r}); got parent_message_id="
+            f"{tool_start.parent_message_id!r} for tool {tool_start.tool_call_name!r}"
+        )
+
+
+async def test_subsequent_text_message_does_not_reuse_parent_id():
+    """The next text segment after the tool call must use a fresh message_id.
+
+    The fix must NOT collapse the two ids together — the rotation that the
+    current code performs is correct, it just happens before the wrong
+    consumer reads message_id.
+    """
+    stream = STREAM_TEXT_THEN_TOOL + [
+        {"data": "Here are the results..."},
+    ]
+    agent = _build_agent(THREAD + "-2", stream)
+    events = await _collect(agent, _run_input(THREAD + "-2", tools=TOOLS))
+
+    text_starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    tool_start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+
+    assert len(text_starts) == 2, f"Expected 2 TEXT_MESSAGE_START events, got {len(text_starts)}"
+    first_id, second_id = text_starts[0].message_id, text_starts[1].message_id
+
+    assert first_id != second_id, "Each text segment must have its own message_id"
+    assert tool_start.parent_message_id == first_id, (
+        "parent_message_id should reference the first (preceding) text message, "
+        f"not the second one. first={first_id!r}, second={second_id!r}, "
+        f"parent={tool_start.parent_message_id!r}"
+    )

--- a/integrations/aws-strands/python/tests/test_tool_call_parent_message_id.py
+++ b/integrations/aws-strands/python/tests/test_tool_call_parent_message_id.py
@@ -1,0 +1,246 @@
+"""Tests for ``ToolCallStartEvent.parent_message_id`` in Strands.
+
+Issue #1610 originally found a phantom parent id in streams without a visible
+tool-call assistant message. Current main emits ``MessagesSnapshotEvent`` by
+default, so the tool-call assistant id is visible through the snapshot and must
+stay aligned with #1638's snapshot contract. These tests pin both modes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ag_ui.core import AssistantMessage, EventType, RunAgentInput, Tool, UserMessage
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _build_agent(
+    thread_id: str,
+    stream_events: list,
+    config: StrandsAgentConfig | None = None,
+) -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(),
+        name="test-agent",
+        config=config or StrandsAgentConfig(),
+    )
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+    mock_inner.session_manager = None
+
+    async def _stream(_msg):
+        for event in stream_events:
+            yield event
+
+    mock_inner.stream_async = _stream
+    agent._agents_by_thread[thread_id] = mock_inner
+    return agent
+
+
+def _run_input(thread_id: str, tools: list | None = None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=tools or [],
+        context=[],
+        forwarded_props={},
+    )
+
+
+async def _collect(agent: StrandsAgent, inp: RunAgentInput) -> list:
+    return [e async for e in agent.run(inp)]
+
+
+def _tool_start(events: list, tool_call_id: str | None = None):
+    return next(
+        e
+        for e in events
+        if e.type == EventType.TOOL_CALL_START
+        and (tool_call_id is None or e.tool_call_id == tool_call_id)
+    )
+
+
+def _snapshot_assistant_id_for_tool(events: list, tool_call_id: str) -> str:
+    snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+    assert snapshots, "expected a MessagesSnapshotEvent"
+
+    for message in snapshots[-1].messages:
+        if isinstance(message, AssistantMessage) and message.tool_calls:
+            if any(tool_call.id == tool_call_id for tool_call in message.tool_calls):
+                return message.id
+
+    raise AssertionError(f"tool call {tool_call_id!r} missing from final snapshot")
+
+
+async def _args_streamer(context):
+    yield context.args_str
+
+
+THREAD = "parent-msg-id-thread"
+TOOLS = [Tool(name="frontend_tool", description="d", parameters={})]
+STREAM_TEXT_THEN_TOOL = [
+    {"data": "Let me check those tables:"},
+    {
+        "current_tool_use": {
+            "name": "frontend_tool",
+            "toolUseId": "st-1",
+            "input": {"ok": True},
+        }
+    },
+    {"event": {"contentBlockStop": {}}},
+]
+
+
+async def test_default_parent_id_matches_tool_call_snapshot_message_id():
+    agent = _build_agent(THREAD + "-default", STREAM_TEXT_THEN_TOOL)
+    events = await _collect(agent, _run_input(THREAD + "-default", tools=TOOLS))
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_start = _tool_start(events)
+    snapshot_id = _snapshot_assistant_id_for_tool(events, tool_start.tool_call_id)
+
+    assert tool_start.parent_message_id == snapshot_id
+    assert tool_start.parent_message_id != text_end.message_id
+
+
+async def test_default_args_streamer_parent_id_matches_snapshot_message_id():
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "frontend_tool": ToolBehavior(args_streamer=_args_streamer),
+        },
+    )
+    agent = _build_agent(THREAD + "-args-default", STREAM_TEXT_THEN_TOOL, config)
+    events = await _collect(
+        agent,
+        _run_input(THREAD + "-args-default", tools=TOOLS),
+    )
+
+    tool_start = _tool_start(events)
+    snapshot_id = _snapshot_assistant_id_for_tool(events, tool_start.tool_call_id)
+
+    assert tool_start.parent_message_id == snapshot_id
+
+
+async def test_snapshot_disabled_parent_id_uses_preceding_text_message():
+    config = StrandsAgentConfig(emit_messages_snapshot=False)
+    agent = _build_agent(THREAD + "-disabled", STREAM_TEXT_THEN_TOOL, config)
+    events = await _collect(agent, _run_input(THREAD + "-disabled", tools=TOOLS))
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_start = _tool_start(events)
+
+    assert [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT] == []
+    assert tool_start.parent_message_id == text_end.message_id
+
+
+async def test_snapshot_disabled_tool_first_call_has_no_parent_id():
+    config = StrandsAgentConfig(emit_messages_snapshot=False)
+    stream = [
+        {
+            "current_tool_use": {
+                "name": "frontend_tool",
+                "toolUseId": "st-1",
+                "input": {},
+            }
+        },
+        {"event": {"contentBlockStop": {}}},
+    ]
+    agent = _build_agent(THREAD + "-tool-first", stream, config)
+    events = await _collect(agent, _run_input(THREAD + "-tool-first", tools=TOOLS))
+
+    assert [e for e in events if e.type == EventType.TEXT_MESSAGE_START] == []
+    assert _tool_start(events).parent_message_id is None
+
+
+async def test_snapshot_disabled_back_to_back_tool_calls_share_text_parent():
+    config = StrandsAgentConfig(emit_messages_snapshot=False)
+    stream = [
+        {"data": "Calling two tools:"},
+        {
+            "current_tool_use": {
+                "name": "backend_tool",
+                "toolUseId": "st-a",
+                "input": {},
+            }
+        },
+        {"event": {"contentBlockStop": {}}},
+        {
+            "current_tool_use": {
+                "name": "backend_tool",
+                "toolUseId": "st-b",
+                "input": {},
+            }
+        },
+        {"event": {"contentBlockStop": {}}},
+    ]
+    agent = _build_agent(THREAD + "-back-to-back", stream, config)
+    events = await _collect(agent, _run_input(THREAD + "-back-to-back"))
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+
+    assert len(tool_starts) == 2
+    assert [e.parent_message_id for e in tool_starts] == [
+        text_end.message_id,
+        text_end.message_id,
+    ]
+
+
+async def test_snapshot_disabled_args_streamer_uses_preceding_text_parent():
+    config = StrandsAgentConfig(
+        emit_messages_snapshot=False,
+        tool_behaviors={
+            "frontend_tool": ToolBehavior(args_streamer=_args_streamer),
+        },
+    )
+    agent = _build_agent(THREAD + "-args-disabled", STREAM_TEXT_THEN_TOOL, config)
+    events = await _collect(
+        agent,
+        _run_input(THREAD + "-args-disabled", tools=TOOLS),
+    )
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_start = _tool_start(events)
+
+    assert [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT] == []
+    assert tool_start.parent_message_id == text_end.message_id
+
+
+async def test_skip_messages_snapshot_uses_visible_text_parent():
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "frontend_tool": ToolBehavior(skip_messages_snapshot=True),
+        },
+    )
+    agent = _build_agent(THREAD + "-skip", STREAM_TEXT_THEN_TOOL, config)
+    events = await _collect(agent, _run_input(THREAD + "-skip", tools=TOOLS))
+
+    text_end = next(e for e in events if e.type == EventType.TEXT_MESSAGE_END)
+    tool_start = _tool_start(events)
+    snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+
+    assert tool_start.parent_message_id == text_end.message_id
+    assert snapshots
+    for message in snapshots[-1].messages:
+        assert not (
+            isinstance(message, AssistantMessage)
+            and message.tool_calls
+            and any(
+                tool_call.id == tool_start.tool_call_id
+                for tool_call in message.tool_calls
+            )
+        )


### PR DESCRIPTION
## Problem

Fixes #1610. The original bug was that `ToolCallStartEvent.parent_message_id` could point at a rotated message id the client had not seen. This PR's earlier fix made every tool call point at the preceding text message, but current `main` has changed since then: #1638 now emits `MessagesSnapshotEvent` by default and requires `parent_message_id` to match the snapshot `AssistantMessage` id that owns the tool call.

The remaining bug is narrower: when message snapshots are disabled globally, or skipped for a tool, the adapter can still emit a `parent_message_id` that no text event or snapshot exposes.

## Why

For snapshot-enabled consumers, the snapshot is canonical history. Pointing `parent_message_id` at preceding text would make the wire event disagree with the `MessagesSnapshotEvent` entry and regress #1638.

For snapshot-disabled/raw consumers, the tool-call assistant message id is never emitted, so using it as `parent_message_id` is a phantom reference. In those streams, the only visible parent is the latest emitted assistant text message, or `None` when the run starts with a tool call.

## Fix

- Rebased the PR onto current `main`.
- Track the latest assistant text message id that was actually emitted on the wire.
- Preserve the #1638 contract when a tool-call snapshot will be emitted: `parent_message_id` stays aligned with the snapshot `AssistantMessage` id.
- Fall back to the latest emitted text id, or `None` for tool-first streams, when snapshots are globally disabled or skipped for a tool.
- Apply the same logic to both tool-call emission paths, including `behavior.args_streamer`.
- Centralize the tool-call snapshot emission predicate in `_will_emit_tool_snapshot(...)` so parent-id selection and snapshot appends stay in lockstep.
- Added Python coverage for default snapshot alignment, snapshot-disabled text/tool/tool-first/back-to-back flows, `args_streamer`, and `skip_messages_snapshot`.
- Includes a Dojo chat E2E send-stabilization commit in `apps/dojo/e2e/utils/copilot-actions.ts` to unblock the suite.

Validated the Strands changes with `.venv/bin/pytest tests/test_tool_call_parent_message_id.py tests/test_messages_snapshot_message_id_rotation.py` and `.venv/bin/pytest`.
