### PR TITLE
feat(kotlin-sdk): support REASONING_* events, deprecate THINKING_* (#1650)

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-12
+
+### Added
+- **Reasoning events** ([#1650](https://github.com/ag-ui-protocol/ag-ui/issues/1650)). The Kotlin SDK now supports the seven `REASONING_*` events that have replaced `THINKING_*` in the TypeScript and Python SDKs. Without this change a Kotlin client connected to a server emitting `REASONING_*` events would fail polymorphic deserialization because the discriminator `type` did not match any `BaseEvent` subclass.
+  - New `EventType` enum entries and `BaseEvent` subclasses in `com.agui.core.types`:
+    - `REASONING_START` / `ReasoningStartEvent(messageId)`
+    - `REASONING_MESSAGE_START` / `ReasoningMessageStartEvent(messageId, role = "reasoning")` — `role` is validated at construction to match the TS `z.literal("reasoning")` and Python `Literal["reasoning"]` schema.
+    - `REASONING_MESSAGE_CONTENT` / `ReasoningMessageContentEvent(messageId, delta)` — non-empty `delta` required.
+    - `REASONING_MESSAGE_END` / `ReasoningMessageEndEvent(messageId)`
+    - `REASONING_MESSAGE_CHUNK` / `ReasoningMessageChunkEvent(messageId?, delta?)` — both optional to support chunk-style streaming where only the first chunk carries the `messageId`.
+    - `REASONING_END` / `ReasoningEndEvent(messageId)`
+    - `REASONING_ENCRYPTED_VALUE` / `ReasoningEncryptedValueEvent(subtype, entityId, encryptedValue)` — `subtype` validated to be `"tool-call"` or `"message"` (parity with TS/Python).
+- **Reasoning telemetry on `AgentState`.** New `AgentState.reasoning: ReasoningTelemetryState?` field tracks one or more reasoning streams keyed by `messageId`. Each `ReasoningStreamState` carries the stream's accumulated `text`, an `isActive` flag, and any attached `ReasoningEncryptedValue` payloads. `AbstractAgent` exposes a corresponding `reasoning` snapshot property.
+- **`DefaultApplyEvents` wires up `REASONING_*` events.** Maintains a per-`messageId` stream map so concurrent reasoning streams are tracked independently (something the previous `ThinkingTelemetryState` could not represent). `REASONING_MESSAGE_CHUNK` auto-creates streams and re-uses the last active `messageId` when the chunk omits it; `REASONING_ENCRYPTED_VALUE` attaches to the most recently active stream. The reasoning map and last-active id are cleared on `RUN_STARTED`.
+- **Tests.**
+  - 13 new serialization tests in `EventSerializationTest` covering round-trip, role/subtype validation, empty-delta rejection, nullable chunk fields, raw-event passthrough, and discriminator routing for all seven new events.
+  - 4 new apply-handler tests in `DefaultApplyEventsTest` covering a single-stream lifecycle, two interleaved concurrent streams, encrypted-value attachment, and chunk-style auto-population.
+
+### Deprecated
+- All five `THINKING_*` events and the matching `EventType` enum entries are marked `@Deprecated(WARNING)` with `ReplaceWith` hints pointing at the corresponding `REASONING_*` types. They remain on the wire and continue to flow through `DefaultApplyEvents` and `EventVerifier` unchanged. Slated for removal in 1.0.0.
+  - `ThinkingStartEvent` → `ReasoningStartEvent`
+  - `ThinkingEndEvent` → `ReasoningEndEvent`
+  - `ThinkingTextMessageStartEvent` → `ReasoningMessageStartEvent`
+  - `ThinkingTextMessageContentEvent` → `ReasoningMessageContentEvent`
+  - `ThinkingTextMessageEndEvent` → `ReasoningMessageEndEvent`
+- `ThinkingTelemetryState` and `AgentState.thinking` / `AbstractAgent.thinking` are deprecated in favour of `ReasoningTelemetryState` and `reasoning`. The old fields are still populated by the existing `THINKING_*` apply handlers so downstream consumers continue to work unchanged.
+
+### Notes for integrators
+- **Wire compatibility is unchanged.** Servers emitting `THINKING_*` continue to round-trip exactly as before; servers emitting `REASONING_*` are now decodable.
+- **No `EventVerifier` changes.** The verifier passes `REASONING_*` events through unchanged, matching the TypeScript SDK. Existing `THINKING_*` lifecycle validation is unchanged.
+- **`Role` enum is unchanged.** `ReasoningMessageStartEvent.role` is modeled as a constrained `String` rather than a new `Role.REASONING` value, to avoid introducing a ghost role with no matching `Message` subclass (and to match the TS/Python literal-string schemas exactly).
+
 ## [0.3.0] - 2026-05-09
 
 ### Added

--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 //   - publish.sh script (reads dynamically)
 //   - GitHub Actions workflow (reads dynamically)
 // Only update these values here - they propagate automatically
-version = "0.3.0"
+version = "0.4.0"
 group = "com.ag-ui.community"
 
 allprojects {

--- a/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/agent/AbstractAgent.kt
+++ b/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/agent/AbstractAgent.kt
@@ -37,7 +37,16 @@ abstract class AbstractAgent(
     var customEvents: List<CustomEvent> = emptyList()
         protected set
     
+    @Deprecated(
+        message = "Use 'reasoning' instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("reasoning"),
+        level = DeprecationLevel.WARNING
+    )
+    @Suppress("DEPRECATION")
     var thinking: ThinkingTelemetryState? = null
+        protected set
+
+    var reasoning: ReasoningTelemetryState? = null
         protected set
     
     val debug: Boolean = config.debug
@@ -278,8 +287,12 @@ abstract class AbstractAgent(
             agentState.customEvents?.let {
                 customEvents = it
             }
+            @Suppress("DEPRECATION")
             agentState.thinking?.let {
                 thinking = it
+            }
+            agentState.reasoning?.let {
+                reasoning = it
             }
 
             if (messagesChanged) {
@@ -548,21 +561,29 @@ data class RunAgentParameters(
 
 /**
  * Represents the transformed agent state.
- * Contains the current state of the agent including messages, thinking telemetry,
+ * Contains the current state of the agent including messages, reasoning telemetry,
  * state data, and auxiliary events.
- * 
+ *
  * @property messages Optional list of messages in the current conversation
- * @property thinking Optional thinking telemetry describing the agent's internal reasoning stream
+ * @property thinking Optional thinking telemetry (deprecated; use [reasoning])
+ * @property reasoning Optional reasoning telemetry describing the agent's internal reasoning streams
  * @property state Optional state object containing agent-specific data
  * @property rawEvents Optional list of RAW events that have been received
  * @property customEvents Optional list of CUSTOM events that have been received
  */
+@Suppress("DEPRECATION")
 data class AgentState(
     val messages: List<Message>? = null,
+    @Deprecated(
+        message = "Use 'reasoning' instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("reasoning"),
+        level = DeprecationLevel.WARNING
+    )
     val thinking: ThinkingTelemetryState? = null,
     val state: State? = null,
     val rawEvents: List<RawEvent>? = null,
-    val customEvents: List<CustomEvent>? = null
+    val customEvents: List<CustomEvent>? = null,
+    val reasoning: ReasoningTelemetryState? = null
 )
 
 /**
@@ -572,8 +593,53 @@ data class AgentState(
  * @property title Optional title or description supplied with the thinking step
  * @property messages Ordered list of thinking text messages emitted by the agent
  */
+@Deprecated(
+    message = "Use ReasoningTelemetryState instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningTelemetryState"),
+    level = DeprecationLevel.WARNING
+)
 data class ThinkingTelemetryState(
     val isThinking: Boolean,
     val title: String? = null,
     val messages: List<String> = emptyList()
+)
+
+/**
+ * Represents a single reasoning stream identified by its messageId.
+ *
+ * @property messageId Unique identifier for this reasoning stream
+ * @property isActive Whether this stream is still receiving events (false after REASONING_END)
+ * @property text The accumulated reasoning text emitted on this stream
+ * @property encryptedValues Encrypted reasoning payloads attached to this stream (e.g. provider signatures)
+ */
+data class ReasoningStreamState(
+    val messageId: String,
+    val isActive: Boolean,
+    val text: String,
+    val encryptedValues: List<ReasoningEncryptedValue> = emptyList()
+)
+
+/**
+ * An encrypted reasoning payload attached to a reasoning stream.
+ *
+ * @property subtype Either "tool-call" or "message"
+ * @property entityId Identifier of the tool call or message this value attaches to
+ * @property encryptedValue Provider-specific encrypted payload
+ */
+data class ReasoningEncryptedValue(
+    val subtype: String,
+    val entityId: String,
+    val encryptedValue: String
+)
+
+/**
+ * Represents the agent's reasoning telemetry across one or more streams.
+ *
+ * Replacement for [ThinkingTelemetryState]. Reasoning events carry a messageId so
+ * concurrent reasoning streams are tracked independently.
+ *
+ * @property streams One entry per messageId in the order the streams were first observed
+ */
+data class ReasoningTelemetryState(
+    val streams: List<ReasoningStreamState> = emptyList()
 )

--- a/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/state/DefaultApplyEvents.kt
+++ b/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/state/DefaultApplyEvents.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.agui.client.state
 
 import com.agui.client.agent.AbstractAgent
@@ -5,6 +7,9 @@ import com.agui.client.agent.AgentEventParams
 import com.agui.client.agent.AgentState
 import com.agui.client.agent.AgentStateMutation
 import com.agui.client.agent.AgentSubscriber
+import com.agui.client.agent.ReasoningEncryptedValue
+import com.agui.client.agent.ReasoningStreamState
+import com.agui.client.agent.ReasoningTelemetryState
 import com.agui.client.agent.ThinkingTelemetryState
 import com.agui.client.agent.runSubscribersWithMutation
 import com.agui.core.types.*
@@ -50,6 +55,20 @@ fun defaultApplyEvents(
     var thinkingBuffer: StringBuilder? = null
     var initialMessagesEmitted = false
 
+    // Reasoning telemetry — per-messageId streams, ordered by first appearance.
+    class MutableReasoningStream(
+        val messageId: String,
+        var isActive: Boolean = true,
+        val text: StringBuilder = StringBuilder(),
+        val encryptedValues: MutableList<ReasoningEncryptedValue> = mutableListOf()
+    )
+    val reasoningStreams = linkedMapOf<String, MutableReasoningStream>()
+    var reasoningVisible = false
+    var lastActiveReasoningMessageId: String? = null
+
+    fun reasoningStream(messageId: String): MutableReasoningStream =
+        reasoningStreams.getOrPut(messageId) { MutableReasoningStream(messageId) }
+
     logger.d {
         "defaultApplyEvents start: initial messages=${messages.joinToString { "${it.messageRole}:${it.id}" }} state=$state"
     }
@@ -75,6 +94,20 @@ fun defaultApplyEvents(
             isThinking = active,
             title = thinkingTitle,
             messages = snapshot
+        )
+    }
+
+    fun currentReasoningState(): ReasoningTelemetryState? {
+        if (!reasoningVisible && reasoningStreams.isEmpty()) return null
+        return ReasoningTelemetryState(
+            streams = reasoningStreams.values.map {
+                ReasoningStreamState(
+                    messageId = it.messageId,
+                    isActive = it.isActive,
+                    text = it.text.toString(),
+                    encryptedValues = it.encryptedValues.toList()
+                )
+            }
         )
     }
 
@@ -265,6 +298,12 @@ fun defaultApplyEvents(
                     emit(AgentState(thinking = ThinkingTelemetryState(isThinking = false, title = null, messages = emptyList())))
                     emitted = true
                 }
+
+                reasoningStreams.clear()
+                reasoningVisible = false
+                lastActiveReasoningMessageId = null
+                emit(AgentState(reasoning = ReasoningTelemetryState(streams = emptyList())))
+                emitted = true
             }
 
             is StateSnapshotEvent -> {
@@ -359,6 +398,105 @@ fun defaultApplyEvents(
                 currentThinkingState()?.let {
                     emit(AgentState(thinking = it))
                     emitted = true
+                }
+            }
+
+            is ReasoningStartEvent -> {
+                reasoningVisible = true
+                val stream = reasoningStream(event.messageId)
+                stream.isActive = true
+                lastActiveReasoningMessageId = event.messageId
+                currentReasoningState()?.let {
+                    emit(AgentState(reasoning = it))
+                    emitted = true
+                }
+            }
+
+            is ReasoningMessageStartEvent -> {
+                reasoningVisible = true
+                val stream = reasoningStream(event.messageId)
+                stream.isActive = true
+                lastActiveReasoningMessageId = event.messageId
+                currentReasoningState()?.let {
+                    emit(AgentState(reasoning = it))
+                    emitted = true
+                }
+            }
+
+            is ReasoningMessageContentEvent -> {
+                reasoningVisible = true
+                val stream = reasoningStream(event.messageId)
+                stream.isActive = true
+                stream.text.append(event.delta)
+                lastActiveReasoningMessageId = event.messageId
+                currentReasoningState()?.let {
+                    emit(AgentState(reasoning = it))
+                    emitted = true
+                }
+            }
+
+            is ReasoningMessageEndEvent -> {
+                // Per-message end; keep stream open until REASONING_END.
+                currentReasoningState()?.let {
+                    emit(AgentState(reasoning = it))
+                    emitted = true
+                }
+            }
+
+            is ReasoningMessageChunkEvent -> {
+                val messageId = event.messageId ?: lastActiveReasoningMessageId
+                if (messageId != null) {
+                    reasoningVisible = true
+                    val stream = reasoningStream(messageId)
+                    stream.isActive = true
+                    event.delta?.let { stream.text.append(it) }
+                    lastActiveReasoningMessageId = messageId
+                    currentReasoningState()?.let {
+                        emit(AgentState(reasoning = it))
+                        emitted = true
+                    }
+                } else {
+                    logger.w {
+                        "Received REASONING_MESSAGE_CHUNK with no messageId and no active reasoning stream; dropping."
+                    }
+                }
+            }
+
+            is ReasoningEndEvent -> {
+                val stream = reasoningStream(event.messageId)
+                stream.isActive = false
+                if (lastActiveReasoningMessageId == event.messageId) {
+                    lastActiveReasoningMessageId = null
+                }
+                currentReasoningState()?.let {
+                    emit(AgentState(reasoning = it))
+                    emitted = true
+                }
+            }
+
+            is ReasoningEncryptedValueEvent -> {
+                // The encrypted-value event has no messageId; attach to the most recently active stream.
+                val targetMessageId = lastActiveReasoningMessageId
+                    ?: reasoningStreams.values.lastOrNull { it.isActive }?.messageId
+                    ?: reasoningStreams.values.lastOrNull()?.messageId
+                if (targetMessageId != null) {
+                    reasoningVisible = true
+                    val stream = reasoningStream(targetMessageId)
+                    stream.encryptedValues.add(
+                        ReasoningEncryptedValue(
+                            subtype = event.subtype,
+                            entityId = event.entityId,
+                            encryptedValue = event.encryptedValue
+                        )
+                    )
+                    currentReasoningState()?.let {
+                        emit(AgentState(reasoning = it))
+                        emitted = true
+                    }
+                } else {
+                    logger.w {
+                        "Received REASONING_ENCRYPTED_VALUE with no reasoning stream to attach to; dropping (subtype=${event.subtype}, entityId=${event.entityId})."
+                    }
                 }
             }
 

--- a/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/verify/EventVerifier.kt
+++ b/sdks/community/kotlin/library/client/src/commonMain/kotlin/com/agui/client/verify/EventVerifier.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.agui.client.verify
 
 import com.agui.core.types.*

--- a/sdks/community/kotlin/library/client/src/commonTest/kotlin/com/agui/client/state/DefaultApplyEventsTest.kt
+++ b/sdks/community/kotlin/library/client/src/commonTest/kotlin/com/agui/client/state/DefaultApplyEventsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.agui.client.state
 
 import com.agui.client.agent.AbstractAgent
@@ -211,5 +213,96 @@ class DefaultApplyEventsTest {
         assertNotNull(thinking)
         assertFalse(thinking.isThinking)
         assertEquals(listOf("Considering options"), thinking.messages)
+    }
+
+    @Test
+    fun tracksReasoningSingleStreamLifecycle() = runTest {
+        val input = baseInput()
+        val events = flowOf<BaseEvent>(
+            ReasoningStartEvent(messageId = "r1"),
+            ReasoningMessageStartEvent(messageId = "r1"),
+            ReasoningMessageContentEvent(messageId = "r1", delta = "Step 1"),
+            ReasoningMessageContentEvent(messageId = "r1", delta = " -> Step 2"),
+            ReasoningMessageEndEvent(messageId = "r1"),
+            ReasoningEndEvent(messageId = "r1")
+        )
+
+        val states = defaultApplyEvents(input, events).toList()
+        val reasoning = states.last().reasoning
+        assertNotNull(reasoning)
+        assertEquals(1, reasoning.streams.size)
+        val stream = reasoning.streams.first()
+        assertEquals("r1", stream.messageId)
+        assertFalse(stream.isActive)
+        assertEquals("Step 1 -> Step 2", stream.text)
+    }
+
+    @Test
+    fun tracksReasoningConcurrentStreams() = runTest {
+        val input = baseInput()
+        val events = flowOf<BaseEvent>(
+            ReasoningStartEvent(messageId = "r1"),
+            ReasoningStartEvent(messageId = "r2"),
+            ReasoningMessageContentEvent(messageId = "r1", delta = "alpha"),
+            ReasoningMessageContentEvent(messageId = "r2", delta = "beta"),
+            ReasoningMessageContentEvent(messageId = "r1", delta = " more"),
+            ReasoningEndEvent(messageId = "r2"),
+            ReasoningEndEvent(messageId = "r1")
+        )
+
+        val states = defaultApplyEvents(input, events).toList()
+        val reasoning = states.last().reasoning
+        assertNotNull(reasoning)
+        assertEquals(2, reasoning.streams.size)
+
+        val r1 = reasoning.streams.first { it.messageId == "r1" }
+        val r2 = reasoning.streams.first { it.messageId == "r2" }
+        assertEquals("alpha more", r1.text)
+        assertEquals("beta", r2.text)
+        assertFalse(r1.isActive)
+        assertFalse(r2.isActive)
+    }
+
+    @Test
+    fun reasoningEncryptedValueAttachesToMostRecentStream() = runTest {
+        val input = baseInput()
+        val events = flowOf<BaseEvent>(
+            ReasoningStartEvent(messageId = "r1"),
+            ReasoningMessageContentEvent(messageId = "r1", delta = "thinking..."),
+            ReasoningEncryptedValueEvent(
+                subtype = "message",
+                entityId = "e1",
+                encryptedValue = "ENC_PAYLOAD"
+            ),
+            ReasoningEndEvent(messageId = "r1")
+        )
+
+        val states = defaultApplyEvents(input, events).toList()
+        val reasoning = states.last().reasoning
+        assertNotNull(reasoning)
+        val stream = reasoning.streams.single()
+        assertEquals("r1", stream.messageId)
+        assertEquals(1, stream.encryptedValues.size)
+        val ev = stream.encryptedValues.first()
+        assertEquals("message", ev.subtype)
+        assertEquals("e1", ev.entityId)
+        assertEquals("ENC_PAYLOAD", ev.encryptedValue)
+    }
+
+    @Test
+    fun reasoningChunkAutoPopulatesStream() = runTest {
+        val input = baseInput()
+        val events = flowOf<BaseEvent>(
+            ReasoningMessageChunkEvent(messageId = "r1", delta = "Hello "),
+            ReasoningMessageChunkEvent(delta = "world!")
+        )
+
+        val states = defaultApplyEvents(input, events).toList()
+        val reasoning = states.last().reasoning
+        assertNotNull(reasoning)
+        val stream = reasoning.streams.single()
+        assertEquals("r1", stream.messageId)
+        assertEquals("Hello world!", stream.text)
+        assertTrue(stream.isActive)
     }
 }

--- a/sdks/community/kotlin/library/client/src/commonTest/kotlin/com/agui/client/verify/EventVerifierTest.kt
+++ b/sdks/community/kotlin/library/client/src/commonTest/kotlin/com/agui/client/verify/EventVerifierTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.agui.client.verify
 
 import com.agui.core.types.*

--- a/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Events.kt
+++ b/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Events.kt
@@ -10,19 +10,20 @@ import kotlinx.serialization.json.JsonElement
 
 /**
  * Enum defining all possible event types in the AG-UI protocol.
- * 26 event types as currently implemented.
+ * 33 event types as currently implemented.
  *
  * Events are grouped by category:
  * - Lifecycle Events (5): RUN_STARTED, RUN_FINISHED, RUN_ERROR, STEP_STARTED, STEP_FINISHED
  * - Text Message Events (3): TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_END
  * - Tool Call Events (4): TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END, TOOL_CALL_RESULT
  * - State Management Events (3): STATE_SNAPSHOT, STATE_DELTA, MESSAGES_SNAPSHOT
- * - Thinking Events (5): THINKING_START, THINKING_END, THINKING_TEXT_MESSAGE_START, THINKING_TEXT_MESSAGE_CONTENT, THINKING_TEXT_MESSAGE_END
+ * - Thinking Events (5, deprecated): THINKING_START, THINKING_END, THINKING_TEXT_MESSAGE_START, THINKING_TEXT_MESSAGE_CONTENT, THINKING_TEXT_MESSAGE_END
+ * - Reasoning Events (7): REASONING_START, REASONING_END, REASONING_MESSAGE_START, REASONING_MESSAGE_CONTENT, REASONING_MESSAGE_END, REASONING_MESSAGE_CHUNK, REASONING_ENCRYPTED_VALUE
  * - Special Events (2): RAW, CUSTOM
  * - Chunk Events (2): TEXT_MESSAGE_CHUNK, TOOL_CALL_CHUNK
  * - Activity Events (2): ACTIVITY_SNAPSHOT, ACTIVITY_DELTA
  *
- * Total: 26 events
+ * Total: 33 events
  */
 
 @Serializable
@@ -65,15 +66,40 @@ enum class EventType {
     @SerialName("MESSAGES_SNAPSHOT")
     MESSAGES_SNAPSHOT,
 
-    // Thinking Events
+    // Thinking Events (deprecated — use Reasoning Events)
+    @Deprecated(
+        message = "Use REASONING_START instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("EventType.REASONING_START"),
+        level = DeprecationLevel.WARNING
+    )
     @SerialName("THINKING_START")
     THINKING_START,
+    @Deprecated(
+        message = "Use REASONING_END instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("EventType.REASONING_END"),
+        level = DeprecationLevel.WARNING
+    )
     @SerialName("THINKING_END")
     THINKING_END,
+    @Deprecated(
+        message = "Use REASONING_MESSAGE_START instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("EventType.REASONING_MESSAGE_START"),
+        level = DeprecationLevel.WARNING
+    )
     @SerialName("THINKING_TEXT_MESSAGE_START")
     THINKING_TEXT_MESSAGE_START,
+    @Deprecated(
+        message = "Use REASONING_MESSAGE_CONTENT instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("EventType.REASONING_MESSAGE_CONTENT"),
+        level = DeprecationLevel.WARNING
+    )
     @SerialName("THINKING_TEXT_MESSAGE_CONTENT")
     THINKING_TEXT_MESSAGE_CONTENT,
+    @Deprecated(
+        message = "Use REASONING_MESSAGE_END instead. Will be removed in 1.0.0.",
+        replaceWith = ReplaceWith("EventType.REASONING_MESSAGE_END"),
+        level = DeprecationLevel.WARNING
+    )
     @SerialName("THINKING_TEXT_MESSAGE_END")
     THINKING_TEXT_MESSAGE_END,
 
@@ -93,7 +119,23 @@ enum class EventType {
     @SerialName("ACTIVITY_SNAPSHOT")
     ACTIVITY_SNAPSHOT,
     @SerialName("ACTIVITY_DELTA")
-    ACTIVITY_DELTA
+    ACTIVITY_DELTA,
+
+    // Reasoning Events
+    @SerialName("REASONING_START")
+    REASONING_START,
+    @SerialName("REASONING_MESSAGE_START")
+    REASONING_MESSAGE_START,
+    @SerialName("REASONING_MESSAGE_CONTENT")
+    REASONING_MESSAGE_CONTENT,
+    @SerialName("REASONING_MESSAGE_END")
+    REASONING_MESSAGE_END,
+    @SerialName("REASONING_MESSAGE_CHUNK")
+    REASONING_MESSAGE_CHUNK,
+    @SerialName("REASONING_END")
+    REASONING_END,
+    @SerialName("REASONING_ENCRYPTED_VALUE")
+    REASONING_ENCRYPTED_VALUE
 }
 
 /**
@@ -592,6 +634,11 @@ data class CustomEvent(
  * @param timestamp Optional timestamp when the thinking started
  * @param rawEvent Optional raw JSON representation of the event
  */
+@Deprecated(
+    message = "Use ReasoningStartEvent instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningStartEvent"),
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 @SerialName("THINKING_START")
 data class ThinkingStartEvent(
@@ -600,6 +647,7 @@ data class ThinkingStartEvent(
     override val rawEvent: JsonElement? = null
 ) : BaseEvent() {
     @Transient
+    @Suppress("DEPRECATION")
     override val eventType: EventType = EventType.THINKING_START
 }
 
@@ -613,6 +661,11 @@ data class ThinkingStartEvent(
  * @param timestamp Optional timestamp when the thinking ended
  * @param rawEvent Optional raw JSON representation of the event
  */
+@Deprecated(
+    message = "Use ReasoningEndEvent instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningEndEvent"),
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 @SerialName("THINKING_END")
 data class ThinkingEndEvent(
@@ -620,6 +673,7 @@ data class ThinkingEndEvent(
     override val rawEvent: JsonElement? = null
 ) : BaseEvent() {
     @Transient
+    @Suppress("DEPRECATION")
     override val eventType: EventType = EventType.THINKING_END
 }
 
@@ -633,6 +687,11 @@ data class ThinkingEndEvent(
  * @param timestamp Optional timestamp when thinking message generation started
  * @param rawEvent Optional raw JSON representation of the event
  */
+@Deprecated(
+    message = "Use ReasoningMessageStartEvent instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningMessageStartEvent"),
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 @SerialName("THINKING_TEXT_MESSAGE_START")
 data class ThinkingTextMessageStartEvent(
@@ -640,6 +699,7 @@ data class ThinkingTextMessageStartEvent(
     override val rawEvent: JsonElement? = null
 ) : BaseEvent() {
     @Transient
+    @Suppress("DEPRECATION")
     override val eventType: EventType = EventType.THINKING_TEXT_MESSAGE_START
 }
 
@@ -654,6 +714,11 @@ data class ThinkingTextMessageStartEvent(
  * @param timestamp Optional timestamp when this thinking content was generated
  * @param rawEvent Optional raw JSON representation of the event
  */
+@Deprecated(
+    message = "Use ReasoningMessageContentEvent instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningMessageContentEvent"),
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 @SerialName("THINKING_TEXT_MESSAGE_CONTENT")
 data class ThinkingTextMessageContentEvent(
@@ -662,6 +727,7 @@ data class ThinkingTextMessageContentEvent(
     override val rawEvent: JsonElement? = null
 ) : BaseEvent() {
     @Transient
+    @Suppress("DEPRECATION")
     override val eventType: EventType = EventType.THINKING_TEXT_MESSAGE_CONTENT
     init {
         require(delta.isNotEmpty()) { "Thinking text message content delta cannot be empty" }
@@ -678,6 +744,11 @@ data class ThinkingTextMessageContentEvent(
  * @param timestamp Optional timestamp when thinking message generation completed
  * @param rawEvent Optional raw JSON representation of the event
  */
+@Deprecated(
+    message = "Use ReasoningMessageEndEvent instead. Will be removed in 1.0.0.",
+    replaceWith = ReplaceWith("ReasoningMessageEndEvent"),
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 @SerialName("THINKING_TEXT_MESSAGE_END")
 data class ThinkingTextMessageEndEvent(
@@ -685,6 +756,7 @@ data class ThinkingTextMessageEndEvent(
     override val rawEvent: JsonElement? = null
 ) : BaseEvent() {
     @Transient
+    @Suppress("DEPRECATION")
     override val eventType: EventType = EventType.THINKING_TEXT_MESSAGE_END
 }
 
@@ -801,4 +873,175 @@ data class ActivityDeltaEvent(
 ) : BaseEvent() {
     @Transient
     override val eventType: EventType = EventType.ACTIVITY_DELTA
+}
+
+// ============== Reasoning Events (7) ==============
+
+/**
+ * Event indicating the start of a reasoning step.
+ *
+ * Replacement for [ThinkingStartEvent]. Reasoning events represent the agent's
+ * internal reasoning / chain-of-thought stream and carry a [messageId] so multiple
+ * reasoning streams can be interleaved.
+ *
+ * @param messageId Unique identifier for the reasoning stream
+ * @param timestamp Optional timestamp when the reasoning started
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_START")
+data class ReasoningStartEvent(
+    val messageId: String,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_START
+}
+
+/**
+ * Event indicating the start of a reasoning text message.
+ *
+ * The [role] field is constrained to the literal string "reasoning" to match the
+ * TypeScript and Python SDKs (`z.literal("reasoning")` / `Literal["reasoning"]`).
+ * The default value satisfies common usage; any explicit value other than
+ * "reasoning" will fail construction.
+ *
+ * @param messageId Unique identifier for the reasoning stream this message belongs to
+ * @param role Always the literal string "reasoning"
+ * @param timestamp Optional timestamp when reasoning message generation started
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_MESSAGE_START")
+data class ReasoningMessageStartEvent(
+    val messageId: String,
+    val role: String = "reasoning",
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_MESSAGE_START
+    init {
+        require(role == "reasoning") {
+            "ReasoningMessageStartEvent.role must be \"reasoning\", got \"$role\""
+        }
+    }
+}
+
+/**
+ * Event containing incremental content for a reasoning text message.
+ *
+ * @param messageId Unique identifier for the reasoning stream being updated
+ * @param delta The reasoning text to append (must not be empty)
+ * @param timestamp Optional timestamp when this content was generated
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_MESSAGE_CONTENT")
+data class ReasoningMessageContentEvent(
+    val messageId: String,
+    val delta: String,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_MESSAGE_CONTENT
+    init {
+        require(delta.isNotEmpty()) { "Reasoning message content delta cannot be empty" }
+    }
+}
+
+/**
+ * Event indicating the completion of a reasoning text message.
+ *
+ * @param messageId Unique identifier for the completed reasoning message
+ * @param timestamp Optional timestamp when reasoning message generation completed
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_MESSAGE_END")
+data class ReasoningMessageEndEvent(
+    val messageId: String,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_MESSAGE_END
+}
+
+/**
+ * Chunk event for streaming reasoning content.
+ *
+ * Both [messageId] and [delta] are optional to support the chunk-style streaming
+ * pattern where the first chunk carries the messageId and subsequent chunks
+ * carry only delta text.
+ *
+ * @param messageId Unique identifier for the reasoning stream (required for the first chunk)
+ * @param delta The reasoning text content delta for this chunk
+ * @param timestamp Optional timestamp when the chunk was generated
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_MESSAGE_CHUNK")
+data class ReasoningMessageChunkEvent(
+    val messageId: String? = null,
+    val delta: String? = null,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_MESSAGE_CHUNK
+}
+
+/**
+ * Event indicating the end of a reasoning step.
+ *
+ * Replacement for [ThinkingEndEvent]. Carries the [messageId] of the reasoning
+ * stream that has finished.
+ *
+ * @param messageId Unique identifier for the reasoning stream that has ended
+ * @param timestamp Optional timestamp when the reasoning ended
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_END")
+data class ReasoningEndEvent(
+    val messageId: String,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_END
+}
+
+/**
+ * Event carrying an encrypted reasoning payload (e.g. provider-specific
+ * encrypted signatures used by managed reasoning models).
+ *
+ * The [subtype] is constrained to one of "tool-call" or "message" to match the
+ * TypeScript and Python SDKs.
+ *
+ * @param subtype Either "tool-call" or "message"
+ * @param entityId Identifier for the tool call or message this value attaches to
+ * @param encryptedValue Provider-specific encrypted payload
+ * @param timestamp Optional timestamp when the value was generated
+ * @param rawEvent Optional raw JSON representation of the event
+ */
+@Serializable
+@SerialName("REASONING_ENCRYPTED_VALUE")
+data class ReasoningEncryptedValueEvent(
+    val subtype: String,
+    val entityId: String,
+    val encryptedValue: String,
+    override val timestamp: Long? = null,
+    override val rawEvent: JsonElement? = null
+) : BaseEvent() {
+    @Transient
+    override val eventType: EventType = EventType.REASONING_ENCRYPTED_VALUE
+    init {
+        require(subtype == "tool-call" || subtype == "message") {
+            "ReasoningEncryptedValueEvent.subtype must be \"tool-call\" or \"message\", got \"$subtype\""
+        }
+    }
 }

--- a/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/EventSerializationTest.kt
+++ b/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/EventSerializationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.agui.tests
 
 import com.agui.core.types.*
@@ -582,12 +584,227 @@ class EventSerializationTest {
         }
     }
 
+    // ========== Reasoning Events Tests ==========
+
+    @Test
+    fun testReasoningStartEventSerialization() {
+        val event = ReasoningStartEvent(
+            messageId = "msg_r1",
+            timestamp = 1234567890L
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_START", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+        assertEquals(1234567890L, jsonObj["timestamp"]?.jsonPrimitive?.long)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningStartEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningMessageStartEventSerialization() {
+        val event = ReasoningMessageStartEvent(
+            messageId = "msg_r1",
+            timestamp = 1234567890L
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_MESSAGE_START", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+        assertEquals("reasoning", jsonObj["role"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningMessageStartEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningMessageStartEventRejectsWrongRole() {
+        assertFailsWith<IllegalArgumentException> {
+            ReasoningMessageStartEvent(messageId = "m", role = "assistant")
+        }
+    }
+
+    @Test
+    fun testReasoningMessageContentEventSerialization() {
+        val event = ReasoningMessageContentEvent(
+            messageId = "msg_r1",
+            delta = "Let me think about this..."
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_MESSAGE_CONTENT", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+        assertEquals("Let me think about this...", jsonObj["delta"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningMessageContentEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningMessageContentEmptyDeltaValidation() {
+        assertFailsWith<IllegalArgumentException> {
+            ReasoningMessageContentEvent(messageId = "m", delta = "")
+        }
+    }
+
+    @Test
+    fun testReasoningMessageEndEventSerialization() {
+        val event = ReasoningMessageEndEvent(messageId = "msg_r1", timestamp = 1234567890L)
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_MESSAGE_END", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningMessageEndEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningMessageChunkEventSerialization() {
+        val event = ReasoningMessageChunkEvent(
+            messageId = "msg_r1",
+            delta = "chunk text"
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_MESSAGE_CHUNK", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+        assertEquals("chunk text", jsonObj["delta"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningMessageChunkEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningMessageChunkEventNullable() {
+        val event = ReasoningMessageChunkEvent()
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_MESSAGE_CHUNK", jsonObj["type"]?.jsonPrimitive?.content)
+        assertFalse(jsonObj.containsKey("messageId"))
+        assertFalse(jsonObj.containsKey("delta"))
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningMessageChunkEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningEndEventSerialization() {
+        val event = ReasoningEndEvent(messageId = "msg_r1", timestamp = 1234567890L)
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_END", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("msg_r1", jsonObj["messageId"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningEndEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningEncryptedValueEventSerialization() {
+        val event = ReasoningEncryptedValueEvent(
+            subtype = "tool-call",
+            entityId = "tc_42",
+            encryptedValue = "ENCRYPTED_PAYLOAD"
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("REASONING_ENCRYPTED_VALUE", jsonObj["type"]?.jsonPrimitive?.content)
+        assertEquals("tool-call", jsonObj["subtype"]?.jsonPrimitive?.content)
+        assertEquals("tc_42", jsonObj["entityId"]?.jsonPrimitive?.content)
+        assertEquals("ENCRYPTED_PAYLOAD", jsonObj["encryptedValue"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningEncryptedValueEvent)
+        assertEquals(event, decoded)
+    }
+
+    @Test
+    fun testReasoningEncryptedValueSubtypeMessage() {
+        val event = ReasoningEncryptedValueEvent(
+            subtype = "message",
+            entityId = "m_1",
+            encryptedValue = "ENC"
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is ReasoningEncryptedValueEvent)
+        assertEquals("message", decoded.subtype)
+    }
+
+    @Test
+    fun testReasoningEncryptedValueRejectsBadSubtype() {
+        assertFailsWith<IllegalArgumentException> {
+            ReasoningEncryptedValueEvent(
+                subtype = "other",
+                entityId = "x",
+                encryptedValue = "y"
+            )
+        }
+    }
+
+    @Test
+    fun testReasoningEventsWithRawEvent() {
+        val rawEventData = buildJsonObject {
+            put("modelProvider", "openai")
+            put("model", "o1-preview")
+        }
+
+        val events = listOf<BaseEvent>(
+            ReasoningStartEvent(messageId = "m", rawEvent = rawEventData),
+            ReasoningMessageStartEvent(messageId = "m", rawEvent = rawEventData),
+            ReasoningMessageContentEvent(messageId = "m", delta = "...", rawEvent = rawEventData),
+            ReasoningMessageEndEvent(messageId = "m", rawEvent = rawEventData),
+            ReasoningMessageChunkEvent(messageId = "m", delta = "...", rawEvent = rawEventData),
+            ReasoningEndEvent(messageId = "m", rawEvent = rawEventData),
+            ReasoningEncryptedValueEvent(
+                subtype = "message",
+                entityId = "m",
+                encryptedValue = "ENC",
+                rawEvent = rawEventData
+            )
+        )
+
+        events.forEach { event ->
+            val jsonString = json.encodeToString<BaseEvent>(event)
+            val decoded = json.decodeFromString<BaseEvent>(jsonString)
+
+            assertEquals(rawEventData, decoded.rawEvent)
+            assertEquals("openai", decoded.rawEvent?.jsonObject?.get("modelProvider")?.jsonPrimitive?.content)
+        }
+    }
+
     // ========== Protocol Compliance Tests ==========
 
     @Test
     fun testEventDiscriminatorFormat() {
         // Test that each event type produces the correct discriminator
-        val testCases = mapOf(
+        val testCases = mapOf<BaseEvent, String>(
             RunStartedEvent(threadId = "t", runId = "r") to "RUN_STARTED",
             RunFinishedEvent(threadId = "t", runId = "r") to "RUN_FINISHED",
             RunErrorEvent(message = "err") to "RUN_ERROR",
@@ -609,7 +826,19 @@ class EventSerializationTest {
             ThinkingEndEvent() to "THINKING_END",
             ThinkingTextMessageStartEvent() to "THINKING_TEXT_MESSAGE_START",
             ThinkingTextMessageContentEvent(delta = "thinking...") to "THINKING_TEXT_MESSAGE_CONTENT",
-            ThinkingTextMessageEndEvent() to "THINKING_TEXT_MESSAGE_END"
+            ThinkingTextMessageEndEvent() to "THINKING_TEXT_MESSAGE_END",
+            // Reasoning Events
+            ReasoningStartEvent(messageId = "m") to "REASONING_START",
+            ReasoningMessageStartEvent(messageId = "m") to "REASONING_MESSAGE_START",
+            ReasoningMessageContentEvent(messageId = "m", delta = "d") to "REASONING_MESSAGE_CONTENT",
+            ReasoningMessageEndEvent(messageId = "m") to "REASONING_MESSAGE_END",
+            ReasoningMessageChunkEvent(messageId = "m", delta = "d") to "REASONING_MESSAGE_CHUNK",
+            ReasoningEndEvent(messageId = "m") to "REASONING_END",
+            ReasoningEncryptedValueEvent(
+                subtype = "tool-call",
+                entityId = "e",
+                encryptedValue = "v"
+            ) to "REASONING_ENCRYPTED_VALUE"
         )
 
         testCases.forEach { (event, expectedType) ->


### PR DESCRIPTION
## Summary

Closes #1650.

Adds the seven `REASONING_*` events that have replaced `THINKING_*` in the TypeScript and Python SDKs to the Kotlin community SDK so a Kotlin client can deserialize streams from servers emitting the new events (without this change, the polymorphic discriminator `type` does not match any `BaseEvent` subclass).

- New `EventType` entries and `BaseEvent` subclasses in `com.agui.core.types`: `ReasoningStartEvent`, `ReasoningMessageStartEvent` (role validated == `"reasoning"`), `ReasoningMessageContentEvent`, `ReasoningMessageEndEvent`, `ReasoningMessageChunkEvent`, `ReasoningEndEvent`, `ReasoningEncryptedValueEvent` (subtype validated == `"tool-call"` | `"message"`).
- New `ReasoningTelemetryState` (per-`messageId` streams + encrypted-value attachments) and `AgentState.reasoning` field. `ThinkingTelemetryState` and `AgentState.thinking` deprecated.
- `DefaultApplyEvents` now wires `REASONING_*` events into per-stream state, including chunk auto-streaming and encrypted-value attachment to the most recently active stream. Existing `THINKING_*` handling is unchanged.
- `EventVerifier` is unchanged for `REASONING_*` events (matches the TypeScript SDK; no new lifecycle rules).
- All five `THINKING_*` events and matching `EventType` entries are marked `@Deprecated(WARNING)` with `ReplaceWith` hints; slated for removal in 1.0.0.
- Library version bumped 0.3.0 → 0.4.0; CHANGELOG updated.

## Test plan

- [x] `./gradlew :kotlin-core:jvmTest` — 70 tests pass (13 new `REASONING_*` serialization tests covering round-trip, role/subtype validation, empty-delta rejection, nullable chunk fields, raw-event passthrough, discriminator routing).
- [x] `./gradlew :kotlin-client:jvmTest` — 14 tests pass (4 new apply-handler tests: single-stream lifecycle, two interleaved concurrent streams, encrypted-value attachment, chunk auto-population).
- [x] `./gradlew :kotlin-tools:jvmTest` — passes.
- [x] `./gradlew :kotlin-core:compileCommonMainKotlinMetadata :kotlin-client:compileCommonMainKotlinMetadata` — multiplatform metadata compiles cleanly (only the expected internal `WARNING`-level deprecation references, suppressed at file level on the verifier and test files that legitimately exercise the deprecated thinking events).
- [x] Manual interop check against an ADK-middleware server emitting `REASONING_*` from Gemini 2.5 Flash with `ThinkingConfig(include_thoughts=True)` (e.g. the existing `examples/server/api/agentic_chat_reasoning.py` sample).

## Notes

- Wire compatibility unchanged. Servers emitting `THINKING_*` continue to round-trip exactly as before; servers emitting `REASONING_*` are now decodable.
- `ReasoningMessageStartEvent.role` is modeled as a constrained `String` rather than a new `Role.REASONING` enum value, to avoid introducing a ghost role with no matching `Message` subclass and to match the TS `z.literal("reasoning")` and Python `Literal["reasoning"]` schemas exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)