### PR TITLE
fix(mastra): preserve message.id including undefined-id edge case (supersedes #1687)

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -616,5 +616,32 @@ describe("convertAGUIMessagesToMastra", () => {
       expect((result[1] as any).id).toBe("assistant-id");
       expect((result[2] as any).id).toBe("tool-id");
     });
+
+    it("omits id key entirely when message.id is undefined for all roles (issue #1659)", () => {
+      // Mastra's inputToMastraDBMessage uses `"id" in message` at runtime.
+      // For `{ id: undefined, ... }`, that check returns true, defeating the
+      // intended fix. The id key must be absent, not present-with-undefined.
+      const messages: Message[] = [
+        { id: undefined as any, role: "user", content: "hello" },
+        {
+          id: undefined as any,
+          role: "assistant",
+          content: "hi",
+          toolCalls: [],
+        },
+        {
+          id: undefined as any,
+          role: "tool",
+          content: "result",
+          toolCallId: "tc-1",
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect("id" in result[0]).toBe(false);
+      expect("id" in result[1]).toBe(false);
+      expect("id" in result[2]).toBe(false);
+    });
   });
 });

--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -10,7 +10,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "Hello world" }]);
+      expect(result).toEqual([{ id: "1", role: "user", content: "Hello world" }]);
     });
 
     it("converts array content with text parts", () => {
@@ -29,6 +29,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "text", text: "First part" },
@@ -53,6 +54,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "text", text: "Single part" },
@@ -74,6 +76,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [],
         },
@@ -87,7 +90,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       const result = convertAGUIMessagesToMastra(messages);
 
-      expect(result).toEqual([{ role: "user", content: "" }]);
+      expect(result).toEqual([{ id: "1", role: "user", content: "" }]);
     });
 
     it("preserves non-text parts as structured content", () => {
@@ -109,6 +112,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "text", text: "Keep this" },
@@ -135,6 +139,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "text", text: "  hello  " },
@@ -168,6 +173,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "image", image: "https://example.com/photo.jpg" },
@@ -198,6 +204,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "image", image: "data:image/png;base64,abc123" },
@@ -228,6 +235,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             {
@@ -262,6 +270,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             {
@@ -282,7 +291,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result).toEqual([
-        { role: "user", content: "Just a string" },
+        { id: "1", role: "user", content: "Just a string" },
       ]);
     });
 
@@ -333,6 +342,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "user",
           content: [
             { type: "text", text: "Look at this image:" },
@@ -354,6 +364,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "assistant",
           content: [{ type: "text", text: "I can help with that" }],
         },
