### PR TITLE
feat(aws-strands): add tool_stream_event_handler hook to ToolBehavior

### DIFF
--- a/integrations/aws-strands/python/pyproject.toml
+++ b/integrations/aws-strands/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag_ui_strands"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
     { name = "AG-UI Contributors" }
 ]

--- a/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
@@ -14,6 +14,7 @@ from .config import (
     ToolResultContext,
     PredictStateMapping,
     SessionManagerProvider,
+    ToolStreamEventHandler,
 )
 
 __all__ = [
@@ -29,5 +30,6 @@ __all__ = [
     "ToolResultContext",
     "PredictStateMapping",
     "SessionManagerProvider",
+    "ToolStreamEventHandler",
 ]
 

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -626,9 +626,25 @@ class StrandsAgent:
                     elif "tool_stream_event" in event:
                         tool_stream = event["tool_stream_event"]
                         stream_data = tool_stream.get("data", {})
+                        _tse_tool_use = tool_stream.get("tool_use", {})
+                        _tse_tool_name = _tse_tool_use.get("name", "")
+                        _tse_tool_use_id = _tse_tool_use.get("toolUseId", "")
+                        _tse_behavior = self.config.tool_behaviors.get(_tse_tool_name) if _tse_tool_name else None
 
-                        # Emit state snapshot if tool yielded state
-                        if isinstance(stream_data, dict) and "state" in stream_data:
+                        if _tse_behavior and _tse_behavior.tool_stream_event_handler:
+                            try:
+                                async for _tse_event in _tse_behavior.tool_stream_event_handler(
+                                    _tse_tool_use_id, stream_data
+                                ):
+                                    if _tse_event is not None:
+                                        yield _tse_event
+                            except Exception as _tse_exc:
+                                logger.warning(
+                                    f"tool_stream_event_handler failed for {_tse_tool_name}: {_tse_exc}",
+                                    exc_info=True,
+                                )
+                        elif isinstance(stream_data, dict) and "state" in stream_data:
+                            # Default behaviour: emit state snapshot when tool yields {"state": ...}
                             yield StateSnapshotEvent(
                                 type=EventType.STATE_SNAPSHOT,
                                 snapshot=stream_data["state"],

--- a/integrations/aws-strands/python/src/ag_ui_strands/config.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/config.py
@@ -48,6 +48,17 @@ StateFromResult = Callable[[ToolResultContext], Awaitable[Optional[StatePayload]
 CustomResultHandler = Callable[[ToolResultContext], AsyncIterator[Any]]
 StateContextBuilder = Callable[[RunAgentInput, str], str]
 SessionManagerProvider = Callable[[RunAgentInput], Awaitable[Optional[SessionManager]] | Optional[SessionManager]]
+ToolStreamEventHandler = Callable[[str, Any], AsyncIterator[Any]]
+"""Handler for raw tool_stream_event data emitted by async-generator tools.
+
+Called with (tool_use_id: str, stream_data: Any) for every intermediate event
+yielded by the tool while it is executing. The handler may yield zero or more
+AG-UI Event objects which are forwarded directly into the top-level event stream.
+
+When a handler is registered for a tool, the default behaviour of emitting a
+StateSnapshotEvent for ``{"state": ...}`` payloads is suppressed for that tool.
+The handler is responsible for any state updates it wants to emit.
+"""
 
 
 @dataclass
@@ -78,6 +89,7 @@ class ToolBehavior:
     state_from_args: Optional[StateFromArgs] = None
     state_from_result: Optional[StateFromResult] = None
     custom_result_handler: Optional[CustomResultHandler] = None
+    tool_stream_event_handler: Optional[ToolStreamEventHandler] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Add a new optional `ToolStreamEventHandler` callback to `ToolBehavior` that is invoked for every intermediate event yielded by an async-generator tool (`tool_stream_event`).

## Motivation

When an orchestrator agent calls a specialist sub-agent via an async-generator `@tool`, Strands wraps each yielded value in a `tool_stream_event`. The existing handler only checks for `{"state": ...}` payloads and ignores everything else — making it impossible to surface the specialist's streaming activity (text, tool calls, results) to the frontend without reimplementing the entire event loop in a subclass.

This hook makes that use case a first-class citizen.

## Changes

### `config.py`
- Added `ToolStreamEventHandler = Callable[[str, Any], AsyncIterator[Any]]` type alias
- Added `tool_stream_event_handler: Optional[ToolStreamEventHandler] = None` field to `ToolBehavior`

### `agent.py`
- Replaced the 5-line `tool_stream_event` branch with a dispatch: if a `ToolBehavior` with `tool_stream_event_handler` is registered for the tool, call it and forward its yielded events; otherwise fall through to the existing `{"state": ...}` snapshot behaviour

### `__init__.py`
- Exported `ToolStreamEventHandler`

## Behaviour

- **Backward compatible**: tools without a `tool_stream_event_handler` continue to work exactly as before
- When a handler is registered, the default state-snapshot behaviour is suppressed for that tool; the handler is responsible for any state updates it wants to emit
- The handler receives `(tool_use_id: str, stream_data: Any)` and may yield zero or more AG-UI `Event` objects which are forwarded directly into the top-level stream