### PR TITLE
fix(ci): resolve merge conflict markers in unit-python-sdk.yml

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -98,7 +98,6 @@ jobs:
       - name: Run tests
         working-directory: integrations/langgraph/python
         run: uv run python -m unittest discover tests -v
-<<<<<<< HEAD
 
   watsonx-python:
     runs-on: ubuntu-latest
@@ -136,8 +135,6 @@ jobs:
       - name: Run tests
         working-directory: integrations/watsonx/python
         run: uv run python -m pytest tests/ -v
-||||||| parent of 461a511e (ci: add adk-middleware, aws-strands, and langroid Python tests to CI)
-=======
 
   adk-middleware-python:
     runs-on: ubuntu-latest
@@ -249,4 +246,3 @@ jobs:
       - name: Run tests
         working-directory: integrations/langroid/python
         run: uv run python -m unittest discover tests -v
->>>>>>> 461a511e (ci: add adk-middleware, aws-strands, and langroid Python tests to CI)


### PR DESCRIPTION
## Summary
Unresolved merge conflict markers were left in `unit-python-sdk.yml` when PR #1672
(adk-middleware, aws-strands, langroid tests) merged on top of PR #1665 (watsonx
integration). The YAML was unparseable and Python SDK CI was broken on main.

Resolves the conflict to include all six test jobs: `python`, `langgraph-python`,
`watsonx-python`, `adk-middleware-python`, `aws-strands-python`, and `langroid-python`.