### PR TITLE
fix(langgraph): check interrupt resume before regenerate heuristic

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -750,23 +750,32 @@ class LangGraphAgent:
 
             msg = deepcopy(msg)
             existing_messages[idx] = msg
-            repaired = False
+            repaired_any = False
             for tc in msg.tool_calls:
                 if isinstance(tc.get('args'), str):
                     raw_args = tc['args']
                     try:
                         tc['args'] = json.loads(raw_args)
+                        repaired_any = True
                     except (json.JSONDecodeError, TypeError) as exc:
-                        logger.warning(
+                        # Surface the failure loudly: this corrupts a tool
+                        # call's args, which downstream LLMs may silently
+                        # treat as an empty call. Include the tool_call_id
+                        # and a bounded excerpt so the cause is debuggable
+                        # without dumping unbounded payloads to logs.
+                        logger.error(
                             "Resetting tool_call args after JSON decode failure "
                             "(tool_call_id=%r, error=%s): %r",
                             tc.get('id'),
                             exc,
-                            raw_args,
+                            raw_args[:200],
                         )
                         tc['args'] = {}
-                    repaired = True
-            if repaired:
+            # Only return the repaired copy when at least one parse succeeded.
+            # Otherwise the checkpoint message stays authoritative; appending a
+            # repaired copy with empty args would duplicate the original tool
+            # call with corrupted arguments downstream.
+            if repaired_any:
                 repaired_ai_messages.append(msg)
 
         # Fix orphan ToolMessages injected by patch_orphan_tool_calls:

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -207,11 +207,11 @@ class LangGraphAgent:
                 and 'resume' in command_input
                 and command_input['resume'] is not None
             )
-            node_name_for_mode = (
-                node_name_input
-                if node_name_input and node_name_input != "__end__"
-                else self.active_run.get("node_name")
-            )
+            # active_run was just reset to INITIAL_ACTIVE_RUN above, so
+            # active_run["node_name"] is always None here — the else branch
+            # was dead code. Resolve to None directly to make the intent
+            # explicit.
+            node_name_for_mode = node_name_input if (node_name_input and node_name_input != "__end__") else None
 
             if not has_resume_input and thread_id and node_name_for_mode:
                 self.active_run["mode"] = "continue"

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -552,13 +552,23 @@ class LangGraphAgent:
 
         if has_resume_input:
             if isinstance(resume_input, str):
+                # Contract: a string resume payload is forwarded raw to
+                # Command(resume=...) when not valid JSON. Callers may
+                # legitimately pass plain strings, but a malformed JSON
+                # *looking* string is almost always an integration bug —
+                # surface it at WARNING so it's visible without breaking
+                # the legitimate raw-string case.
+                raw_resume = resume_input
                 try:
-                    resume_input = json.loads(resume_input)
-                except json.JSONDecodeError:
-                    # Keep as string if not valid JSON — callers may legitimately
-                    # pass raw string resume payloads.
-                    logger.debug(
-                        "failed to parse resume_input as JSON, treating as string"
+                    resume_input = json.loads(raw_resume)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "failed to parse resume_input as JSON, treating as string "
+                        "(thread_id=%r, run_id=%r, error=%s): %r",
+                        thread_id,
+                        self.active_run.get("id"),
+                        exc,
+                        raw_resume[:200],
                     )
             stream_input = Command(resume=resume_input)
         else:

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -200,14 +200,38 @@ class LangGraphAgent:
             config["configurable"] = {**(config.get('configurable', {})), "thread_id": thread_id}
 
             agent_state = await self.graph.aget_state(config)
-            resume_input = forwarded_props.get('command', {}).get('resume', None)
+            command_input = forwarded_props.get('command', {}) if forwarded_props else {}
+            has_resume_input = (
+                isinstance(command_input, dict)
+                and 'resume' in command_input
+                and command_input['resume'] is not None
+            )
+            node_name_for_mode = (
+                node_name_input
+                if node_name_input and node_name_input != "__end__"
+                else self.active_run.get("node_name")
+            )
 
-            if resume_input is None and thread_id and self.active_run.get("node_name") != "__end__" and self.active_run.get("node_name"):
+            if not has_resume_input and thread_id and node_name_for_mode:
                 self.active_run["mode"] = "continue"
+                self.active_run["node_name"] = node_name_for_mode
             else:
                 self.active_run["mode"] = "start"
 
             prepared_stream_response = await self.prepare_stream(input=input, agent_state=agent_state, config=config)
+
+            state = prepared_stream_response["state"]
+            stream = prepared_stream_response["stream"]
+            config = prepared_stream_response["config"]
+            events_to_dispatch = prepared_stream_response.get('events_to_dispatch', None)
+
+            if events_to_dispatch is not None and len(events_to_dispatch) > 0:
+                for event in events_to_dispatch:
+                    yield self._dispatch_event(event)
+                return
+
+            if node_name_input and self.active_run.get("mode") == "continue":
+                self.active_run["node_name"] = None
 
             yield self._dispatch_event(
                 RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["id"])
@@ -220,19 +244,9 @@ class LangGraphAgent:
                 yield ev
 
             # In case of resume (interrupt), re-start resumed step
-            if resume_input and self.active_run.get("node_name"):
+            if has_resume_input and self.active_run.get("node_name"):
                 for ev in self.handle_node_change(self.active_run.get("node_name")):
                     yield ev
-
-            state = prepared_stream_response["state"]
-            stream = prepared_stream_response["stream"]
-            config = prepared_stream_response["config"]
-            events_to_dispatch = prepared_stream_response.get('events_to_dispatch', None)
-
-            if events_to_dispatch is not None and len(events_to_dispatch) > 0:
-                for event in events_to_dispatch:
-                    yield self._dispatch_event(event)
-                return
 
             should_exit = False
             current_graph_state = state
@@ -452,7 +466,13 @@ class LangGraphAgent:
         config["configurable"]["thread_id"] = thread_id
         interrupts = self._collect_interrupts(agent_state.tasks)
         has_active_interrupts = len(interrupts) > 0
-        resume_input = forwarded_props.get('command', {}).get('resume', None)
+        command_input = forwarded_props.get('command', {})
+        resume_input = command_input.get('resume', None) if isinstance(command_input, dict) else None
+        has_resume_input = (
+            isinstance(command_input, dict)
+            and 'resume' in command_input
+            and resume_input is not None
+        )
 
         self.active_run["schema_keys"] = self.get_schema_keys(config)
 
@@ -461,35 +481,10 @@ class LangGraphAgent:
         # (the tool call that triggered the interrupt) that the frontend
         # never received. The message-count comparison below would see
         # "checkpoint has more messages than frontend sent" and incorrectly
