### PR TITLE
ci: run release-script tests in CI

### DIFF
--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -1,0 +1,55 @@
+name: Test Release Scripts
+
+# Runs node:test unit tests under scripts/release/. Lives outside Nx because
+# scripts/release/ is not an Nx project (pnpm test = nx run-many -t test skips
+# it), which is why the existing generate-ai-release-notes.test.ts has been
+# local-only since it landed. Sibling lint-release-workflows.yml covers
+# actionlint + shellcheck; this file covers the TypeScript tests.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/release/**"
+      - ".github/workflows/test-release-scripts.yml"
+  pull_request:
+    paths:
+      - "scripts/release/**"
+      - ".github/workflows/test-release-scripts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: "10.33.4"
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        # --ignore-scripts: we only need tsx + node; skip postinstall builds.
+        # --frozen-lockfile: hermetic, matches release workflow discipline.
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Run release-script tests
+        # failglob makes the *.test.ts glob exit non-zero if no files match,
+        # so an empty scripts/release/ tree fails loudly instead of silently
+        # passing (node --test treats unexpanded globs as missing-test specs
+        # and exits 0).
+        run: |
+          set -euo pipefail
+          shopt -s failglob
+          pnpm exec node --test --import tsx scripts/release/*.test.ts


### PR DESCRIPTION
## Summary

Wires `scripts/release/*.test.ts` into CI. The `generate-ai-release-notes.test.ts` file added in #1785 was local-only because `scripts/release/` isn't an Nx project and `pnpm test` = `nx run-many -t test` skipped it. Sibling `prepare-release.ts` also has no CI coverage; this fix unblocks both by globbing the directory.

## Design

New workflow `.github/workflows/test-release-scripts.yml` rather than extending `lint-release-workflows.yml`. The existing file is scoped to actionlint + shellcheck + allowlist-sync — mixing a TypeScript test job into a lint-only workflow would dilute its purpose. Triggers are path-scoped to `scripts/release/**` so the workflow only runs when it has something to test.

Glob behavior: `shopt -s failglob` makes `scripts/release/*.test.ts` fail loudly if zero files match. `node --test` silently exits 0 on an unexpanded glob, which would let an empty release-scripts directory silently pass; failglob prevents that.

Action SHAs copy `publish-release.yml` exactly (`checkout@de0fac2e...`, `pnpm/action-setup@b906affc...`, `setup-node@49933ea5...`) for supply-chain consistency.

## Test plan

- [x] `actionlint` clean on new file
- [x] YAML parses
- [x] `prettier --check` clean
- [x] Local: `pnpm exec node --test --import tsx scripts/release/*.test.ts` -> 8 pass / 0 fail
- [ ] PR's own CI run executes the new step and reports 8/0