### PR TITLE
fix(adk-middleware): move HITL persistence producer-side to preserve streaming fidelity (#1755)

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -78,6 +78,82 @@ from .utils.converters import convert_message_content_to_parts
 import logging
 logger = logging.getLogger(__name__)
 
+
+class _HitlDeferringQueue(asyncio.Queue):
+    """``asyncio.Queue`` that defers HITL ``ToolCallEndEvent``s.
+
+    Why: writing ``pending_tool_calls`` to ``session.state`` while ADK's
+    Runner still owns its in-memory session trips
+    ``DatabaseSessionService``'s OCC check on ADK >= 1.27 (issue #1732).
+    PR #1735 fixed that by making the consumer ``await execution.task``
+    before persisting, but that approach buffers every event after the
+    first HITL ``TOOL_CALL_END`` in ``event_queue`` until the producer
+    exits — losing streaming fidelity for non-HITL events that arrive
+    afterwards (parallel tool calls, post-LRO text, backend tool
+    results in resumable HITL).
+
+    This queue defers ONLY the HITL ``ToolCallEndEvent`` itself. All
+    other events stream live. The producer flushes the deferred TCEs
+    once it has persisted the matching IDs to ``session.state`` — see
+    ``_run_adk_in_background``. Putting the completion sentinel
+    (``None``) implicitly flushes any remaining deferred TCEs, so the
+    consumer sees them before the stream ends.
+
+    The release-on-result branch handles the edge case of a tool that
+    is marked HITL but resolves in-stream: when a ``ToolCallResultEvent``
+    for a deferred id arrives, the buffered TCE is released
+    immediately (preserving TCE→Result ordering on the wire) and
+    removed from the deferred set so it is not persisted at flush time.
+    """
+
+    def __init__(self, long_running_tool_ids: Set[str]) -> None:
+        super().__init__()
+        self._long_running_tool_ids = long_running_tool_ids
+        self._deferred_hitl_ends: Dict[str, "ToolCallEndEvent"] = {}
+
+    async def put(self, item):  # type: ignore[override]
+        # ``None`` is the completion sentinel; release any remaining
+        # deferred TCEs first so the consumer sees them before the
+        # stream ends.
+        if item is None:
+            await self.flush_deferred()
+            await super().put(item)
+            return
+
+        # Defer HITL TOOL_CALL_END events until the producer has
+        # persisted the corresponding ``pending_tool_calls`` entry.
+        if isinstance(item, ToolCallEndEvent) and (
+            item.tool_call_id in self._long_running_tool_ids
+        ):
+            self._deferred_hitl_ends[item.tool_call_id] = item
+            return
+
+        # Tools marked HITL but resolving in-stream: release the
+        # buffered TCE first so the client sees TCE→Result in order,
+        # and remove the id from the deferred set so it is not
+        # persisted at flush time (the result implies no client-side
+        # continuation, so the cross-pod handoff invariant from #1581
+        # is moot for this id).
+        if isinstance(item, ToolCallResultEvent) and (
+            item.tool_call_id in self._deferred_hitl_ends
+        ):
+            deferred_end = self._deferred_hitl_ends.pop(item.tool_call_id)
+            await super().put(deferred_end)
+
+        await super().put(item)
+
+    @property
+    def deferred_hitl_ids(self) -> List[str]:
+        """Tool call IDs still buffered (not yet released)."""
+        return list(self._deferred_hitl_ends.keys())
+
+    async def flush_deferred(self) -> None:
+        """Release all buffered HITL TCEs onto the underlying queue."""
+        for event in list(self._deferred_hitl_ends.values()):
+            await super().put(event)
+        self._deferred_hitl_ends.clear()
+
+
 class ADKAgent:
     """Middleware to bridge AG-UI Protocol with Google ADK agents.
     
@@ -612,6 +688,40 @@ class ADKAgent:
         # Use thread_id as default (assumes thread per user)
         return f"thread_user_{input.thread_id}"
     
+    async def _finalize_hitl_buffer(
+        self,
+        event_queue,
+        thread_id: str,
+        app_name: str,
+        user_id: str,
+    ) -> None:
+        """Persist any HITL pending_tool_calls IDs buffered in the queue.
+
+        Used by ``_run_adk_in_background`` to flush HITL persistence work
+        right before signalling completion or returning early. The matching
+        deferred ``ToolCallEndEvent`` instances stay in the queue's buffer
+        until a subsequent ``put(None)`` (or explicit ``flush_deferred``)
+        releases them onto the underlying queue — that ordering preserves
+        PR #1581's invariant ("persist before the client sees the event").
+
+        Idempotent: safe to call multiple times. No-op when ``event_queue``
+        is not a :class:`_HitlDeferringQueue` or has no deferred events.
+        See issue #1755.
+        """
+        if not isinstance(event_queue, _HitlDeferringQueue):
+            return
+        for hitl_tool_call_id in list(event_queue.deferred_hitl_ids):
+            try:
+                await self._add_pending_tool_call_with_context(
+                    thread_id, hitl_tool_call_id, app_name, user_id
+                )
+            except Exception as persist_error:
+                logger.error(
+                    f"Failed to persist HITL pending_tool_call "
+                    f"{hitl_tool_call_id} for thread {thread_id}: "
+                    f"{persist_error}"
+                )
+
     async def _add_pending_tool_call_with_context(self, thread_id: str, tool_call_id: str, app_name: str, user_id: str):
         """Add a tool call to the session's pending list for HITL tracking.
 
@@ -1698,44 +1808,17 @@ class ADKAgent:
             # Stream events and track tool calls
             logger.debug(f"Starting to stream events for execution {execution.thread_id}")
             app_name = self._get_app_name(input)
-            tool_call_ids: List[str] = []
 
             logger.debug(f"About to iterate over _stream_events for execution {execution.thread_id}")
             async for event in self._stream_events(execution):
-                # Register HITL tool calls in the backend session store BEFORE
-                # yielding ToolCallEndEvent. Otherwise a horizontally-scaled
-                # deployment can race: the client receives the event, posts the
-                # tool result to a different pod, and that pod sees an empty
-                # pending_tool_calls list because this pod hasn't written yet.
-                # See issue #1581.
-                #
-                # Only persist pending_tool_calls for *HITL* tool calls — i.e.
-                # those flagged in execution.long_running_tool_ids by the
-                # producer (ADK Event.long_running_tool_ids) or by
-                # ClientProxyTool. In-stream backend tools resolve on this same
-                # pod and never need the cross-pod handoff; writing to
-                # session.state for them just trips DatabaseSessionService's
-                # storage-update marker while the ADK Runner is mid-stream.
-                # See issue #1652.
-                if isinstance(event, ToolCallEndEvent):
-                    is_hitl = event.tool_call_id in execution.long_running_tool_ids
-                    logger.info(
-                        f"Detected ToolCallEndEvent with id: {event.tool_call_id} "
-                        f"(hitl={is_hitl})"
-                    )
-                    if is_hitl:
-                        # ADK 1.27+ DatabaseSessionService rejects session writes
-                        # while the runner still owns an in-flight append_event.
-                        if not execution.task.done():
-                            logger.debug(
-                                "Waiting for ADK runner to finish before persisting "
-                                f"HITL pending_tool_calls for {event.tool_call_id}"
-                            )
-                            await execution.task
-                        tool_call_ids.append(event.tool_call_id)
-                        await self._add_pending_tool_call_with_context(
-                            execution.thread_id, event.tool_call_id, app_name, user_id
-                        )
+                # HITL pending_tool_calls persistence happens on the producer
+                # side via _HitlDeferringQueue: HITL TOOL_CALL_END events are
+                # buffered until the producer's persistence write completes
+                # after runner.run_async exits. By the time the consumer
+                # observes a ToolCallEndEvent here, the corresponding
+                # pending_tool_calls entry is already in session.state (or
+                # the event was a non-HITL TCE that doesn't need persistence
+                # at all). See issues #1581, #1652, #1732, and #1755.
 
                 # Always mark tool_call_id as processed when its result is
                 # observed, so replay logic skips it on resumption (fixes #437
@@ -1746,18 +1829,6 @@ class ADKAgent:
                     self._session_manager.mark_messages_processed(
                         app_name, execution.thread_id, [event.tool_call_id]
                     )
-
-                    # Backend tools complete within the same stream and emit a
-                    # ToolCallResultEvent — no client continuation is expected,
-                    # so remove the just-registered ID from the pending list.
-                    # Only IDs we actually persisted above appear in
-                    # tool_call_ids, so this naturally skips backend tools that
-                    # never went through _add_pending_tool_call_with_context.
-                    if event.tool_call_id in tool_call_ids:
-                        tool_call_ids.remove(event.tool_call_id)
-                        await self._remove_pending_tool_call(
-                            execution.thread_id, event.tool_call_id, user_id
-                        )
 
                 logger.debug(f"Yielding event: {type(event).__name__}")
                 yield event
@@ -1865,7 +1936,19 @@ class ADKAgent:
         Returns:
             ExecutionState tracking the background execution
         """
-        event_queue = asyncio.Queue()
+        # Shared set of HITL (long-running) tool call IDs. Populated by the
+        # producer side (EventTranslator's LRO branch in
+        # _run_adk_in_background and ClientProxyTool) BEFORE TOOL_CALL_END is
+        # enqueued, so the deferring queue (next line) can identify HITL
+        # ends at put time. See issues #1652 and #1755.
+        long_running_tool_ids: set[str] = set()
+
+        # Wrap the inner asyncio.Queue with _HitlDeferringQueue so HITL
+        # ToolCallEndEvents are held back until the producer has persisted
+        # the matching pending_tool_calls IDs. Non-HITL events stream
+        # through unblocked, restoring the streaming fidelity that PR
+        # #1735's consumer-side gate sacrificed. See issue #1755.
+        event_queue: _HitlDeferringQueue = _HitlDeferringQueue(long_running_tool_ids)
         logger.debug(f"Created event queue {id(event_queue)} for thread {input.thread_id}")
         # Extract necessary information
         user_id = self._get_user_id(input)
@@ -1966,15 +2049,6 @@ class ADKAgent:
                     _update_agent_tools_recursive(sub_agent)
 
         _update_agent_tools_recursive(adk_agent)
-
-        # Shared set of HITL (long-running) tool call IDs. Populated by the
-        # producer side (EventTranslator's LRO branch in _run_adk_in_background
-        # and ClientProxyTool) before TOOL_CALL_END is enqueued. The consumer
-        # in _run_new_execution reads it via ExecutionState to decide whether
-        # to persist pending_tool_calls to session.state — only HITL calls
-        # need the cross-pod handoff that pending_tool_calls provides.
-        # See issue #1652.
-        long_running_tool_ids: set[str] = set()
 
         # Create background task
         logger.debug(f"Creating background task for thread {input.thread_id}")
@@ -2502,6 +2576,14 @@ class ADKAgent:
                             f"Received non-partial event during LRO drain, persistence complete "
                             f"(thread={input.thread_id})"
                         )
+                        # #1755: persist any buffered HITL pending_tool_calls
+                        # IDs, then signal completion so the deferring queue
+                        # flushes the deferred TCE(s) onto the underlying
+                        # queue before the consumer exits.
+                        await self._finalize_hitl_buffer(
+                            event_queue, input.thread_id, app_name, user_id
+                        )
+                        await event_queue.put(None)
                         return
                     else:
                         # Still partial, keep draining
@@ -2649,6 +2731,17 @@ class ADKAgent:
                                 f"LRO detected with partial=False, persistence already complete "
                                 f"(thread={input.thread_id})"
                             )
+                            # #1755: persist any buffered HITL
+                            # pending_tool_calls IDs, then signal
+                            # completion so the deferring queue flushes
+                            # deferred TCE(s) before the consumer exits.
+                            await self._finalize_hitl_buffer(
+                                event_queue,
+                                input.thread_id,
+                                app_name,
+                                user_id,
+                            )
+                            await event_queue.put(None)
                             return
 
             # Force close any streaming messages
@@ -2749,7 +2842,14 @@ class ADKAgent:
                     )
                     logger.debug("Emitted post-confirm StateSnapshotEvent for timing separation")
 
-            # Signal completion - ADK execution is done
+            # Persist HITL pending_tool_calls IDs that the deferring queue
+            # has buffered, then signal completion. The put(None) below
+            # triggers an implicit flush via _HitlDeferringQueue.put so
+            # the consumer sees the deferred TCEs before the stream ends.
+            # See issue #1755.
+            await self._finalize_hitl_buffer(
+                event_queue, input.thread_id, app_name, user_id
+            )
             logger.debug(f"Background task sending completion signal for thread {input.thread_id}")
             await event_queue.put(None)
             logger.debug(f"Background task completion signal sent for thread {input.thread_id}")

--- a/integrations/adk-middleware/python/tests/test_multi_instance_hitl.py
+++ b/integrations/adk-middleware/python/tests/test_multi_instance_hitl.py
@@ -106,9 +106,9 @@ class TestMultiInstanceHITL:
         async def mock_run_a(*args, **kwargs):
             eq = kwargs["event_queue"]
             # Real producers register HITL tool call IDs in the shared
-            # long_running_tool_ids set BEFORE enqueuing TOOL_CALL_END so the
-            # consumer's gate persists pending_tool_calls (issue #1652).
-            # This mock represents a HITL/client tool, so honor that contract.
+            # long_running_tool_ids set BEFORE enqueuing TOOL_CALL_END so
+            # the deferring queue can identify the HITL end at put time
+            # (issues #1652, #1755).
             kwargs["long_running_tool_ids"].add(tool_call_id)
             await eq.put(ToolCallStartEvent(
                 type=EventType.TOOL_CALL_START,
@@ -124,6 +124,12 @@ class TestMultiInstanceHITL:
                 type=EventType.TOOL_CALL_END,
                 tool_call_id=tool_call_id,
             ))
+            # Simulate the real producer's pre-None persistence step
+            # (#1755 moved this work from the consumer to the producer).
+            for hitl_id in list(getattr(eq, "deferred_hitl_ids", [])):
+                await instance_a._add_pending_tool_call_with_context(
+                    thread_id, hitl_id, "test_app", "test_user"
+                )
             await eq.put(None)
 
         with patch.object(instance_a, "_run_adk_in_background", side_effect=mock_run_a):
@@ -304,6 +310,14 @@ class TestMultiInstanceHITL:
                 type=EventType.TOOL_CALL_END,
                 tool_call_id=tool_call_id,
             ))
+            # Simulate the real producer's pre-None persistence step.
+            # The _HitlDeferringQueue holds the TCE until the producer
+            # persists pending_tool_calls; ``put(None)`` then triggers
+            # an implicit flush of buffered TCEs. See issue #1755.
+            for hitl_id in list(getattr(eq, "deferred_hitl_ids", [])):
+                await instance_a._add_pending_tool_call_with_context(
+                    thread_id, hitl_id, "test_app", "test_user"
+                )
             await eq.put(None)
 
         observed_end = False
@@ -324,12 +338,14 @@ class TestMultiInstanceHITL:
     async def test_pending_tool_call_waits_for_runner_before_tool_call_end_event(
         self, instance_a, sample_tool,
     ):
-        """Regression test for #1732.
+        """Regression test for #1732 and #1755.
 
-        DatabaseSessionService in ADK 1.27+ rejects mid-run session writes. The
-        middleware must still persist pending_tool_calls before the client sees
-        ToolCallEndEvent, but only after the producer has finished its current
-        runner append_event work.
+        DatabaseSessionService in ADK 1.27+ rejects mid-run session writes.
+        With the producer-side persistence design from #1755, the producer
+        buffers the HITL TCE in ``_HitlDeferringQueue`` and persists the id
+        only AFTER ``runner.run_async`` exits. The TCE is then flushed onto
+        the queue before the completion sentinel, so the client sees the
+        event with persistence already complete.
         """
         thread_id = "stale_session_thread"
         tool_call_id = "tool_call_stale_session"
@@ -366,6 +382,14 @@ class TestMultiInstanceHITL:
             ))
             await runner_can_finish.wait()
             producer_finished = True