-        # enter the regenerate path, destroying the interrupt state and
-        # making it impossible to resume.  Fixes #1743.
-        events_to_dispatch = []
-        if has_active_interrupts and not resume_input:
-            events_to_dispatch.append(
-                RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["id"])
-            )
-
-            for interrupt in interrupts:
-                events_to_dispatch.append(
-                    CustomEvent(
-                        type=EventType.CUSTOM,
-                        name=LangGraphEventTypes.OnInterrupt.value,
-                        value=dump_json_safe(interrupt.value),
-                        raw_event=interrupt,
-                    )
-                )
-
-            events_to_dispatch.append(
-                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["id"])
-            )
-            return {
-                "stream": None,
-                "state": None,
-                "config": None,
-                "events_to_dispatch": events_to_dispatch,
-            }
-
-        if not has_active_interrupts:
+        # enter the regenerate path instead of resuming. Treat only non-None
+        # resume values as present so falsy resume payloads remain valid while
+        # resume=None follows the no-resume interrupt path. Fixes #1743.
+        if not has_resume_input:
             non_system_messages = [msg for msg in langchain_messages if not isinstance(msg, SystemMessage)]
             if len(agent_state.values.get("messages", [])) > len(non_system_messages):
                 # Only trigger time-travel regeneration if the incoming messages are NOT already
@@ -525,10 +520,36 @@ class LangGraphAgent:
                                 config=config
                             )
 
+        events_to_dispatch = []
+        if has_active_interrupts and not has_resume_input:
+            events_to_dispatch.append(
+                RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=self.active_run["id"])
+            )
+
+            for interrupt in interrupts:
+                events_to_dispatch.append(
+                    CustomEvent(
+                        type=EventType.CUSTOM,
+                        name=LangGraphEventTypes.OnInterrupt.value,
+                        value=dump_json_safe(interrupt.value),
+                        raw_event=interrupt,
+                    )
+                )
+
+            events_to_dispatch.append(
+                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=self.active_run["id"])
+            )
+            return {
+                "stream": None,
+                "state": None,
+                "config": None,
+                "events_to_dispatch": events_to_dispatch,
+            }
+
         if self.active_run["mode"] == "continue":
             await self.graph.aupdate_state(config, state, as_node=self.active_run.get("node_name"))
 
-        if resume_input:
+        if has_resume_input:
             if isinstance(resume_input, str):
                 try:
                     resume_input = json.loads(resume_input)

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -740,27 +740,34 @@ class LangGraphAgent:
         # requires toolUse.input to be a JSON object (dict).
         repaired_ai_messages: List[AIMessage] = []
         for idx, msg in enumerate(existing_messages):
-            if isinstance(msg, AIMessage) and getattr(msg, 'tool_calls', None):
-                msg = deepcopy(msg)
-                existing_messages[idx] = msg
-                repaired = False
-                for tc in msg.tool_calls:
-                    if isinstance(tc.get('args'), str):
-                        raw_args = tc['args']
-                        try:
-                            tc['args'] = json.loads(raw_args)
-                        except (json.JSONDecodeError, TypeError) as exc:
-                            logger.warning(
-                                "Resetting tool_call args after JSON decode failure "
-                                "(tool_call_id=%r, error=%s): %r",
-                                tc.get('id'),
-                                exc,
-                                raw_args,
-                            )
-                            tc['args'] = {}
-                        repaired = True
-                if repaired:
-                    repaired_ai_messages.append(msg)
+            # Only AIMessages with tool_calls can need repair. Skip the rest
+            # cheaply so we don't deepcopy every checkpoint message just to
+            # discover there was nothing to fix.
+            if not (isinstance(msg, AIMessage) and getattr(msg, 'tool_calls', None)):
+                continue
+            if not any(isinstance(tc.get('args'), str) for tc in msg.tool_calls):
+                continue
+
+            msg = deepcopy(msg)
+            existing_messages[idx] = msg
+            repaired = False
+            for tc in msg.tool_calls:
+                if isinstance(tc.get('args'), str):
+                    raw_args = tc['args']
+                    try:
+                        tc['args'] = json.loads(raw_args)
+                    except (json.JSONDecodeError, TypeError) as exc:
+                        logger.warning(
+                            "Resetting tool_call args after JSON decode failure "
+                            "(tool_call_id=%r, error=%s): %r",
+                            tc.get('id'),
+                            exc,
+                            raw_args,
+                        )
+                        tc['args'] = {}
+                    repaired = True
+            if repaired:
+                repaired_ai_messages.append(msg)
 
         # Fix orphan ToolMessages injected by patch_orphan_tool_calls:
         # Find the real content from AG-UI messages and replace the fake content.

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -2,6 +2,7 @@ import logging
 import re
 import uuid
 import json
+from copy import deepcopy
 from typing import Optional, List, Any, Union, AsyncGenerator, Generator, Literal, Dict, TypedDict
 from typing_extensions import NotRequired, Self
 import inspect
@@ -731,14 +732,18 @@ class LangGraphAgent:
         # (HumanMessage / AIMessage / ToolMessage / SystemMessage) — not the
         # TypedDict LangGraphPlatformMessage wire-shape. Annotate accordingly
         # so downstream attribute access (``.tool_calls``, ``.content``) type-checks.
-        existing_messages: List[BaseMessage] = state.get("messages", [])
+        existing_messages: List[BaseMessage] = list(state.get("messages", []))
 
         # Fix tool_call args that are strings instead of dicts.
         # This happens when CopilotKit's after_agent restores frontend tool_calls
         # and the checkpoint saves them with string args. Bedrock Converse API
         # requires toolUse.input to be a JSON object (dict).
-        for msg in existing_messages:
+        repaired_ai_messages: List[AIMessage] = []
+        for idx, msg in enumerate(existing_messages):
             if isinstance(msg, AIMessage) and getattr(msg, 'tool_calls', None):
+                msg = deepcopy(msg)
+                existing_messages[idx] = msg
+                repaired = False
                 for tc in msg.tool_calls:
                     if isinstance(tc.get('args'), str):
                         raw_args = tc['args']
@@ -753,6 +758,9 @@ class LangGraphAgent:
                                 raw_args,
                             )
                             tc['args'] = {}
+                        repaired = True
+                if repaired:
+                    repaired_ai_messages.append(msg)
 
         # Fix orphan ToolMessages injected by patch_orphan_tool_calls:
         # Find the real content from AG-UI messages and replace the fake content.
@@ -764,6 +772,7 @@ class LangGraphAgent:
             if isinstance(m, ToolMessage) and hasattr(m, 'tool_call_id')
         }
         replaced_tool_call_ids = set()
+        repaired_tool_messages: List[ToolMessage] = []
         if agui_tool_content:
             last_human_idx = -1
             for i in range(len(existing_messages) - 1, -1, -1):
