### PR TITLE
fix(aws-strands): guard JSONSerializableDict import against strands reorganization

### DIFF
--- a/integrations/aws-strands/python/tests/test_context_forwarding.py
+++ b/integrations/aws-strands/python/tests/test_context_forwarding.py
@@ -11,9 +11,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 from strands import Agent
 from strands.tools.registry import ToolRegistry
-from strands.types.json_dict import JSONSerializableDict
 
 from ag_ui.core import Context, RunAgentInput, UserMessage
+
+try:
+    from strands.types.json_dict import JSONSerializableDict  # strands <2.0
+except ImportError:
+    try:
+        from strands.types import JSONSerializableDict  # strands >=2.0 (reorganized)
+    except ImportError:
+        class JSONSerializableDict(dict):  # type: ignore[no-redef]
+            def set(self, key, value): self[key] = value  # noqa: E704
 
 from ag_ui_strands.agent import StrandsAgent
 
@@ -32,7 +40,7 @@ class _CapturingCore:
         self.tool_registry = ToolRegistry()
         self.state = JSONSerializableDict()
 
-    async def stream_async(self, _msg: str):
+    async def stream_async(self, _msg: str, **_kwargs):
         if False:
             yield
 

--- a/integrations/aws-strands/python/tests/test_context_forwarding.py
+++ b/integrations/aws-strands/python/tests/test_context_forwarding.py
@@ -40,7 +40,7 @@ class _CapturingCore:
         self.tool_registry = ToolRegistry()
         self.state = JSONSerializableDict()
 
-    async def stream_async(self, _msg: str, **_kwargs):
+    async def stream_async(self, _msg: str):
         if False:
             yield
 

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -45,7 +45,7 @@ class _CapturingCore:
         self.init_kwargs = kwargs
         self.tool_registry = ToolRegistry()
 
-    async def stream_async(self, _msg: str, **_kwargs):
+    async def stream_async(self, _msg: str):
         if False:
             yield
 

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -45,7 +45,7 @@ class _CapturingCore:
         self.init_kwargs = kwargs
         self.tool_registry = ToolRegistry()
 
-    async def stream_async(self, _msg: str):
+    async def stream_async(self, _msg: str, **_kwargs):
         if False:
             yield
 


### PR DESCRIPTION
## Summary

- `test_context_forwarding.py` hard-imported `JSONSerializableDict` from `strands.types.json_dict`, a private submodule removed in newer strands-agents versions. This caused `ModuleNotFoundError` at pytest collection time on PR #1689, where a version bump made the `uv.lock` stale and `uv sync` re-resolved deps to a newer strands release.

- Replace the hard import with a try/except chain that tries known module locations in order, falling back to a minimal `dict` subclass only as a last resort:

```python
try:
    from strands.types.json_dict import JSONSerializableDict  # strands <2.0
except ImportError:
    try:
        from strands.types import JSONSerializableDict  # strands >=2.0 (reorganized)
    except ImportError:
        class JSONSerializableDict(dict):
            def set(self, key, value): self[key] = value
```

## Test plan

- [ ] `aws-strands-python` CI job on PR #1689 passes after cherry-picking this fix and regenerating `uv.lock` with the bumped version

https://claude.ai/code/session_01Uuz3Zkim3z4S8XcgtdP4vs