### PR TITLE
docs(events): demote 'Modified Lifecycle Events' out of Draft Events

### DIFF
--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -748,44 +748,6 @@ A side-band annotation event that can occur anywhere in the stream.
 | `metaType` | Application-defined type (e.g., "thumbs_up", "tag") |
 | `payload`  | Application-defined payload                         |
 
-### Modified Lifecycle Events
-
-<span
-  style={{
-    backgroundColor: "#3b82f6",
-    color: "white",
-    padding: "2px 6px",
-    borderRadius: "4px",
-    fontSize: "0.75em",
-    fontWeight: "bold",
-  }}
->
-  DRAFT
-</span>
-[View Specification](/concepts/interrupts)
-
-Extensions to existing lifecycle events to support interrupts and branching.
-
-#### RunFinished (Extended)
-
-The `RunFinished` event gains new fields to support interrupt-aware workflows.
-
-| Property  | Description                                                                                                                       |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `outcome` | Optional discriminated union: `{ type: "success" }` or `{ type: "interrupt", interrupts: [...] }`. Omitted on legacy producers.   |
-| `result`  | Optional. Free-form completion payload. Lives at the event root for back-compat with legacy producers; coexists with any outcome. |
-
-See [Serialization](/concepts/serialization) for lineage and input capture.
-
-#### RunStarted (Extended)
-
-The `RunStarted` event gains new fields to support branching and input tracking.
-
-| Property      | Description                                       |
-| ------------- | ------------------------------------------------- |
-| `parentRunId` | Optional: Parent run ID for branching/time travel |
-| `input`       | Optional: The exact agent input for this run      |
-
 ## Event Flow Patterns
 
 Events in the protocol typically follow specific patterns:

--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -748,6 +748,31 @@ A side-band annotation event that can occur anywhere in the stream.
 | `metaType` | Application-defined type (e.g., "thumbs_up", "tag") |
 | `payload`  | Application-defined payload                         |
 
+## Modified Lifecycle Events
+
+Extensions to existing lifecycle events to support interrupts and branching.
+See [Interrupts](/concepts/interrupts) for the full lifecycle.
+
+### RunFinished (Extended)
+
+The `RunFinished` event gains new fields to support interrupt-aware workflows.
+
+| Property  | Description                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `outcome` | Optional discriminated union: `{ type: "success" }` or `{ type: "interrupt", interrupts: [...] }`. Omitted on legacy producers.   |
+| `result`  | Optional. Free-form completion payload. Lives at the event root for back-compat with legacy producers; coexists with any outcome. |
+
+See [Serialization](/concepts/serialization) for lineage and input capture.
+
+### RunStarted (Extended)
+
+The `RunStarted` event gains new fields to support branching and input tracking.
+
+| Property      | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `parentRunId` | Optional: Parent run ID for branching/time travel |
+| `input`       | Optional: The exact agent input for this run      |
+
 ## Event Flow Patterns
 
 Events in the protocol typically follow specific patterns:


### PR DESCRIPTION
The interrupts proposal was promoted from `docs/drafts/` to `docs/concepts/` in #1569, but the "Modified Lifecycle Events" subsection in `events.mdx` was left under `## Draft Events` with a DRAFT badge — so the docs still mark interrupts as draft.

This PR keeps the property tables and the Serialization cross-link, but moves the section out to its own top-level `## Modified Lifecycle Events` and drops the DRAFT span and "View Specification" link, leaving `## Draft Events` to cover Meta Events only.

PS: really excited to get the interruptions into the standard and the code packages