### PR TITLE
fix(agno): bump maxVersion to 0.0.53 for multimodal support

### DIFF
--- a/integrations/agno/typescript/src/index.ts
+++ b/integrations/agno/typescript/src/index.ts
@@ -7,6 +7,6 @@ import { HttpAgent } from "@ag-ui/client";
 
 export class AgnoAgent extends HttpAgent {
   public override get maxVersion(): string {
-    return "0.0.39";
+    return "0.0.53";
   }
 }


### PR DESCRIPTION
## Summary

Bumps `maxVersion` from `"0.0.39"` to `"0.0.53"` in the Agno integration.

## Problem

The hardcoded `maxVersion="0.0.39"` triggers the backward compatibility middleware in `@ag-ui/client` which:
- **Flattens array content to strings** — multimodal `InputContent` arrays become plain text
- **Drops all binary content** — images, audio, video are silently removed

This means AG-UI frontends (Dojo, CopilotKit, custom) cannot send multimodal inputs to Agno backends.

## Solution

Update `maxVersion` to `"0.0.53"` (current latest). This bypasses the content-flattening middleware and allows modern multimodal `InputContent` (images, audio, video, documents) to pass through unchanged.

## Related

- Unblocks [agno-agi/agno#7937](https://github.com/agno-agi/agno/pull/7937) which adds server-side multimodal handling
- Similar to the fix needed for AWS Strands in [#820](https://github.com/ag-ui-protocol/ag-ui/issues/820)

## Testing

After this change, Agno backends will receive the full `InputContent` array with `type: "binary"` entries preserved, allowing image/audio/video uploads to work.