### PR TITLE
Add --frozen-lockfile to publish-commit build

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -33,7 +33,7 @@ jobs:
           node-version-file: "package.json"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Summary
- Add `--frozen-lockfile` to `pnpm install` in publish-commit.yml build job
- Prevents the build from silently mutating the lockfile, keeping CI reproducible

## Test plan
- Workflow-only change; all other workflows in the repo already use --frozen-lockfile