### PR TITLE
fix(adk-middleware): strip nested `required` so Gemini accepts function declarations with nested object schemas

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/client_proxy_tool.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/client_proxy_tool.py
@@ -46,16 +46,24 @@ except (ImportError, AttributeError):
     })
 
 
-def _clean_schema_for_genai(schema: Any) -> Any:
+def _clean_schema_for_genai(schema: Any, _top_level: bool = True) -> Any:
     """Recursively clean a JSON Schema dict for google.genai.types.Schema.
 
-    Three transformations:
+    Four transformations:
     1. Strip ``$``-prefixed keys (``$schema``, ``$id``, ``$ref``, ``$defs``,
        ``$comment``) — these are JSON Schema infrastructure, never in genai.
     2. Map ``examples`` → ``example`` (first element only) and
        ``const`` → ``enum`` (single-value list), preserving useful context.
     3. Filter remaining keys to only those accepted by ``types.Schema``,
        using an allowlist derived from ``types.Schema.model_fields``.
+    4. Drop ``required`` from any sub-schema (anything that is not the
+       outermost parameters object). Gemini's function-calling API silently
+       rejects function declarations whose parameter schema carries
+       ``required`` below the top level — e.g. on the ``items.properties``
+       of an array, or on a nested property's own ``properties``. The
+       model emits no error event and no content events, just
+       ``RUN_STARTED → RUN_FINISHED``, which surfaces as a frozen agent.
+       Top-level ``required`` is preserved (Gemini accepts it there).
     """
     if isinstance(schema, dict):
         result = {}
@@ -74,21 +82,25 @@ def _clean_schema_for_genai(schema: Any) -> Any:
             # Only keep keys that genai.types.Schema accepts
             if k not in _ALLOWED_SCHEMA_KEYS:
                 continue
+            # Drop `required` everywhere except the outermost parameters
+            # object. See transformation 4 in the docstring.
+            if k == "required" and not _top_level:
+                continue
             # "properties" and "defs" are dict-of-schemas — recurse into
             # values but preserve the user-defined keys (property names).
             if k in ("properties", "defs") and isinstance(v, dict):
                 result[k] = {
-                    prop_name: _clean_schema_for_genai(prop_schema)
+                    prop_name: _clean_schema_for_genai(prop_schema, _top_level=False)
                     for prop_name, prop_schema in v.items()
                 }
             # "default", "example", "enum" are opaque values — don't recurse
             elif k in ("default", "example", "enum"):
                 result[k] = v
             else:
-                result[k] = _clean_schema_for_genai(v)
+                result[k] = _clean_schema_for_genai(v, _top_level=False)
         return result
     if isinstance(schema, list):
-        return [_clean_schema_for_genai(item) for item in schema]
+        return [_clean_schema_for_genai(item, _top_level=False) for item in schema]
     return schema
 
 

--- a/integrations/adk-middleware/python/tests/test_client_proxy_tool.py
+++ b/integrations/adk-middleware/python/tests/test_client_proxy_tool.py
@@ -613,6 +613,101 @@ class TestCleanSchemaForGenai:
     def test_handles_empty_list(self):
         assert _clean_schema_for_genai([]) == []
 
