### PR TITLE
fix(release): remove ag-ui-claude-sdk from publish pipeline

### DIFF
--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -69,13 +69,6 @@
         { "name": "@ag-ui/claude-agent-sdk", "path": "integrations/claude-agent-sdk/typescript", "ecosystem": "typescript" }
       ]
     },
-    "integration-claude-agent-sdk-py": {
-      "description": "Claude Agent SDK integration (Python)",
-      "sharedVersion": false,
-      "packages": [
-        { "name": "ag-ui-claude-sdk", "path": "integrations/claude-agent-sdk/python", "ecosystem": "python", "buildSystem": "uv" }
-      ]
-    },
     "integration-crewai-ts": {
       "description": "CrewAI integration (TypeScript)",
       "sharedVersion": false,


### PR DESCRIPTION
## Summary

Every publish workflow run since [#1590](https://github.com/ag-ui-protocol/ag-ui/pull/1590) merged on April 24 has been failing with the same error:

```
403 Forbidden: The user 'CopilotKit' isn't allowed to upload to project 'ag-ui-claude-sdk'
```

The PyPI project [`ag-ui-claude-sdk`](https://pypi.org/project/ag-ui-claude-sdk/) at version 0.1.0 is owned by a different account than the one the CI's PyPI token belongs to. The detection script keeps seeing local 0.1.1 > PyPI 0.1.0 and tries to publish, which fails and exits the workflow. Subsequent steps — git tags, GitHub releases, the `release/next` branch cleanup — get skipped, even though every other package in the run successfully published to npm/PyPI.

This is why recent releases (`integration-mastra`, langgraph TS SDK, ADK middleware 0.6.1, etc.) appeared as failed CI runs despite the packages actually shipping.

This PR removes the `integration-claude-agent-sdk-py` scope from `release.config.json` so the Python package is no longer detected as needing publish. The TypeScript-side `@ag-ui/claude-agent-sdk` is unaffected.

## Why this fix instead of workflow-level error handling

Considered making the publish step `continue-on-error: true` and adding a final fail step to surface partial failures, but that just relabels where the red X comes from — every publish would still show as failed in CI until the underlying PyPI issue is resolved. Removing the broken package from the config stops the noise immediately.

## Follow-up

Re-add the `integration-claude-agent-sdk-py` scope once one of the following is resolved:
- The CI's PyPI token is granted maintainer access on the existing PyPI project, or
- Ownership of `ag-ui-claude-sdk` on PyPI is transferred to the team's account, or
- The package is renamed to one the team owns

## Test plan

- [ ] Next merged version-bump PR triggers `publish-release.yml` and the workflow completes green
- [ ] Detection logs show no entry for `ag-ui-claude-sdk`
- [ ] Tags and GitHub releases are created for any packages that did publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)