### PR TITLE
fix(adk-middleware): AGUIToolset.bind() is not concurrency-safe

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -79,29 +79,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _unbind_agui_toolsets_recursive(agent: Any) -> None:
-    """Walk an agent tree and unbind every ``AGUIToolset`` placeholder.
-
-    Counterpart to ``_update_agent_tools_recursive`` (defined inside
-    ``ADKAgent._start_background_execution``). Run from
-    ``_run_adk_in_background``'s ``finally`` block so each run starts with
-    placeholders in their construction-time state, avoiding cross-run
-    delegate leakage.
-
-    Tolerant of non-LlmAgent nodes (skip silently) and agents without a
-    ``tools`` attribute. Catches per-toolset exceptions so one bad
-    placeholder doesn't break cleanup for the rest of the tree.
-    """
-    if isinstance(agent, LlmAgent) and hasattr(agent, "tools"):
-        for tool in agent.tools or []:
-            if isinstance(tool, AGUIToolset):
-                try:
-                    tool.unbind()
-                except Exception:
-                    # Best-effort cleanup; never raise out of unbind.
-                    pass
-    for sub_agent in getattr(agent, "sub_agents", None) or []:
-        _unbind_agui_toolsets_recursive(sub_agent)
 class _HitlDeferringQueue(asyncio.Queue):
     """``asyncio.Queue`` that defers HITL ``ToolCallEndEvent``s.
 
@@ -2063,19 +2040,20 @@ class ADKAgent:
         client_proxy_toolsets: list[ClientProxyToolset] = []
 
         def _update_agent_tools_recursive(agent: Any) -> None:
-            """Bind a ``ClientProxyToolset`` to every ``AGUIToolset`` placeholder
-            in the agent tree.
+            """Replace every ``AGUIToolset`` placeholder with a per-run
+            ``ClientProxyToolset`` in the agent tree.
 
-            Pre-2026-05 (ADK 1.x): we replaced the placeholder wholesale
-            (``agent.tools = [..., ClientProxyToolset(...)]``). ADK 1.x resolved
-            ``get_tools()`` lazily on each run so the replacement was visible.
-
-            Post-2026-05 (ADK 2.0, ag-ui#1389): ``Runner.__init__`` eagerly
-            caches ``get_tools()`` results, so replacing the toolset object
-            leaves the Runner pointing at the stale placeholder. We now keep
-            the placeholder instance and bind a fresh delegate to it via
-            ``AGUIToolset.bind(...)`` — same object identity, dynamic tool
-            list, compatible with both ADK majors.
+            The placeholder carries no client info; this builds a concrete
+            ``ClientProxyToolset`` from ``input.tools`` (with this run's
+            ``event_queue``) and swaps it into the per-run agent's ``tools``
+            list. Because ``_shallow_copy_agent_tree`` gave this agent its own
+            ``tools`` list and the construction-time placeholder is never
+            mutated, concurrent runs are fully isolated. (An earlier
+            ``AGUIToolset.bind()`` delegation stored the per-run toolset on the
+            shared placeholder and was not concurrency-safe; replacement restores
+            per-run isolation. ADK 2.0 GA reads ``agent.tools`` fresh per
+            invocation, so the swap is picked up — see
+            ``tests/test_agui_toolset_concurrency.py``.)
 
             Args:
                 agent: Agent instance to process recursively.
@@ -2085,13 +2063,14 @@ class ADKAgent:
 
             if isinstance(agent, LlmAgent) and hasattr(agent, "tools"):
                 tool_count = len(agent.tools) if agent.tools else 0
-                logger.info(f"[TOOL_SETUP] Agent {agent.name} has {tool_count} tools before binding")
+                logger.info(f"[TOOL_SETUP] Agent {agent.name} has {tool_count} tools before replacement")
 
+                new_tools: list[ToolUnion] = []
                 for tool in agent.tools:
                     if isinstance(tool, AGUIToolset):
                         logger.info(
                             f"[TOOL_SETUP] Agent {agent.name}: Found AGUIToolset with "
-                            f"filter={tool.tool_filter}; binding ClientProxyToolset delegate"
+                            f"filter={tool.tool_filter}; replacing with per-run ClientProxyToolset"
                         )
                         proxy_toolset = ClientProxyToolset(
                             ag_ui_tools=input.tools,
@@ -2101,20 +2080,17 @@ class ADKAgent:
                             predict_state=self._predict_state,
                         )
                         client_proxy_toolsets.append(proxy_toolset)
-                        # Bind delegate to the placeholder. Object identity
-                        # of `tool` in agent.tools is preserved — critical
-                        # for ADK 2.0's eager Runner.__init__ tool cache
-                        # (ag-ui#1389). For ADK 1.x this is functionally
-                        # equivalent to the previous replace-the-object
-                        # approach: get_tools() forwards to the delegate
-                        # either way.
-                        tool.bind(proxy_toolset)
-                        logger.info(
-                            f"[TOOL_SETUP] Bound ClientProxyToolset delegate to AGUIToolset "
-                            f"for agent {agent.name}"
-                        )
+                        # Swap the placeholder for a fresh per-run
+                        # ClientProxyToolset in THIS run's tools list.
+                        # _shallow_copy_agent_tree gave this agent its own list,
+                        # so concurrent runs never share a proxy (each carries
+                        # its own input.tools + event_queue) and the
+                        # construction-time AGUIToolset is never mutated.
+                        tool = proxy_toolset
+                    new_tools.append(tool)
 
-                logger.info(f"[TOOL_SETUP] Agent {agent.name} tool binding complete")
+                agent.tools = new_tools
+                logger.info(f"[TOOL_SETUP] Agent {agent.name} now has {len(new_tools)} tools after replacement")
 
             # Recursively process sub-agents if they exist
             # This handles SequentialAgent, LoopAgent, and other composite agents
@@ -2997,21 +2973,6 @@ class ADKAgent:
                             close_error,
                         )
 
-            # Unbind every AGUIToolset in the agent tree so the next run on
-            # the same agent starts from a clean slate. Without this, a stale
-            # ClientProxyToolset (whose event_queue belongs to the previous
-            # run) would still satisfy AGUIToolset.get_tools() — usually
-            # harmless because the next run rebinds before tool invocation,
-            # but worth defensive cleanup to avoid surprising debug output
-            # if get_tools() is queried mid-cleanup.
-            try:
-                _unbind_agui_toolsets_recursive(adk_agent)
-            except Exception as unbind_error:
-                logger.debug(
-                    "Error while unbinding AGUIToolset for thread %s: %s",
-                    input.thread_id,
-                    unbind_error,
-                )
             # Flush any LRO ID remap captured during the runner loop. This
             # runs after the runner has been closed, so the
             # ``update_session_state`` write can't trip OCC against ADK's

--- a/integrations/adk-middleware/python/src/ag_ui_adk/agui_toolset.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/agui_toolset.py
@@ -1,62 +1,43 @@
-"""AGUIToolset — a frontend-tool placeholder that delegates to ClientProxyToolset.
+"""AGUIToolset — a placeholder that ``ADKAgent`` replaces per run.
 
-Why a placeholder + delegation?
--------------------------------
 AG-UI integrations declare an ``AGUIToolset`` on their ADK agents at agent-
 construction time, before any AG-UI run is in flight. At run-time
 :class:`~ag_ui_adk.adk_agent.ADKAgent` knows the actual frontend tools the
-client supplied (``input.tools``) and wires up a concrete
-:class:`~ag_ui_adk.client_proxy_toolset.ClientProxyToolset` that proxies tool
-calls back to the client over the AG-UI stream.
+client supplied (``input.tools``) and substitutes a concrete
+:class:`~ag_ui_adk.client_proxy_toolset.ClientProxyToolset` for this placeholder
+in the *per-run copy* of the agent tree
+(``ADKAgent._start_background_execution._update_agent_tools_recursive``).
 
-In ADK 1.x the middleware simply replaced the placeholder in
-``agent.tools = [..., ClientProxyToolset(...)]`` once it knew the client tools.
-That worked because ADK 1.x resolved toolsets lazily — every call to
-``runner.run_async`` re-walked ``agent.tools`` and called ``get_tools()`` fresh.
+The substitution happens on a per-run shallow copy whose ``tools`` list is its
+own, so every concurrent run gets its own ``ClientProxyToolset`` (its own
+``input.tools`` and ``event_queue``); the construction-time placeholder is never
+mutated and never shared across runs. (An earlier ``bind()``-delegation design
+stored the per-run toolset on this shared instance and was not concurrency-safe;
+per-run replacement restores isolation. ADK 2.0 GA reads ``agent.tools`` fresh
+per invocation, so the replacement is picked up.)
 
-ADK 2.0 (GA 2026-05-19) changed this: ``Runner.__init__`` eagerly walks
-``agent.tools`` and caches whatever each toolset returns from ``get_tools()``.
-The original "swap the toolset" approach now races the cache — the Runner may
-already hold a reference to the placeholder when ``_update_agent_tools_recursive``
-replaces it, leaving the LLM with an empty tool list (ag-ui#1389).
-
-Fix: keep the placeholder instance, give it a ``bind()`` method that attaches
-a concrete delegate, and have ``get_tools()`` forward to the delegate. Object
-identity is preserved end-to-end so ADK 2.0's cache stays valid; the delegate
-can be replaced or unbound between runs without invalidating any ADK state.
-
-Compat: this preserves the 1.x behavior 1:1. If ``bind()`` is never called
-(misconfiguration), ``get_tools()`` returns ``[]`` instead of raising, so the
-LLM sees zero frontend tools rather than blowing up at agent construction
-time inside ADK's own toolset-discovery flow. The original
-``NotImplementedError`` path is retained for an explicit ``unbind() +
-get_tools()`` sequence so misuse is still detectable in tests.
+If ``get_tools()`` is called on the placeholder itself, the substitution did not
+happen (a misconfiguration — e.g. the agent was run without being wrapped by
+``ADKAgent``), so it raises rather than silently exposing zero tools.
 """
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import List, Optional, Union
 
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.base_toolset import BaseToolset, ToolPredicate
 from google.adk.agents.readonly_context import ReadonlyContext
 
