### PR TITLE
fix: use ag-ui-devops-bot to create release PR so CI fires

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -182,11 +182,22 @@ jobs:
             jq -r '.packages[] | "- **\(.name)**: \(.oldVersion) → \(.newVersion)"' /tmp/bump-result.json
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Mint devops-bot token
+        id: app-token
+        if: inputs.dry_run != true && steps.bump.outputs.changed_count != '0'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: "3877599"
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+
       - name: Configure git credentials for push
         if: inputs.dry_run != true && steps.bump.outputs.changed_count != '0'
-        run: git config --local url."https://x-access-token:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+        run: |
+          git config user.name "ag-ui-devops-bot[bot]"
+          git config user.email "3877599+ag-ui-devops-bot[bot]@users.noreply.github.com"
+          git config --local url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Commit and push version bumps
         if: inputs.dry_run != true && steps.bump.outputs.changed_count != '0'
@@ -282,7 +293,7 @@ jobs:
           INPUT_SCOPE: ${{ inputs.scope }}
           INPUT_BUMP: ${{ inputs.bump }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require("fs");
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary

Auto-created release PRs from `prepare-release.yml` have been silently bypassing CI. GitHub's recursive-workflow protection blocks `pull_request`-triggered workflows from firing on PRs opened with the default `GITHUB_TOKEN`. The PR gets created and the bump commit lands, but the unit/e2e/build pipeline never runs against the proposed release.

Confirmed across the last 5 auto-created `release/next` PRs (#1620, #1686, #1739, #1778, etc.): only `release / publish` (closed-event), `Security: Fork PR Alert`, Mintlify, and Vercel checks appear. The actual `unit` / `e2e` / `pkg-pr-new` / `pr-check-binaries` / `auto-approve-community` / `build-python-preview` workflows are absent. Sole exception is #1591, where a human (`mxmzb`) pushed a commit — that PR ran all `pull_request` workflows, proving the bot-vs-human contrast.

## Change

Mints a token from the `ag-ui-devops-bot` GitHub App (App ID `3877599`, owned by ag-ui-protocol org) and uses it for:
- The `release/next` push (so the bump commit comes from the bot)
- The `actions/github-script` step that creates / updates the release PR (so CI fires)

Bot identity: `ag-ui-devops-bot[bot]` (`3877599+ag-ui-devops-bot[bot]@users.noreply.github.com`). `DEVOPS_BOT_PRIVATE_KEY` secret already provisioned. `actions/create-github-app-token` pinned to `fee1f7d6` (v2.2.2).

## Test plan

- [x] `actionlint` clean
- [x] `prettier --check` clean
- [x] YAML parses
- [ ] First post-merge release-PR run shows `unit`/`e2e`/etc. checks present and green

Credit to Tyler Slaton for flagging this during review of #1785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)