+            # Simulate the real producer's pre-None persistence step.
+            # _HitlDeferringQueue buffered the TCE above; the real
+            # producer iterates ``deferred_hitl_ids`` and persists each
+            # before ``put(None)`` flushes the buffered events. See #1755.
+            for hitl_id in list(getattr(eq, "deferred_hitl_ids", [])):
+                await instance_a._add_pending_tool_call_with_context(
+                    thread_id, hitl_id, "test_app", "test_user"
+                )
             await eq.put(None)
 
         async def mock_add_pending(thread_id_arg, tool_call_id_arg, app_name, user_id):
@@ -402,6 +426,141 @@ class TestMultiInstanceHITL:
 
         assert pending_persisted.is_set()
         assert any(isinstance(event, ToolCallEndEvent) for event in events)
+
+    @pytest.mark.asyncio
+    async def test_non_hitl_events_stream_live_after_hitl_tce(
+        self, instance_a, sample_tool,
+    ):
+        """Streaming-fidelity regression test for issue #1755.
+
+        PR #1735 fixed #1732 by gating the consumer until the producer
+        finishes, but that buffered EVERY event after the first HITL
+        ``ToolCallEndEvent`` in ``event_queue`` until ``runner.run_async``
+        exited. For resumable HITL with parallel tool calls or post-LRO
+        text, that turned a smooth stream into a burst at the end.
+
+        The #1755 fix defers ONLY the HITL TCE (in
+        ``_HitlDeferringQueue``); non-HITL events stream through the
+        underlying queue unblocked. This test asserts: a non-HITL event
+        enqueued AFTER a HITL TCE reaches the client BEFORE the producer
+        finishes. With PR #1735's gate in place (and without the #1755
+        wrapper), this would time out.
+        """
+        thread_id = "streaming_thread"
+        hitl_tool_call_id = "hitl_tcid"
+        non_hitl_tool_call_id = "non_hitl_tcid"
+
+        await instance_a._ensure_session_exists(
+            app_name="test_app", user_id="test_user",
+            thread_id=thread_id, initial_state={},
+        )
+
+        input_a = RunAgentInput(
+            thread_id=thread_id,
+            run_id="run_streaming",
+            messages=[UserMessage(id="msg_1", role="user", content="Do stuff")],
+            tools=[sample_tool],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        producer_should_finish = asyncio.Event()
+        non_hitl_event_observed = asyncio.Event()
+
+        async def mock_run(*args, **kwargs):
+            eq = kwargs["event_queue"]
+            kwargs["long_running_tool_ids"].add(hitl_tool_call_id)
+            # HITL TCE — deferred by the wrapper.
+            await eq.put(ToolCallEndEvent(
+                type=EventType.TOOL_CALL_END,
+                tool_call_id=hitl_tool_call_id,
+            ))
+            # Non-HITL event emitted AFTER the HITL TCE — must flow
+            # through the underlying queue immediately so the consumer
+            # can yield it to the client without waiting for the
+            # producer to exit.
+            await eq.put(ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=non_hitl_tool_call_id,
+                tool_call_name="non_hitl_tool",
+            ))
+            # Hold the producer open until the test confirms the
+            # non-HITL event reached the client.
+            await producer_should_finish.wait()
+            # Simulate the real producer's pre-None persistence step
+            # (#1755 moves this from the consumer to the producer).
+            for hitl_id in list(getattr(eq, "deferred_hitl_ids", [])):
+                await instance_a._add_pending_tool_call_with_context(
+                    thread_id, hitl_id, "test_app", "test_user"
+                )
+            await eq.put(None)
+
+        received_events: list = []
+
+        async def collect():
+            async for event in instance_a.run(input_a):
+                received_events.append(event)
+                if (
+                    isinstance(event, ToolCallStartEvent)
+                    and event.tool_call_id == non_hitl_tool_call_id
+                ):
+                    non_hitl_event_observed.set()
+
+        with patch.object(instance_a, "_run_adk_in_background", side_effect=mock_run):
+            collector = asyncio.create_task(collect())
+
+            # Wait up to 1s for the non-HITL event. With PR #1735's
+            # consumer-side gate (and without the #1755 wrapper) this
+            # would time out because the consumer would be blocked
+            # awaiting execution.task.
+            await asyncio.wait_for(
+                non_hitl_event_observed.wait(), timeout=1.0
+            )
+
+            # HITL TCE must NOT have reached the client yet —
+            # persistence hasn't happened.
+            hitl_tce_already_seen = any(
+                isinstance(e, ToolCallEndEvent)
+                and e.tool_call_id == hitl_tool_call_id
+                for e in received_events
+            )
+            assert not hitl_tce_already_seen, (
+                "HITL ToolCallEndEvent must be deferred until "
+                "pending_tool_calls is persisted (PR #1581's invariant)."
+            )
+
+            # Release the producer; it persists then puts None which
+            # implicitly flushes the deferred TCE.
+            producer_should_finish.set()
+            await asyncio.wait_for(collector, timeout=3.0)
+
+        # HITL TCE was eventually delivered.
+        hitl_indices = [
+            i for i, e in enumerate(received_events)
+            if isinstance(e, ToolCallEndEvent)
+            and e.tool_call_id == hitl_tool_call_id
+        ]
+        assert hitl_indices, (
+            "HITL ToolCallEndEvent must reach the client after the "
+            "producer persists pending_tool_calls and flushes the buffer."
+        )
+
+        non_hitl_indices = [
+            i for i, e in enumerate(received_events)
+            if isinstance(e, ToolCallStartEvent)
+            and e.tool_call_id == non_hitl_tool_call_id
+        ]
+        assert non_hitl_indices, (
+            "Test setup error: non-HITL event was never received."
+        )
+
+        # Order: non-HITL streamed live (early); HITL TCE flushed at end.
+        assert non_hitl_indices[0] < hitl_indices[0], (
+            f"Non-HITL event should be delivered before the deferred HITL "
+            f"TCE; got non_hitl_idx={non_hitl_indices[0]}, "
+            f"hitl_idx={hitl_indices[0]}."
+        )
 
     @pytest.mark.asyncio
     async def test_backend_tool_result_clears_pending_before_stream_ends(

--- a/integrations/adk-middleware/python/tests/test_tool_tracking_hitl.py
+++ b/integrations/adk-middleware/python/tests/test_tool_tracking_hitl.py
@@ -113,6 +113,13 @@ class TestHITLToolTracking:
                 tool_call_id=tool_call_id
             ))
 