-if TYPE_CHECKING:
-    from .client_proxy_toolset import ClientProxyToolset
-
 
 class AGUIToolset(BaseToolset):
-    """Frontend-tool placeholder that delegates to a bound ``ClientProxyToolset``.
+    """Frontend-tool placeholder, replaced per-run by a ``ClientProxyToolset``.
 
     Construction-time: declared on the ADK agent with ``tool_filter`` and
-    ``tool_name_prefix`` (no client info yet).
-
-    Run-time: :class:`~ag_ui_adk.adk_agent.ADKAgent._start_background_execution`
-    builds a :class:`~ag_ui_adk.client_proxy_toolset.ClientProxyToolset` using
-    ``input.tools`` and calls :meth:`bind` on this instance.
-
-    The Runner can be created either before or after ``bind()`` — both orders
-    work because ``get_tools()`` is delegated rather than memoized.
+    ``tool_name_prefix`` (no client info yet). Run-time:
+    :meth:`~ag_ui_adk.adk_agent.ADKAgent._start_background_execution` swaps it for
+    a :class:`~ag_ui_adk.client_proxy_toolset.ClientProxyToolset` built from
+    ``input.tools`` in the per-run agent copy.
     """
 
     def __init__(
@@ -68,89 +49,32 @@ class AGUIToolset(BaseToolset):
         """Initialize the toolset.
 
         Args:
-            tool_filter: Filter to apply to tools — forwarded to the bound
-                ``ClientProxyToolset`` at delegation time.
+            tool_filter: Filter to apply to tools — forwarded to the per-run
+                ``ClientProxyToolset`` at substitution time.
             tool_name_prefix: Prefix to prepend to tool names — also forwarded
-                to the bound delegate.
+                to the per-run ``ClientProxyToolset``.
         """
-        # BaseToolset.__init__ initializes the cache attributes
-        # (``_use_invocation_cache``, ``_cached_invocation_id``,
-        # ``_cached_prefixed_tools``) on both ADK 1.x and 2.0. ADK 2.0's
-        # ``llm_agent.py:185`` eagerly reads ``_use_invocation_cache`` and
-        # silently drops the toolset when missing — required now that bind()
-        # delegation preserves the instance across the run (#1389).
+        # BaseToolset.__init__ initializes ADK 2.0's toolset cache attributes
+        # (``_use_invocation_cache`` et al.). A no-op on ADK 1.x. Kept so the
+        # placeholder is a well-formed BaseToolset even though it is normally
+        # replaced before ADK ever resolves it.
         super().__init__(tool_filter=tool_filter, tool_name_prefix=tool_name_prefix)
         self.tool_filter = tool_filter
         self.tool_name_prefix = tool_name_prefix
-        # The bound delegate. Replaced by `bind()` once the run-time
-        # ClientProxyToolset is constructed. `None` means no client tools
-        # have been wired up yet (legitimate at agent-construction time
-        # but a misconfiguration if get_tools() is called and `_unbound_raises`
-        # is True).
-        self._delegate: Optional["ClientProxyToolset"] = None
-        # When True, `get_tools()` without a bound delegate raises (legacy
-        # 1.x behavior preserved for explicit-misuse detection). When False
-        # (the default), unbound get_tools() returns []. Toggled by tests
-        # that want to verify the placeholder is never reached in production.
-        self._unbound_raises: bool = False
-
-    def bind(self, delegate: "ClientProxyToolset") -> None:
-        """Bind a concrete delegate that ``get_tools()`` will forward to.
-
-        Called by :func:`~ag_ui_adk.adk_agent._update_agent_tools_recursive`
-        once the run-time :class:`~ag_ui_adk.client_proxy_toolset.ClientProxyToolset`
-        has been constructed from ``input.tools``.
-
-        Subsequent calls overwrite the binding — this is intentional so that
-        a single ``AGUIToolset`` instance can be reused across runs with
-        different client tool sets (e.g. multi-turn conversations).
-
-        Args:
-            delegate: The ``ClientProxyToolset`` that should serve ``get_tools()``
-                calls for the lifetime of the current run.
-        """
-        self._delegate = delegate
-
-    def unbind(self) -> None:
-        """Detach the currently-bound delegate.
-
-        Called by ``_run_adk_in_background`` cleanup paths so a stale
-        ``ClientProxyToolset`` reference doesn't linger on the placeholder
-        between runs. After ``unbind()`` the placeholder reverts to its
-        construction-time state — safe to ``bind()`` again next run.
-        """
-        self._delegate = None
 
     async def get_tools(
         self,
         readonly_context: Optional[ReadonlyContext] = None,
     ) -> list[BaseTool]:
-        """Return tools from the bound delegate, or ``[]`` if unbound.
+        """Placeholders are replaced before use; reaching this is a misconfiguration.
 
-        This is called by ADK's tool-discovery flow — in 1.x lazily on each
-        ``run_async``, in 2.0 eagerly during ``Runner.__init__``. Either way
-        the bound delegate forwards the actual tool list.
-
-        Args:
-            readonly_context: Context used to filter tools available to the
-                agent. Forwarded verbatim to the delegate.
-
-        Returns:
-            list[BaseTool]: The delegate's tool list, or ``[]`` if no
-            delegate is bound. Raises ``NotImplementedError`` when unbound
-            only if ``_unbound_raises`` is set (legacy 1.x parity for tests).
+        Raises:
+            NotImplementedError: always — the run-time ``ClientProxyToolset``
+            substitution in ``ADKAgent`` did not happen (e.g. the agent was run
+            without being wrapped by ``ADKAgent``).
         """
-        if self._delegate is None:
-            if self._unbound_raises:
-                raise NotImplementedError(
-                    "AGUIToolset is a placeholder and must be bound to a "
-                    "ClientProxyToolset before use (call AGUIToolset.bind(...) "
-                    "or wrap the agent with ADKAgent which does it for you)."
-                )
-            # Construction-time / between-runs: no delegate. Return empty
-            # rather than raising — ADK 2.0's eager Runner cache otherwise
-            # crashes agent registration. The actual binding happens before
-            # the LLM is invoked, so this empty list is never observed by
-            # the LLM in production paths.
-            return []
-        return await self._delegate.get_tools(readonly_context)
+        raise NotImplementedError(
+            "AGUIToolset is a placeholder and must be replaced with a "
+            "ClientProxyToolset before use (wrap the agent with ADKAgent, which "
+            "does this per run)."
+        )

--- a/integrations/adk-middleware/python/tests/test_adk_2_0_compat.py
+++ b/integrations/adk-middleware/python/tests/test_adk_2_0_compat.py
@@ -120,6 +120,72 @@ class TestAGUIToolsetReplacement:
         assert root_agent.tools[0] is agui
         assert isinstance(root_agent.tools[0], AGUIToolset)
 
