### PR TITLE
fix(langgraph): drop reasoning + developer roles when converting AG-UI messages back to LangChain

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -235,6 +235,14 @@ def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]
     langchain_messages = []
     for message in messages:
         role = message.role
+        # Reasoning + developer AG-UI messages are display-only / handled
+        # elsewhere; their content is already represented in adjacent AIMessage
+        # content blocks (reasoning) or in the agent's configured system prompt
+        # (developer). Re-materializing them as standalone LangChain messages
+        # duplicates context on every turn and can drive the model into a
+        # tool-call loop.
+        if role in ("reasoning", "developer"):
+            continue
         if role == "user":
             # Handle multimodal content
             if isinstance(message.content, str):

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -9,6 +9,8 @@ from ag_ui.core import (
     AssistantMessage as AGUIAssistantMessage,
     SystemMessage as AGUISystemMessage,
     ToolMessage as AGUIToolMessage,
+    ReasoningMessage as AGUIReasoningMessage,
+    DeveloperMessage as AGUIDeveloperMessage,
     ToolCall as AGUIToolCall,
     FunctionCall as AGUIFunctionCall,
     TextInputContent,
@@ -131,6 +133,31 @@ class TestAguiMessagesToLangchain:
         assert isinstance(result[0], HumanMessage)
         assert isinstance(result[1], AIMessage)
         assert isinstance(result[2], HumanMessage)
+
+    def test_reasoning_messages_dropped(self):
+        # Reasoning content is already represented inside the assistant
+        # AIMessage's content blocks at the LangChain layer; emitting a
+        # separate LangGraph message would duplicate context on the next turn
+        # and can drive the model into a tool-call loop.
+        msgs = [
+            AGUIUserMessage(id="u1", role="user", content="Hi"),
+            AGUIReasoningMessage(id="r1", role="reasoning", content="thinking..."),
+            AGUIAssistantMessage(id="a1", role="assistant", content="Hello"),
+        ]
+        result = agui_messages_to_langchain(msgs)
+        assert len(result) == 2
+        assert isinstance(result[0], HumanMessage)
+        assert isinstance(result[1], AIMessage)
+
+    def test_developer_messages_dropped(self):
+        # Developer prompts are configured on the agent itself, not round-tripped.
+        msgs = [
+            AGUIDeveloperMessage(id="d1", role="developer", content="be concise"),
+            AGUIUserMessage(id="u1", role="user", content="Hi"),
+        ]
+        result = agui_messages_to_langchain(msgs)
+        assert len(result) == 1
+        assert isinstance(result[0], HumanMessage)
 
 
 class TestLangchainMessagesToAgui:

--- a/integrations/langgraph/typescript/src/message-conversion.test.ts
+++ b/integrations/langgraph/typescript/src/message-conversion.test.ts
@@ -77,6 +77,31 @@ describe("Message Conversion - All Types", () => {
       expect(result[1].type).toBe("ai");
       expect(result[2].type).toBe("human");
     });
+
+    it("should drop reasoning messages (display-only)", () => {
+      // Reasoning content already lives inside the assistant AIMessage's
+      // content blocks at the LangChain layer; emitting a separate LangGraph
+      // message would duplicate context on the next turn.
+      const msgs: Message[] = [
+        { id: "u1", role: "user", content: "Hi" },
+        { id: "r1", role: "reasoning", content: "thinking..." },
+        { id: "a1", role: "assistant", content: "Hello" },
+      ];
+      const result = aguiMessagesToLangChain(msgs);
+      expect(result).toHaveLength(2);
+      expect(result[0].type).toBe("human");
+      expect(result[1].type).toBe("ai");
+    });
+
+    it("should drop developer messages (handled by agent system prompt)", () => {
+      const msgs: Message[] = [
+        { id: "d1", role: "developer", content: "be concise" } as any,
+        { id: "u1", role: "user", content: "Hi" },
+      ];
+      const result = aguiMessagesToLangChain(msgs);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("human");
+    });
   });
 
   describe("langchainMessagesToAgui", () => {

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -219,7 +219,15 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
 }
 
 export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[] {
-  return messages.map((message, index) => {
+  return messages
+    // Reasoning AG-UI messages are display-only — their content already lives
+    // inside the corresponding assistant AIMessage's content blocks
+    // (langchain-openai writes them there for the Responses API). Developer
+    // messages are part of the agent's configured system prompt. Re-materializing
+    // either as standalone LangChain messages duplicates context on every turn
+    // and can drive the model into a tool-call loop.
+    .filter((message) => message.role !== "reasoning" && message.role !== "developer")
+    .map((message, index) => {
     switch (message.role) {
       case "user":
         // Handle multimodal content


### PR DESCRIPTION
## Summary

The AG-UI client materializes `REASONING_MESSAGE_*` events into `{role: "reasoning"}` messages so reasoning is renderable in the chat UI (per the AG-UI message spec). On the next turn, `aguiMessagesToLangChain` (TS) / `agui_messages_to_langchain` (Py) threw `"message role is not supported"` for these (and the same applied to `developer` messages).

Naively converting them into `AIMessage(content=[{type: "reasoning", ...}])` — the natural LangChain Responses API shape — creates a duplicate of the reasoning content that already lives inside the original assistant `AIMessage.content` produced by `langchain-openai`. Each turn that duplicate gets re-appended to the LangGraph checkpoint, polluting context and driving the model into a tool-call loop (10+ "Thought for a few seconds" bubbles, repeated tool calls, eventual recursion-limit failure).

Reasoning round-trips correctly through the assistant message's content blocks at the LangChain layer; the AG-UI `reasoning` message is purely a display artifact and should be **dropped** on conversion back. Same for `developer` (system prompt is configured on the agent itself).

This PR drops `reasoning` and `developer` AG-UI messages in `aguiMessagesToLangChain` / `agui_messages_to_langchain` only. `langchainMessagesToAgui` is untouched — its current 1:1 behavior matches the streaming `REASONING_*` events.

## Changes

- `integrations/langgraph/typescript/src/utils.ts` — filter `reasoning` / `developer` before the role switch.
- `integrations/langgraph/python/ag_ui_langgraph/utils.py` — same.
- Tests added in both `message-conversion.test.ts` and `tests/test_message_conversion.py` covering the drop semantics and message ordering.

## Linked

CopilotKit/CopilotKit PR with the matching `function_call` content-block fix in `CopilotKitMiddleware`: https://github.com/CopilotKit/CopilotKit/pull/4473

## Test plan

- [x] TS unit tests (\`message-conversion.test.ts\`) — reasoning/developer dropped, message ordering preserved.
- [x] Python unit tests (\`tests/test_message_conversion.py\`) — same coverage on Py side.
- [x] End-to-end repro in CopilotKit/examples/integrations/langgraph-python (LangGraph Python + OpenAI \`gpt-5.5\` Responses API + reasoning summary): before this patch, second turn 400s on "message role is not supported"; with this patch + the linked CopilotKit fix, multi-turn reasoning conversation works without loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)