### PR TITLE
feat(integrations): per-request header forwarding across 5 adapters + LGP prepareStream fix

### DIFF
--- a/integrations/claude-agent-sdk/typescript/src/adapter.headers.test.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.headers.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock workspace packages that aren't built in worktree isolation
+vi.mock("@ag-ui/client", () => {
+  class AbstractAgent {
+    constructor(_config?: Record<string, unknown>) {}
+    clone() {
+      return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+    }
+  }
+  return {
+    AbstractAgent,
+    EventType: {
+      RUN_STARTED: "RUN_STARTED",
+      RUN_FINISHED: "RUN_FINISHED",
+      RUN_ERROR: "RUN_ERROR",
+      TEXT_MESSAGE_START: "TEXT_MESSAGE_START",
+      TEXT_MESSAGE_CONTENT: "TEXT_MESSAGE_CONTENT",
+      TEXT_MESSAGE_END: "TEXT_MESSAGE_END",
+      TOOL_CALL_START: "TOOL_CALL_START",
+      TOOL_CALL_ARGS: "TOOL_CALL_ARGS",
+      TOOL_CALL_END: "TOOL_CALL_END",
+      TOOL_CALL_RESULT: "TOOL_CALL_RESULT",
+      STATE_SNAPSHOT: "STATE_SNAPSHOT",
+      MESSAGES_SNAPSHOT: "MESSAGES_SNAPSHOT",
+      CUSTOM: "CUSTOM",
+      REASONING_START: "REASONING_START",
+      REASONING_MESSAGE_START: "REASONING_MESSAGE_START",
+      REASONING_MESSAGE_CONTENT: "REASONING_MESSAGE_CONTENT",
+      REASONING_MESSAGE_END: "REASONING_MESSAGE_END",
+      REASONING_END: "REASONING_END",
+      REASONING_ENCRYPTED_VALUE: "REASONING_ENCRYPTED_VALUE",
+    },
+    randomUUID: () => crypto.randomUUID(),
+  };
+});
+
+vi.mock("@ag-ui/core", () => ({}));
+
+// Mock the Claude Agent SDK so we don't need real API credentials
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => {
+    // Return an async iterable that immediately yields a result message
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({
+            value: {
+              type: "result",
+              result: "test response",
+              is_error: false,
+            },
+            done: false,
+          })
+          .mockResolvedValueOnce({ value: undefined, done: true }),
+      }),
+      interrupt: vi.fn(),
+    };
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+}));
+
+// Mock the SDK types import
+vi.mock("@anthropic-ai/sdk/resources/beta/messages/messages", () => ({}));
+
+import { ClaudeAgentAdapter } from "./adapter";
+
+describe("ClaudeAgentAdapter headers property", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    // Also suppress console.error from adapter error paths
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits debug log when headers are set", async () => {
+    const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+    adapter.headers = { "x-aimock-context": "test-integration" };
+
+    const events: unknown[] = [];
+    await new Promise<void>((resolve, reject) => {
+      adapter
+        .run({
+          threadId: "t1",
+          runId: "r1",
+          messages: [],
+          tools: [],
+          context: [],
+        })
+        .subscribe({
+          next: (event) => events.push(event),
+          error: reject,
+          complete: resolve,
+        });
+    });
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      "[ClaudeAdapter] headers set but not forwarded (Claude Agent SDK does not support per-request HTTP headers)",
+    );
+  });
+
+  it("does NOT emit debug log when headers are undefined", async () => {
+    const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+    // headers left undefined
+
+    const events: unknown[] = [];
+    await new Promise<void>((resolve, reject) => {
+      adapter
+        .run({
+          threadId: "t2",
+          runId: "r2",
+          messages: [],
+          tools: [],
+          context: [],
+        })
+        .subscribe({
+          next: (event) => events.push(event),
+          error: reject,
+          complete: resolve,
+        });
+    });
+
+    const headerCalls = debugSpy.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        call[0].includes("headers set but not forwarded"),
+    );
+    expect(headerCalls).toHaveLength(0);
+  });
+
+  it("does NOT emit debug log when headers is an empty object", async () => {
+    const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+    adapter.headers = {};
+
+    const events: unknown[] = [];
+    await new Promise<void>((resolve, reject) => {
+      adapter
+        .run({
+          threadId: "t3",
+          runId: "r3",
+          messages: [],
+          tools: [],
+          context: [],
+        })
+        .subscribe({
+          next: (event) => events.push(event),
+          error: reject,
+          complete: resolve,
+        });
+    });
+
+    const headerCalls = debugSpy.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof call[0] === "string" &&
+        call[0].includes("headers set but not forwarded"),
+    );
+    expect(headerCalls).toHaveLength(0);
+  });
+
+  describe("clone()", () => {
+    it("preserves headers across clone()", () => {
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      adapter.headers = {
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      };
+
+      const cloned = adapter.clone();
+
+      expect(cloned.headers).toEqual({
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      });
+    });
+
+    it("creates a defensive copy (mutating clone does not affect original)", () => {
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      adapter.headers = { "x-aimock-context": "original" };
+
+      const cloned = adapter.clone();
+      cloned.headers!["x-aimock-context"] = "mutated";
+      cloned.headers!["x-new"] = "added";
+
+      expect(adapter.headers).toEqual({ "x-aimock-context": "original" });
+      expect(cloned.headers).not.toBe(adapter.headers);
+    });
+
+    it("leaves headers undefined on clone when not set on original", () => {
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+
+      const cloned = adapter.clone();
+
+      expect(cloned.headers).toBeUndefined();
+    });
+  });
+
+  it("declares headers as a public property", () => {
+    const adapter = new ClaudeAgentAdapter();
+    // Should be undefined by default
+    expect(adapter.headers).toBeUndefined();
+
+    // Should accept assignment
+    adapter.headers = { "x-test": "value" };
+    expect(adapter.headers).toEqual({ "x-test": "value" });
+  });
+});

--- a/integrations/claude-agent-sdk/typescript/src/adapter.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.ts
@@ -37,9 +37,7 @@ import {
   buildAguiToolMessage,
   isStateManagementTool,
 } from "./utils";
