### PR TITLE
fix(adk-middleware): set FunctionResponse.name to the called function name, not tool_call_id

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
@@ -202,15 +202,31 @@ def convert_message_content_to_parts(content: Optional[Union[str, List[Any]]]) -
 
 def convert_ag_ui_messages_to_adk(messages: List[Message]) -> List[ADKEvent]:
     """Convert AG-UI messages to ADK events.
-    
+
     Args:
         messages: List of AG-UI messages
-        
+
     Returns:
         List of ADK events
     """
     adk_events = []
-    
+
+    # Build a tool_call_id -> function_name lookup so we can populate
+    # `FunctionResponse.name` correctly when we hit a ToolMessage. AG-UI's
+    # ToolMessage doesn't carry the function name (only `tool_call_id`),
+    # but Gemini's `FunctionResponse.name` MUST equal the called
+    # function's name so providers (real Gemini and proxies like aimock)
+    # can correlate the response back to the originating FunctionCall.
+    # Without this, `name` would be set to the tool_call_id, which is a
+    # UUID-like string that no prior FunctionCall.name will match — the
+    # round-trip silently breaks (e.g. multi-leg fixture proxies fall
+    # back to a generated id and stop matching second-leg responses).
+    tool_call_id_to_name: dict[str, str] = {}
+    for prior in messages:
+        if isinstance(prior, AssistantMessage) and prior.tool_calls:
+            for tool_call in prior.tool_calls:
+                tool_call_id_to_name[tool_call.id] = tool_call.function.name
+
     for message in messages:
         try:
             # Create base event
@@ -254,12 +270,22 @@ def convert_ag_ui_messages_to_adk(messages: List[Message]) -> List[ADKEvent]:
                     )
             
             elif isinstance(message, ToolMessage):
