### PR TITLE
fix(langgraph): use valid vision model in agentic_chat_multimodal example

### DIFF
--- a/integrations/langgraph/python/examples/agents/agentic_chat_multimodal/agent.py
+++ b/integrations/langgraph/python/examples/agents/agentic_chat_multimodal/agent.py
@@ -28,7 +28,7 @@ async def chat_node(state: AgentState, config: Optional[RunnableConfig] = None):
     to LangChain's multimodal format by the AG-UI integration layer.
     """
 
-    model = ChatOpenAI(model="gpt-5.4")
+    model = ChatOpenAI(model="gpt-4o")
 
     if config is None:
         config = RunnableConfig(recursion_limit=25)


### PR DESCRIPTION
## Summary
- The LangGraph Python `agentic_chat_multimodal` example agent hardcoded `model="gpt-5.4"`, which is not a real OpenAI model ID.
- As a result, the Dojo's [Agentic Chat Multimodal](https://dojo.ag-ui.com/langgraph/feature/agentic_chat_multimodal) page returned no assistant response when a user uploaded an image and asked a question — the OpenAI call errored before any tokens streamed back.
- Switched the model to `gpt-4o`, matching the sibling `multimodal_messages` example.

## Test plan
- [ ] Start the LangGraph Python example server.
- [ ] Open the Dojo at `/langgraph/feature/agentic_chat_multimodal`.
- [ ] Upload an image, ask "what's happening" — verify the assistant streams a description back.
- [ ] Click "Analyze a photo" suggestion — verify the canned multimodal flow returns a response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)