### PR TITLE
fix(langgraph): emit tool events after text transitions

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -922,7 +922,17 @@ class LangGraphAgent:
                     for predict_tool in predict_state_metadata
                 )
 
-            is_tool_call_start_event = not has_current_stream and tool_call_data and tool_call_data.get("name")
+            is_text_to_tool_call_transition = (
+                has_current_stream
+                and not current_stream.get("tool_call_id")
+                and tool_call_data
+                and tool_call_data.get("name")
+            )
+            is_tool_call_start_event = (
+                (not has_current_stream or is_text_to_tool_call_transition)
+                and tool_call_data
+                and tool_call_data.get("name")
+            )
             is_tool_call_args_event = has_current_stream and current_stream.get("tool_call_id") and tool_call_data and tool_call_data.get("args")
             is_tool_call_end_event = has_current_stream and current_stream.get("tool_call_id") and not tool_call_data
 
@@ -1014,6 +1024,14 @@ class LangGraphAgent:
                 self.messages_in_process[self.active_run["id"]] = None
                 return
 
+            if is_text_to_tool_call_transition:
+                yield self._dispatch_event(
+                    TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=current_stream["id"], raw_event=event)
+                )
+                self.messages_in_process[self.active_run["id"]] = None
+                current_stream = None
+                has_current_stream = False
+                is_message_end_event = False
 
             if is_message_end_event:
                 yield self._dispatch_event(

--- a/integrations/langgraph/python/tests/test_emit_events.py
+++ b/integrations/langgraph/python/tests/test_emit_events.py
@@ -182,3 +182,74 @@ class TestHandleSingleEventCustomEvents:
             events.append(ev)
 
         assert any(e.type == EventType.STATE_SNAPSHOT for e in events)
+
+    @pytest.mark.asyncio
+    async def test_text_to_tool_call_transition_emits_tool_events(self):
+        agent = self._make_agent()
+
+        async def collect(event):
+            events = []
+            async for ev in agent._handle_single_event(event, {}):
+                events.append(ev)
+            return events
+
+        text_chunk = {
+            "event": LangGraphEventTypes.OnChatModelStream.value,
+            "metadata": {},
+            "data": {
+                "chunk": {
+                    "id": "msg-1",
+                    "content": "Hello",
+                    "tool_call_chunks": [],
+                    "response_metadata": {},
+                }
+            },
+        }
+        transition_chunk = {
+            "event": LangGraphEventTypes.OnChatModelStream.value,
+            "metadata": {},
+            "data": {
+                "chunk": {
+                    "id": "msg-1",
+                    "content": "",
+                    "tool_call_chunks": [
+                        {"id": "call-1", "name": "render_ui", "args": "", "index": 0}
+                    ],
+                    "response_metadata": {},
+                }
+            },
+        }
+        args_chunk = {
+            "event": LangGraphEventTypes.OnChatModelStream.value,
+            "metadata": {},
+            "data": {
+                "chunk": {
+                    "id": "msg-1",
+                    "content": "",
+                    "tool_call_chunks": [
+                        {"id": None, "name": None, "args": '{"title":"ok"}', "index": 0}
+                    ],
+                    "response_metadata": {},
+                }
+            },
+        }
+        end_event = {
+            "event": LangGraphEventTypes.OnChatModelEnd.value,
+            "data": {},
+        }
+
+        events = []
+        for event in [text_chunk, transition_chunk, args_chunk, end_event]:
+            events.extend(await collect(event))
+
+        assert [event.type for event in events] == [
+            EventType.TEXT_MESSAGE_START,
+            EventType.TEXT_MESSAGE_CONTENT,
+            EventType.TEXT_MESSAGE_END,
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+        ]
+        assert events[3].tool_call_id == "call-1"
+        assert events[3].tool_call_name == "render_ui"
+        assert events[4].delta == '{"title":"ok"}'


### PR DESCRIPTION
## Summary

- close the open text stream before starting a tool call carried on the same LangGraph chunk
- let the existing `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END` path handle the tool stream after that transition
- add a regression test for the text-to-tool chunk sequence from the issue

Fixes #1678.

## Validation

- `python -m venv .venv`
- `.venv\Scripts\python.exe -m pip install -e . pytest pytest-asyncio fastapi`
- `.venv\Scripts\python.exe -m pytest tests\test_emit_events.py::TestHandleSingleEventCustomEvents::test_text_to_tool_call_transition_emits_tool_events -q`
- `.venv\Scripts\python.exe -m pytest tests\test_emit_events.py -q`
- `.venv\Scripts\python.exe -m pytest tests -q`
- `.venv\Scripts\python.exe -m py_compile ag_ui_langgraph\agent.py tests\test_emit_events.py`
- `git diff --check`
