### PR TITLE
fix(client): seed flushState from prior batch's running state (#1720)

### DIFF
--- a/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
+++ b/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
@@ -553,5 +553,90 @@ describe("Event Compaction", () => {
         settings: { theme: "light" },
       });
     });
+
+    // Regression tests for #1720 — flushState used to start each batch
+    // from `state = {}`, so a delta in a later flush that referenced
+    // a path from an earlier flush's snapshot raised
+    // OPERATION_PATH_CANNOT_ADD / JsonPointerException. flushState
+    // now seeds from the prior batch's running state.
+
+    it("carries state across runs when run 2 has only deltas (no snapshot)", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { run_log: [] } },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "add", path: "/run_log/-", value: { kind: "token", text: "hi" } }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        // Run 2: no STATE_SNAPSHOT — must inherit `/run_log` from run 1
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "add", path: "/run_log/-", value: { kind: "token", text: "there" } }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      // Before the fix this throws OPERATION_PATH_CANNOT_ADD on run 2.
+      expect(() => compactEvents(events)).not.toThrow();
+
+      const compacted = compactEvents(events);
+      const snapshots = compacted.filter(
+        (e) => e.type === EventType.STATE_SNAPSHOT,
+      ) as StateSnapshotEvent[];
+
+      // Run 1 snapshot
+      expect(snapshots[0].snapshot).toEqual({ run_log: [{ kind: "token", text: "hi" }] });
+      // Run 2 snapshot has BOTH entries — state carried across runs
+      expect(snapshots[1].snapshot).toEqual({
+        run_log: [
+          { kind: "token", text: "hi" },
+          { kind: "token", text: "there" },
+        ],
+      });
+    });
+
+    it("does not throw when a post-run delta replaces a field from the prior snapshot", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { pipeline_stage: "classifier" } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        // Inter-run delta clears the stage; without the prior-batch
+        // seed this raises JsonPointerException because /pipeline_stage
+        // doesn't exist on a fresh `{}`.
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "replace", path: "/pipeline_stage", value: null }],
+        },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      expect(() => compactEvents(events)).not.toThrow();
+    });
+
+    it("trailing-only deltas (no run boundary) see prior state", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { counter: 0 } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        // No more RUN events — these land in the trailing flush
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "replace", path: "/counter", value: 5 }],
+        },
+      ];
+
+      expect(() => compactEvents(events)).not.toThrow();
+
+      const compacted = compactEvents(events);
+      const snapshots = compacted.filter(
+        (e) => e.type === EventType.STATE_SNAPSHOT,
+      ) as StateSnapshotEvent[];
+
+      // Last snapshot reflects both the run-1 baseline AND the trailing delta
+      expect(snapshots[snapshots.length - 1].snapshot).toEqual({ counter: 5 });
+    });
   });
 });

--- a/sdks/typescript/packages/client/src/compact/compact.ts
+++ b/sdks/typescript/packages/client/src/compact/compact.ts
@@ -47,6 +47,12 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
 
   // State compaction: collects state events, flushed at RUN_STARTED (pre-run/inter-run), RUN_FINISHED/RUN_ERROR (in-run), and at end (trailing)
   let stateEvents: (StateSnapshotEvent | StateDeltaEvent)[] = [];
+  // Running state carried across flushState calls so a STATE_DELTA in a
+  // later flush (e.g. run 2 without its own STATE_SNAPSHOT) can target
+  // paths established by an earlier flush (e.g. run 1's snapshot).
+  // Without this seed, the per-flush `state = {}` reset turned valid
+  // multi-run streams into OPERATION_PATH_CANNOT_ADD failures. See #1720.
+  let runningState: any = {};
 
   for (const event of events) {
     // Handle text message streaming events
@@ -138,7 +144,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       pendingToolCalls.delete(toolCallId);
     } else if (event.type === EventType.RUN_STARTED) {
       // Flush any pre-run state events before starting a new run
-      flushState(stateEvents, compacted);
+      runningState = flushState(stateEvents, compacted, runningState);
       stateEvents = [];
       compacted.push(event);
     } else if (
@@ -146,7 +152,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       event.type === EventType.RUN_ERROR
     ) {
       // Flush compacted state into output before the run boundary event
-      flushState(stateEvents, compacted);
+      runningState = flushState(stateEvents, compacted, runningState);
       stateEvents = [];
       compacted.push(event);
     } else if (
@@ -199,7 +205,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
   }
 
   // Flush any remaining state events (incomplete run or events outside runs)
-  flushState(stateEvents, compacted);
+  flushState(stateEvents, compacted, runningState);
 
   return compacted;
 }
@@ -285,12 +291,20 @@ function flushToolCall(
 function flushState(
   stateEvents: (StateSnapshotEvent | StateDeltaEvent)[],
   compacted: BaseEvent[],
-): void {
+  initialState: any = {},
+): any {
   if (stateEvents.length === 0) {
-    return;
+    // Nothing changed; the prior batch's running state is still current.
+    return initialState;
   }
 
-  let state: any = {};
+  // Seed from the prior batch instead of `{}`. STATE_SNAPSHOT in this
+  // batch still replaces wholesale (existing semantics); STATE_DELTA
+  // applies on top of whatever the prior batch produced — so a delta
+  // referencing a path established by an earlier flush no longer
+  // raises OPERATION_PATH_CANNOT_ADD on a phantom empty document.
+  // See issue #1720 for the breakage mode this guards against.
+  let state: any = structuredClone_(initialState);
 
   for (const event of stateEvents) {
     if (event.type === EventType.STATE_SNAPSHOT) {
@@ -307,4 +321,5 @@ function flushState(
   };
 
   compacted.push(compactedSnapshot);
+  return state;
 }


### PR DESCRIPTION
Closes #1720. See issue for full diagnosis. Adds the running-state seed proposed there, plus 3 new tests covering the cross-run repro, the replace-variant, and trailing deltas. All 28 compact tests pass (`pnpm test compact`). Backwards-compat: flushState now takes an optional `initialState` (default `{}`) and returns the new state for the caller to carry forward.