### PR TITLE
fix(release): add repository.url to package.json for OIDC provenance validation

### DIFF
--- a/integrations/a2a/typescript/package.json
+++ b/integrations/a2a/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/a2a",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/ag2/typescript/package.json
+++ b/integrations/ag2/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/ag2",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "author": "AG-UI Team",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/agno/typescript/package.json
+++ b/integrations/agno/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/agno",
   "author": "Manu Hortet <manu@agno.com>",
   "version": "0.0.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/claude-agent-sdk/typescript/package.json
+++ b/integrations/claude-agent-sdk/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/claude-agent-sdk",
   "version": "0.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "description": "AG-UI integration for Anthropic Claude Agent SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/community/spring-ai/typescript/package.json
+++ b/integrations/community/spring-ai/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/spring-ai",
   "author": "Pascal Wilbrink<pascal.wilbrink@gmail.com>",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/crew-ai/typescript/package.json
+++ b/integrations/crew-ai/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/crewai",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/langchain/typescript/package.json
+++ b/integrations/langchain/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/langchain",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/langgraph",
   "version": "0.0.33",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/llama-index/typescript/package.json
+++ b/integrations/llama-index/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/llamaindex",
   "author": "Logan Markewich <logan@runllama.ai>",
   "version": "0.1.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/mastra",
   "version": "1.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/integrations/pydantic-ai/typescript/package.json
+++ b/integrations/pydantic-ai/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/pydantic-ai",
   "author": "Steven Hartland <steve@rocketscience.gg>",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/integrations/watsonx/typescript/package.json
+++ b/integrations/watsonx/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/watsonx",
   "author": "AG-UI Contributors",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "description": "AG-UI integration for IBM watsonx orchestrate agents",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/middlewares/a2a-middleware/package.json
+++ b/middlewares/a2a-middleware/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/a2a-middleware",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/middlewares/a2ui-middleware/package.json
+++ b/middlewares/a2ui-middleware/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/a2ui-middleware",
   "author": "Markus Ecker",
   "version": "0.0.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/middlewares/mcp-apps-middleware/package.json
+++ b/middlewares/mcp-apps-middleware/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/mcp-apps-middleware",
   "author": "Markus Ecker",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/sdks/typescript/packages/cli/package.json
+++ b/sdks/typescript/packages/cli/package.json
@@ -2,6 +2,10 @@
   "name": "create-ag-ui-app",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.53",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/packages/client/package.json
+++ b/sdks/typescript/packages/client/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/client",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.53",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/packages/core/package.json
+++ b/sdks/typescript/packages/core/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/core",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.53",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/packages/encoder/package.json
+++ b/sdks/typescript/packages/encoder/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/encoder",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.53",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/proto",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.53",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

npm strict-validates that the provenance attestation's source repo claim matches the tarball's `package.json.repository.url`. Without a matching `repository.url`, the publish fails with HTTP 422 "Failed to validate repository information" — exactly what's blocking the ag-ui release pipeline now that OIDC trusted publishers are wired up.

Same fix CopilotKit applied in CopilotKit/CopilotKit#4977.

## Failed run that surfaced this

Run `26462489045` — all 6 attempted publishes failed with:

```
npm error code E422
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/ag-ui-protocol/ag-ui" from provenance
```

## What changed

Added the following block (after the `version` line) to all 20 JS/TS packages on the `scripts/release/release.config.json` allowlist:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/ag-ui-protocol/ag-ui.git"
},
```

Packages updated:

- `@ag-ui/core`, `@ag-ui/client`, `@ag-ui/encoder`, `@ag-ui/proto`, `create-ag-ui-app`
- `@ag-ui/a2a`, `@ag-ui/ag2`, `@ag-ui/agno`, `@ag-ui/claude-agent-sdk`, `@ag-ui/crewai`
- `@ag-ui/langchain`, `@ag-ui/langgraph`, `@ag-ui/llamaindex`, `@ag-ui/mastra`
- `@ag-ui/pydantic-ai`, `@ag-ui/spring-ai`, `@ag-ui/watsonx`
- `@ag-ui/a2a-middleware`, `@ag-ui/a2ui-middleware`, `@ag-ui/mcp-apps-middleware`

Python packages on the allowlist are unaffected (they use `pyproject.toml`, not npm).

## Test plan

- [ ] All ag-ui JS/TS package.json files on the release allowlist have `repository.url` set to `https://github.com/ag-ui-protocol/ag-ui.git`
- [ ] After merge, re-dispatch the publish pipeline and confirm packages land on npm with `_npmUser: GitHub Actions` and `dist.attestations` populated (no more E422)