### PR TITLE
chore(langgraph): bump @ag-ui/langgraph to 0.0.32

### DIFF
--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/langgraph",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -49,12 +49,12 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./middlewares": {
-      "import": "./dist/middlewares/index.mjs",
-      "require": "./dist/middlewares/index.js"
+      "require": "./dist/middlewares/index.js",
+      "import": "./dist/middlewares/index.mjs"
     },
     "./package.json": "./package.json"
   }


### PR DESCRIPTION
## Summary
Version bump to trigger npm publish for `@ag-ui/langgraph` v0.0.32.

Includes the fix from #1704 — handle `type: "generic"` (ChatMessage) in `langchainMessagesToAgui`.