### PR TITLE
chore: release header forwarding integrations

### DIFF
--- a/integrations/claude-agent-sdk/typescript/package.json
+++ b/integrations/claude-agent-sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/claude-agent-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "AG-UI integration for Anthropic Claude Agent SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/langchain/typescript/package.json
+++ b/integrations/langchain/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/langchain",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/langgraph",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/mastra",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Bumps versions for the 4 ag-ui TypeScript integration packages that received per-request header forwarding in #1763:

- `@ag-ui/langgraph` 0.0.32 → 0.0.33 (also includes prepareStream configurable+context partition fix)
- `@ag-ui/mastra` 1.0.2 → 1.0.3
- `@ag-ui/langchain` 0.0.1 → 0.0.2
- `@ag-ui/claude-agent-sdk` 0.0.2 → 0.0.3

`@ag-ui/vercel-ai-sdk` is not in release.config.json and has never been published — deferred as a separate follow-up.

`publish-release.yml` fires on merge and auto-publishes all four packages to npm via the existing OIDC trusted publisher setup.

## Test plan

- [ ] All four packages publish successfully (check `npm view @ag-ui/<pkg> version` after publish-release.yml completes)