+            # Simulate the real producer's pre-None persistence step
+            # (#1755 moves this from the consumer to the producer).
+            for hitl_id in list(getattr(event_queue, "deferred_hitl_ids", [])):
+                await adk_middleware._add_pending_tool_call_with_context(
+                    "test_thread", hitl_id, "test_app", "test_user"
+                )
+
             # Signal completion
             await event_queue.put(None)
 
@@ -174,6 +181,12 @@ class TestHITLToolTracking:
                 tool_call_id=tool_call_id
             ))
 
+            # Simulate the real producer's pre-None persistence step (#1755).
+            for hitl_id in list(getattr(event_queue, "deferred_hitl_ids", [])):
+                await adk_middleware._add_pending_tool_call_with_context(
+                    "test_thread", hitl_id, "test_app", "test_user"
+                )
+
             # Signal completion
             await event_queue.put(None)
 
@@ -229,6 +242,12 @@ class TestHITLToolTracking:
                 type=EventType.TOOL_CALL_END,
                 tool_call_id=tool_call_id
             ))
+
+            # Simulate the real producer's pre-None persistence step (#1755).
+            for hitl_id in list(getattr(event_queue, "deferred_hitl_ids", [])):
+                await adk_middleware._add_pending_tool_call_with_context(
+                    "test_thread", hitl_id, "test_app", "test_user"
+                )
 
             # Signal completion
             await event_queue.put(None)
