### PR TITLE
fix(a2ui-middleware): supersede same-surface activity messages within an outer tool call

### DIFF
--- a/integrations/langgraph/typescript/examples/package.json
+++ b/integrations/langgraph/typescript/examples/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@copilotkit/sdk-js": "0.0.0-mme-ag-ui-0-0-46-20260227141603",
-    "@langchain/core": "^1.1.7",
+    "@langchain/core": "^1.1.44",
     "@langchain/anthropic": "^0.3.0",
     "@langchain/google-genai": "^0.2.0",
     "@langchain/openai": "^1.2.0",
-    "@langchain/langgraph": "^1.0.7",
+    "@langchain/langgraph": "^1.1.0",
     "dotenv": "^16.4.5",
     "langchain": "^1.2.3",
     "uuid": "^10.0.0"

--- a/integrations/langgraph/typescript/examples/pnpm-lock.yaml
+++ b/integrations/langgraph/typescript/examples/pnpm-lock.yaml
@@ -10,28 +10,28 @@ importers:
     dependencies:
       '@copilotkit/sdk-js':
         specifier: 0.0.0-mme-ag-ui-0-0-46-20260227141603
-        version: 0.0.0-mme-ag-ui-0-0-46-20260227141603(@ag-ui/core@0.0.42)(@langchain/community@0.0.53(openai@6.15.0(zod@3.25.76)))(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(typescript@5.8.3)(zod@3.25.76)
+        version: 0.0.0-mme-ag-ui-0-0-46-20260227141603(@ag-ui/core@0.0.42)(@langchain/community@0.0.53(openai@6.15.0(zod@3.25.76)))(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(typescript@5.8.3)(zod@3.25.76)
       '@langchain/anthropic':
         specifier: ^0.3.0
-        version: 0.3.34(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod@3.25.76)
+        version: 0.3.34(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod@3.25.76)
       '@langchain/core':
-        specifier: ^1.1.7
-        version: 1.1.7(openai@6.15.0(zod@3.25.76))
+        specifier: ^1.1.44
+        version: 1.1.47(openai@6.15.0(zod@3.25.76))
       '@langchain/google-genai':
         specifier: ^0.2.0
-        version: 0.2.18(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))
+        version: 0.2.18(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))
       '@langchain/langgraph':
-        specifier: ^1.0.7
-        version: 1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
+        specifier: ^1.1.0
+        version: 1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
       '@langchain/openai':
         specifier: ^1.2.0