@@ -780,19 +789,26 @@ class LangGraphAgent:
                             and hasattr(msg, 'tool_call_id')
                             and msg.tool_call_id in agui_tool_content
                     ):
+                        msg = deepcopy(msg)
                         msg.content = agui_tool_content[msg.tool_call_id]
+                        existing_messages[i] = msg
+                        repaired_tool_messages.append(msg)
                         replaced_tool_call_ids.add(msg.tool_call_id)
 
         existing_message_ids = {msg.id for msg in existing_messages}
 
         new_messages = [
-            msg for msg in messages
-            if msg.id not in existing_message_ids
-            and not (
-                isinstance(msg, ToolMessage)
-                and hasattr(msg, 'tool_call_id')
-                and msg.tool_call_id in replaced_tool_call_ids
-            )
+            *repaired_ai_messages,
+            *repaired_tool_messages,
+            *[
+                msg for msg in messages
+                if msg.id not in existing_message_ids
+                and not (
+                    isinstance(msg, ToolMessage)
+                    and hasattr(msg, 'tool_call_id')
+                    and msg.tool_call_id in replaced_tool_call_ids
+                )
+            ],
         ]
 
         tools = input.tools or []

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -456,41 +456,13 @@ class LangGraphAgent:
 
         self.active_run["schema_keys"] = self.get_schema_keys(config)
 
-        non_system_messages = [msg for msg in langchain_messages if not isinstance(msg, SystemMessage)]
-        if len(agent_state.values.get("messages", [])) > len(non_system_messages):
-            # Only trigger time-travel regeneration if the incoming messages are NOT already
-            # in the checkpoint. If they are, this is a continuation (e.g. after CopilotKit
-            # intercepted a tool call), not a time-travel edit — regenerating would loop.
-            #
-            # We exclude ToolMessages from the ID comparison because CopilotKit assigns new
-            # IDs to tool results that won't match the placeholder IDs AgentCoreMemorySaver
-            # wrote to the checkpoint. Human and AI message IDs are stable across requests
-            # and are sufficient to distinguish continuation from time-travel.
-            incoming_non_tool_ids = {
-                getattr(m, "id", None)
-                for m in langchain_messages
-                if getattr(m, "id", None) and not isinstance(m, ToolMessage)
-            }
-            checkpoint_ids = {getattr(m, "id", None) for m in agent_state.values.get("messages", []) if getattr(m, "id", None)}
-            is_continuation = bool(incoming_non_tool_ids) and incoming_non_tool_ids.issubset(checkpoint_ids)
-
-            if not is_continuation:
-                last_user_message: Optional[HumanMessage] = None
-                for i in range(len(langchain_messages) - 1, -1, -1):
-                    candidate = langchain_messages[i]
-                    if isinstance(candidate, HumanMessage):
-                        last_user_message = candidate
-                        break
-
-                if last_user_message:
-                    last_user_id = last_user_message.id
-                    if last_user_id and last_user_id in checkpoint_ids:
-                        return await self.prepare_regenerate_stream(
-                            input=input,
-                            message_checkpoint=last_user_message,
-                            config=config
-                        )
-
+        # Interrupt resume must be checked BEFORE the regenerate heuristic.
+        # When an interrupt is active the checkpoint contains an AI message
+        # (the tool call that triggered the interrupt) that the frontend
+        # never received. The message-count comparison below would see
+        # "checkpoint has more messages than frontend sent" and incorrectly
+        # enter the regenerate path, destroying the interrupt state and
+        # making it impossible to resume.  Fixes #1743.
         events_to_dispatch = []
         if has_active_interrupts and not resume_input:
             events_to_dispatch.append(
@@ -516,6 +488,42 @@ class LangGraphAgent:
                 "config": None,
                 "events_to_dispatch": events_to_dispatch,
             }
+
+        if not has_active_interrupts:
+            non_system_messages = [msg for msg in langchain_messages if not isinstance(msg, SystemMessage)]
+            if len(agent_state.values.get("messages", [])) > len(non_system_messages):
+                # Only trigger time-travel regeneration if the incoming messages are NOT already
+                # in the checkpoint. If they are, this is a continuation (e.g. after CopilotKit
+                # intercepted a tool call), not a time-travel edit — regenerating would loop.
+                #
+                # We exclude ToolMessages from the ID comparison because CopilotKit assigns new
+                # IDs to tool results that won't match the placeholder IDs AgentCoreMemorySaver
+                # wrote to the checkpoint. Human and AI message IDs are stable across requests
+                # and are sufficient to distinguish continuation from time-travel.
+                incoming_non_tool_ids = {
+                    getattr(m, "id", None)
+                    for m in langchain_messages
+                    if getattr(m, "id", None) and not isinstance(m, ToolMessage)
+                }
+                checkpoint_ids = {getattr(m, "id", None) for m in agent_state.values.get("messages", []) if getattr(m, "id", None)}
+                is_continuation = bool(incoming_non_tool_ids) and incoming_non_tool_ids.issubset(checkpoint_ids)
+
+                if not is_continuation:
+                    last_user_message: Optional[HumanMessage] = None
+                    for i in range(len(langchain_messages) - 1, -1, -1):
+                        candidate = langchain_messages[i]
+                        if isinstance(candidate, HumanMessage):
+                            last_user_message = candidate
+                            break
+
+                    if last_user_message:
+                        last_user_id = last_user_message.id
+                        if last_user_id and last_user_id in checkpoint_ids:
+                            return await self.prepare_regenerate_stream(
+                                input=input,
+                                message_checkpoint=last_user_message,
+                                config=config
+                            )
 
         if self.active_run["mode"] == "continue":
             await self.graph.aupdate_state(config, state, as_node=self.active_run.get("node_name"))

--- a/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
+++ b/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
@@ -6,12 +6,13 @@ without mutating checkpoint message objects in place.
 
 import unittest
 from copy import deepcopy
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.graph.state import CompiledStateGraph
 
 from ag_ui_langgraph import LangGraphAgent
+from ag_ui_langgraph import agent as agent_module
 
 
 def _make_agent():
@@ -226,6 +227,82 @@ class TestOrphanToolMessageMerge(unittest.TestCase):
         repaired = result["messages"][0]
         self.assertIsNot(repaired, ai_message)
         self.assertEqual(repaired.tool_calls[0]["args"], {"approved": False})
