### PR TITLE
chore(adk-middleware): bump to 0.6.4 and release changelog

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-05-26
+
 ### Added
 
 - **DEPS**: `google-adk` upper bound lifted from `<2.0.0` to `<3.0.0`. The middleware
   is now compatible with both ADK 1.x and ADK 2.x (GA 2026-05-19). See the two
   paired fixes below for the source changes that enable 2.0 support without
-  regressing 1.x. CI should ideally run the suite under both ADK 1.33 and ADK 2.0
-  to keep the dual-pin invariant honest.
+  regressing 1.x. Verified against `google-adk==1.33.0`, `google-adk==2.0.0`, and
+  `google-adk[a2a]==2.1.0` (the `[a2a]` extra only pulls `a2a-sdk` and does not
+  intersect any middleware code path). CI should ideally run the suite under both
+  ADK 1.33 and the latest 2.x to keep the dual-pin invariant honest.
 
 ### Fixed
 

--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ag_ui_adk"
 description = "ADK Middleware for AG-UI Protocol"
-version = "0.6.3"
+version = "0.6.4"
 readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }


### PR DESCRIPTION
## Summary

- Bump `ag_ui_adk` from `0.6.3` → `0.6.4` so the dual-pin support merged in #1746 (closes #1389, #1669) can ship to PyPI.
- Graduate the `[Unreleased]` block to `## [0.6.4] - 2026-05-26` and record that the suite was additionally verified against `google-adk[a2a]==2.1.0` (832 passed, 5 skipped, 0 failed). The `[a2a]` extra only pulls `a2a-sdk` and does not intersect any middleware code path.

Publishing this also unblocks #1768 (reporter was hitting the `<2.0.0` cap on the still-published 0.6.3 artifact while trying to install `google-adk[a2a]>=2.1.0`).

## Test plan

- [x] `.venv/bin/pytest tests/` against `google-adk==1.33.0` — passes (per PR #1746 baseline)
- [x] `.venv/bin/pytest tests/` against `google-adk==2.0.0` — passes (per PR #1746 baseline)
- [x] `.venv/bin/pytest tests/` against `google-adk[a2a]==2.1.0` — 832 passed, 5 skipped (4 pre-existing Vertex live + 1 LLM flake-skip), 0 failed
- [ ] After merge: confirm the release workflow picks up `ag_ui_adk==0.6.4` to PyPI, then respond on #1768 with the upgrade instruction and close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)