-        version: 1.2.0(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))
+        version: 1.2.0(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
         specifier: ^1.2.3
-        version: 1.2.8(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
+        version: 1.2.8(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -378,8 +378,8 @@ packages:
     resolution: {integrity: sha512-+fjyYi8wy6x1P+Ee1RWfIIEyxd9Ee9jksEwvrggPwwI/p45kIDTdYTblXsM13y4mNWTiACyLSdbwnPaxxdoz+w==}
     engines: {node: '>=18'}
 
-  '@langchain/core@1.1.7':
-    resolution: {integrity: sha512-NSZSi33+V/8RVv1szsUiX7u+jXVCDImr2VO74SiKgJrhyxXKdJcxa3HMPKwdU+tkgQ6T+R7wxVYQ1Cnd4Z48tA==}
+  '@langchain/core@1.1.47':
+    resolution: {integrity: sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==}
     engines: {node: '>=20'}
 
   '@langchain/google-genai@0.2.18':
@@ -394,26 +394,36 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.1
 
-  '@langchain/langgraph-sdk@1.3.1':
-    resolution: {integrity: sha512-zTi7DZHwqtMEzapvm3I1FL4Q7OZsxtq9tTXy6s2gcCxyIU3sphqRboqytqVN7dNHLdTCLb8nXy49QKurs2MIBg==}
+  '@langchain/langgraph-checkpoint@1.0.2':
+    resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.0.1
+      '@langchain/core': ^1.1.44
+
+  '@langchain/langgraph-sdk@1.9.4':
+    resolution: {integrity: sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
       react: ^18 || ^19
       react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
     peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
       react:
         optional: true
       react-dom:
         optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
-  '@langchain/langgraph@1.0.7':
-    resolution: {integrity: sha512-EBGqNOWoRiEoLUaeuiXRpUM8/DE6QcwiirNyd97XhezStebBoTTilWH8CUt6S94JRGl5zwfBBRHfzotDnZS/eA==}
+  '@langchain/langgraph@1.3.2':
+    resolution: {integrity: sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.0.1
-      zod: ^3.25.32 || ^4.1.0
+      '@langchain/core': ^1.1.44
+      zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
       zod-to-json-schema:
@@ -428,6 +438,9 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.0.0
+
+  '@langchain/protocol@0.0.15':
+    resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -446,6 +459,12 @@ packages:
   '@segment/analytics-node@2.3.0':
     resolution: {integrity: sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==}
     engines: {node: '>=20'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -563,6 +582,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   expr-eval@2.0.2:
     resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
 
@@ -629,6 +651,10 @@ packages:
   is-any-array@2.0.1:
     resolution: {integrity: sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
@@ -668,6 +694,26 @@ packages:
       '@opentelemetry/sdk-trace-base':
         optional: true
       openai:
+        optional: true
+
+  langsmith@0.7.1:
+    resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
         optional: true
 
   math-intrinsics@1.1.0:
@@ -754,13 +800,25 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
+  p-queue@9.3.0:
+    resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
+    engines: {node: '>=20'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -812,8 +870,13 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   web-streams-polyfill@4.0.0-beta.3:
@@ -851,13 +914,13 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@copilotkit/sdk-js@0.0.0-mme-ag-ui-0-0-46-20260227141603(@ag-ui/core@0.0.42)(@langchain/community@0.0.53(openai@6.15.0(zod@3.25.76)))(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(typescript@5.8.3)(zod@3.25.76)':
+  '@copilotkit/sdk-js@0.0.0-mme-ag-ui-0-0-46-20260227141603(@ag-ui/core@0.0.42)(@langchain/community@0.0.53(openai@6.15.0(zod@3.25.76)))(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(typescript@5.8.3)(zod@3.25.76)':
     dependencies:
       '@copilotkit/shared': 0.0.0-mme-ag-ui-0-0-46-20260227141603(@ag-ui/core@0.0.42)
       '@langchain/community': 0.0.53(openai@6.15.0(zod@3.25.76))
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
-      '@langchain/langgraph': 1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
-      langchain: 1.2.8(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
+      '@langchain/langgraph': 1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
+      langchain: 1.2.8(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
       typescript: 5.8.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -877,10 +940,10 @@ snapshots:
 
   '@google/generative-ai@0.24.1': {}
 
-  '@langchain/anthropic@0.3.34(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod@3.25.76)':
+  '@langchain/anthropic@0.3.34(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.65.0(zod@3.25.76)
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
       fast-xml-parser: 4.5.6
     transitivePeerDependencies:
       - zod
@@ -933,48 +996,54 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76))':
+  '@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
+      '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.20
-      langsmith: 0.4.0(openai@6.15.0(zod@3.25.76))
+      langsmith: 0.7.1(openai@6.15.0(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
+      - ws
 
-  '@langchain/google-genai@0.2.18(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))':
+  '@langchain/google-genai@0.2.18(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))':
     dependencies:
       '@google/generative-ai': 0.24.1
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
       uuid: 11.1.0
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.3.1(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))':
     dependencies:
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 9.0.1
-    optionalDependencies:
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
+      uuid: 10.0.0
 
-  '@langchain/langgraph@1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph-sdk@1.9.4(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.3.1(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
+      '@langchain/protocol': 0.0.15
+      '@types/json-schema': 7.0.15
+      p-queue: 9.3.0
+      p-retry: 7.1.1
+      uuid: 13.0.2
+
+  '@langchain/langgraph@1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.9.4(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
     optionalDependencies:
@@ -982,6 +1051,8 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-dom
+      - svelte
+      - vue
 
   '@langchain/openai@0.0.34':
     dependencies:
@@ -994,14 +1065,16 @@ snapshots:
       - encoding
       - ws
 
-  '@langchain/openai@1.2.0(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))':
+  '@langchain/openai@1.2.0(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
       js-tiktoken: 1.0.20
       openai: 6.15.0(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
+
+  '@langchain/protocol@0.0.15': {}
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -1031,6 +1104,10 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -1135,6 +1212,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.4: {}
+
   expr-eval@2.0.2: {}
 
   fast-xml-parser@4.5.6:
@@ -1202,6 +1281,8 @@ snapshots:
 
   is-any-array@2.0.1: {}
 
+  is-network-error@1.3.2: {}
+
   jose@5.10.0: {}
 
   js-tiktoken@1.0.20:
@@ -1213,11 +1294,11 @@ snapshots:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
-  langchain@1.2.8(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)):
+  langchain@1.2.8(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 1.1.7(openai@6.15.0(zod@3.25.76))
-      '@langchain/langgraph': 1.0.7(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.7(openai@6.15.0(zod@3.25.76)))
+      '@langchain/core': 1.1.47(openai@6.15.0(zod@3.25.76))
+      '@langchain/langgraph': 1.3.2(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.47(openai@6.15.0(zod@3.25.76)))
       langsmith: 0.4.0(openai@6.15.0(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
@@ -1228,6 +1309,8 @@ snapshots:
       - openai
       - react
       - react-dom
+      - svelte
+      - vue
       - zod-to-json-schema
 
   langsmith@0.1.68(openai@4.104.0(zod@3.25.76)):
@@ -1260,6 +1343,12 @@ snapshots:
       p-queue: 6.6.2
       semver: 7.7.2
       uuid: 10.0.0
+    optionalDependencies:
+      openai: 6.15.0(zod@3.25.76)
+
+  langsmith@0.7.1(openai@6.15.0(zod@3.25.76)):
+    dependencies:
+      p-queue: 6.6.2
     optionalDependencies:
       openai: 6.15.0(zod@3.25.76)
 
@@ -1329,14 +1418,25 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
+  p-queue@9.3.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   retry@0.13.1: {}
 
@@ -1369,6 +1469,8 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@11.1.0: {}
+
+  uuid@13.0.2: {}
 
   uuid@9.0.1: {}
 

--- a/middlewares/a2ui-middleware/src/index.ts
+++ b/middlewares/a2ui-middleware/src/index.ts
@@ -267,6 +267,22 @@ export class A2UIMiddleware extends Middleware {
         dataEmitted: boolean;    // whether data model has been sent
       }>();
 
+      // Outer tool call context. Any non-A2UI tool call (e.g. ``generate_a2ui``
+      // wrapping a subagent that emits ``render_a2ui`` calls) is treated as
+      // the "outer" call. The outer id becomes the activity messageId
+      // discriminator so multiple inner ``render_a2ui`` attempts within the
+      // same outer call (e.g. validate-then-retry) supersede each other on
+      // the frontend instead of stacking as distinct chat entries.
+      //
+      // When no outer call is active (the agent calls ``render_a2ui``
+      // directly), behaviour falls back to the inner tool_call_id, matching
+      // the pre-existing scheme.
+      const nonOuterToolNames = new Set<string>([
+        ...a2uiToolNames,
+        LOG_A2UI_EVENT_TOOL_NAME,
+      ]);
+      let currentOuterCallId: string | null = null;
+
       const subscription = source.subscribe({
         next: (eventWithState) => {
           const event = eventWithState.event;
@@ -283,6 +299,10 @@ export class A2UIMiddleware extends Middleware {
                 schema: null, args: "", emittedCount: 0,
                 schemaEmitted: false, dataEmitted: false,
               });
+            } else if (!nonOuterToolNames.has(startEvent.toolCallName)) {
+              // Any other tool call becomes the active outer-call context.
+              // ``render_a2ui`` events that follow will dedup against this id.
+              currentOuterCallId = startEvent.toolCallId;
             }
           }
 
@@ -349,7 +369,7 @@ export class A2UIMiddleware extends Middleware {
                     const content: Record<string, unknown> = { [A2UI_OPERATIONS_KEY]: ops };
                     const snapshotEvent: ActivitySnapshotEvent = {
                       type: EventType.ACTIVITY_SNAPSHOT,
-                      messageId: `a2ui-surface-${surfaceId}-${argsEvent.toolCallId}`,
+                      messageId: `a2ui-surface-${surfaceId}-${currentOuterCallId ?? argsEvent.toolCallId}`,
                       activityType: A2UIActivityType,
                       content,
                       replace: true,
@@ -375,7 +395,7 @@ export class A2UIMiddleware extends Middleware {
                   const content: Record<string, unknown> = { [A2UI_OPERATIONS_KEY]: ops };
                   const snapshotEvent: ActivitySnapshotEvent = {
                     type: EventType.ACTIVITY_SNAPSHOT,
-                    messageId: `a2ui-surface-${surfaceId}-${argsEvent.toolCallId}`,
+                    messageId: `a2ui-surface-${surfaceId}-${currentOuterCallId ?? argsEvent.toolCallId}`,
                     activityType: A2UIActivityType,
                     content,
                     replace: true,
@@ -435,11 +455,16 @@ export class A2UIMiddleware extends Middleware {
                   // crash on unresolved path bindings before data exists.
                   for (const activityEvent of this.createA2UIActivityEvents(
                     parsed.operations,
-                    resultEvent.toolCallId,
+                    currentOuterCallId ?? resultEvent.toolCallId,
                   )) {
                     subscriber.next(activityEvent);
                   }
                 }
+              }
+
+              // Clear outer-call context when its TOOL_CALL_RESULT arrives.
+              if (currentOuterCallId === resultEvent.toolCallId) {
+                currentOuterCallId = null;
               }
             }
           }


### PR DESCRIPTION
## Summary

Track the most recent non-A2UI tool call as the active "outer" context in `A2UIMiddleware` and use its `tool_call_id` (instead of the inner `render_a2ui` call's id) when building the activity messageId for streamed surface events.

When an outer tool (e.g. a `generate_a2ui` wrapper that delegates to a subagent) emits multiple inner `render_a2ui` attempts for the **same surface** — for example, a validate-then-retry flow where the first attempt is invalid — the attempts now share a messageId and **supersede each other on the frontend** instead of stacking as distinct chat entries.

## Why

This is a prerequisite for an upcoming validate+retry feature on top of `get_a2ui_tools`. With the previous messageId scheme, each subagent retry produced a fresh `tool_call_id`, which leaked into the activity messageId and caused the frontend to render N stacked surfaces (one per attempt). The dojo e2e suite hits this as a strict-mode locator failure ("resolved to N elements") even though the final accepted attempt is correct.

The middleware-level fix is framework-agnostic — it works for any AG-UI integration emitting `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_RESULT` events the same way, regardless of whether the agent runs on LangGraph, ADK, Mastra, Strands, etc.

## What changed

`middlewares/a2ui-middleware/src/index.ts` — within `processStream`:

- New `nonOuterToolNames = { ...a2uiToolNames, LOG_A2UI_EVENT_TOOL_NAME }` set and a `currentOuterCallId: string | null` cursor.
- On `TOOL_CALL_START`: any tool whose name isn't in `nonOuterToolNames` becomes the active outer context.
- On `TOOL_CALL_RESULT` for that outer call: clear the cursor.
- Streaming activity emission (two sites) and direct `createA2UIActivityEvents` emission now use `currentOuterCallId ?? <tool_call_id>` as the messageId discriminator.

When no outer context is active (e.g. the main agent calls `render_a2ui` directly), behaviour falls back to the inner `tool_call_id`, identical to the pre-existing scheme.

## Behaviour matrix

| Scenario | Previous messageId discriminator | New | Activity count |
|---|---|---|---|
| `a2ui_fixed_schema` (`search_flights` returns ops directly) | `search_flights` id | `search_flights` is the outer → uses its own id | unchanged |
| `a2ui_dynamic_schema` single attempt | inner `render_a2ui` id | outer `generate_a2ui` id | unchanged (still 1 entry) |
| `a2ui_dynamic_schema` with retry (N inner attempts) | N distinct ids → N stacked entries | one outer id → 1 morphing entry | fixed |
| Direct `render_a2ui` from main agent (LG platform `a2ui_chat`) | own id | own id (no outer in `nonOuterToolNames`) | unchanged |
| Two distinct top-level renders | distinct ids | distinct outer ids | unchanged |
| Edit-existing-UI (intent="update") | distinct render ids | distinct outer ids | unchanged (still distinct entries) |

## Test plan

- [x] `pnpm test` in `middlewares/a2ui-middleware/` — 70/70 tests pass
- [ ] Dojo e2e on `langgraph-fastapi` — `a2uiFixedSchema`, `a2uiDynamicSchema`, `a2uiAdvanced` should remain green (no retry flow exists on `main` today, only the messageId scheme changed)
- [ ] Dojo e2e on `langgraph-python` and `langgraph-typescript` — same expectation