+
+
+class TestAIMessageRepairErrors(unittest.TestCase):
+    """Tool-call arg JSON parse failures must surface via logger.error and
+    must not append a repaired AIMessage to new_messages when nothing was
+    successfully parsed — otherwise the checkpoint message is duplicated
+    with empty args."""
+
+    def test_unparseable_tool_call_args_log_error_with_tool_call_id_and_excerpt(self):
+        agent = _make_agent()
+        bad_args = "not json {{" + ("x" * 300)
+        ai_message = AIMessage(
+            id="ai-bad-args",
+            content="",
+            tool_calls=[
+                {"id": "tc-bad", "name": "approval", "args": {}},
+            ],
+        )
+        ai_message.tool_calls[0]["args"] = bad_args
+        checkpoint_messages = [
+            HumanMessage(id="u-1", content="hi"),
+            ai_message,
+        ]
+        state = {"messages": checkpoint_messages}
+        before_checkpoint = _message_signature(checkpoint_messages)
+
+        with patch.object(agent_module, "logger") as mock_logger:
+            result = agent.langgraph_default_merge_state(state, [], _input())
+
+        # Checkpoint signature unchanged — we did not mutate the originals.
+        self.assertEqual(before_checkpoint, _message_signature(checkpoint_messages))
+
+        # The repaired AI message is NOT returned because no tool_call was
+        # successfully parsed; otherwise we would duplicate the checkpoint
+        # message with empty args.
+        self.assertEqual(result["messages"], [])
+
+        # logger.error called with the tool_call_id and a bounded excerpt.
+        self.assertTrue(mock_logger.error.called, "expected logger.error to be called")
+        call_args = mock_logger.error.call_args
+        formatted = call_args[0][0] % call_args[0][1:]
+        self.assertIn("tc-bad", formatted)
+        # The excerpt must be bounded at 200 chars.
+        self.assertIn(bad_args[:200], formatted)
+        self.assertNotIn(bad_args, formatted)
+
+    def test_mixed_parseable_and_unparseable_tool_calls_returns_repaired_message(self):
+        """When at least one tool_call parses successfully, the repaired
+        AIMessage is returned with the parsed value plus {} for the failure."""
+        agent = _make_agent()
+        ai_message = AIMessage(
+            id="ai-mixed",
+            content="",
+            tool_calls=[
+                {"id": "tc-good", "name": "t", "args": {}},
+                {"id": "tc-bad", "name": "t", "args": {}},
+            ],
+        )
+        ai_message.tool_calls[0]["args"] = '{"approved": true}'
+        ai_message.tool_calls[1]["args"] = "not json"
+        checkpoint_messages = [
+            HumanMessage(id="u-1", content="hi"),
+            ai_message,
+        ]
+        state = {"messages": checkpoint_messages}
+        before_checkpoint = _message_signature(checkpoint_messages)
+
+        with patch.object(agent_module, "logger") as mock_logger:
+            result = agent.langgraph_default_merge_state(state, [], _input())
+
+        self.assertEqual(before_checkpoint, _message_signature(checkpoint_messages))
+        self.assertEqual([m.id for m in result["messages"]], ["ai-mixed"])
+        repaired = result["messages"][0]
+        self.assertEqual(repaired.tool_calls[0]["args"], {"approved": True})
+        self.assertEqual(repaired.tool_calls[1]["args"], {})
+        self.assertTrue(mock_logger.error.called)
 
 
 if __name__ == "__main__":

--- a/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
+++ b/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
@@ -1,12 +1,11 @@
 """Tests for langgraph_default_merge_state orphan-ToolMessage handling (#1412).
 
-The fix preserves in-place content replacements on existing orphan
-ToolMessages by excluding the AG-UI duplicate from the new_messages list.
-Before the fix, `{"messages": new_messages}` would overwrite state["messages"]
-with a copy that still contained the orphan placeholder text.
+The fix sends repaired replacement ToolMessages in the message update
+without mutating checkpoint message objects in place.
 """
 
 import unittest
+from copy import deepcopy
 from unittest.mock import MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -24,7 +23,7 @@ def _make_agent():
 
 def _orphan_placeholder(tool_name: str, tool_call_id: str) -> str:
     # Must match LangGraphAgent._ORPHAN_TOOL_MSG_RE so the fix path recognises
-    # the ToolMessage as an orphan to be repaired in-place.
+    # the ToolMessage as an orphan to be repaired.
     return (
         f"Tool call '{tool_name}' with id '{tool_call_id}' "
         f"was interrupted before completion."
@@ -38,6 +37,19 @@ def _input(tools=None):
     input_mock = MagicMock()
     input_mock.tools = tools or []
     return input_mock
+
+
+def _message_signature(messages):
+    return [
+        (
+            type(message).__name__,
+            getattr(message, "id", None),
+            deepcopy(getattr(message, "content", None)),
+            deepcopy(getattr(message, "tool_calls", None)),
+            getattr(message, "tool_call_id", None),
+        )
+        for message in messages
+    ]
 
 
 class TestOrphanToolMessageMerge(unittest.TestCase):
@@ -70,11 +82,14 @@ class TestOrphanToolMessageMerge(unittest.TestCase):
             state, [agui_tool_msg], _input(),
         )
 
-        # Orphan content was patched in place on the existing message.
-        self.assertEqual(orphan.content, "the real tool result")
-        # And the AG-UI ToolMessage was NOT re-added.
         new_messages = result["messages"]