-                # Tool messages become function responses
+                # Tool messages become function responses. `name` must be
+                # the called function's name (looked up from the prior
+                # AssistantMessage's tool_calls by id); falling back to
+                # the tool_call_id only when the lookup misses (e.g. the
+                # caller sent a ToolMessage without the originating
+                # AssistantMessage in the same batch — rare, but the old
+                # behaviour). `id` carries the tool_call_id so providers
+                # that key on it directly still see it.
+                function_name = tool_call_id_to_name.get(
+                    message.tool_call_id, message.tool_call_id
+                )
                 event.content = types.Content(
                     role="function",
                     parts=[types.Part(
                         function_response=types.FunctionResponse(
-                            name=message.tool_call_id, 
+                            name=function_name,
                             response={"result": message.content} if isinstance(message.content, str) else message.content,
                             id=message.tool_call_id
                         )

--- a/integrations/adk-middleware/python/tests/test_utils_converters.py
+++ b/integrations/adk-middleware/python/tests/test_utils_converters.py
@@ -421,7 +421,15 @@ class TestConvertAGUIMessagesToADK:
         assert func_part.function_call.args == {"expression": "2 + 2"}
 
     def test_convert_tool_message(self):
-        """Test converting a ToolMessage to ADK event."""
+        """Test the fallback path: a ToolMessage with no prior AssistantMessage
+        in the same batch falls back to using tool_call_id as the
+        FunctionResponse.name. Preserves backwards-compatible behaviour for
+        malformed inputs / orphan tool messages.
+
+        For the corrected round-trip path (AssistantMessage with the matching
+        tool_call present in the batch), see
+        `test_tool_message_uses_function_name_from_prior_assistant_call`.
+        """
         tool_msg = ToolMessage(
             id="tool_1",
             role="tool",
@@ -438,9 +446,142 @@ class TestConvertAGUIMessagesToADK:
         assert event.content.role == "function"
 
         func_response = event.content.parts[0].function_response
+        # Fallback: no prior AssistantMessage with the matching tool_call.id
+        # in this batch, so the converter degrades gracefully to using the
+        # tool_call_id as the function name. Gemini will not be able to
+        # correlate the response back to a call by name in this case, but at
+        # least the conversion doesn't crash.
         assert func_response.name == "call_123"
         assert func_response.id == "call_123"
         assert func_response.response == {"result": '{"temperature": 72, "condition": "sunny"}'}
+
+    def test_tool_message_uses_function_name_from_prior_assistant_call(self):
+        """When a ToolMessage is preceded by an AssistantMessage carrying a
+        tool_call with the matching id, FunctionResponse.name MUST be set to
+        the called function's name (not the tool_call_id).
+
+        Gemini's wire contract is that FunctionResponse.name equals the
+        originating FunctionCall.name; downstream consumers that recover the
+        call id by name (real Gemini's session correlator, the aimock
+        gemini->openai translator, etc.) hit a UUID-shaped name with no
+        matching prior call when this is wrong, silently breaking the
+        round-trip.
+        """
+        assistant_msg = AssistantMessage(
+            id="assistant_1",
+            role="assistant",
+            tool_calls=[
+                ToolCall(
+                    id="call_weather_001",
+                    type="function",
+                    function=FunctionCall(
+                        name="get_weather",
+                        arguments='{"city": "Tokyo"}',
+                    ),
+                )
+            ],
+        )
+        tool_msg = ToolMessage(
+            id="tool_1",
+            role="tool",
+            content='{"temperature": 72, "condition": "sunny"}',
+            tool_call_id="call_weather_001",
+        )
+
+        adk_events = convert_ag_ui_messages_to_adk([assistant_msg, tool_msg])
+
+        # Two events: assistant turn + tool turn.
+        assert len(adk_events) == 2
+        tool_event = adk_events[1]
+        assert tool_event.content.role == "function"
+        func_response = tool_event.content.parts[0].function_response
+        # Critical: name = function name, NOT tool_call_id.
+        assert func_response.name == "get_weather"
+        # id continues to carry the tool_call_id for clients that key on it.
+        assert func_response.id == "call_weather_001"
+
+    def test_multiple_tool_messages_each_use_their_own_function_name(self):
+        """Each ToolMessage looks up its OWN function name by tool_call_id —
+        not a shared / first-found name. Exercises the per-id mapping when an
+        AssistantMessage carries multiple tool_calls and multiple ToolMessages
+        follow in any order.
+        """
+        assistant_msg = AssistantMessage(
+            id="assistant_1",
+            role="assistant",
+            tool_calls=[
+                ToolCall(
+                    id="call_a",
+                    type="function",
+                    function=FunctionCall(name="get_weather", arguments="{}"),
+                ),
+                ToolCall(
+                    id="call_b",
+                    type="function",
+                    function=FunctionCall(name="get_time", arguments="{}"),
+                ),
+            ],
+        )
+        # Tool messages out of declaration order — id-based lookup must still
+        # resolve each to the correct function name.
+        tool_b = ToolMessage(
+            id="tool_b",
+            role="tool",
+            content="2pm",
+            tool_call_id="call_b",
+        )
+        tool_a = ToolMessage(
+            id="tool_a",
+            role="tool",
+            content="sunny",
+            tool_call_id="call_a",
+        )
+
+        adk_events = convert_ag_ui_messages_to_adk([assistant_msg, tool_b, tool_a])
+
+        # 3 events total; events[1] is tool_b, events[2] is tool_a.
+        b_response = adk_events[1].content.parts[0].function_response
+        a_response = adk_events[2].content.parts[0].function_response
+        assert b_response.name == "get_time"
+        assert b_response.id == "call_b"
+        assert a_response.name == "get_weather"
+        assert a_response.id == "call_a"
+
+    def test_tool_message_lookup_falls_back_when_id_unknown(self):
+        """If a ToolMessage's tool_call_id doesn't match any prior
+        AssistantMessage's tool_call in the same batch, the converter falls
+        back to the pre-fix behaviour (name = tool_call_id) rather than
+        crashing. Exercises the same defensive guard as
+        `test_convert_tool_message` but with a prior AssistantMessage that
+        contains an UNRELATED tool_call — proving the lookup is keyed on id,
+        not just presence.
+        """
+        assistant_msg = AssistantMessage(
+            id="assistant_1",
+            role="assistant",
+            tool_calls=[
+                ToolCall(
+                    id="call_known",
+                    type="function",
+                    function=FunctionCall(name="get_weather", arguments="{}"),
+                )
+            ],
+        )
+        # ToolMessage's tool_call_id references a DIFFERENT id (the
+        # AssistantMessage's tool_call.id is "call_known", not "call_orphan").
+        tool_msg = ToolMessage(
+            id="tool_orphan",
+            role="tool",
+            content="orphan result",
+            tool_call_id="call_orphan",
+        )
+
+        adk_events = convert_ag_ui_messages_to_adk([assistant_msg, tool_msg])
+
+        orphan_response = adk_events[1].content.parts[0].function_response
+        # Falls back to tool_call_id since no matching prior call.
+        assert orphan_response.name == "call_orphan"
+        assert orphan_response.id == "call_orphan"
 
     def test_convert_tool_message_with_dict_content(self):
         """Test converting a ToolMessage with dict content (not JSON string)."""


### PR DESCRIPTION
## Summary

`convert_ag_ui_messages_to_adk` in `integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py` was building `types.FunctionResponse` with `name=message.tool_call_id`, which conflates the response's `name` field (meant to be the called function's name, e.g. `get_weather`) with the correlation id.

Gemini's wire contract is that `FunctionResponse.name` MUST equal the originating `FunctionCall.name`. Setting it to the tool_call_id (a UUID-shaped string) means any downstream consumer that recovers the call id by name (real Gemini's session correlator, aimock's gemini→openai translator, etc.) hits a "name" no prior `FunctionCall.name` matches — the round-trip silently breaks.

## Change

- Build a `tool_call_id -> function_name` lookup from the `AssistantMessage`s in the same conversion batch.
- When materializing a `ToolMessage` as a `FunctionResponse`, use the lookup to set `name = <originating tool name>`.
- Fall back to `message.tool_call_id` only when no prior call is in the same batch (preserves the old behavior for malformed inputs rather than throwing).

`FunctionResponse.id` continues to carry the `tool_call_id` (that part was correct).

## How this was found

While porting `CopilotKit/showcase/integrations/google-adk` to D5 parity with `langgraph-python`, multi-leg fixture chains (e.g. `tool-rendering-reasoning-chain` driving AAPL→MSFT) failed because the second-leg fixture was never matched. Inspecting the request body the ADK runtime sent to its model provider showed `FunctionResponse: { name: "call_rc_stock_aapl_001", ... }` — the call id, not the function name.

## Test plan

- [ ] Existing adk-middleware tests still pass.
- [ ] A round-trip test that emits an `AssistantMessage` with `tool_calls: [{ id: "call_a", function: { name: "get_weather" } }]` followed by a `ToolMessage(tool_call_id="call_a", content="…")` produces `FunctionResponse(name="get_weather", id="call_a")` in the converted ADK content, not `FunctionResponse(name="call_a", id="call_a")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)