-import {
-  handleToolUseBlock,
-} from "./handlers";
+import { handleToolUseBlock } from "./handlers";
 
 /**
  * AG-UI adapter for the Anthropic Claude Agent SDK.
@@ -47,14 +45,38 @@ import {
  * Manages the SDK query lifecycle internally via per-request `query()` calls
  * with session resume for multi-turn. Call `adapter.run(input)` to get an
  * Observable of AG-UI events.
+ *
+ * **Header forwarding:** CopilotKit Runtime sets `agent.headers` with per-request
+ * forwarded headers (e.g. `x-aimock-context`, `x-test-id`). This property is
+ * declared here for forward compatibility so the runtime's assignment is not lost.
+ * However, headers are NOT functionally forwarded to LLM calls because the Claude
+ * Agent SDK is process-based — `query()` spawns a CLI child process, and there is
+ * no mechanism to inject HTTP headers into the LLM API calls made by that process.
+ *
+ * If the Claude Agent SDK adds a `headers` or `extraHeaders` option to its
+ * `Options` type in the future, this adapter should wire `this.headers` through
+ * at that point.
  */
 export class ClaudeAgentAdapter extends AbstractAgent {
   private static readonly DEFAULT_MAX_SESSIONS = 1000;
   private static readonly DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 
+  /**
+   * Per-request HTTP headers set by CopilotKit Runtime via `configureAgentForRequest()`.
+   *
+   * These headers are NOT functionally forwarded to LLM calls because the Claude
+   * Agent SDK has no per-request HTTP header mechanism (it is process-based, not HTTP).
+   * This property exists for forward compatibility — if Anthropic adds per-request
+   * header support to the SDK Options type, wire it here.
+   */
+  public headers?: Record<string, string>;
+
   private config: ClaudeAgentAdapterConfig;
   private activeQueries = new Map<string, Query>();
-  private sessions = new Map<string, { sessionId: string; lastUsed: number; active: boolean }>();
+  private sessions = new Map<
+    string,
+    { sessionId: string; lastUsed: number; active: boolean }
+  >();
 
   constructor(config: ClaudeAgentAdapterConfig = {}) {
     super(config);
@@ -62,8 +84,10 @@ export class ClaudeAgentAdapter extends AbstractAgent {
   }
 
   private evictSessions(): void {
-    const ttlMs = this.config.sessionTtlMs ?? ClaudeAgentAdapter.DEFAULT_SESSION_TTL_MS;
-    const maxSessions = this.config.maxSessions ?? ClaudeAgentAdapter.DEFAULT_MAX_SESSIONS;
+    const ttlMs =
+      this.config.sessionTtlMs ?? ClaudeAgentAdapter.DEFAULT_SESSION_TTL_MS;
+    const maxSessions =
+      this.config.maxSessions ?? ClaudeAgentAdapter.DEFAULT_MAX_SESSIONS;
     const now = Date.now();
 
     // Remove idle entries older than TTL
@@ -93,6 +117,9 @@ export class ClaudeAgentAdapter extends AbstractAgent {
   public clone(): ClaudeAgentAdapter {
     const cloned = super.clone() as ClaudeAgentAdapter;
     cloned.config = { ...this.config };
+    if (this.headers) {
+      cloned.headers = { ...this.headers };
+    }
     return cloned;
   }
 
@@ -104,6 +131,12 @@ export class ClaudeAgentAdapter extends AbstractAgent {
 
   run(input: RunAgentInput): Observable<BaseEvent> {
     return new Observable<ProcessedEvent>((subscriber) => {
+      if (this.headers && Object.keys(this.headers).length > 0) {
+        console.debug(
+          "[ClaudeAdapter] headers set but not forwarded (Claude Agent SDK does not support per-request HTTP headers)",
+        );
+      }
+
       // Inject resume for known threads
       const threadId = input.threadId ?? "default";
       let runInput = input;
@@ -128,7 +161,10 @@ export class ClaudeAgentAdapter extends AbstractAgent {
         ? new AbortController()
         : undefined;
       if (abortController) {
-        timeoutHandle = setTimeout(() => abortController.abort(), this.config.queryTimeoutMs!);
+        timeoutHandle = setTimeout(
+          () => abortController.abort(),
+          this.config.queryTimeoutMs!,
+        );
       }
 
       const queryStream = query({
@@ -156,17 +192,20 @@ export class ClaudeAgentAdapter extends AbstractAgent {
   private async translateStream(
     input: RunAgentInput,
     messageStream: AsyncIterable<unknown>,
-    subscriber: Subscriber<ProcessedEvent>
+    subscriber: Subscriber<ProcessedEvent>,
   ): Promise<void> {
     const threadId = input.threadId ?? randomUUID();
     const runId = input.runId ?? randomUUID();
 
-    const runCtx = { currentState: hasState(input.state) ? input.state : null, lastResultData: undefined as Record<string, unknown> | undefined };
+    const runCtx = {
+      currentState: hasState(input.state) ? input.state : null,
+      lastResultData: undefined as Record<string, unknown> | undefined,
+    };
 
     try {
       if (input.parentRunId) {
         console.debug(
-          `[ClaudeAdapter] Run ${runId.slice(0, 8)}... branched from ${input.parentRunId.slice(0, 8)}...`
+          `[ClaudeAdapter] Run ${runId.slice(0, 8)}... branched from ${input.parentRunId.slice(0, 8)}...`,
         );
       }
 
@@ -177,11 +216,11 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       });
 
       const frontendToolNames = new Set(
-        input.tools?.length ? extractToolNames(input.tools) : []
+        input.tools?.length ? extractToolNames(input.tools) : [],
       );
       if (frontendToolNames.size > 0) {
         console.debug(
-          `[ClaudeAdapter] Frontend tools detected: [${[...frontendToolNames].join(", ")}]`
+          `[ClaudeAdapter] Frontend tools detected: [${[...frontendToolNames].join(", ")}]`,
         );
       }
 
@@ -199,7 +238,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
         input,
         frontendToolNames,
         subscriber,
-        runCtx
+        runCtx,
       );
 
       subscriber.next({
@@ -255,7 +294,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       const base = (merged.systemPrompt as string) ?? "";
       merged.systemPrompt = base ? `${base}\n\n${addendum}` : addendum;
       console.debug(
-        `[ClaudeAdapter] Appended state/context (${addendum.length} chars) to systemPrompt`
+        `[ClaudeAdapter] Appended state/context (${addendum.length} chars) to systemPrompt`,
       );
     }
 
@@ -285,7 +324,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       if (toolsToAdd.length > 0) {
         merged.allowedTools = [...allowedTools, ...toolsToAdd];
         console.debug(
-          `[ClaudeAdapter] Auto-granted permission to ag_ui tools: [${toolsToAdd.join(", ")}]`
+          `[ClaudeAdapter] Auto-granted permission to ag_ui tools: [${toolsToAdd.join(", ")}]`,
         );
       }
     }
@@ -295,7 +334,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       applyForwardedProps(
         input.forwardedProps as Record<string, unknown>,
         merged,
-        ALLOWED_FORWARDED_PROPS
+        ALLOWED_FORWARDED_PROPS,
       );
     }
 
@@ -309,7 +348,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
     // Add frontend tools from input.tools
     if (input.tools?.length) {
       console.debug(
-        `[ClaudeAdapter] Building dynamic MCP server with ${input.tools.length} frontend tools`
+        `[ClaudeAdapter] Building dynamic MCP server with ${input.tools.length} frontend tools`,
       );
       for (const toolDef of input.tools) {
         try {
@@ -323,7 +362,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
     // Add state management tool if meaningful state is provided
     if (hasState(input.state)) {
       console.debug(
-        "[ClaudeAdapter] Adding ag_ui_update_state tool for state management"
+        "[ClaudeAdapter] Adding ag_ui_update_state tool for state management",
       );
       agUiTools.push(createStateManagementTool());
     }
@@ -342,7 +381,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       };
 
       console.debug(
-        `[ClaudeAdapter] Created ag_ui MCP server with ${agUiTools.length} tools`
+        `[ClaudeAdapter] Created ag_ui MCP server with ${agUiTools.length} tools`,
       );
     }
 
@@ -357,7 +396,10 @@ export class ClaudeAgentAdapter extends AbstractAgent {
     input: RunAgentInput,
     frontendToolNames: Set<string>,
     subscriber: Subscriber<ProcessedEvent>,
-    runCtx: { currentState: unknown; lastResultData: Record<string, unknown> | undefined }
+    runCtx: {
+      currentState: unknown;
+      lastResultData: Record<string, unknown> | undefined;
+    },
   ): Promise<void> {
     // Per-run state (local to this invocation)
     let currentMessageId: string | null = null;
@@ -388,8 +430,16 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       }
     };
 
-    type ToolCallEntry = { id: string; type: "function"; function: { name: string; arguments: string } };
-    let pendingMsg: { id: string; content: string; toolCalls: ToolCallEntry[] } | null = null;
+    type ToolCallEntry = {
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    };
+    let pendingMsg: {
+      id: string;
+      content: string;
+      toolCalls: ToolCallEntry[];
+    } | null = null;
 
     const flushPendingMsg = () => {
       if (!pendingMsg) return;
@@ -398,7 +448,9 @@ export class ClaudeAgentAdapter extends AbstractAgent {
           id: pendingMsg.id,
           role: "assistant" as const,
           ...(pendingMsg.content ? { content: pendingMsg.content } : {}),
-          ...(pendingMsg.toolCalls.length > 0 ? { toolCalls: pendingMsg.toolCalls } : {}),
+          ...(pendingMsg.toolCalls.length > 0
+            ? { toolCalls: pendingMsg.toolCalls }
+            : {}),
         });
       }
       pendingMsg = null;
@@ -411,7 +463,9 @@ export class ClaudeAgentAdapter extends AbstractAgent {
         messageCount++;
         if (haltEventStream) break;
 
-        const message = rawMessage as Record<string, unknown> & { type: string };
+        const message = rawMessage as Record<string, unknown> & {
+          type: string;
+        };
 
         // Handle streaming events
         if (message.type === "stream_event") {
@@ -496,8 +550,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
               });
             } else if (block.type === "tool_use") {
               currentToolCallId = (block.id as string) ?? null;
-              currentToolCallName =
-                (block.name as string) ?? "unknown";
+              currentToolCallName = (block.name as string) ?? "unknown";
               accumulatedToolJson = "";
 
               if (currentToolCallId) {
@@ -517,8 +570,14 @@ export class ClaudeAgentAdapter extends AbstractAgent {
           } else if (eventType === "content_block_stop") {
             if (inReasoningBlock && reasoningMessageId) {
               inReasoningBlock = false;
-              subscriber.next({ type: EventType.REASONING_MESSAGE_END, messageId: reasoningMessageId });
-              subscriber.next({ type: EventType.REASONING_END, messageId: reasoningMessageId });
+              subscriber.next({
+                type: EventType.REASONING_MESSAGE_END,
+                messageId: reasoningMessageId,
+              });
+              subscriber.next({
+                type: EventType.REASONING_END,
+                messageId: reasoningMessageId,
+              });
 
               // Emit encrypted signature if present
               if (accumulatedSignature && currentMessageId) {
@@ -542,8 +601,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                 try {
                   const stateArgs = JSON.parse(accumulatedToolJson);
                   if (typeof stateArgs === "object" && stateArgs !== null) {
-                    let updates =
-                      stateArgs.state_updates ?? stateArgs;
+                    let updates = stateArgs.state_updates ?? stateArgs;
 
                     // Parse nested JSON string if needed
                     if (typeof updates === "string") {
@@ -577,7 +635,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                   }
                 } catch {
                   console.warn(
-                    "[ClaudeAdapter] Failed to parse tool JSON for state update"
+                    "[ClaudeAdapter] Failed to parse tool JSON for state update",
                   );
                   subscriber.next({
                     type: EventType.CUSTOM,
@@ -627,7 +685,9 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                   currentMessageId = null;
                 }
 
-                console.debug(`[ClaudeAdapter] Frontend tool halt: ${currentToolDisplayName}`);
+                console.debug(
+                  `[ClaudeAdapter] Frontend tool halt: ${currentToolDisplayName}`,
+                );
 
                 currentToolCallId = null;
                 currentToolCallName = null;
@@ -665,12 +725,11 @@ export class ClaudeAgentAdapter extends AbstractAgent {
             }
             currentMessageId = null;
           } else if (eventType === "message_delta") {
-            
             const delta = (event.delta as Record<string, unknown>) ?? {};
             const stopReason = delta.stop_reason as string | undefined;
             if (stopReason) {
               console.debug(
-                `[ClaudeAdapter] Message stop_reason: ${stopReason}`
+                `[ClaudeAdapter] Message stop_reason: ${stopReason}`,
               );
             }
           }
@@ -697,7 +756,10 @@ export class ClaudeAgentAdapter extends AbstractAgent {
             const { updatedState } = handleToolUseBlock(
               toolBlock,
               assistantMsg.parent_tool_use_id ?? undefined,
-              threadId, runId, runCtx.currentState, subscriber
+              threadId,
+              runId,
+              runCtx.currentState,
+              subscriber,
             );
             if (toolBlock.id) processedToolIds.add(toolBlock.id);
             if (updatedState !== null) runCtx.currentState = updatedState;
@@ -717,7 +779,9 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                 currentMessageId = null;
               }
 
-              console.debug(`[ClaudeAdapter] Frontend tool halt (non-streaming): ${blockDisplayName}`);
+              console.debug(
+                `[ClaudeAdapter] Frontend tool halt (non-streaming): ${blockDisplayName}`,
+              );
               haltEventStream = true;
               break;
             }
@@ -739,7 +803,6 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                 const toolUseId = block.tool_use_id as string;
                 const resultContent = block.content;
 
-                
                 const toolMsg = buildAguiToolMessage(toolUseId, resultContent);
                 upsertMessage(toolMsg);
 
@@ -764,11 +827,19 @@ export class ClaudeAgentAdapter extends AbstractAgent {
 
           // Capture session_id for multi-turn resume
           if (subtype === "init") {
-            const sid = (raw.session_id ?? data?.session_id) as string | undefined;
+            const sid = (raw.session_id ?? data?.session_id) as
+              | string
+              | undefined;
             if (sid) {
-              this.sessions.set(threadId, { sessionId: sid, lastUsed: Date.now(), active: false });
+              this.sessions.set(threadId, {
+                sessionId: sid,
+                lastUsed: Date.now(),
+                active: false,
+              });
               this.evictSessions();
-              console.debug(`[ClaudeAdapter] Captured session_id=${sid} for thread=${threadId}`);
+              console.debug(
+                `[ClaudeAdapter] Captured session_id=${sid} for thread=${threadId}`,
+              );
             }
           }
 
@@ -783,7 +854,6 @@ export class ClaudeAgentAdapter extends AbstractAgent {
         else if (message.type === "result") {
           const resultMsg = message as SDKResultMessage;
 
-          
           runCtx.lastResultData = {
             isError: (resultMsg as { is_error?: boolean }).is_error ?? false,
             durationMs: (resultMsg as { duration_ms?: number }).duration_ms,
@@ -793,31 +863,51 @@ export class ClaudeAgentAdapter extends AbstractAgent {
             totalCostUsd: (resultMsg as { total_cost_usd?: number })
               .total_cost_usd,
             usage:
-              (resultMsg as { usage?: Record<string, unknown> })
-                .usage ?? {},
-            structuredOutput:
-              (resultMsg as { structured_output?: unknown })
-                .structured_output,
+              (resultMsg as { usage?: Record<string, unknown> }).usage ?? {},
+            structuredOutput: (resultMsg as { structured_output?: unknown })
+              .structured_output,
           };
 
           const resultText = (resultMsg as { result?: string }).result;
           if (!hasStreamedText && resultText) {
             const resultMsgId = randomUUID();
-            subscriber.next({ type: EventType.TEXT_MESSAGE_START, threadId, runId, messageId: resultMsgId, role: "assistant" });
-            subscriber.next({ type: EventType.TEXT_MESSAGE_CONTENT, threadId, runId, messageId: resultMsgId, delta: resultText });
-            subscriber.next({ type: EventType.TEXT_MESSAGE_END, threadId, runId, messageId: resultMsgId });
+            subscriber.next({
+              type: EventType.TEXT_MESSAGE_START,
+              threadId,
+              runId,
+              messageId: resultMsgId,
+              role: "assistant",
+            });
+            subscriber.next({
+              type: EventType.TEXT_MESSAGE_CONTENT,
+              threadId,
+              runId,
+              messageId: resultMsgId,
+              delta: resultText,
+            });
+            subscriber.next({
+              type: EventType.TEXT_MESSAGE_END,
+              threadId,
+              runId,
+              messageId: resultMsgId,
+            });
 
-            upsertMessage({ id: resultMsgId, role: "assistant" as const, content: resultText });
+            upsertMessage({
+              id: resultMsgId,
+              role: "assistant" as const,
+              content: resultText,
+            });
           }
         }
       }
-
     } finally {
       // ── Event cleanup ──
       // Close any hanging events so the frontend doesn't get stuck
       // waiting for END events that will never arrive.
       if (currentToolCallId) {
-        console.debug(`[ClaudeAdapter] Cleanup: closing hanging TOOL_CALL_START for ${currentToolCallId}`);
+        console.debug(
+          `[ClaudeAdapter] Cleanup: closing hanging TOOL_CALL_START for ${currentToolCallId}`,
+        );
         subscriber.next({
           type: EventType.TOOL_CALL_END,
           threadId,
@@ -828,15 +918,25 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       }
 
       if (inReasoningBlock && reasoningMessageId) {
-        console.debug("[ClaudeAdapter] Cleanup: closing hanging reasoning block");
-        subscriber.next({ type: EventType.REASONING_MESSAGE_END, messageId: reasoningMessageId });
-        subscriber.next({ type: EventType.REASONING_END, messageId: reasoningMessageId });
+        console.debug(
+          "[ClaudeAdapter] Cleanup: closing hanging reasoning block",
+        );
+        subscriber.next({
+          type: EventType.REASONING_MESSAGE_END,
+          messageId: reasoningMessageId,
+        });
+        subscriber.next({
+          type: EventType.REASONING_END,
+          messageId: reasoningMessageId,
+        });
         inReasoningBlock = false;
         reasoningMessageId = null;
       }
 
       if (hasStreamedText && currentMessageId) {
-        console.debug(`[ClaudeAdapter] Cleanup: closing hanging TEXT_MESSAGE_START for ${currentMessageId}`);
+        console.debug(
+          `[ClaudeAdapter] Cleanup: closing hanging TEXT_MESSAGE_START for ${currentMessageId}`,
+        );
         subscriber.next({
           type: EventType.TEXT_MESSAGE_END,
           threadId,
@@ -858,9 +958,12 @@ export class ClaudeAgentAdapter extends AbstractAgent {
 
     // Emit MESSAGES_SNAPSHOT with input messages + new messages from this run
     if (runMessages.length > 0) {
-      const allMessages: Message[] = [...(input.messages ?? []), ...runMessages];
+      const allMessages: Message[] = [
+        ...(input.messages ?? []),
+        ...runMessages,
+      ];
       console.debug(
-        `[ClaudeAdapter] MESSAGES_SNAPSHOT: ${allMessages.length} msgs (${messageCount} SDK messages processed)`
+        `[ClaudeAdapter] MESSAGES_SNAPSHOT: ${allMessages.length} msgs (${messageCount} SDK messages processed)`,
       );
       subscriber.next({
         type: EventType.MESSAGES_SNAPSHOT,

--- a/integrations/langchain/typescript/src/__tests__/headers.test.ts
+++ b/integrations/langchain/typescript/src/__tests__/headers.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventType, RunAgentInput } from "@ag-ui/client";
+import { LangChainAgent, ChainFnParams } from "../agent";
+import { firstValueFrom, toArray } from "rxjs";
+
+/**
+ * Creates a minimal mock model with a .stream() method that resolves to a
+ * string (the simplest LangChainResponse type — see streaming.ts).
+ *
+ * The mock captures the call arguments so tests can assert on them.
+ */
+function createMockModel() {
+  const streamMock = vi.fn().mockResolvedValue("test response");
+  return {
+    stream: streamMock,
+    bindTools: vi.fn().mockReturnValue({ stream: streamMock }),
+    _streamMock: streamMock,
+  };
+}
+
+/**
+ * Minimal RunAgentInput for testing.
+ */
+function makeInput(overrides?: Partial<RunAgentInput>): RunAgentInput {
+  return {
+    threadId: "thread-1",
+    runId: "run-1",
+    messages: [{ id: "msg-1", role: "user", content: "hello" }],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  } as RunAgentInput;
+}
+
+/**
+ * Helper to collect all events from a LangChainAgent run.
+ */
+async function collectEvents(agent: LangChainAgent, input: RunAgentInput) {
+  return firstValueFrom(agent.run(input).pipe(toArray()));
+}
+
+describe("LangChainAgent header forwarding", () => {
+  describe("model pattern", () => {
+    it("forwards headers via options.headers when headers are set", async () => {
+      const mockModel = createMockModel();
+      const agent = new LangChainAgent({
+        model: mockModel as any,
+      });
+
+      agent.headers = {
+        "x-aimock-context": "langchain-test",
+        "x-test-id": "test-123",
+      };
+
+      await collectEvents(agent, makeInput());
+
+      // The model.stream() call should have received options.headers
+      const streamCall = mockModel._streamMock.mock.calls[0];
+      expect(streamCall).toBeDefined();
+
+      const callOptions = streamCall[1];
+      expect(callOptions).toBeDefined();
+      expect(callOptions.options).toBeDefined();
+      expect(callOptions.options.headers).toEqual({
+        "x-aimock-context": "langchain-test",
+        "x-test-id": "test-123",
+      });
+    });
+
+    it("does not include options key when headers are not set", async () => {
+      const mockModel = createMockModel();
+      const agent = new LangChainAgent({
+        model: mockModel as any,
+      });
+
+      // No headers set — agent.headers is undefined
+
+      await collectEvents(agent, makeInput());
+
+      const streamCall = mockModel._streamMock.mock.calls[0];
+      expect(streamCall).toBeDefined();
+
+      const callOptions = streamCall[1];
+      expect(callOptions).toBeDefined();
+      expect(callOptions.signal).toBeInstanceOf(AbortSignal);
+      // options key should NOT be present
+      expect(callOptions.options).toBeUndefined();
+    });
+
+    it("does not include options key when headers are empty object", async () => {
+      const mockModel = createMockModel();
+      const agent = new LangChainAgent({
+        model: mockModel as any,
+      });
+
+      agent.headers = {};
+
+      await collectEvents(agent, makeInput());
+
+      const streamCall = mockModel._streamMock.mock.calls[0];
+      const callOptions = streamCall[1];
+      expect(callOptions.options).toBeUndefined();
+    });
+
+    it("still emits RUN_STARTED and RUN_FINISHED with headers set", async () => {
+      const mockModel = createMockModel();
+      const agent = new LangChainAgent({
+        model: mockModel as any,
+      });
+
+      agent.headers = { "x-aimock-context": "test" };
+
+      const events = await collectEvents(agent, makeInput());
+      const types = events.map((e) => e.type);
+
+      expect(types[0]).toBe(EventType.RUN_STARTED);
+      expect(types[types.length - 1]).toBe(EventType.RUN_FINISHED);
+    });
+  });
+
+  describe("chainFn pattern", () => {
+    it("exposes headers in chainFn params when headers are set", async () => {
+      let receivedParams: ChainFnParams | undefined;
+
+      const agent = new LangChainAgent({
+        chainFn: async (params: ChainFnParams) => {
+          receivedParams = params;
+          return "test response";
+        },
+      });
+
+      agent.headers = {
+        "x-aimock-context": "langchain-chainfn-test",
+        "x-custom-header": "value",
+      };
+
+      await collectEvents(agent, makeInput());
+
+      expect(receivedParams).toBeDefined();
+      expect(receivedParams!.headers).toEqual({
+        "x-aimock-context": "langchain-chainfn-test",
+        "x-custom-header": "value",
+      });
+    });
+
+    it("passes undefined headers when no headers are set on agent", async () => {
+      let receivedParams: ChainFnParams | undefined;
+
+      const agent = new LangChainAgent({
+        chainFn: async (params: ChainFnParams) => {
+          receivedParams = params;
+          return "test response";
+        },
+      });
+
+      // No headers set
+
+      await collectEvents(agent, makeInput());
+
+      expect(receivedParams).toBeDefined();
+      // headers field exists in params but its value is undefined
+      expect("headers" in receivedParams!).toBe(true);
+      expect(receivedParams!.headers).toBeUndefined();
+    });
+
+    it("chainFn can destructure headers alongside other params", async () => {
+      let capturedHeaders: Record<string, string> | undefined;
+      let capturedThreadId: string | undefined;
+
+      const agent = new LangChainAgent({
+        chainFn: async ({ headers, threadId }: ChainFnParams) => {
+          capturedHeaders = headers;
+          capturedThreadId = threadId;
+          return "test response";
+        },
+      });
+
+      agent.headers = { "x-test": "works" };
+
+      await collectEvents(agent, makeInput({ threadId: "thread-42" }));
+
+      expect(capturedHeaders).toEqual({ "x-test": "works" });
+      expect(capturedThreadId).toBe("thread-42");
+    });
+  });
+
+  describe("clone()", () => {
+    it("preserves headers across clone()", () => {
+      const agent = new LangChainAgent({
+        chainFn: async () => "test",
+      });
+      agent.headers = {
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      };
+
+      const cloned = agent.clone();
+
+      expect(cloned.headers).toEqual({
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      });
+    });
+
+    it("creates a defensive copy (mutating clone does not affect original)", () => {
+      const agent = new LangChainAgent({
+        chainFn: async () => "test",
+      });
+      agent.headers = { "x-aimock-context": "original" };
+
+      const cloned = agent.clone();
+      cloned.headers!["x-aimock-context"] = "mutated";
+      cloned.headers!["x-new"] = "added";
+
+      expect(agent.headers).toEqual({ "x-aimock-context": "original" });
+      expect(cloned.headers).not.toBe(agent.headers);
+    });
+
+    it("leaves headers undefined on clone when not set on original", () => {
+      const agent = new LangChainAgent({
+        chainFn: async () => "test",
+      });
+
+      const cloned = agent.clone();
+
+      expect(cloned.headers).toBeUndefined();
+    });
+  });
+
+  describe("headers property", () => {
+    it("is publicly assignable on the agent instance", () => {
+      const agent = new LangChainAgent({
+        chainFn: async () => "test",
+      });
+
+      // Verify initial state
+      expect(agent.headers).toBeUndefined();
+
+      // Verify assignment works (as CopilotKit Runtime does)
+      agent.headers = { "x-aimock-context": "test" };
+      expect(agent.headers).toEqual({ "x-aimock-context": "test" });
+
+      // Verify spread-merge pattern (as configureAgentForRequest does)
+      agent.headers = {
+        ...agent.headers,
+        "x-new-header": "value",
+      };
+      expect(agent.headers).toEqual({
+        "x-aimock-context": "test",
+        "x-new-header": "value",
+      });
+    });
+  });
+});

--- a/integrations/langchain/typescript/src/agent.ts
+++ b/integrations/langchain/typescript/src/agent.ts
@@ -43,6 +43,11 @@ export interface ChainFnParams {
    * Run ID
    */
   runId: string;
+  /**
+   * Per-request HTTP headers forwarded from the runtime (e.g. x-aimock-context).
+   * Undefined when no headers are set on the agent instance.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -53,7 +58,9 @@ export interface LangChainAgentChainFnConfig {
    * Custom function that handles LangChain execution
    * This allows full control over chains, graphs, and custom logic
    */
-  chainFn: (params: ChainFnParams) => Promise<LangChainResponse> | LangChainResponse;
+  chainFn: (
+    params: ChainFnParams,
+  ) => Promise<LangChainResponse> | LangChainResponse;
 }
 
 /**
@@ -77,12 +84,16 @@ export interface LangChainAgentModelConfig {
 /**
  * Dual configuration: either chainFn OR model
  */
-export type LangChainAgentConfig = LangChainAgentChainFnConfig | LangChainAgentModelConfig;
+export type LangChainAgentConfig =
+  | LangChainAgentChainFnConfig
+  | LangChainAgentModelConfig;
 
 /**
  * Type guard to check if config uses chainFn pattern
  */
-function isChainFnConfig(config: LangChainAgentConfig): config is LangChainAgentChainFnConfig {
+function isChainFnConfig(
+  config: LangChainAgentConfig,
+): config is LangChainAgentChainFnConfig {
   return "chainFn" in config;
 }
 
@@ -112,6 +123,13 @@ function isChainFnConfig(config: LangChainAgentConfig): config is LangChainAgent
 export class LangChainAgent extends AbstractAgent {
   private abortController?: AbortController;
 
+  /**
+   * Per-request HTTP headers to forward to the underlying LLM provider.
+   * Set by CopilotKit Runtime via configureAgentForRequest() to propagate
+   * x-aimock-context, x-aimock-strict, x-test-id, and other forwarded headers.
+   */
+  public headers?: Record<string, string>;
+
   constructor(private config: LangChainAgentConfig) {
     super();
   }
@@ -134,14 +152,16 @@ export class LangChainAgent extends AbstractAgent {
       (async () => {
         try {
           // Convert AG-UI messages to LangChain messages
-          const langchainMessages = convertAGUIMessagesToLangChain(input.messages);
+          const langchainMessages = convertAGUIMessagesToLangChain(
+            input.messages,
+          );
 
           // Add system message if using model config with prompt
           if (!isChainFnConfig(this.config) && this.config.prompt) {
             const systemPrompt = this.buildSystemPrompt(
               this.config.prompt,
               input.context,
-              input.state
+              input.state,
             );
             langchainMessages.unshift({
               content: systemPrompt,
@@ -150,13 +170,15 @@ export class LangChainAgent extends AbstractAgent {
           }
 
           // Convert AG-UI tools to LangChain tools
-          const langchainTools = convertAGUIToolsToLangChain(input.tools as any[]);
+          const langchainTools = convertAGUIToolsToLangChain(
+            input.tools as any[],
+          );
 
           let response: LangChainResponse;
 
           // Execute based on configuration pattern
           if (isChainFnConfig(this.config)) {
-            // Pattern A: User-provided chainFn
+            // Pattern A: User-provided chainFn — expose headers so user code can forward them
             response = await this.config.chainFn({
               messages: langchainMessages,
               tools: langchainTools,
@@ -164,18 +186,37 @@ export class LangChainAgent extends AbstractAgent {
               context: input.context,
               threadId: input.threadId,
               runId: input.runId,
+              headers: this.headers,
             });
           } else {
             // Pattern B: Direct model usage
             const modelConfig = this.config as LangChainAgentModelConfig;
             const boundModel = modelConfig.bindToolsOptions
-              ? modelConfig.model.bindTools?.(langchainTools, modelConfig.bindToolsOptions)
+              ? modelConfig.model.bindTools?.(
+                  langchainTools,
+                  modelConfig.bindToolsOptions,
+                )
               : modelConfig.model.bindTools?.(langchainTools);
 
-            const model = boundModel || modelConfig.model;
-            response = await model.stream(langchainMessages, {
+            // `options.headers` is a provider-specific extension supported by @langchain/openai
+            // and @langchain/anthropic via their underlying SDK's RequestOptions. It is NOT
+            // part of BaseChatModel's typed surface — hence the explicit shape annotation.
+            const callOptions: {
+              signal: AbortSignal;
+              options?: { headers: Record<string, string> };
+            } = {
               signal: abortController.signal,
-            });
+            };
+
+            if (this.headers && Object.keys(this.headers).length > 0) {
+              callOptions.options = { headers: this.headers };
+            }
+
+            const model = boundModel || modelConfig.model;
+            response = await model.stream(
+              langchainMessages,
+              callOptions as Parameters<typeof model.stream>[1],
+            );
           }
 
           // Stream the response and emit AG-UI events
@@ -226,7 +267,7 @@ export class LangChainAgent extends AbstractAgent {
   private buildSystemPrompt(
     prompt: string,
     context: Array<{ description: string; value: string }>,
-    state?: any
+    state?: any,
   ): string {
     const parts: string[] = [prompt];
 
@@ -246,7 +287,7 @@ export class LangChainAgent extends AbstractAgent {
         parts.push(
           "\n## Application State\n" +
             "This is state from the application.\n" +
-            `\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\`\n`
+            `\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\`\n`,
         );
       }
     }
@@ -255,7 +296,11 @@ export class LangChainAgent extends AbstractAgent {
   }
 
   clone(): LangChainAgent {
-    return new LangChainAgent(this.config);
+    const cloned = new LangChainAgent(this.config);
+    if (this.headers) {
+      cloned.headers = { ...this.headers };
+    }
+    return cloned;
   }
 
   abortRun(): void {

--- a/integrations/langgraph/typescript/src/__tests__/agent.test.ts
+++ b/integrations/langgraph/typescript/src/__tests__/agent.test.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LangGraphAgent, LangGraphAgentConfig } from "../agent";
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/** Minimal mock assistant returned by assistants.search */
+const MOCK_ASSISTANT = {
+  assistant_id: "asst-1",
+  graph_id: "test-graph",
+  config: { configurable: {} },
+};
+
+/** Minimal mock graph info returned by assistants.getGraph */
+const MOCK_GRAPH_INFO = { nodes: [], edges: [] };
+
+/**
+ * Build a LangGraphAgent with mocked LangGraphClient internals so that
+ * prepareStream can execute without hitting a real LangGraph server.
+ *
+ * The returned `capturedPayload` will hold the payload passed to runs.stream
+ * after prepareStream runs.
+ */
+function buildMockedAgent(
+  configOverrides: Partial<LangGraphAgentConfig> = {},
+  schemaKeysOverride?: {
+    config?: string[] | null;
+    input?: string[] | null;
+    output?: string[] | null;
+    context?: string[] | null;
+  },
+) {
+  const capturedPayload: { value: Record<string, unknown> | null } = {
+    value: null,
+  };
+
+  const agent = new LangGraphAgent({
+    graphId: "test-graph",
+    deploymentUrl: "http://localhost:8000",
+    ...configOverrides,
+  });
+
+  // Initialize activeRun (normally set by runAgentStream before prepareStream is called)
+  (agent as any).activeRun = {
+    id: "run-1",
+    threadId: "thread-1",
+    hasFunctionStreaming: false,
+    modelMadeToolCall: false,
+  };
+
+  // Mock the client methods that prepareStream calls
+  (agent as any).client = {
+    threads: {
+      get: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
+      create: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
+      getState: vi
+        .fn()
+        .mockResolvedValue({ values: { messages: [] }, tasks: [] }),
+      getHistory: vi.fn().mockResolvedValue([]),
+      updateState: vi.fn().mockResolvedValue({}),
+    },
+    assistants: {
+      search: vi.fn().mockResolvedValue([MOCK_ASSISTANT]),
+      getGraph: vi.fn().mockResolvedValue(MOCK_GRAPH_INFO),
+      getSchemas: vi.fn().mockResolvedValue({
+        config_schema: schemaKeysOverride?.config
+          ? {
+              properties: Object.fromEntries(
+                schemaKeysOverride.config.map((k) => [k, {}]),
+              ),
+            }
+          : undefined,
+        input_schema: schemaKeysOverride?.input
+          ? {
+              properties: Object.fromEntries(
+                schemaKeysOverride.input.map((k) => [k, {}]),
+              ),
+            }
+          : { properties: { messages: {}, tools: {} } },
+        output_schema: schemaKeysOverride?.output
+          ? {
+              properties: Object.fromEntries(
+                schemaKeysOverride.output.map((k) => [k, {}]),
+              ),
+            }
+          : { properties: { messages: {}, tools: {} } },
+        ...(schemaKeysOverride?.context
+          ? {
+              context_schema: {
+                properties: Object.fromEntries(
+                  schemaKeysOverride.context.map((k) => [k, {}]),
+                ),
+              },
+            }
+          : {}),
+      }),
+    },
+    runs: {
+      stream: vi
+        .fn()
+        .mockImplementation(
+          (_threadId: string, _assistantId: string, payload: any) => {
+            capturedPayload.value = payload;
+            // Return an async iterable that yields nothing (stream is not tested here)
+            return {
+              [Symbol.asyncIterator]() {
+                return { next: async () => ({ done: true, value: undefined }) };
+              },
+            };
+          },
+        ),
+    },
+  };
+
+  // Mock subscriber
+  const events: any[] = [];
+  (agent as any).subscriber = {
+    next: (e: any) => events.push(e),
+    error: vi.fn(),
+    complete: vi.fn(),
+    closed: false,
+  };
+
+  return { agent, capturedPayload, events };
+}
+
+/**
+ * Helper to run prepareStream on a mocked agent and return the captured payload.
+ */
+async function runPrepareStream(
+  agent: LangGraphAgent,
+  inputOverrides: Record<string, any> = {},
+) {
+  const defaultInput = {
+    runId: "run-1",
+    threadId: "thread-1",
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...inputOverrides,
+  };
+
+  return agent.prepareStream(defaultInput as any, [
+    "events",
+    "values",
+    "updates",
+    "messages-tuple",
+  ]);
+}
+
+// ─── Part A: prepareStream payload shape ─────────────────────────────────────
+
+describe("prepareStream payload partitioning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("test 1: configurable-only payload when no context_schema keys match", async () => {
+    // No context_schema declared — all configurable stays in config.configurable
+    const { agent, capturedPayload } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { thread_scoped: "val1", app_key: "val2" },
+        },
+      },
+      { config: ["thread_scoped", "app_key"], context: [] },
+    );
+
+    await runPrepareStream(agent, {
+      context: [{ description: "foo", value: "bar" }],
+    });
+
+    const payload = capturedPayload.value!;
+    // ag-ui context array must NOT leak into payload-level context
+    expect(payload).not.toHaveProperty("context");
+    // configurable should be preserved
+    expect(payload.config).toBeDefined();
+    expect((payload.config as any).configurable).toBeDefined();
+    expect((payload.config as any).configurable.thread_scoped).toBe("val1");
+    expect((payload.config as any).configurable.app_key).toBe("val2");
+  });
+
+  it("test 2: context-only payload when context_schema keys exist", async () => {
+    const { agent, capturedPayload } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { my_app_key: "val", thread_scoped: "other" },
+        },
+      },
+      { config: ["thread_scoped", "my_app_key"], context: ["my_app_key"] },
+    );
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    // context should contain the context_schema key
+    expect(payload.context).toEqual({ my_app_key: "val" });
+    // configurable should be absent (stripped because context wins)
+    expect((payload.config as any)?.configurable).toBeUndefined();
+  });
+
+  it("test 3: context-wins data-loss scenario with warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { agent, capturedPayload } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { my_app_key: "val", thread_scoped: "other" },
+        },
+      },
+      { config: ["thread_scoped", "my_app_key"], context: ["my_app_key"] },
+    );
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    // (a) context equals only the context_schema key
+    expect(payload.context).toEqual({ my_app_key: "val" });
+    // (b) configurable absent from payload
+    expect((payload.config as any)?.configurable).toBeUndefined();
+    // (c) console.warn was called with dropped key name
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("thread_scoped"),
+    );
+    // (d) warning prefix appears
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[@ag-ui/langgraph]"),
+    );
+  });
+
+  it("test 4: no double-population (no key in both configurable and context)", async () => {
+    const { agent, capturedPayload } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { ctx_key: "a", cfg_key: "b" },
+        },
+      },
+      { config: ["ctx_key", "cfg_key"], context: ["ctx_key"] },
+    );
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    const contextKeys = payload.context
+      ? Object.keys(payload.context as object)
+      : [];
+    const configurableKeys = (payload.config as any)?.configurable
+      ? Object.keys((payload.config as any).configurable)
+      : [];
+
+    // No key should appear in both
+    const overlap = contextKeys.filter((k) => configurableKeys.includes(k));
+    expect(overlap).toHaveLength(0);
+  });
+
+  it("test 5: warning logged when non-context_schema configurable keys are dropped", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { agent } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { ctx_key: "a", orphan_key: "b" },
+        },
+      },
+      { config: ["ctx_key", "orphan_key"], context: ["ctx_key"] },
+    );
+
+    await runPrepareStream(agent);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("orphan_key"));
+  });
+
+  it("test 6: RunAgentInput.context array is NOT spread into payload context", async () => {
+    const { agent, capturedPayload } = buildMockedAgent(
+      {},
+      { config: [], context: [] },
+    );
+
+    await runPrepareStream(agent, {
+      context: [{ description: "foo", value: "bar" }],
+    });
+
+    const payload = capturedPayload.value!;
+    // No context_schema keys match, so context should be absent
+    expect(payload).not.toHaveProperty("context");
+    // Verify the ag-ui array did NOT produce {0: {...}} in the payload
+    expect(payload.context).toBeUndefined();
+  });
+
+  it("test 7: mergeConfigs preserves context_schema keys in allowlist", async () => {
+    const { agent } = buildMockedAgent(
+      {},
+      { config: ["config_key"], context: ["ctx_key"] },
+    );
+
+    // Pre-populate assistant so mergeConfigs can run
+    (agent as any).assistant = MOCK_ASSISTANT;
+
+    const schemaKeys = {
+      config: ["config_key"],
+      context: ["ctx_key"],
+      input: null,
+      output: null,
+    };
+
+    const result = await (agent as any).mergeConfigs({
+      configs: [
+        {
+          configurable: { config_key: "a", ctx_key: "b", unknown_key: "c" },
+        },
+      ],
+      assistant: MOCK_ASSISTANT,
+      schemaKeys,
+    });
+
+    expect(result.configurable).toHaveProperty("config_key", "a");
+    expect(result.configurable).toHaveProperty("ctx_key", "b");
+    expect(result.configurable).not.toHaveProperty("unknown_key");
+  });
+});
+
+// ─── Part B: header forwarding ───────────────────────────────────────────────
+//
+// The LangGraphClient stores onRequest as a `protected` property on BaseClient.
+// At runtime it's a regular JS property, but the Client class is a wrapper that
+// creates sub-clients (runs, threads, etc.) as separate objects. We test header
+// forwarding by intercepting global fetch, since onRequest runs inside fetch calls.
+//
+
+describe("header forwarding via onRequest hook", () => {
+  let fetchSpy: ReturnType<typeof vi.fn<typeof fetch>>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("test 8: default headerFactory reads agent.headers", async () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+
+    agent.headers = { "X-Test": "123" };
+
+    // Trigger a real fetch through the client (assistants.search is simplest)
+    try {
+      await agent.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape, that's fine
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, fetchInit] = fetchSpy.mock.calls[0];
+    const headers = fetchInit!.headers;
+    expect(headers).toHaveProperty("X-Test", "123");
+  });
+
+  it("test 9: custom headerFactory overrides default", async () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+      headerFactory: () => ({ "X-Custom": "abc" }),
+    });
+
+    // Set agent.headers — should be ignored because custom factory overrides
+    agent.headers = { "X-Ignored": "nope" };
+
+    try {
+      await agent.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, fetchInit] = fetchSpy.mock.calls[0];
+    const headers = fetchInit!.headers;
+    expect(headers).toHaveProperty("X-Custom", "abc");
+    expect(headers).not.toHaveProperty("X-Ignored");
+  });
+
+  it("test 10: clone() creates independent header context (concurrent isolation)", async () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+
+    const cloned = agent.clone() as LangGraphAgent;
+
+    // Set DIFFERENT headers on each at the same time
+    agent.headers = { "X-Source": "original" };
+    cloned.headers = { "X-Source": "cloned" };
+
+    // Fire both requests; do NOT clear mock between — proves concurrent isolation
+    try {
+      await agent.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape
+    }
+    try {
+      await cloned.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // First call carries original headers
+    const [, origInit] = fetchSpy.mock.calls[0];
+    expect(origInit!.headers).toHaveProperty("X-Source", "original");
+    // Second call carries clone headers
+    const [, cloneInit] = fetchSpy.mock.calls[1];
+    expect(cloneInit!.headers).toHaveProperty("X-Source", "cloned");
+  });
+
+  it("test 11: propertyHeaders and dynamic headers coexist", async () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+      propertyHeaders: { "X-Static": "s" },
+    });
+    agent.headers = { "X-Dynamic": "d" };
+
+    try {
+      await agent.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, fetchInit] = fetchSpy.mock.calls[0];
+    const headers = fetchInit!.headers;
+    // The SDK's mergeHeaders lowercases header names (uses `new Headers()` internally).
+    // propertyHeaders go through mergeHeaders → lowercase. Dynamic headers from onRequest
+    // keep their original casing since they are spread directly.
+    expect(headers).toHaveProperty("x-static", "s");
+    expect(headers).toHaveProperty("X-Dynamic", "d");
+  });
+
+  it("test 12: empty headers produce no extra headers (no-op)", async () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+    // headers is default {} — empty
+
+    try {
+      await agent.client.assistants.search({ graphId: "test-graph" });
+    } catch {
+      // May fail due to mock response shape
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, fetchInit] = fetchSpy.mock.calls[0];
+    const headers = fetchInit!.headers as Record<string, string>;
+    // Should NOT have any extra X- headers from our hook
+    const xHeaders = Object.keys(headers).filter((k) => k.startsWith("X-"));
+    expect(xHeaders).toHaveLength(0);
+  });
+});
+
+// ─── Integration tests (skipped without LANGGRAPH_API_URL) ───────────────────
+
+describe("integration tests (require LANGGRAPH_API_URL)", () => {
+  it.todo(
+    "test 13: successful stream against langgraph-api >= 0.7.x — integration test (gated on LANGGRAPH_API_URL)",
+  );
+
+  it.todo(
+    "test 14: headers arrive at the langgraph-api server — integration test (gated on LANGGRAPH_API_URL)",
+  );
+});

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -110,6 +110,16 @@ interface RegenerateInput extends RunAgentExtendedInput {
 }
 
 export interface LangGraphAgentConfig extends AgentConfig {
+  /**
+   * Optional pre-constructed LangGraphClient. When provided, the agent uses
+   * this client directly and does NOT install its own `onRequest` hook.
+   *
+   * WARNING: Custom-client users do NOT get per-request header forwarding via
+   * `headers` / `headerFactory`. The runtime's `agent.headers` writes will be
+   * inert — the custom client is responsible for any header injection.
+   * If you need per-request header forwarding, omit this field and let the
+   * adapter construct its own client.
+   */
   client?: LangGraphClient;
   deploymentUrl: string;
   langsmithApiKey?: string;
@@ -117,6 +127,18 @@ export interface LangGraphAgentConfig extends AgentConfig {
   assistantConfig?: LangGraphConfig;
   agentName?: string;
   graphId: string;
+  /**
+   * Optional factory that returns per-request headers.
+   * Called on every HTTP request to langgraph-api.
+   * Use this for dynamic headers that change between requests (e.g., trace IDs).
+   * For static headers, use propertyHeaders instead.
+   *
+   * WARNING: Custom factories must not capture mutable agent state across clones.
+   * Each clone gets its own `onRequest` closure; the factory should read from the
+   * specific agent instance (e.g., `() => myAgent.headers`), not from a shared
+   * variable that could be mutated by a different clone or request.
+   */
+  headerFactory?: () => Record<string, string>;
 }
 
 const ROOT_SUBGRAPH_NAME = "root";
@@ -126,6 +148,9 @@ export class LangGraphAgent extends AbstractAgent {
   assistantConfig?: LangGraphConfig;
   agentName?: string;
   graphId: string;
+  /** Per-request headers set by the runtime (e.g., CopilotKit).
+   *  Read by the default headerFactory on every outgoing request. */
+  public headers: Record<string, string> = {};
   assistant?: Assistant;
   messagesInProcess: MessagesInProgressRecord;
   emittedToolCallStartIds: Set<string> = new Set();
@@ -156,17 +181,44 @@ export class LangGraphAgent extends AbstractAgent {
     this.graphId = config.graphId;
     this.assistantConfig = config.assistantConfig;
     this.reasoningProcess = null;
+
+    // Default factory reads this.headers (set per-clone by CopilotKit Runtime)
+    const agent = this;
+    const headerFactory = config.headerFactory ?? (() => agent.headers);
+
+    if (config?.client && config.headerFactory) {
+      console.debug(
+        "[@ag-ui/langgraph] Both `config.client` and `config.headerFactory` were set. " +
+          "Custom clients bypass the adapter's onRequest hook — `headerFactory` will not " +
+          "be invoked. Either omit `client` to enable adapter-managed header forwarding, " +
+          "or wire headers into your custom client directly.",
+      );
+    }
+
     this.client =
       config?.client ??
       new LangGraphClient({
         apiUrl: config.deploymentUrl,
         apiKey: config.langsmithApiKey,
         defaultHeaders: { ...(config.propertyHeaders ?? {}) },
+        onRequest: (url: URL, init: RequestInit): RequestInit => {
+          const dynamicHeaders = headerFactory();
+          if (!dynamicHeaders || Object.keys(dynamicHeaders).length === 0) {
+            return init;
+          }
+          return {
+            ...init,
+            headers: {
+              ...(init.headers as Record<string, string>),
+              ...dynamicHeaders,
+            },
+          };
+        },
       });
   }
 
   public clone() {
-    return Object.assign(super.clone(), {
+    const cloned = Object.assign(super.clone(), {
       config: this.config,
       messagesInProcess: structuredClone(this.messagesInProcess),
       agentName: this.agentName,
@@ -176,6 +228,7 @@ export class LangGraphAgent extends AbstractAgent {
         ? structuredClone(this.reasoningProcess)
         : null,
       constantSchemaKeys: [...this.constantSchemaKeys],
+      headers: { ...this.headers },
       client: this.client,
 
       assistant: this.assistant,
@@ -185,6 +238,31 @@ export class LangGraphAgent extends AbstractAgent {
       subgraphs: this.subgraphs ? new Set(this.subgraphs) : new Set(),
       currentSubgraph: ROOT_SUBGRAPH_NAME,
     });
+
+    // Rebuild client so onRequest captures the cloned agent's headers
+    if (!this.config.client) {
+      const headerFactory = this.config.headerFactory ?? (() => cloned.headers);
+      cloned.client = new LangGraphClient({
+        apiUrl: this.config.deploymentUrl,
+        apiKey: this.config.langsmithApiKey,
+        defaultHeaders: { ...(this.config.propertyHeaders ?? {}) },
+        onRequest: (url: URL, init: RequestInit): RequestInit => {
+          const dynamicHeaders = headerFactory();
+          if (!dynamicHeaders || Object.keys(dynamicHeaders).length === 0) {
+            return init;
+          }
+          return {
+            ...init,
+            headers: {
+              ...(init.headers as Record<string, string>),
+              ...dynamicHeaders,
+            },
+          };
+        },
+      });
+    }
+
+    return cloned;
   }
 
   dispatchEvent(event: ProcessedEvents) {
@@ -204,7 +282,10 @@ export class LangGraphAgent extends AbstractAgent {
     });
   }
 
-  async runAgentStream(input: RunAgentExtendedInput, subscriber: Subscriber<ProcessedEvents>) {
+  async runAgentStream(
+    input: RunAgentExtendedInput,
+    subscriber: Subscriber<ProcessedEvents>,
+  ) {
     this.activeRun = {
       id: input.runId,
       threadId: input.threadId,
@@ -221,17 +302,35 @@ export class LangGraphAgent extends AbstractAgent {
     }
     const threadId = input.threadId ?? randomUUID();
     const streamMode =
-      input.forwardedProps?.streamMode ?? (["events", "values", "updates", "messages-tuple"] satisfies StreamMode[]);
-    const preparedStream = await this.prepareStream({ ...input, threadId }, streamMode);
+      input.forwardedProps?.streamMode ??
+      ([
+        "events",
+        "values",
+        "updates",
+        "messages-tuple",
+      ] satisfies StreamMode[]);
+    const preparedStream = await this.prepareStream(
+      { ...input, threadId },
+      streamMode,
+    );
 
     if (!preparedStream) {
       return subscriber.error("No stream to regenerate");
     }
 
-    await this.handleStreamEvents(preparedStream, threadId, subscriber, input, Array.isArray(streamMode) ? streamMode : [streamMode]);
+    await this.handleStreamEvents(
+      preparedStream,
+      threadId,
+      subscriber,
+      input,
+      Array.isArray(streamMode) ? streamMode : [streamMode],
+    );
   }
 
-  async prepareRegenerateStream(input: RegenerateInput, streamMode: StreamMode | StreamMode[]) {
+  async prepareRegenerateStream(
+    input: RegenerateInput,
+    streamMode: StreamMode | StreamMode[],
+  ) {
     const { threadId, messageCheckpoint, forwardedProps } = input;
 
     const timeTravelCheckpoint = await this.getCheckpointByMessage(
@@ -247,15 +346,20 @@ export class LangGraphAgent extends AbstractAgent {
     }
 
     const fork = await this.client.threads.updateState(threadId, {
-      values: this.langGraphDefaultMergeState(timeTravelCheckpoint.values, [], input),
+      values: this.langGraphDefaultMergeState(
+        timeTravelCheckpoint.values,
+        [],
+        input,
+      ),
       checkpointId: timeTravelCheckpoint.checkpoint.checkpoint_id!,
       asNode: timeTravelCheckpoint.next?.[0] ?? "__start__",
     });
 
     let payloadConfig: LangGraphConfig | undefined;
-    const configsToMerge = [this.assistantConfig, forwardedProps?.config].filter(
-      Boolean,
-    ) as LangGraphConfig[];
+    const configsToMerge = [
+      this.assistantConfig,
+      forwardedProps?.config,
+    ].filter(Boolean) as LangGraphConfig[];
     if (configsToMerge.length) {
       payloadConfig = await this.mergeConfigs({
         configs: configsToMerge,
@@ -277,13 +381,20 @@ export class LangGraphAgent extends AbstractAgent {
       config: payloadConfig,
     };
     return {
-      streamResponse: this.client.runs.stream(threadId, this.assistant.assistant_id, payload),
+      streamResponse: this.client.runs.stream(
+        threadId,
+        this.assistant.assistant_id,
+        payload,
+      ),
       state: timeTravelCheckpoint as ThreadState<State>,
       streamMode,
     };
   }
 
-  async prepareStream(input: RunAgentExtendedInput, streamMode: StreamMode | StreamMode[]) {
+  async prepareStream(
+    input: RunAgentExtendedInput,
+    streamMode: StreamMode | StreamMode[],
+  ) {
     let {
       threadId: inputThreadId,
       state: inputState,
@@ -303,7 +414,10 @@ export class LangGraphAgent extends AbstractAgent {
       this.assistant = await this.getAssistant();
     }
 
-    const thread = await this.getOrCreateThread(threadId, forwardedProps?.threadMetadata);
+    const thread = await this.getOrCreateThread(
+      threadId,
+      forwardedProps?.threadMetadata,
+    );
     this.activeRun!.threadId = thread.thread_id;
 
     const agentState: ThreadState<State> =
@@ -331,8 +445,12 @@ export class LangGraphAgent extends AbstractAgent {
     // Both sides must filter system messages for an accurate comparison,
     // since the LangGraph state may contain system messages injected by
     // the connector (e.g. CopilotKit context) that the frontend doesn't track.
-    const stateNonSystemCount = agentStateMessages.filter((m: LangGraphPlatformMessage) => m.type !== "system").length;
-    const inputNonSystemCount = messages.filter((m) => m.role !== "system").length;
+    const stateNonSystemCount = agentStateMessages.filter(
+      (m: LangGraphPlatformMessage) => m.type !== "system",
+    ).length;
+    const inputNonSystemCount = messages.filter(
+      (m) => m.role !== "system",
+    ).length;
 
     if (stateNonSystemCount > inputNonSystemCount) {
       let lastUserMessage: LangGraphMessage | null = null;
@@ -345,7 +463,9 @@ export class LangGraphAgent extends AbstractAgent {
       }
 
       if (!lastUserMessage) {
-        return this.subscriber.error("No user message found in messages to regenerate");
+        return this.subscriber.error(
+          "No user message found in messages to regenerate",
+        );
       }
 
       return this.prepareRegenerateStream(
@@ -353,7 +473,9 @@ export class LangGraphAgent extends AbstractAgent {
         streamMode,
       );
     }
-    this.activeRun!.graphInfo = await this.client.assistants.getGraph(this.assistant.assistant_id);
+    this.activeRun!.graphInfo = await this.client.assistants.getGraph(
+      this.assistant.assistant_id,
+    );
 
     const mode =
       !forwardedProps?.command?.resume &&
@@ -380,9 +502,10 @@ export class LangGraphAgent extends AbstractAgent {
     });
 
     let payloadConfig: LangGraphConfig | undefined;
-    const configsToMerge = [this.assistantConfig, forwardedProps?.config].filter(
-      Boolean,
-    ) as LangGraphConfig[];
+    const configsToMerge = [
+      this.assistantConfig,
+      forwardedProps?.config,
+    ].filter(Boolean) as LangGraphConfig[];
     if (configsToMerge.length) {
       payloadConfig = await this.mergeConfigs({
         configs: configsToMerge,
@@ -391,44 +514,114 @@ export class LangGraphAgent extends AbstractAgent {
       });
     }
     // @ts-ignore
-    const { command, ...restProps } = forwardedProps
-    if (command?.resume && typeof command.resume === 'string') {
+    const { command, ...restProps } = forwardedProps;
+    if (command?.resume && typeof command.resume === "string") {
       try {
         command.resume = JSON.parse(command.resume);
       } catch {
         // Keep as string if not valid JSON
       }
     }
-    const payload = {
+
+    // Build context from configurable keys that match the graph's context_schema.
+    // RunAgentInput.context is a separate ag-ui concept (Array<{description, value}>)
+    // that already flows into the graph's input state via langGraphDefaultMergeState.
+    // It does NOT go into the payload-level context field.
+    const contextSchemaKeys = new Set(
+      this.activeRun!.schemaKeys?.context ?? [],
+    );
+    const configurable = payloadConfig?.configurable ?? {};
+
+    // Partition configurable: keys declared in context_schema go to context,
+    // the rest stay in configurable (for backward compat with older servers).
+    const contextFromConfigurable: Record<string, unknown> = {};
+    const remainingConfigurable: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(configurable)) {
+      if (contextSchemaKeys.has(key)) {
+        contextFromConfigurable[key] = value;
+      } else {
+        remainingConfigurable[key] = value;
+      }
+    }
+
+    // Build payload-level context ONLY from configurable keys matching context_schema.
+    // Do NOT spread RunAgentInput.context here — it is Array<{description, value}>,
+    // not Record<string, unknown>, and belongs in the graph's input state, not the
+    // payload-level context field.
+    const mergedContext = { ...contextFromConfigurable };
+
+    // Build final config: if remaining configurable is empty, omit it
+    const finalConfig = payloadConfig
+      ? {
+          ...payloadConfig,
+          configurable:
+            Object.keys(remainingConfigurable).length > 0
+              ? remainingConfigurable
+              : undefined,
+        }
+      : undefined;
+
+    // If both context and configurable would be present, context wins
+    // (matches langgraph-api >= 0.7.x expectation).
+    // If context is empty, omit it (backward compat with older servers).
+    const hasContext = Object.keys(mergedContext).length > 0;
+    const hasConfigurable =
+      finalConfig?.configurable != null &&
+      Object.keys(finalConfig.configurable).length > 0;
+
+    // Warn if non-schema configurable keys are being dropped because context wins
+    if (hasContext && hasConfigurable) {
+      const droppedKeys = Object.keys(remainingConfigurable);
+      if (droppedKeys.length > 0) {
+        console.warn(
+          `[@ag-ui/langgraph] Dropping configurable keys not in context_schema: [${droppedKeys.join(", ")}]. Use context instead.`,
+        );
+      }
+    }
+
+    // Strip configurable cleanly using destructuring to avoid leaving an
+    // explicit `configurable: undefined` key in the serialized payload.
+    const configForPayload = (() => {
+      if (!finalConfig) return undefined;
+      if (hasConfigurable && !hasContext) return finalConfig; // old-style: configurable only
+      const { configurable: _stripped, ...configSansConfigurable } =
+        finalConfig;
+      return Object.keys(configSansConfigurable).length > 0
+        ? configSansConfigurable
+        : undefined;
+    })();
+
+    const payload: Record<string, unknown> = {
       ...restProps,
       command,
       streamMode,
       input: payloadInput,
-      config: payloadConfig,
-      context: {
-        ...context,
-        ...(payloadConfig?.configurable ?? {}),
-      }
+      config: configForPayload,
+      ...(hasContext ? { context: mergedContext } : {}),
     };
 
     // If there are still outstanding unresolved interrupts, we must force resolution of them before moving forward
     // Collect interrupts from ALL tasks, not just tasks[0] (fixes #1409).
     // The SDK doesn't export a Task type, so we use `any` here.
-    const interrupts = (agentState.tasks ?? []).flatMap((t: any) => t.interrupts ?? []) as Interrupt[];
+    const interrupts = (agentState.tasks ?? []).flatMap(
+      (t: any) => t.interrupts ?? [],
+    ) as Interrupt[];
     if (interrupts?.length && !forwardedProps?.command?.resume) {
       this.dispatchEvent({
         type: EventType.RUN_STARTED,
         threadId,
         runId: input.runId,
       });
-      this.handleNodeChange(nodeNameInput)
+      this.handleNodeChange(nodeNameInput);
 
       interrupts.forEach((interrupt) => {
         this.dispatchEvent({
           type: EventType.CUSTOM,
           name: LangGraphEventTypes.OnInterrupt,
           value:
-            typeof interrupt.value === "string" ? interrupt.value : JSON.stringify(interrupt.value),
+            typeof interrupt.value === "string"
+              ? interrupt.value
+              : JSON.stringify(interrupt.value),
           rawEvent: interrupt,
         });
       });
@@ -443,14 +636,19 @@ export class LangGraphAgent extends AbstractAgent {
 
     return {
       // @ts-ignore
-      streamResponse: this.client.runs.stream(threadId, this.assistant.assistant_id, payload),
+      streamResponse: this.client.runs.stream(
+        threadId,
+        this.assistant.assistant_id,
+        payload,
+      ),
       state: threadState as ThreadState<State>,
     };
   }
 
   async handleStreamEvents(
     stream: Awaited<
-      ReturnType<typeof this.prepareStream> | ReturnType<typeof this.prepareRegenerateStream>
+      | ReturnType<typeof this.prepareStream>
+      | ReturnType<typeof this.prepareRegenerateStream>
     >,
     threadId: string,
     subscriber: Subscriber<ProcessedEvents>,
@@ -477,7 +675,7 @@ export class LangGraphAgent extends AbstractAgent {
         threadId,
         runId: this.activeRun!.id,
       });
-      this.handleNodeChange(nodeNameInput)
+      this.handleNodeChange(nodeNameInput);
 
       for await (let streamResponseChunk of streamResponse) {
         // If a cancel was requested and we haven't sent it yet, try now.
@@ -488,7 +686,10 @@ export class LangGraphAgent extends AbstractAgent {
           this.activeRun?.id
         ) {
           try {
-            await this.client.runs.cancel(this.activeRun.threadId, this.activeRun.id);
+            await this.client.runs.cancel(
+              this.activeRun.threadId,
+              this.activeRun.id,
+            );
           } catch (_) {
             // Ignore cancellation errors
           } finally {
@@ -502,7 +703,8 @@ export class LangGraphAgent extends AbstractAgent {
           break;
         }
 
-        const subgraphsStreamEnabled = input.forwardedProps?.streamSubgraphs ?? true;
+        const subgraphsStreamEnabled =
+          input.forwardedProps?.streamSubgraphs ?? true;
         const isSubgraphStream =
           subgraphsStreamEnabled &&
           (streamResponseChunk.event.startsWith("events") ||
@@ -512,10 +714,17 @@ export class LangGraphAgent extends AbstractAgent {
         // so we need to check for that mapping in addition to the direct mode name.
         const isMessagesTupleEvent =
           streamResponseChunk.event === "messages" &&
-          (Array.isArray(streamModes) ? streamModes : [streamModes]).includes("messages-tuple" as StreamMode);
+          (Array.isArray(streamModes) ? streamModes : [streamModes]).includes(
+            "messages-tuple" as StreamMode,
+          );
 
         // @ts-ignore
-        if (!streamModes.includes(streamResponseChunk.event as StreamMode) && !isSubgraphStream && !isMessagesTupleEvent && streamResponseChunk.event !== 'error') {
+        if (
+          !streamModes.includes(streamResponseChunk.event as StreamMode) &&
+          !isSubgraphStream &&
+          !isMessagesTupleEvent &&
+          streamResponseChunk.event !== "error"
+        ) {
           continue;
         }
 
@@ -527,7 +736,9 @@ export class LangGraphAgent extends AbstractAgent {
           data: any;
           [key: string]: unknown;
         };
-        const chunk = streamResponseChunk as EventsStreamEvent & { data: EventsChunkData };
+        const chunk = streamResponseChunk as EventsStreamEvent & {
+          data: EventsChunkData;
+        };
 
         if (streamResponseChunk.event === "error") {
           this.dispatchEvent({
@@ -548,7 +759,10 @@ export class LangGraphAgent extends AbstractAgent {
             ...chunk.data,
           };
           continue;
-        } else if (subgraphsStreamEnabled && chunk.event.startsWith("values|")) {
+        } else if (
+          subgraphsStreamEnabled &&
+          chunk.event.startsWith("values|")
+        ) {
           latestStateValues = {
             ...latestStateValues,
             ...chunk.data,
@@ -566,7 +780,8 @@ export class LangGraphAgent extends AbstractAgent {
         const ns: string = metadata.langgraph_checkpoint_ns ?? "";
         const nsRoot = ns.split("|")[0].split(":")[0];
         if (ns.includes("|") && nsRoot) this.subgraphs.add(nsRoot);
-        const currentSubgraph = (nsRoot && this.subgraphs.has(nsRoot)) ? nsRoot : ROOT_SUBGRAPH_NAME;
+        const currentSubgraph =
+          nsRoot && this.subgraphs.has(nsRoot) ? nsRoot : ROOT_SUBGRAPH_NAME;
 
         if (currentSubgraph !== this.currentSubgraph) {
           this.currentSubgraph = currentSubgraph;
@@ -578,9 +793,16 @@ export class LangGraphAgent extends AbstractAgent {
           this.activeRun!.id = metadata.run_id;
           this.activeRun!.serverRunIdKnown = true;
           // If cancel was requested earlier (before server id was known), send it now.
-          if (this.cancelRequested && !this.cancelSent && this.activeRun?.threadId) {
+          if (
+            this.cancelRequested &&
+            !this.cancelSent &&
+            this.activeRun?.threadId
+          ) {
             try {
-              await this.client.runs.cancel(this.activeRun.threadId!, this.activeRun.id);
+              await this.client.runs.cancel(
+                this.activeRun.threadId!,
+                this.activeRun.id,
+              );
             } catch (_) {
               // Ignore cancellation errors
             } finally {
@@ -590,7 +812,7 @@ export class LangGraphAgent extends AbstractAgent {
         }
 
         if (currentNodeName && currentNodeName !== this.activeRun!.nodeName) {
-          this.handleNodeChange(currentNodeName)
+          this.handleNodeChange(currentNodeName);
         }
 
         shouldExit =
@@ -604,7 +826,10 @@ export class LangGraphAgent extends AbstractAgent {
         // LangGraph JS doesn't emit `values` chunks with the latest state between
         // tool execution and run end, so without this update, intermediate
         // STATE_SNAPSHOTs go stale after a tool Command updates state.
-        if (eventType === LangGraphEventTypes.OnChainEnd && chunkData.data?.output != null) {
+        if (
+          eventType === LangGraphEventTypes.OnChainEnd &&
+          chunkData.data?.output != null
+        ) {
           const output: any = chunkData.data.output;
           if (typeof output === "object" && !Array.isArray(output)) {
             latestStateValues = { ...latestStateValues, ...output };
@@ -617,13 +842,19 @@ export class LangGraphAgent extends AbstractAgent {
                 (item as any).update &&
                 typeof (item as any).update === "object"
               ) {
-                latestStateValues = { ...latestStateValues, ...(item as any).update };
+                latestStateValues = {
+                  ...latestStateValues,
+                  ...(item as any).update,
+                };
               }
             }
           }
         }
 
-        if (eventType === LangGraphEventTypes.OnChainEnd && this.activeRun!.nodeName === currentNodeName) {
+        if (
+          eventType === LangGraphEventTypes.OnChainEnd &&
+          this.activeRun!.nodeName === currentNodeName
+        ) {
           this.activeRun!.exitingNode = true;
         }
         if (this.activeRun!.exitingNode) {
@@ -645,17 +876,23 @@ export class LangGraphAgent extends AbstractAgent {
 
         // we only want to update the node name under certain conditions
         // since we don't need any internal node names to be sent to the frontend
-        if (this.activeRun!.graphInfo?.["nodes"].some((node) => node.id === currentNodeName)) {
-          this.handleNodeChange(currentNodeName)
+        if (
+          this.activeRun!.graphInfo?.["nodes"].some(
+            (node) => node.id === currentNodeName,
+          )
+        ) {
+          this.handleNodeChange(currentNodeName);
         }
 
-        updatedState.values = this.activeRun!.manuallyEmittedState ?? latestStateValues;
+        updatedState.values =
+          this.activeRun!.manuallyEmittedState ?? latestStateValues;
 
         if (!this.activeRun!.nodeName) {
           continue;
         }
 
-        const hasStateDiff = JSON.stringify(updatedState) !== JSON.stringify(state);
+        const hasStateDiff =
+          JSON.stringify(updatedState) !== JSON.stringify(state);
         // Suppress STATE_SNAPSHOT while a message is in progress, or while a
         // predict_state tool call is streaming args (modelMadeToolCall=true).
         // During tool arg streaming the graph state does not yet reflect the
@@ -693,7 +930,9 @@ export class LangGraphAgent extends AbstractAgent {
       state = await this.client.threads.getState(threadId);
       const tasks = state.tasks;
       // Collect interrupts from ALL tasks, not just tasks[0] (fixes #1409)
-      const interrupts = (tasks ?? []).flatMap((t: any) => t.interrupts ?? []) as Interrupt[];
+      const interrupts = (tasks ?? []).flatMap(
+        (t: any) => t.interrupts ?? [],
+      ) as Interrupt[];
       const isEndNode = state.next.length === 0;
       const writes = state.metadata?.writes ?? {};
 
@@ -701,7 +940,9 @@ export class LangGraphAgent extends AbstractAgent {
       let newNodeName = this.activeRun!.nodeName!;
 
       if (!interrupts?.length) {
-        newNodeName = isEndNode ? "__end__" : (state.next[0] ?? Object.keys(writes)[0]);
+        newNodeName = isEndNode
+          ? "__end__"
+          : (state.next[0] ?? Object.keys(writes)[0]);
       }
 
       interrupts.forEach((interrupt) => {
@@ -709,7 +950,9 @@ export class LangGraphAgent extends AbstractAgent {
           type: EventType.CUSTOM,
           name: LangGraphEventTypes.OnInterrupt,
           value:
-            typeof interrupt.value === "string" ? interrupt.value : JSON.stringify(interrupt.value),
+            typeof interrupt.value === "string"
+              ? interrupt.value
+              : JSON.stringify(interrupt.value),
           rawEvent: interrupt,
         });
       });
@@ -736,12 +979,14 @@ export class LangGraphAgent extends AbstractAgent {
   }
 
   private async getStateAndMessagesSnapshots(threadId: string): Promise<void> {
-    const state: ThreadState<State> = await this.client.threads.getState(threadId);
+    const state: ThreadState<State> =
+      await this.client.threads.getState(threadId);
     this.dispatchEvent({
       type: EventType.STATE_SNAPSHOT,
       snapshot: this.getStateSnapshot(state),
     });
-    const checkpointMessages: LangGraphMessage[] = (state.values as State).messages ?? [];
+    const checkpointMessages: LangGraphMessage[] =
+      (state.values as State).messages ?? [];
     this.dispatchEvent({
       type: EventType.MESSAGES_SNAPSHOT,
       messages: langchainMessagesToAgui(checkpointMessages),
@@ -773,26 +1018,34 @@ export class LangGraphAgent extends AbstractAgent {
         let currentStream = this.getMessageInProgress(this.activeRun!.id);
         const hasCurrentStream = Boolean(currentStream?.id);
         const toolCallData = event.data.chunk.tool_call_chunks?.[0];
-        const toolCallUsedToPredictState = event.metadata["predict_state"]?.some(
-          (predictStateTool: PredictStateTool) => predictStateTool.tool === toolCallData?.name,
+        const toolCallUsedToPredictState = event.metadata[
+          "predict_state"
+        ]?.some(
+          (predictStateTool: PredictStateTool) =>
+            predictStateTool.tool === toolCallData?.name,
         );
 
         const isToolCallStartEvent = !hasCurrentStream && toolCallData?.name;
         const isToolCallArgsEvent =
           hasCurrentStream && currentStream?.toolCallId && toolCallData?.args;
-        const isToolCallEndEvent = hasCurrentStream && currentStream?.toolCallId && !toolCallData;
+        const isToolCallEndEvent =
+          hasCurrentStream && currentStream?.toolCallId && !toolCallData;
 
         if (isToolCallEndEvent || isToolCallArgsEvent || isToolCallStartEvent) {
           this.activeRun!.hasFunctionStreaming = true;
         }
 
         const reasoningData = resolveReasoningContent(event.data);
-        const encryptedReasoningData = resolveEncryptedReasoningContent(event.data);
+        const encryptedReasoningData = resolveEncryptedReasoningContent(
+          event.data,
+        );
         const messageContent = resolveMessageContent(event.data.chunk.content);
         const isMessageContentEvent = Boolean(!toolCallData && messageContent);
 
         const isMessageEndEvent =
-          hasCurrentStream && !currentStream?.toolCallId && !isMessageContentEvent;
+          hasCurrentStream &&
+          !currentStream?.toolCallId &&
+          !isMessageContentEvent;
 
         if (reasoningData) {
           this.handleReasoningEvent(reasoningData);
@@ -926,7 +1179,8 @@ export class LangGraphAgent extends AbstractAgent {
         if (this.getMessageInProgress(this.activeRun!.id)?.toolCallId) {
           const resolved = this.dispatchEvent({
             type: EventType.TOOL_CALL_END,
-            toolCallId: this.getMessageInProgress(this.activeRun!.id)!.toolCallId!,
+            toolCallId: this.getMessageInProgress(this.activeRun!.id)!
+              .toolCallId!,
             rawEvent: event,
           });
           if (resolved) {
@@ -1009,41 +1263,56 @@ export class LangGraphAgent extends AbstractAgent {
         });
         break;
       case LangGraphEventTypes.OnToolEnd:
-        let toolCallOutput = event.data?.output
+        let toolCallOutput = event.data?.output;
 
         // Command from within a tool. We need to grab result from the tool result message
-        if (toolCallOutput && !toolCallOutput.tool_call_id && toolCallOutput.update?.messages?.find((message: { type: string }) => message.type === 'tool')) {
-          toolCallOutput = toolCallOutput.update?.messages?.find((message: { type: string }) => message.type === 'tool')
+        if (
+          toolCallOutput &&
+          !toolCallOutput.tool_call_id &&
+          toolCallOutput.update?.messages?.find(
+            (message: { type: string }) => message.type === "tool",
+          )
+        ) {
+          toolCallOutput = toolCallOutput.update?.messages?.find(
+            (message: { type: string }) => message.type === "tool",
+          );
         }
 
         if (toolCallOutput && toolCallOutput.update?.messages?.length) {
-          type MessageFields = ToolMessageFieldsWithToolCallId & { type: string }
-          toolCallOutput.update?.messages.filter((message: MessageFields) => message.type === 'tool').forEach((message: MessageFields) => {
-            if (!this.activeRun!.hasFunctionStreaming) {
-              this.dispatchEvent({
-                type: EventType.TOOL_CALL_START,
-                toolCallId: message.tool_call_id,
-                toolCallName: message.name ?? '',
-                parentMessageId: message.id,
-                rawEvent: event,
-              })
-              this.dispatchEvent({
-                type: EventType.TOOL_CALL_ARGS,
-                toolCallId: message.tool_call_id,
-                delta: JSON.stringify(event.data.input),
-                rawEvent: event,
-              });
-            }
+          type MessageFields = ToolMessageFieldsWithToolCallId & {
+            type: string;
+          };
+          toolCallOutput.update?.messages
+            .filter((message: MessageFields) => message.type === "tool")
+            .forEach((message: MessageFields) => {
+              if (!this.activeRun!.hasFunctionStreaming) {
+                this.dispatchEvent({
+                  type: EventType.TOOL_CALL_START,
+                  toolCallId: message.tool_call_id,
+                  toolCallName: message.name ?? "",
+                  parentMessageId: message.id,
+                  rawEvent: event,
+                });
+                this.dispatchEvent({
+                  type: EventType.TOOL_CALL_ARGS,
+                  toolCallId: message.tool_call_id,
+                  delta: JSON.stringify(event.data.input),
+                  rawEvent: event,
+                });
+              }
 
-            this.dispatchEvent({
-              type: EventType.TOOL_CALL_RESULT,
-              toolCallId: message.tool_call_id,
-              content: typeof message?.content === 'string' ? message?.content : JSON.stringify(message?.content),
-              messageId: randomUUID(),
-              rawEvent: event,
-              role: "tool",
-            })
-          })
+              this.dispatchEvent({
+                type: EventType.TOOL_CALL_RESULT,
+                toolCallId: message.tool_call_id,
+                content:
+                  typeof message?.content === "string"
+                    ? message?.content
+                    : JSON.stringify(message?.content),
+                messageId: randomUUID(),
+                rawEvent: event,
+                role: "tool",
+              });
+            });
 
           // Tool has completed — reset so the next snapshot reflects real state.
           this.activeRun!.modelMadeToolCall = false;
@@ -1062,7 +1331,7 @@ export class LangGraphAgent extends AbstractAgent {
             toolCallName: toolCallOutput.name,
             parentMessageId: toolCallOutput.id,
             rawEvent: event,
-          })
+          });
           this.dispatchEvent({
             type: EventType.TOOL_CALL_ARGS,
             toolCallId: toolCallOutput.tool_call_id,
@@ -1205,7 +1474,9 @@ export class LangGraphAgent extends AbstractAgent {
       }
       this.dispatchEvent({
         type: EventType.TEXT_MESSAGE_CONTENT,
-        messageId: (this.getMessageInProgress(this.activeRun!.id) ?? { id: chunk.id }).id,
+        messageId: (
+          this.getMessageInProgress(this.activeRun!.id) ?? { id: chunk.id }
+        ).id,
         delta: content,
       });
     }
@@ -1236,7 +1507,10 @@ export class LangGraphAgent extends AbstractAgent {
 
     const reasoningStepIndex = reasoningData.index;
 
-    if (this.reasoningProcess?.index && this.reasoningProcess.index !== reasoningStepIndex) {
+    if (
+      this.reasoningProcess?.index &&
+      this.reasoningProcess.index !== reasoningStepIndex
+    ) {
       if (this.reasoningProcess.type) {
         this.dispatchEvent({
           type: EventType.REASONING_MESSAGE_END,
@@ -1291,13 +1565,19 @@ export class LangGraphAgent extends AbstractAgent {
     const schemaKeys = this.activeRun!.schemaKeys!;
     // Do not emit state keys that are not part of the output schema
     if (schemaKeys?.output) {
-      state = filterObjectBySchemaKeys(state, [...this.constantSchemaKeys, ...schemaKeys.output]);
+      state = filterObjectBySchemaKeys(state, [
+        ...this.constantSchemaKeys,
+        ...schemaKeys.output,
+      ]);
     }
     // return state
     return state;
   }
 
-  async getOrCreateThread(threadId: string, threadMetadata?: Record<string, any>): Promise<Thread> {
+  async getOrCreateThread(
+    threadId: string,
+    threadMetadata?: Record<string, any>,
+  ): Promise<Thread> {
     let thread: Thread;
     try {
       try {
@@ -1319,7 +1599,9 @@ export class LangGraphAgent extends AbstractAgent {
     return this.client.threads.get(threadId);
   }
 
-  async createThread(payload?: Parameters<typeof this.client.threads.create>[0]) {
+  async createThread(
+    payload?: Parameters<typeof this.client.threads.create>[0],
+  ) {
     return this.client.threads.create(payload);
   }
 
@@ -1340,6 +1622,7 @@ export class LangGraphAgent extends AbstractAgent {
           ? filterObjectBySchemaKeys(cfg?.configurable, [
               ...this.constantSchemaKeys,
               ...(schemaKeys?.config ?? []),
+              ...(schemaKeys?.context ?? []),
             ])
           : cfg?.configurable;
       }
@@ -1354,7 +1637,8 @@ export class LangGraphAgent extends AbstractAgent {
       const isRecursionLimitSetToDefault =
         acc.recursion_limit == null && cfg.recursion_limit === 25;
       // Deep compare configs to avoid unnecessary update calls
-      const configsAreDifferent = JSON.stringify(newConfig) !== JSON.stringify(acc);
+      const configsAreDifferent =
+        JSON.stringify(newConfig) !== JSON.stringify(acc);
 
       // Check if the only difference is the recursion_limit being set to default
       const isOnlyRecursionLimitDifferent =
@@ -1389,7 +1673,10 @@ export class LangGraphAgent extends AbstractAgent {
 
   async getAssistant(): Promise<Assistant> {
     try {
-      const assistants = await this.client.assistants.search({ graphId: this.graphId, limit: 1 });
+      const assistants = await this.client.assistants.search({
+        graphId: this.graphId,
+        limit: 1,
+      });
       const retrievedAssistant = assistants.find(
         (searchResult) => searchResult.graph_id === this.graphId,
       );
@@ -1398,43 +1685,60 @@ export class LangGraphAgent extends AbstractAgent {
       No agent found with graph ID ${this.graphId} found..\n
 
       These are the available agents: [${assistants.map((a) => `${a.graph_id} (ID: ${a.assistant_id})`).join(", ")}]
-      `
+      `;
         console.error(notFoundMessage);
         throw new Error(notFoundMessage);
       }
 
       return retrievedAssistant;
     } catch (error) {
-      const redefinedError = new Error(`Failed to retrieve assistant: ${(error as Error).message}`)
+      const redefinedError = new Error(
+        `Failed to retrieve assistant: ${(error as Error).message}`,
+      );
       this.dispatchEvent({
         type: EventType.RUN_ERROR,
         message: redefinedError.message,
       });
-      this.subscriber.error()
+      this.subscriber.error();
       throw redefinedError;
     }
   }
 
   async getSchemaKeys(): Promise<SchemaKeys> {
     try {
-      const graphSchema = await this.client.assistants.getSchemas(this.assistant!.assistant_id);
+      const graphSchema = await this.client.assistants.getSchemas(
+        this.assistant!.assistant_id,
+      );
       let configSchema = null;
-      let contextSchema: string[] = []
-      if ('context_schema' in graphSchema && graphSchema.context_schema?.properties) {
+      let contextSchema: string[] = [];
+      if (
+        "context_schema" in graphSchema &&
+        graphSchema.context_schema?.properties
+      ) {
         contextSchema = Object.keys(graphSchema.context_schema.properties);
       }
       if (graphSchema.config_schema?.properties) {
         configSchema = Object.keys(graphSchema.config_schema.properties);
       }
-      if (!graphSchema.input_schema?.properties || !graphSchema.output_schema?.properties) {
-        return { config: [], input: null, output: null, context: contextSchema };
+      if (
+        !graphSchema.input_schema?.properties ||
+        !graphSchema.output_schema?.properties
+      ) {
+        return {
+          config: [],
+          input: null,
+          output: null,
+          context: contextSchema,
+        };
       }
       const inputSchema = Object.keys(graphSchema.input_schema.properties);
       const outputSchema = Object.keys(graphSchema.output_schema.properties);
 
       return {
         input:
-          inputSchema && inputSchema.length ? [...inputSchema, ...this.constantSchemaKeys] : null,
+          inputSchema && inputSchema.length
+            ? [...inputSchema, ...this.constantSchemaKeys]
+            : null,
         output:
           outputSchema && outputSchema.length
             ? [...outputSchema, ...this.constantSchemaKeys]
@@ -1443,39 +1747,66 @@ export class LangGraphAgent extends AbstractAgent {
         config: configSchema,
       };
     } catch (e) {
-      return { config: [], input: this.constantSchemaKeys, output: this.constantSchemaKeys, context: [] };
+      return {
+        config: [],
+        input: this.constantSchemaKeys,
+        output: this.constantSchemaKeys,
+        context: [],
+      };
     }
   }
 
-  langGraphDefaultMergeState(state: State, messages: LangGraphMessage[], input: RunAgentExtendedInput): State<StateEnrichment> {
-    if (messages.length > 0 && "role" in messages[0] && messages[0].role === "system") {
+  langGraphDefaultMergeState(
+    state: State,
+    messages: LangGraphMessage[],
+    input: RunAgentExtendedInput,
+  ): State<StateEnrichment> {
+    if (
+      messages.length > 0 &&
+      "role" in messages[0] &&
+      messages[0].role === "system"
+    ) {
       // remove system message
       messages = messages.slice(1);
     }
 
     // merge with existing messages
     const existingMessages: LangGraphPlatformMessage[] = state.messages || [];
-    const existingMessageIds = new Set(existingMessages.map((message) => message.id));
+    const existingMessageIds = new Set(
+      existingMessages.map((message) => message.id),
+    );
 
-    const newMessages = messages.filter((message) => !existingMessageIds.has(message.id));
+    const newMessages = messages.filter(
+      (message) => !existingMessageIds.has(message.id),
+    );
 
     // Input tools first so they win over stale state tools on name collision
-    const langGraphTools: LangGraphToolWithName[] = [...(input.tools ?? []), ...(state.tools ?? [])].reduce((acc, tool) => {
+    const langGraphTools: LangGraphToolWithName[] = [
+      ...(input.tools ?? []),
+      ...(state.tools ?? []),
+    ].reduce((acc, tool) => {
       let mappedTool = tool;
       if (!tool.type) {
         mappedTool = {
-            type: "function",
+          type: "function",
+          name: tool.name,
+          function: {
             name: tool.name,
-            function: {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters,
-            },
-        }
+            description: tool.description,
+            parameters: tool.parameters,
+          },
+        };
       }
 
       // Verify no duplicated
-      if (acc.find((t: LangGraphToolWithName) => (t.name === mappedTool.name) || t.function.name === mappedTool.function.name)) return acc;
+      if (
+        acc.find(
+          (t: LangGraphToolWithName) =>
+            t.name === mappedTool.name ||
+            t.function.name === mappedTool.function.name,
+        )
+      )
+        return acc;
 
       return [...acc, mappedTool];
     }, []);
@@ -1484,7 +1815,7 @@ export class LangGraphAgent extends AbstractAgent {
       ...state,
       messages: newMessages,
       tools: langGraphTools,
-      'ag-ui': {
+      "ag-ui": {
         tools: langGraphTools,
         context: input.context,
       },
@@ -1543,7 +1874,9 @@ export class LangGraphAgent extends AbstractAgent {
     const reversed = [...history].reverse(); // oldest → newest
 
     let targetState = reversed.find((state) =>
-      (state.values as State).messages?.some((m: LangGraphPlatformMessage) => m.id === messageId),
+      (state.values as State).messages?.some(
+        (m: LangGraphPlatformMessage) => m.id === messageId,
+      ),
     );
 
     if (!targetState) throw new Error("Message not found");
@@ -1554,16 +1887,27 @@ export class LangGraphAgent extends AbstractAgent {
     );
     const messagesAfter = targetStateMessages.slice(messageIndex + 1);
     if (messagesAfter.length) {
-      return this.getCheckpointByMessage(messageId, threadId, targetState.parent_checkpoint);
+      return this.getCheckpointByMessage(
+        messageId,
+        threadId,
+        targetState.parent_checkpoint,
+      );
     }
 
     const targetStateIndex = reversed.indexOf(targetState);
 
-    const { messages, ...targetStateValuesWithoutMessages } = targetState.values as State;
-    const selectedCheckpoint = reversed[targetStateIndex - 1] ?? { ...targetState, values: {} };
+    const { messages, ...targetStateValuesWithoutMessages } =
+      targetState.values as State;
+    const selectedCheckpoint = reversed[targetStateIndex - 1] ?? {
+      ...targetState,
+      values: {},
+    };
     return {
       ...selectedCheckpoint,
-      values: { ...selectedCheckpoint.values, ...targetStateValuesWithoutMessages },
+      values: {
+        ...selectedCheckpoint.values,
+        ...targetStateValuesWithoutMessages,
+      },
     };
   }
 }

--- a/integrations/mastra/typescript/src/__tests__/header-forwarding.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/header-forwarding.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "vitest";
+import {
+  FakeLocalAgent,
+  FakeRemoteAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+import { MastraAgent } from "../mastra";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTextChunks() {
+  return [
+    { type: "text-delta", payload: { text: "Hello" } },
+    { type: "finish", payload: {} },
+  ];
+}
+
+function makeLocalAgentCapturingStream(streamChunks: any[]) {
+  const fakeAgent = new FakeLocalAgent({ streamChunks });
+  const streamCalls: Array<{ messages: any; opts: any }> = [];
+
+  const originalStream = fakeAgent.stream.bind(fakeAgent);
+  fakeAgent.stream = async (messages: any, opts?: any) => {
+    streamCalls.push({ messages, opts });
+    return originalStream(messages, opts);
+  };
+
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fakeAgent as any,
+    resourceId: "resource-1",
+  });
+
+  return { agent, fakeAgent, streamCalls };
+}
+
+function makeRemoteAgentCapturingStream(streamChunks: any[]) {
+  const fakeAgent = new FakeRemoteAgent({ streamChunks });
+  const streamCalls: Array<{ messages: any; opts: any }> = [];
+
+  const originalStream = fakeAgent.stream.bind(fakeAgent);
+  fakeAgent.stream = async (messages: any, opts?: any) => {
+    streamCalls.push({ messages, opts });
+    return originalStream(messages, opts);
+  };
+
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fakeAgent as any,
+    resourceId: "resource-1",
+  });
+
+  return { agent, fakeAgent, streamCalls };
+}
+
+function makeLocalAgentCapturingResumeStream(resumeChunks: any[]) {
+  const fakeAgent = new FakeLocalAgent({ streamChunks: [] });
+  const resumeCalls: Array<{ resumeData: any; opts: any }> = [];
+
+  (fakeAgent as any).resumeStream = async (resumeData: any, opts: any) => {
+    resumeCalls.push({ resumeData, opts });
+    return {
+      fullStream: (async function* () {
+        for (const chunk of resumeChunks) yield chunk;
+      })(),
+    };
+  };
+
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fakeAgent as any,
+    resourceId: "resource-1",
+  });
+
+  return { agent, fakeAgent, resumeCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("header forwarding", () => {
+  describe("stream() - local agent", () => {
+    it("forwards headers via modelSettings.headers when set", async () => {
+      const { agent, streamCalls } =
+        makeLocalAgentCapturingStream(makeTextChunks());
+      agent.headers = { "x-aimock-context": "test", "x-test-id": "abc" };
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      expect(opts.modelSettings).toBeDefined();
+      expect(opts.modelSettings.headers).toEqual({
+        "x-aimock-context": "test",
+        "x-test-id": "abc",
+      });
+    });
+
+    it("does not include modelSettings when headers is undefined", async () => {
+      const { agent, streamCalls } =
+        makeLocalAgentCapturingStream(makeTextChunks());
+      // headers is undefined by default
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      expect(opts.modelSettings).toBeUndefined();
+    });
+
+    it("does not include modelSettings when headers is empty object", async () => {
+      const { agent, streamCalls } =
+        makeLocalAgentCapturingStream(makeTextChunks());
+      agent.headers = {};
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      expect(opts.modelSettings).toBeUndefined();
+    });
+
+    it("preserves existing stream options alongside modelSettings", async () => {
+      const { agent, streamCalls } =
+        makeLocalAgentCapturingStream(makeTextChunks());
+      agent.headers = { "x-aimock-context": "test" };
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      // Existing options are preserved
+      expect(opts.memory).toBeDefined();
+      expect(opts.runId).toBeDefined();
+      expect(opts.clientTools).toBeDefined();
+      // Headers injected via modelSettings
+      expect(opts.modelSettings.headers).toEqual({
+        "x-aimock-context": "test",
+      });
+    });
+  });
+
+  describe("stream() - remote agent", () => {
+    it("forwards headers via modelSettings.headers when set", async () => {
+      const { agent, streamCalls } =
+        makeRemoteAgentCapturingStream(makeTextChunks());
+      agent.headers = { "x-aimock-context": "remote-test" };
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      expect(opts.modelSettings).toBeDefined();
+      expect(opts.modelSettings.headers).toEqual({
+        "x-aimock-context": "remote-test",
+      });
+    });
+
+    it("does not include modelSettings when headers is undefined", async () => {
+      const { agent, streamCalls } =
+        makeRemoteAgentCapturingStream(makeTextChunks());
+
+      await collectEvents(
+        agent,
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
+
+      expect(streamCalls).toHaveLength(1);
+      const opts = streamCalls[0].opts;
+      expect(opts.modelSettings).toBeUndefined();
+    });
+  });
+
+  describe("clone()", () => {
+    it("preserves headers across clone()", () => {
+      const { agent } = makeLocalAgentCapturingStream(makeTextChunks());
+      agent.headers = {
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      };
+
+      const cloned = agent.clone() as MastraAgent;
+
+      expect(cloned.headers).toEqual({
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      });
+    });
+
+    it("creates a defensive copy (mutating clone does not affect original)", () => {
+      const { agent } = makeLocalAgentCapturingStream(makeTextChunks());
+      agent.headers = { "x-aimock-context": "original" };
+
+      const cloned = agent.clone() as MastraAgent;
+      cloned.headers!["x-aimock-context"] = "mutated";
+      cloned.headers!["x-new"] = "added";
+
+      expect(agent.headers).toEqual({ "x-aimock-context": "original" });
+      expect(cloned.headers).not.toBe(agent.headers);
+    });
+
+    it("leaves headers undefined on clone when not set on original", () => {
+      const { agent } = makeLocalAgentCapturingStream(makeTextChunks());
+      // headers is undefined by default
+
+      const cloned = agent.clone() as MastraAgent;
+
+      expect(cloned.headers).toBeUndefined();
+    });
+  });
+
+  describe("resumeStream()", () => {
+    const resumeTextChunks = [
+      { type: "text-delta", payload: { text: "Resumed response" } },
+      { type: "finish", payload: {} },
+    ];
+
+    it("forwards headers via modelSettings.headers on resumeStream", async () => {
+      const { agent, resumeCalls } =
+        makeLocalAgentCapturingResumeStream(resumeTextChunks);
+      agent.headers = { "x-aimock-context": "resume-test" };
+
+      const input = makeInput({
+        forwardedProps: {
+          command: {
+            resume: { approved: true },
+            interruptEvent: JSON.stringify({
+              toolCallId: "tc-1",
+              runId: "run-1",
+            }),
+          },
+        },
+      });
+
+      await collectEvents(agent, input);
+
+      expect(resumeCalls).toHaveLength(1);
+      const opts = resumeCalls[0].opts;
+      expect(opts.modelSettings).toBeDefined();
+      expect(opts.modelSettings.headers).toEqual({
+        "x-aimock-context": "resume-test",
+      });
+    });
+
+    it("does not include modelSettings on resumeStream when headers is undefined", async () => {
+      const { agent, resumeCalls } =
+        makeLocalAgentCapturingResumeStream(resumeTextChunks);
+      // headers is undefined by default
+
+      const input = makeInput({
+        forwardedProps: {
+          command: {
+            resume: { approved: true },
+            interruptEvent: JSON.stringify({
+              toolCallId: "tc-1",
+              runId: "run-1",
+            }),
+          },
+        },
+      });
+
+      await collectEvents(agent, input);
+
+      expect(resumeCalls).toHaveLength(1);
+      const opts = resumeCalls[0].opts;
+      expect(opts.modelSettings).toBeUndefined();
+    });
+
+    it("does not include modelSettings on resumeStream when headers is empty", async () => {
+      const { agent, resumeCalls } =
+        makeLocalAgentCapturingResumeStream(resumeTextChunks);
+      agent.headers = {};
+
+      const input = makeInput({
+        forwardedProps: {
+          command: {
+            resume: { approved: true },
+            interruptEvent: JSON.stringify({
+              toolCallId: "tc-1",
+              runId: "run-1",
+            }),
+          },
+        },
+      });
+
+      await collectEvents(agent, input);
+
+      expect(resumeCalls).toHaveLength(1);
+      const opts = resumeCalls[0].opts;
+      expect(opts.modelSettings).toBeUndefined();
+    });
+
+    it("preserves existing resumeStream options alongside modelSettings", async () => {
+      const { agent, resumeCalls } =
+        makeLocalAgentCapturingResumeStream(resumeTextChunks);
+      agent.headers = { "x-test-id": "preserve-test" };
+
+      const input = makeInput({
+        forwardedProps: {
+          command: {
+            resume: { approved: true },
+            interruptEvent: JSON.stringify({
+              toolCallId: "tc-1",
+              runId: "run-1",
+            }),
+          },
+        },
+      });
+
+      await collectEvents(agent, input);
+
+      expect(resumeCalls).toHaveLength(1);
+      const opts = resumeCalls[0].opts;
+      // Existing resume options are preserved
+      expect(opts.toolCallId).toBe("tc-1");
+      expect(opts.runId).toBe("run-1");
+      expect(opts.memory).toBeDefined();
+      expect(opts.requestContext).toBeDefined();
+      // Headers injected via modelSettings
+      expect(opts.modelSettings.headers).toEqual({
+        "x-test-id": "preserve-test",
+      });
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -71,6 +71,7 @@ export class MastraAgent extends AbstractAgent {
   agent: LocalMastraAgent | RemoteMastraAgent;
   resourceId?: string;
   requestContext?: RequestContext;
+  public headers?: Record<string, string>;
 
   constructor(private config: MastraAgentConfig) {
     const { agent, resourceId, requestContext, ...rest } = config;
@@ -81,7 +82,11 @@ export class MastraAgent extends AbstractAgent {
   }
 
   public clone() {
-    return new MastraAgent(this.config);
+    const cloned = new MastraAgent(this.config);
+    if (this.headers) {
+      cloned.headers = { ...this.headers };
+    }
+    return cloned;
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
@@ -104,7 +109,10 @@ export class MastraAgent extends AbstractAgent {
 
         // resume: false means the user explicitly declined the tool call.
         // Close the run cleanly without calling resumeStream.
-        if (forwardedCommand?.resume === false && forwardedCommand?.interruptEvent) {
+        if (
+          forwardedCommand?.resume === false &&
+          forwardedCommand?.interruptEvent
+        ) {
           await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
           subscriber.next({
             type: EventType.RUN_FINISHED,
@@ -115,7 +123,10 @@ export class MastraAgent extends AbstractAgent {
           return;
         }
 
-        if (forwardedCommand?.resume != null && forwardedCommand?.interruptEvent) {
+        if (
+          forwardedCommand?.resume != null &&
+          forwardedCommand?.interruptEvent
+        ) {
           // Safely parse interruptEvent — client-supplied data
           let interruptEvent: any;
           try {
@@ -135,9 +146,7 @@ export class MastraAgent extends AbstractAgent {
           // Validate required fields for resume
           if (!interruptEvent?.toolCallId || !interruptEvent?.runId) {
             subscriber.error(
-              new Error(
-                "Invalid interruptEvent: missing toolCallId or runId",
-              ),
+              new Error("Invalid interruptEvent: missing toolCallId or runId"),
             );
             return;
           }
@@ -153,23 +162,38 @@ export class MastraAgent extends AbstractAgent {
           }
 
           try {
+            const resumeOptions: Record<string, unknown> = {
+              toolCallId: interruptEvent.toolCallId,
+              runId: interruptEvent.runId,
+              memory: {
+                thread: input.threadId,
+                resource: this.resourceId ?? input.threadId,
+              },
+              requestContext: this.requestContext,
+            };
+            if (this.headers && Object.keys(this.headers).length > 0) {
+              resumeOptions.modelSettings = {
+                ...((resumeOptions.modelSettings as
+                  | Record<string, unknown>
+                  | undefined) ?? {}),
+                headers: this.headers,
+              };
+            }
             const response = await this.agent.resumeStream(
               forwardedCommand.resume,
-              {
-                toolCallId: interruptEvent.toolCallId,
-                runId: interruptEvent.runId,
-                memory: {
-                  thread: input.threadId,
-                  resource: this.resourceId ?? input.threadId,
-                },
-                requestContext: this.requestContext,
-              },
+              resumeOptions,
             );
 
             // Null/invalid response from resumeStream is an error
-            if (!response || typeof response !== "object" || !response.fullStream) {
+            if (
+              !response ||
+              typeof response !== "object" ||
+              !response.fullStream
+            ) {
               subscriber.error(
-                new Error("resumeStream returned no valid response (missing fullStream)"),
+                new Error(
+                  "resumeStream returned no valid response (missing fullStream)",
+                ),
               );
               return;
             }
@@ -177,7 +201,9 @@ export class MastraAgent extends AbstractAgent {
             const callbacks = this.makeStreamCallbacks(
               subscriber,
               () => messageId,
-              (id) => { messageId = id; },
+              (id) => {
+                messageId = id;
+              },
               input.runId,
             );
             const hadError = await this.processFullStream(response.fullStream, {
@@ -209,25 +235,23 @@ export class MastraAgent extends AbstractAgent {
               requestContext: this.requestContext,
             });
 
-            if (
-              memory &&
-              input.state &&
-              Object.keys(input.state).length > 0
-            ) {
-              let thread: StorageThreadType | null = await memory.getThreadById({
-                threadId: input.threadId,
-                // Mastra's abstract Memory.getThreadById type is narrower than
-                // its runtime contract — concrete Memory subclasses (and
-                // `AGENT_MEMORY_MISSING_RESOURCE_ID` checks along the thread
-                // lifecycle) expect `resourceId`. We forward it here to stay
-                // consistent with the sibling saveThread call below (which
-                // also normalizes `thread.resourceId`) and the
-                // `emitWorkingMemorySnapshot` call to `getWorkingMemory`, and
-                // to match the rest of the run's memory options (`resource:`
-                // on `.stream()` / `.resumeStream()` in `streamMastraAgent`).
-                // @ts-expect-error upstream type omits resourceId; runtime accepts it
-                resourceId: this.resourceId ?? input.threadId,
-              });
+            if (memory && input.state && Object.keys(input.state).length > 0) {
+              let thread: StorageThreadType | null = await memory.getThreadById(
+                {
+                  threadId: input.threadId,
+                  // Mastra's abstract Memory.getThreadById type is narrower than
+                  // its runtime contract — concrete Memory subclasses (and
+                  // `AGENT_MEMORY_MISSING_RESOURCE_ID` checks along the thread
+                  // lifecycle) expect `resourceId`. We forward it here to stay
+                  // consistent with the sibling saveThread call below (which
+                  // also normalizes `thread.resourceId`) and the
+                  // `emitWorkingMemorySnapshot` call to `getWorkingMemory`, and
+                  // to match the rest of the run's memory options (`resource:`
+                  // on `.stream()` / `.resumeStream()` in `streamMastraAgent`).
+                  // @ts-expect-error upstream type omits resourceId; runtime accepts it
+                  resourceId: this.resourceId ?? input.threadId,
+                },
+              );
 
               if (!thread) {
                 thread = {
@@ -283,7 +307,9 @@ export class MastraAgent extends AbstractAgent {
           const streamCallbacks = this.makeStreamCallbacks(
             subscriber,
             () => messageId,
-            (id) => { messageId = id; },
+            (id) => {
+              messageId = id;
+            },
             input.runId,
           );
 
@@ -686,7 +712,7 @@ export class MastraAgent extends AbstractAgent {
 
     if (this.isLocalMastraAgent(this.agent)) {
       try {
-        const response = await this.agent.stream(convertedMessages, {
+        const streamOptions: Record<string, unknown> = {
           memory: {
             thread: threadId,
             resource: resourceId,
@@ -694,7 +720,19 @@ export class MastraAgent extends AbstractAgent {
           runId,
           clientTools,
           requestContext,
-        });
+        };
+        if (this.headers && Object.keys(this.headers).length > 0) {
+          streamOptions.modelSettings = {
+            ...((streamOptions.modelSettings as
+              | Record<string, unknown>
+              | undefined) ?? {}),
+            headers: this.headers,
+          };
+        }
+        const response = await this.agent.stream(
+          convertedMessages,
+          streamOptions,
+        );
 
         if (response && typeof response === "object") {
           const hadError = await this.processFullStream(response.fullStream, {
@@ -719,7 +757,7 @@ export class MastraAgent extends AbstractAgent {
     } else {
       let stopped = false;
       try {
-        const response = await this.agent.stream(convertedMessages, {
+        const streamOptions: Record<string, unknown> = {
           memory: {
             thread: threadId,
             resource: resourceId,
@@ -727,7 +765,19 @@ export class MastraAgent extends AbstractAgent {
           runId,
           clientTools,
           requestContext,
-        });
+        };
+        if (this.headers && Object.keys(this.headers).length > 0) {
+          streamOptions.modelSettings = {
+            ...((streamOptions.modelSettings as
+              | Record<string, unknown>
+              | undefined) ?? {}),
+            headers: this.headers,
+          };
+        }
+        const response = await this.agent.stream(
+          convertedMessages,
+          streamOptions,
+        );
 
         // Remote agents use processDataStream (callback-based) — share
         // chunk handling logic via createChunkProcessor.

--- a/integrations/vercel-ai-sdk/typescript/src/__tests__/headers.test.ts
+++ b/integrations/vercel-ai-sdk/typescript/src/__tests__/headers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { VercelAISDKAgent } from "../index";
+import { RunAgentInput } from "@ag-ui/client";
+import { firstValueFrom, toArray } from "rxjs";
+
+// Mock the `ai` module so we can intercept streamText calls
+const mockStreamText = vi.fn();
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => {
+      mockStreamText(...args);
+      // Return a minimal streamText-like response that processDataStream can consume
+      const stream = new ReadableStream({
+        start(controller) {
+          // Vercel AI SDK data stream protocol:
+          // '0:"text"\n' = text part
+          // 'e:{"finishReason":"stop","usage":{"promptTokens":1,"completionTokens":1},"isContinued":false}\n' = finish step
+          // 'd:{"finishReason":"stop","usage":{"promptTokens":1,"completionTokens":1}}\n' = finish message
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode('0:"hello"\n'));
+          controller.enqueue(
+            encoder.encode(
+              'e:{"finishReason":"stop","usage":{"promptTokens":1,"completionTokens":1},"isContinued":false}\n',
+            ),
+          );
+          controller.enqueue(
+            encoder.encode(
+              'd:{"finishReason":"stop","usage":{"promptTokens":1,"completionTokens":1}}\n',
+            ),
+          );
+          controller.close();
+        },
+      });
+
+      return {
+        toDataStreamResponse: () => ({
+          body: stream,
+        }),
+      };
+    },
+  };
+});
+
+// Minimal mock model satisfying LanguageModelV1 shape
+const mockModel = {
+  specificationVersion: "v1" as const,
+  provider: "test",
+  modelId: "test-model",
+  defaultObjectGenerationMode: "json" as const,
+  supportsImageUrls: false,
+  supportsStructuredOutputs: false,
+  doGenerate: vi.fn(),
+  doStream: vi.fn(),
+};
+
+function makeInput(overrides?: Partial<RunAgentInput>): RunAgentInput {
+  return {
+    threadId: "thread-1",
+    runId: "run-1",
+    messages: [{ id: "msg-1", role: "user", content: "Hello" }],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+describe("VercelAISDKAgent header forwarding", () => {
+  beforeEach(() => {
+    mockStreamText.mockClear();
+  });
+
+  it("forwards headers to streamText when set", async () => {
+    const agent = new VercelAISDKAgent({
+      agentId: "test",
+      model: mockModel as any,
+    });
+    agent.headers = {
+      "x-aimock-context": "vercel-test",
+      "x-test-id": "abc-123",
+    };
+
+    const events = await firstValueFrom(agent.run(makeInput()).pipe(toArray()));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockStreamText.mock.calls[0][0];
+    expect(callArgs.headers).toEqual({
+      "x-aimock-context": "vercel-test",
+      "x-test-id": "abc-123",
+    });
+  });
+
+  it("does not include headers in streamText call when headers is undefined", async () => {
+    const agent = new VercelAISDKAgent({
+      agentId: "test",
+      model: mockModel as any,
+    });
+    // headers is undefined by default
+
+    const events = await firstValueFrom(agent.run(makeInput()).pipe(toArray()));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockStreamText.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty("headers");
+  });
+
+  describe("clone()", () => {
+    it("preserves headers across clone()", () => {
+      const agent = new VercelAISDKAgent({
+        agentId: "test",
+        model: mockModel as any,
+      });
+      agent.headers = {
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      };
+
+      const cloned = agent.clone() as VercelAISDKAgent;
+
+      expect(cloned.headers).toEqual({
+        "x-aimock-context": "test-clone",
+        "x-test-id": "clone-123",
+      });
+    });
+
+    it("creates a defensive copy (mutating clone does not affect original)", () => {
+      const agent = new VercelAISDKAgent({
+        agentId: "test",
+        model: mockModel as any,
+      });
+      agent.headers = { "x-aimock-context": "original" };
+
+      const cloned = agent.clone() as VercelAISDKAgent;
+      cloned.headers!["x-aimock-context"] = "mutated";
+      cloned.headers!["x-new"] = "added";
+
+      expect(agent.headers).toEqual({ "x-aimock-context": "original" });
+      expect(cloned.headers).not.toBe(agent.headers);
+    });
+
+    it("leaves headers undefined on clone when not set on original", () => {
+      const agent = new VercelAISDKAgent({
+        agentId: "test",
+        model: mockModel as any,
+      });
+
+      const cloned = agent.clone() as VercelAISDKAgent;
+
+      expect(cloned.headers).toBeUndefined();
+    });
+  });
+
+  it("does not include headers in streamText call when headers is empty", async () => {
+    const agent = new VercelAISDKAgent({
+      agentId: "test",
+      model: mockModel as any,
+    });
+    agent.headers = {};
+
+    const events = await firstValueFrom(agent.run(makeInput()).pipe(toArray()));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(mockStreamText).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockStreamText.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty("headers");
+  });
+});

--- a/integrations/vercel-ai-sdk/typescript/src/index.ts
+++ b/integrations/vercel-ai-sdk/typescript/src/index.ts
@@ -97,6 +97,7 @@ export class VercelAISDKAgent extends AbstractAgent {
   model: LanguageModelV1;
   maxSteps: number;
   toolChoice: ToolChoice<Record<string, unknown>>;
+  public headers?: Record<string, string>;
   constructor(private config: VercelAISDKAgentConfig) {
     const { model, maxSteps, toolChoice, ...rest } = config;
     super({ ...rest });
@@ -106,7 +107,11 @@ export class VercelAISDKAgent extends AbstractAgent {
   }
 
   public clone() {
-    return new VercelAISDKAgent(this.config);
+    const cloned = new VercelAISDKAgent(this.config);
+    if (this.headers) {
+      cloned.headers = { ...this.headers };
+    }
+    return cloned;
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {
@@ -125,6 +130,9 @@ export class VercelAISDKAgent extends AbstractAgent {
         tools: convertToolToVerlAISDKTools(input.tools),
         maxSteps: this.maxSteps,
         toolChoice: this.toolChoice,
+        ...(this.headers && Object.keys(this.headers).length > 0
+          ? { headers: this.headers }
+          : {}),
       });
 
       let messageId = randomUUID();


### PR DESCRIPTION
## Summary

Adds per-request x-* header forwarding across all five framework integrations (`langgraph`, `mastra`, `vercel-ai-sdk`, `langchain`, `claude-agent-sdk`) and fixes the LangGraph adapter's `prepareStream` HTTP 400 from `langgraph-api>=0.7.x` when both `configurable` and `context` are present in the merged runtime config.

Five logical commits, one per adapter:

1. **langgraph** — Adds a runtime `headers` map + `headerFactory` + `onRequest` hook on `LangGraphClient` so per-request x-* headers attach to every outbound HTTP call. Partitions the merged runtime config in `prepareStream` into `configurable` and `context` so langgraph-api 0.7+ no longer rejects with HTTP 400; extends `mergeConfigs()` with the `context_schema` allowlist (gated on `schemaKeys?.config`). Preserves headers and hook through `clone()` by rebuilding the `LangGraphClient` on the new instance.

2. **mastra** — Forwards a runtime `headers` map on every `stream()` and `resumeStream()` call via `modelSettings.headers`, the Mastra-native per-call header escape hatch. `clone()` defensive-copies the map so concurrent runs don't interfere.

3. **vercel-ai-sdk** — Forwards a runtime `headers` map via `CallSettings.headers` (the SDK's documented per-call parameter). `clone()` defensive-copies the map.

4. **langchain** — Forwards a runtime `headers` map via provider-specific `options.headers`; OpenAI and Anthropic chat models receive headers, other providers ignore them safely. `clone()` defensive-copies the map.

5. **claude-agent-sdk** — Declares a `headers` property for surface parity. The Claude Agent SDK is process-based and does not yet expose an HTTP-level header injection surface, so the property is recorded on the adapter for forward compatibility; tests verify the runtime map + `clone()` preservation behavior.

## Why now

Solves the orphan-headers gap surfaced in showcase D6: agents extending `AbstractAgent` directly (not through `HttpAgent`) had no mechanism for per-request header forwarding, breaking cross-integration isolation when AIMock context tags depend on x-* propagation. The LangGraph configurable+context HTTP 400 was the primary D6 blocker; the other four adapters were latent orphans that would have surfaced as soon as a downstream user enabled per-request headers.

## Companion PR

Depends on the matching CopilotKit PR that wires the Python middleware side of header forwarding (`_extract_forwarded_headers_from_config`, `copilotkit==0.1.90` pin, `LANGGRAPH_HTTP` env). The two PRs ship together for D6.

## CR loop

- R1: 12 findings across 14 reviewers (4 ag-ui clusters + 6 CopilotKit clusters).
- R2 fix: prepareStream partition shape, mergeConfigs allowlist gating, mastra clone preservation, vercel-ai-sdk headers wiring, langchain provider options, headers cast widening.
- R2 confirmation: 14 reviewers; ag-ui side converged with only Important-tier nits.
- Pre-push-quality: green (prettier, typecheck on new code, tests across all 5 integrations, build).

## Test plan

- [ ] CI green across all 5 integration packages
- [ ] LangGraph adapter no longer returns HTTP 400 against langgraph-api >= 0.7.x when both configurable and context are present
- [ ] Per-request x-* headers reach the underlying provider for each adapter that supports HTTP-level injection (langgraph, mastra, vercel-ai-sdk, langchain)
- [ ] clone() preserves headers and hook wiring (covered in unit tests)
- [ ] No regressions in pre-existing adapter behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)