### PR TITLE
feat(kotlin-chatapp): display reasoning events, bump samples to agui 0.4.0

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Examples
+- Chatapp surfaces `REASONING_*` events as a transient "💭 Reasoning…" bubble (new `MessageRole.REASONING` + `EphemeralType.REASONING`), mirroring the existing tool-call / step ephemeral pattern. Clears on `RUN_FINISHED`, run cancel, or run error. Handles `REASONING_START` / `REASONING_END`, `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END`, and `REASONING_MESSAGE_CHUNK`.
+- Bump all Kotlin sample apps (chatapp, chatapp-java, chatapp-wearos, chatapp-swiftui, tools) from `agui-core 0.3.0` to `0.4.0` and consume the published artefacts from Maven by removing the `includeBuild("../../library")` + dependencySubstitution blocks from the four chatapp variants' settings files.
+- Bump chatapp Kotlin `2.1.20 → 2.2.20` so the iOS targets can consume `com.mikepenz:multiplatform-markdown-renderer-m3:0.37.0` klibs (require ABI 2.2.0+).
+
 ## [0.3.0] - 2026-05-09
 
 ### Added

--- a/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.3.0"
+agui-core = "0.4.0"
 a2ui4k = "0.8.1"
 appcompat = "1.7.1"
 core = "1.6.1"

--- a/sdks/community/kotlin/examples/chatapp-java/settings.gradle
+++ b/sdks/community/kotlin/examples/chatapp-java/settings.gradle
@@ -22,13 +22,3 @@ rootProject.name = "agui-chatapp-java"
 include(":app")
 include(":chatapp-shared")
 project(":chatapp-shared").projectDir = file("../chatapp-shared")
-
-// Include local library for development (using local modules with new Activity types)
-includeBuild("../../library") {
-    dependencySubstitution {
-        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
-        // kotlin-a2ui is fetched from Maven (com.contextable:kotlin-a2ui)
-    }
-}

--- a/sdks/community/kotlin/examples/chatapp-shared/src/commonMain/kotlin/com/agui/example/chatapp/chat/ChatController.kt
+++ b/sdks/community/kotlin/examples/chatapp-shared/src/commonMain/kotlin/com/agui/example/chatapp/chat/ChatController.kt
@@ -18,6 +18,12 @@ import com.agui.core.types.AssistantMessage
 import com.agui.core.types.BaseEvent
 import com.agui.core.types.DeveloperMessage
 import com.agui.core.types.Message
+import com.agui.core.types.ReasoningEndEvent
+import com.agui.core.types.ReasoningMessageChunkEvent
+import com.agui.core.types.ReasoningMessageContentEvent
+import com.agui.core.types.ReasoningMessageEndEvent
+import com.agui.core.types.ReasoningMessageStartEvent
+import com.agui.core.types.ReasoningStartEvent
 import com.agui.core.types.Role
 import com.agui.core.types.RunErrorEvent
 import com.agui.core.types.RunFinishedEvent