+    @pytest.mark.asyncio
+    async def test_swapped_in_toolset_resolves_nonempty_via_get_tools_with_prefix(self) -> None:
+        """#1389 regression guard (replaces the removed object-identity test).
+
+        The actual #1389 failure was an *empty* tool list: in ADK 2.x a toolset
+        that is not a well-formed ``BaseToolset`` (no ``super().__init__()`` ->
+        missing ``_use_invocation_cache``) is silently dropped to ``[]`` by
+        ``llm_agent._convert_tool_union_to_tools``'s ``try/except``. Assert the
+        per-run ``ClientProxyToolset`` the middleware swaps in resolves
+        *non-empty* tools through ``get_tools_with_prefix`` (the ADK path that
+        reads ``_use_invocation_cache``), and that the agent's
+        ``canonical_tools`` still exposes the frontend tool -- so we cannot
+        silently regress to the empty-tool-list symptom.
+        """
+        agui = AGUIToolset()  # no filter -> every frontend tool passes through
+        root_agent = Agent(
+            name="probe_agent",
+            model="gemini-2.5-flash",
+            instruction="probe",
+            tools=[agui],
+        )
+
+        captured: dict = {}
+
+        async def _noop(self, **kwargs):
+            captured.update(kwargs)
+            return None
+
+        with patch.object(ADKAgent, "_run_adk_in_background", _noop):
+            adk_agent = ADKAgent(
+                adk_agent=root_agent,
+                app_name="probe_app",
+                user_id="probe_user",
+                use_in_memory_services=True,
+            )
+            run_input = RunAgentInput(
+                thread_id="probe_thread",
+                run_id="probe_run",
+                messages=[UserMessage(id="m1", role="user", content="hi")],
+                context=[],
+                state={},
+                tools=[Tool(
+                    name="frontend_tool",
+                    description="a frontend tool",
+                    parameters={"type": "object", "properties": {}},
+                )],
+                forwarded_props={},
+            )
+            exec_state = await adk_agent._start_background_execution(run_input)
+            await asyncio.gather(exec_state.task, return_exceptions=True)
+
+        swapped_in = captured["adk_agent"].tools[0]
+        assert isinstance(swapped_in, ClientProxyToolset)
+
+        # The #1389 failure mode was *empty* tools through this exact path
+        # (get_tools_with_prefix reads _use_invocation_cache on ADK 2.x). A
+        # well-formed toolset resolves the frontend tool rather than [].
+        resolved = await swapped_in.get_tools_with_prefix()
+        assert resolved, "swapped-in ClientProxyToolset resolved no tools (#1389 regression)"
+        assert [t.name for t in resolved] == ["frontend_tool"]
+
+        # End-to-end: the agent's real resolution entrypoint (which would drop a
+        # malformed toolset to [] via try/except) still exposes the tool.
+        canonical = await captured["adk_agent"].canonical_tools()
+        assert "frontend_tool" in [t.name for t in canonical]
+
 
 # ---------------------------------------------------------------------------
 # ag-ui#1669 — Workflow root HITL rehydrate gate

