### PR TITLE
fix(ci): install workspace deps in publish job for nx + pnpm protocol resolution

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -273,10 +273,14 @@ jobs:
         with:
           name: ts-build-artifacts
 
-      # nx release publish needs the workspace context (package.json files)
-      # but we do NOT run pnpm install here — that would execute lifecycle
-      # scripts from repo package manifests in the same process tree as
-      # publishing secrets. The built dist/ artifacts are sufficient.
+      # nx release publish needs the full pnpm workspace installed so that:
+      # 1. nx can resolve the project graph and find the nx-release-publish executor
+      # 2. pnpm publish can resolve workspace:* protocol deps to real versions
+      # We use --ignore-scripts to preserve the security boundary: no lifecycle
+      # scripts run in the same process tree as publishing secrets.
+      - name: Install dependencies (no lifecycle scripts)
+        if: needs.build.outputs.ts_count != '0'
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Publish TypeScript packages
         if: needs.build.outputs.ts_count != '0'
         env:


### PR DESCRIPTION
## Summary

Fix the release/publish workflow's publish job which has been failing because `nx release publish` can't find the workspace without `node_modules`.

## Root cause

The publish job intentionally skipped `pnpm install` to avoid running lifecycle scripts near publishing secrets (`NPM_TOKEN`, `PYPI_API_TOKEN`). But `nx release publish` requires:

1. **nx in node_modules** — without it, `npx nx` downloads a mismatched version from npm that can't find the workspace
2. **@nx/js executor** — the `@nx/js:release-publish` executor runs `pnpm publish` which resolves `workspace:*` protocols to real semver versions during packing
3. **Full workspace context** — nx needs the project graph to find and order packages for publish

Without `pnpm install`, raw `npm publish` would ship `package.json` files containing literal `"workspace:*"` specifiers — broken packages on npm.

## Fix

```yaml
- name: Install dependencies (no lifecycle scripts)
  run: pnpm install --frozen-lockfile --ignore-scripts
```

`--ignore-scripts` preserves the security boundary (no lifecycle scripts execute near secrets). `--frozen-lockfile` ensures deterministic installs.

## Impact

This has been blocking all npm publishes. After merge + manual dispatch, `@ag-ui/watsonx` and `create-ag-ui-app` should publish successfully.

## Test plan

- [ ] Admin merge → manual `workflow_dispatch` → verify `@ag-ui/watsonx@0.0.1` appears on npm