@@ -431,6 +450,11 @@ class TestHITLToolTracking:
                 type=EventType.TOOL_CALL_END,
                 tool_call_id="pending_tool_123"
             ))
+            # Simulate the real producer's pre-None persistence step (#1755).
+            for hitl_id in list(getattr(event_queue, "deferred_hitl_ids", [])):
+                await adk_middleware._add_pending_tool_call_with_context(
+                    "test_thread", hitl_id, "test_app", "test_user"
+                )
             await event_queue.put(None)
 
         with patch.object(adk_middleware, '_run_adk_in_background', side_effect=mock_run_adk_in_background):
@@ -489,6 +513,11 @@ class TestHITLToolTracking:
                 type=EventType.TOOL_CALL_END,
                 tool_call_id="pending_tool_456"
             ))
+            # Simulate the real producer's pre-None persistence step (#1755).
+            for hitl_id in list(getattr(event_queue, "deferred_hitl_ids", [])):
+                await adk_middleware._add_pending_tool_call_with_context(
+                    "test_thread", hitl_id, "test_app", "test_user"
+                )
             await event_queue.put(None)
 
         with patch.object(adk_middleware, '_run_adk_in_background', side_effect=mock_run_adk_in_background):


### PR DESCRIPTION
## Summary

Closes #1755.

