### PR TITLE
fix(langgraph): handle generic (ChatMessage) type in message converter

### DIFF
--- a/integrations/langgraph/typescript/src/message-conversion.test.ts
+++ b/integrations/langgraph/typescript/src/message-conversion.test.ts
@@ -141,6 +141,31 @@ describe("Message Conversion - All Types", () => {
       expect(result[0].toolCallId).toBe("tc1");
     });
 
+    it("should handle generic (ChatMessage) type as assistant", () => {
+      const msg = {
+        id: "g1",
+        type: "generic",
+        content: "hello from generic",
+        tool_calls: [{ id: "tc1", name: "search", args: { q: "weather" } }],
+      } as any as LangGraphMessage;
+      const result: any[] = langchainMessagesToAgui([msg]);
+      expect(result[0].role).toBe("assistant");
+      expect(result[0].content).toBe("hello from generic");
+      expect(result[0].toolCalls).toHaveLength(1);
+      expect(result[0].toolCalls[0].function.name).toBe("search");
+    });
+
+    it("should handle generic type with no tool calls", () => {
+      const msg = {
+        id: "g2",
+        type: "generic",
+        content: "plain generic message",
+      } as any as LangGraphMessage;
+      const result: any[] = langchainMessagesToAgui([msg]);
+      expect(result[0].role).toBe("assistant");
+      expect(result[0].content).toBe("plain generic message");
+    });
+
     it("should throw for unsupported type", () => {
       const msg = { id: "x", type: "unknown", content: "", role: "other" } as any;
       expect(() => langchainMessagesToAgui([msg])).toThrow("not supported");

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -184,6 +184,7 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
           role: "user",
           content: userContent,
         };
+      case "generic":
       case "ai":
         const aiContent = resolveMessageContent(message.content)
         return {


### PR DESCRIPTION
## Summary
- Add `case "generic":` fall-through to `case "ai":` in `langchainMessagesToAgui`
- Add 2 tests for generic message type conversion

## Why this is needed

The LangGraph TypeScript server (`@langchain/langgraph-api` + `@langchain/openai`) serializes `ChatOpenAI` responses as `ChatMessage` with `type: "generic"` when reading from thread state, rather than `AIMessage` with `type: "ai"`. This is a LangChain TS serialization behavior — `ChatMessage._getType()` returns `"generic"`.

The `langchainMessagesToAgui` converter's switch statement only handled `human`, `ai`, `system`, `tool` — hitting the `default` throw on `"generic"`. This caused `INCOMPLETE_STREAM` / `agent_run_error_event` errors in any CopilotKit demo that uses multi-turn tool calls through a LangGraph TypeScript agent (the agent run itself succeeds, but the AG-UI adapter fails when converting state messages afterward).

The Python adapter (`ag-ui-langgraph` v0.0.35) doesn't have this issue because it uses `isinstance()` checks against LangChain message classes, which correctly identifies `ChatMessage` as an assistant message subclass.

`ChatMessage` has the same shape as `AIMessage` (content + optional tool_calls), so the fix is a single fall-through case.

## Verified
- Reproduced on CopilotKit showcase `headless-complete` weather tool (LangGraph TypeScript)
- Patched into running Docker container, clicked the weather suggestion — error gone, response renders
- 142 tests pass (2 new, 0 failures)

## Test plan
- [x] `pnpm test` in `integrations/langgraph/typescript` — 142 pass
- [x] End-to-end: showcase headless-complete weather tool works after patch