--- a/integrations/adk-middleware/python/tests/test_adk_2_0_compat.py
+++ b/integrations/adk-middleware/python/tests/test_adk_2_0_compat.py
@@ -25,6 +25,7 @@ from ag_ui.core import (
     BaseEvent,
     FunctionCall,
     RunStartedEvent,
+    Tool,
     ToolCall,
     ToolMessage,
     UserMessage,
@@ -45,123 +46,48 @@ from ag_ui_adk.session_manager import SessionManager
 # ---------------------------------------------------------------------------
 
 
-class TestAGUIToolsetDelegation:
-    """Verify the bind/unbind pattern that fixes ag-ui#1389 in ADK 2.0."""
+class TestAGUIToolsetReplacement:
+    """Verify the per-run replacement pattern (ag-ui#1746 follow-up: replaces the
+    bind/unbind delegation, which stored per-run state on a shared instance and
+    was not concurrency-safe)."""
 
     def test_construction_initializes_baseToolset_state(self) -> None:
-        """ag-ui#1389 sub-fix: AGUIToolset.__init__ MUST call
-        ``super().__init__()`` so ADK 2.0's ``_use_invocation_cache``
-        attribute is set. Without this, ADK 2.0's ``llm_agent.py:185``
-        ``getattr(toolset, '_use_invocation_cache')`` raises
-        AttributeError and the toolset is silently dropped from the LLM
-        tool list."""
+        """AGUIToolset.__init__ calls ``super().__init__()`` so ADK 2.0's
+        ``BaseToolset`` cache attributes (``_use_invocation_cache`` et al.) are
+        initialized and the placeholder is a well-formed toolset."""
         toolset = AGUIToolset(tool_filter=['x'], tool_name_prefix='pfx_')
-        # On ADK 2.0 these attrs must exist; on ADK 1.x calling
-        # super().__init__ is a no-op so the absence is also OK there.
-        # We assert the 2.0 invariant — the test will be a no-op on 1.x.
+        # On ADK 2.0 these attrs must exist; on ADK 1.x super().__init__ is a
+        # no-op so the absence is also OK there.
         if hasattr(ADKBaseToolset, '_use_invocation_cache') or any(
             'invocation_cache' in name
             for name in dir(toolset)
         ):
             assert hasattr(toolset, '_use_invocation_cache')
 
-    def test_unbound_get_tools_returns_empty_list(self) -> None:
-        """Before bind() is called, ``get_tools()`` returns ``[]`` rather
-        than raising. This lets ADK 2.0's eager ``Runner.__init__`` walk
-        the toolset without crashing — actual tool list is supplied by
-        the run-time ``bind()`` call in ``_update_agent_tools_recursive``.
-        """
+    def test_placeholder_get_tools_raises(self) -> None:
+        """The placeholder is replaced per-run before use; calling
+        ``get_tools()`` on it directly means the substitution didn't happen
+        (misconfiguration), so it raises."""
         toolset = AGUIToolset()
-        result = asyncio.run(toolset.get_tools())
-        assert result == []
-
-    def test_unbound_get_tools_raises_when_explicit(self) -> None:
-        """Legacy 1.x ``NotImplementedError`` behavior is preserved when
-        a test explicitly opts in via ``_unbound_raises = True``."""
-        toolset = AGUIToolset()
-        toolset._unbound_raises = True
         with pytest.raises(NotImplementedError, match="placeholder"):
             asyncio.run(toolset.get_tools())
 
-    def test_bind_then_get_tools_forwards_to_delegate(self) -> None:
-        """Once a delegate is bound, ``get_tools()`` forwards to it."""
-        toolset = AGUIToolset(tool_filter=['x'])
-        delegate = MagicMock(spec=ClientProxyToolset)
-
-        async def mock_get_tools(readonly_context=None):
-            return ['mock_tool_1', 'mock_tool_2']
-
-        delegate.get_tools = mock_get_tools
-        toolset.bind(delegate)
-        result = asyncio.run(toolset.get_tools())
-        assert result == ['mock_tool_1', 'mock_tool_2']
-
-    def test_unbind_resets_to_empty(self) -> None:
-        """``unbind()`` detaches the delegate so a subsequent ``get_tools()``
-        falls back to the unbound branch."""
-        toolset = AGUIToolset()
-        delegate = MagicMock(spec=ClientProxyToolset)
-
-        async def mock_get_tools(readonly_context=None):
-            return ['delegate_tool']
-
-        delegate.get_tools = mock_get_tools
-        toolset.bind(delegate)
-        toolset.unbind()
-        result = asyncio.run(toolset.get_tools())
-        assert result == []
-        assert toolset._delegate is None
-
-    def test_rebind_overwrites_previous_delegate(self) -> None:
-        """Successive ``bind()`` calls replace the binding — supports
-        multi-turn runs where each turn supplies a different
-        ``input.tools`` and therefore a different ``ClientProxyToolset``.
-        """
-        toolset = AGUIToolset()
-
-        delegate_a = MagicMock(spec=ClientProxyToolset)
-        delegate_b = MagicMock(spec=ClientProxyToolset)
-
-        async def get_a(readonly_context=None):
-            return ['a']
-
-        async def get_b(readonly_context=None):
-            return ['b']
-
-        delegate_a.get_tools = get_a
-        delegate_b.get_tools = get_b
-
-        toolset.bind(delegate_a)
-        assert asyncio.run(toolset.get_tools()) == ['a']
-
-        toolset.bind(delegate_b)
-        assert asyncio.run(toolset.get_tools()) == ['b']
-
     @pytest.mark.asyncio
-    async def test_object_identity_preserved_across_run(self) -> None:
-        """The original ``AGUIToolset`` instance is reused across the
-        run — critical for ADK 2.0 because ``Runner.__init__`` caches a
-        reference to it during eager ``get_tools()`` resolution.
-
-        Test: declare an ``AGUIToolset`` on an agent, capture its id,
-        run the agent, and verify the same id is in ``agent.tools`` after
-        ``_update_agent_tools_recursive`` has bound a delegate.
-        """
+    async def test_placeholder_replaced_per_run(self) -> None:
+        """``ADKAgent`` replaces the ``AGUIToolset`` placeholder with a per-run
+        ``ClientProxyToolset`` in the per-run agent copy, leaving the
+        construction-time placeholder untouched — so concurrent runs stay
+        isolated (no shared mutable delegate)."""
         agui = AGUIToolset(tool_filter=['probe_tool'])
-        original_id = id(agui)
-        root_agent = Agent(
-            name="probe_agent",
-            instruction="probe",
-            tools=[agui],
-        )
+        root_agent = Agent(name="probe_agent", instruction="probe", tools=[agui])
 
-        with patch.object(ADKAgent, "_run_adk_in_background") as bg_mock:
+        captured: dict = {}
 
-            async def empty_gen() -> AsyncGenerator[BaseEvent, None]:
-                if False:
-                    yield
-                return
+        async def _noop(self, **kwargs):
+            captured.update(kwargs)
+            return None
 
+        with patch.object(ADKAgent, "_run_adk_in_background", _noop):
             adk_agent = ADKAgent(
                 adk_agent=root_agent,
                 app_name="probe_app",
@@ -171,26 +97,28 @@ class TestAGUIToolsetDelegation:
             run_input = RunAgentInput(
                 thread_id="probe_thread",
                 run_id="probe_run",
-                messages=[
-                    UserMessage(id="m1", role="user", content="hi")
-                ],
+                messages=[UserMessage(id="m1", role="user", content="hi")],
                 context=[],
                 state={},
-                tools=[],
+                tools=[Tool(
+                    name="probe_tool",
+                    description="probe tool",
+                    parameters={"type": "object", "properties": {}},
+                )],
                 forwarded_props={},
             )
-            async for ev in adk_agent.run(run_input):
-                if not isinstance(ev, RunStartedEvent):
-                    break
+            exec_state = await adk_agent._start_background_execution(run_input)
+            await asyncio.gather(exec_state.task, return_exceptions=True)
 
-            captured_agent = bg_mock.call_args.kwargs['adk_agent']
-            captured_toolset = captured_agent.tools[0]
-            # Object identity preserved → ADK 2.0 Runner cache stays valid
-            assert id(captured_toolset) == original_id
-            assert isinstance(captured_toolset, AGUIToolset)
-            # And a delegate is bound
-            assert captured_toolset._delegate is not None
-            assert isinstance(captured_toolset._delegate, ClientProxyToolset)
+        per_run_agent = captured["adk_agent"]
+        replaced = per_run_agent.tools[0]
+        # Placeholder was replaced with a per-run ClientProxyToolset carrying
+        # this run's filter.
+        assert isinstance(replaced, ClientProxyToolset)
+        assert replaced.tool_filter == ['probe_tool']
+        # Construction-time placeholder untouched (not mutated, not shared in).
+        assert root_agent.tools[0] is agui
+        assert isinstance(root_agent.tools[0], AGUIToolset)
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/adk-middleware/python/tests/test_adk_agent.py
+++ b/integrations/adk-middleware/python/tests/test_adk_agent.py
@@ -949,42 +949,30 @@ class TestADKAgent:
             assert agent_under_test.tools == []
             assert len(agent_under_test.sub_agents) == 2
 
-            # ag-ui#1389: AGUIToolset placeholders are NOT replaced wholesale —
-            # they get a ClientProxyToolset delegate bound to them, preserving
-            # object identity so ADK 2.0's eager Runner cache stays valid.
-            # Test the delegated behavior: each AGUIToolset.tool_filter and
-            # the underlying delegate's tool_filter must match the declared
-            # tool_filter from agent construction.
+            # AGUIToolset placeholders are replaced per-run by a
+            # ClientProxyToolset carrying the declared tool_filter, on the
+            # per-run agent copy (the originals are left untouched).
 
-            # hello_agent: AGUIToolset with hello_tool filter, delegate also has it
+            # hello_agent: AGUIToolset(hello_tool) -> ClientProxyToolset(hello_tool)
             assert agent_under_test.sub_agents[0].name == "hello_agent"
             assert len(agent_under_test.sub_agents[0].tools) == 1
             hello_toolset = agent_under_test.sub_agents[0].tools[0]
-            assert isinstance(hello_toolset, AGUIToolset)
+            assert isinstance(hello_toolset, ClientProxyToolset)
             assert hello_toolset.tool_filter == ['hello_tool']
-            assert hello_toolset._delegate is not None
-            assert isinstance(hello_toolset._delegate, ClientProxyToolset)
-            assert hello_toolset._delegate.tool_filter == ['hello_tool']
 
-            # deep_agent: AGUIToolset with deep_tool filter, delegate also has it
+            # deep_agent: AGUIToolset(deep_tool) -> ClientProxyToolset(deep_tool)
             assert agent_under_test.sub_agents[0].sub_agents[0].name == "deep_agent"
             assert len(agent_under_test.sub_agents[0].sub_agents[0].tools) == 1
             deep_toolset = agent_under_test.sub_agents[0].sub_agents[0].tools[0]
-            assert isinstance(deep_toolset, AGUIToolset)
+            assert isinstance(deep_toolset, ClientProxyToolset)
             assert deep_toolset.tool_filter == ['deep_tool']
-            assert deep_toolset._delegate is not None
-            assert isinstance(deep_toolset._delegate, ClientProxyToolset)
-            assert deep_toolset._delegate.tool_filter == ['deep_tool']
 
-            # goodbye_agent: AGUIToolset with goodbye_tool filter, delegate also has it
+            # goodbye_agent: AGUIToolset(goodbye_tool) -> ClientProxyToolset(goodbye_tool)
             assert agent_under_test.sub_agents[1].name == "goodbye_agent"
             assert len(agent_under_test.sub_agents[1].tools) == 1
             goodbye_toolset = agent_under_test.sub_agents[1].tools[0]
-            assert isinstance(goodbye_toolset, AGUIToolset)
+            assert isinstance(goodbye_toolset, ClientProxyToolset)
             assert goodbye_toolset.tool_filter == ['goodbye_tool']
-            assert goodbye_toolset._delegate is not None
-            assert isinstance(goodbye_toolset._delegate, ClientProxyToolset)
-            assert goodbye_toolset._delegate.tool_filter == ['goodbye_tool']
 
     @pytest.mark.asyncio
     async def test_non_deepcopyable_tool_does_not_crash(self):
@@ -1038,27 +1026,24 @@ class TestADKAgent:
             submethod_mocked.assert_called_once()
             agent_under_test = submethod_mocked.call_args.kwargs['adk_agent']
 
-            # The unpicklable toolset should be preserved (shared by reference).
-            # ag-ui#1389: AGUIToolsets now also stay by reference (bind-delegation
-            # pattern) instead of being replaced, so both tools should be
-            # present in agent.tools — just the AGUIToolset now has a bound
-            # ClientProxyToolset delegate.
+            # The AGUIToolset is replaced per-run by a ClientProxyToolset; the
+            # unpicklable toolset is preserved by reference (shared, not copied),
+            # so both tools are present and no pickling occurred.
             assert len(agent_under_test.tools) == 2
+            assert not any(isinstance(t, AGUIToolset) for t in agent_under_test.tools)
 
-            agui_toolsets = [
-                t for t in agent_under_test.tools if isinstance(t, AGUIToolset)
+            proxies = [
+                t for t in agent_under_test.tools if isinstance(t, ClientProxyToolset)
             ]
-            assert len(agui_toolsets) == 1
-            assert agui_toolsets[0]._delegate is not None
-            assert isinstance(agui_toolsets[0]._delegate, ClientProxyToolset)
+            assert len(proxies) == 1
 
-            non_proxy_non_agui_tools = [
+            others = [
                 t for t in agent_under_test.tools
-                if not isinstance(t, (ClientProxyToolset, AGUIToolset))
+                if not isinstance(t, ClientProxyToolset)
             ]
-            assert len(non_proxy_non_agui_tools) == 1
-            assert non_proxy_non_agui_tools[0] is unpicklable
-            assert non_proxy_non_agui_tools[0].errlog is sys.stderr
+            assert len(others) == 1
+            assert others[0] is unpicklable
+            assert others[0].errlog is sys.stderr
 
     @pytest.mark.asyncio
     async def test_original_agent_not_mutated_after_run(self):

--- a/integrations/adk-middleware/python/tests/test_agui_toolset_concurrency.py
+++ b/integrations/adk-middleware/python/tests/test_agui_toolset_concurrency.py
@@ -1,51 +1,17 @@
-"""Concurrency-safety proof for ``AGUIToolset.bind()`` delegation (ag-ui#1746).
+"""Concurrency-safety regression guard for AGUIToolset (ag-ui#1746 follow-up).
 
-Background
-----------
-PR #1746 replaced the ADK-1.x "swap the toolset object" strategy with a
-``bind()``/``unbind()`` delegation pattern so a single ``AGUIToolset``
-*instance* survives across a run (required by ADK 2.0's eager
-``Runner.__init__`` tool cache — see #1389).
+History: PR #1746 made ``ADKAgent`` attach the per-run ``ClientProxyToolset`` to
+a single shared ``AGUIToolset`` instance via ``bind()`` (one mutable ``_delegate``
+slot). Because ``_shallow_copy_agent_tree`` shares tool objects by reference and
+``max_concurrent_executions`` defaults to 10, concurrent runs clobbered each
+other's delegate — Run A's frontend tool calls could be routed to Run B's event
+stream, and the first run's cleanup could strand an in-flight peer.
 
-The defect proven here is that the delegate is stored in a **single mutable
-slot on an instance that is shared by reference across concurrent runs**:
-
-* :meth:`ADKAgent._shallow_copy_agent_tree` deliberately shares tool objects
-  by reference (``copied.tools = list(tools)`` keeps the same elements) so
-  every per-run copy of the agent points at the *same* construction-time
-  ``AGUIToolset`` object.
-* ``ADKAgent`` runs up to ``max_concurrent_executions`` (default **10**)
-  background executions at once. Runs are serialized only per
-  ``(thread_id, user_id)`` — two different threads/users run concurrently.
-* Each run builds its *own* per-run :class:`ClientProxyToolset` (carrying that
-  run's ``input.tools`` and that run's ``event_queue``) and calls
-  ``AGUIToolset.bind(proxy)`` on the shared placeholder. The second bind
-  clobbers the first; ``_run_adk_in_background``'s ``finally`` then calls
-  ``unbind()`` on the shared placeholder regardless of which run is cleaning up.
-
-Consequences, both reproduced below:
-
-1. **Cross-client tool routing.** Run A's ``get_tools()`` resolves Run B's
-   tool list, and the resolved :class:`ClientProxyTool` objects carry Run B's
-   ``event_queue`` — so Run A's frontend tool calls are streamed to Run B's
-   client.
-2. **Stranded in-flight run.** When the first run to finish hits its
-   ``finally`` and unbinds, a still-in-flight concurrent run loses every tool.
-
-Version note
-------------
-These tests run against whichever ``google-adk`` is installed. On ADK 1.x
-(``get_tools()`` resolved fresh on every ``run_async``) the cross-talk is
-direct and unmasked. ADK 2.0's per-Runner ``get_tools()`` cache only *narrows*
-the window for the tool-list cross-talk (an unlucky bind/Runner-construction
-ordering still hits it) and does nothing for the unbind-strand defect — the
-root cause (per-run state on a shared instance) is version-independent.
-
-The tests assert the **concurrency-safe invariant** (each run sees its own
-tools, on its own stream, unaffected by its peers). They therefore *fail* on
-the current code and are marked ``xfail(strict=True)``; remove the marker once
-each run is given an isolated delegate (e.g. a per-run placeholder copy or a
-run-scoped delegate keyed off the execution rather than a single shared slot).
+Fix: ``_update_agent_tools_recursive`` now *replaces* the placeholder with a
+fresh per-run ``ClientProxyToolset`` in the per-run copy's ``tools`` list. Each
+run gets its own toolset (its own ``input.tools`` + ``event_queue``); the
+construction-time placeholder is never mutated. These tests assert that
+isolation so the shared-state design can't return.
 """
 
 from __future__ import annotations
@@ -54,22 +20,13 @@ import asyncio
 from typing import Any, Callable, Dict, List
 from unittest.mock import patch
 
-import pytest
-
 from ag_ui.core import Tool, UserMessage
 from ag_ui.core.types import RunAgentInput
 from google.adk.agents import LlmAgent
 
 from ag_ui_adk import ADKAgent
-from ag_ui_adk.adk_agent import _unbind_agui_toolsets_recursive
 from ag_ui_adk.agui_toolset import AGUIToolset
-
-_XFAIL_REASON = (
-    "ag-ui#1746: AGUIToolset.bind() stores the per-run ClientProxyToolset on a "
-    "single slot of an instance shared by reference across concurrent runs, so "
-    "concurrent runs clobber each other's delegate. Remove this marker once each "
-    "run gets an isolated delegate."
-)
+from ag_ui_adk.client_proxy_toolset import ClientProxyToolset
 
 
 def _make_input(thread_id: str, tool_name: str) -> RunAgentInput:
@@ -92,11 +49,7 @@ def _make_input(thread_id: str, tool_name: str) -> RunAgentInput:
 
 
 def _build_agent() -> tuple[ADKAgent, AGUIToolset]:
-    """An ADKAgent whose root LlmAgent declares a single (unfiltered) AGUIToolset.
-
-    Returns the wrapper and the construction-time placeholder instance so tests
-    can assert on the object that gets shared across runs.
-    """
+    """An ADKAgent whose root LlmAgent declares a single (unfiltered) AGUIToolset."""
     placeholder = AGUIToolset()  # no tool_filter -> every client tool passes through
     root = LlmAgent(name="root", instruction="be helpful", tools=[placeholder])
     agent = ADKAgent(
@@ -109,12 +62,7 @@ def _build_agent() -> tuple[ADKAgent, AGUIToolset]:
 
 
 def _patch_background_noop() -> tuple[Any, List[Dict[str, Any]]]:
-    """Patch ``_run_adk_in_background`` with an async no-op that records its kwargs.
-
-    The no-op deliberately does NOT run the real ``finally`` unbind, so a test can
-    observe the binding state produced by ``_start_background_execution`` for each
-    run (and drive the cleanup itself when it wants to model a specific interleaving).
-    """
+    """Patch ``_run_adk_in_background`` with an async no-op that records its kwargs."""
     captured: List[Dict[str, Any]] = []
 
     async def _noop(self, **kwargs):  # bound as a method -> receives self
@@ -129,92 +77,64 @@ async def _await_tasks(*execs) -> None:
 
 
 class TestAGUIToolsetConcurrencySafety:
-    """Two concurrent runs must not corrupt each other's frontend toolset."""
+    """Two concurrent runs must each get their own isolated frontend toolset."""
 
-    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
-    async def test_concurrent_bind_routes_first_runs_tools_to_second_runs_stream(self) -> None:
-        """Run A, started first and still in flight, must keep seeing *its own*
-        tools on *its own* event stream after a concurrent Run B starts.
-
-        On the current code both runs share one ``AGUIToolset``; Run B's
-        ``bind()`` overwrites Run A's delegate, so Run A's Runner resolves Run
-        B's tool list and Run B's ``event_queue`` — a cross-client leak.
-        """
+    async def test_concurrent_runs_get_isolated_proxy_toolsets(self) -> None:
+        """Each run replaces the placeholder with its OWN ClientProxyToolset
+        (its own tools + event_queue); the construction-time placeholder is
+        never mutated and is not shared into either run's tools list."""
         agent, placeholder = _build_agent()
         bg_patch, captured = _patch_background_noop()
 
         with bg_patch:
-            # Run A starts and is now in flight (background task created, not finished).
             exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
-            # Run B (a different thread => not serialized) starts while A is in flight.
             exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
             await _await_tasks(exec_a, exec_b)
 
         tree_a, tree_b = captured[0]["adk_agent"], captured[1]["adk_agent"]
-        toolset_a = tree_a.tools[0]  # the AGUIToolset Run A's Runner will resolve through
-        queue_a = captured[0]["event_queue"]
-        queue_b = captured[1]["event_queue"]
+        ts_a, ts_b = tree_a.tools[0], tree_b.tools[0]
+        queue_a, queue_b = captured[0]["event_queue"], captured[1]["event_queue"]
 
-        # Root cause (reported in the failure message, not asserted, so a fix that
-        # isolates delegates without un-sharing the instance still flips this test):
-        root_cause = (
-            f"shared placeholder across runs: {toolset_a is tree_b.tools[0]}; "
-            f"placeholder is construction-time obj: {toolset_a is placeholder}"
-        )
+        # Placeholder was REPLACED in each per-run copy, with distinct proxies.
+        assert isinstance(ts_a, ClientProxyToolset) and isinstance(ts_b, ClientProxyToolset)
+        assert ts_a is not ts_b, "concurrent runs must not share a ClientProxyToolset"
 
-        # What Run A's Runner sees when it resolves tools (fresh per run_async on ADK 1.x):
-        resolved_a = await toolset_a.get_tools()
-        resolved_names = [t.name for t in resolved_a]
+        # Construction-time placeholder untouched (not mutated, not in either run).
+        assert agent._adk_agent.tools[0] is placeholder
+        assert isinstance(agent._adk_agent.tools[0], AGUIToolset)
 
-        assert resolved_names == ["toolA"], (
-            f"Run A's LLM was offered Run B's tools: got {resolved_names}, "
-            f"expected ['toolA']. ({root_cause})"
-        )
-        assert resolved_a[0].event_queue is queue_a, (
-            "Run A's frontend tool call would be delivered on Run B's AG-UI event "
-            "stream (the shared delegate carries Run B's event_queue) — a "
-            f"cross-client leak. ({root_cause})"
-        )
+        # Each run resolves ITS OWN tools, on ITS OWN event stream.
+        resolved_a = await ts_a.get_tools()
+        resolved_b = await ts_b.get_tools()
+        assert [t.name for t in resolved_a] == ["toolA"]
+        assert [t.name for t in resolved_b] == ["toolB"]
+        assert resolved_a[0].event_queue is queue_a
+        assert resolved_b[0].event_queue is queue_b
         assert resolved_a[0].event_queue is not queue_b
 
-    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
-    async def test_inflight_run_not_stranded_by_other_runs_cleanup(self) -> None:
-        """When the first run to finish unbinds in its ``finally``, a concurrent
-        still-in-flight run must keep its tools.
-
-        On the current code ``_run_adk_in_background``'s ``finally`` calls
-        ``_unbind_agui_toolsets_recursive`` on the *shared* placeholder, so Run
-        A finishing strands in-flight Run B with an empty tool list.
-        """
+    async def test_inflight_run_unaffected_by_other_runs_completion(self) -> None:
+        """A run completing must not disturb a concurrent in-flight run's tools
+        (the old ``finally`` unbind of the shared placeholder is gone)."""
         agent, _placeholder = _build_agent()
         bg_patch, captured = _patch_background_noop()
 
         with bg_patch:
             exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
             exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
-            await _await_tasks(exec_a, exec_b)
+            # Run A finishes; its (no-op) background task completes.
+            await _await_tasks(exec_a)
 
-        tree_a, tree_b = captured[0]["adk_agent"], captured[1]["adk_agent"]
-        toolset_b = tree_b.tools[0]  # Run B is still in flight
+            # Run B is still in flight and keeps its full tool list.
+            ts_b = captured[1]["adk_agent"].tools[0]
+            resolved_b = [t.name for t in await ts_b.get_tools()]
+            assert resolved_b == ["toolB"], (
+                f"in-flight Run B lost tools (got {resolved_b}) after Run A completed"
+            )
+            await _await_tasks(exec_b)
 
-        # Run A finishes first and runs exactly what its real `finally` block runs:
-        _unbind_agui_toolsets_recursive(tree_a)
-
-        resolved_b = [t.name for t in await toolset_b.get_tools()]
-        assert resolved_b == ["toolB"], (
-            f"In-flight Run B lost its tools (got {resolved_b}) because concurrent "
-            "Run A's cleanup unbound the shared AGUIToolset placeholder."
-        )
-
-    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
     async def test_real_concurrent_runs_each_resolve_their_own_tools(self) -> None:
-        """Same defect under genuine concurrent asyncio scheduling.
-
-        Two background executions run as real overlapping tasks. A barrier makes
-        the interleaving deterministic: Run A resolves its tools (as its Runner
-        would, mid-flight) only *after* Run B has bound. Each run must observe
-        its own tools/stream.
-        """
+        """Under genuine concurrent asyncio scheduling, each run's toolset (as a
+        Runner would resolve it mid-flight) yields that run's own tools/stream."""
         agent, _placeholder = _build_agent()
 
         release = asyncio.Event()
@@ -224,9 +144,8 @@ class TestAGUIToolsetConcurrencySafety:
         async def runner_fake(self, *, input, adk_agent, event_queue, client_proxy_toolsets, **kwargs):
             label = input.thread_id
             started[label].set()
-            await release.wait()  # park until both runs have bound
-            toolset = adk_agent.tools[0]
-            tools = await toolset.get_tools()  # what this run's Runner resolves
+            await release.wait()  # park until both runs have set up
+            tools = await adk_agent.tools[0].get_tools()  # what this run's Runner resolves
             resolved[label] = {
                 "names": [t.name for t in tools],
                 "own_queue": event_queue,
@@ -242,17 +161,15 @@ class TestAGUIToolsetConcurrencySafety:
 
         with patch.object(ADKAgent, "_run_adk_in_background", runner_fake):
             exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
-            await asyncio.wait_for(started["thread-A"].wait(), 5)  # A bound & parked
+            await asyncio.wait_for(started["thread-A"].wait(), 5)
             exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
-            await asyncio.wait_for(started["thread-B"].wait(), 5)  # B bound (clobbers A)
+            await asyncio.wait_for(started["thread-B"].wait(), 5)
             release.set()
             await _wait_until(lambda: {"thread-A", "thread-B"} <= resolved.keys())
             await _await_tasks(exec_a, exec_b)
 
-        assert resolved["thread-A"]["names"] == ["toolA"], (
-            f"Run A resolved {resolved['thread-A']['names']} under concurrent "
-            "scheduling — Run B's concurrent bind() overwrote Run A's tools."
-        )
-        assert resolved["thread-A"]["resolved_queue"] is resolved["thread-A"]["own_queue"], (
-            "Run A's tool calls would be routed to Run B's event stream."
-        )
+        assert resolved["thread-A"]["names"] == ["toolA"]
+        assert resolved["thread-B"]["names"] == ["toolB"]
+        assert resolved["thread-A"]["resolved_queue"] is resolved["thread-A"]["own_queue"]
+        assert resolved["thread-B"]["resolved_queue"] is resolved["thread-B"]["own_queue"]
+        assert resolved["thread-A"]["resolved_queue"] is not resolved["thread-B"]["own_queue"]

--- a/integrations/adk-middleware/python/tests/test_agui_toolset_concurrency.py
+++ b/integrations/adk-middleware/python/tests/test_agui_toolset_concurrency.py
@@ -1,0 +1,258 @@
+"""Concurrency-safety proof for ``AGUIToolset.bind()`` delegation (ag-ui#1746).
+
+Background
+----------
+PR #1746 replaced the ADK-1.x "swap the toolset object" strategy with a
+``bind()``/``unbind()`` delegation pattern so a single ``AGUIToolset``
+*instance* survives across a run (required by ADK 2.0's eager
+``Runner.__init__`` tool cache — see #1389).
+
+The defect proven here is that the delegate is stored in a **single mutable
+slot on an instance that is shared by reference across concurrent runs**:
+
+* :meth:`ADKAgent._shallow_copy_agent_tree` deliberately shares tool objects
+  by reference (``copied.tools = list(tools)`` keeps the same elements) so
+  every per-run copy of the agent points at the *same* construction-time
+  ``AGUIToolset`` object.
+* ``ADKAgent`` runs up to ``max_concurrent_executions`` (default **10**)
+  background executions at once. Runs are serialized only per
+  ``(thread_id, user_id)`` — two different threads/users run concurrently.
+* Each run builds its *own* per-run :class:`ClientProxyToolset` (carrying that
+  run's ``input.tools`` and that run's ``event_queue``) and calls
+  ``AGUIToolset.bind(proxy)`` on the shared placeholder. The second bind
+  clobbers the first; ``_run_adk_in_background``'s ``finally`` then calls
+  ``unbind()`` on the shared placeholder regardless of which run is cleaning up.
+
+Consequences, both reproduced below:
+
+1. **Cross-client tool routing.** Run A's ``get_tools()`` resolves Run B's
+   tool list, and the resolved :class:`ClientProxyTool` objects carry Run B's
+   ``event_queue`` — so Run A's frontend tool calls are streamed to Run B's
+   client.
+2. **Stranded in-flight run.** When the first run to finish hits its
+   ``finally`` and unbinds, a still-in-flight concurrent run loses every tool.
+
+Version note
+------------
+These tests run against whichever ``google-adk`` is installed. On ADK 1.x
+(``get_tools()`` resolved fresh on every ``run_async``) the cross-talk is
+direct and unmasked. ADK 2.0's per-Runner ``get_tools()`` cache only *narrows*
+the window for the tool-list cross-talk (an unlucky bind/Runner-construction
+ordering still hits it) and does nothing for the unbind-strand defect — the
+root cause (per-run state on a shared instance) is version-independent.
+
+The tests assert the **concurrency-safe invariant** (each run sees its own
+tools, on its own stream, unaffected by its peers). They therefore *fail* on
+the current code and are marked ``xfail(strict=True)``; remove the marker once
+each run is given an isolated delegate (e.g. a per-run placeholder copy or a
+run-scoped delegate keyed off the execution rather than a single shared slot).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from ag_ui.core import Tool, UserMessage
+from ag_ui.core.types import RunAgentInput
+from google.adk.agents import LlmAgent
+
+from ag_ui_adk import ADKAgent
+from ag_ui_adk.adk_agent import _unbind_agui_toolsets_recursive
+from ag_ui_adk.agui_toolset import AGUIToolset
+
+_XFAIL_REASON = (
+    "ag-ui#1746: AGUIToolset.bind() stores the per-run ClientProxyToolset on a "
+    "single slot of an instance shared by reference across concurrent runs, so "
+    "concurrent runs clobber each other's delegate. Remove this marker once each "
+    "run gets an isolated delegate."
+)
+
+
+def _make_input(thread_id: str, tool_name: str) -> RunAgentInput:
+    """A minimal new-run input for ``thread_id`` exposing exactly one frontend tool."""
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id=f"run_{thread_id}",
+        messages=[UserMessage(id=f"m_{thread_id}", role="user", content="hi")],
+        context=[],
+        state={},
+        tools=[
+            Tool(
+                name=tool_name,
+                description=f"the {tool_name} tool",
+                parameters={"type": "object", "properties": {}},
+            )
+        ],
+        forwarded_props={},
+    )
+
+
+def _build_agent() -> tuple[ADKAgent, AGUIToolset]:
+    """An ADKAgent whose root LlmAgent declares a single (unfiltered) AGUIToolset.
+
+    Returns the wrapper and the construction-time placeholder instance so tests
+    can assert on the object that gets shared across runs.
+    """
+    placeholder = AGUIToolset()  # no tool_filter -> every client tool passes through
+    root = LlmAgent(name="root", instruction="be helpful", tools=[placeholder])
+    agent = ADKAgent(
+        adk_agent=root,
+        app_name="concurrency_app",
+        user_id="shared_user",
+        use_in_memory_services=True,
+    )
+    return agent, placeholder
+
+
+def _patch_background_noop() -> tuple[Any, List[Dict[str, Any]]]:
+    """Patch ``_run_adk_in_background`` with an async no-op that records its kwargs.
+
+    The no-op deliberately does NOT run the real ``finally`` unbind, so a test can
+    observe the binding state produced by ``_start_background_execution`` for each
+    run (and drive the cleanup itself when it wants to model a specific interleaving).
+    """
+    captured: List[Dict[str, Any]] = []
+
+    async def _noop(self, **kwargs):  # bound as a method -> receives self
+        captured.append(kwargs)
+        return None
+
+    return patch.object(ADKAgent, "_run_adk_in_background", _noop), captured
+
+
+async def _await_tasks(*execs) -> None:
+    await asyncio.gather(*(e.task for e in execs), return_exceptions=True)
+
+
+class TestAGUIToolsetConcurrencySafety:
+    """Two concurrent runs must not corrupt each other's frontend toolset."""
+
+    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
+    async def test_concurrent_bind_routes_first_runs_tools_to_second_runs_stream(self) -> None:
+        """Run A, started first and still in flight, must keep seeing *its own*
+        tools on *its own* event stream after a concurrent Run B starts.
+
+        On the current code both runs share one ``AGUIToolset``; Run B's
+        ``bind()`` overwrites Run A's delegate, so Run A's Runner resolves Run
+        B's tool list and Run B's ``event_queue`` — a cross-client leak.
+        """
+        agent, placeholder = _build_agent()
+        bg_patch, captured = _patch_background_noop()
+
+        with bg_patch:
+            # Run A starts and is now in flight (background task created, not finished).
+            exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
+            # Run B (a different thread => not serialized) starts while A is in flight.
+            exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
+            await _await_tasks(exec_a, exec_b)
+
+        tree_a, tree_b = captured[0]["adk_agent"], captured[1]["adk_agent"]
+        toolset_a = tree_a.tools[0]  # the AGUIToolset Run A's Runner will resolve through
+        queue_a = captured[0]["event_queue"]
+        queue_b = captured[1]["event_queue"]
+
+        # Root cause (reported in the failure message, not asserted, so a fix that
+        # isolates delegates without un-sharing the instance still flips this test):
+        root_cause = (
+            f"shared placeholder across runs: {toolset_a is tree_b.tools[0]}; "
+            f"placeholder is construction-time obj: {toolset_a is placeholder}"
+        )
+
+        # What Run A's Runner sees when it resolves tools (fresh per run_async on ADK 1.x):
+        resolved_a = await toolset_a.get_tools()
+        resolved_names = [t.name for t in resolved_a]
+
+        assert resolved_names == ["toolA"], (
+            f"Run A's LLM was offered Run B's tools: got {resolved_names}, "
+            f"expected ['toolA']. ({root_cause})"
+        )
+        assert resolved_a[0].event_queue is queue_a, (
+            "Run A's frontend tool call would be delivered on Run B's AG-UI event "
+            "stream (the shared delegate carries Run B's event_queue) — a "
+            f"cross-client leak. ({root_cause})"
+        )
+        assert resolved_a[0].event_queue is not queue_b
+
+    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
+    async def test_inflight_run_not_stranded_by_other_runs_cleanup(self) -> None:
+        """When the first run to finish unbinds in its ``finally``, a concurrent
+        still-in-flight run must keep its tools.
+
+        On the current code ``_run_adk_in_background``'s ``finally`` calls
+        ``_unbind_agui_toolsets_recursive`` on the *shared* placeholder, so Run
+        A finishing strands in-flight Run B with an empty tool list.
+        """
+        agent, _placeholder = _build_agent()
+        bg_patch, captured = _patch_background_noop()
+
+        with bg_patch:
+            exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
+            exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
+            await _await_tasks(exec_a, exec_b)
+
+        tree_a, tree_b = captured[0]["adk_agent"], captured[1]["adk_agent"]
+        toolset_b = tree_b.tools[0]  # Run B is still in flight
+
+        # Run A finishes first and runs exactly what its real `finally` block runs:
+        _unbind_agui_toolsets_recursive(tree_a)
+
+        resolved_b = [t.name for t in await toolset_b.get_tools()]
+        assert resolved_b == ["toolB"], (
+            f"In-flight Run B lost its tools (got {resolved_b}) because concurrent "
+            "Run A's cleanup unbound the shared AGUIToolset placeholder."
+        )
+
+    @pytest.mark.xfail(strict=True, reason=_XFAIL_REASON)
+    async def test_real_concurrent_runs_each_resolve_their_own_tools(self) -> None:
+        """Same defect under genuine concurrent asyncio scheduling.
+
+        Two background executions run as real overlapping tasks. A barrier makes
+        the interleaving deterministic: Run A resolves its tools (as its Runner
+        would, mid-flight) only *after* Run B has bound. Each run must observe
+        its own tools/stream.
+        """
+        agent, _placeholder = _build_agent()
+
+        release = asyncio.Event()
+        started: Dict[str, asyncio.Event] = {"thread-A": asyncio.Event(), "thread-B": asyncio.Event()}
+        resolved: Dict[str, Dict[str, Any]] = {}
+
+        async def runner_fake(self, *, input, adk_agent, event_queue, client_proxy_toolsets, **kwargs):
+            label = input.thread_id
+            started[label].set()
+            await release.wait()  # park until both runs have bound
+            toolset = adk_agent.tools[0]
+            tools = await toolset.get_tools()  # what this run's Runner resolves
+            resolved[label] = {
+                "names": [t.name for t in tools],
+                "own_queue": event_queue,
+                "resolved_queue": tools[0].event_queue if tools else None,
+            }
+
+        async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
+            deadline = asyncio.get_event_loop().time() + timeout
+            while not pred():
+                if asyncio.get_event_loop().time() > deadline:
+                    raise AssertionError("condition not met within timeout")
+                await asyncio.sleep(0.005)
+
+        with patch.object(ADKAgent, "_run_adk_in_background", runner_fake):
+            exec_a = await agent._start_background_execution(_make_input("thread-A", "toolA"))
+            await asyncio.wait_for(started["thread-A"].wait(), 5)  # A bound & parked
+            exec_b = await agent._start_background_execution(_make_input("thread-B", "toolB"))
+            await asyncio.wait_for(started["thread-B"].wait(), 5)  # B bound (clobbers A)
+            release.set()
+            await _wait_until(lambda: {"thread-A", "thread-B"} <= resolved.keys())
+            await _await_tasks(exec_a, exec_b)
+
+        assert resolved["thread-A"]["names"] == ["toolA"], (
+            f"Run A resolved {resolved['thread-A']['names']} under concurrent "
+            "scheduling — Run B's concurrent bind() overwrote Run A's tools."
+        )
+        assert resolved["thread-A"]["resolved_queue"] is resolved["thread-A"]["own_queue"], (
+            "Run A's tool calls would be routed to Run B's event stream."
+        )


### PR DESCRIPTION
#  `AGUIToolset.bind()` delegation is not concurrency-safe

@contextablemark While reading the 0.6.4 changelog I notice the switch from per-run *copy/replace* to shared-instance `bind()` delegation for `AGUIToolset`. The copy was there on purpose to prevent shared concurrency issues, I probably should have noted this when I wrote it. I had Claude write up the issue and add a test suite to prove the problem. I don't have time this week to fix it, but I wanted to get the tests in place and bring it to your attention ASAP since this allows a data leak between concurrent user runs.

## Summary

#1746 fixed ADK 2.0 tool registration (#1389) by switching `AGUIToolset` from
per-run *replacement* to `bind()` / `unbind()` *delegation* on a single
placeholder instance. The problem: that placeholder is **shared by reference
across concurrent runs**, and `bind()` stores per-run state (the run's
`ClientProxyToolset`, which carries that run's `input.tools` **and** its
`event_queue`) in **one mutable slot**. Two runs in flight at the same time
therefore corrupt each other.

`ADKAgent` is built to run things concurrently: `max_concurrent_executions`
defaults to **10**, and runs are serialized only per `(thread_id, user_id)`.
A single `ADKAgent` serving multiple end-users/threads (the standard FastAPI
endpoint pattern) hits this on overlapping requests — it is not a corner case.

## Root cause

- `ADKAgent._shallow_copy_agent_tree` copies the agent per run but deliberately
  shares tool objects **by reference** (`copied.tools = list(tools)` — a new
  list with the *same* elements; `adk_agent.py:~1947`). Every per-run agent
  tree points at the *same* construction-time `AGUIToolset`.
- `_update_agent_tools_recursive` mutates that shared instance via
  `tool.bind(proxy_toolset)` (`adk_agent.py:~2111`), which sets the single
  `self._delegate` slot (`agui_toolset.py:112`).
- `_run_adk_in_background`'s `finally` calls `_unbind_agui_toolsets_recursive`
  on the shared instance (`adk_agent.py:~3008`), regardless of which run is
  cleaning up.

The in-code comment at `adk_agent.py:~3000` only reasons about *sequential*
runs ("the next run rebinds before tool invocation"); it does not account for
the concurrent runs the design permits.

## Failure modes (both reproduced by the tests)

1. **Cross-client tool-call leak.** Run B's `bind()` overwrites Run A's
   delegate, so Run A's Runner resolves Run B's tools — and the resolved
   `ClientProxyTool`s carry Run B's `event_queue` (`client_proxy_toolset.py:95-104`).
   Run A's `TOOL_CALL_START/ARGS/END` are then `.put()` onto Run B's stream
   (`client_proxy_tool.py:290-336`). The leaked arguments are generated from
   Run A's conversation/state → a genuine cross-user confidentiality breach,
   plus Run A stalls (its client was never told about the call).

2. **Stranded in-flight run.** When the first run to finish hits its `finally`
   and unbinds the shared placeholder, a still-in-flight concurrent run's
   `get_tools()` returns `[]` — it loses every frontend tool mid-flight.

### Scope of the leak (what crosses vs. what doesn't)

The event queue is **outbound** (agent → client), and the only emission path
routed through the shared delegate is `ClientProxyTool` (tool *calls*).
Everything else — text, `MESSAGES_SNAPSHOT`, even `ToolCallResultEvent` for
backend tools — is pumped onto the run's *own* queue by the per-run
`EventTranslator`, and inbound tool **results** arrive in a separate
`RunAgentInput` matched per `(thread_id, user)` and fed to ADK as input.

- **Tool calls / arguments (agent → client): leak** to the other user's stream.
- **Tool results (client → agent): do not** transit the misroutable queue.

## What's in this PR

- `integrations/adk-middleware/python/tests/test_agui_toolset_concurrency.py`
  — three `@pytest.mark.xfail(strict=True)` tests asserting the
  concurrency-safe invariant (each run keeps its own tools, on its own stream):
  - `test_concurrent_bind_routes_first_runs_tools_to_second_runs_stream`
  - `test_inflight_run_not_stranded_by_other_runs_cleanup`
  - `test_real_concurrent_runs_each_resolve_their_own_tools` (genuine
    overlapping `asyncio` tasks, made deterministic with a barrier)

They fail on current code and will **XPASS** (and trip `strict`) once each run
gets an isolated delegate — a built-in reminder to remove the markers when the
bug is fixed.

## How to see the proof

```bash
cd integrations/adk-middleware/python
# force the asserts to run (xfail ignored) -> the 3 failures ARE the proof:
pytest tests/test_agui_toolset_concurrency.py --runxfail
```

```
Run A's LLM was offered Run B's tools: got ['toolB'], expected ['toolA'].
In-flight Run B lost its tools (got []) because concurrent Run A's cleanup unbound the shared AGUIToolset placeholder.
Run A resolved ['toolB'] under concurrent scheduling — Run B's concurrent bind() overwrote Run A's tools.
3 failed
```

A normal run reports `3 xfailed`, so the suite stays green.

> Version note: verified on the installed `google-adk` 1.x, where `get_tools()`
> is resolved fresh on every `run_async` so the leak is direct. The defect is
> version-independent — ADK 2.0's per-Runner `get_tools()` cache only *narrows*
> the window for the tool-list cross-talk and does nothing for the
> unbind-strand; the root cause is per-run state on a shared instance.

## Regression origin

Pre-#1746 was concurrency-safe: `_update_agent_tools_recursive` built a **fresh
per-run list** (`agent.tools = new_tools`) holding a per-run
`ClientProxyToolset` and never mutated shared state — the old `AGUIToolset` had
no `bind`/`unbind`/`_delegate`. #1746 traded that per-run isolation for
shared-instance mutation in order to preserve object identity for ADK 2.0's
eager `Runner.__init__` tool cache.

---

## Update — I made some time to work on this. Fix added, and what the cross-version ADK investigation showed

Since I opened this with the failing tests, I dug into ADK's tool-resolution behavior across versions and **pushed the fix to this branch**. The three concurrency tests are now passing regression guards (no longer `xfail`).

### The fix

Restore per-run **replacement**: `_update_agent_tools_recursive` swaps the `AGUIToolset` placeholder for a fresh per-run `ClientProxyToolset` in the per-run agent copy's `tools` list. `_shallow_copy_agent_tree` already gives each run its own list, so concurrent runs are isolated by construction and the construction-time placeholder is never mutated. Removed `bind`/`unbind`/`_delegate` from `AGUIToolset` and the `_unbind_agui_toolsets_recursive` cleanup. The `<3.0.0` pin and the #1669 workflow fix are untouched.

### Was #1389 real? Yes — but it was an *alpha* behavior that GA fixed

#1389 was filed against `google-adk==2.0.0a2`. I reproduced its exact scenarios on the alpha, on 2.0.0 GA, and on 1.33.0:

| pattern | 1.33.0 | 2.0.0a2 (alpha) | 2.0.0 (GA) |
|---|---|---|---|
| eager tool resolution at `Runner.__init__` | no | no | no |
| same-object mutation (what `bind()` does) reaches the LLM | yes | yes | yes |
| object **replacement** (`agent.tools = [new]`) reaches the LLM | yes | **no → `[]`** | yes |

On the **alpha**, `LlmAgent` snapshots its toolset *object references* at agent-construction time (and that snapshot rides through `model_copy`), so swapping the toolset object was invisible — only mutating the already-referenced object worked. That is precisely why the pre-#1746 replacement broke on the alpha and why `bind()` fixed it: `bind()` keeps the cached object and changes what it returns. **GA reads `agent.tools` fresh per invocation** (`base_llm_flow.py` → `agent.canonical_tools(ReadonlyContext(...))`, cached per-`InvocationContext`), so replacement is visible again — and `Runner.__init__` does no eager tool resolution on either the alpha or GA.

> Correction to the "Version note" above: it isn't that GA's cache merely *narrows the window* — GA has no eager-init resolution at all. The load-bearing #1389 cause was the alpha's construction-time reference caching, which GA removed. So `bind()` was a legitimate fix for the alpha, but on GA (and 1.x) it is unnecessary — and it introduced the concurrency bug.

### Why replacement (not a contextvar)

Keeping the shared instance but resolving the per-run delegate from a `ContextVar` would also be concurrency-safe and would even work on the alpha, but contextvar propagation across ADK's task/thread boundaries is fragile. Per-run replacement is concurrency-safe by construction and works on every GA/1.x version, so it's the simpler choice. **Pre-releases (`2.0.0a2`) are not supported** — replacement provably regresses #1389 there, but a normal install (`>=1.16.0,<3.0.0`) never resolves a pre-release.

### Validation

Full suite, both majors (clean venvs):

- google-adk **2.0.0** — 832 passed, 4 skipped
- google-adk **1.33.0** — 830 passed, 6 skipped (the 2 extra skips are the #1669 Workflow tests, absent on 1.x)

Plus an end-to-end check driving a real `Runner.run_async` turn with a fake model: the replaced frontend tool lands in `LlmRequest.tools_dict` on GA (the dispatch table #1389 reported as `[]`), and two concurrent turns each advertise only their own tool.

### Why this class of bug (design note)

ADK's own long-lived toolsets stay concurrency-safe by never storing per-invocation state on the instance. `McpToolset`, for example, resolves credentials per call from the `ToolContext` and keys its connection pool by a hash of the (per-user) auth headers — never a single "current" slot. `bind()` stored the per-run `event_queue` + tools on the shared placeholder, which is the pattern that breaks under concurrency. Per-run replacement restores that invariant.

### Note on history

There's no single commit to revert: #1746 bundled the `bind()` change with the #1669 workflow fix and the `<3.0.0` pin lift in one commit (`c770be3f`), so this is a forward patch that keeps both of those.

