### PR TITLE
fix(watsonx): add Python package to release config for PyPI publishing

### DIFF
--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -139,11 +139,18 @@
         { "name": "@ag-ui/spring-ai", "path": "integrations/community/spring-ai/typescript", "ecosystem": "typescript" }
       ]
     },
-    "integration-watsonx": {
+    "integration-watsonx-ts": {
       "description": "Watsonx integration (TypeScript)",
       "sharedVersion": false,
       "packages": [
         { "name": "@ag-ui/watsonx", "path": "integrations/watsonx/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "integration-watsonx-py": {
+      "description": "Watsonx integration (Python)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "ag_ui_watsonx", "path": "integrations/watsonx/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
     "middleware-a2a": {


### PR DESCRIPTION
## Summary

Add `ag_ui_watsonx` to `release.config.json` so the Python package publishes to PyPI on merge.

The TypeScript package (`@ag-ui/watsonx`) was already configured and published successfully to npm. The Python package was missing from the config.

## Changes

- Rename scope `integration-watsonx` → `integration-watsonx-ts` (consistency with langgraph naming)
- Add new scope `integration-watsonx-py` with `ag_ui_watsonx` pointing to `integrations/watsonx/python`, ecosystem `python`, buildSystem `uv`

## Verification

The release pipeline for Python packages is straightforward (no bootstrap issues):
1. **Detection**: `detect-py-version-changes.sh` queries PyPI → 404 for new package → marked as `NEW (unpublished)` → included
2. **Build**: `uv build` in the package dir → produces wheel + sdist in `dist/`
3. **Publish**: `uv publish dist/*` with `PYPI_API_TOKEN` → PyPI accepts first publish without special flags

No `--access public` equivalent needed (unlike npm scoped packages). No workspace protocol resolution needed (unlike pnpm). Clean path.

## Test plan

- [x] `verify-nx-release-allowlist.sh` passes (TS packages still in sync)
- [x] Python packages list includes `ag_ui_watsonx` with correct path and buildSystem
- [ ] After merge + workflow_dispatch: `pip install ag_ui_watsonx` resolves from PyPI