### PR TITLE
Add GitHub Environment protection to publish workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -66,6 +66,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -216,6 +216,7 @@ jobs:
     if: inputs.dry_run != true
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -51,6 +51,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
 

--- a/.github/workflows/publish-java-sdk.yml
+++ b/.github/workflows/publish-java-sdk.yml
@@ -47,6 +47,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: maven
 
     defaults:
       run:

--- a/.github/workflows/publish-kotlin-sdk.yml
+++ b/.github/workflows/publish-kotlin-sdk.yml
@@ -122,6 +122,7 @@ jobs:
   publish:
     needs: build-and-test
     runs-on: macos-latest
+    environment: maven
 
     permissions:
       contents: read

--- a/.github/workflows/publish-python-preview.yml
+++ b/.github/workflows/publish-python-preview.yml
@@ -16,6 +16,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    environment: pypi
     permissions:
       actions: read
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -243,6 +243,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.dry_run != true || github.event_name != 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

- Add `environment:` declarations to all 7 publish/release jobs across ag-ui workflows
- This enables GitHub Environment protection rules (required reviewers, deployment branch policies, wait timers) to gate package publishing

### Workflows updated

| Workflow | Job | Environment |
|----------|-----|-------------|
| prerelease.yml | publish | npm |
| publish-commit.yml | publish | npm |
| publish-release.yml | publish | npm |
| publish-java-sdk.yml | publish | maven |
| publish-kotlin-sdk.yml | publish | maven |
| publish-python-preview.yml | publish | pypi |
| prepare-release.yml | create-release-pr | npm |

### Environments created

- `npm` - for TypeScript package publishing
- `pypi` - for Python package publishing  
- `maven` - for Java/Kotlin package publishing

### Next steps

After merging, add required reviewers to each environment via repo Settings > Environments.

## Test plan

- [ ] Verify workflow YAML is valid (no syntax errors)
- [ ] Confirm environments exist in repo settings
- [ ] Test a dry-run prerelease to verify environment gates work