### PR TITLE
fix(proto): make generation script cross-platform

### DIFF
--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:exports": "publint --strict && attw --pack",
-    "generate": "mkdir -p ./src/generated && npx protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto.CMD --ts_proto_out=./src/generated --ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false -I ./src/proto ./src/proto/*.proto",
+    "generate": "node ./scripts/generate.mjs",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },

--- a/sdks/typescript/packages/proto/scripts/generate.mjs
+++ b/sdks/typescript/packages/proto/scripts/generate.mjs
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const generatedDir = "src/generated";
+const protoDir = "src/proto";
+const binDir = join(packageDir, "node_modules", ".bin");
+const plugin = join(
+  binDir,
+  process.platform === "win32" ? "protoc-gen-ts_proto.CMD" : "protoc-gen-ts_proto",
+);
+const protoc = join(packageDir, "node_modules", "@protobuf-ts", "protoc", "protoc.js");
+
+mkdirSync(join(packageDir, generatedDir), { recursive: true });
+
+const protoFiles = readdirSync(join(packageDir, protoDir))
+  .filter((file) => file.endsWith(".proto"))
+  .sort()
+  .map((file) => join(protoDir, file));
+
+const result = spawnSync(
+  process.execPath,
+  [
+    protoc,
+    `--plugin=protoc-gen-ts_proto=${plugin}`,
+    `--ts_proto_out=${generatedDir}`,
+    "--ts_proto_opt=esModuleInterop=true,outputJsonMethods=false,outputClientImpl=false",
+    "-I",
+    protoDir,
+    ...protoFiles,
+  ],
+  {
+    cwd: packageDir,
+    stdio: "inherit",
+  },
+);
+
+if (result.error) {
+  console.error(result.error.message);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
﻿## Summary
- replace the proto package's Unix-only `mkdir -p` shell snippet with a small Node generation script
- keep the existing `protoc` / `ts-proto` arguments and choose the Windows `.CMD` plugin shim only on Windows
- leave generated files untouched; local generation only changed protobuf comment text because the installed protoc package version differs from the checked-in output

Fixes #1552

## Verification
- `pnpm --filter @ag-ui/proto generate`
- `pnpm --filter @ag-ui/proto build`
- `pnpm --filter @ag-ui/proto test`
- `pnpm exec prettier --check sdks/typescript/packages/proto/package.json sdks/typescript/packages/proto/scripts/generate.mjs`
- `node --check sdks\typescript\packages\proto\scripts\generate.mjs`
- `git diff --check`

## Note
- `pnpm --filter @ag-ui/proto lint` currently fails locally because `eslint` is not available to the proto workspace script even after `pnpm install --frozen-lockfile`; no lintable source files were changed.
