### PR TITLE
[Bug]: [mastra] User multi-part text content is collapsed

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -38,6 +38,48 @@ describe("convertAGUIMessagesToMastra", () => {
       ]);
     });
 
+    it("converts array content with single text part", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "user",
+          content: [
+            { type: "text", text: "Single part" },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Single part" },
+          ],
+        },
+      ]);
+    });
+
+    it("converts empty array content", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "user",
+          content: [],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [],
+        },
+      ]);
+    });
+
     it("returns empty string for null/undefined content", () => {
       const messages: Message[] = [
         { id: "1", role: "user", content: undefined as any },

--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -28,7 +28,13 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result).toEqual([
-        { role: "user", content: "First part\nSecond part" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "First part" },
+            { type: "text", text: "Second part" },
+          ],
+        },
       ]);
     });
 
@@ -70,7 +76,7 @@ describe("convertAGUIMessagesToMastra", () => {
       ]);
     });
 
-    it("trims whitespace from text parts and filters empty", () => {
+    it("leaves whitespace from text parts as-is", () => {
       const messages: Message[] = [
         {
           id: "1",
@@ -85,7 +91,16 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "hello\nworld" }]);
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "  hello  " },
+            { type: "text", text: "   " },
+            { type: "text", text: "world" },
+          ],
+        },
+      ]);
     });
   });
 
@@ -214,25 +229,6 @@ describe("convertAGUIMessagesToMastra", () => {
             },
           ],
         },
-      ]);
-    });
-
-    it("returns plain string for text-only array (backwards compat)", () => {
-      const messages: Message[] = [
-        {
-          id: "1",
-          role: "user",
-          content: [
-            { type: "text", text: "Hello" },
-            { type: "text", text: "World" },
-          ],
-        },
-      ];
-
-      const result = convertAGUIMessagesToMastra(messages);
-
-      expect(result).toEqual([
-        { role: "user", content: "Hello\nWorld" },
       ]);
     });
 

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -50,18 +50,6 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
     return "";
   }
 
-  const hasNonTextParts = content.some((part) => part.type !== "text");
-
-  if (!hasNonTextParts) {
-    // Backwards compat: text-only arrays return a joined string
-    type TextInput = Extract<InputContent, { type: "text" }>;
-    const textParts = content
-      .filter((part): part is TextInput => part.type === "text")
-      .map((part: TextInput) => part.text.trim())
-      .filter(Boolean);
-    return textParts.join("\n");
-  }
-
   // Structured content array with mixed types
   const parts: any[] = [];
   for (const part of content) {

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -50,7 +50,7 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
     return "";
   }
 
-  // Structured content array with mixed types
+  // Convert content parts to Mastra format
   const parts: any[] = [];
   for (const part of content) {
     switch (part.type) {

--- a/integrations/mastra/typescript/tsconfig.json
+++ b/integrations/mastra/typescript/tsconfig.json
@@ -18,8 +18,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "stripInternal": true,
-    "types": ["vitest/globals"]
+    "stripInternal": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Closes #1649

List of changes:
- Remove `hasNonTextParts` logic
- Remove `.trim()` logic and filtering for empty parts for user content: this logic was only executed if all parts were of `type=text`
- Whitespace in text parts is now preserved as-is (previously `.trim()`ed and empty parts filtered out)
- Remove test-case (is duplicated [here](https://github.com/ag-ui-protocol/ag-ui/blob/e6ea7c7943acb515290c4fd7d69be3c0b35c5e99/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts#L16-L33), which was updated)
- Update test-case `trims whitespace from text parts and filters empty`: this logic was only executed if all parts were of `type=text`
- Update `tsconfig.json`: `compilerOptions.types` was duplicated