### PR TITLE
fix(client): ignore replayed tool call starts

### DIFF
--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -186,6 +186,56 @@ describe("defaultApplyEvents with tool calls", () => {
     expect((finalMessages[ownerIndex + 1] as any).toolCallId).toBe("tool1");
   });
 
+  it("should not duplicate a replayed tool call start", async () => {
+    const events$ = new Subject<BaseEvent>();
+    const initialState: RunAgentInput = {
+      messages: [
+        {
+          id: "msg1",
+          role: "assistant",
+          toolCalls: [
+            {
+              id: "tool1",
+              type: "function",
+              function: { name: "search", arguments: '{"query": ' },
+            },
+          ],
+        },
+      ],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+      parentMessageId: "msg1",
+    } as ToolCallStartEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "tool1",
+      delta: '"weather"}',
+    } as ToolCallArgsEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    expect(stateUpdates.length).toBe(1);
+
+    const assistantMsg = stateUpdates[0].messages?.[0] as AssistantMessage;
+    expect(assistantMsg.toolCalls?.length).toBe(1);
+    expect(assistantMsg.toolCalls?.[0]?.id).toBe("tool1");
+    expect(assistantMsg.toolCalls?.[0]?.function?.arguments).toBe('{"query": "weather"}');
+  });
+
   it("should handle multiple tool calls correctly", async () => {
     // Create a subject and state for events
     const events$ = new Subject<BaseEvent>();

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -301,17 +301,18 @@ export const defaultApplyEvents = (
 
             targetMessage.toolCalls ??= [];
 
-            // Add the new tool call
-            targetMessage.toolCalls.push({
-              id: toolCallId,
-              type: "function",
-              function: {
-                name: toolCallName,
-                arguments: "",
-              },
-            });
+            if (!targetMessage.toolCalls.some((tc) => tc.id === toolCallId)) {
+              targetMessage.toolCalls.push({
+                id: toolCallId,
+                type: "function",
+                function: {
+                  name: toolCallName,
+                  arguments: "",
+                },
+              });
 
-            applyMutation({ messages });
+              applyMutation({ messages });
+            }
           }
 
           return emitUpdates();


### PR DESCRIPTION
﻿## Summary
- make `TOOL_CALL_START` handling idempotent when a replayed event references an existing `toolCallId`
- keep appending later `TOOL_CALL_ARGS` to the existing tool call
- add a regression test for replaying a completed tool call start over pre-populated message state

Fixes #1524

## Verification
- `pnpm --filter @ag-ui/client test -- src/apply/__tests__/default.tool-calls.test.ts`
- `pnpm --filter @ag-ui/client build`
- `pnpm exec prettier --check sdks/typescript/packages/client/src/apply/default.ts sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts`
- `git diff --check`

## Note
- `pnpm --filter @ag-ui/client typecheck` currently fails in this checkout on existing test-suite type issues such as missing Vitest globals in many `src/**/__tests__/*.ts` files. The targeted test and package build pass.