@@ -383,6 +394,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "assistant",
           content: [
             {
@@ -419,6 +431,7 @@ describe("convertAGUIMessagesToMastra", () => {
 
       expect(result).toEqual([
         {
+          id: "1",
           role: "assistant",
           content: [
             { type: "text", text: "Let me check" },
@@ -495,6 +508,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result[1]).toEqual({
+        id: "2",
         role: "tool",
         content: [
           {
@@ -520,6 +534,7 @@ describe("convertAGUIMessagesToMastra", () => {
       const result = convertAGUIMessagesToMastra(messages);
 
       expect(result[0]).toEqual({
+        id: "1",
         role: "tool",
         content: [
           {
@@ -576,6 +591,30 @@ describe("convertAGUIMessagesToMastra", () => {
 
     it("returns empty array for empty messages", () => {
       expect(convertAGUIMessagesToMastra([])).toEqual([]);
+    });
+
+    it("preserves message id for all roles (issue #1659)", () => {
+      const messages: Message[] = [
+        { id: "user-id", role: "user", content: "hello" },
+        {
+          id: "assistant-id",
+          role: "assistant",
+          content: "hi",
+          toolCalls: [],
+        },
+        {
+          id: "tool-id",
+          role: "tool",
+          content: "result",
+          toolCallId: "tc-1",
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect((result[0] as any).id).toBe("user-id");
+      expect((result[1] as any).id).toBe("assistant-id");
+      expect((result[2] as any).id).toBe("tool-id");
     });
   });
 });

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -7,6 +7,15 @@ import { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import { RequestContext } from "@mastra/core/request-context";
 import { MastraAgent } from "./mastra";
 
+/**
+ * CoreMessage extended with an optional `id` field.
+ * Mastra's `inputToMastraDBMessage` checks `"id" in message` at runtime
+ * and preserves it when present, but the upstream AI SDK type doesn't
+ * declare the field. This type makes the pass-through explicit.
+ * Ref: https://github.com/mastra-ai/mastra/blob/13f46064564fc4aee14aa11878f9352d79f4efc4/packages/core/src/agent/message-list/conversion/input-converter.ts#L79
+ */
+type CoreMessageWithId = CoreMessage & { id?: string };
+
 function mediaSourceToUrl(source: InputContentDataSource | InputContentUrlSource): string {
   if (source.type === "data") {
     return `data:${source.mimeType};base64,${source.value}`;
@@ -92,8 +101,8 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
   return parts;
 };
 
-export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] {
-  const result: CoreMessage[] = [];
+export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWithId[] {
+  const result: CoreMessageWithId[] = [];
 
   for (const message of messages) {
     if (message.role === "assistant") {
@@ -111,12 +120,14 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
         });
       }
       result.push({
+        id: message.id,
         role: "assistant",
         content: parts,
       });
     } else if (message.role === "user") {
       const userContent = toMastraContent(message.content);
       result.push({
+        id: message.id,
         role: "user",
         content: userContent,
       });
@@ -133,6 +144,7 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessage[] 
         }
       }
       result.push({
+        id: message.id,
         role: "tool",
         content: [
           {

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -120,14 +120,14 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWit
         });
       }
       result.push({
-        id: message.id,
+        ...(message.id !== undefined ? { id: message.id } : {}),
         role: "assistant",
         content: parts,
       });
     } else if (message.role === "user") {
       const userContent = toMastraContent(message.content);
       result.push({
-        id: message.id,
+        ...(message.id !== undefined ? { id: message.id } : {}),
         role: "user",
         content: userContent,
       });
@@ -144,7 +144,7 @@ export function convertAGUIMessagesToMastra(messages: Message[]): CoreMessageWit
         }
       }
       result.push({
-        id: message.id,
+        ...(message.id !== undefined ? { id: message.id } : {}),
         role: "tool",
         content: [
           {


### PR DESCRIPTION
## Summary

Supersedes #1687 by @carloscco — includes the original commit (`3280e225`) plus a follow-on fix for an edge case that was defeating the very check the original PR added.

## The original fix (from #1687, credit @carloscco)

Adds `id: message.id` to the three result objects (`user`, `assistant`, `tool` roles) in `convertAGUIMessagesToMastra` so that Mastra's `inputToMastraDBMessage` preserves the AG-UI message id instead of generating a new DB id. Introduces `CoreMessageWithId = CoreMessage & { id?: string }` and updates the unit-test suite + adds a regression test for #1659.

## The follow-on fix (this PR adds)

The original `{ id: message.id, role: ..., ... }` writes the `id` property unconditionally. When `message.id` is `undefined`, JavaScript's object-literal syntax produces `{ id: undefined, ... }` — the property is **present** with value `undefined`, not absent. The original PR's doc comment cites Mastra's runtime check `"id" in message`, which evaluates to `true` for `{ id: undefined }`. So when AG-UI hands us a message without an id, Mastra will try to "preserve" an undefined id downstream — defeating the very fix in the messages-without-id case.

Switched to conditional spread:

```ts
result.push({
  ...(message.id !== undefined ? { id: message.id } : {}),
  role: "user",
  content: ...,
});
```

Same in the `assistant` and `tool` branches.

## Test plan

- [x] Red/green verification: new test `omits id key entirely when message.id is undefined for all roles (issue #1659)` fails before the fix (exact error: `expected true to be false` on `"id" in result[0]`), passes after.
- [x] `pnpm typecheck` passes.
- [x] `pnpm test` — `message-conversion.test.ts` 24/24 (was 23/23); full integration suite 112/112.
- [x] Existing #1659 regression test in #1687 still passes.

## Files changed

- `integrations/mastra/typescript/src/utils.ts` (+6 / −3) — conditional id spread in 3 branches
- `integrations/mastra/typescript/src/__tests__/message-conversion.test.ts` (+72 / −5) — original test updates from #1687 + new undefined-id test

Closes #1659.