-        self.assertEqual(new_messages, [])
+        self.assertEqual([m.id for m in new_messages], ["orphan-1"])
+        self.assertIsNot(new_messages[0], orphan)
+        self.assertEqual(new_messages[0].content, "the real tool result")
+        self.assertEqual(
+            orphan.content,
+            _orphan_placeholder("my_tool", tool_call_id),
+        )
 
     def test_tool_message_without_matching_orphan_is_still_added(self):
         """If no orphan exists for a tool_call_id, the AG-UI ToolMessage must
@@ -142,12 +157,75 @@ class TestOrphanToolMessageMerge(unittest.TestCase):
             state, [replaced_agui, fresh_agui, ai_new], _input(),
         )
 
-        # replaced_agui dropped; fresh_agui and ai_new preserved, order kept.
+        # replaced_agui dropped; repaired orphan, fresh_agui, and ai_new preserved.
         self.assertEqual(
             [m.id for m in result["messages"]],
-            ["agui-fresh", "a-new"],
+            ["orphan-1", "agui-fresh", "a-new"],
         )
-        self.assertEqual(orphan.content, "real")
+        self.assertIsNot(result["messages"][0], orphan)
+        self.assertEqual(result["messages"][0].content, "real")
+        self.assertEqual(orphan.content, _orphan_placeholder("t", replaced_id))
+
+    def test_replaced_orphan_does_not_mutate_checkpoint_message(self):
+        agent = _make_agent()
+        tool_call_id = "tc-no-mutate"
+        orphan = ToolMessage(
+            id="orphan-1",
+            content=_orphan_placeholder("t", tool_call_id),
+            tool_call_id=tool_call_id,
+        )
+        checkpoint_messages = [
+            HumanMessage(id="u-1", content="hi"),
+            AIMessage(id="a-1", content="", tool_calls=[
+                {"id": tool_call_id, "name": "t", "args": {}},
+            ]),
+            orphan,
+        ]
+        state = {"messages": checkpoint_messages}
+        agui_tool_msg = ToolMessage(
+            id="agui-replaced", content="real", tool_call_id=tool_call_id,
+        )
+        before_checkpoint = _message_signature(checkpoint_messages)
+
+        result = agent.langgraph_default_merge_state(
+            state, [agui_tool_msg], _input(),
+        )
+
+        self.assertEqual(before_checkpoint, _message_signature(checkpoint_messages))
+        self.assertEqual([m.id for m in result["messages"]], ["orphan-1"])
+        self.assertIsNot(result["messages"][0], orphan)
+        self.assertEqual(result["messages"][0].content, "real")
+
+    def test_repaired_ai_message_tool_call_args_are_returned_without_mutating_checkpoint(self):
+        agent = _make_agent()
+        ai_message = AIMessage(
+            id="ai-string-args",
+            content="",
+            tool_calls=[
+                {
+                    "id": "tc-string-args",
+                    "name": "approval",
+                    "args": {},
+                }
+            ],
+        )
+        ai_message.tool_calls[0]["args"] = '{"approved": false}'
+        checkpoint_messages = [
+            HumanMessage(id="u-1", content="hi"),
+            ai_message,
+        ]
+        state = {"messages": checkpoint_messages}
+        before_checkpoint = _message_signature(checkpoint_messages)
+
+        result = agent.langgraph_default_merge_state(state, [], _input())
+
+        self.assertEqual(before_checkpoint, _message_signature(checkpoint_messages))
+        self.assertIsInstance(checkpoint_messages[1].tool_calls[0]["args"], str)
+        self.assertEqual(checkpoint_messages[1].tool_calls[0]["args"], '{"approved": false}')
+        self.assertEqual([m.id for m in result["messages"]], ["ai-string-args"])
+        repaired = result["messages"][0]
+        self.assertIsNot(repaired, ai_message)
+        self.assertEqual(repaired.tool_calls[0]["args"], {"approved": False})
 
 
 if __name__ == "__main__":

--- a/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
+++ b/integrations/langgraph/python/tests/test_orphan_tool_message_merge.py
@@ -210,7 +210,7 @@ class TestOrphanToolMessageMerge(unittest.TestCase):
                 }
             ],
         )
-        ai_message.tool_calls[0]["args"] = '{"approved": false}'
+        ai_message.tool_calls[0]["args"] = '{"approved": false}'  # type: ignore[typeddict-item]
         checkpoint_messages = [
             HumanMessage(id="u-1", content="hi"),
             ai_message,
@@ -245,7 +245,7 @@ class TestAIMessageRepairErrors(unittest.TestCase):
                 {"id": "tc-bad", "name": "approval", "args": {}},
             ],
         )
-        ai_message.tool_calls[0]["args"] = bad_args
+        ai_message.tool_calls[0]["args"] = bad_args  # type: ignore[typeddict-item]
         checkpoint_messages = [
             HumanMessage(id="u-1", content="hi"),
             ai_message,
@@ -285,8 +285,8 @@ class TestAIMessageRepairErrors(unittest.TestCase):
                 {"id": "tc-bad", "name": "t", "args": {}},
             ],
         )
-        ai_message.tool_calls[0]["args"] = '{"approved": true}'
-        ai_message.tool_calls[1]["args"] = "not json"
+        ai_message.tool_calls[0]["args"] = '{"approved": true}'  # type: ignore[typeddict-item]
+        ai_message.tool_calls[1]["args"] = "not json"  # type: ignore[typeddict-item]
         checkpoint_messages = [
             HumanMessage(id="u-1", content="hi"),
             ai_message,

--- a/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
+++ b/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
@@ -610,7 +610,7 @@ class TestCheckpointSignature(unittest.TestCase):
         ]
 
         before = _checkpoint_signature(messages)
-        messages[0].content[0]["text"] = "after"
+        messages[0].content[0]["text"] = "after"  # type: ignore[index]
         messages[0].tool_calls[0]["args"]["approved"] = True
 
         self.assertNotEqual(before, _checkpoint_signature(messages))

--- a/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
+++ b/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
@@ -11,14 +11,15 @@ still allow edit/regenerate detection before replaying interrupt events.
 """
 
 import unittest
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, List
 from unittest.mock import AsyncMock, MagicMock
 
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
-from ag_ui.core import EventType, UserMessage
+from ag_ui.core import EventType, ToolMessage as AGUIToolMessage, UserMessage
 
 from tests._helpers import make_agent
 
@@ -63,6 +64,27 @@ def _make_input(
 async def _empty_stream():
     if False:
         yield None
+
+
+def _checkpoint_signature(messages):
+    """Return stable message fields so tests can assert no checkpoint mutation."""
+    return [
+        (
+            type(message).__name__,
+            getattr(message, "id", None),
+            deepcopy(getattr(message, "content", None)),
+            deepcopy(getattr(message, "tool_calls", None)),
+            getattr(message, "tool_call_id", None),
+        )
+        for message in messages
+    ]
+
+
+def _orphan_placeholder(tool_name: str, tool_call_id: str) -> str:
+    return (
+        f"Tool call '{tool_name}' with id '{tool_call_id}' "
+        f"was interrupted before completion."
+    )
 
 
 class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase):
@@ -165,11 +187,14 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
 
         agent.prepare_regenerate_stream = AsyncMock()
         config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
 
         result = await agent.prepare_stream(inp, state, config)
 
         agent.prepare_regenerate_stream.assert_not_awaited()
         self.assertIsNotNone(result.get("stream"))
+        agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
 
         stream_input = agent.graph.astream_events.call_args.kwargs["input"]
         self.assertIsInstance(stream_input, Command)
@@ -207,11 +232,13 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
 
                 agent.prepare_regenerate_stream = AsyncMock()
                 config = {"configurable": {"thread_id": "t1"}}
+                before_checkpoint = _checkpoint_signature(checkpoint_messages)
 
                 result = await agent.prepare_stream(inp, state, config)
 
                 agent.prepare_regenerate_stream.assert_not_awaited()
                 agent.graph.aupdate_state.assert_not_called()
+                self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
                 self.assertIsNotNone(result.get("stream"))
 
                 stream_input = agent.graph.astream_events.call_args.kwargs["input"]
