### PR TITLE
fix: drop environment: npm from publish-commit publish job

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -51,7 +51,6 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    environment: npm
     permissions:
       contents: read
 

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - run: corepack enable
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
 
@@ -39,7 +39,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pkg-pr-new-build
           path: |
@@ -56,20 +56,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4.3.0
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - run: corepack enable
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pkg-pr-new-build
 


### PR DESCRIPTION
## Summary

The `publish` job in `.github/workflows/publish-commit.yml` runs `pkg-pr-new publish`, which posts to pkg-pr-new's preview-package service — NOT to npmjs.org. pkg-pr-new uses its own OIDC token and does not need any npm-environment scope.

The `environment: npm` annotation was collateral from the OIDC migration in #1766. Because the `npm` GitHub Environment has `deployment_branch_policy: { protected_branches: true }`, every non-`main` branch push has been failing the `publish` job in 2–3s at the deployment-branch-policy gate, with no logs and no steps recorded.

Confirmed pattern across recent feature branches (`feat/ai-release-notes`, `fix/langgraph-resume-skips-regeneration`, `renovate-migration/cleanup-dependabot-gha`, and others). PR #1781 was the first instance and got admin-merged; this fix prevents the next admin-merge.

## Change

One line removed: the `environment: npm` annotation on the `publish` job. The `build` job never had it; nothing else changes.

## Test plan

- [x] `actionlint .github/workflows/publish-commit.yml` clean
- [x] YAML parses
- [x] `prettier --check` clean
- [ ] First feature-branch push after merge produces a green `publish` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)