### PR TITLE
fix(adk-middleware): re-parent copied sub-agents in _shallow_copy_agent_tree

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **FIX**: `_shallow_copy_agent_tree` now re-parents copied sub-agents so `transfer_to_agent` resolves against the per-run copy (#1719)
+  - `ADKAgent._shallow_copy_agent_tree` recursively copies the agent tree before each run so that per-execution tool replacement (`AGUIToolset` → `ClientProxyToolset` via `_update_agent_tools_recursive`) doesn't mutate the originals. Pydantic's `model_copy(deep=False)` inherits every field by reference, including `parent_agent`, so each recursively-copied sub-agent still pointed at the **original** parent.
+  - ADK's `transfer_to_agent` resolves the target by walking `parent_agent` up to the root and searching the root's `sub_agents` registry. Because each copied sub-agent's `parent_agent` referenced the original (pre-copy) root — whose `tools` were never updated for this run — the transfer either failed to find the target or, where it did find one, escaped into the stale original tree whose `AGUIToolset` was never swapped for `ClientProxyToolset`. The transfer was silently dropped or executed against unwired tools.
+  - The fix re-parents each copied sub-agent to its copied parent after the recursive copy: `sub.parent_agent = copied`. A guard skips the early-return branch where `model_copy` raised `AttributeError` and the input was returned as-is (e.g. non-Pydantic test mocks), so the original tree's `parent_agent` is never mutated through the back door.
+  - New regression test `test_shallow_copy_reparents_sub_agents` in `tests/test_adk_agent.py` asserts (a) the copied child's `parent_agent is` the copied root (not the original), and (b) the original child's `parent_agent` still points at the original root — pinning the no-mutation invariant alongside the re-parenting fix.
+  - **Reporter**: [@jb-delafosse](https://github.com/jb-delafosse) filed [#1719](https://github.com/ag-ui-protocol/ag-ui/issues/1719) with a minimal repro, accurate root-cause analysis, and the proposed re-parenting fix this implementation is based on. Thanks!
+
 ## [0.6.3] - 2026-05-16
 
 ### Fixed

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1827,7 +1827,18 @@ class ADKAgent:
 
         sub_agents = getattr(copied, 'sub_agents', None)
         if isinstance(sub_agents, (list, tuple)):
-            copied.sub_agents = [ADKAgent._shallow_copy_agent_tree(sa) for sa in sub_agents]
+            copied_subs = [ADKAgent._shallow_copy_agent_tree(sa) for sa in sub_agents]
+            # Re-parent each copied sub-agent so parent_agent points at the
+            # copied parent rather than the original.  Without this, ADK's
+            # transfer_to_agent walks parent_agent up to the original (stale)
+            # tree, escaping the per-run copy whose tools were replaced.
+            # Skip the early-return case where the sub-agent could not be
+            # copied and was returned as-is (e.g. non-Pydantic test mocks) —
+            # mutating its parent_agent would leak into the original tree.
+            for sub, original in zip(copied_subs, sub_agents):
+                if isinstance(sub, BaseAgent) and sub is not original:
+                    sub.parent_agent = copied
+            copied.sub_agents = copied_subs
 
         return copied
 

--- a/integrations/adk-middleware/python/tests/test_adk_agent.py
+++ b/integrations/adk-middleware/python/tests/test_adk_agent.py
@@ -1077,6 +1077,27 @@ class TestADKAgent:
         assert root_agent.sub_agents[0].tools == original_child_tools
         assert all(isinstance(t, AGUIToolset) for t in root_agent.sub_agents[0].tools)
 
+    def test_shallow_copy_reparents_sub_agents(self):
+        """Copied sub-agents must point at the copied parent, not the original.
+
+        Regression for issue #1719: without re-parenting, ADK's
+        transfer_to_agent walks parent_agent up to the original tree whose
+        tools were never replaced, so the per-run copy is bypassed.
+        """
+        child = Agent(name="child", instruction="child")
+        root = Agent(name="root", instruction="root", sub_agents=[child])
+
+        assert child.parent_agent is root
+
+        copied_root = ADKAgent._shallow_copy_agent_tree(root)
+        copied_child = copied_root.sub_agents[0]
+
+        assert copied_root is not root
+        assert copied_child is not child
+        assert copied_child.parent_agent is copied_root
+        # Original tree must remain untouched.
+        assert child.parent_agent is root
+
 
 class TestSessionManagerDispatch:
     """Regression tests for session_manager / session_service dispatch (issue #1601)."""


### PR DESCRIPTION
Pydantic's model_copy(deep=False) inherits parent_agent by reference, so
each recursively-copied sub-agent still pointed at the original parent.
ADK's transfer_to_agent walks parent_agent up to the root and searches
its sub_agents registry — landing in the original tree whose tools were
never replaced by _update_agent_tools_recursive, so the per-run copy was
silently bypassed.

Re-parent each copied sub-agent to its copied parent after the recursive
copy. Guard against the early-return branch where the sub-agent could
not be copied (non-Pydantic), so we don't leak the new parent back into
the original tree.

Fixes #1719.