### PR TITLE
fix(cli): drop unsupported --no-banner flag for copilotkit v2

### DIFF
--- a/sdks/typescript/packages/cli/src/index.ts
+++ b/sdks/typescript/packages/cli/src/index.ts
@@ -130,7 +130,6 @@ async function handleCopilotKitNextJs() {
     [
       "copilotkit@latest",
       "create",
-      "--no-banner",
       "-n", projectName.name,
       ...frameworkArgs,
     ],


### PR DESCRIPTION
## Summary

`copilotkit@2.0.0` (released ~3 days ago) rewrote the CopilotKit CLI and removed the `--no-banner` flag. `create-ag-ui-app` still passes that flag to the spawned `npx copilotkit@latest create`, which now aborts with `Unknown option '--no-banner'` whenever a user picks **CopilotKit/Next.js**. This PR drops the unsupported flag from the spawn argv.

## Reproduction (from #1627)

```
$ npx create-ag-ui-app@latest

   █████╗  ██████╗       ██╗   ██╗ ██╗
  ...
  Agent User Interactivity Protocol

✔ What client do you want to use? CopilotKit/Next.js
✔ What would you like to name your project? my-ag-ui-app
(node:3653) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true ...
Unknown option '--no-banner'

❌ Project creation failed.
```

## Fix

```diff
   const copilotkit = spawn("npx",
     [
       "copilotkit@latest",
       "create",
-      "--no-banner",
       "-n", projectName.name,
       ...frameworkArgs,
     ],
```

`sdks/typescript/packages/cli/src/index.ts`, inside `handleCopilotKitNextJs()`. One-line removal.

## Backward compatibility

The spawn target is hard-coded to `copilotkit@latest`, so users always resolve to the `latest` dist-tag.

- **copilotkit ≥ 2.0.0** (current `latest`, what was broken): **fixed**.
- **copilotkit 1.x**: `--no-banner` was a cosmetic `-q, --no-banner` that suppressed the banner. Removing the flag means CopilotKit's banner now prints during nested creation — harmless. In practice this path is unreachable since `@latest` no longer resolves to 1.x.

No replacement flag exists in v2 (`copilotkit create` v2 only accepts `-n -i -f -h`).

## Testing

- `pnpm --filter create-ag-ui-app build` — clean
- `pnpm --filter create-ag-ui-app typecheck` — clean
- `pnpm --filter create-ag-ui-app test:exports` (publint --strict + attw) — clean
- End-to-end smoke: ran the locally-built CLI with `--mastra`, scaffolding completed successfully against current `copilotkit@latest` (project `smoke-test` created, no `Unknown option` error).

## Out of scope (separate follow-up)

Noticed while reading the file: line 113 reads `options.crewiAiFlows` while line 43 declares the flag as `crewaiFlows` (typo: `crewi` vs `crewai`). CrewAI Flows scaffolding via the framework flag is silently broken — happy to file a follow-up issue/PR after this one merges.

Fixes #1627