### PR TITLE
fix(ci): switch to OIDC trusted publishers for npm auth

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -219,6 +219,7 @@ jobs:
     environment: npm
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -244,15 +245,6 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Configure npm auth
-        if: needs.build.outputs.ts_count != '0'
-        run: |
-          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download TypeScript build artifacts
         if: needs.build.outputs.ts_count != '0'
@@ -264,7 +256,6 @@ jobs:
         if: needs.build.outputs.ts_count != '0'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NEEDS_BUILD_OUTPUTS_TS_PROJECTS: ${{ needs.build.outputs.ts_projects }}
         run: |
           echo "Publishing TypeScript canary: ${NEEDS_BUILD_OUTPUTS_TS_PROJECTS}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -269,15 +269,6 @@ jobs:
         with:
           node-version: "22"
           registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Configure npm auth
-        if: needs.build.outputs.ts_count != '0'
-        run: |
-          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download TypeScript build artifacts
         if: needs.build.outputs.ts_count != '0'
@@ -297,7 +288,6 @@ jobs:
         if: needs.build.outputs.ts_count != '0'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TS_GROUPS: ${{ needs.build.outputs.ts_groups_json }}
         run: |
           echo "$TS_GROUPS" > /tmp/ts-groups.json


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to prerelease publish job
- Remove redundant `npm config set` auth steps and duplicate `NPM_TOKEN` env vars from both `publish-release.yml` and `prerelease.yml`
- Trusted publishers configured for all `@ag-ui/*` packages via `npm trust github`

## Context
All npm tokens expired May 19. OIDC trusted publishers replace them — ephemeral tokens, no rotation needed. `publish-release.yml` already had `id-token: write`; `prerelease.yml` did not.

## Test plan
- [ ] Merge and verify next release publishes via OIDC