PR #1735 fixed #1732 by making the consumer ``await execution.task`` when it dequeues a HITL ``ToolCallEndEvent`` before persisting ``pending_tool_calls``. That gate fired on the **first** HITL TCE and held the consumer until the producer exited. For resumable HITL with parallel tool calls or post-LRO text events, **every** event the producer enqueued after the LRO sat in ``event_queue`` until runner exit and arrived at the client as a burst instead of streaming live.

This PR moves the HITL persistence step producer-side and defers **only the HITL ``ToolCallEndEvent`` itself**. All other events stream live.

## Mechanism

New ``_HitlDeferringQueue`` (subclass of ``asyncio.Queue``) replaces the bare queue created in ``_start_background_execution``. On ``put``:

- HITL ``ToolCallEndEvent`` whose id is in ``long_running_tool_ids`` → **buffered** in a local dict instead of the inner queue.
- ``ToolCallResultEvent`` for a deferred id → release the buffered TCE first (preserves TCE→Result order on the wire) and remove the id from the deferred set (no client continuation → no need to persist).
- ``None`` sentinel → implicit ``flush_deferred`` first, then put None so the consumer sees deferred TCEs before the stream ends.
- Anything else → passthrough.

``_run_adk_in_background`` calls a new ``_finalize_hitl_buffer`` helper (iterates ``deferred_hitl_ids`` and calls ``_add_pending_tool_call_with_context`` for each) at all three exit points: the normal-exit, the LRO drain return, and the non-resumable LRO return. Each is followed by ``put(None)`` so the deferring queue flushes via its ``put(None)`` override.

