### PR TITLE
chore(adk-middleware): bump to 0.6.2 and release changelog

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-12
+
 ### Security
 
 - **FIX**: `/agents/state` no longer bypasses `extract_state_from_request` (#1646)

--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ag_ui_adk"
 description = "ADK Middleware for AG-UI Protocol"
-version = "0.6.1"
+version = "0.6.2"
 readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }


### PR DESCRIPTION
## Summary

- Promote the `Unreleased` section in `adk-middleware/python/CHANGELOG.md` to `[0.6.2] - 2026-05-12`
- Bump `pyproject.toml` version `0.6.1` → `0.6.2`

Patch bump: the unreleased delta is a single security fix — `/agents/state` no longer bypasses `extract_state_from_request` (#1646, merged via #1657). The deprecated `AgentStateRequest.appName`/`userId` body fields remain behind a `DeprecationWarning`; removal is held for a future major.

Follows the pattern of the prior bump (e35684f8 / #1619).

## Test plan

- [x] `pyproject.toml` version reads `0.6.2`
- [x] `CHANGELOG.md` `[0.6.2]` section is dated `2026-05-12` and contains the #1646 security entry
- [x] No code changes; existing 799-test suite still passes (verified on the #1657 branch before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)