### PR TITLE
fix(mastra): surface output processor rewrites via useProcessedFinalText opt-in

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/output-processor.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/output-processor.test.ts
@@ -1,0 +1,324 @@
+import type { CustomEvent, TextMessageChunkEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import { MastraAgent } from "../mastra";
+import {
+  FakeLocalAgent,
+  FakeMemory,
+  FakeRemoteAgent,
+  collectEvents,
+  makeInput,
+} from "./helpers";
+
+// Helper: text-delta chunk shape
+const textDelta = (text: string) => ({
+  type: "text-delta",
+  payload: { text },
+});
+
+// Helper: finish / step-finish chunk shapes with optional response.uiMessages.
+const finish = (uiMessages?: any[]) => ({
+  type: "finish",
+  payload: uiMessages !== undefined ? { response: { uiMessages } } : {},
+});
+const stepFinish = (uiMessages?: any[]) => ({
+  type: "step-finish",
+  payload: uiMessages !== undefined ? { response: { uiMessages } } : {},
+});
+
+// Helper: a tool-call-suspended chunk (interrupt), used to exercise the
+// mid-turn buffer flush.
+const suspend = (toolCallId = "tc-1", toolName = "approve") => ({
+  type: "tool-call-suspended",
+  payload: {
+    toolCallId,
+    toolName,
+    suspendPayload: { reason: "needs approval" },
+    args: { amount: 250 },
+    resumeSchema: '{"type":"object","properties":{"ok":{"type":"boolean"}}}',
+  },
+});
+
+// Helper: build an agent with a specific stream and processor flag.
+// `memory: new FakeMemory()` keeps the working-memory snapshot path off — the
+// fake returns `undefined` for getWorkingMemory so no STATE_SNAPSHOT events
+// pollute the assertion target.
+const buildAgent = (
+  streamChunks: any[],
+  useProcessedFinalText: boolean,
+  isRemote = false,
+) => {
+  const agent = isRemote
+    ? new FakeRemoteAgent({ streamChunks })
+    : new FakeLocalAgent({ memory: new FakeMemory(), streamChunks });
+  return new MastraAgent({
+    agentId: "test-agent",
+    agent: agent as any,
+    resourceId: "resource-1",
+    useProcessedFinalText,
+  });
+};
+
+const textEventDeltas = (events: any[]): string[] =>
+  events
+    .filter(
+      (e): e is TextMessageChunkEvent =>
+        e.type === EventType.TEXT_MESSAGE_CHUNK,
+    )
+    .map((e) => e.delta ?? "");
+
+describe("useProcessedFinalText", () => {
+  describe("disabled (default — no regression)", () => {
+    it("streams text-delta chunks individually when flag is false", async () => {
+      const agent = buildAgent(
+        [textDelta("Hello "), textDelta("world"), finish()],
+        false,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["Hello ", "world"]);
+    });
+
+    it("ignores finish.payload.response.uiMessages when flag is false", async () => {
+      // Even with processor-rewritten uiMessages present, the default
+      // behavior must keep streaming raw deltas — flipping behavior on
+      // upstream-only changes would be a breaking surprise.
+      const agent = buildAgent(
+        [
+          textDelta("raw text"),
+          finish([{ role: "assistant", content: "REWRITTEN" }]),
+        ],
+        false,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["raw text"]);
+    });
+
+    it("still streams deltas across step-finish + finish when flag is false", async () => {
+      // Guards the flag-off path against the buffering/split logic: the real
+      // Mastra terminal shape (step-finish followed by finish) must not alter
+      // delta streaming or duplicate anything.
+      const agent = buildAgent(
+        [
+          textDelta("a"),
+          textDelta("b"),
+          stepFinish([{ role: "assistant", content: "IGNORED" }]),
+          finish([{ role: "assistant", content: "IGNORED" }]),
+        ],
+        false,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("enabled — local agent", () => {
+    it("suppresses text-delta and emits processor-rewritten text from uiMessages", async () => {
+      const agent = buildAgent(
+        [
+          textDelta("raw "),
+          textDelta("output"),
+          finish([
+            { role: "user", content: "Hi" },
+            { role: "assistant", content: "rewritten output" },
+          ]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["rewritten output"]);
+    });
+
+    it("uses the LAST assistant message when uiMessages contains multiple", async () => {
+      // Defensive: a supervisor flow may include earlier assistant turns in
+      // uiMessages. We only care about the final one (which the processor
+      // rewrote).
+      const agent = buildAgent(
+        [
+          textDelta("raw"),
+          finish([
+            { role: "assistant", content: "stale earlier turn" },
+            { role: "user", content: "follow up" },
+            { role: "assistant", content: "final rewritten" },
+          ]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["final rewritten"]);
+    });
+
+    it("falls back to buffered raw text when uiMessages is absent", async () => {
+      // Mastra versions before #11549 (or non-processor agents) won't emit
+      // response.uiMessages. We must not drop the LLM's text in that case.
+      const agent = buildAgent(
+        [textDelta("buffered "), textDelta("text"), finish()],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["buffered text"]);
+    });
+
+    it("falls back to buffered raw text when uiMessages has no assistant message", async () => {
+      const agent = buildAgent(
+        [textDelta("buffered"), finish([{ role: "user", content: "Hi" }])],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["buffered"]);
+    });
+
+    it("extracts text from array-of-parts content shape", async () => {
+      // Mastra UIMessage.content can be an array of parts (text/tool/etc.)
+      // — we should concatenate text parts and ignore non-text parts.
+      const agent = buildAgent(
+        [
+          textDelta("raw"),
+          finish([
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: "part one " },
+                { type: "tool-call", toolCallId: "x", toolName: "y" },
+                { type: "text", text: "part two" },
+              ],
+            },
+          ]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["part one part two"]);
+    });
+
+    it("falls back to buffered text when assistant message has empty content", async () => {
+      // A tool-only final assistant message (no text parts) should not
+      // suppress the buffered text — otherwise the user sees nothing.
+      const agent = buildAgent(
+        [
+          textDelta("buffered fallback"),
+          finish([
+            {
+              role: "assistant",
+              content: [{ type: "tool-call", toolCallId: "x", toolName: "y" }],
+            },
+          ]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["buffered fallback"]);
+    });
+
+    it("emits nothing for text when neither buffered text nor uiMessages text exists", async () => {
+      // Tool-only response with no LLM text at all — must not emit empty
+      // TEXT_MESSAGE_CHUNK (would render an empty assistant bubble).
+      const agent = buildAgent([finish([])], true);
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual([]);
+    });
+
+    it("handles step-finish boundaries by releasing per-step text", async () => {
+      // Multi-step flow: each step-finish releases its buffered text using
+      // its own uiMessages snapshot. Earlier step's buffer must not leak
+      // into a later step.
+      const agent = buildAgent(
+        [
+          textDelta("step1 "),
+          textDelta("raw"),
+          stepFinish([{ role: "assistant", content: "step1 rewritten" }]),
+          textDelta("step2 raw"),
+          finish([{ role: "assistant", content: "step2 final" }]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual([
+        "step1 rewritten",
+        "step2 final",
+      ]);
+    });
+
+    // --- Regression guards for the finish-boundary release logic -----------
+
+    it("emits the final text ONCE when step-finish and finish carry the same uiMessages", async () => {
+      // Real Mastra ends a single-step response with a `step-finish`
+      // immediately followed by a terminal `finish`, and BOTH carry the same
+      // processor-rewritten uiMessages. The release must not emit it twice
+      // (the second would land under the already-rotated messageId as a
+      // duplicate assistant bubble).
+      const agent = buildAgent(
+        [
+          textDelta("raw"),
+          stepFinish([{ role: "assistant", content: "final rewritten" }]),
+          finish([{ role: "assistant", content: "final rewritten" }]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["final rewritten"]);
+    });
+
+    it("does not emit raw then processed when only the terminal finish carries uiMessages", async () => {
+      // If a non-terminal step-finish lacks uiMessages, we must keep buffering
+      // rather than emit the raw text — otherwise a later finish that DOES
+      // carry processor text would double-render (raw + processed).
+      const agent = buildAgent(
+        [
+          textDelta("raw "),
+          textDelta("text"),
+          stepFinish(),
+          finish([{ role: "assistant", content: "rewritten" }]),
+        ],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["rewritten"]);
+    });
+
+    it("flushes buffered text as raw when the turn suspends before any finish", async () => {
+      // A tool suspend interrupts the turn — no finish will release the buffer.
+      // Text streamed before the suspend must still reach the client.
+      const agent = buildAgent(
+        [textDelta("thinking "), textDelta("out loud"), suspend()],
+        true,
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["thinking out loud"]);
+      // The interrupt itself must still be emitted (legacy on_interrupt path).
+      const custom = events.find(
+        (e): e is CustomEvent => e.type === EventType.CUSTOM,
+      );
+      expect(custom?.name).toBe("on_interrupt");
+    });
+  });
+
+  describe("enabled — remote agent", () => {
+    it("buffers and surfaces uiMessages for remote agents too", async () => {
+      // Remote agent path uses processDataStream but shares
+      // createChunkProcessor — verify the buffering applies symmetrically.
+      const agent = buildAgent(
+        [
+          textDelta("raw"),
+          finish([{ role: "assistant", content: "rewritten" }]),
+        ],
+        true,
+        true, // isRemote
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["rewritten"]);
+    });
+
+    it("emits final text once for remote step-finish + finish duplication", async () => {
+      const agent = buildAgent(
+        [
+          textDelta("raw"),
+          stepFinish([{ role: "assistant", content: "rewritten" }]),
+          finish([{ role: "assistant", content: "rewritten" }]),
+        ],
+        true,
+        true, // isRemote
+      );
+      const events = await collectEvents(agent, makeInput());
+      expect(textEventDeltas(events)).toEqual(["rewritten"]);
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -217,6 +217,49 @@ interface RemoteResumableAgent {
   ): Promise<RemoteResumeResponse | null | undefined>;
 }
 
+/**
+ * Walks `finish.payload.response.uiMessages` to pull the final assistant text
+ * after Mastra's output processors have run.
+ *
+ * Returns `undefined` when:
+ *   - `uiMessages` is absent (older Mastra, or a non-finish chunk),
+ *   - no assistant message is present,
+ *   - the assistant message contains no text parts (tool-only response),
+ * so callers can fall back to the buffered raw text.
+ *
+ * Accepts both string content and array-of-parts content shapes (Mastra's
+ * UIMessage tolerates either depending on how the agent assembled its
+ * response).
+ */
+function extractLastAssistantText(uiMessages: unknown): string | undefined {
+  if (!Array.isArray(uiMessages)) return undefined;
+  for (let i = uiMessages.length - 1; i >= 0; i--) {
+    const message = uiMessages[i];
+    if (!message || (message as { role?: string }).role !== "assistant") {
+      continue;
+    }
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === "string") {
+      return content.length > 0 ? content : undefined;
+    }
+    if (Array.isArray(content)) {
+      const text = content
+        .filter(
+          (part: any): part is { type: "text"; text: string } =>
+            part?.type === "text" && typeof part.text === "string",
+        )
+        .map((part) => part.text)
+        .join("");
+      return text.length > 0 ? text : undefined;
+    }
+    // Some UIMessage shapes expose pre-joined text via a `text` field.
+    const text = (message as { text?: unknown }).text;
+    if (typeof text === "string" && text.length > 0) return text;
+    return undefined;
+  }
+  return undefined;
+}
+
 export interface MastraAgentConfig extends AgentConfig {
   agent: LocalMastraAgent | RemoteMastraAgent;
   resourceId?: string;
@@ -287,6 +330,31 @@ export interface MastraAgentConfig extends AgentConfig {
    * own `Memory` instance).
    */
   remoteClient?: MastraClient;
+  /**
+   * When the configured agent uses `outputProcessors` that rewrite assistant
+   * text (e.g. character-voice transforms, redaction, format normalization),
+   * the processor-modified text is available only on the `finish` /
+   * `step-finish` chunk's `payload.response.uiMessages` — surfaced upstream in
+   * https://github.com/mastra-ai/mastra/pull/11549 to expose processor output
+   * through streaming.
+   *
+   * Set to `true` to buffer intermediate `text-delta` chunks and emit only the
+   * processor-modified text extracted from that boundary's `uiMessages`. When a
+   * boundary has no usable `uiMessages` (older Mastra, or processors that did
+   * not modify text), the buffered raw text is emitted on the terminal `finish`
+   * as a fallback so no text is ever dropped.
+   *
+   * Default: `false` (current behavior — text-delta chunks stream to the client
+   * in real time, processor rewrites are not surfaced).
+   *
+   * Trade-off: enabling this loses real-time text streaming — the final
+   * assistant text appears at once after the agent's last step. Required when
+   * downstream consumers (e.g. CopilotKit chat UI) must render the
+   * post-processor text rather than the raw LLM output.
+   *
+   * Tracking: https://github.com/ag-ui-protocol/ag-ui/issues/1726
+   */
+  useProcessedFinalText?: boolean;
 }
 
 interface MastraAgentStreamOptions {
@@ -386,6 +454,8 @@ export class MastraAgent extends AbstractAgent {
   a2ui?: A2UIInjectConfig;
   /** See MastraAgentConfig.remoteClient. Set for remote agents only. */
   remoteClient?: MastraClient;
+  /** See MastraAgentConfig.useProcessedFinalText. Default false. */
+  useProcessedFinalText: boolean;
 
   /**
    * Suffix appended to a turn's base (Mastra-stored) messageId to key the
@@ -415,6 +485,7 @@ export class MastraAgent extends AbstractAgent {
       emitInterruptOutcome,
       a2ui,
       remoteClient,
+      useProcessedFinalText,
       ...rest
     } = config;
     super(rest);
@@ -425,6 +496,7 @@ export class MastraAgent extends AbstractAgent {
     this.untilIdle = untilIdle;
     this.a2ui = a2ui;
     this.remoteClient = remoteClient;
+    this.useProcessedFinalText = useProcessedFinalText ?? false;
   }
 
   public clone() {
@@ -1256,6 +1328,62 @@ export class MastraAgent extends AbstractAgent {
       }
     };
 
+    // --- useProcessedFinalText buffering ------------------------------------
+    // When the flag is on, `text-delta` chunks are accumulated here instead of
+    // streamed, and the assistant text is emitted once per boundary from the
+    // processor-modified `finish.payload.response.uiMessages` (falling back to
+    // this raw buffer on the terminal `finish`). All of this is inert when the
+    // flag is off — bufferedText stays "" and the release helpers early-return.
+    let bufferedText = "";
+    // The last text we emitted within the current message window. Mastra ends a
+    // response with a `step-finish` immediately followed by a terminal `finish`,
+    // and BOTH can carry the same `response.uiMessages`; without this guard the
+    // second boundary would re-emit the identical text as a duplicate bubble
+    // (under the already-rotated messageId). Reset on each start / step-start so
+    // dedup is scoped to one message and never suppresses distinct per-step text.
+    let lastEmittedText: string | undefined;
+
+    // Emit `text` as one assistant TEXT_MESSAGE_CHUNK, skipping an exact repeat
+    // of what we just emitted for this message (see lastEmittedText).
+    const emitProcessedText = (text: string) => {
+      if (text === lastEmittedText) return;
+      callbacks.onTextPart?.(text);
+      lastEmittedText = text;
+    };
+
+    // Release buffered/processed assistant text at a finish boundary. Prefers
+    // the processor-modified text from `uiMessages`; on the terminal `finish`
+    // falls back to the raw buffer so nothing is dropped. On a non-terminal
+    // `step-finish` with no `uiMessages`, keeps buffering (the text may still be
+    // rewritten and surfaced on a later boundary — emitting raw now then
+    // processed later would double-render).
+    const releaseBufferedText = (chunkPayload: any, isTerminal: boolean) => {
+      if (!this.useProcessedFinalText) return;
+      const processedText = extractLastAssistantText(
+        chunkPayload?.response?.uiMessages,
+      );
+      if (processedText !== undefined) {
+        bufferedText = "";
+        emitProcessedText(processedText);
+        return;
+      }
+      if (isTerminal && bufferedText) {
+        const raw = bufferedText;
+        bufferedText = "";
+        emitProcessedText(raw);
+      }
+    };
+
+    // Flush the raw buffer as-is (used when a turn ends without a `finish`, e.g.
+    // a tool suspend/interrupt) so text streamed before the interrupt is not
+    // lost. No-op when the flag is off or nothing is buffered.
+    const flushBufferedTextRaw = () => {
+      if (!this.useProcessedFinalText || !bufferedText) return;
+      const raw = bufferedText;
+      bufferedText = "";
+      emitProcessedText(raw);
+    };
+
     // taskIds for which an ACTIVITY_SNAPSHOT has already been emitted. Guards
     // against emitting a delta before its snapshot and bounds progress ticks to
     // tasks the client knows about.
@@ -1339,7 +1467,13 @@ export class MastraAgent extends AbstractAgent {
           break;
         case "text-delta": {
           flush();
-          callbacks.onTextPart?.(chunk.payload.text);
+          if (this.useProcessedFinalText) {
+            // Hold deltas until a finish boundary — the processor-modified text
+            // arrives via finish.payload.response.uiMessages.
+            bufferedText += chunk.payload.text;
+          } else {
+            callbacks.onTextPart?.(chunk.payload.text);
+          }
           break;
         }
         // Tool-call args stream incrementally: start → delta(s) → end → the
@@ -1561,6 +1695,10 @@ export class MastraAgent extends AbstractAgent {
             );
             return true;
           }
+          // The turn interrupts here — no `finish` will release the buffer, so
+          // emit any assistant text streamed before the suspend (raw; a suspend
+          // carries no processor uiMessages) ahead of the interrupt event.
+          flushBufferedTextRaw();
           callbacks.onToolSuspended({
             toolCallId: chunk.payload.toolCallId,
             toolName: chunk.payload.toolName,
@@ -1579,9 +1717,20 @@ export class MastraAgent extends AbstractAgent {
         // the messageId so the next step's text gets a fresh ID. When a stream
         // ends with step-finish followed by finish, onFinishMessagePart fires
         // twice — the second rotation produces an unused messageId, which is harmless.
-        case "finish":
+        //
+        // For useProcessedFinalText, both release buffered/processed text BEFORE
+        // rotating the id (so the emitted text inherits the finishing step's
+        // messageId), but only the terminal `finish` may fall back to the raw
+        // buffer — see releaseBufferedText.
         case "step-finish": {
           flush();
+          releaseBufferedText(chunk.payload, false);
+          callbacks.onFinishMessagePart?.();
+          break;
+        }
+        case "finish": {
+          flush();
+          releaseBufferedText(chunk.payload, true);
           callbacks.onFinishMessagePart?.();
           break;
         }
@@ -1590,6 +1739,9 @@ export class MastraAgent extends AbstractAgent {
         // the streamed assistant id equals the stored id (see onMessageId).
         case "start":
         case "step-start": {
+          // A fresh message window begins: reset the dedup guard so distinct
+          // per-step text is never suppressed (see lastEmittedText).
+          lastEmittedText = undefined;
           if (chunk.payload?.messageId) {
             callbacks.onMessageId?.(chunk.payload.messageId);
           }


### PR DESCRIPTION
## Summary

`@ag-ui/mastra` ignores `finish.payload.response.uiMessages`, so Mastra agents with `outputProcessors` that rewrite assistant text (character-voice transforms, redaction, format normalization) produce text on the server that never reaches AG-UI consumers — they only see the raw pre-processor `text-delta` stream.

This PR adds an opt-in `useProcessedFinalText` config flag. When enabled:
- `text-delta` chunks are buffered (not streamed) until a `finish` chunk
- On each `finish` / `step-finish`, the rewritten text is extracted from `payload.response.uiMessages` and emitted as a single `TEXT_MESSAGE_CHUNK`
- If `uiMessages` is missing or has no assistant text (older Mastra, tool-only response), the buffered raw text is emitted as a fallback so no text is ever dropped

Default is `false` — existing real-time streaming behavior is unchanged.

Fixes #1726
Related: mastra-ai/mastra#11454, mastra-ai/mastra#11549 (upstream Mastra fix that surfaced processor-modified text via `response.uiMessages`).

## Trade-off

Enabling the flag loses real-time text streaming for that agent — the final assistant text appears at once after the agent's last step. Acceptable for processors that operate on the full assistant text (character voice, structured rewriting); opt-in keeps existing UX intact for everyone else.

## Tests

11 new tests in `output-processor.test.ts`:
- Flag off: text-delta streamed individually; `uiMessages` ignored (no regression)
- Flag on / local agent:
  - text-delta suppressed, `uiMessages` rewrite emitted
  - last assistant message wins when multiple are present
  - falls back to buffered raw text when `uiMessages` absent
  - falls back when `uiMessages` has no assistant message
  - falls back when assistant message has no text parts (tool-only)
  - extracts text from array-of-parts content shape
  - emits nothing when neither buffered text nor `uiMessages` text exists
  - `step-finish` boundaries release per-step text independently
- Flag on / remote agent: buffering applies symmetrically

All 121 tests pass (110 existing + 11 new). `pnpm typecheck` and `pnpm build` clean.

## Usage

```ts
new MastraAgent({
  agentId: "my-agent",
  agent: myMastraAgent,
  resourceId: userId,
  useProcessedFinalText: true,
});
```