@@ -246,12 +273,127 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
 
         agent.prepare_regenerate_stream = AsyncMock()
         config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
 
         result = await agent.prepare_stream(inp, state, config)
 
         agent.prepare_regenerate_stream.assert_not_awaited()
         agent.graph.astream_events.assert_not_called()
         agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
+        self.assertIsNone(result.get("stream"))
+
+        events = result.get("events_to_dispatch", [])
+        types = [getattr(e, "type", None) for e in events]
+        self.assertIn(EventType.RUN_STARTED, types)
+        self.assertIn(EventType.CUSTOM, types)
+        self.assertIn(EventType.RUN_FINISHED, types)
+
+    async def test_none_resume_interrupt_replay_does_not_mutate_string_tool_call_args(self):
+        """Interrupt replay must not repair checkpoint tool_call args in place."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc-1",
+                        "name": "approval",
+                        "args": {},
+                    }
+                ],
+            ),
+        ]
+        checkpoint_messages[1].tool_calls[0]["args"] = '{"approved": false}'
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="confirm?")])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": None}},
+        )
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_not_awaited()
+        agent.graph.astream_events.assert_not_called()
+        agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
+        self.assertIsNone(result.get("stream"))
+
+        events = result.get("events_to_dispatch", [])
+        types = [getattr(e, "type", None) for e in events]
+        self.assertIn(EventType.RUN_STARTED, types)
+        self.assertIn(EventType.CUSTOM, types)
+        self.assertIn(EventType.RUN_FINISHED, types)
+
+    async def test_interrupt_replay_does_not_mutate_orphan_tool_message_content(self):
+        """Interrupt replay must not repair checkpoint ToolMessage content in place."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        tool_call_id = "tc-1"
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[
+                    {
+                        "id": tool_call_id,
+                        "name": "approval",
+                        "args": {},
+                    }
+                ],
+            ),
+            ToolMessage(
+                id="orphan-1",
+                content=_orphan_placeholder("approval", tool_call_id),
+                tool_call_id=tool_call_id,
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="confirm?")])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+            AGUIToolMessage(
+                id="agui-tool-1",
+                role="tool",
+                content="approved",
+                tool_call_id=tool_call_id,
+            ),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": None}},
+        )
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_not_awaited()
+        agent.graph.astream_events.assert_not_called()
+        agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
         self.assertIsNone(result.get("stream"))
 
         events = result.get("events_to_dispatch", [])
@@ -294,12 +436,14 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
         }
         agent.prepare_regenerate_stream = AsyncMock(return_value=prepared_regenerate)
         config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
 
         result = await agent.prepare_stream(inp, state, config)
 
         agent.prepare_regenerate_stream.assert_awaited_once()
         self.assertIs(result, prepared_regenerate)
         agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
 
     async def test_interrupt_without_resume_dispatches_interrupt_events(self):
         """When there's an active interrupt but no resume value, the agent
@@ -327,10 +471,13 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
 
         agent.prepare_regenerate_stream = AsyncMock()
         config = {"configurable": {"thread_id": "t1"}}
+        before_checkpoint = _checkpoint_signature(checkpoint_messages)
 
         result = await agent.prepare_stream(inp, state, config)
 
         agent.prepare_regenerate_stream.assert_not_awaited()
+        agent.graph.aupdate_state.assert_not_called()
+        self.assertEqual(before_checkpoint, _checkpoint_signature(checkpoint_messages))
         self.assertIsNone(result.get("stream"))
 
         events = result.get("events_to_dispatch", [])
@@ -386,3 +533,28 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
         result = await agent.prepare_stream(inp, state, config)
 
         self.assertIsNotNone(result.get("stream"))
+
+
+class TestCheckpointSignature(unittest.TestCase):
+    """Checkpoint mutation assertions must observe in-place mutations."""
+
+    def test_checkpoint_signature_does_not_retain_mutable_message_references(self):
+        messages = [
+            AIMessage(
+                id="ai1",
+                content=[{"type": "text", "text": "before"}],
+                tool_calls=[
+                    {
+                        "id": "tc-1",
+                        "name": "approval",
+                        "args": {"approved": False},
+                    }
+                ],
+            ),
+        ]
+
+        before = _checkpoint_signature(messages)
+        messages[0].content[0]["text"] = "after"
+        messages[0].tool_calls[0]["args"]["approved"] = True
+
+        self.assertNotEqual(before, _checkpoint_signature(messages))

--- a/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
+++ b/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
@@ -14,13 +14,14 @@ import unittest
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, List
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
 from ag_ui.core import EventType, ToolMessage as AGUIToolMessage, UserMessage
 
+from ag_ui_langgraph import agent as agent_module
 from tests._helpers import make_agent
 
 
@@ -533,6 +534,61 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
         result = await agent.prepare_stream(inp, state, config)
 
         self.assertIsNotNone(result.get("stream"))
+
+
+class TestResumeInputJSONParseLogging(unittest.IsolatedAsyncioTestCase):
+    """Malformed JSON in a string resume payload must surface via logger.warning
+    with the offending excerpt; the raw string must still be forwarded to
+    Command(resume=...) so callers passing literal strings keep working."""
+
+    async def test_malformed_resume_json_string_logs_warning_and_preserves_raw(self):
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value={"question": "Approve?"})])],
+        )
+
+        malformed = '{"approved: true}'
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": malformed}},
+        )
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+
+        with patch.object(agent_module, "logger") as mock_logger:
+            result = await agent.prepare_stream(inp, state, config)
+
+        self.assertIsNotNone(result.get("stream"))
+        agent.prepare_regenerate_stream.assert_not_awaited()
+
+        # Raw string preserved into Command(resume=...).
+        stream_input = agent.graph.astream_events.call_args.kwargs["input"]
+        self.assertIsInstance(stream_input, Command)
+        self.assertEqual(stream_input.resume, malformed)
+
+        # Warning surfaced with the malformed payload excerpt.
+        self.assertTrue(
+            mock_logger.warning.called,
+            "expected logger.warning for malformed resume_input JSON",
+        )
+        call_args = mock_logger.warning.call_args
+        formatted = call_args[0][0] % call_args[0][1:]
+        self.assertIn(malformed, formatted)
 
 
 class TestCheckpointSignature(unittest.TestCase):

--- a/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
+++ b/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
@@ -1,0 +1,182 @@
+"""Tests for prepare_stream interrupt-resume ordering — fixes #1743.
+
+The bug: the regenerate heuristic (message-count comparison) runs
+*before* the interrupt check, so when a checkpoint contains an AI
+message from the interrupt that the frontend never saw, prepare_stream
+incorrectly enters the regenerate path, destroying the interrupt state.
+
+The fix moves interrupt handling before the regenerate heuristic so
+that resume requests bypass the message-count comparison entirely.
+"""
+
+import unittest
+from dataclasses import dataclass, field
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ag_ui.core import EventType, RunAgentInput, UserMessage
+
+from tests._helpers import make_agent
+
+
+@dataclass
+class FakeInterrupt:
+    value: Any
+
+
+@dataclass
+class FakeTask:
+    interrupts: List[FakeInterrupt] = field(default_factory=list)
+
+
+def _make_state(messages, tasks=None):
+    """Build a mock agent_state with messages and optional tasks."""
+    state = MagicMock()
+    state.values = {"messages": messages}
+    state.tasks = tasks or []
+    return state
+
+
+def _make_input(
+    messages,
+    thread_id="t1",
+    forwarded_props=None,
+):
+    """Build a RunAgentInput-compatible mock."""
+    inp = MagicMock()
+    inp.thread_id = thread_id
+    inp.messages = messages
+    inp.state = {}
+    inp.tools = []
+    inp.context = []
+    inp.forwarded_props = forwarded_props or {}
+    return inp
+
+
+class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase):
+    """Interrupt resumes must bypass the regenerate heuristic (#1743)."""
+
+    async def test_resume_with_interrupt_does_not_regenerate(self):
+        """Core regression: checkpoint has more messages than frontend
+        sent (the AI tool-call from the interrupt), and a resume value is
+        present. The old code would enter prepare_regenerate_stream; the
+        fix must skip it and produce a Command(resume=...) stream."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value={"question": "Approve?"})])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": "yes"}},
+        )
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_not_awaited()
+        self.assertIsNotNone(result.get("stream"))
+
+    async def test_interrupt_without_resume_dispatches_interrupt_events(self):
+        """When there's an active interrupt but no resume value, the agent
+        must dispatch interrupt events (not enter regenerate)."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="confirm?")])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(messages=frontend_messages, forwarded_props={})
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_not_awaited()
+        self.assertIsNone(result.get("stream"))
+
+        events = result.get("events_to_dispatch", [])
+        types = [getattr(e, "type", None) for e in events]
+        self.assertIn(EventType.RUN_STARTED, types)
+        self.assertIn(EventType.CUSTOM, types)
+        self.assertIn(EventType.RUN_FINISHED, types)
+
+    async def test_no_interrupt_normal_flow_produces_stream(self):
+        """Without active interrupts, the normal streaming path must
+        still work — the fix must not break standard message flow."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="hello"),
+        ]
+        state = _make_state(messages=checkpoint_messages, tasks=[FakeTask()])
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="hello"),
+            UserMessage(id="h2", role="user", content="follow up"),
+        ]
+        inp = _make_input(messages=frontend_messages, forwarded_props={})
+
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        self.assertIsNotNone(result.get("stream"))
+
+    async def test_resume_with_no_interrupt_proceeds_normally(self):
+        """A resume value without active interrupts should not crash;
+        the resume path at the bottom of prepare_stream handles it."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+        ]
+        state = _make_state(messages=checkpoint_messages, tasks=[FakeTask()])
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": "yes"}},
+        )
+
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        self.assertIsNotNone(result.get("stream"))

