### PR TITLE
Release v0.6.1 of ADK Middleware

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] - 2026-04-30
 
 ### Added
 

--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ag_ui_adk"
 description = "ADK Middleware for AG-UI Protocol"
-version = "0.6.0"
+version = "0.6.1"
 readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }


### PR DESCRIPTION
## Description
This PR releases version 0.6.1 of the ADK Middleware for AG-UI Protocol.

## Changes
- Updated version from 0.6.0 to 0.6.1 in `pyproject.toml`
- Updated CHANGELOG.md with release date (2026-04-30)

## Test Plan
N/A - This is a version bump and changelog update with no functional code changes.

https://claude.ai/code/session_01LiWsMqbzWsoziiFUMkghHh