+    # --- Nested-required stripping (Gemini silent-failure workaround) ---
+
+    def test_preserves_top_level_required(self):
+        """Top-level `required` is preserved — Gemini accepts it there."""
+        schema = {
+            "type": "object",
+            "properties": {"x": {"type": "string"}, "y": {"type": "number"}},
+            "required": ["x", "y"],
+        }
+        result = _clean_schema_for_genai(schema)
+        assert result["required"] == ["x", "y"]
+
+    def test_strips_required_inside_array_items(self):
+        """`required` on object items of an array is dropped.
+
+        Gemini's function-calling API silently rejects function declarations
+        carrying `required` below the top level. This is the most common
+        shape produced by Zod's `z.array(z.object({...}))` and is the exact
+        schema the CopilotKit chart-rendering demo (and any similar
+        array-of-records pattern) uses.
+        """
+        schema = {
+            "type": "object",
+            "required": ["data"],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {"type": "string"},
+                            "value": {"type": "number"},
+                        },
+                        "required": ["label", "value"],
+                    },
+                }
+            },
+        }
+        result = _clean_schema_for_genai(schema)
+        # top-level required preserved
+        assert result["required"] == ["data"]
+        # nested required stripped
+        assert "required" not in result["properties"]["data"]["items"]
+        # but the nested properties themselves remain intact
+        items_props = result["properties"]["data"]["items"]["properties"]
+        assert items_props["label"]["type"] == "string"
+        assert items_props["value"]["type"] == "number"
+
+    def test_strips_required_inside_nested_object_property(self):
+        """`required` on a nested object property is dropped."""
+        schema = {
+            "type": "object",
+            "required": ["address"],
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                    "required": ["street", "city"],
+                }
+            },
+        }
+        result = _clean_schema_for_genai(schema)
+        assert result["required"] == ["address"]
+        assert "required" not in result["properties"]["address"]
+
+    def test_strips_required_at_arbitrary_depth(self):
+        """`required` is stripped no matter how deep it's nested."""
+        schema = {
+            "type": "object",
+            "required": ["a"],
+            "properties": {
+                "a": {
+                    "type": "object",
+                    "properties": {
+                        "b": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"c": {"type": "string"}},
+                                "required": ["c"],
+                            },
+                        }
+                    },
+                    "required": ["b"],
+                }
+            },
+        }
+        result = _clean_schema_for_genai(schema)
+        assert result["required"] == ["a"]
+        assert "required" not in result["properties"]["a"]
+        assert "required" not in result["properties"]["a"]["properties"]["b"]["items"]
+
 
 class TestGetDeclarationWithJsonSchemaMeta:
     """Test _get_declaration strips JSON Schema meta-fields (issue #1349)."""


### PR DESCRIPTION
Gemini's function-calling API silently rejects function declarations whose parameter schema carries a `required` field below the top-level object — e.g. on the `items.properties` of an array, or on a nested property's own `properties`. The model emits no error event and no content events, just RUN_STARTED → STATE_SNAPSHOT → RUN_FINISHED, which surfaces as a frozen agent: the user sends a message, no chart/UI ever renders, no text ever streams back.

The most common shape that trips this is Zod's `z.array(z.object({...}))` when the inner object marks fields as required:

```json
{
  "type": "object",
  "required": ["data"],
  "properties": {
    "data": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {"label": {...}, "value": {...}},
        "required": ["label", "value"]   ← Gemini chokes on this
      }
    }
  }
}
```

This shape is produced by every CopilotKit gen-UI demo that renders structured data (charts, tables, lists of records). It's also what any backend tool that takes an array of typed records will generate from Pydantic / Zod / similar libraries. The bug has been latent since `_clean_schema_for_genai` was introduced in #1349 — OpenAI-backed consumers don't hit it because OpenAI's function-calling API accepts `required` at every nesting level, and simpler ADK demos with flat schemas don't have nested objects to begin with.

Fix: add a `_top_level` parameter to `_clean_schema_for_genai` (defaults to True for the outermost call, False on every recursive call). When False, drop any `required` key. Top-level `required` is preserved — Gemini does accept it there.

Verified against the CopilotKit `gen-ui-tool-based` demo: before the fix, `render_bar_chart` calls returned empty SSE streams; after the fix, TOOL_CALL_START + TOOL_CALL_ARGS containing the structured chart payload are emitted and the chart renders end-to-end.

Tests: four new regression tests in `TestCleanSchemaForGenai` cover (1) top-level required preservation, (2) the array-of-objects shape, (3) nested-object-property required, (4) arbitrary-depth required. All 41 existing tests in `test_client_proxy_tool.py` continue to pass.