### PR TITLE
[codex] Fix client stream transform subscription timing

### DIFF
--- a/sdks/typescript/packages/client/src/transform/__tests__/http.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/http.test.ts
@@ -3,7 +3,7 @@ import { HttpEvent, HttpEventType } from "../../run/http-request";
 import { parseProtoStream } from "../proto";
 import * as proto from "@ag-ui/proto";
 import { BaseEvent, EventType } from "@ag-ui/core";
-import { Subject, of, throwError } from "rxjs";
+import { firstValueFrom, of, Subject, throwError, toArray } from "rxjs";
 import { describe, it, expect, vi, beforeEach, Mock, test } from "vitest";
 
 // Mock dependencies
@@ -55,6 +55,35 @@ describe("transformHttpEventStream", () => {
     // Then
     expect(parseProtoStream).toHaveBeenCalled();
     expect(receivedEvents).toEqual([mockBaseEvent]);
+  });
+
+  test("should not drop events from a synchronous cold SSE source", async () => {
+    const headers = new Headers([["content-type", "text/event-stream"]]);
+    const data = new TextEncoder().encode(
+      'data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"msg-1","delta":"hello"}\n\n',
+    );
+
+    const result$ = transformHttpEventStream(
+      of(
+        {
+          type: HttpEventType.HEADERS,
+          status: 200,
+          headers,
+        },
+        {
+          type: HttpEventType.DATA,
+          data,
+        },
+      ),
+    );
+
+    await expect(firstValueFrom(result$.pipe(toArray()))).resolves.toEqual([
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "msg-1",
+        delta: "hello",
+      },
+    ]);
   });
 
   test("should emit RUN_ERROR and complete on AbortError without erroring", () => {

--- a/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
@@ -1,5 +1,5 @@
 import { HttpEvent, HttpEventType } from "../../run/http-request";
-import { firstValueFrom, Subject, take } from "rxjs";
+import { firstValueFrom, of, Subject, take, toArray } from "rxjs";
 import {
   EventType,
   TextMessageStartEvent,
@@ -71,6 +71,40 @@ describe("parseProtoStream", () => {
     expect(receivedEvent.role).toEqual(originalEvent.role);
     // Complete the stream
     chunk$.complete();
+  });
+
+  it("should not drop events from a synchronous cold protobuf source", async () => {
+    const headers = new Headers();
+    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+
+    const originalEvent = {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: "msg123",
+      delta: "Hello world",
+      timestamp: Date.now(),
+    };
+    const encodedEvent = eventEncoder.encodeBinary(originalEvent);
+
+    const event$ = transformHttpEventStream(
+      of(
+        {
+          type: HttpEventType.HEADERS,
+          status: 200,
+          headers,
+        },
+        {
+          type: HttpEventType.DATA,
+          data: encodedEvent,
+        },
+      ),
+    );
+
+    const events = await firstValueFrom(event$.pipe(toArray()));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toEqual(originalEvent.type);
+    expect((events[0] as TextMessageContentEvent).messageId).toEqual(originalEvent.messageId);
+    expect((events[0] as TextMessageContentEvent).delta).toEqual(originalEvent.delta);
   });
 
   it("should handle multiple protobuf events in a single chunk", async () => {

--- a/sdks/typescript/packages/client/src/transform/http.ts
+++ b/sdks/typescript/packages/client/src/transform/http.ts
@@ -1,5 +1,5 @@
 import { BaseEvent, EventSchemas } from "@ag-ui/core";
-import { Subject, ReplaySubject, Observable } from "rxjs";
+import { ReplaySubject, Observable, Subject, Subscription } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
 import { parseSSEStream } from "./sse";
 import { parseProtoStream } from "./proto";
@@ -16,81 +16,99 @@ export const transformHttpEventStream = (
 ): Observable<BaseEvent> => {
   const log = resolveDebugLogger(debugLogger);
   const eventSubject = new Subject<BaseEvent>();
+  const subscription = new Subscription();
 
   // Use ReplaySubject to buffer events until we decide on the parser
   const bufferSubject = new ReplaySubject<HttpEvent>();
 
   // Flag to track whether we've set up the parser
   let parserInitialized = false;
+  let sourceInitialized = false;
 
-  // Subscribe to source and buffer events while we determine the content type
-  source$.subscribe({
-    next: (event: HttpEvent) => {
-      // Forward event to buffer
-      bufferSubject.next(event);
+  const initializeSource = () => {
+    if (sourceInitialized) {
+      return;
+    }
+    sourceInitialized = true;
+    // Subscribe to source and buffer events while we determine the content type
+    subscription.add(
+      source$.subscribe({
+        next: (event: HttpEvent) => {
+          // Forward event to buffer
+          bufferSubject.next(event);
 
-      // If we get headers and haven't initialized a parser yet, check content type
-      if (event.type === HttpEventType.HEADERS && !parserInitialized) {
-        parserInitialized = true;
-        const contentType = event.headers.get("content-type");
+          // If we get headers and haven't initialized a parser yet, check content type
+          if (event.type === HttpEventType.HEADERS && !parserInitialized) {
+            parserInitialized = true;
+            const contentType = event.headers.get("content-type");
 
-        log?.lifecycle("HTTP", "Stream format detected:", {
-          contentType,
-          parser: contentType === proto.AGUI_MEDIA_TYPE ? "protobuf" : "sse",
-        });
+            log?.lifecycle("HTTP", "Stream format detected:", {
+              contentType,
+              parser: contentType === proto.AGUI_MEDIA_TYPE ? "protobuf" : "sse",
+            });
 
-        // Choose parser based on content type
-        if (contentType === proto.AGUI_MEDIA_TYPE) {
-          // Use protocol buffer parser
-          parseProtoStream(bufferSubject).subscribe({
-            next: (event) => eventSubject.next(event),
-            error: (err) => eventSubject.error(err),
-            complete: () => eventSubject.complete(),
-          });
-        } else {
-          // Use SSE JSON parser for all other cases
-          parseSSEStream(bufferSubject, log).subscribe({
-            next: (json) => {
-              try {
-                const parsedEvent = EventSchemas.parse(json);
-                log?.event("HTTP", "Event validated:", parsedEvent, {
-                  type: parsedEvent.type,
-                  valid: true,
-                });
-                eventSubject.next(parsedEvent as BaseEvent);
-              } catch (err) {
-                log?.event("HTTP", "Event invalid:", { json, error: String(err) });
-                eventSubject.error(err);
-              }
-            },
-            error: (err) => {
-              if ((err as DOMException)?.name === "AbortError") {
-                eventSubject.next({
-                  type: EventType.RUN_ERROR,
-                  message: (err as DOMException).message || "Request aborted",
-                  code: "abort",
-                  rawEvent: err,
-                });
-                eventSubject.complete();
-                return;
-              }
-              return eventSubject.error(err);
-            },
-            complete: () => eventSubject.complete(),
-          });
-        }
-      } else if (!parserInitialized) {
-        eventSubject.error(new Error("No headers event received before data events"));
-      }
-    },
-    error: (err) => {
-      bufferSubject.error(err);
-      eventSubject.error(err);
-    },
-    complete: () => {
-      bufferSubject.complete();
-    },
+            // Choose parser based on content type
+            if (contentType === proto.AGUI_MEDIA_TYPE) {
+              // Use protocol buffer parser
+              subscription.add(
+                parseProtoStream(bufferSubject).subscribe({
+                  next: (event) => eventSubject.next(event),
+                  error: (err) => eventSubject.error(err),
+                  complete: () => eventSubject.complete(),
+                }),
+              );
+            } else {
+              // Use SSE JSON parser for all other cases
+              subscription.add(
+                parseSSEStream(bufferSubject, log).subscribe({
+                  next: (json) => {
+                    try {
+                      const parsedEvent = EventSchemas.parse(json);
+                      log?.event("HTTP", "Event validated:", parsedEvent, {
+                        type: parsedEvent.type,
+                        valid: true,
+                      });
+                      eventSubject.next(parsedEvent as BaseEvent);
+                    } catch (err) {
+                      log?.event("HTTP", "Event invalid:", { json, error: String(err) });
+                      eventSubject.error(err);
+                    }
+                  },
+                  error: (err) => {
+                    if ((err as DOMException)?.name === "AbortError") {
+                      eventSubject.next({
+                        type: EventType.RUN_ERROR,
+                        message: (err as DOMException).message || "Request aborted",
+                        code: "abort",
+                        rawEvent: err,
+                      });
+                      eventSubject.complete();
+                      return;
+                    }
+                    return eventSubject.error(err);
+                  },
+                  complete: () => eventSubject.complete(),
+                }),
+              );
+            }
+          } else if (!parserInitialized) {
+            eventSubject.error(new Error("No headers event received before data events"));
+          }
+        },
+        error: (err) => {
+          bufferSubject.error(err);
+          eventSubject.error(err);
+        },
+        complete: () => {
+          bufferSubject.complete();
+        },
+      }),
+    );
+  };
+
+  return new Observable<BaseEvent>((subscriber) => {
+    const outputSubscription = eventSubject.subscribe(subscriber);
+    initializeSource();
+    return () => outputSubscription.unsubscribe();
   });
-
-  return eventSubject.asObservable();
 };

--- a/sdks/typescript/packages/client/src/transform/proto.ts
+++ b/sdks/typescript/packages/client/src/transform/proto.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject } from "rxjs";
+import { Observable } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
 import { BaseEvent } from "@ag-ui/core";
 import * as proto from "@ag-ui/proto";
@@ -9,76 +9,77 @@ import * as proto from "@ag-ui/proto";
  * followed by the protocol buffer encoded message.
  */
 export const parseProtoStream = (source$: Observable<HttpEvent>): Observable<BaseEvent> => {
-  const eventSubject = new Subject<BaseEvent>();
-  let buffer = new Uint8Array(0);
+  return new Observable<BaseEvent>((subscriber) => {
+    let buffer = new Uint8Array(0);
 
-  source$.subscribe({
-    next: (event: HttpEvent) => {
-      if (event.type === HttpEventType.HEADERS) {
-        return;
-      }
+    const subscription = source$.subscribe({
+      next: (event: HttpEvent) => {
+        if (event.type === HttpEventType.HEADERS) {
+          return;
+        }
 
-      if (event.type === HttpEventType.DATA && event.data) {
-        // Append the new data to our buffer
-        const newBuffer = new Uint8Array(buffer.length + event.data.length);
-        newBuffer.set(buffer, 0);
-        newBuffer.set(event.data, buffer.length);
-        buffer = newBuffer;
+        if (event.type === HttpEventType.DATA && event.data) {
+          // Append the new data to our buffer
+          const newBuffer = new Uint8Array(buffer.length + event.data.length);
+          newBuffer.set(buffer, 0);
+          newBuffer.set(event.data, buffer.length);
+          buffer = newBuffer;
 
-        // Process as many complete messages as possible
-        processBuffer();
-      }
-    },
-    error: (err) => eventSubject.error(err),
-    complete: () => {
-      // Try to process any remaining data in the buffer
-      if (buffer.length > 0) {
-        try {
+          // Process as many complete messages as possible
           processBuffer();
+        }
+      },
+      error: (err) => subscriber.error(err),
+      complete: () => {
+        // Try to process any remaining data in the buffer
+        if (buffer.length > 0) {
+          try {
+            processBuffer();
+          } catch (error: unknown) {
+            console.warn("Incomplete or invalid protocol buffer data at stream end");
+          }
+        }
+        subscriber.complete();
+      },
+    });
+
+    /**
+     * Process as many complete messages as possible from the buffer
+     */
+    function processBuffer() {
+      // Keep processing while we have enough data for at least a header (4 bytes)
+      while (buffer.length >= 4) {
+        // Read message length from the first 4 bytes (big-endian uint32)
+        const view = new DataView(buffer.buffer, buffer.byteOffset, 4);
+        const messageLength = view.getUint32(0, false); // false = big-endian
+
+        // Check if we have the complete message (header + message body)
+        const totalLength = 4 + messageLength;
+        if (buffer.length < totalLength) {
+          // Not enough data yet, wait for more
+          break;
+        }
+
+        try {
+          // Extract the message (skipping the 4-byte header)
+          const message = buffer.slice(4, totalLength);
+
+          // Decode the protocol buffer message using the imported decode function
+          const event = proto.decode(message);
+
+          // Emit the parsed event
+          subscriber.next(event);
+
+          // Remove the processed message from the buffer
+          buffer = buffer.slice(totalLength);
         } catch (error: unknown) {
-          console.warn("Incomplete or invalid protocol buffer data at stream end");
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          subscriber.error(new Error(`Failed to decode protocol buffer message: ${errorMessage}`));
+          return;
         }
       }
-      eventSubject.complete();
-    },
-  });
-
-  /**
-   * Process as many complete messages as possible from the buffer
-   */
-  function processBuffer() {
-    // Keep processing while we have enough data for at least a header (4 bytes)
-    while (buffer.length >= 4) {
-      // Read message length from the first 4 bytes (big-endian uint32)
-      const view = new DataView(buffer.buffer, buffer.byteOffset, 4);
-      const messageLength = view.getUint32(0, false); // false = big-endian
-
-      // Check if we have the complete message (header + message body)
-      const totalLength = 4 + messageLength;
-      if (buffer.length < totalLength) {
-        // Not enough data yet, wait for more
-        break;
-      }
-
-      try {
-        // Extract the message (skipping the 4-byte header)
-        const message = buffer.slice(4, totalLength);
-
-        // Decode the protocol buffer message using the imported decode function
-        const event = proto.decode(message);
-
-        // Emit the parsed event
-        eventSubject.next(event);
-
-        // Remove the processed message from the buffer
-        buffer = buffer.slice(totalLength);
-      } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        eventSubject.error(new Error(`Failed to decode protocol buffer message: ${errorMessage}`));
-        return;
-      }
     }
-  }
 
-  return eventSubject.asObservable();
+    return () => subscription.unsubscribe();
+  });
 };

--- a/sdks/typescript/packages/client/src/transform/sse.ts
+++ b/sdks/typescript/packages/client/src/transform/sse.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject } from "rxjs";
+import { Observable } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
 import { type DebugLoggerInput, resolveDebugLogger } from "@/debug-logger";
 
@@ -15,78 +15,78 @@ export const parseSSEStream = (
   debugLogger?: DebugLoggerInput,
 ): Observable<any> => {
   const log = resolveDebugLogger(debugLogger);
-  const jsonSubject = new Subject<any>();
-  // Create TextDecoder with stream option set to true to handle split UTF-8 characters
-  const decoder = new TextDecoder("utf-8", { fatal: false });
-  let buffer = "";
+  return new Observable<any>((subscriber) => {
+    // Create TextDecoder with stream option set to true to handle split UTF-8 characters
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    let buffer = "";
 
-  // Subscribe to the source once and multicast to all subscribers
-  source$.subscribe({
-    next: (event: HttpEvent) => {
-      if (event.type === HttpEventType.HEADERS) {
-        return;
-      }
+    const subscription = source$.subscribe({
+      next: (event: HttpEvent) => {
+        if (event.type === HttpEventType.HEADERS) {
+          return;
+        }
 
-      if (event.type === HttpEventType.DATA && event.data) {
-        // Decode chunk carefully to handle UTF-8
-        const text = decoder.decode(event.data, { stream: true });
-        buffer += text;
+        if (event.type === HttpEventType.DATA && event.data) {
+          // Decode chunk carefully to handle UTF-8
+          const text = decoder.decode(event.data, { stream: true });
+          buffer += text;
 
-        // Process complete events (separated by double newlines)
-        const events = buffer.split(/\n\n/);
-        // Keep the last potentially incomplete event in buffer
-        buffer = events.pop() || "";
+          // Process complete events (separated by double newlines)
+          const events = buffer.split(/\n\n/);
+          // Keep the last potentially incomplete event in buffer
+          buffer = events.pop() || "";
 
-        for (const event of events) {
-          processSSEEvent(event);
+          for (const event of events) {
+            processSSEEvent(event);
+          }
+        }
+      },
+      error: (err) => subscriber.error(err),
+      complete: () => {
+        // Use the final call to decoder.decode() to flush any remaining bytes
+        if (buffer) {
+          buffer += decoder.decode();
+          // Process any remaining SSE event data
+          processSSEEvent(buffer);
+        }
+        subscriber.complete();
+      },
+    });
+
+    /**
+     * Helper function to process an SSE event.
+     * Extracts and joins data lines, then parses the result as JSON.
+     *
+     * Follows the SSE spec by processing lines starting with 'data:',
+     * ignoring a single space if it is present after the colon.
+     *
+     * @param eventText The raw event text to process
+     */
+    function processSSEEvent(eventText: string) {
+      const lines = eventText.split("\n");
+      const dataLines: string[] = [];
+
+      for (const line of lines) {
+        if (line.startsWith("data:")) {
+          // Remove 'data:' prefix, and optionally a single space afterwards
+          dataLines.push(line.slice(5).replace(/^ /, ""));
         }
       }
-    },
-    error: (err) => jsonSubject.error(err),
-    complete: () => {
-      // Use the final call to decoder.decode() to flush any remaining bytes
-      if (buffer) {
-        buffer += decoder.decode();
-        // Process any remaining SSE event data
-        processSSEEvent(buffer);
+
+      // Only process if we have data lines
+      if (dataLines.length > 0) {
+        try {
+          // Join multi-line data and parse JSON
+          const jsonStr = dataLines.join("\n");
+          const json = JSON.parse(jsonStr);
+          log?.event("SSE", "Event received:", json, { type: json.type });
+          subscriber.next(json);
+        } catch (err) {
+          subscriber.error(err);
+        }
       }
-      jsonSubject.complete();
-    },
+    }
+
+    return () => subscription.unsubscribe();
   });
-
-  /**
-   * Helper function to process an SSE event.
-   * Extracts and joins data lines, then parses the result as JSON.
-   *
-   * Follows the SSE spec by processing lines starting with 'data:',
-   * ignoring a single space if it is present after the colon.
-   *
-   * @param eventText The raw event text to process
-   */
-  function processSSEEvent(eventText: string) {
-    const lines = eventText.split("\n");
-    const dataLines: string[] = [];
-
-    for (const line of lines) {
-      if (line.startsWith("data:")) {
-        // Remove 'data:' prefix, and optionally a single space afterwards
-        dataLines.push(line.slice(5).replace(/^ /, ""));
-      }
-    }
-
-    // Only process if we have data lines
-    if (dataLines.length > 0) {
-      try {
-        // Join multi-line data and parse JSON
-        const jsonStr = dataLines.join("\n");
-        const json = JSON.parse(jsonStr);
-        log?.event("SSE", "Event received:", json, { type: json.type });
-        jsonSubject.next(json);
-      } catch (err) {
-        jsonSubject.error(err);
-      }
-    }
-  }
-
-  return jsonSubject.asObservable();
 };


### PR DESCRIPTION
## Summary
- Delay HTTP stream source subscription until the transformed observable has an attached subscriber.
- Keep the existing hot/multicast behavior for `transformHttpEventStream` so short-lived subscribers do not tear down the source.
- Make SSE and protobuf parser helpers subscribe lazily and add regression coverage for synchronous cold SSE/protobuf sources.

## Why
The client transform helpers subscribed to their inputs immediately when constructed. With synchronous or very fast cold sources, events could be emitted into the internal subject before callers subscribed to the returned observable, causing parsed events to be dropped.

## Validation
- `pnpm --filter @ag-ui/client exec vitest run src/transform/__tests__/sse.test.ts src/transform/__tests__/http.test.ts src/transform/__tests__/proto.test.ts`
- `pnpm nx run @ag-ui/client:test`
- `git diff --check`

## Notes
- `pnpm nx run @ag-ui/client:typecheck` currently fails on existing test-suite typecheck issues, including missing Vitest globals such as `describe`/`expect` in test files; this is unrelated to this patch.