@@ -108,6 +114,7 @@ class ChatController(
     private val streamingMessageIds = mutableSetOf<String>()
     private val supplementalMessages = linkedMapOf<String, DisplayMessage>()
     private val ephemeralMessages = mutableMapOf<EphemeralType, DisplayMessage>()
+    private val reasoningBuffer = StringBuilder()
     private val surfaceStateManager = SurfaceStateManager()
     private data class StoredMessage(var message: Message, val displayId: String)
 
@@ -649,6 +656,7 @@ class ChatController(
             role = when (type) {
                 EphemeralType.TOOL_CALL -> MessageRole.TOOL_CALL
                 EphemeralType.STEP -> MessageRole.STEP_INFO
+                EphemeralType.REASONING -> MessageRole.REASONING
             },
             content = "$icon $content".trim(),
             ephemeralGroupId = type.name,
@@ -665,6 +673,7 @@ class ChatController(
     }
 
     private fun clearAllEphemeralMessages() {
+        reasoningBuffer.clear()
         if (ephemeralMessages.isNotEmpty()) {
             ephemeralMessages.clear()
             refreshMessages()
@@ -727,6 +736,41 @@ class ChatController(
                 scope.launch {
                     delay(500)
                     clearEphemeralMessage(EphemeralType.STEP)
+                }
+            }
+            is ReasoningStartEvent -> {
+                reasoningBuffer.clear()
+                setEphemeralMessage(
+                    content = Strings.REASONING_PLACEHOLDER,
+                    type = EphemeralType.REASONING,
+                    icon = "💭"
+                )
+            }
+            is ReasoningMessageStartEvent -> Unit
+            is ReasoningMessageContentEvent -> {
+                reasoningBuffer.append(event.delta)
+                setEphemeralMessage(
+                    content = reasoningBuffer.toString(),
+                    type = EphemeralType.REASONING,
+                    icon = "💭"
+                )
+            }
+            is ReasoningMessageChunkEvent -> {
+                event.delta?.takeIf { it.isNotEmpty() }?.let { delta ->
+                    reasoningBuffer.append(delta)
+                    setEphemeralMessage(
+                        content = reasoningBuffer.toString(),
+                        type = EphemeralType.REASONING,
+                        icon = "💭"
+                    )
+                }
+            }
+            is ReasoningMessageEndEvent -> Unit
+            is ReasoningEndEvent -> {
+                scope.launch {
+                    delay(500)
+                    clearEphemeralMessage(EphemeralType.REASONING)
+                    reasoningBuffer.clear()
                 }
             }
             is RunErrorEvent -> {
@@ -888,12 +932,12 @@ data class ChatState(
 
 /** Classic chat roles shown in the UI layers. */
 enum class MessageRole {
-    USER, ASSISTANT, SYSTEM, DEVELOPER, ERROR, TOOL_CALL, STEP_INFO
+    USER, ASSISTANT, SYSTEM, DEVELOPER, ERROR, TOOL_CALL, STEP_INFO, REASONING
 }
 
-/** Distinguishes transient tool/step messages. */
+/** Distinguishes transient tool/step/reasoning messages. */
 enum class EphemeralType {
-    TOOL_CALL, STEP
+    TOOL_CALL, STEP, REASONING
 }
 
 /** Representation of rendered chat messages for UIs. */

--- a/sdks/community/kotlin/examples/chatapp-shared/src/commonMain/kotlin/com/agui/example/chatapp/util/StringResourceProvider.kt
+++ b/sdks/community/kotlin/examples/chatapp-shared/src/commonMain/kotlin/com/agui/example/chatapp/util/StringResourceProvider.kt
@@ -65,6 +65,7 @@ object Strings {
     const val AGENT_ERROR_PREFIX = "Agent error: "
     const val FAILED_TO_CONNECT_PREFIX = "Failed to connect: "
     const val CONNECTED_TO_PREFIX = "Connected to "
+    const val REASONING_PLACEHOLDER = "Reasoning…"
 
     // Validation messages
     const val NAME_REQUIRED = "Name is required"

--- a/sdks/community/kotlin/examples/chatapp-shared/src/commonTest/kotlin/com/agui/example/chatapp/chat/ChatControllerTest.kt
+++ b/sdks/community/kotlin/examples/chatapp-shared/src/commonTest/kotlin/com/agui/example/chatapp/chat/ChatControllerTest.kt
@@ -4,7 +4,14 @@ import com.agui.client.agent.AgentSubscriber
 import com.agui.client.agent.AgentSubscription
 import com.agui.core.types.AssistantMessage
 import com.agui.core.types.BaseEvent
+import com.agui.core.types.ReasoningEndEvent
+import com.agui.core.types.ReasoningMessageChunkEvent
+import com.agui.core.types.ReasoningMessageContentEvent
+import com.agui.core.types.ReasoningMessageEndEvent
+import com.agui.core.types.ReasoningMessageStartEvent
+import com.agui.core.types.ReasoningStartEvent
 import com.agui.core.types.RunErrorEvent
+import com.agui.core.types.RunFinishedEvent
 import com.agui.core.types.ToolCallEndEvent
 import com.agui.core.types.ToolCallStartEvent
 import com.agui.core.types.UserMessage
@@ -121,6 +128,83 @@ class ChatControllerTest {
         advanceUntilIdle()
 
         assertFalse(controller.state.value.messages.any { it.role == MessageRole.TOOL_CALL })
+
+        controller.close()
+        scope.cancel()
+        AgentRepository.resetInstance()
+    }
+
+    @Test
+    fun reasoningEventsStreamEphemeralBubble() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val settings = FakeSettings()
+        AgentRepository.resetInstance()
+        UserIdManager.resetInstance()
+
+        val repository = AgentRepository.getInstance(settings)
+        val userIdManager = UserIdManager.getInstance(settings)
+        val controller = ChatController(
+            externalScope = scope,
+            agentFactory = StubChatAgentFactory(),
+            settings = settings,
+            agentRepository = repository,
+            userIdManager = userIdManager
+        )
+
+        controller.handleAgentEvent(ReasoningStartEvent(messageId = "r-1"))
+        val placeholder = controller.state.value.messages.singleOrNull { it.role == MessageRole.REASONING }
+        assertTrue(placeholder != null)
+        assertEquals(EphemeralType.REASONING, placeholder.ephemeralType)
+
+        controller.handleAgentEvent(ReasoningMessageStartEvent(messageId = "r-1"))
+        controller.handleAgentEvent(ReasoningMessageContentEvent(messageId = "r-1", delta = "First "))
+        controller.handleAgentEvent(ReasoningMessageContentEvent(messageId = "r-1", delta = "thought."))
+        val streaming = controller.state.value.messages.single { it.role == MessageRole.REASONING }
+        assertTrue(streaming.content.contains("First thought."))
+
+        controller.handleAgentEvent(ReasoningMessageEndEvent(messageId = "r-1"))
+        controller.handleAgentEvent(ReasoningEndEvent(messageId = "r-1"))
+        advanceTimeBy(500)
+        advanceUntilIdle()
+
+        assertFalse(controller.state.value.messages.any { it.role == MessageRole.REASONING })
+
+        controller.close()
+        scope.cancel()
+        AgentRepository.resetInstance()
+    }
+
+    @Test
+    fun reasoningChunkEventsAppendDelta() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(dispatcher)
+        val settings = FakeSettings()
+        AgentRepository.resetInstance()
+        UserIdManager.resetInstance()
+
+        val repository = AgentRepository.getInstance(settings)
+        val userIdManager = UserIdManager.getInstance(settings)
+        val controller = ChatController(
+            externalScope = scope,
+            agentFactory = StubChatAgentFactory(),
+            settings = settings,
+            agentRepository = repository,
+            userIdManager = userIdManager
+        )
+
+        controller.handleAgentEvent(ReasoningStartEvent(messageId = "r-2"))
+        controller.handleAgentEvent(ReasoningMessageChunkEvent(messageId = "r-2", delta = "Chunk-A "))
+        controller.handleAgentEvent(ReasoningMessageChunkEvent(messageId = null, delta = "Chunk-B"))
+        controller.handleAgentEvent(ReasoningMessageChunkEvent(messageId = null, delta = null))
+
+        val streaming = controller.state.value.messages.single { it.role == MessageRole.REASONING }
+        assertTrue(streaming.content.contains("Chunk-A Chunk-B"))
+
+        controller.handleAgentEvent(RunFinishedEvent(threadId = "t", runId = "r"))
+        advanceUntilIdle()
+
+        assertFalse(controller.state.value.messages.any { it.role == MessageRole.REASONING })
 
         controller.close()
         scope.cancel()

--- a/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.3.0"
+agui-core = "0.4.0"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/settings.gradle.kts
@@ -6,15 +6,6 @@ project(":chatapp-shared").projectDir = File(rootDir, "../chatapp-shared")
 include(":shared")
 project(":shared").projectDir = File(rootDir, "shared")
 
-// Include local library for development (using local modules with new Activity types)
-includeBuild("../../library") {
-    dependencySubstitution {
-        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
-    }
-}
-
 pluginManagement {
     repositories {
         google()

--- a/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.3.0"
+agui-core = "0.4.0"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp-wearos/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp-wearos/settings.gradle.kts
@@ -4,16 +4,6 @@ include(":wearApp")
 include(":chatapp-shared")
 project(":chatapp-shared").projectDir = file("../chatapp-shared")
 
-// Include local library for development (using local modules with new Activity types)
-includeBuild("../../library") {
-    dependencySubstitution {
-        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
-        substitute(module("com.ag-ui.community:kotlin-a2ui")).using(project(":kotlin-a2ui"))
-    }
-}
-
 pluginManagement {
     repositories {
         google()

--- a/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.3.0"
+agui-core = "0.4.0"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
-kotlin = "2.1.20"
+kotlin = "2.2.20"
 #Downgrading to avoid an R8 error
 ktor = "3.1.3"
 kotlinx-serialization = "1.8.1"

--- a/sdks/community/kotlin/examples/chatapp/settings.gradle.kts
+++ b/sdks/community/kotlin/examples/chatapp/settings.gradle.kts
@@ -7,15 +7,6 @@ include(":desktopApp")
 include(":chatapp-shared")
 project(":chatapp-shared").projectDir = file("../chatapp-shared")
 
-// Include local library for development (using local modules with new Activity types)
-includeBuild("../../library") {
-    dependencySubstitution {
-        substitute(module("com.ag-ui.community:kotlin-core")).using(project(":kotlin-core"))
-        substitute(module("com.ag-ui.community:kotlin-client")).using(project(":kotlin-client"))
-        substitute(module("com.ag-ui.community:kotlin-tools")).using(project(":kotlin-tools"))
-    }
-}
-
 pluginManagement {
     repositories {
         google()
@@ -25,7 +16,7 @@ pluginManagement {
     }
 
     plugins {
-        val kotlinVersion = "2.1.20"
+        val kotlinVersion = "2.2.20"
         val composeVersion = "1.9.3"
         val agpVersion = "8.12.0"
 

--- a/sdks/community/kotlin/examples/chatapp/shared/src/commonMain/kotlin/com/agui/example/chatapp/ui/screens/chat/components/MessageBubble.kt
+++ b/sdks/community/kotlin/examples/chatapp/shared/src/commonMain/kotlin/com/agui/example/chatapp/ui/screens/chat/components/MessageBubble.kt
@@ -37,6 +37,7 @@ fun MessageBubble(
     val isSystem = message.role == MessageRole.SYSTEM || message.role == MessageRole.DEVELOPER
     val isToolCall = message.role == MessageRole.TOOL_CALL
     val isStepInfo = message.role == MessageRole.STEP_INFO
+    val isReasoning = message.role == MessageRole.REASONING
     val isEphemeral = message.ephemeralGroupId != null
     val messageTextColor = when {
         isUser -> MaterialTheme.colorScheme.onPrimary
@@ -44,6 +45,7 @@ fun MessageBubble(
         isSystem -> MaterialTheme.colorScheme.onTertiary
         isToolCall -> MaterialTheme.colorScheme.onSecondaryContainer
         isStepInfo -> MaterialTheme.colorScheme.onTertiaryContainer
+        isReasoning -> MaterialTheme.colorScheme.onPrimaryContainer
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
 
@@ -93,6 +95,7 @@ fun MessageBubble(
                         isSystem -> MaterialTheme.colorScheme.tertiary
                         isToolCall -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.7f)
                         isStepInfo -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.7f)
+                        isReasoning -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
                         else -> MaterialTheme.colorScheme.surfaceVariant
                     }
                 )

--- a/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.3.0"
+agui-core = "0.4.0"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"


### PR DESCRIPTION
## Summary
- Surface `REASONING_*` events as a transient "💭 Reasoning…" bubble in chatapp via new `MessageRole.REASONING` + `EphemeralType.REASONING`, reusing the existing tool-call / step ephemeral pattern; clears on `RUN_FINISHED` / cancel / error.
- Bump all Kotlin sample apps (chatapp, chatapp-java, chatapp-wearos, chatapp-swiftui, tools) to `agui-core 0.4.0` and stop building against the local library — consume the published Maven artefacts by removing the `includeBuild("../../library")` + dependencySubstitution blocks from the four chatapp variants.
- Bump chatapp Kotlin `2.1.20 → 2.2.20` so the iOS targets can consume `com.mikepenz:multiplatform-markdown-renderer-m3:0.37.0` klibs (require ABI 2.2.0+).

## Event coverage
Handles the full lifecycle: `REASONING_START` / `REASONING_END`, `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END`, and `REASONING_MESSAGE_CHUNK` (including the null-`messageId` later-chunk shape). `REASONING_ENCRYPTED_VALUE` is intentionally not consumed.

## Test plan
- [x] `:chatapp-shared:desktopTest --tests ChatControllerTest` — 5/5 passing, including 2 new tests (`reasoningEventsStreamEphemeralBubble`, `reasoningChunkEventsAppendDelta`)
- [x] `:desktopApp:run` — assembled and launched cleanly; reasoning bubble renders against a Gemini-backed AG-UI agent emitting REASONING events
- [x] `./gradlew assemble` for chatapp — Android debug+release, Desktop, and iOS (arm64 / simulator-arm64 / x64 debug compile + release framework linking) all succeed
- [x] Maven resolution verified: `:shared:dependencies --configuration androidDebugRuntimeClasspath` shows `com.ag-ui.community:kotlin-{core,client,tools}:0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)