### PR TITLE
fix(adk-middleware): defer LRO ID remap writes until runner finishes (#1754)

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -2035,6 +2035,13 @@ class ADKAgent:
             long_running_tool_ids = set()
         runner: Optional[Runner] = None
         backend_session_id: Optional[str] = None
+        # Buffer LRO ID remap updates discovered during the runner loop.
+        # Flushed once in the finally block AFTER runner.run_async has
+        # finished, so the mid-runner session-state write that would
+        # otherwise trip DatabaseSessionService's OCC check on ADK >= 1.27
+        # never happens. See issue #1754 (same shape as #1732, different
+        # writer that PR #1735's consumer-side fix can't reach).
+        pending_lro_id_remap: Dict[str, str] = {}
         logger.debug(f"[BG_EXEC] _run_adk_in_background called for thread={input.thread_id}")
         logger.debug(f"[BG_EXEC]   tool_results={len(tool_results) if tool_results else 0}, message_batch={len(message_batch) if message_batch else 0}")
         try:
@@ -2491,12 +2498,13 @@ class ADKAgent:
                     if not event_partial:
                         # Capture LRO ID remapping: the final (persisted) event
                         # may carry different function-call IDs than the partial
-                        # event we already emitted to the client.
+                        # event we already emitted to the client. Buffer here
+                        # and flush in finally; writing mid-runner would bump
+                        # the session row's storage marker and trip OCC on
+                        # ADK's next ``append_event`` (issue #1754).
                         lro_remap = self._extract_lro_id_remap(adk_event, event_translator)
                         if lro_remap:
-                            await self._store_lro_id_remap(
-                                lro_remap, backend_session_id, app_name, user_id
-                            )
+                            pending_lro_id_remap.update(lro_remap)
 
                         logger.info(
                             f"Received non-partial event during LRO drain, persistence complete "
@@ -2598,12 +2606,13 @@ class ADKAgent:
                     # Capture LRO ID remapping from non-partial events.
                     # The final (persisted) event may carry different function-call
                     # IDs than the partial event we already emitted to the client.
+                    # Buffer here and flush in finally; writing mid-runner would
+                    # bump the session row's storage marker and trip OCC on ADK's
+                    # next ``append_event`` (issue #1754).
                     if has_lro_function_call and not event_partial:
                         lro_remap = self._extract_lro_id_remap(adk_event, event_translator)
                         if lro_remap:
-                            await self._store_lro_id_remap(
-                                lro_remap, backend_session_id, app_name, user_id
-                            )
+                            pending_lro_id_remap.update(lro_remap)
 
                     # Hard stop the execution if we find any long running tool
                     # AND the agent is NOT using ADK's native resumability.
@@ -2781,6 +2790,26 @@ class ADKAgent:
                             input.thread_id,
                             close_error,
                         )
+
+            # Flush any LRO ID remap captured during the runner loop. This
+            # runs after the runner has been closed, so the
+            # ``update_session_state`` write can't trip OCC against ADK's
+            # in-memory ``invocation_context.session``. See issue #1754.
+            if pending_lro_id_remap and backend_session_id is not None:
+                try:
+                    await self._store_lro_id_remap(
+                        pending_lro_id_remap,
+                        backend_session_id,
+                        app_name,
+                        user_id,
+                    )
+                except Exception as flush_error:
+                    logger.warning(
+                        "Failed to flush LRO ID remap on runner exit "
+                        "(thread=%s): %s",
+                        input.thread_id,
+                        flush_error,
+                    )
 
             # Drop any pending per-invocation `temp:` state so a later run on
             # the same session does not inherit stale values (e.g. a rotated

--- a/integrations/adk-middleware/python/tests/test_lro_sse_id_remap.py
+++ b/integrations/adk-middleware/python/tests/test_lro_sse_id_remap.py
@@ -18,11 +18,14 @@ Integration tests require GOOGLE_API_KEY or Vertex AI auth.
 
 import asyncio
 import json
+import logging
 import os
 import uuid
 import warnings
 import pytest
-from typing import Dict, List, Optional
+import pytest_asyncio
+from pathlib import Path
+from typing import AsyncGenerator, Dict, List, Optional
 from unittest.mock import MagicMock, AsyncMock, patch
 
 from ag_ui.core import (
@@ -1241,6 +1244,310 @@ class TestLROSSEIdRemapIntegration:
         assert "RUN_ERROR" not in run2_types, (
             f"Baseline (no streaming) failed. Events: {run2_types}"
         )
+
+
+# =============================================================================
+# Stale-session regression for the lro_tool_call_id_remap writer (issue #1754)
+# =============================================================================
+
+# The middleware writes ``lro_tool_call_id_remap`` to ``session.state`` from
+# inside the producer's ``async for adk_event in runner.run_async(...)`` loop
+# in ``_run_adk_in_background`` (``adk_agent.py:2497`` LRO drain branch and
+# ``:2604`` main branch). That write goes through ``update_session_state`` ->
+# ``session_service.append_event``, which bumps the storage marker on the
+# session row that ADK's Runner still holds in ``invocation_context.session``.
+# On resumable HITL (``ResumabilityConfig(is_resumable=True)``) ADK does NOT
+# hard-stop the runner after the LRO event, so a subsequent ADK
+# ``append_event`` on the stale in-memory session raises
+# ``ValueError: The session has been modified in storage since it was loaded``
+# from ``DatabaseSessionService``'s OCC check (ADK >= 1.27).
+#
+# Same OCC failure shape as #1732, but a separate writer that PR #1735's
+# consumer-side fix can't reach (the writes live inside the producer task).
+# See follow-up issue #1754.
+
+
+_STALE_MARKER_1754 = (
+    "The session has been modified in storage since it was loaded"
+)
+
+
+class _StaleSessionDetector1754(logging.Handler):
+    """Catch the stale-session ValueError surfaced through the adk_agent logger.
+
+    The ValueError is raised by ADK's runner
+    (``DatabaseSessionService.append_event``) and propagates out of the
+    background task, where ``_run_adk_in_background`` logs it via
+    ``logger.error('Background execution error: ...', exc_info=True)`` before
+    emitting a ``RunErrorEvent``. We listen on the root logger for the marker
+    string so the test can detect the bug from outside ADKAgent.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        self.tripped: bool = False
+        self.first: Optional[str] = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = record.getMessage()
+        if _STALE_MARKER_1754 in msg:
+            self.tripped = True
+            if self.first is None:
+                self.first = f"{record.name}: {msg}"
+
+
+def _make_db_url_1754(tmp_path: Path) -> str:
+    """Default to a temporary sqlite+aiosqlite file (same OCC code path as
+    Postgres). Override with ``AGUI_DATABASE_URL`` to run against a real
+    Postgres in CI/local."""
+    override = os.getenv("AGUI_DATABASE_URL")
+    if override:
+        return override
+    db_path = tmp_path / f"repro_1754_{uuid.uuid4().hex}.db"
+    return f"sqlite+aiosqlite:///{db_path}"
+
+
+# Backend tool callable used by the deterministic scripted-LLM test. Returning
+# a result (not None) is required: it forces ADK to build a function_response
+# event AFTER the LRO event, which is the subsequent ``append_event`` call
+# that exposes the stale in-memory session marker.
+def log_action(action: str = "") -> str:
+    """Backend tool callable used by the deterministic #1754 test."""
+    return f"logged: {action}"
+
+
+def _scripted_lro_plus_backend_llm(backend_tool_name: str, frontend_tool_name: str):
+    """Stub LLM that emits the exact event shape needed to trip #1754.
+
+    Drives a single turn that yields:
+      1. ``partial=True`` with two parallel ``function_call`` parts (the
+         backend tool plus the frontend tool). Both calls are emitted
+         without IDs, so ADK's ``populate_client_function_call_id``
+         assigns fresh UUIDs.
+      2. ``partial=False`` with the same two function_call parts. ADK
+         assigns NEW UUIDs again — divergent from chunk #1.
+
+    The middleware's ``_extract_lro_id_remap`` sees the chunk-1 → chunk-2
+    ID divergence and calls ``_store_lro_id_remap`` mid-runner (the bug
+    site). ADK then dispatches both tools: the backend tool returns a
+    result, so ADK builds a ``function_response`` event and calls
+    ``append_event`` on it — that's the subsequent ADK write that fails
+    OCC because the in-memory session is now stale.
+    """
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types as genai_types
+
+    class _ScriptedLroPlusBackend(BaseLlm):
+        backend_tool: str = backend_tool_name
+        frontend_tool: str = frontend_tool_name
+
+        async def generate_content_async(
+            self, llm_request, stream: bool = False
+        ) -> AsyncGenerator[LlmResponse, None]:
+            def _make_response(*, partial: bool) -> LlmResponse:
+                return LlmResponse(
+                    content=genai_types.Content(
+                        role="model",
+                        parts=[
+                            genai_types.Part(
+                                function_call=genai_types.FunctionCall(
+                                    name=self.backend_tool,
+                                    args={"action": "archive_files"},
+                                )
+                            ),
+                            genai_types.Part(
+                                function_call=genai_types.FunctionCall(
+                                    name=self.frontend_tool,
+                                    args={"action": "archive_files"},
+                                )
+                            ),
+                        ],
+                    ),
+                    partial=partial,
+                    turn_complete=not partial,
+                )
+
+            # Chunk: ADK skips function_call execution for partial=True
+            # but the middleware still translates these into TOOL_CALL_*
+            # events, populating ``lro_emitted_ids_by_name`` with id_A.
+            yield _make_response(partial=True)
+            # Final: ADK assigns NEW UUIDs (id_B), appends this event,
+            # then dispatches both tools and builds the function_response.
+            yield _make_response(partial=False)
+
+    return _ScriptedLroPlusBackend(model="scripted-lro-plus-backend")
+
+
+class TestLroIdRemapStaleSessionRegression:
+    """Deterministic regression test for issue #1754.
+
+    Drives a resumable HITL turn with a scripted LLM that emits a
+    partial -> final pair containing parallel function_calls (one
+    backend, one frontend). The scripted shape guarantees:
+
+      - LRO ID divergence between partial and final events (because ADK
+        assigns fresh UUIDs to function_calls without explicit IDs each
+        time ``populate_client_function_call_id`` runs).
+      - The middleware calls ``_store_lro_id_remap`` mid-runner.
+      - ADK builds a ``function_response`` event for the backend tool
+        AFTER the middleware's write, then calls ``append_event`` on it.
+        That second ADK ``append_event`` is where the stale in-memory
+        session triggers the OCC error.
+
+    Real ADK runner + real ``DatabaseSessionService`` are used so the
+    OCC check actually fires. No real LLM is needed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_session_manager(self):
+        SessionManager.reset_instance()
+        yield
+        SessionManager.reset_instance()
+
+    @pytest_asyncio.fixture
+    async def detector(self):
+        handler = _StaleSessionDetector1754()
+        root = logging.getLogger()
+        prev_level = root.level
+        root.addHandler(handler)
+        root.setLevel(logging.ERROR)
+        try:
+            yield handler
+        finally:
+            root.removeHandler(handler)
+            root.setLevel(prev_level)
+
+    @pytest.mark.asyncio
+    async def test_resumable_hitl_lro_remap_does_not_trip_stale_session(
+        self, detector, tmp_path
+    ):
+        """End-to-end #1754 reproducer.
+
+        Without the producer-side buffer-and-flush fix, this test fails
+        with ``ValueError: The session has been modified in storage since
+        it was loaded`` — same shape as #1732, different writer.
+        """
+        from ag_ui_adk.agui_toolset import AGUIToolset
+        from google.adk.agents import LlmAgent
+        from google.adk.apps import App, ResumabilityConfig
+        from google.adk.sessions import DatabaseSessionService
+
+        db_url = _make_db_url_1754(tmp_path)
+        session_service = DatabaseSessionService(db_url=db_url)
+        app_name = f"repro_1754_{uuid.uuid4().hex[:8]}"
+
+        frontend_tool = AGUITool(
+            name="approve_action",
+            description="Ask the user to approve an action.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string"},
+                },
+                "required": ["action"],
+            },
+        )
+
+        scripted_model = _scripted_lro_plus_backend_llm(
+            backend_tool_name="log_action",
+            frontend_tool_name="approve_action",
+        )
+
+        agent = LlmAgent(
+            name="hitl_lro_remap_agent",
+            model=scripted_model,
+            instruction="Call the tools when asked.",
+            # ``log_action`` is a real Python callable -> wrapped as
+            # a regular FunctionTool (is_long_running=False) by ADK.
+            # ``AGUIToolset()`` is the placeholder swapped at runtime
+            # for ClientProxyToolset built from RunAgentInput.tools.
+            tools=[log_action, AGUIToolset()],
+        )
+
+        adk_app = App(
+            name=app_name,
+            root_agent=agent,
+            resumability_config=ResumabilityConfig(is_resumable=True),
+        )
+
+        adk_agent = ADKAgent.from_app(
+            adk_app,
+            user_id="user_1",
+            session_service=session_service,
+        )
+
+        thread_id = f"thread_{uuid.uuid4().hex[:8]}"
+        events: List[BaseEvent] = []
+        saw_run_error = False
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            async for event in adk_agent.run(
+                RunAgentInput(
+                    thread_id=thread_id,
+                    run_id=str(uuid.uuid4()),
+                    state={},
+                    messages=[
+                        UserMessage(
+                            id=str(uuid.uuid4()),
+                            content="Please archive the project files.",
+                        )
+                    ],
+                    tools=[frontend_tool],
+                    context=[],
+                    forwarded_props={},
+                )
+            ):
+                events.append(event)
+                if type(event).__name__ == "RunErrorEvent":
+                    saw_run_error = True
+                    logging.getLogger(__name__).error(
+                        f"RunErrorEvent: code={getattr(event, 'code', None)} "
+                        f"message={getattr(event, 'message', None)}"
+                    )
+
+        # (1) The #1754 regression assertion. Without the producer-side
+        # fix, _store_lro_id_remap bumps the DB version mid-runner and
+        # ADK's next append_event (for the backend tool's function_response)
+        # raises the OCC ValueError, which gets logged by
+        # _run_adk_in_background as "Background execution error: ...".
+        assert not detector.tripped, (
+            f"Stale-session error logged during resumable HITL + LRO-remap "
+            f"turn: {detector.first}. This is the regression from issue "
+            f"#1754 (same OCC shape as #1732, different writer)."
+        )
+
+        # (2) No RUN_ERROR surfaces to the client.
+        assert not saw_run_error, (
+            "RunErrorEvent surfaced from resumable HITL + LRO-remap turn — "
+            "#1754 regression. Check test logs for the underlying "
+            "ValueError message."
+        )
+
+        # (3) If a remap was captured (chunk-1 IDs differ from chunk-2),
+        # it must be persisted by run-end so future tool-result
+        # submissions can translate the client-facing IDs back to
+        # ADK-persisted IDs.
+        metadata = adk_agent._get_session_metadata(thread_id, "user_1")
+        if metadata is None:
+            return
+        session_id, lookup_app_name, user_id = metadata
+        session = await session_service.get_session(
+            session_id=session_id,
+            app_name=lookup_app_name,
+            user_id=user_id,
+        )
+        assert session is not None
+        stored_remap = session.state.get("lro_tool_call_id_remap", {})
+        assert isinstance(stored_remap, dict), (
+            f"lro_tool_call_id_remap must be a dict; got {type(stored_remap)}"
+        )
+        for k, v in stored_remap.items():
+            assert isinstance(k, str) and isinstance(v, str), (
+                f"lro_tool_call_id_remap entries must be str->str; got "
+                f"{type(k)}->{type(v)}"
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Closes #1754.

`_store_lro_id_remap` is called from inside `_run_adk_in_background`'s `async for adk_event in runner.run_async(...)` loop at two sites ([adk_agent.py:2497](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py#L2497) LRO drain branch and [:2604](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py#L2604) main branch). That write goes through `update_session_state` → `session_service.append_event`, which bumps the storage marker on the session row ADK's Runner still holds in `invocation_context.session`. On resumable HITL (`ResumabilityConfig(is_resumable=True)`), ADK does not hard-stop after the LRO event, and its subsequent `append_event` (e.g. for a parallel backend tool's `function_response`) raises:

```
ValueError: The session has been modified in storage since it was loaded.
Please reload the session before appending more events.
```

This is the same OCC failure shape as #1732 (PR #1735 fixed), but a separate writer in the producer task that the consumer-side `await execution.task` gate cannot reach.

## Fix

Buffer remap updates in a local `pending_lro_id_remap: Dict[str, str]` during the runner loop, and flush them once in the function's `finally` block after the runner has been closed. The flush goes through the same `_store_lro_id_remap` path but executes after ADK no longer holds the in-memory session, so no OCC violation can occur. Multiple captured remaps are merged into a single batched write.

Same shape as the recommendation in #1754's body — mirrors PR #1735's principle ("defer state writes until the Runner is no longer touching the session") on the producer side.

## Test plan

Adds a **deterministic regression test** in `tests/test_lro_sse_id_remap.py::TestLroIdRemapStaleSessionRegression` that reproduces the exact `#1754` traceback against a real ADK runner without needing a live LLM:

- Scripted LLM emits `partial=True` + `partial=False` LlmResponses, each containing parallel `function_call` parts (backend `log_action` + frontend `approve_action`) with no IDs set.
- ADK's `populate_client_function_call_id` assigns fresh UUIDs on each chunk → LRO ID divergence.
- Middleware calls `_store_lro_id_remap` mid-runner.
- ADK builds a `function_response` event for the backend tool AFTER the middleware's write.
- ADK's `_exec_with_plugin.append_event` for that function_response trips OCC.

The scripted setup forces all the conditions reliably — no real Gemini call needed.

**Verification:**

- [x] Test reproduces the bug with the fix reverted (exact traceback at `ag_ui_adk/adk_agent.py:2453` matches the #1754 issue body's pattern)
- [x] Test passes with the fix in place
- [x] `tests/test_lro_sse_id_remap.py` — **21 passed**
- [x] HITL-related suites (`test_pending_tool_calls_gating.py`, `test_multi_instance_hitl.py`, `test_lro_sse_persistence.py`, `test_resumability_config.py`, `test_lro_tool_response_persistence.py`) — **55 passed**
- [x] Full suite — **806 passed, 1 skipped**

## Related

- Companion to #1732 / PR #1735 (same OCC mechanism, different writer)
- #1753 covers the #1732 regression test (the consumer-side writer); this PR covers the producer-side writer
- #1755 (streaming-fidelity improvement) is the natural follow-up — moving HITL `pending_tool_calls` persistence producer-side would unify both writes through the same `finally`-block flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)