### PR TITLE
fix(spring-ai): stream tool events immediately

### DIFF
--- a/sdks/community/java/integrations/spring-ai/src/main/java/com/agui/spring/ai/SpringAIAgent.java
+++ b/sdks/community/java/integrations/spring-ai/src/main/java/com/agui/spring/ai/SpringAIAgent.java
@@ -3,7 +3,6 @@ package com.agui.spring.ai;
 import com.agui.core.agent.AgentSubscriber;
 import com.agui.core.agent.AgentSubscriberParams;
 import com.agui.core.agent.RunAgentInput;
-import com.agui.core.event.BaseEvent;
 import com.agui.core.exception.AGUIException;
 import com.agui.core.function.FunctionCall;
 import com.agui.core.message.*;
@@ -134,7 +133,7 @@ public class SpringAIAgent extends LocalAgent {
      * <li>Extracting the user message from input</li>
      * <li>Setting up the chat request with tools, advisors, and memory</li>
      * <li>Streaming the response and emitting appropriate events</li>
-     * <li>Handling tool calls and deferred events</li>
+     * <li>Handling tool calls and streaming tool events</li>
      * <li>Managing conversation memory</li>
      * </ul>
      *
@@ -169,21 +168,19 @@ public class SpringAIAgent extends LocalAgent {
                 subscriber
         );
 
-        final List<BaseEvent> deferredEvents = new ArrayList<>();
-
         var assistantMessage = new AssistantMessage();
         assistantMessage.setId(messageId);
         assistantMessage.setName(this.agentId);
 
         try {
-            getChatRequest(input, content, messageId, deferredEvents, this.createSystemMessage(state, input.context(),
+            getChatRequest(input, content, messageId, this.createSystemMessage(state, input.context(),
                     Objects.nonNull(this.systemMessageProvider) ? this.systemMessageProvider.apply(this) : this.systemMessage), subscriber)
                     .stream()
                     .chatResponse()
                     .subscribe(
-                            evt -> onEvent(subscriber, evt, assistantMessage, messageId, deferredEvents),
+                            evt -> onEvent(subscriber, evt, assistantMessage, messageId),
                             err -> this.emitEvent(runErrorEvent(err.getMessage()), subscriber),
-                            () -> onComplete(input, assistantMessage, subscriber, messageId, deferredEvents)
+                            () -> onComplete(input, assistantMessage, subscriber, messageId)
                     );
         } catch (AGUIException e) {
             this.emitEvent(runErrorEvent(e.getMessage()), subscriber);
@@ -199,9 +196,8 @@ public class SpringAIAgent extends LocalAgent {
      * @param subscriber the event subscriber to notify
      * @param evt the chat response event from Spring AI
      * @param messageId the unique identifier for the current message
-     * @param deferredEvents Events that will be deferred and emitted later
      */
-    private void onEvent(AgentSubscriber subscriber, ChatResponse evt, AssistantMessage assistantMessage, String messageId, List<BaseEvent> deferredEvents) {
+    private void onEvent(AgentSubscriber subscriber, ChatResponse evt, AssistantMessage assistantMessage, String messageId) {
         if (evt.hasToolCalls()) {
             assistantMessage.setToolCalls(new ArrayList<>());
             evt.getResult().getOutput().getToolCalls()
@@ -211,9 +207,9 @@ public class SpringAIAgent extends LocalAgent {
                         assistantMessage.getToolCalls().add(call);
 
                         var toolCallId = toolCall.id();
-                        deferredEvents.add(toolCallStartEvent(messageId, toolCall.name(), toolCallId));
-                        deferredEvents.add(toolCallArgsEvent(toolCall.arguments(), toolCallId));
-                        deferredEvents.add(toolCallEndEvent(toolCallId));
+                        this.emitEvent(toolCallStartEvent(messageId, toolCall.name(), toolCallId), subscriber);
+                        this.emitEvent(toolCallArgsEvent(toolCall.arguments(), toolCallId), subscriber);
+                        this.emitEvent(toolCallEndEvent(toolCallId), subscriber);
 
                         subscriber.onNewToolCall(call);
                     });
@@ -237,7 +233,7 @@ public class SpringAIAgent extends LocalAgent {
      * This method is called when the streaming response is complete and handles:
      * <ul>
      * <li>Emitting the text message end event</li>
-     * <li>Processing any deferred tool call events</li>
+     * <li>Adding the final assistant message</li>
      * <li>Emitting the run finished event</li>
      * <li>Finalizing the agent run with updated state</li>
      * </ul>
@@ -245,15 +241,9 @@ public class SpringAIAgent extends LocalAgent {
      * @param input the original run input parameters
      * @param subscriber the event subscriber to notify
      * @param messageId the unique identifier for the current message
-     * @param deferredEvents list of tool call events to process after message completion
      */
-    private void onComplete(RunAgentInput input, AssistantMessage assistantMessage, AgentSubscriber subscriber, String messageId, List<BaseEvent> deferredEvents) {
+    private void onComplete(RunAgentInput input, AssistantMessage assistantMessage, AgentSubscriber subscriber, String messageId) {
         this.emitEvent(textMessageEndEvent(messageId), subscriber);
-
-        deferredEvents.forEach(deferredEvent -> {
-            this.emitEvent(deferredEvent, subscriber);
-
-        });
 
         subscriber.onNewMessage(assistantMessage);
 
@@ -275,11 +265,10 @@ public class SpringAIAgent extends LocalAgent {
      * @param input the run input containing messages, tools, and context
      * @param content the user message content to send
      * @param messageId unique identifier for the current message
-     * @param deferredEvents list to collect events for later processing
      * @param systemMessage the formatted system message including state and context
      * @return configured ChatClient request specification ready for execution
      */
-    private ChatClient.ChatClientRequestSpec getChatRequest(RunAgentInput input, String content, String messageId, List<BaseEvent> deferredEvents, SystemMessage systemMessage, AgentSubscriber subscriber) throws AGUIException {
+    private ChatClient.ChatClientRequestSpec getChatRequest(RunAgentInput input, String content, String messageId, SystemMessage systemMessage, AgentSubscriber subscriber) throws AGUIException {
         ChatClient.ChatClientRequestSpec chatRequest = this.chatClient.prompt(
                         Prompt
                                 .builder()
@@ -305,7 +294,7 @@ public class SpringAIAgent extends LocalAgent {
                                 .map((tool) -> this.toolMapper.toSpringTool(
                                         tool,
                                         messageId,
-                                        deferredEvents::add
+                                        event -> this.emitEvent(event, subscriber)
                                 )).toList()
                 );
             } catch (RuntimeException e) {
@@ -320,10 +309,10 @@ public class SpringAIAgent extends LocalAgent {
                                 .stream()
                                 .map(toolCallback -> new AgUiFunctionToolCallback(toolCallback, (AgUiToolCallbackParams params) -> {
                                     var toolCallId = UUID.randomUUID().toString();
-                                    deferredEvents.add(toolCallStartEvent(messageId, toolCallback.getToolDefinition().name(), toolCallId));
-                                    deferredEvents.add(toolCallArgsEvent(params.arguments(), toolCallId));
-                                    deferredEvents.add(toolCallEndEvent(toolCallId));
-                                    deferredEvents.add(toolCallResultEvent(toolCallId, params.result(), messageId, Role.tool));
+                                    this.emitEvent(toolCallStartEvent(messageId, toolCallback.getToolDefinition().name(), toolCallId), subscriber);
+                                    this.emitEvent(toolCallArgsEvent(params.arguments(), toolCallId), subscriber);
+                                    this.emitEvent(toolCallEndEvent(toolCallId), subscriber);
+                                    this.emitEvent(toolCallResultEvent(toolCallId, params.result(), messageId, Role.tool), subscriber);
 
 
                                 }))

--- a/sdks/community/java/integrations/spring-ai/src/test/java/com/agui/spring/ai/SpringAIAgentTest.java
+++ b/sdks/community/java/integrations/spring-ai/src/test/java/com/agui/spring/ai/SpringAIAgentTest.java
@@ -1,0 +1,125 @@
+package com.agui.spring.ai;
+
+import com.agui.core.agent.AgentSubscriber;
+import com.agui.core.agent.RunAgentInput;
+import com.agui.core.context.Context;
+import com.agui.core.event.BaseEvent;
+import com.agui.core.message.BaseMessage;
+import com.agui.core.state.State;
+import com.agui.core.type.EventType;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SpringAIAgentTest {
+
+    @Test
+    void shouldEmitToolEventsBeforeCompletingMessage() throws Exception {
+        var agent = SpringAIAgent.builder()
+                .agentId("test-agent")
+                .chatModel(mock(ChatModel.class))
+                .state(new State())
+                .messages(new ArrayList<>())
+                .systemMessage("You are helpful.")
+                .build();
+
+        var capturedEvents = new ArrayList<BaseEvent>();
+        var subscriber = new AgentSubscriber() {
+            @Override
+            public void onEvent(BaseEvent event) {
+                capturedEvents.add(event);
+            }
+        };
+
+        var messageId = "message-1";
+        var assistantMessage = new com.agui.core.message.AssistantMessage();
+        var springToolCall = new org.springframework.ai.chat.messages.AssistantMessage.ToolCall(
+                "call-1",
+                "function",
+                "get_weather",
+                "{\"city\":\"Paris\"}"
+        );
+        var springAssistantMessage = new org.springframework.ai.chat.messages.AssistantMessage(
+                "",
+                Map.of(),
+                List.of(springToolCall)
+        );
+        var response = new ChatResponse(List.of(new Generation(springAssistantMessage)));
+
+        invokeOnEvent(agent, subscriber, response, assistantMessage, messageId);
+
+        var typesBeforeComplete = capturedEvents.stream().map(BaseEvent::getType).toList();
+        assertThat(typesBeforeComplete).containsExactly(
+                EventType.TOOL_CALL_START,
+                EventType.TOOL_CALL_ARGS,
+                EventType.TOOL_CALL_END
+        );
+
+        var input = new RunAgentInput(
+                "thread-1",
+                "run-1",
+                new State(),
+                List.<BaseMessage>of(),
+                emptyList(),
+                List.<Context>of(),
+                null
+        );
+
+        invokeOnComplete(agent, input, assistantMessage, subscriber, messageId);
+
+        var types = capturedEvents.stream().map(BaseEvent::getType).toList();
+        assertThat(types).containsExactly(
+                EventType.TOOL_CALL_START,
+                EventType.TOOL_CALL_ARGS,
+                EventType.TOOL_CALL_END,
+                EventType.TEXT_MESSAGE_END,
+                EventType.RUN_FINISHED
+        );
+    }
+
+    private static void invokeOnEvent(
+            SpringAIAgent agent,
+            AgentSubscriber subscriber,
+            ChatResponse response,
+            com.agui.core.message.AssistantMessage assistantMessage,
+            String messageId
+    ) throws Exception {
+        Method onEvent = SpringAIAgent.class.getDeclaredMethod(
+                "onEvent",
+                AgentSubscriber.class,
+                ChatResponse.class,
+                com.agui.core.message.AssistantMessage.class,
+                String.class
+        );
+        onEvent.setAccessible(true);
+        onEvent.invoke(agent, subscriber, response, assistantMessage, messageId);
+    }
+
+    private static void invokeOnComplete(
+            SpringAIAgent agent,
+            RunAgentInput input,
+            com.agui.core.message.AssistantMessage assistantMessage,
+            AgentSubscriber subscriber,
+            String messageId
+    ) throws Exception {
+        Method onComplete = SpringAIAgent.class.getDeclaredMethod(
+                "onComplete",
+                RunAgentInput.class,
+                com.agui.core.message.AssistantMessage.class,
+                AgentSubscriber.class,
+                String.class
+        );
+        onComplete.setAccessible(true);
+        onComplete.invoke(agent, input, assistantMessage, subscriber, messageId);
+    }
+}


### PR DESCRIPTION
﻿## Summary
- stream Spring AI tool lifecycle events as soon as the model reports tool calls
- stop buffering tool events until `onComplete`
- add a regression test for tool events arriving before message completion

Fixes #1668.

## Why
`SpringAIAgent` kept tool call lifecycle events in a deferred list and emitted them after `TEXT_MESSAGE_END`. SSE clients therefore saw tool calls only after the assistant message finished, even though Spring AI had already surfaced the tool call in the streamed response.

## Validation
```powershell
$env:JAVA_HOME='C:\dev\tools\jdk-17.0.19+10'
$env:Path="$env:JAVA_HOME\bin;C:\dev\tools\apache-maven-3.9.16\bin;$env:Path"
mvn -pl integrations/spring-ai -am -DskipITs test
```
