### PR TITLE
fix(proto): make generate script cross-platform

### DIFF
--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -18,7 +18,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:exports": "publint --strict && attw --pack",
-    "generate": "mkdir -p ./src/generated && npx protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto.CMD --ts_proto_out=./src/generated --ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false -I ./src/proto ./src/proto/*.proto",
+    "generate": "node ./scripts/generate.cjs",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },

--- a/sdks/typescript/packages/proto/scripts/generate.cjs
+++ b/sdks/typescript/packages/proto/scripts/generate.cjs
@@ -1,0 +1,35 @@
+const { spawnSync } = require("node:child_process");
+const { mkdirSync, readdirSync } = require("node:fs");
+const { join, resolve } = require("node:path");
+
+const packageRoot = resolve(__dirname, "..");
+const binSuffix = process.platform === "win32" ? ".cmd" : "";
+const protoc = join(packageRoot, "node_modules", ".bin", `protoc${binSuffix}`);
+const tsProtoPlugin = join(packageRoot, "node_modules", ".bin", `protoc-gen-ts_proto${binSuffix}`);
+const protoDir = join(packageRoot, "src", "proto");
+const generatedDir = join(packageRoot, "src", "generated");
+
+mkdirSync(generatedDir, { recursive: true });
+
+const protoFiles = readdirSync(protoDir)
+  .filter((name) => name.endsWith(".proto"))
+  .map((name) => join(protoDir, name));
+
+const result = spawnSync(
+  protoc,
+  [
+    `--plugin=protoc-gen-ts_proto=${tsProtoPlugin}`,
+    `--ts_proto_out=${generatedDir}`,
+    "--ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false",
+    "-I",
+    protoDir,
+    ...protoFiles,
+  ],
+  { shell: process.platform === "win32", stdio: "inherit" },
+);
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- replace the `@ag-ui/proto` generate shell command with a small Node script
- create `src/generated` with `fs.mkdirSync(..., { recursive: true })`
- enumerate `.proto` files in Node so Windows does not depend on shell glob expansion

Fixes #1552.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @ag-ui/proto run generate`
- `node --check sdks\typescript\packages\proto\scripts\generate.cjs`
- `pnpm --filter @ag-ui/core run build`
- `pnpm --filter @ag-ui/proto run build`
- `pnpm --filter @ag-ui/proto run test`
- `git diff --check`

Note: `pnpm --filter @ag-ui/proto run lint` currently fails because the package script calls `eslint`, but this checkout does not install an `eslint` executable. I left that unrelated toolchain issue untouched.