``_run_new_execution`` no longer needs the ``await execution.task`` / ``_add_pending_tool_call_with_context`` block — by the time the consumer observes a TCE, the producer has already persisted. The ``ToolCallResultEvent``→``_remove_pending_tool_call`` unpersist branch is also gone (the queue's release-on-result path handles that case).

## Streaming-fidelity comparison

| Event after first HITL TCE | PR #1735 (today) | #1755 |
|---|---|---|
| Non-HITL tool call | Buffered | **Streams live** |
| Post-LRO text | Buffered | **Streams live** |
| Backend tool result | Buffered | **Streams live** |
| HITL TCE itself | Held for runner | Held for runner |

## Invariants preserved

- **PR #1581**: ``pending_tool_calls`` persisted BEFORE the client sees the ``ToolCallEndEvent`` (the queue holds the TCE until ``put(None)`` fires the flush, which happens after ``_finalize_hitl_buffer``).
- **PR #1735 / #1732**: no mid-runner ``session.state`` writes (persistence is the producer's last act before signalling completion).
- **#1652**: only HITL/LRO ids are persisted; backend tools are passthrough.

## Tests

**New test** ``test_non_hitl_events_stream_live_after_hitl_tce`` in ``tests/test_multi_instance_hitl.py``: streaming-fidelity regression. Producer enqueues HITL TCE, then a non-HITL ``ToolCallStartEvent``, then blocks. Asserts the non-HITL event reaches the client within 1s (well before the producer finishes) AND that the HITL TCE arrives later, after persistence.

> With PR #1735's consumer-side gate alone (no #1755 wrapper) the consumer would block on ``execution.task`` and the 1s wait would time out.

**Existing mocks** in ``test_multi_instance_hitl.py`` and ``test_tool_tracking_hitl.py`` updated to call ``_add_pending_tool_call_with_context`` before ``put(None)``, matching the real producer's behavior. The mocks replace the producer, so they need to simulate the producer-side persistence step that PR #1735's consumer-side gate previously did automatically.

## Verification

- [x] New streaming-fidelity test passes with the fix
- [x] All HITL-related suites pass: ``test_multi_instance_hitl`` (7), ``test_pending_tool_calls_gating`` (8), ``test_lro_sse_persistence`` (5), ``test_lro_sse_id_remap`` (20), ``test_resumability_config`` (11), ``test_lro_tool_response_persistence`` (4), ``test_tool_tracking_hitl`` (8) — **63 passed**
- [x] Full test suite — **806 passed, 1 skipped**

## Related

- Closes #1755
- Builds on #1735 (#1732 fix) and #1757 (#1754 fix); same underlying design principle ("don't write session.state while ADK's Runner owns the in-memory session") applied via a different mechanism
- The ``_finalize_hitl_buffer`` helper's call sites mirror the ``_finalize`` pattern from #1757's ``pending_lro_id_remap`` flush — both perform their persistence in producer ``finally``-style cleanup before the queue's completion sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)