### PR TITLE
fix(ci): use multiline-safe GITHUB_OUTPUT for release groups JSON

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -182,8 +182,9 @@ jobs:
         if: steps.detect_ts.outputs.count != '0'
         id: save_groups
         run: |
-          GROUPS=$(cat /tmp/ts-groups.json)
-          echo "groups=$GROUPS" >> "$GITHUB_OUTPUT"
+          echo "groups<<EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/ts-groups.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Upload TypeScript build artifacts
         if: steps.detect_ts.outputs.count != '0'


### PR DESCRIPTION
## Summary

Fix the `Save groups to output` step in the release/publish workflow that has been failing silently on the last 3 merged PRs (aws-strands 0.1.8, adk-middleware 0.6.2, watsonx 0.0.1).

## Root cause

The step writes JSON to `$GITHUB_OUTPUT` using the single-line pattern:
```bash
echo "groups=$JSON" >> "$GITHUB_OUTPUT"
```

This fails with exit code 1 (no error message) when the JSON contains characters the shell or GitHub's output parser can't handle in a single-line value.

## Fix

Switch to the heredoc-delimited multiline pattern — the standard workaround for JSON values in GitHub Actions outputs:
```bash
echo "groups<<EOF" >> "$GITHUB_OUTPUT"
cat /tmp/ts-groups.json >> "$GITHUB_OUTPUT"
echo "EOF" >> "$GITHUB_OUTPUT"
```

## Impact

Without this fix, the `build` job fails → `publish` job is skipped → no packages reach npm/PyPI on merge. This blocks all releases.

## Test plan

- [ ] Re-run the watsonx release publish after merge to verify `@ag-ui/watsonx` publishes to npm