--- a/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
+++ b/integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py
@@ -1,12 +1,13 @@
-"""Tests for prepare_stream interrupt-resume ordering — fixes #1743.
+"""Tests for prepare_stream interrupt-resume ordering -- fixes #1743.
 
 The bug: the regenerate heuristic (message-count comparison) runs
 *before* the interrupt check, so when a checkpoint contains an AI
 message from the interrupt that the frontend never saw, prepare_stream
 incorrectly enters the regenerate path, destroying the interrupt state.
 
-The fix moves interrupt handling before the regenerate heuristic so
-that resume requests bypass the message-count comparison entirely.
+The fix treats an explicit, non-None resume key as a resume command that
+bypasses the regenerate heuristic. Active interrupts without a resume
+still allow edit/regenerate detection before replaying interrupt events.
 """
 
 import unittest
@@ -15,8 +16,9 @@ from typing import Any, List
 from unittest.mock import AsyncMock, MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.types import Command
 
-from ag_ui.core import EventType, RunAgentInput, UserMessage
+from ag_ui.core import EventType, UserMessage
 
 from tests._helpers import make_agent
 
@@ -36,6 +38,8 @@ def _make_state(messages, tasks=None):
     state = MagicMock()
     state.values = {"messages": messages}
     state.tasks = tasks or []
+    state.next = []
+    state.metadata = {"writes": {}}
     return state
 
 
@@ -51,12 +55,84 @@ def _make_input(
     inp.state = {}
     inp.tools = []
     inp.context = []
+    inp.run_id = "run-1"
     inp.forwarded_props = forwarded_props or {}
     return inp
 
 
+async def _empty_stream():
+    if False:
+        yield None
+
+
 class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase):
     """Interrupt resumes must bypass the regenerate heuristic (#1743)."""
+
+    async def test_handle_stream_events_uses_forwarded_node_name_for_continue_mode(self):
+        """A no-resume request with node_name should continue from that node."""
+        agent = make_agent()
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+        ]
+        initial_state = _make_state(messages=checkpoint_messages)
+        agent.graph.aget_state = AsyncMock(return_value=initial_state)
+        agent.graph.astream_events.return_value = _empty_stream()
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+            UserMessage(id="h2", role="user", content="follow up"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"node_name": "approval_node"},
+        )
+
+        collected = []
+        async for event in agent._handle_stream_events(inp):
+            collected.append(event)
+
+        agent.graph.aupdate_state.assert_awaited_once()
+        self.assertEqual(
+            agent.graph.aupdate_state.await_args.kwargs.get("as_node"),
+            "approval_node",
+        )
+
+    async def test_interrupt_none_resume_with_node_name_does_not_emit_unmatched_step(self):
+        """Short-circuit interrupt replay must not start a step it never finishes."""
+        agent = make_agent()
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        initial_state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="confirm?")])],
+        )
+        agent.graph.aget_state = AsyncMock(return_value=initial_state)
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"node_name": "approval_node", "command": {"resume": None}},
+        )
+
+        events = []
+        async for event in agent._handle_stream_events(inp):
+            events.append(event)
+
+        types = [getattr(event, "type", None) for event in events]
+        self.assertNotIn(EventType.STEP_STARTED, types)
+        self.assertNotIn(EventType.STEP_FINISHED, types)
+        self.assertEqual(types.count(EventType.RUN_STARTED), 1)
+        self.assertEqual(types.count(EventType.RUN_FINISHED), 1)
 
     async def test_resume_with_interrupt_does_not_regenerate(self):
         """Core regression: checkpoint has more messages than frontend
@@ -94,6 +170,136 @@ class TestPrepareStreamInterruptResumeOrdering(unittest.IsolatedAsyncioTestCase)
 
         agent.prepare_regenerate_stream.assert_not_awaited()
         self.assertIsNotNone(result.get("stream"))
+
+        stream_input = agent.graph.astream_events.call_args.kwargs["input"]
+        self.assertIsInstance(stream_input, Command)
+        self.assertEqual(stream_input.resume, "yes")
+
+    async def test_falsy_resume_payloads_with_interrupt_are_treated_as_present(self):
+        """Non-None resume payloads, not truthiness, should select Command(resume=...)."""
+        falsy_payloads = [False, 0, "", {}, []]
+
+        for payload in falsy_payloads:
+            with self.subTest(payload=payload):
+                agent = make_agent()
+                agent.active_run = {"id": "run-1", "mode": "start"}
+
+                checkpoint_messages = [
+                    HumanMessage(id="h1", content="do something"),
+                    AIMessage(
+                        id="ai1",
+                        content="",
+                        tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+                    ),
+                ]
+                state = _make_state(
+                    messages=checkpoint_messages,
+                    tasks=[FakeTask(interrupts=[FakeInterrupt(value={"question": "Approve?"})])],
+                )
+
+                frontend_messages = [
+                    UserMessage(id="h1", role="user", content="do something"),
+                ]
+                inp = _make_input(
+                    messages=frontend_messages,
+                    forwarded_props={"command": {"resume": payload}},
+                )
+
+                agent.prepare_regenerate_stream = AsyncMock()
+                config = {"configurable": {"thread_id": "t1"}}
+
+                result = await agent.prepare_stream(inp, state, config)
+
+                agent.prepare_regenerate_stream.assert_not_awaited()
+                agent.graph.aupdate_state.assert_not_called()
+                self.assertIsNotNone(result.get("stream"))
+
+                stream_input = agent.graph.astream_events.call_args.kwargs["input"]
+                self.assertIsInstance(stream_input, Command)
+                self.assertEqual(stream_input.resume, payload)
+
+    async def test_none_resume_payload_with_interrupt_is_treated_as_absent(self):
+        """resume=None follows the no-resume interrupt replay path."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="do something"),
+            AIMessage(
+                id="ai1",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="confirm?")])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="do something"),
+        ]
+        inp = _make_input(
+            messages=frontend_messages,
+            forwarded_props={"command": {"resume": None}},
+        )
+
+        agent.prepare_regenerate_stream = AsyncMock()
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_not_awaited()
+        agent.graph.astream_events.assert_not_called()
+        agent.graph.aupdate_state.assert_not_called()
+        self.assertIsNone(result.get("stream"))
+
+        events = result.get("events_to_dispatch", [])
+        types = [getattr(e, "type", None) for e in events]
+        self.assertIn(EventType.RUN_STARTED, types)
+        self.assertIn(EventType.CUSTOM, types)
+        self.assertIn(EventType.RUN_FINISHED, types)
+
+    async def test_interrupt_without_resume_still_allows_regenerate_heuristic(self):
+        """Active interrupts must not globally suppress the edit/regenerate path."""
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "mode": "start"}
+
+        checkpoint_messages = [
+            HumanMessage(id="h1", content="original"),
+            AIMessage(id="ai1", content="first answer"),
+            HumanMessage(id="h2", content="regenerate from here"),
+            AIMessage(
+                id="ai2",
+                content="",
+                tool_calls=[{"id": "tc-1", "name": "approval", "args": {}}],
+            ),
+        ]
+        state = _make_state(
+            messages=checkpoint_messages,
+            tasks=[FakeTask(interrupts=[FakeInterrupt(value="pending approval")])],
+        )
+
+        frontend_messages = [
+            UserMessage(id="h1", role="user", content="original"),
+            UserMessage(id="h-edited", role="user", content="edited earlier"),
+            UserMessage(id="h2", role="user", content="regenerate from here"),
+        ]
+        inp = _make_input(messages=frontend_messages, forwarded_props={})
+
+        prepared_regenerate = {
+            "stream": "regenerate-stream",
+            "state": {"messages": checkpoint_messages},
+            "config": {"configurable": {"thread_id": "t1"}},
+        }
+        agent.prepare_regenerate_stream = AsyncMock(return_value=prepared_regenerate)
+        config = {"configurable": {"thread_id": "t1"}}
+
+        result = await agent.prepare_stream(inp, state, config)
+
+        agent.prepare_regenerate_stream.assert_awaited_once()
+        self.assertIs(result, prepared_regenerate)
+        agent.graph.aupdate_state.assert_not_called()
 
     async def test_interrupt_without_resume_dispatches_interrupt_events(self):
         """When there's an active interrupt but no resume value, the agent


### PR DESCRIPTION
Fixes #1743

## Summary

This fixes LangGraph interrupt resume handling without suppressing unrelated edit/regenerate flows or mutating checkpoint messages in place.

The original failure mode was that `prepare_stream` compared checkpoint and frontend message counts before honoring an active interrupt. During an interrupt, the checkpoint can contain an AI tool-call message that the frontend never received, so the count check incorrectly entered the regenerate path and destroyed the interrupt state before `Command(resume=...)` could run.

## Final Behavior

- Explicit non-`None` `forwarded_props.command.resume` values are treated as resume input. Falsy values such as `false`, `0`, empty string, `{}`, and `[]` remain valid resume payloads.
- `resume: None` is treated as absent and follows the no-resume interrupt replay path.
- Active interrupts no longer broadly suppress edit/regenerate detection; resume bypasses regenerate, while no-resume requests can still regenerate when they are actual edits.
- Interrupt replay short-circuits without emitting unmatched step lifecycle events.
- Checkpoint cleanup repairs are non-mutating: repaired `AIMessage.tool_calls[*].args` and orphan `ToolMessage.content` are returned as replacement messages instead of mutating saved checkpoint objects.

## Commit Structure

Commits were rewritten by area of concern:

- `eda0a584` - original interrupt-resume fix by Ueslei
- `438bb00d` - lifecycle and falsy/absent resume hardening by Jordan
- `9f3fc14b` - checkpoint non-mutation repairs by Jordan

## Test Plan

- `uv run python -m unittest tests.test_orphan_tool_message_merge tests.test_prepare_stream_interrupt_resume -v` - 18 tests passed
- `uv run python -m unittest discover tests -v` - 164 tests passed
- `uv build` - package build passed
- `git diff --check origin/main..HEAD -- integrations/langgraph/python/ag_ui_langgraph/agent.py integrations/langgraph/python/tests/test_prepare_stream_interrupt_resume.py integrations/langgraph/python/tests/test_orphan_tool_message_merge.py` - passed

## Notes

The branch was force-updated to drop the merge-from-main commit and keep the PR history linear while preserving authorship for the contributor-owned fix.