### PR TITLE
fix(ruby): preserve opaque hash keys and emit timestamp as epoch ms (stacked on #1783)

### DIFF
--- a/docs/sdk/ruby/core/capabilities.mdx
+++ b/docs/sdk/ruby/core/capabilities.mdx
@@ -8,214 +8,10 @@ description: "Documentation for agent capability declarations in the Agent User 
 Agent capabilities define what an agent can do. They are declared by the agent
 implementation and communicated to the client during a run.
 
-All fields are optional — agents only declare what they support. Omitted
-fields mean the capability is not declared (unknown), not that it's
-unsupported.
-
-## SubAgentInfo
-
-`AgUiProtocol::Core::Capabilities::SubAgentInfo`
-
-Describes a sub-agent that can be invoked by a parent agent.
-
-| Property      | Type                | Description                                                                                    |
-| ------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
-| `name`        | `String`            | Unique name or identifier of the sub-agent.                                                    |
-| `description` | `String` (optional) | What this sub-agent specializes in. Helps clients build agent selection UIs. , Default: `nil`. |
-
-## IdentityCapabilities
-
-`AgUiProtocol::Core::Capabilities::IdentityCapabilities`
-
-Basic metadata about the agent.
-
-Useful for discovery UIs, agent marketplaces, and debugging. Set these when
-you want clients to display agent information or when multiple agents are
-available and users need to pick one.
-
-| Property            | Type                               | Description                                                                                                    |
-| ------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `name`              | `String` (optional)                | Human-readable name shown in UIs and agent selectors. , Default: `nil`.                                        |
-| `type`              | `String` (optional)                | The framework or platform powering this agent (e.g., \"langgraph\", \"mastra\", \"crewai\"). , Default: `nil`. |
-| `description`       | `String` (optional)                | What this agent does — helps users and routing logic decide when to use it. , Default: `nil`.                  |
-| `version`           | `String` (optional)                | Semantic version of the agent (e.g., \"1.2.0\"). Useful for compatibility checks. , Default: `nil`.            |
-| `provider`          | `String` (optional)                | Organization or team that maintains this agent. , Default: `nil`.                                              |
-| `documentation_url` | `String` (optional)                | URL to the agent's documentation or homepage. , Default: `nil`.                                                |
-| `metadata`          | `Hash<String , Object>` (optional) | Arbitrary key-value pairs for integration-specific identity info. , Default: `nil`.                            |
-
-## TransportCapabilities
-
-`AgUiProtocol::Core::Capabilities::TransportCapabilities`
-
-Declares which transport mechanisms the agent supports.
-
-Clients use this to pick the best connection strategy. Only set flags to
-`true` for transports your agent actually handles — omit or set `false` for
-unsupported ones.
-
-| Property             | Type                 | Description                                                                                           |
-| -------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `streaming`          | `Boolean` (optional) | Set +true+ if the agent streams responses via SSE. Most agents enable this. , Default: `nil`.         |
-| `websocket`          | `Boolean` (optional) | Set +true+ if the agent accepts persistent WebSocket connections. , Default: `nil`.                   |
-| `http_binary`        | `Boolean` (optional) | Set +true+ if the agent supports the AG-UI binary protocol (protobuf over HTTP). , Default: `nil`.    |
-| `push_notifications` | `Boolean` (optional) | Set +true+ if the agent can send async updates via webhooks after a run finishes. , Default: `nil`.   |
-| `resumable`          | `Boolean` (optional) | Set +true+ if the agent supports resuming interrupted streams via sequence numbers. , Default: `nil`. |
-
-## ToolsCapabilities
-
-`AgUiProtocol::Core::Capabilities::ToolsCapabilities`
-
-Tool calling capabilities.
-
-Distinguishes between tools the agent itself provides (listed in `items`) and
-tools the client passes at runtime via <code>RunAgentInput.tools</code>.
-Enable this when your agent can call functions, search the web, execute code,
-etc.
-
-| Property          | Type                     | Description                                                                                                                                                             |
-| ----------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `supported`       | `Boolean` (optional)     | Set +true+ if the agent can make tool calls at all. Set +false+ to explicitly signal tool calling is disabled even if items are present. , Default: `nil`.              |
-| `items`           | `Array<Tool>` (optional) | The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools. , Default: `nil`. |
-| `parallel_calls`  | `Boolean` (optional)     | Set +true+ if the agent can invoke multiple tools concurrently within a single step. , Default: `nil`.                                                                  |
-| `client_provided` | `Boolean` (optional)     | Set +true+ if the agent accepts and uses tools provided by the client at runtime. , Default: `nil`.                                                                     |
-
-## OutputCapabilities
-
-`AgUiProtocol::Core::Capabilities::OutputCapabilities`
-
-Output format support.
-
-Enable `structured_output` when your agent can return responses conforming to
-a JSON schema, which is useful for programmatic consumption.
-
-| Property               | Type                       | Description                                                                                                                                    |
-| ---------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `structured_output`    | `Boolean` (optional)       | Set +true+ if the agent can produce structured JSON output matching a provided schema. , Default: `nil`.                                       |
-| `supported_mime_types` | `Array<String>` (optional) | MIME types the agent can produce (e.g., [\"text/plain\", \"application/json\"]). Omit if the agent only produces plain text. , Default: `nil`. |
-
-## StateCapabilities
-
-`AgUiProtocol::Core::Capabilities::StateCapabilities`
-
-State and memory management capabilities.
-
-These tell the client how the agent handles shared state and whether
-conversation context persists across runs.
-
-| Property           | Type                 | Description                                                                                                                                             |
-| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `snapshots`        | `Boolean` (optional) | Set +true+ if the agent emits STATE_SNAPSHOT events (full state replacement). , Default: `nil`.                                                         |
-| `deltas`           | `Boolean` (optional) | Set +true+ if the agent emits STATE_DELTA events (JSON Patch incremental updates). , Default: `nil`.                                                    |
-| `memory`           | `Boolean` (optional) | Set +true+ if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall). , Default: `nil`. |
-| `persistent_state` | `Boolean` (optional) | Set +true+ if state is preserved across multiple runs within the same thread. When +false+, state resets on each run. , Default: `nil`.                 |
-
-## MultiAgentCapabilities
-
-`AgUiProtocol::Core::Capabilities::MultiAgentCapabilities`
-
-Multi-agent coordination capabilities.
-
-Enable these when your agent can orchestrate or hand off work to other agents.
-
-| Property     | Type                             | Description                                                                                              |
-| ------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `supported`  | `Boolean` (optional)             | Set +true+ if the agent participates in any form of multi-agent coordination. , Default: `nil`.          |
-| `delegation` | `Boolean` (optional)             | Set +true+ if the agent can delegate subtasks to other agents while retaining control. , Default: `nil`. |
-| `handoffs`   | `Boolean` (optional)             | Set +true+ if the agent can transfer the conversation entirely to another agent. , Default: `nil`.       |
-| `sub_agents` | `Array<SubAgentInfo>` (optional) | List of sub-agents this agent can invoke. Helps clients build agent selection UIs. , Default: `nil`.     |
-
-## ReasoningCapabilities
-
-`AgUiProtocol::Core::Capabilities::ReasoningCapabilities`
-
-Reasoning and thinking capabilities.
-
-Enable these when your agent exposes its internal thought process (e.g.,
-chain-of-thought, extended thinking).
-
-| Property    | Type                 | Description                                                                                                                                                                   |
-| ----------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `supported` | `Boolean` (optional) | Set +true+ if the agent produces reasoning/thinking tokens visible to the client. , Default: `nil`.                                                                           |
-| `streaming` | `Boolean` (optional) | Set +true+ if reasoning tokens are streamed incrementally (vs. returned all at once). , Default: `nil`.                                                                       |
-| `encrypted` | `Boolean` (optional) | Set +true+ if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque +encrypted_value+ fields instead of readable content. , Default: `nil`. |
-
-## MultimodalInputCapabilities
-
-`AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities`
-
-Modalities the agent can accept as input.
-
-Clients use this to show/hide file upload buttons, audio recorders, image
-pickers, etc.
-
-| Property | Type                 | Description                                                                                     |
-| -------- | -------------------- | ----------------------------------------------------------------------------------------------- |
-| `image`  | `Boolean` (optional) | Set +true+ if the agent can process image inputs (e.g., screenshots, photos). , Default: `nil`. |
-| `audio`  | `Boolean` (optional) | Set +true+ if the agent can process audio inputs (speech, recordings). , Default: `nil`.        |
-| `video`  | `Boolean` (optional) | Set +true+ if the agent can process video inputs. , Default: `nil`.                             |
-| `pdf`    | `Boolean` (optional) | Set +true+ if the agent can process PDF documents. , Default: `nil`.                            |
-| `file`   | `Boolean` (optional) | Set +true+ if the agent can process arbitrary file uploads. , Default: `nil`.                   |
-
-## MultimodalOutputCapabilities
-
-`AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities`
-
-Modalities the agent can produce as output.
-
-Clients use this to anticipate rich content in the agent's response.
-
-| Property | Type                 | Description                                                                                       |
-| -------- | -------------------- | ------------------------------------------------------------------------------------------------- |
-| `image`  | `Boolean` (optional) | Set +true+ if the agent can generate images as part of its response. , Default: `nil`.            |
-| `audio`  | `Boolean` (optional) | Set +true+ if the agent can produce audio output (text-to-speech, audio files). , Default: `nil`. |
-
-## MultimodalCapabilities
-
-`AgUiProtocol::Core::Capabilities::MultimodalCapabilities`
-
-Multimodal input and output support.
-
-Organized into `input` and `output` sub-objects so clients can independently
-query what the agent accepts versus what it produces.
-
-| Property | Type                                      | Description                                                                                     |
-| -------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `input`  | `MultimodalInputCapabilities` (optional)  | Modalities the agent can accept as input (images, audio, video, PDFs, files). , Default: `nil`. |
-| `output` | `MultimodalOutputCapabilities` (optional) | Modalities the agent can produce as output (images, audio). , Default: `nil`.                   |
-
-## ExecutionCapabilities
-
-`AgUiProtocol::Core::Capabilities::ExecutionCapabilities`
-
-Execution control and limits.
-
-Declare these so clients can set expectations about how long or how many steps
-an agent run might take.
-
-| Property             | Type                 | Description                                                                                                                                                    |
-| -------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `code_execution`     | `Boolean` (optional) | Set +true+ if the agent can execute code (e.g., Python, JavaScript) during a run. , Default: `nil`.                                                            |
-| `sandboxed`          | `Boolean` (optional) | Set +true+ if code execution happens in a sandboxed/isolated environment. Only meaningful when +code_execution+ is +true+. , Default: `nil`.                   |
-| `max_iterations`     | `Integer` (optional) | Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations. , Default: `nil`. |
-| `max_execution_time` | `Integer` (optional) | Maximum wall-clock time (in milliseconds) the agent will run before timing out. , Default: `nil`.                                                              |
-
-## HumanInTheLoopCapabilities
-
-`AgUiProtocol::Core::Capabilities::HumanInTheLoopCapabilities`
-
-Human-in-the-loop interaction support.
-
-Enable these when your agent can pause execution to request human input,
-approval, or feedback before continuing.
-
-| Property             | Type                 | Description                                                                                                                                                  |
-| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `supported`          | `Boolean` (optional) | Set +true+ if the agent supports any form of human-in-the-loop interaction. , Default: `nil`.                                                                |
-| `approvals`          | `Boolean` (optional) | Set +true+ if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data). , Default: `nil`. |
-| `interventions`      | `Boolean` (optional) | Set +true+ if the agent allows humans to intervene and modify its plan mid-execution. , Default: `nil`.                                                      |
-| `feedback`           | `Boolean` (optional) | Set +true+ if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session. , Default: `nil`.    |
-| `interrupts`         | `Boolean` (optional) | Set +true+ if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]). , Default: `nil`.        |
-| `approve_with_edits` | `Boolean` (optional) | Set +true+ if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true. , Default: `nil`.                       |
+All fields on `AgentCapabilities` and its sub-capability classes are optional
+— agents only declare what they support. (Nested helper types like
+`SubAgentInfo` may still have required identifier fields.) Omitted fields mean
+the capability is not declared (unknown), not that it's unsupported.
 
 ## AgentCapabilities
 
@@ -230,17 +26,226 @@ unsupported.
 The `custom` field is an escape hatch for integration-specific capabilities
 that don't fit into the standard categories.
 
-| Property            | Type                                    | Description                                                                                 |
-| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `identity`          | `IdentityCapabilities` (optional)       | Agent identity and metadata. , Default: `nil`.                                              |
-| `transport`         | `TransportCapabilities` (optional)      | Supported transport mechanisms (SSE, WebSocket, binary, etc.). , Default: `nil`.            |
-| `tools`             | `ToolsCapabilities` (optional)          | Tools the agent provides and tool calling configuration. , Default: `nil`.                  |
-| `output`            | `OutputCapabilities` (optional)         | Output format support (structured output, MIME types). , Default: `nil`.                    |
-| `state`             | `StateCapabilities` (optional)          | State and memory management (snapshots, deltas, persistence). , Default: `nil`.             |
-| `multi_agent`       | `MultiAgentCapabilities` (optional)     | Multi-agent coordination (delegation, handoffs, sub-agents). , Default: `nil`.              |
-| `reasoning`         | `ReasoningCapabilities` (optional)      | Reasoning and thinking support (chain-of-thought, encrypted thinking). , Default: `nil`.    |
-| `multimodal`        | `MultimodalCapabilities` (optional)     | Multimodal input/output support (images, audio, video, files). , Default: `nil`.            |
-| `execution`         | `ExecutionCapabilities` (optional)      | Execution control and limits (code execution, timeouts, iteration caps). , Default: `nil`.  |
-| `human_in_the_loop` | `HumanInTheLoopCapabilities` (optional) | Human-in-the-loop support (approvals, interventions, feedback). , Default: `nil`.           |
-| `custom`            | `Hash<String , Object>` (optional)      | Integration-specific capabilities not covered by the standard categories. , Default: `nil`. |
+| Property            | Type                                        | Description                                                                                                                        |
+| ------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `identity`          | `IdentityCapabilities` (optional)           | Agent identity and metadata. Default: `nil`.                                                                                       |
+| `transport`         | `TransportCapabilities` (optional)          | Supported transport mechanisms (SSE, WebSocket, binary, etc.). Default: `nil`.                                                     |
+| `tools`             | `ToolsCapabilities` (optional)              | Tools the agent provides and tool calling configuration. Default: `nil`.                                                           |
+| `output`            | `OutputCapabilities` (optional)             | Output format support (structured output, MIME types). Default: `nil`.                                                             |
+| `state`             | `StateCapabilities` (optional)              | State and memory management (snapshots, deltas, persistence). Default: `nil`.                                                      |
+| `multi_agent`       | `MultiAgentCapabilities` (optional)         | Multi-agent coordination (delegation, handoffs, sub-agents). Default: `nil`.                                                       |
+| `reasoning`         | `ReasoningCapabilities` (optional)          | Reasoning and thinking support (chain-of-thought, encrypted thinking). Default: `nil`.                                             |
+| `multimodal`        | `MultimodalCapabilities` (optional)         | Multimodal input/output support (images, audio, video, files). Default: `nil`.                                                     |
+| `execution`         | `ExecutionCapabilities` (optional)          | Execution control and limits (code execution, timeouts, iteration caps). Default: `nil`.                                           |
+| `human_in_the_loop` | `HumanInTheLoopCapabilities` (optional)     | Human-in-the-loop support (approvals, interventions, feedback). Default: `nil`.                                                    |
+| `custom`            | `Hash{String, Symbol => Object}` (optional) | Integration-specific capabilities not covered by the standard categories. String or Symbol keys are both accepted. Default: `nil`. |
+
+## IdentityCapabilities
+
+`AgUiProtocol::Core::Capabilities::IdentityCapabilities`
+
+Basic metadata about the agent.
+
+Useful for discovery UIs, agent marketplaces, and debugging. Set these when
+you want clients to display agent information or when multiple agents are
+available and users need to pick one.
+
+| Property            | Type                                        | Description                                                                                                                |
+| ------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `name`              | `String` (optional)                         | Human-readable name shown in UIs and agent selectors. Default: `nil`.                                                      |
+| `type`              | `String` (optional)                         | The framework or platform powering this agent (e.g., "langgraph", "mastra", "crewai"). Default: `nil`.                     |
+| `description`       | `String` (optional)                         | What this agent does — helps users and routing logic decide when to use it. Default: `nil`.                                |
+| `version`           | `String` (optional)                         | Semantic version of the agent (e.g., "1.2.0"). Useful for compatibility checks. Default: `nil`.                            |
+| `provider`          | `String` (optional)                         | Organization or team that maintains this agent. Default: `nil`.                                                            |
+| `documentation_url` | `String` (optional)                         | URL to the agent's documentation or homepage. Default: `nil`.                                                              |
+| `metadata`          | `Hash{String, Symbol => Object}` (optional) | Arbitrary key-value pairs for integration-specific identity info. String or Symbol keys are both accepted. Default: `nil`. |
+
+## TransportCapabilities
+
+`AgUiProtocol::Core::Capabilities::TransportCapabilities`
+
+Declares which transport mechanisms the agent supports.
+
+Clients use this to pick the best connection strategy. Only set flags to
+`true` for transports your agent actually handles — omit or set `false` for
+unsupported ones.
+
+| Property             | Type                 | Description                                                                                         |
+| -------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| `streaming`          | `Boolean` (optional) | Set `true` if the agent streams responses via SSE. Most agents enable this. Default: `nil`.         |
+| `websocket`          | `Boolean` (optional) | Set `true` if the agent accepts persistent WebSocket connections. Default: `nil`.                   |
+| `http_binary`        | `Boolean` (optional) | Set `true` if the agent supports the AG-UI binary protocol (protobuf over HTTP). Default: `nil`.    |
+| `push_notifications` | `Boolean` (optional) | Set `true` if the agent can send async updates via webhooks after a run finishes. Default: `nil`.   |
+| `resumable`          | `Boolean` (optional) | Set `true` if the agent supports resuming interrupted streams via sequence numbers. Default: `nil`. |
+
+## ToolsCapabilities
+
+`AgUiProtocol::Core::Capabilities::ToolsCapabilities`
+
+Tool calling capabilities.
+
+Distinguishes between tools the agent itself provides (listed in `items`) and
+tools the client passes at runtime via <code>RunAgentInput.tools</code>.
+Enable this when your agent can call functions, search the web, execute code,
+etc.
+
+| Property          | Type                     | Description                                                                                                                                                           |
+| ----------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supported`       | `Boolean` (optional)     | Set `true` if the agent can make tool calls at all. Set `false` to explicitly signal tool calling is disabled even if items are present. Default: `nil`.              |
+| `items`           | `Array<Tool>` (optional) | The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools. Default: `nil`. |
+| `parallel_calls`  | `Boolean` (optional)     | Set `true` if the agent can invoke multiple tools concurrently within a single step. Default: `nil`.                                                                  |
+| `client_provided` | `Boolean` (optional)     | Set `true` if the agent accepts and uses tools provided by the client at runtime. Default: `nil`.                                                                     |
+
+## OutputCapabilities
+
+`AgUiProtocol::Core::Capabilities::OutputCapabilities`
+
+Output format support.
+
+Enable `structured_output` when your agent can return responses conforming to
+a JSON schema, which is useful for programmatic consumption.
+
+| Property               | Type                       | Description                                                                                                                              |
+| ---------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `structured_output`    | `Boolean` (optional)       | Set `true` if the agent can produce structured JSON output matching a provided schema. Default: `nil`.                                   |
+| `supported_mime_types` | `Array<String>` (optional) | MIME types the agent can produce (e.g., ["text/plain", "application/json"]). Omit if the agent only produces plain text. Default: `nil`. |
+
+## StateCapabilities
+
+`AgUiProtocol::Core::Capabilities::StateCapabilities`
+
+State and memory management capabilities.
+
+These tell the client how the agent handles shared state and whether
+conversation context persists across runs.
+
+| Property           | Type                 | Description                                                                                                                                           |
+| ------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshots`        | `Boolean` (optional) | Set `true` if the agent emits STATE_SNAPSHOT events (full state replacement). Default: `nil`.                                                         |
+| `deltas`           | `Boolean` (optional) | Set `true` if the agent emits STATE_DELTA events (JSON Patch incremental updates). Default: `nil`.                                                    |
+| `memory`           | `Boolean` (optional) | Set `true` if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall). Default: `nil`. |
+| `persistent_state` | `Boolean` (optional) | Set `true` if state is preserved across multiple runs within the same thread. When `false`, state resets on each run. Default: `nil`.                 |
+
+## MultiAgentCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultiAgentCapabilities`
+
+Multi-agent coordination capabilities.
+
+Enable these when your agent can orchestrate or hand off work to other agents.
+
+| Property     | Type                             | Description                                                                                            |
+| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `supported`  | `Boolean` (optional)             | Set `true` if the agent participates in any form of multi-agent coordination. Default: `nil`.          |
+| `delegation` | `Boolean` (optional)             | Set `true` if the agent can delegate subtasks to other agents while retaining control. Default: `nil`. |
+| `handoffs`   | `Boolean` (optional)             | Set `true` if the agent can transfer the conversation entirely to another agent. Default: `nil`.       |
+| `sub_agents` | `Array<SubAgentInfo>` (optional) | List of sub-agents this agent can invoke. Helps clients build agent selection UIs. Default: `nil`.     |
+
+## ReasoningCapabilities
+
+`AgUiProtocol::Core::Capabilities::ReasoningCapabilities`
+
+Reasoning and thinking capabilities.
+
+Enable these when your agent exposes its internal thought process (e.g.,
+chain-of-thought, extended thinking).
+
+| Property    | Type                 | Description                                                                                                                                                                 |
+| ----------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supported` | `Boolean` (optional) | Set `true` if the agent produces reasoning/thinking tokens visible to the client. Default: `nil`.                                                                           |
+| `streaming` | `Boolean` (optional) | Set `true` if reasoning tokens are streamed incrementally (vs. returned all at once). Default: `nil`.                                                                       |
+| `encrypted` | `Boolean` (optional) | Set `true` if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque `encrypted_value` fields instead of readable content. Default: `nil`. |
+
+## MultimodalCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalCapabilities`
+
+Multimodal input and output support.
+
+Organized into `input` and `output` sub-objects so clients can independently
+query what the agent accepts versus what it produces.
+
+| Property | Type                                      | Description                                                                                   |
+| -------- | ----------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `input`  | `MultimodalInputCapabilities` (optional)  | Modalities the agent can accept as input (images, audio, video, PDFs, files). Default: `nil`. |
+| `output` | `MultimodalOutputCapabilities` (optional) | Modalities the agent can produce as output (images, audio). Default: `nil`.                   |
+
+## MultimodalInputCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities`
+
+Modalities the agent can accept as input.
+
+Clients use this to show/hide file upload buttons, audio recorders, image
+pickers, etc.
+
+| Property | Type                 | Description                                                                                   |
+| -------- | -------------------- | --------------------------------------------------------------------------------------------- |
+| `image`  | `Boolean` (optional) | Set `true` if the agent can process image inputs (e.g., screenshots, photos). Default: `nil`. |
+| `audio`  | `Boolean` (optional) | Set `true` if the agent can process audio inputs (speech, recordings). Default: `nil`.        |
+| `video`  | `Boolean` (optional) | Set `true` if the agent can process video inputs. Default: `nil`.                             |
+| `pdf`    | `Boolean` (optional) | Set `true` if the agent can process PDF documents. Default: `nil`.                            |
+| `file`   | `Boolean` (optional) | Set `true` if the agent can process arbitrary file uploads. Default: `nil`.                   |
+
+## MultimodalOutputCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities`
+
+Modalities the agent can produce as output.
+
+Clients use this to anticipate rich content in the agent's response.
+
+| Property | Type                 | Description                                                                                     |
+| -------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| `image`  | `Boolean` (optional) | Set `true` if the agent can generate images as part of its response. Default: `nil`.            |
+| `audio`  | `Boolean` (optional) | Set `true` if the agent can produce audio output (text-to-speech, audio files). Default: `nil`. |
+
+## ExecutionCapabilities
+
+`AgUiProtocol::Core::Capabilities::ExecutionCapabilities`
+
+Execution control and limits.
+
+Declare these so clients can set expectations about how long or how many steps
+an agent run might take.
+
+| Property             | Type                 | Description                                                                                                                                                  |
+| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `code_execution`     | `Boolean` (optional) | Set `true` if the agent can execute code (e.g., Python, JavaScript) during a run. Default: `nil`.                                                            |
+| `sandboxed`          | `Boolean` (optional) | Set `true` if code execution happens in a sandboxed/isolated environment. Only meaningful when `code_execution` is `true`. Default: `nil`.                   |
+| `max_iterations`     | `Integer` (optional) | Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations. Default: `nil`. |
+| `max_execution_time` | `Integer` (optional) | Maximum wall-clock time (in milliseconds) the agent will run before timing out. Default: `nil`.                                                              |
+
+## HumanInTheLoopCapabilities
+
+`AgUiProtocol::Core::Capabilities::HumanInTheLoopCapabilities`
+
+Human-in-the-loop interaction support.
+
+Enable these when your agent can pause execution to request human input,
+approval, or feedback before continuing.
+
+| Property             | Type                 | Description                                                                                                                                                |
+| -------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supported`          | `Boolean` (optional) | Set `true` if the agent supports any form of human-in-the-loop interaction. Default: `nil`.                                                                |
+| `approvals`          | `Boolean` (optional) | Set `true` if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data). Default: `nil`. |
+| `interventions`      | `Boolean` (optional) | Set `true` if the agent allows humans to intervene and modify its plan mid-execution. Default: `nil`.                                                      |
+| `feedback`           | `Boolean` (optional) | Set `true` if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session. Default: `nil`.    |
+| `interrupts`         | `Boolean` (optional) | Set `true` if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]). Default: `nil`.        |
+| `approve_with_edits` | `Boolean` (optional) | Set `true` if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true. Default: `nil`.                       |
+
+## Value Types
+
+Value types referenced by capability classes.
+
+### SubAgentInfo
+
+`AgUiProtocol::Core::Capabilities::SubAgentInfo`
+
+Describes a sub-agent that can be invoked by a parent agent.
+
+| Property      | Type                | Description                                                                                  |
+| ------------- | ------------------- | -------------------------------------------------------------------------------------------- |
+| `name`        | `String`            | Unique name or identifier of the sub-agent.                                                  |
+| `description` | `String` (optional) | What this sub-agent specializes in. Helps clients build agent selection UIs. Default: `nil`. |
 

--- a/docs/sdk/ruby/core/capabilities.mdx
+++ b/docs/sdk/ruby/core/capabilities.mdx
@@ -1,0 +1,246 @@
+---
+title: "Capabilities"
+description: "Documentation for agent capability declarations in the Agent User Interaction Protocol (Ruby SDK)"
+---
+
+# Agent Capabilities
+
+Agent capabilities define what an agent can do. They are declared by the agent
+implementation and communicated to the client during a run.
+
+All fields are optional — agents only declare what they support. Omitted
+fields mean the capability is not declared (unknown), not that it's
+unsupported.
+
+## SubAgentInfo
+
+`AgUiProtocol::Core::Capabilities::SubAgentInfo`
+
+Describes a sub-agent that can be invoked by a parent agent.
+
+| Property      | Type                | Description                                                                                    |
+| ------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| `name`        | `String`            | Unique name or identifier of the sub-agent.                                                    |
+| `description` | `String` (optional) | What this sub-agent specializes in. Helps clients build agent selection UIs. , Default: `nil`. |
+
+## IdentityCapabilities
+
+`AgUiProtocol::Core::Capabilities::IdentityCapabilities`
+
+Basic metadata about the agent.
+
+Useful for discovery UIs, agent marketplaces, and debugging. Set these when
+you want clients to display agent information or when multiple agents are
+available and users need to pick one.
+
+| Property            | Type                               | Description                                                                                                    |
+| ------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `name`              | `String` (optional)                | Human-readable name shown in UIs and agent selectors. , Default: `nil`.                                        |
+| `type`              | `String` (optional)                | The framework or platform powering this agent (e.g., \"langgraph\", \"mastra\", \"crewai\"). , Default: `nil`. |
+| `description`       | `String` (optional)                | What this agent does — helps users and routing logic decide when to use it. , Default: `nil`.                  |
+| `version`           | `String` (optional)                | Semantic version of the agent (e.g., \"1.2.0\"). Useful for compatibility checks. , Default: `nil`.            |
+| `provider`          | `String` (optional)                | Organization or team that maintains this agent. , Default: `nil`.                                              |
+| `documentation_url` | `String` (optional)                | URL to the agent's documentation or homepage. , Default: `nil`.                                                |
+| `metadata`          | `Hash<String , Object>` (optional) | Arbitrary key-value pairs for integration-specific identity info. , Default: `nil`.                            |
+
+## TransportCapabilities
+
+`AgUiProtocol::Core::Capabilities::TransportCapabilities`
+
+Declares which transport mechanisms the agent supports.
+
+Clients use this to pick the best connection strategy. Only set flags to
+`true` for transports your agent actually handles — omit or set `false` for
+unsupported ones.
+
+| Property             | Type                 | Description                                                                                           |
+| -------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `streaming`          | `Boolean` (optional) | Set +true+ if the agent streams responses via SSE. Most agents enable this. , Default: `nil`.         |
+| `websocket`          | `Boolean` (optional) | Set +true+ if the agent accepts persistent WebSocket connections. , Default: `nil`.                   |
+| `http_binary`        | `Boolean` (optional) | Set +true+ if the agent supports the AG-UI binary protocol (protobuf over HTTP). , Default: `nil`.    |
+| `push_notifications` | `Boolean` (optional) | Set +true+ if the agent can send async updates via webhooks after a run finishes. , Default: `nil`.   |
+| `resumable`          | `Boolean` (optional) | Set +true+ if the agent supports resuming interrupted streams via sequence numbers. , Default: `nil`. |
+
+## ToolsCapabilities
+
+`AgUiProtocol::Core::Capabilities::ToolsCapabilities`
+
+Tool calling capabilities.
+
+Distinguishes between tools the agent itself provides (listed in `items`) and
+tools the client passes at runtime via <code>RunAgentInput.tools</code>.
+Enable this when your agent can call functions, search the web, execute code,
+etc.
+
+| Property          | Type                     | Description                                                                                                                                                             |
+| ----------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supported`       | `Boolean` (optional)     | Set +true+ if the agent can make tool calls at all. Set +false+ to explicitly signal tool calling is disabled even if items are present. , Default: `nil`.              |
+| `items`           | `Array<Tool>` (optional) | The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools. , Default: `nil`. |
+| `parallel_calls`  | `Boolean` (optional)     | Set +true+ if the agent can invoke multiple tools concurrently within a single step. , Default: `nil`.                                                                  |
+| `client_provided` | `Boolean` (optional)     | Set +true+ if the agent accepts and uses tools provided by the client at runtime. , Default: `nil`.                                                                     |
+
+## OutputCapabilities
+
+`AgUiProtocol::Core::Capabilities::OutputCapabilities`
+
+Output format support.
+
+Enable `structured_output` when your agent can return responses conforming to
+a JSON schema, which is useful for programmatic consumption.
+
+| Property               | Type                       | Description                                                                                                                                    |
+| ---------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `structured_output`    | `Boolean` (optional)       | Set +true+ if the agent can produce structured JSON output matching a provided schema. , Default: `nil`.                                       |
+| `supported_mime_types` | `Array<String>` (optional) | MIME types the agent can produce (e.g., [\"text/plain\", \"application/json\"]). Omit if the agent only produces plain text. , Default: `nil`. |
+
+## StateCapabilities
+
+`AgUiProtocol::Core::Capabilities::StateCapabilities`
+
+State and memory management capabilities.
+
+These tell the client how the agent handles shared state and whether
+conversation context persists across runs.
+
+| Property           | Type                 | Description                                                                                                                                             |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshots`        | `Boolean` (optional) | Set +true+ if the agent emits STATE_SNAPSHOT events (full state replacement). , Default: `nil`.                                                         |
+| `deltas`           | `Boolean` (optional) | Set +true+ if the agent emits STATE_DELTA events (JSON Patch incremental updates). , Default: `nil`.                                                    |
+| `memory`           | `Boolean` (optional) | Set +true+ if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall). , Default: `nil`. |
+| `persistent_state` | `Boolean` (optional) | Set +true+ if state is preserved across multiple runs within the same thread. When +false+, state resets on each run. , Default: `nil`.                 |
+
+## MultiAgentCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultiAgentCapabilities`
+
+Multi-agent coordination capabilities.
+
+Enable these when your agent can orchestrate or hand off work to other agents.
+
+| Property     | Type                             | Description                                                                                              |
+| ------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `supported`  | `Boolean` (optional)             | Set +true+ if the agent participates in any form of multi-agent coordination. , Default: `nil`.          |
+| `delegation` | `Boolean` (optional)             | Set +true+ if the agent can delegate subtasks to other agents while retaining control. , Default: `nil`. |
+| `handoffs`   | `Boolean` (optional)             | Set +true+ if the agent can transfer the conversation entirely to another agent. , Default: `nil`.       |
+| `sub_agents` | `Array<SubAgentInfo>` (optional) | List of sub-agents this agent can invoke. Helps clients build agent selection UIs. , Default: `nil`.     |
+
+## ReasoningCapabilities
+
+`AgUiProtocol::Core::Capabilities::ReasoningCapabilities`
+
+Reasoning and thinking capabilities.
+
+Enable these when your agent exposes its internal thought process (e.g.,
+chain-of-thought, extended thinking).
+
+| Property    | Type                 | Description                                                                                                                                                                   |
+| ----------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supported` | `Boolean` (optional) | Set +true+ if the agent produces reasoning/thinking tokens visible to the client. , Default: `nil`.                                                                           |
+| `streaming` | `Boolean` (optional) | Set +true+ if reasoning tokens are streamed incrementally (vs. returned all at once). , Default: `nil`.                                                                       |
+| `encrypted` | `Boolean` (optional) | Set +true+ if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque +encrypted_value+ fields instead of readable content. , Default: `nil`. |
+
+## MultimodalInputCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities`
+
+Modalities the agent can accept as input.
+
+Clients use this to show/hide file upload buttons, audio recorders, image
+pickers, etc.
+
+| Property | Type                 | Description                                                                                     |
+| -------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| `image`  | `Boolean` (optional) | Set +true+ if the agent can process image inputs (e.g., screenshots, photos). , Default: `nil`. |
+| `audio`  | `Boolean` (optional) | Set +true+ if the agent can process audio inputs (speech, recordings). , Default: `nil`.        |
+| `video`  | `Boolean` (optional) | Set +true+ if the agent can process video inputs. , Default: `nil`.                             |
+| `pdf`    | `Boolean` (optional) | Set +true+ if the agent can process PDF documents. , Default: `nil`.                            |
+| `file`   | `Boolean` (optional) | Set +true+ if the agent can process arbitrary file uploads. , Default: `nil`.                   |
+
+## MultimodalOutputCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities`
+
+Modalities the agent can produce as output.
+
+Clients use this to anticipate rich content in the agent's response.
+
+| Property | Type                 | Description                                                                                       |
+| -------- | -------------------- | ------------------------------------------------------------------------------------------------- |
+| `image`  | `Boolean` (optional) | Set +true+ if the agent can generate images as part of its response. , Default: `nil`.            |
+| `audio`  | `Boolean` (optional) | Set +true+ if the agent can produce audio output (text-to-speech, audio files). , Default: `nil`. |
+
+## MultimodalCapabilities
+
+`AgUiProtocol::Core::Capabilities::MultimodalCapabilities`
+
+Multimodal input and output support.
+
+Organized into `input` and `output` sub-objects so clients can independently
+query what the agent accepts versus what it produces.
+
+| Property | Type                                      | Description                                                                                     |
+| -------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `input`  | `MultimodalInputCapabilities` (optional)  | Modalities the agent can accept as input (images, audio, video, PDFs, files). , Default: `nil`. |
+| `output` | `MultimodalOutputCapabilities` (optional) | Modalities the agent can produce as output (images, audio). , Default: `nil`.                   |
+
+## ExecutionCapabilities
+
+`AgUiProtocol::Core::Capabilities::ExecutionCapabilities`
+
+Execution control and limits.
+
+Declare these so clients can set expectations about how long or how many steps
+an agent run might take.
+
+| Property             | Type                 | Description                                                                                                                                                    |
+| -------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code_execution`     | `Boolean` (optional) | Set +true+ if the agent can execute code (e.g., Python, JavaScript) during a run. , Default: `nil`.                                                            |
+| `sandboxed`          | `Boolean` (optional) | Set +true+ if code execution happens in a sandboxed/isolated environment. Only meaningful when +code_execution+ is +true+. , Default: `nil`.                   |
+| `max_iterations`     | `Integer` (optional) | Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations. , Default: `nil`. |
+| `max_execution_time` | `Integer` (optional) | Maximum wall-clock time (in milliseconds) the agent will run before timing out. , Default: `nil`.                                                              |
+
+## HumanInTheLoopCapabilities
+
+`AgUiProtocol::Core::Capabilities::HumanInTheLoopCapabilities`
+
+Human-in-the-loop interaction support.
+
+Enable these when your agent can pause execution to request human input,
+approval, or feedback before continuing.
+
+| Property             | Type                 | Description                                                                                                                                                  |
+| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `supported`          | `Boolean` (optional) | Set +true+ if the agent supports any form of human-in-the-loop interaction. , Default: `nil`.                                                                |
+| `approvals`          | `Boolean` (optional) | Set +true+ if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data). , Default: `nil`. |
+| `interventions`      | `Boolean` (optional) | Set +true+ if the agent allows humans to intervene and modify its plan mid-execution. , Default: `nil`.                                                      |
+| `feedback`           | `Boolean` (optional) | Set +true+ if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session. , Default: `nil`.    |
+| `interrupts`         | `Boolean` (optional) | Set +true+ if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]). , Default: `nil`.        |
+| `approve_with_edits` | `Boolean` (optional) | Set +true+ if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true. , Default: `nil`.                       |
+
+## AgentCapabilities
+
+`AgUiProtocol::Core::Capabilities::AgentCapabilities`
+
+A categorized snapshot of an agent's current capabilities.
+
+All fields are optional — agents only declare what they support. Omitted
+fields mean the capability is not declared (unknown), not that it's
+unsupported.
+
+The `custom` field is an escape hatch for integration-specific capabilities
+that don't fit into the standard categories.
+
+| Property            | Type                                    | Description                                                                                 |
+| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `identity`          | `IdentityCapabilities` (optional)       | Agent identity and metadata. , Default: `nil`.                                              |
+| `transport`         | `TransportCapabilities` (optional)      | Supported transport mechanisms (SSE, WebSocket, binary, etc.). , Default: `nil`.            |
+| `tools`             | `ToolsCapabilities` (optional)          | Tools the agent provides and tool calling configuration. , Default: `nil`.                  |
+| `output`            | `OutputCapabilities` (optional)         | Output format support (structured output, MIME types). , Default: `nil`.                    |
+| `state`             | `StateCapabilities` (optional)          | State and memory management (snapshots, deltas, persistence). , Default: `nil`.             |
+| `multi_agent`       | `MultiAgentCapabilities` (optional)     | Multi-agent coordination (delegation, handoffs, sub-agents). , Default: `nil`.              |
+| `reasoning`         | `ReasoningCapabilities` (optional)      | Reasoning and thinking support (chain-of-thought, encrypted thinking). , Default: `nil`.    |
+| `multimodal`        | `MultimodalCapabilities` (optional)     | Multimodal input/output support (images, audio, video, files). , Default: `nil`.            |
+| `execution`         | `ExecutionCapabilities` (optional)      | Execution control and limits (code execution, timeouts, iteration caps). , Default: `nil`.  |
+| `human_in_the_loop` | `HumanInTheLoopCapabilities` (optional) | Human-in-the-loop support (approvals, interventions, feedback). , Default: `nil`.           |
+| `custom`            | `Hash<String , Object>` (optional)      | Integration-specific capabilities not covered by the standard categories. , Default: `nil`. |
+

--- a/docs/sdk/ruby/core/events.mdx
+++ b/docs/sdk/ruby/core/events.mdx
@@ -21,6 +21,13 @@ AgUiProtocol::Core::Events::EventType::ACTIVITY_SNAPSHOT
 AgUiProtocol::Core::Events::EventType::CUSTOM
 AgUiProtocol::Core::Events::EventType::MESSAGES_SNAPSHOT
 AgUiProtocol::Core::Events::EventType::RAW
+AgUiProtocol::Core::Events::EventType::REASONING_ENCRYPTED_VALUE
+AgUiProtocol::Core::Events::EventType::REASONING_END
+AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_CHUNK
+AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_CONTENT
+AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_END
+AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_START
+AgUiProtocol::Core::Events::EventType::REASONING_START
 AgUiProtocol::Core::Events::EventType::RUN_ERROR
 AgUiProtocol::Core::Events::EventType::RUN_FINISHED
 AgUiProtocol::Core::Events::EventType::RUN_STARTED
@@ -107,13 +114,49 @@ run_id: "r1", result: { "a" => 1 })
 
 **@category** [] Lifecycle Events
 
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `thread_id` | `String`            | ID of the conversation thread                                       |
-| `run_id`    | `String`            | ID of the run                                                       |
-| `result`    | `Object` (optional) | Result data from the agent run , Default: `nil`.                    |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                                                                 | Description                                                         |
+| ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `thread_id` | `String`                                                             | ID of the conversation thread                                       |
+| `run_id`    | `String`                                                             | ID of the run                                                       |
+| `result`    | `Object` (optional)                                                  | Result data from the agent run , Default: `nil`.                    |
+| `outcome`   | `RunFinishedSuccessOutcome , RunFinishedInterruptOutcome` (optional) | Outcome of the run , Default: `nil`.                                |
+| `timestamp` | `Time` (optional)                                                    | Timestamp when the event was created , Default: `nil`.              |
+| `raw_event` | `Object` (optional)                                                  | Original event data if this event was transformed , Default: `nil`. |
+
+### RunFinishedInterruptOutcome
+
+`AgUiProtocol::Core::Events::RunFinishedInterruptOutcome`
+
+Represents an interrupt outcome for a run.
+
+```ruby outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
+    interrupts: [
+      AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
+    ]
+
+) ```
+
+| Property     | Type                                          | Description                            |
+| ------------ | --------------------------------------------- | -------------------------------------- |
+| `interrupts` | `Array<AgUiProtocol::Core::Types::Interrupt>` | List of interrupts                     |
+| `type`       | `String` (optional)                           | Outcome type , Default: `"interrupt"`. |
+
+### RunFinishedSuccessOutcome
+
+`AgUiProtocol::Core::Events::RunFinishedSuccessOutcome`
+
+Represents a successful outcome for a run.
+
+```ruby outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+```
+
+| Property          | Type     | Description                                       |
+| ----------------- | -------- | ------------------------------------------------- |
+| `subtype`         | `String` | Subtype ("tool-call" or "message")                |
+| `entity_id`       | `String` | ID of the entity being encrypted                  |
+| `encrypted_value` | `String` | The encrypted value                               |
+| `timestamp`       | `Time`   | Timestamp when the event was created              |
+| `raw_event`       | `Object` | Original event data if this event was transformed |
 
 ### RunStartedEvent
 

--- a/docs/sdk/ruby/core/events.mdx
+++ b/docs/sdk/ruby/core/events.mdx
@@ -13,7 +13,7 @@ and the frontend. This section documents the event types and their properties.
 
 `AgUiProtocol::Core::Events::EventType`
 
-The `EventType` module defines all possible event types in the system
+The `EventType` module defines all possible event types in the system.
 
 ```ruby
 AgUiProtocol::Core::Events::EventType::ACTIVITY_DELTA
@@ -55,8 +55,12 @@ AgUiProtocol::Core::Events::EventType::TOOL_CALL_START
 
 `AgUiProtocol::Core::Events::BaseEvent`
 
-All events inherit from the `BaseEvent` class, which provides common
-properties shared across all event types. ```ruby
+All event classes inherit from `BaseEvent`, which provides common properties
+shared across all event types. Value types in this module
+(RunFinishedSuccessOutcome, RunFinishedInterruptOutcome) inherit directly from
+`Model` — they are payload types referenced by events, not events themselves.
+
+```ruby
 
 event = AgUiProtocol::Core::Events::BaseEvent.new(
     type: AgUiProtocol::Core::Events::EventType::RAW,
@@ -67,11 +71,11 @@ event = AgUiProtocol::Core::Events::BaseEvent.new(
 
 ```
 
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `type`      | `String`            | The type of event                                                   |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `type`      | `String`            | The type of event                                                  |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ## Lifecycle Events
 
@@ -90,20 +94,21 @@ occurred", code: "RUN_ERROR")
 
 ```
 
-**@category** [] Lifecycle Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `message`   | `String`            | Error message                                                       |
-| `code`      | `String` (optional) | Error code , Default: `nil`.                                        |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `message`   | `String`            | Error message                                                      |
+| `code`      | `String` (optional) | Error code. Default: `nil`.                                        |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### RunFinishedEvent
 
 `AgUiProtocol::Core::Events::RunFinishedEvent`
 
-Signals the successful completion of an agent run.
+Signals the completion of an agent run. The `outcome` field discriminates
+between success and interrupt: provide either a `RunFinishedSuccessOutcome` or
+`RunFinishedInterruptOutcome` (or use the legacy `result` field; the two are
+mutually exclusive).
 
 ```ruby
 
@@ -112,51 +117,14 @@ run_id: "r1", result: { "a" => 1 })
 
 ```
 
-**@category** [] Lifecycle Events
-
-| Property    | Type                                                                 | Description                                                         |
-| ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `thread_id` | `String`                                                             | ID of the conversation thread                                       |
-| `run_id`    | `String`                                                             | ID of the run                                                       |
-| `result`    | `Object` (optional)                                                  | Result data from the agent run , Default: `nil`.                    |
-| `outcome`   | `RunFinishedSuccessOutcome , RunFinishedInterruptOutcome` (optional) | Outcome of the run , Default: `nil`.                                |
-| `timestamp` | `Time` (optional)                                                    | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional)                                                  | Original event data if this event was transformed , Default: `nil`. |
-
-### RunFinishedInterruptOutcome
-
-`AgUiProtocol::Core::Events::RunFinishedInterruptOutcome`
-
-Represents an interrupt outcome for a run.
-
-```ruby outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
-    interrupts: [
-      AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
-    ]
-
-) ```
-
-| Property     | Type                                          | Description                            |
-| ------------ | --------------------------------------------- | -------------------------------------- |
-| `interrupts` | `Array<AgUiProtocol::Core::Types::Interrupt>` | List of interrupts                     |
-| `type`       | `String` (optional)                           | Outcome type , Default: `"interrupt"`. |
-
-### RunFinishedSuccessOutcome
-
-`AgUiProtocol::Core::Events::RunFinishedSuccessOutcome`
-
-Represents a successful outcome for a run.
-
-```ruby outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
-```
-
-| Property          | Type     | Description                                       |
-| ----------------- | -------- | ------------------------------------------------- |
-| `subtype`         | `String` | Subtype ("tool-call" or "message")                |
-| `entity_id`       | `String` | ID of the entity being encrypted                  |
-| `encrypted_value` | `String` | The encrypted value                               |
-| `timestamp`       | `Time`   | Timestamp when the event was created              |
-| `raw_event`       | `Object` | Original event data if this event was transformed |
+| Property    | Type                                                                | Description                                                                        |
+| ----------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `thread_id` | `String`                                                            | ID of the conversation thread                                                      |
+| `run_id`    | `String`                                                            | ID of the run                                                                      |
+| `result`    | `Object` (optional)                                                 | Result data from the agent run. Mutually exclusive with `outcome`. Default: `nil`. |
+| `outcome`   | `RunFinishedSuccessOutcome, RunFinishedInterruptOutcome` (optional) | Outcome of the run. Mutually exclusive with `result`. Default: `nil`.              |
+| `timestamp` | `Time` (optional)                                                   | Timestamp when the event was created. Default: `nil`.                              |
+| `raw_event` | `Object` (optional)                                                 | Original event data if this event was transformed. Default: `nil`.                 |
 
 ### RunStartedEvent
 
@@ -187,14 +155,14 @@ event = AgUiProtocol::Core::Events::RunStartedEvent.new(
 
 ```
 
-**@category** [] Lifecycle Events
-
-| Property        | Type                | Description                                                                                                           |
-| --------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `thread_id`     | `String`            | ID of the conversation thread                                                                                         |
-| `run_id`        | `String`            | ID of the run                                                                                                         |
-| `parent_run_id` | `String` (optional) | Lineage pointer for branching/time travel. If present, refers to a prior run within the same thread , Default: `nil`. |
-| `input`         | `Object` (optional) | The exact agent input payload sent to the agent for this run. May omit messages already in history , Default: `nil`.  |
+| Property        | Type                | Description                                                                                                          |
+| --------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `thread_id`     | `String`            | ID of the conversation thread                                                                                        |
+| `run_id`        | `String`            | ID of the run                                                                                                        |
+| `parent_run_id` | `String` (optional) | Lineage pointer for branching/time travel. If present, refers to a prior run within the same thread. Default: `nil`. |
+| `input`         | `Object` (optional) | The exact agent input payload sent to the agent for this run. May omit messages already in history. Default: `nil`.  |
+| `timestamp`     | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.                                                                |
+| `raw_event`     | `Object` (optional) | Original event data if this event was transformed. Default: `nil`.                                                   |
 
 ### StepFinishedEvent
 
@@ -208,13 +176,11 @@ event = AgUiProtocol::Core::Events::StepFinishedEvent.new(step_name: "s1")
 
 ```
 
-**@category** [] Lifecycle Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `step_name` | `String`            | Name of the step                                                    |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `step_name` | `String`            | Name of the step                                                   |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### StepStartedEvent
 
@@ -228,13 +194,11 @@ event = AgUiProtocol::Core::Events::StepStartedEvent.new(step_name: "s1")
 
 ```
 
-**@category** [] Lifecycle Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `step_name` | `String`            | Name of the step                                                    |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `step_name` | `String`            | Name of the step                                                   |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ## Text Message Events
 
@@ -247,7 +211,8 @@ These events represent the lifecycle of text messages in a conversation.
 Convenience event for complete text messages without manually emitting
 `TextMessageStart`/`TextMessageEnd`.
 
-```ruby event = AgUiProtocol::Core::Events::TextMessageChunkEvent.new(
+```ruby
+event = AgUiProtocol::Core::Events::TextMessageChunkEvent.new(
     message_id: "m1",
     delta: "Hello"
 
@@ -265,15 +230,13 @@ Behavior:
     content pieces; completion triggers an implied end in clients that perform
     expansion.
 
-**@category** [] Text Message Events
-
-| Property     | Type                | Description                                                         |
-| ------------ | ------------------- | ------------------------------------------------------------------- |
-| `message_id` | `String` (optional) | required on first chunk for a message , Default: `nil`.             |
-| `role`       | `String` (optional) | must be one of TEXT_MESSAGE_ROLE_VALUES , Default: `nil`.           |
-| `delta`      | `String` (optional) | Text content chunk , Default: `nil`.                                |
-| `timestamp`  | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`  | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String` (optional) | required on first chunk for a message. Default: `nil`.             |
+| `role`       | `String` (optional) | must be one of TEXT_MESSAGE_ROLE_VALUES. Default: `nil`.           |
+| `delta`      | `String` (optional) | Text content chunk. Default: `nil`.                                |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### TextMessageContentEvent
 
@@ -291,14 +254,12 @@ event = AgUiProtocol::Core::Events::TextMessageContentEvent.new(
 
 ```
 
-**@category** [] Text Message Events
-
-| Property     | Type                | Description                                                         |
-| ------------ | ------------------- | ------------------------------------------------------------------- |
-| `message_id` | `String`            | Matches the ID from TextMessageStartEvent                           |
-| `delta`      | `String`            | Text content chunk (non-empty)                                      |
-| `timestamp`  | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`  | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Matches the ID from TextMessageStartEvent                          |
+| `delta`      | `String`            | Text content chunk (non-empty)                                     |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### TextMessageEndEvent
 
@@ -312,13 +273,11 @@ event = AgUiProtocol::Core::Events::TextMessageEndEvent.new(message_id: "m1")
 
 ```
 
-**@category** [] Text Message Events
-
-| Property     | Type                | Description                                                         |
-| ------------ | ------------------- | ------------------------------------------------------------------- |
-| `message_id` | `String`            | Matches the ID from TextMessageStartEvent                           |
-| `timestamp`  | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`  | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Matches the ID from TextMessageStartEvent                          |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### TextMessageStartEvent
 
@@ -335,79 +294,12 @@ event = AgUiProtocol::Core::Events::TextMessageStartEvent.new(
 
 ```
 
-**@category** [] Text Message Events
-
-| Property     | Type                | Description                                                         |
-| ------------ | ------------------- | ------------------------------------------------------------------- |
-| `message_id` | `String`            | Unique identifier for the message                                   |
-| `timestamp`  | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`  | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
-
-### ThinkingEndEvent
-
-`AgUiProtocol::Core::Events::ThinkingEndEvent`
-
-Event indicating the end of a thinking step event.
-
-```ruby event = AgUiProtocol::Core::Events::ThinkingEndEvent.new ```
-
-**@category** [] Thinking Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
-
-### ThinkingStartEvent
-
-`AgUiProtocol::Core::Events::ThinkingStartEvent`
-
-Event indicating the start of a thinking step event.
-
-```ruby event = AgUiProtocol::Core::Events::ThinkingStartEvent.new(title:
-"step") ```
-
-**@category** [] Thinking Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `title`     | `String` (optional) | Title of the thinking step , Default: `nil`.                        |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
-
-### ThinkingTextMessageContentEvent
-
-`AgUiProtocol::Core::Events::ThinkingTextMessageContentEvent`
-
-Event indicating a piece of a thinking text message.
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `delta`     | `String`            | Text content                                                        |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
-
-### ThinkingTextMessageEndEvent
-
-`AgUiProtocol::Core::Events::ThinkingTextMessageEndEvent`
-
-Event indicating the end of a thinking text message.
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
-
-### ThinkingTextMessageStartEvent
-
-`AgUiProtocol::Core::Events::ThinkingTextMessageStartEvent`
-
-Event indicating the start of a thinking text message.
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property     | Type                | Description                                                                               |
+| ------------ | ------------------- | ----------------------------------------------------------------------------------------- |
+| `message_id` | `String`            | Unique identifier for the message                                                         |
+| `role`       | `String` (optional) | Must be one of TEXT_MESSAGE_ROLE_VALUES; defaults to "assistant". Default: `"assistant"`. |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.                                     |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`.                        |
 
 ## Tool Call Events
 
@@ -429,14 +321,12 @@ event = AgUiProtocol::Core::Events::ToolCallArgsEvent.new(
 
 ```
 
-**@category** [] Tool Call Events
-
-| Property       | Type                | Description                                                         |
-| -------------- | ------------------- | ------------------------------------------------------------------- |
-| `tool_call_id` | `String`            | Matches the ID from ToolCallStartEvent                              |
-| `delta`        | `String`            | Argument data chunk                                                 |
-| `timestamp`    | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`    | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property       | Type                | Description                                                        |
+| -------------- | ------------------- | ------------------------------------------------------------------ |
+| `tool_call_id` | `String`            | Matches the ID from ToolCallStartEvent                             |
+| `delta`        | `String`            | Argument data chunk                                                |
+| `timestamp`    | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`    | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### ToolCallChunkEvent
 
@@ -465,16 +355,14 @@ Behavior:
     args pieces; completion triggers an implied end in clients that perform
     expansion.
 
-**@category** [] Tool Call Events
-
-| Property            | Type                | Description                                                         |
-| ------------------- | ------------------- | ------------------------------------------------------------------- |
-| `tool_call_id`      | `String` (optional) | Matches the ID from ToolCallStartEvent , Default: `nil`.            |
-| `tool_call_name`    | `String` (optional) | Name of the tool being called , Default: `nil`.                     |
-| `parent_message_id` | `String` (optional) | ID of the parent message , Default: `nil`.                          |
-| `delta`             | `String` (optional) | Argument data chunk , Default: `nil`.                               |
-| `timestamp`         | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`         | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property            | Type                | Description                                                        |
+| ------------------- | ------------------- | ------------------------------------------------------------------ |
+| `tool_call_id`      | `String` (optional) | Matches the ID from ToolCallStartEvent. Default: `nil`.            |
+| `tool_call_name`    | `String` (optional) | Name of the tool being called. Default: `nil`.                     |
+| `parent_message_id` | `String` (optional) | ID of the parent message. Default: `nil`.                          |
+| `delta`             | `String` (optional) | Argument data chunk. Default: `nil`.                               |
+| `timestamp`         | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`         | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### ToolCallEndEvent
 
@@ -488,13 +376,11 @@ event = AgUiProtocol::Core::Events::ToolCallEndEvent.new(tool_call_id: "tc1")
 
 ```
 
-**@category** [] Tool Call Events
-
-| Property       | Type                | Description                                                         |
-| -------------- | ------------------- | ------------------------------------------------------------------- |
-| `tool_call_id` | `String`            | Matches the ID from ToolCallStartEvent                              |
-| `timestamp`    | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`    | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property       | Type                | Description                                                        |
+| -------------- | ------------------- | ------------------------------------------------------------------ |
+| `tool_call_id` | `String`            | Matches the ID from ToolCallStartEvent                             |
+| `timestamp`    | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`    | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### ToolCallResultEvent
 
@@ -513,16 +399,14 @@ event = AgUiProtocol::Core::Events::ToolCallResultEvent.new(
 
 ```
 
-**@category** [] Tool Call Events
-
-| Property       | Type                | Description                                                                   |
-| -------------- | ------------------- | ----------------------------------------------------------------------------- |
-| `message_id`   | `String`            | ID of the conversation message this result belongs to                         |
-| `tool_call_id` | `String`            | Matches the ID from the corresponding ToolCallStartEvent                      |
-| `content`      | `String`            | The actual result/output content from the tool execution                      |
-| `role`         | `String` (optional) | Optional role identifier, typically "tool" for tool results , Default: `nil`. |
-| `timestamp`    | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.                        |
-| `raw_event`    | `Object` (optional) | Original event data if this event was transformed , Default: `nil`.           |
+| Property       | Type                | Description                                                                  |
+| -------------- | ------------------- | ---------------------------------------------------------------------------- |
+| `message_id`   | `String`            | ID of the conversation message this result belongs to                        |
+| `tool_call_id` | `String`            | Matches the ID from the corresponding ToolCallStartEvent                     |
+| `content`      | `String`            | The actual result/output content from the tool execution                     |
+| `role`         | `String` (optional) | Optional role identifier, typically "tool" for tool results. Default: `nil`. |
+| `timestamp`    | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.                        |
+| `raw_event`    | `Object` (optional) | Original event data if this event was transformed. Default: `nil`.           |
 
 ### ToolCallStartEvent
 
@@ -541,15 +425,228 @@ event = AgUiProtocol::Core::Events::ToolCallStartEvent.new(
 
 ```
 
-**@category** [] Tool Call Events
+| Property            | Type                | Description                                                        |
+| ------------------- | ------------------- | ------------------------------------------------------------------ |
+| `tool_call_id`      | `String`            | Unique identifier for the tool call                                |
+| `tool_call_name`    | `String`            | Name of the tool being called                                      |
+| `parent_message_id` | `String` (optional) | ID of the parent message. Default: `nil`.                          |
+| `timestamp`         | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`         | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
-| Property            | Type                | Description                                                         |
-| ------------------- | ------------------- | ------------------------------------------------------------------- |
-| `tool_call_id`      | `String`            | Unique identifier for the tool call                                 |
-| `tool_call_name`    | `String`            | Name of the tool being called                                       |
-| `parent_message_id` | `String` (optional) | ID of the parent message , Default: `nil`.                          |
-| `timestamp`         | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`         | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+## Thinking Events
+
+These events represent the lifecycle of an agent's thinking steps, conveying
+intermediate reasoning to the frontend without contributing to the final
+message.
+
+### ThinkingEndEvent
+
+`AgUiProtocol::Core::Events::ThinkingEndEvent`
+
+Event indicating the end of a thinking step event.
+
+```ruby
+event = AgUiProtocol::Core::Events::ThinkingEndEvent.new 
+```
+
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ThinkingStartEvent
+
+`AgUiProtocol::Core::Events::ThinkingStartEvent`
+
+Event indicating the start of a thinking step event.
+
+```ruby
+event = AgUiProtocol::Core::Events::ThinkingStartEvent.new(title:
+"step") 
+```
+
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `title`     | `String` (optional) | Title of the thinking step. Default: `nil`.                        |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ThinkingTextMessageContentEvent
+
+`AgUiProtocol::Core::Events::ThinkingTextMessageContentEvent`
+
+Event indicating a piece of a thinking text message.
+
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `delta`     | `String`            | Text content                                                       |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ThinkingTextMessageEndEvent
+
+`AgUiProtocol::Core::Events::ThinkingTextMessageEndEvent`
+
+Event indicating the end of a thinking text message.
+
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ThinkingTextMessageStartEvent
+
+`AgUiProtocol::Core::Events::ThinkingTextMessageStartEvent`
+
+Event indicating the start of a thinking text message.
+
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+## Reasoning Events
+
+These events convey structured reasoning blocks emitted by an agent, including
+streaming reasoning messages and encrypted reasoning values.
+
+### ReasoningEncryptedValueEvent
+
+`AgUiProtocol::Core::Events::ReasoningEncryptedValueEvent`
+
+Event containing an encrypted value within a reasoning block.
+
+```ruby
+event = AgUiProtocol::Core::Events::ReasoningEncryptedValueEvent.new(
+    subtype: "tool-call",
+    entity_id: "tc_1",
+    encrypted_value: "encrypted..."
+
+) 
+```
+
+| Property          | Type                | Description                                                                                 |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------- |
+| `subtype`         | `String`            | free-form string; protocol values are "tool-call" or "message" but not enforced by this SDK |
+| `entity_id`       | `String`            | ID of the entity being encrypted                                                            |
+| `encrypted_value` | `String`            | The encrypted value                                                                         |
+| `timestamp`       | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.                                       |
+| `raw_event`       | `Object` (optional) | Original event data if this event was transformed. Default: `nil`.                          |
+
+### ReasoningEndEvent
+
+`AgUiProtocol::Core::Events::ReasoningEndEvent`
+
+Signals the end of a reasoning block.
+
+```ruby
+event = AgUiProtocol::Core::Events::ReasoningEndEvent.new(message_id:
+"reason_1") 
+```
+
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Matches the ID from ReasoningStartEvent                            |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ReasoningMessageChunkEvent
+
+`AgUiProtocol::Core::Events::ReasoningMessageChunkEvent`
+
+Convenience event for reasoning messages without manually emitting start/end.
+
+```ruby
+event = AgUiProtocol::Core::Events::ReasoningMessageChunkEvent.new(
+    message_id: "reason_msg_1",
+    delta: "step 1..."
+
+) 
+```
+
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String` (optional) | Optional on first chunk. Default: `nil`.                           |
+| `delta`      | `String` (optional) | Optional reasoning content chunk. Default: `nil`.                  |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ReasoningMessageContentEvent
+
+`AgUiProtocol::Core::Events::ReasoningMessageContentEvent`
+
+Represents a chunk of content in a streaming reasoning message.
+
+```ruby
+event =
+AgUiProtocol::Core::Events::ReasoningMessageContentEvent.new(message_id:
+"reason_msg_1", delta: "step 1...") 
+```
+
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Matches the ID from ReasoningMessageStartEvent                     |
+| `delta`      | `String`            | Reasoning content chunk                                            |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ReasoningMessageEndEvent
+
+`AgUiProtocol::Core::Events::ReasoningMessageEndEvent`
+
+Signals the end of a reasoning message.
+
+```ruby
+event =
+AgUiProtocol::Core::Events::ReasoningMessageEndEvent.new(message_id:
+"reason_msg_1") 
+```
+
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Matches the ID from ReasoningMessageStartEvent                     |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
+
+### ReasoningMessageStartEvent
+
+`AgUiProtocol::Core::Events::ReasoningMessageStartEvent`
+
+Signals the start of a reasoning message within a reasoning block.
+
+The `role` is always "reasoning" (enforced). The optional <code>role:</code>
+kwarg exists to support round-trip deserialization from `to_h` output (which
+emits `role: "reasoning"`); supplying any other value raises ArgumentError.
+
+```ruby
+event =
+AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id:
+"reason_msg_1") 
+```
+
+| Property     | Type                | Description                                                                                                                                                         |
+| ------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message_id` | `String`            | Unique identifier                                                                                                                                                   |
+| `role`       | `String` (optional) | Optional. Must be "reasoning" if provided. Always stored as "reasoning"; the kwarg exists to support round-trip deserialization from `to_h` output. Default: `nil`. |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.                                                                                                               |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`.                                                                                                  |
+
+### ReasoningStartEvent
+
+`AgUiProtocol::Core::Events::ReasoningStartEvent`
+
+Signals the start of a reasoning block.
+
+```ruby
+event =
+AgUiProtocol::Core::Events::ReasoningStartEvent.new(message_id: "reason_1")
+```
+
+| Property     | Type                | Description                                                        |
+| ------------ | ------------------- | ------------------------------------------------------------------ |
+| `message_id` | `String`            | Unique identifier for the reasoning message                        |
+| `timestamp`  | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`  | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ## State Management Events
 
@@ -561,19 +658,19 @@ These events are used to manage agent state.
 
 Provides incremental updates to an activity snapshot using JSON Patch.
 
-```ruby event = AgUiProtocol::Core::Events::ActivityDeltaEvent.new(message_id:
+```ruby
+event = AgUiProtocol::Core::Events::ActivityDeltaEvent.new(message_id:
 "m1", activity_type: "PLAN", patch: [{ "op" => "replace", "path" => "/a",
-"value" => 2 }]) ```
+"value" => 2 }]) 
+```
 
-**@category** [] State Management Events
-
-| Property        | Type                | Description                                                         |
-| --------------- | ------------------- | ------------------------------------------------------------------- |
-| `message_id`    | `String`            | Identifier for the target `ActivityMessage`                         |
-| `activity_type` | `String`            | Activity discriminator mirroring the most recent snapshot           |
-| `patch`         | `Array<Object>`     | JSON Patch operations applied to the structured activity content    |
-| `timestamp`     | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event`     | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property        | Type                | Description                                                        |
+| --------------- | ------------------- | ------------------------------------------------------------------ |
+| `message_id`    | `String`            | Identifier for the target `ActivityMessage`                        |
+| `activity_type` | `String`            | Activity discriminator mirroring the most recent snapshot          |
+| `patch`         | `Array<Object>`     | JSON Patch operations applied to the structured activity content   |
+| `timestamp`     | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event`     | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### ActivitySnapshotEvent
 
@@ -581,20 +678,20 @@ Provides incremental updates to an activity snapshot using JSON Patch.
 
 Delivers a complete snapshot of an activity message.
 
-```ruby event =
+```ruby
+event =
 AgUiProtocol::Core::Events::ActivitySnapshotEvent.new(message_id: "m1",
-activity_type: "PLAN", content: { "a" => 1 }) ```
+activity_type: "PLAN", content: { "a" => 1 }) 
+```
 
-**@category** [] State Management Events
-
-| Property        | Type                 | Description                                                                                           |
-| --------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `message_id`    | `String`             | Identifier for the target `ActivityMessage`                                                           |
-| `activity_type` | `String`             | Activity discriminator such as `"PLAN"` or `"SEARCH"`                                                 |
-| `content`       | `Object`             | Structured payload describing the full activity state                                                 |
-| `replace`       | `Boolean` (optional) | When `false`, the snapshot is ignored if a message with the same ID already exists , Default: `true`. |
-| `timestamp`     | `Time` (optional)    | Timestamp when the event was created , Default: `nil`.                                                |
-| `raw_event`     | `Object` (optional)  | Original event data if this event was transformed , Default: `nil`.                                   |
+| Property        | Type                 | Description                                                                                          |
+| --------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `message_id`    | `String`             | Identifier for the target `ActivityMessage`                                                          |
+| `activity_type` | `String`             | Activity discriminator such as `"PLAN"` or `"SEARCH"`                                                |
+| `content`       | `Object`             | Structured payload describing the full activity state                                                |
+| `replace`       | `Boolean` (optional) | When `false`, the snapshot is ignored if a message with the same ID already exists. Default: `true`. |
+| `timestamp`     | `Time` (optional)    | Timestamp when the event was created. Default: `nil`.                                                |
+| `raw_event`     | `Object` (optional)  | Original event data if this event was transformed. Default: `nil`.                                   |
 
 ### MessagesSnapshotEvent
 
@@ -602,17 +699,18 @@ activity_type: "PLAN", content: { "a" => 1 }) ```
 
 Provides a snapshot of all messages in a conversation.
 
-```ruby event =
-AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(messages: [{ "id" =>
-"m1", "content" => "hi" }]) ```
+```ruby
+event = AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(
+    messages: [AgUiProtocol::Core::Types::UserMessage.new(id: "m1", content: "hi")]
 
-**@category** [] State Management Events
+) 
+```
 
-| Property    | Type                                            | Description                                                         |
-| ----------- | ----------------------------------------------- | ------------------------------------------------------------------- |
-| `messages`  | `Array<AgUiProtocol::Core::Types::BaseMessage>` | Array of message objects                                            |
-| `timestamp` | `Time` (optional)                               | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional)                             | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                                                                                        | Description                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `messages`  | `Array<AgUiProtocol::Core::Types::BaseMessage, AgUiProtocol::Core::Types::ActivityMessage>` | Array of message objects. Accepts both BaseMessage subclasses and ActivityMessage for parity with RunAgentInput. |
+| `timestamp` | `Time` (optional)                                                                           | Timestamp when the event was created. Default: `nil`.                                                            |
+| `raw_event` | `Object` (optional)                                                                         | Original event data if this event was transformed. Default: `nil`.                                               |
 
 ### StateDeltaEvent
 
@@ -620,16 +718,16 @@ AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(messages: [{ "id" =>
 
 Provides a partial update to an agent's state using JSON Patch.
 
-```ruby event = AgUiProtocol::Core::Events::StateDeltaEvent.new(delta: [{ "op"
-=> "replace", "path" => "/a", "value" => 2 }]) ```
+```ruby
+event = AgUiProtocol::Core::Events::StateDeltaEvent.new(delta: [{ "op"
+=> "replace", "path" => "/a", "value" => 2 }]) 
+```
 
-**@category** [] State Management Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `delta`     | `Array<Object>`     | Array of JSON Patch operations                                      |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `delta`     | `Array<Object>`     | Array of JSON Patch operations                                     |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### StateSnapshotEvent
 
@@ -637,16 +735,16 @@ Provides a partial update to an agent's state using JSON Patch.
 
 Provides a complete snapshot of an agent's state.
 
-```ruby event = AgUiProtocol::Core::Events::StateSnapshotEvent.new(snapshot: {
-"a" => 1 }) ```
+```ruby
+event = AgUiProtocol::Core::Events::StateSnapshotEvent.new(snapshot: {
+"a" => 1 }) 
+```
 
-**@category** [] State Management Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `snapshot`  | `Object`            | Complete state snapshot                                             |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `snapshot`  | `Object`            | Complete state snapshot                                            |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ## Special Events
 
@@ -656,17 +754,17 @@ Provides a complete snapshot of an agent's state.
 
 Used for application-specific custom events.
 
-```ruby event = AgUiProtocol::Core::Events::CustomEvent.new(name: "my_event",
-value: { "a" => 1 }) ```
+```ruby
+event = AgUiProtocol::Core::Events::CustomEvent.new(name: "my_event",
+value: { "a" => 1 }) 
+```
 
-**@category** [] Special Events
-
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `name`      | `String`            | Name of the custom event                                            |
-| `value`     | `Object`            | Value of the custom event                                           |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `name`      | `String`            | Name of the custom event                                           |
+| `value`     | `Object`            | Value of the custom event                                          |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
 ### RawEvent
 
@@ -674,15 +772,58 @@ value: { "a" => 1 }) ```
 
 Used to pass through events from external systems.
 
-```ruby event = AgUiProtocol::Core::Events::RawEvent.new(event: { "type" =>
-"my_event", "data" => { "a" => 1 } }, source: "my_source") ```
+```ruby
+event = AgUiProtocol::Core::Events::RawEvent.new(event: { "type" =>
+"my_event", "data" => { "a" => 1 } }, source: "my_source") 
+```
 
-**@category** [] Special Events
+| Property    | Type                | Description                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------ |
+| `event`     | `Object`            | Original event data                                                |
+| `source`    | `String` (optional) | Source of the event. Default: `nil`.                               |
+| `timestamp` | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
+| `raw_event` | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
-| Property    | Type                | Description                                                         |
-| ----------- | ------------------- | ------------------------------------------------------------------- |
-| `event`     | `Object`            | Original event data                                                 |
-| `source`    | `String` (optional) | Source of the event , Default: `nil`.                               |
-| `timestamp` | `Time` (optional)   | Timestamp when the event was created , Default: `nil`.              |
-| `raw_event` | `Object` (optional) | Original event data if this event was transformed , Default: `nil`. |
+## Run Outcome Types
+
+Value types referenced by `RunFinishedEvent.outcome`.
+
+### RunFinishedInterruptOutcome
+
+`AgUiProtocol::Core::Events::RunFinishedInterruptOutcome`
+
+Represents an interrupt outcome for a run.
+
+```ruby
+outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
+    interrupts: [
+      AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
+    ]
+
+) 
+```
+
+| Property     | Type                                          | Description                                                                                                                                                         |
+| ------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interrupts` | `Array<AgUiProtocol::Core::Types::Interrupt>` | List of interrupts                                                                                                                                                  |
+| `type`       | `String` (optional)                           | Optional. Must be "interrupt" if provided. Always stored as "interrupt"; the kwarg exists to support round-trip deserialization from `to_h` output. Default: `nil`. |
+
+### RunFinishedSuccessOutcome
+
+`AgUiProtocol::Core::Events::RunFinishedSuccessOutcome`
+
+Represents a successful outcome for a run.
+
+The `type` discriminator is enforced — only "success" is accepted (or nil for
+default). The optional <code>type:</code> kwarg exists to support round-trip
+deserialization from `to_h` output (which emits `type: "success"`); supplying
+any other value raises ArgumentError.
+
+```ruby
+outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+```
+
+| Property | Type                | Description                                                                                                                                                     |
+| -------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`   | `String` (optional) | Optional. Must be "success" if provided. Always stored as "success"; the kwarg exists to support round-trip deserialization from `to_h` output. Default: `nil`. |
 

--- a/docs/sdk/ruby/core/overview.mdx
+++ b/docs/sdk/ruby/core/overview.mdx
@@ -25,6 +25,9 @@ Core data structures that represent the building blocks of the system:
 - [Message types](/sdk/ruby/core/types#message-types) - User assistant communication and tool usage
 - [Context](/sdk/ruby/core/types#context) - Contextual information provided to agents
 - [Tool](/sdk/ruby/core/types#tool) - Defines functions that agents can call
+- [Interrupt and Resume](/sdk/ruby/core/types#interrupt) - Human-in-the-loop workflow support
+- [Multimodal Input Types](/sdk/ruby/core/types#imageinputcontent) - Image, audio, video, and document content fragments
+- [ReasoningMessage](/sdk/ruby/core/types#reasoningmessage) - Chain-of-thought reasoning messages
 - [State](/sdk/ruby/core/types#state) - Agent state management
 
 <Card
@@ -44,6 +47,7 @@ Events that power communication between agents and frontends:
 - [Lifecycle Events](/sdk/ruby/core/events#lifecycle-events) - Run and step tracking
 - [Text Message Events](/sdk/ruby/core/events#text-message-events) - Assistant message streaming
 - [Tool Call Events](/sdk/ruby/core/events#tool-call-events) - Function call lifecycle
+- [Reasoning Events](/sdk/ruby/core/events#reasoning-events) - Chain-of-thought streaming events
 - [State Management Events](/sdk/ruby/core/events#state-management-events) - Agent state updates
 - [Special Events](/sdk/ruby/core/events#special-events) - Raw and custom events
 
@@ -55,4 +59,29 @@ Events that power communication between agents and frontends:
   iconType="solid"
 >
   Complete documentation of all events in the AgUiProtocol::Core::Events namespace
+</Card>
+
+## Capabilities
+
+Agent capability declarations that define what an agent can do:
+
+- [AgentCapabilities](/sdk/ruby/core/capabilities#agentcapabilities) - Top-level capability declaration
+- [IdentityCapabilities](/sdk/ruby/core/capabilities#identitycapabilities) - Agent identity and versioning
+- [TransportCapabilities](/sdk/ruby/core/capabilities#transportcapabilities) - Protocol and encoding support
+- [ToolsCapabilities](/sdk/ruby/core/capabilities#toolscapabilities) - Tool execution features
+- [StateCapabilities](/sdk/ruby/core/capabilities#statecapabilities) - State management modes
+- [MultiAgentCapabilities](/sdk/ruby/core/capabilities#multiagentcapabilities) - Multi-agent coordination
+- [ReasoningCapabilities](/sdk/ruby/core/capabilities#reasoningcapabilities) - Reasoning and encrypted values
+- [MultimodalCapabilities](/sdk/ruby/core/capabilities#multimodalcapabilities) - Multimodal input support
+- [ExecutionCapabilities](/sdk/ruby/core/capabilities#executioncapabilities) - Timeout and retry settings
+- [HumanInTheLoopCapabilities](/sdk/ruby/core/capabilities#humanintheloopcapabilities) - Interrupt and approval support
+
+<Card
+  title="Capabilities Reference"
+  icon="cube"
+  href="/sdk/ruby/core/capabilities"
+  color="#3B82F6"
+  iconType="solid"
+>
+  Complete documentation of all capabilities in the AgUiProtocol::Core::Capabilities namespace
 </Card>

--- a/docs/sdk/ruby/core/overview.mdx
+++ b/docs/sdk/ruby/core/overview.mdx
@@ -22,9 +22,10 @@ require "ag_ui_protocol"
 Core data structures that represent the building blocks of the system:
 
 - [RunAgentInput](/sdk/ruby/core/types#runagentinput) - Input parameters for running agents
-- [Message types](/sdk/ruby/core/types#message-types) - User assistant communication and tool usage
+- [Message types](/sdk/ruby/core/types#message-types) - User and assistant message communication with tool usage
 - [Context](/sdk/ruby/core/types#context) - Contextual information provided to agents
 - [Tool](/sdk/ruby/core/types#tool) - Defines functions that agents can call
+- [FunctionCall](/sdk/ruby/core/types#functioncall) - Tool invocation payload (name and JSON-encoded arguments)
 - [Interrupt and Resume](/sdk/ruby/core/types#interrupt) - Human-in-the-loop workflow support
 - [Multimodal Input Types](/sdk/ruby/core/types#imageinputcontent) - Image, audio, video, and document content fragments
 - [ReasoningMessage](/sdk/ruby/core/types#reasoningmessage) - Chain-of-thought reasoning messages
@@ -65,16 +66,19 @@ Events that power communication between agents and frontends:
 
 Agent capability declarations that define what an agent can do:
 
-- [AgentCapabilities](/sdk/ruby/core/capabilities#agentcapabilities) - Top-level capability declaration
-- [IdentityCapabilities](/sdk/ruby/core/capabilities#identitycapabilities) - Agent identity and versioning
-- [TransportCapabilities](/sdk/ruby/core/capabilities#transportcapabilities) - Protocol and encoding support
-- [ToolsCapabilities](/sdk/ruby/core/capabilities#toolscapabilities) - Tool execution features
-- [StateCapabilities](/sdk/ruby/core/capabilities#statecapabilities) - State management modes
-- [MultiAgentCapabilities](/sdk/ruby/core/capabilities#multiagentcapabilities) - Multi-agent coordination
-- [ReasoningCapabilities](/sdk/ruby/core/capabilities#reasoningcapabilities) - Reasoning and encrypted values
-- [MultimodalCapabilities](/sdk/ruby/core/capabilities#multimodalcapabilities) - Multimodal input support
-- [ExecutionCapabilities](/sdk/ruby/core/capabilities#executioncapabilities) - Timeout and retry settings
-- [HumanInTheLoopCapabilities](/sdk/ruby/core/capabilities#humanintheloopcapabilities) - Interrupt and approval support
+- [AgentCapabilities](/sdk/ruby/core/capabilities#agentcapabilities) - Top-level categorized snapshot of an agent's capabilities
+- [IdentityCapabilities](/sdk/ruby/core/capabilities#identitycapabilities) - Agent name, type, version, provider, and documentation metadata
+- [TransportCapabilities](/sdk/ruby/core/capabilities#transportcapabilities) - Streaming, WebSocket, HTTP binary, push notifications, and resumable streams
+- [ToolsCapabilities](/sdk/ruby/core/capabilities#toolscapabilities) - Agent-provided tools, parallel calls, and client-provided tool support
+- [OutputCapabilities](/sdk/ruby/core/capabilities#outputcapabilities) - Structured output and supported MIME types
+- [StateCapabilities](/sdk/ruby/core/capabilities#statecapabilities) - Snapshots, deltas, long-term memory, and persistent state
+- [MultiAgentCapabilities](/sdk/ruby/core/capabilities#multiagentcapabilities) - Delegation, handoffs, and sub-agent discovery
+- [ReasoningCapabilities](/sdk/ruby/core/capabilities#reasoningcapabilities) - Reasoning support, streaming, and encrypted (zero-data-retention) thinking
+- [MultimodalCapabilities](/sdk/ruby/core/capabilities#multimodalcapabilities) - Multimodal input and output support
+- [MultimodalInputCapabilities](/sdk/ruby/core/capabilities#multimodalinputcapabilities) - Image, audio, video, PDF, and file inputs
+- [MultimodalOutputCapabilities](/sdk/ruby/core/capabilities#multimodaloutputcapabilities) - Image and audio outputs
+- [ExecutionCapabilities](/sdk/ruby/core/capabilities#executioncapabilities) - Code execution, sandboxing, max iterations, and max execution time
+- [HumanInTheLoopCapabilities](/sdk/ruby/core/capabilities#humanintheloopcapabilities) - Approvals, interventions, feedback, and the interrupt/resume protocol
 
 <Card
   title="Capabilities Reference"

--- a/docs/sdk/ruby/core/types.mdx
+++ b/docs/sdk/ruby/core/types.mdx
@@ -9,6 +9,27 @@ The Agent User Interaction Protocol Ruby SDK is built on a set of core types
 that represent the fundamental structures used throughout the system. This
 page documents these types and their properties.
 
+## AudioInputContent
+
+`AgUiProtocol::Core::Types::AudioInputContent`
+
+Represents an audio content fragment inside a multimodal user message.
+
+```ruby
+
+content = AgUiProtocol::Core::Types::AudioInputContent.new(
+    source: { type: "url", value: "https://example.com/audio.mp3", mime_type: "audio/mp3" }
+
+)
+
+```
+
+| Property   | Type                                                    | Description                                        |
+| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
+| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
+| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
+| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"audio"`. |
+
 ## Context
 
 `AgUiProtocol::Core::Types::Context`
@@ -26,6 +47,173 @@ value: "es-CL")
 | ------------- | -------- | -------------------------------------------- |
 | `description` | `String` | Description of what this context represents. |
 | `value`       | `String` | The actual context value.                    |
+
+## DocumentInputContent
+
+`AgUiProtocol::Core::Types::DocumentInputContent`
+
+Represents a document content fragment inside a multimodal user message.
+
+```ruby
+
+content = AgUiProtocol::Core::Types::DocumentInputContent.new(
+    source: { type: "url", value: "https://example.com/doc.pdf", mime_type: "application/pdf" }
+
+)
+
+```
+
+| Property   | Type                                                    | Description                                           |
+| ---------- | ------------------------------------------------------- | ----------------------------------------------------- |
+| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                        |
+| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                   |
+| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"document"`. |
+
+## ImageInputContent
+
+`AgUiProtocol::Core::Types::ImageInputContent`
+
+Represents an image content fragment inside a multimodal user message.
+
+```ruby
+
+content = AgUiProtocol::Core::Types::ImageInputContent.new(
+    source: { type: "url", value: "https://example.com/cat.png", mime_type: "image/png" }
+
+)
+
+```
+
+| Property   | Type                                                    | Description                                        |
+| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
+| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
+| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
+| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"image"`. |
+
+## InputContentDataSource
+
+`AgUiProtocol::Core::Types::InputContentDataSource`
+
+Represents a data source for multimodal input content using base64-encoded
+data.
+
+```ruby
+
+source = AgUiProtocol::Core::Types::InputContentDataSource.new(
+    value: "base64encoded...",
+    mime_type: "image/png"
+
+)
+
+```
+
+| Property    | Type                | Description                                     |
+| ----------- | ------------------- | ----------------------------------------------- |
+| `value`     | `String`            | Base64 encoded content                          |
+| `mime_type` | `String`            | MIME type of the content                        |
+| `type`      | `String` (optional) | Identifies the source type , Default: `"data"`. |
+
+## InputContentUrlSource
+
+`AgUiProtocol::Core::Types::InputContentUrlSource`
+
+Represents a URL source for multimodal input content.
+
+```ruby
+
+source = AgUiProtocol::Core::Types::InputContentUrlSource.new(
+    value: "https://example.com/image.png",
+    mime_type: "image/png"
+
+)
+
+```
+
+| Property    | Type                | Description                                    |
+| ----------- | ------------------- | ---------------------------------------------- |
+| `value`     | `String`            | URL string                                     |
+| `mime_type` | `String` (optional) | Optional MIME type , Default: `nil`.           |
+| `type`      | `String` (optional) | Identifies the source type , Default: `"url"`. |
+
+## Interrupt
+
+`AgUiProtocol::Core::Types::Interrupt`
+
+Represents an interrupt that occurred during agent execution for
+human-in-the-loop workflows.
+
+```ruby
+
+interrupt = AgUiProtocol::Core::Types::Interrupt.new(
+    id: "int_1",
+    reason: "input_required",
+    message: "Please provide additional information"
+
+)
+
+```
+
+| Property          | Type                | Description                                            |
+| ----------------- | ------------------- | ------------------------------------------------------ |
+| `id`              | `String`            | Unique identifier                                      |
+| `reason`          | `String`            | Reason for the interrupt                               |
+| `message`         | `String` (optional) | Human-readable message , Default: `nil`.               |
+| `tool_call_id`    | `String` (optional) | Associated tool call if applicable , Default: `nil`.   |
+| `response_schema` | `Object` (optional) | JSON schema for response , Default: `nil`.             |
+| `expires_at`      | `String` (optional) | ISO timestamp when interrupt expires , Default: `nil`. |
+| `metadata`        | `Object` (optional) | Arbitrary metadata , Default: `nil`.                   |
+
+## ReasoningMessage
+
+`AgUiProtocol::Core::Types::ReasoningMessage`
+
+Represents a reasoning message from an agent with chain-of-thought content.
+
+```ruby
+
+msg = AgUiProtocol::Core::Types::ReasoningMessage.new(
+    id: "reason_1",
+    content: "Let me think through this step by step...",
+    encrypted_value: nil
+
+)
+
+```
+
+| Property          | Type                | Description                                                                    |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------ |
+| `id`              | `String`            | Unique identifier for the message                                              |
+| `content`         | `String`            | Reasoning content (plaintext when not encrypted)                               |
+| `encrypted_value` | `String` (optional) | Encrypted reasoning content when in zero-data-retention mode , Default: `nil`. |
+
+## ResumeEntry
+
+`AgUiProtocol::Core::Types::ResumeEntry`
+
+Represents an entry for resuming an interrupted run.
+
+```ruby
+
+entry = AgUiProtocol::Core::Types::ResumeEntry.new(
+    interrupt_id: "int_1",
+    status: "resolved",
+    payload: { "answer" => "42" }
+
+)
+
+```
+
+| Property       | Type     | Description                                   |
+| -------------- | -------- | --------------------------------------------- |
+| `interrupt_id` | `String` | ID of the interrupt being resolved            |
+| `status`       | `String` | Resolution status ("resolved" or "cancelled") |
+| `payload`      | `Object` | Response payload for the interrupt            |
+
+## ResumeStatus
+
+`AgUiProtocol::Core::Types::ResumeStatus`
+
+Valid values for resume status in interrupt resolution.
 
 ## RunAgentInput
 
@@ -50,16 +238,17 @@ input = AgUiProtocol::Core::Types::RunAgentInput.new(
 
 ```
 
-| Property          | Type                 | Description                                                 |
-| ----------------- | -------------------- | ----------------------------------------------------------- |
-| `thread_id`       | `String`             | ID of the conversation thread                               |
-| `run_id`          | `String`             | ID of the current run                                       |
-| `state`           | `Object`             | Current state of the agent                                  |
-| `messages`        | `Array<BaseMessage>` | List of messages in the conversation                        |
-| `tools`           | `Array<Tool>`        | List of tools available to the agent                        |
-| `context`         | `Array<Context>`     | List of context objects provided to the agent               |
-| `forwarded_props` | `Object`             | Additional properties forwarded to the agent                |
-| `parent_run_id`   | `String` (optional)  | Lineage pointer for branching/time travel , Default: `nil`. |
+| Property          | Type                            | Description                                                 |
+| ----------------- | ------------------------------- | ----------------------------------------------------------- |
+| `thread_id`       | `String`                        | ID of the conversation thread                               |
+| `run_id`          | `String`                        | ID of the current run                                       |
+| `state`           | `Object`                        | Current state of the agent                                  |
+| `messages`        | `Array<BaseMessage>`            | List of messages in the conversation                        |
+| `tools`           | `Array<Tool>`                   | List of tools available to the agent                        |
+| `context`         | `Array<Context>`                | List of context objects provided to the agent               |
+| `forwarded_props` | `Object`                        | Additional properties forwarded to the agent                |
+| `parent_run_id`   | `String` (optional)             | Lineage pointer for branching/time travel , Default: `nil`. |
+| `resume`          | `Array<ResumeEntry>` (optional) | Entries for resuming interrupted runs , Default: `nil`.     |
 
 ## Tool
 
@@ -100,11 +289,12 @@ tool_call = AgUiProtocol::Core::Types::ToolCall.new(
 
 ```
 
-| Property   | Type                  | Description                                    |
-| ---------- | --------------------- | ---------------------------------------------- |
-| `id`       | `String`              | Unique identifier for the tool call            |
-| `function` | `FunctionCall , Hash` | Function name and arguments                    |
-| `type`     | `String` (optional)   | Type of the tool call , Default: `'function'`. |
+| Property          | Type                  | Description                                                              |
+| ----------------- | --------------------- | ------------------------------------------------------------------------ |
+| `id`              | `String`              | Unique identifier for the tool call                                      |
+| `function`        | `FunctionCall , Hash` | Function name and arguments                                              |
+| `type`            | `String` (optional)   | Type of the tool call , Default: `'function'`.                           |
+| `encrypted_value` | `String` (optional)   | Encrypted tool call value for zero-data-retention mode , Default: `nil`. |
 
 ### FunctionCall
 
@@ -128,6 +318,27 @@ fn = AgUiProtocol::Core::Types::FunctionCall.new(
 | ----------- | -------- | ----------------------- |
 | `name`      | `String` | Function name.          |
 | `arguments` | `String` | JSON-encoded arguments. |
+
+## VideoInputContent
+
+`AgUiProtocol::Core::Types::VideoInputContent`
+
+Represents a video content fragment inside a multimodal user message.
+
+```ruby
+
+content = AgUiProtocol::Core::Types::VideoInputContent.new(
+    source: { type: "url", value: "https://example.com/video.mp4", mime_type: "video/mp4" }
+
+)
+
+```
+
+| Property   | Type                                                    | Description                                        |
+| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
+| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
+| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
+| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"video"`. |
 
 ## Message Types
 
@@ -206,7 +417,8 @@ content = AgUiProtocol::Core::Types::BinaryInputContent.new(
 
 ```
 
-> **Validation:** At least one of `id`, `url`, or `data` must be provided.
+> <strong>Validation:</strong> At least one of `id`, `url`, or `data` must be
+provided.
 
 **@category** [] Message Types
 
@@ -320,12 +532,13 @@ msg = AgUiProtocol::Core::Types::ToolMessage.new(
 
 **@category** [] Message Types
 
-| Property       | Type                | Description                                              |
-| -------------- | ------------------- | -------------------------------------------------------- |
-| `id`           | `String`            | Unique identifier for the message.                       |
-| `content`      | `String`            | Tool result content.                                     |
-| `tool_call_id` | `String`            | ID of the tool call this message responds to.            |
-| `error`        | `String` (optional) | Error payload if the tool call failed. , Default: `nil`. |
+| Property          | Type                | Description                                                                 |
+| ----------------- | ------------------- | --------------------------------------------------------------------------- |
+| `id`              | `String`            | Unique identifier for the message.                                          |
+| `content`         | `String`            | Tool result content.                                                        |
+| `tool_call_id`    | `String`            | ID of the tool call this message responds to.                               |
+| `error`           | `String` (optional) | Error payload if the tool call failed. , Default: `nil`.                    |
+| `encrypted_value` | `String` (optional) | Encrypted tool message value for zero-data-retention mode , Default: `nil`. |
 
 ### UserMessage
 
@@ -348,11 +561,11 @@ msg = AgUiProtocol::Core::Types::UserMessage.new(
 
 **@category** [] Message Types
 
-| Property  | Type                                                    | Description                                                           |
-| --------- | ------------------------------------------------------- | --------------------------------------------------------------------- |
-| `id`      | `String`                                                | Unique identifier for the message                                     |
-| `content` | `String , Array<TextInputContent , BinaryInputContent>` | Either a plain text string or an ordered list of multimodal fragments |
-| `name`    | `String` (optional)                                     | Optional name of the sender , Default: `nil`.                         |
+| Property  | Type                                                                                                                                       | Description                                                           |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `id`      | `String`                                                                                                                                   | Unique identifier for the message                                     |
+| `content` | `String , Array<TextInputContent , BinaryInputContent , ImageInputContent , AudioInputContent , VideoInputContent , DocumentInputContent>` | Either a plain text string or an ordered list of multimodal fragments |
+| `name`    | `String` (optional)                                                                                                                        | Optional name of the sender , Default: `nil`.                         |
 
 ## State
 

--- a/docs/sdk/ruby/core/types.mdx
+++ b/docs/sdk/ruby/core/types.mdx
@@ -24,11 +24,11 @@ content = AgUiProtocol::Core::Types::AudioInputContent.new(
 
 ```
 
-| Property   | Type                                                    | Description                                        |
-| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
-| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
-| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
-| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"audio"`. |
+| Property   | Type                                                  | Description                                       |
+| ---------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `source`   | `InputContentDataSource, InputContentUrlSource, Hash` | Content source                                    |
+| `metadata` | `Object` (optional)                                   | Optional metadata. Default: `nil`.                |
+| `type`     | `String` (optional)                                   | Identifies the fragment type. Default: `"audio"`. |
 
 ## Context
 
@@ -63,11 +63,11 @@ content = AgUiProtocol::Core::Types::DocumentInputContent.new(
 
 ```
 
-| Property   | Type                                                    | Description                                           |
-| ---------- | ------------------------------------------------------- | ----------------------------------------------------- |
-| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                        |
-| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                   |
-| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"document"`. |
+| Property   | Type                                                  | Description                                          |
+| ---------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| `source`   | `InputContentDataSource, InputContentUrlSource, Hash` | Content source                                       |
+| `metadata` | `Object` (optional)                                   | Optional metadata. Default: `nil`.                   |
+| `type`     | `String` (optional)                                   | Identifies the fragment type. Default: `"document"`. |
 
 ## ImageInputContent
 
@@ -84,11 +84,11 @@ content = AgUiProtocol::Core::Types::ImageInputContent.new(
 
 ```
 
-| Property   | Type                                                    | Description                                        |
-| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
-| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
-| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
-| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"image"`. |
+| Property   | Type                                                  | Description                                       |
+| ---------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `source`   | `InputContentDataSource, InputContentUrlSource, Hash` | Content source                                    |
+| `metadata` | `Object` (optional)                                   | Optional metadata. Default: `nil`.                |
+| `type`     | `String` (optional)                                   | Identifies the fragment type. Default: `"image"`. |
 
 ## InputContentDataSource
 
@@ -107,11 +107,11 @@ source = AgUiProtocol::Core::Types::InputContentDataSource.new(
 
 ```
 
-| Property    | Type                | Description                                     |
-| ----------- | ------------------- | ----------------------------------------------- |
-| `value`     | `String`            | Base64 encoded content                          |
-| `mime_type` | `String`            | MIME type of the content                        |
-| `type`      | `String` (optional) | Identifies the source type , Default: `"data"`. |
+| Property    | Type                | Description                                    |
+| ----------- | ------------------- | ---------------------------------------------- |
+| `value`     | `String`            | Base64 encoded content                         |
+| `mime_type` | `String`            | MIME type of the content                       |
+| `type`      | `String` (optional) | Identifies the source type. Default: `"data"`. |
 
 ## InputContentUrlSource
 
@@ -129,11 +129,11 @@ source = AgUiProtocol::Core::Types::InputContentUrlSource.new(
 
 ```
 
-| Property    | Type                | Description                                    |
-| ----------- | ------------------- | ---------------------------------------------- |
-| `value`     | `String`            | URL string                                     |
-| `mime_type` | `String` (optional) | Optional MIME type , Default: `nil`.           |
-| `type`      | `String` (optional) | Identifies the source type , Default: `"url"`. |
+| Property    | Type                | Description                                   |
+| ----------- | ------------------- | --------------------------------------------- |
+| `value`     | `String`            | URL string                                    |
+| `mime_type` | `String` (optional) | Optional MIME type. Default: `nil`.           |
+| `type`      | `String` (optional) | Identifies the source type. Default: `"url"`. |
 
 ## Interrupt
 
@@ -153,15 +153,15 @@ interrupt = AgUiProtocol::Core::Types::Interrupt.new(
 
 ```
 
-| Property          | Type                | Description                                            |
-| ----------------- | ------------------- | ------------------------------------------------------ |
-| `id`              | `String`            | Unique identifier                                      |
-| `reason`          | `String`            | Reason for the interrupt                               |
-| `message`         | `String` (optional) | Human-readable message , Default: `nil`.               |
-| `tool_call_id`    | `String` (optional) | Associated tool call if applicable , Default: `nil`.   |
-| `response_schema` | `Object` (optional) | JSON schema for response , Default: `nil`.             |
-| `expires_at`      | `String` (optional) | ISO timestamp when interrupt expires , Default: `nil`. |
-| `metadata`        | `Object` (optional) | Arbitrary metadata , Default: `nil`.                   |
+| Property          | Type                | Description                                           |
+| ----------------- | ------------------- | ----------------------------------------------------- |
+| `id`              | `String`            | Unique identifier                                     |
+| `reason`          | `String`            | Reason for the interrupt                              |
+| `message`         | `String` (optional) | Human-readable message. Default: `nil`.               |
+| `tool_call_id`    | `String` (optional) | Associated tool call if applicable. Default: `nil`.   |
+| `response_schema` | `Object` (optional) | JSON schema for response. Default: `nil`.             |
+| `expires_at`      | `String` (optional) | ISO timestamp when interrupt expires. Default: `nil`. |
+| `metadata`        | `Object` (optional) | Arbitrary metadata. Default: `nil`.                   |
 
 ## ReasoningMessage
 
@@ -180,11 +180,11 @@ msg = AgUiProtocol::Core::Types::ReasoningMessage.new(
 
 ```
 
-| Property          | Type                | Description                                                                    |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------ |
-| `id`              | `String`            | Unique identifier for the message                                              |
-| `content`         | `String`            | Reasoning content (plaintext when not encrypted)                               |
-| `encrypted_value` | `String` (optional) | Encrypted reasoning content when in zero-data-retention mode , Default: `nil`. |
+| Property          | Type                | Description                                                                   |
+| ----------------- | ------------------- | ----------------------------------------------------------------------------- |
+| `id`              | `String`            | Unique identifier for the message                                             |
+| `content`         | `String`            | Reasoning content (plaintext when not encrypted)                              |
+| `encrypted_value` | `String` (optional) | Encrypted reasoning content when in zero-data-retention mode. Default: `nil`. |
 
 ## ResumeEntry
 
@@ -203,17 +203,24 @@ entry = AgUiProtocol::Core::Types::ResumeEntry.new(
 
 ```
 
-| Property       | Type     | Description                                   |
-| -------------- | -------- | --------------------------------------------- |
-| `interrupt_id` | `String` | ID of the interrupt being resolved            |
-| `status`       | `String` | Resolution status ("resolved" or "cancelled") |
-| `payload`      | `Object` | Response payload for the interrupt            |
+| Property       | Type                | Description                                                                                   |
+| -------------- | ------------------- | --------------------------------------------------------------------------------------------- |
+| `interrupt_id` | `String`            | ID of the interrupt being resolved                                                            |
+| `status`       | `String` (optional) | Resolution status (free-form; protocol values are "resolved" or "cancelled"). Default: `nil`. |
+| `payload`      | `Object` (optional) | Response payload for the interrupt. Default: `nil`.                                           |
 
-## ResumeStatus
+## Role
 
-`AgUiProtocol::Core::Types::ResumeStatus`
+`AgUiProtocol::Core::Types::Role`
 
-Valid values for resume status in interrupt resolution.
+Represents the possible roles a message sender can have.
+
+```ruby
+
+AgUiProtocol::Core::Types::Role # => ["developer", "system", "assistant",
+"user", "tool", "activity", "reasoning"]
+
+```
 
 ## RunAgentInput
 
@@ -238,17 +245,17 @@ input = AgUiProtocol::Core::Types::RunAgentInput.new(
 
 ```
 
-| Property          | Type                            | Description                                                 |
-| ----------------- | ------------------------------- | ----------------------------------------------------------- |
-| `thread_id`       | `String`                        | ID of the conversation thread                               |
-| `run_id`          | `String`                        | ID of the current run                                       |
-| `state`           | `Object`                        | Current state of the agent                                  |
-| `messages`        | `Array<BaseMessage>`            | List of messages in the conversation                        |
-| `tools`           | `Array<Tool>`                   | List of tools available to the agent                        |
-| `context`         | `Array<Context>`                | List of context objects provided to the agent               |
-| `forwarded_props` | `Object`                        | Additional properties forwarded to the agent                |
-| `parent_run_id`   | `String` (optional)             | Lineage pointer for branching/time travel , Default: `nil`. |
-| `resume`          | `Array<ResumeEntry>` (optional) | Entries for resuming interrupted runs , Default: `nil`.     |
+| Property          | Type                                  | Description                                                |
+| ----------------- | ------------------------------------- | ---------------------------------------------------------- |
+| `thread_id`       | `String`                              | ID of the conversation thread                              |
+| `run_id`          | `String`                              | ID of the current run                                      |
+| `state`           | `Object`                              | Current state of the agent                                 |
+| `messages`        | `Array<BaseMessage, ActivityMessage>` | List of messages in the conversation                       |
+| `tools`           | `Array<Tool>`                         | List of tools available to the agent                       |
+| `context`         | `Array<Context>`                      | List of context objects provided to the agent              |
+| `forwarded_props` | `Object`                              | Additional properties forwarded to the agent               |
+| `parent_run_id`   | `String` (optional)                   | Lineage pointer for branching/time travel. Default: `nil`. |
+| `resume`          | `Array<ResumeEntry>` (optional)       | Entries for resuming interrupted runs. Default: `nil`.     |
 
 ## Tool
 
@@ -289,12 +296,12 @@ tool_call = AgUiProtocol::Core::Types::ToolCall.new(
 
 ```
 
-| Property          | Type                  | Description                                                              |
-| ----------------- | --------------------- | ------------------------------------------------------------------------ |
-| `id`              | `String`              | Unique identifier for the tool call                                      |
-| `function`        | `FunctionCall , Hash` | Function name and arguments                                              |
-| `type`            | `String` (optional)   | Type of the tool call , Default: `'function'`.                           |
-| `encrypted_value` | `String` (optional)   | Encrypted tool call value for zero-data-retention mode , Default: `nil`. |
+| Property          | Type                 | Description                                                             |
+| ----------------- | -------------------- | ----------------------------------------------------------------------- |
+| `id`              | `String`             | Unique identifier for the tool call                                     |
+| `function`        | `FunctionCall, Hash` | Function name and arguments                                             |
+| `type`            | `String` (optional)  | Type of the tool call. Default: `'function'`.                           |
+| `encrypted_value` | `String` (optional)  | Encrypted tool call value for zero-data-retention mode. Default: `nil`. |
 
 ### FunctionCall
 
@@ -311,8 +318,6 @@ fn = AgUiProtocol::Core::Types::FunctionCall.new(
 )
 
 ```
-
-**@category** [] ToolCall
 
 | Property    | Type     | Description             |
 | ----------- | -------- | ----------------------- |
@@ -334,11 +339,11 @@ content = AgUiProtocol::Core::Types::VideoInputContent.new(
 
 ```
 
-| Property   | Type                                                    | Description                                        |
-| ---------- | ------------------------------------------------------- | -------------------------------------------------- |
-| `source`   | `InputContentDataSource , InputContentUrlSource , Hash` | Content source                                     |
-| `metadata` | `Object` (optional)                                     | Optional metadata , Default: `nil`.                |
-| `type`     | `String` (optional)                                     | Identifies the fragment type , Default: `"video"`. |
+| Property   | Type                                                  | Description                                       |
+| ---------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `source`   | `InputContentDataSource, InputContentUrlSource, Hash` | Content source                                    |
+| `metadata` | `Object` (optional)                                   | Optional metadata. Default: `nil`.                |
+| `type`     | `String` (optional)                                   | Identifies the fragment type. Default: `"video"`. |
 
 ## Message Types
 
@@ -351,6 +356,11 @@ messages in the system.
 
 Represents structured activity progress emitted between chat messages.
 
+ActivityMessage intentionally does NOT inherit from BaseMessage because its
+`content` is a structured Hash rather than text/multimodal, which is
+incompatible with BaseMessage#content's type. It still appears alongside other
+messages in the stream but is modeled as its own shape.
+
 ```ruby
 
 msg = AgUiProtocol::Core::Types::ActivityMessage.new(
@@ -361,8 +371,6 @@ msg = AgUiProtocol::Core::Types::ActivityMessage.new(
 )
 
 ```
-
-**@category** [] Message Types
 
 | Property        | Type     | Description                                         |
 | --------------- | -------- | --------------------------------------------------- |
@@ -392,14 +400,13 @@ msg = AgUiProtocol::Core::Types::AssistantMessage.new(
 
 ```
 
-**@category** [] Message Types
-
-| Property     | Type                                | Description                                       |
-| ------------ | ----------------------------------- | ------------------------------------------------- |
-| `id`         | `String`                            | Unique identifier for the message                 |
-| `content`    | `Object` (optional)                 | Text content of the message , Default: `nil`.     |
-| `tool_calls` | `Array<ToolCall , Hash>` (optional) | Tool calls made in this message , Default: `nil`. |
-| `name`       | `String` (optional)                 | Name of the sender , Default: `nil`.              |
+| Property          | Type                               | Description                                                                                   |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `id`              | `String`                           | Unique identifier for the message                                                             |
+| `content`         | `Object` (optional)                | Text content of the message. Default: `nil`.                                                  |
+| `tool_calls`      | `Array<ToolCall, Hash>` (optional) | Tool calls made in this message; Hashes are normalized to ToolCall instances. Default: `nil`. |
+| `name`            | `String` (optional)                | Name of the sender. Default: `nil`.                                                           |
+| `encrypted_value` | `String` (optional)                | Encrypted content for zero-data-retention mode. Default: `nil`.                               |
 
 ### BinaryInputContent
 
@@ -420,16 +427,14 @@ content = AgUiProtocol::Core::Types::BinaryInputContent.new(
 > <strong>Validation:</strong> At least one of `id`, `url`, or `data` must be
 provided.
 
-**@category** [] Message Types
-
-| Property    | Type                | Description                                                     |
-| ----------- | ------------------- | --------------------------------------------------------------- |
-| `type`      | `String` (optional) | Identifies the fragment type , Default: `"binary"`.             |
-| `mime_type` | `String`            | MIME type, for example `"image/png"`                            |
-| `id`        | `String` (optional) | Reference to previously uploaded content , Default: `nil`.      |
-| `url`       | `String` (optional) | Remote URL where the content can be retrieved , Default: `nil`. |
-| `data`      | `String` (optional) | Base64 encoded content , Default: `nil`.                        |
-| `filename`  | `String` (optional) | Optional filename hint , Default: `nil`.                        |
+| Property    | Type                | Description                                                    |
+| ----------- | ------------------- | -------------------------------------------------------------- |
+| `type`      | `String` (optional) | Identifies the fragment type. Default: `"binary"`.             |
+| `mime_type` | `String`            | MIME type, for example `"image/png"`                           |
+| `id`        | `String` (optional) | Reference to previously uploaded content. Default: `nil`.      |
+| `url`       | `String` (optional) | Remote URL where the content can be retrieved. Default: `nil`. |
+| `data`      | `String` (optional) | Base64 encoded content. Default: `nil`.                        |
+| `filename`  | `String` (optional) | Optional filename hint. Default: `nil`.                        |
 
 ### DeveloperMessage
 
@@ -447,28 +452,11 @@ msg = AgUiProtocol::Core::Types::DeveloperMessage.new(
 
 ```
 
-**@category** [] Message Types
-
-| Property  | Type                | Description                                   |
-| --------- | ------------------- | --------------------------------------------- |
-| `id`      | `String`            | Unique identifier for the message             |
-| `content` | `Object`            | Text content of the message (required)        |
-| `name`    | `String` (optional) | Optional name of the sender , Default: `nil`. |
-
-### Role
-
-`AgUiProtocol::Core::Types::Role`
-
-Represents the possible roles a message sender can have.
-
-```ruby
-
-AgUiProtocol::Core::Types::Role # => ["developer", "system", "assistant",
-"user", "tool", "activity"]
-
-```
-
-**@category** [] Message Types
+| Property  | Type                | Description                                  |
+| --------- | ------------------- | -------------------------------------------- |
+| `id`      | `String`            | Unique identifier for the message            |
+| `content` | `Object`            | Text content of the message (required)       |
+| `name`    | `String` (optional) | Optional name of the sender. Default: `nil`. |
 
 ### SystemMessage
 
@@ -486,13 +474,11 @@ msg = AgUiProtocol::Core::Types::SystemMessage.new(
 
 ```
 
-**@category** [] Message Types
-
-| Property  | Type                | Description                                   |
-| --------- | ------------------- | --------------------------------------------- |
-| `id`      | `String`            | Unique identifier for the message             |
-| `content` | `Object`            | Text content of the message (required)        |
-| `name`    | `String` (optional) | Optional name of the sender , Default: `nil`. |
+| Property  | Type                | Description                                  |
+| --------- | ------------------- | -------------------------------------------- |
+| `id`      | `String`            | Unique identifier for the message            |
+| `content` | `Object`            | Text content of the message (required)       |
+| `name`    | `String` (optional) | Optional name of the sender. Default: `nil`. |
 
 ### TextInputContent
 
@@ -506,12 +492,10 @@ content = AgUiProtocol::Core::Types::TextInputContent.new(text: "hello")
 
 ```
 
-**@category** [] Message Types
-
-| Property | Type                | Description                                       |
-| -------- | ------------------- | ------------------------------------------------- |
-| `text`   | `String`            | Text content                                      |
-| `type`   | `String` (optional) | Identifies the fragment type , Default: `"text"`. |
+| Property | Type                | Description                                      |
+| -------- | ------------------- | ------------------------------------------------ |
+| `text`   | `String`            | Text content                                     |
+| `type`   | `String` (optional) | Identifies the fragment type. Default: `"text"`. |
 
 ### ToolMessage
 
@@ -530,15 +514,13 @@ msg = AgUiProtocol::Core::Types::ToolMessage.new(
 
 ```
 
-**@category** [] Message Types
-
-| Property          | Type                | Description                                                                 |
-| ----------------- | ------------------- | --------------------------------------------------------------------------- |
-| `id`              | `String`            | Unique identifier for the message.                                          |
-| `content`         | `String`            | Tool result content.                                                        |
-| `tool_call_id`    | `String`            | ID of the tool call this message responds to.                               |
-| `error`           | `String` (optional) | Error payload if the tool call failed. , Default: `nil`.                    |
-| `encrypted_value` | `String` (optional) | Encrypted tool message value for zero-data-retention mode , Default: `nil`. |
+| Property          | Type                | Description                                                                |
+| ----------------- | ------------------- | -------------------------------------------------------------------------- |
+| `id`              | `String`            | Unique identifier for the message.                                         |
+| `content`         | `String`            | Tool result content.                                                       |
+| `tool_call_id`    | `String`            | ID of the tool call this message responds to.                              |
+| `error`           | `String` (optional) | Error payload if the tool call failed. Default: `nil`.                     |
+| `encrypted_value` | `String` (optional) | Encrypted tool message value for zero-data-retention mode. Default: `nil`. |
 
 ### UserMessage
 
@@ -559,13 +541,12 @@ msg = AgUiProtocol::Core::Types::UserMessage.new(
 
 ```
 
-**@category** [] Message Types
-
-| Property  | Type                                                                                                                                       | Description                                                           |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
-| `id`      | `String`                                                                                                                                   | Unique identifier for the message                                     |
-| `content` | `String , Array<TextInputContent , BinaryInputContent , ImageInputContent , AudioInputContent , VideoInputContent , DocumentInputContent>` | Either a plain text string or an ordered list of multimodal fragments |
-| `name`    | `String` (optional)                                                                                                                        | Optional name of the sender , Default: `nil`.                         |
+| Property          | Type                                                                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | `String`                                                                                                                                   | Unique identifier for the message                                                                                                                                                                                                                                                                                                                                                     |
+| `content`         | `String, Array<TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent, Hash>` | Accepted shapes: a String for plain text, or an Array whose elements are either *InputContent Models (TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent) OR Hashes with a `type:` key (`text`, `binary`, `image`, `audio`, `video`, `document`); Hash entries are normalized internally to the corresponding Model. |
+| `name`            | `String` (optional)                                                                                                                        | Optional name of the sender. Default: `nil`.                                                                                                                                                                                                                                                                                                                                          |
+| `encrypted_value` | `String` (optional)                                                                                                                        | Encrypted content for zero-data-retention mode. Default: `nil`.                                                                                                                                                                                                                                                                                                                       |
 
 ## State
 

--- a/docs/sdk/ruby/encoder/overview.mdx
+++ b/docs/sdk/ruby/encoder/overview.mdx
@@ -44,7 +44,7 @@ EventSource API.
 Internally, the encoder converts events to JSON and formats them as
 Server-Sent Events with the following structure:
 
-``` data: {json-serialized event}n\n ```
+``` data: {json-serialized event}nn ```
 
 This format allows clients to receive a continuous stream of events and
 process them as they arrive.

--- a/docs/sdk/ruby/encoder/overview.mdx
+++ b/docs/sdk/ruby/encoder/overview.mdx
@@ -42,9 +42,10 @@ EventSource API.
 ### Implementation Details
 
 Internally, the encoder converts events to JSON and formats them as
-Server-Sent Events with the following structure:
+Server-Sent Events with the following structure (each event terminated by two
+literal newline characters, shown here as escape sequences):
 
-``` data: {json-serialized event}nn ```
+    data: {json-serialized event}\n\n
 
 This format allows clients to receive a continuous stream of events and
 process them as they arrive.
@@ -67,7 +68,7 @@ Encodes an event into a string representation.
 
 **Returns**: `String`: A string representation of the event in SSE format.
 
-#### `initialize(accept)`
+#### `initialize(accept: nil)`
 
 Creates a new encoder instance.
 

--- a/sdks/community/ruby/CHANGELOG.md
+++ b/sdks/community/ruby/CHANGELOG.md
@@ -7,27 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-05-26
 
-### Added (0.2.0)
+### Added
 
-- Reasoning events: `ReasoningStartEvent`, `ReasoningMessageStartEvent`, `ReasoningMessageContentEvent`, `ReasoningMessageEndEvent`, `ReasoningMessageChunkEvent`, `ReasoningEndEvent`, `ReasoningEncryptedValueEvent`
-- Run outcome support (`RunFinishedSuccessOutcome`, `RunFinishedInterruptOutcome`) in `RunFinishedEvent`
+- Reasoning events: `ReasoningStartEvent`, `ReasoningEndEvent`, `ReasoningMessageStartEvent`, `ReasoningMessageContentEvent`, `ReasoningMessageEndEvent`, `ReasoningMessageChunkEvent`, `ReasoningEncryptedValueEvent`
+- Run outcome support in `RunFinishedEvent`: `RunFinishedSuccessOutcome`, `RunFinishedInterruptOutcome`
 - `reasoning` role added to `TEXT_MESSAGE_ROLE_VALUES`
-- Capabilities module: identity, transport, tools, output, state, multi-agent, reasoning, and multimodal input capability declarations
-- Update YARD template setup for Markdown documentation generation
-- Update Ruby SDK documentation pages (overview, types, events, capabilities)
+- Capabilities module (`AgUiProtocol::Core::Capabilities`) with agent capability declarations:
+  - `IdentityCapabilities` — agent name, type, description, version, provider, documentation URL, and metadata
+  - `TransportCapabilities` — supported transports (streaming, websocket, http_binary, push_notifications, resumable)
+  - `ToolsCapabilities` — tool calling support, agent-provided tools, parallel calls, client-provided tools
+  - `OutputCapabilities` — structured output and supported MIME types
+  - `StateCapabilities` — state snapshots, deltas, long-term memory, persistent state
+  - `MultiAgentCapabilities` — multi-agent coordination, delegation, handoffs, sub-agents
+  - `ReasoningCapabilities` — reasoning/thinking support, streaming, encrypted reasoning
+  - `MultimodalInputCapabilities` — image, audio, video, PDF, file inputs
+  - `MultimodalOutputCapabilities` — image and audio outputs
+  - `MultimodalCapabilities` — combined input/output multimodal support
+  - `ExecutionCapabilities` — code execution, sandboxing, iteration and time limits
+  - `HumanInTheLoopCapabilities` — approvals, interventions, feedback, interrupt protocol, approve-with-edits
+  - `AgentCapabilities` — categorized snapshot aggregating all of the above
+  - `SubAgentInfo` — descriptor for sub-agents invoked by a parent agent
 
-## [0.1.0] - 2025-12-18
+### Changed
 
-### Update Gemspec (0.1.5)
+- YARD template setup for Markdown documentation generation
+- Ruby SDK documentation pages updated (overview, types, events, capabilities)
+
+## [0.1.5] - 2026-02-11
 
 - Update documentation and changelog URLs in the gemspec
 
-### Update Gemspec (0.1.4)
+## [0.1.4] - 2026-01-05
 
 - Added `ag-ui-protocol.rb` alias to `ag_ui_protocol.rb` and fix tapioca rbi generation bug
 - Removed redundant Sorbet type `T.nilable(T.untyped)` to fix Sorbet warnings
 
-### Added (0.1.0)
+## [0.1.0] - 2025-12-18
+
+### Added
 
 - Initial release of the AG-UI Ruby SDK
 - Core protocol implementation with strongly-typed models (`AgUiProtocol::Core::Types`)
@@ -37,4 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Runtime validation via `sorbet-runtime`
 - Test suite covering types, events, and encoding
 
+[0.2.0]: https://github.com/ag-ui-protocol/ag-ui/releases/tag/sdk%2Fruby%2Fv0.2.0
+[0.1.5]: https://github.com/ag-ui-protocol/ag-ui/releases/tag/sdk%2Fruby%2Fv0.1.5
+[0.1.4]: https://github.com/ag-ui-protocol/ag-ui/releases/tag/sdk%2Fruby%2Fv0.1.4
 [0.1.0]: https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/ruby

--- a/sdks/community/ruby/CHANGELOG.md
+++ b/sdks/community/ruby/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the AG-UI Ruby SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-26
+
+### Added (0.2.0)
+
+- Reasoning events: `ReasoningStartEvent`, `ReasoningMessageStartEvent`, `ReasoningMessageContentEvent`, `ReasoningMessageEndEvent`, `ReasoningMessageChunkEvent`, `ReasoningEndEvent`, `ReasoningEncryptedValueEvent`
+- Run outcome support (`RunFinishedSuccessOutcome`, `RunFinishedInterruptOutcome`) in `RunFinishedEvent`
+- `reasoning` role added to `TEXT_MESSAGE_ROLE_VALUES`
+- Capabilities module: identity, transport, tools, output, state, multi-agent, reasoning, and multimodal input capability declarations
+- Update YARD template setup for Markdown documentation generation
+- Update Ruby SDK documentation pages (overview, types, events, capabilities)
+
 ## [0.1.0] - 2025-12-18
 
 ### Update Gemspec (0.1.5)

--- a/sdks/community/ruby/lib/ag_ui_protocol.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol.rb
@@ -7,6 +7,7 @@ require_relative "ag_ui_protocol/version"
 require_relative "ag_ui_protocol/util"
 require_relative "ag_ui_protocol/core/types"
 require_relative "ag_ui_protocol/core/events"
+require_relative "ag_ui_protocol/core/capabilities"
 require_relative "ag_ui_protocol/encoder/event_encoder"
 
 module AgUiProtocol

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
@@ -111,7 +111,8 @@ module AgUiProtocol
             version: @version,
             provider: @provider,
             documentation_url: @documentation_url,
-            metadata: @metadata
+            # `metadata` is arbitrary integration-specific identity info — preserve keys verbatim.
+            metadata: @metadata.nil? ? nil : AgUiProtocol::Util::Opaque.new(@metadata)
           }
         end
       end
@@ -721,7 +722,9 @@ module AgUiProtocol
             multimodal: @multimodal,
             execution: @execution,
             human_in_the_loop: @human_in_the_loop,
-            custom: @custom
+            # `custom` is the explicit escape hatch for integration-specific
+            # capabilities — preserve keys verbatim.
+            custom: @custom.nil? ? nil : AgUiProtocol::Util::Opaque.new(@custom)
           }
         end
       end

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
@@ -9,69 +9,12 @@ module AgUiProtocol
     # Agent capabilities define what an agent can do. They are declared by the agent
     # implementation and communicated to the client during a run.
     #
-    # All fields are optional — agents only declare what they support. Omitted fields mean
-    # the capability is not declared (unknown), not that it's unsupported.
-    #
-    # ## SubAgentInfo
-    #
-    # Describes a sub-agent that can be invoked by a parent agent.
-    #
-    # ## IdentityCapabilities
-    #
-    # Basic metadata about the agent.
-    #
-    # ## TransportCapabilities
-    #
-    # Declares which transport mechanisms the agent supports.
-    #
-    # ## ToolsCapabilities
-    #
-    # Tool calling capabilities.
-    #
-    # ## OutputCapabilities
-    #
-    # Output format support.
-    #
-    # ## StateCapabilities
-    #
-    # State and memory management capabilities.
-    #
-    # ## MultiAgentCapabilities
-    #
-    # Multi-agent coordination capabilities.
-    #
-    # ## ReasoningCapabilities
-    #
-    # Reasoning and thinking capabilities.
-    #
-    # ## MultimodalInputCapabilities
-    #
-    # Modalities the agent can accept as input.
-    #
-    # ## MultimodalOutputCapabilities
-    #
-    # Modalities the agent can produce as output.
-    #
-    # ## MultimodalCapabilities
-    #
-    # Multimodal input and output support.
-    #
-    # ## ExecutionCapabilities
-    #
-    # Execution control and limits.
-    #
-    # ## HumanInTheLoopCapabilities
-    #
-    # Human-in-the-loop interaction support.
-    #
-    # ## AgentCapabilities
-    #
-    # A categorized snapshot of an agent's current capabilities.
+    # All fields on `AgentCapabilities` and its sub-capability classes are optional — agents
+    # only declare what they support. (Nested helper types like `SubAgentInfo` may still have
+    # required identifier fields.) Omitted fields mean the capability is not declared
+    # (unknown), not that it's unsupported.
     module Capabilities
       # Describes a sub-agent that can be invoked by a parent agent.
-      #
-      # @param name [String] Unique name or identifier of the sub-agent.
-      # @param description [String] What this sub-agent specializes in. Helps clients build agent selection UIs.
       class SubAgentInfo < AgUiProtocol::Core::Types::Model
         sig { returns(String) }
         attr_reader :name
@@ -79,6 +22,8 @@ module AgUiProtocol
         sig { returns(T.nilable(String)) }
         attr_reader :description
 
+        # @param name [String] Unique name or identifier of the sub-agent.
+        # @param description [String, nil] What this sub-agent specializes in. Helps clients build agent selection UIs.
         sig do
           params(
             name: String,
@@ -104,14 +49,6 @@ module AgUiProtocol
       # Useful for discovery UIs, agent marketplaces, and debugging. Set these when you want
       # clients to display agent information or when multiple agents are available and users
       # need to pick one.
-      #
-      # @param name [String] Human-readable name shown in UIs and agent selectors.
-      # @param type [String] The framework or platform powering this agent (e.g., \"langgraph\", \"mastra\", \"crewai\").
-      # @param description [String] What this agent does — helps users and routing logic decide when to use it.
-      # @param version [String] Semantic version of the agent (e.g., \"1.2.0\"). Useful for compatibility checks.
-      # @param provider [String] Organization or team that maintains this agent.
-      # @param documentation_url [String] URL to the agent's documentation or homepage.
-      # @param metadata [Hash<String, Object>] Arbitrary key-value pairs for integration-specific identity info.
       class IdentityCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(String)) }
         attr_reader :name
@@ -131,9 +68,16 @@ module AgUiProtocol
         sig { returns(T.nilable(String)) }
         attr_reader :documentation_url
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
         attr_reader :metadata
 
+        # @param name [String, nil] Human-readable name shown in UIs and agent selectors.
+        # @param type [String, nil] The framework or platform powering this agent (e.g., "langgraph", "mastra", "crewai").
+        # @param description [String, nil] What this agent does — helps users and routing logic decide when to use it.
+        # @param version [String, nil] Semantic version of the agent (e.g., "1.2.0"). Useful for compatibility checks.
+        # @param provider [String, nil] Organization or team that maintains this agent.
+        # @param documentation_url [String, nil] URL to the agent's documentation or homepage.
+        # @param metadata [Hash{String, Symbol => Object}, nil] Arbitrary key-value pairs for integration-specific identity info. String or Symbol keys are both accepted.
         sig do
           params(
             name: T.nilable(String),
@@ -142,7 +86,7 @@ module AgUiProtocol
             version: T.nilable(String),
             provider: T.nilable(String),
             documentation_url: T.nilable(String),
-            metadata: T.nilable(T::Hash[String, T.untyped])
+            metadata: T.nilable(T::Hash[T.any(String, Symbol), T.untyped])
           ).void
         end
         def initialize(
@@ -174,14 +118,8 @@ module AgUiProtocol
 
       # Declares which transport mechanisms the agent supports.
       #
-      # Clients use this to pick the best connection strategy. Only set flags to +true+ for
-      # transports your agent actually handles — omit or set +false+ for unsupported ones.
-      #
-      # @param streaming [Boolean] Set +true+ if the agent streams responses via SSE. Most agents enable this.
-      # @param websocket [Boolean] Set +true+ if the agent accepts persistent WebSocket connections.
-      # @param http_binary [Boolean] Set +true+ if the agent supports the AG-UI binary protocol (protobuf over HTTP).
-      # @param push_notifications [Boolean] Set +true+ if the agent can send async updates via webhooks after a run finishes.
-      # @param resumable [Boolean] Set +true+ if the agent supports resuming interrupted streams via sequence numbers.
+      # Clients use this to pick the best connection strategy. Only set flags to `true` for
+      # transports your agent actually handles — omit or set `false` for unsupported ones.
       class TransportCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :streaming
@@ -198,6 +136,11 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :resumable
 
+        # @param streaming [Boolean, nil] Set `true` if the agent streams responses via SSE. Most agents enable this.
+        # @param websocket [Boolean, nil] Set `true` if the agent accepts persistent WebSocket connections.
+        # @param http_binary [Boolean, nil] Set `true` if the agent supports the AG-UI binary protocol (protobuf over HTTP).
+        # @param push_notifications [Boolean, nil] Set `true` if the agent can send async updates via webhooks after a run finishes.
+        # @param resumable [Boolean, nil] Set `true` if the agent supports resuming interrupted streams via sequence numbers.
         sig do
           params(
             streaming: T.nilable(T::Boolean),
@@ -232,14 +175,9 @@ module AgUiProtocol
 
       # Tool calling capabilities.
       #
-      # Distinguishes between tools the agent itself provides (listed in +items+) and tools
-      # the client passes at runtime via +RunAgentInput.tools+. Enable this when your agent
+      # Distinguishes between tools the agent itself provides (listed in `items`) and tools
+      # the client passes at runtime via `RunAgentInput.tools`. Enable this when your agent
       # can call functions, search the web, execute code, etc.
-      #
-      # @param supported [Boolean] Set +true+ if the agent can make tool calls at all. Set +false+ to explicitly signal tool calling is disabled even if items are present.
-      # @param items [Array<Tool>] The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools.
-      # @param parallel_calls [Boolean] Set +true+ if the agent can invoke multiple tools concurrently within a single step.
-      # @param client_provided [Boolean] Set +true+ if the agent accepts and uses tools provided by the client at runtime.
       class ToolsCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :supported
@@ -253,6 +191,10 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :client_provided
 
+        # @param supported [Boolean, nil] Set `true` if the agent can make tool calls at all. Set `false` to explicitly signal tool calling is disabled even if items are present.
+        # @param items [Array<Tool>, nil] The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools.
+        # @param parallel_calls [Boolean, nil] Set `true` if the agent can invoke multiple tools concurrently within a single step.
+        # @param client_provided [Boolean, nil] Set `true` if the agent accepts and uses tools provided by the client at runtime.
         sig do
           params(
             supported: T.nilable(T::Boolean),
@@ -283,11 +225,8 @@ module AgUiProtocol
 
       # Output format support.
       #
-      # Enable +structured_output+ when your agent can return responses conforming to a
+      # Enable `structured_output` when your agent can return responses conforming to a
       # JSON schema, which is useful for programmatic consumption.
-      #
-      # @param structured_output [Boolean] Set +true+ if the agent can produce structured JSON output matching a provided schema.
-      # @param supported_mime_types [Array<String>] MIME types the agent can produce (e.g., [\"text/plain\", \"application/json\"]). Omit if the agent only produces plain text.
       class OutputCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :structured_output
@@ -295,6 +234,8 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Array[String])) }
         attr_reader :supported_mime_types
 
+        # @param structured_output [Boolean, nil] Set `true` if the agent can produce structured JSON output matching a provided schema.
+        # @param supported_mime_types [Array<String>, nil] MIME types the agent can produce (e.g., ["text/plain", "application/json"]). Omit if the agent only produces plain text.
         sig do
           params(
             structured_output: T.nilable(T::Boolean),
@@ -319,11 +260,6 @@ module AgUiProtocol
       #
       # These tell the client how the agent handles shared state and whether conversation
       # context persists across runs.
-      #
-      # @param snapshots [Boolean] Set +true+ if the agent emits STATE_SNAPSHOT events (full state replacement).
-      # @param deltas [Boolean] Set +true+ if the agent emits STATE_DELTA events (JSON Patch incremental updates).
-      # @param memory [Boolean] Set +true+ if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall).
-      # @param persistent_state [Boolean] Set +true+ if state is preserved across multiple runs within the same thread. When +false+, state resets on each run.
       class StateCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :snapshots
@@ -337,6 +273,10 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :persistent_state
 
+        # @param snapshots [Boolean, nil] Set `true` if the agent emits STATE_SNAPSHOT events (full state replacement).
+        # @param deltas [Boolean, nil] Set `true` if the agent emits STATE_DELTA events (JSON Patch incremental updates).
+        # @param memory [Boolean, nil] Set `true` if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall).
+        # @param persistent_state [Boolean, nil] Set `true` if state is preserved across multiple runs within the same thread. When `false`, state resets on each run.
         sig do
           params(
             snapshots: T.nilable(T::Boolean),
@@ -366,11 +306,6 @@ module AgUiProtocol
       # Multi-agent coordination capabilities.
       #
       # Enable these when your agent can orchestrate or hand off work to other agents.
-      #
-      # @param supported [Boolean] Set +true+ if the agent participates in any form of multi-agent coordination.
-      # @param delegation [Boolean] Set +true+ if the agent can delegate subtasks to other agents while retaining control.
-      # @param handoffs [Boolean] Set +true+ if the agent can transfer the conversation entirely to another agent.
-      # @param sub_agents [Array<SubAgentInfo>] List of sub-agents this agent can invoke. Helps clients build agent selection UIs.
       class MultiAgentCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :supported
@@ -384,6 +319,10 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Array[SubAgentInfo])) }
         attr_reader :sub_agents
 
+        # @param supported [Boolean, nil] Set `true` if the agent participates in any form of multi-agent coordination.
+        # @param delegation [Boolean, nil] Set `true` if the agent can delegate subtasks to other agents while retaining control.
+        # @param handoffs [Boolean, nil] Set `true` if the agent can transfer the conversation entirely to another agent.
+        # @param sub_agents [Array<SubAgentInfo>, nil] List of sub-agents this agent can invoke. Helps clients build agent selection UIs.
         sig do
           params(
             supported: T.nilable(T::Boolean),
@@ -416,10 +355,6 @@ module AgUiProtocol
       #
       # Enable these when your agent exposes its internal thought process (e.g.,
       # chain-of-thought, extended thinking).
-      #
-      # @param supported [Boolean] Set +true+ if the agent produces reasoning/thinking tokens visible to the client.
-      # @param streaming [Boolean] Set +true+ if reasoning tokens are streamed incrementally (vs. returned all at once).
-      # @param encrypted [Boolean] Set +true+ if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque +encrypted_value+ fields instead of readable content.
       class ReasoningCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :supported
@@ -430,6 +365,9 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :encrypted
 
+        # @param supported [Boolean, nil] Set `true` if the agent produces reasoning/thinking tokens visible to the client.
+        # @param streaming [Boolean, nil] Set `true` if reasoning tokens are streamed incrementally (vs. returned all at once).
+        # @param encrypted [Boolean, nil] Set `true` if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque `encrypted_value` fields instead of readable content.
         sig do
           params(
             supported: T.nilable(T::Boolean),
@@ -456,12 +394,6 @@ module AgUiProtocol
       # Modalities the agent can accept as input.
       #
       # Clients use this to show/hide file upload buttons, audio recorders, image pickers, etc.
-      #
-      # @param image [Boolean] Set +true+ if the agent can process image inputs (e.g., screenshots, photos).
-      # @param audio [Boolean] Set +true+ if the agent can process audio inputs (speech, recordings).
-      # @param video [Boolean] Set +true+ if the agent can process video inputs.
-      # @param pdf [Boolean] Set +true+ if the agent can process PDF documents.
-      # @param file [Boolean] Set +true+ if the agent can process arbitrary file uploads.
       class MultimodalInputCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :image
@@ -478,6 +410,11 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :file
 
+        # @param image [Boolean, nil] Set `true` if the agent can process image inputs (e.g., screenshots, photos).
+        # @param audio [Boolean, nil] Set `true` if the agent can process audio inputs (speech, recordings).
+        # @param video [Boolean, nil] Set `true` if the agent can process video inputs.
+        # @param pdf [Boolean, nil] Set `true` if the agent can process PDF documents.
+        # @param file [Boolean, nil] Set `true` if the agent can process arbitrary file uploads.
         sig do
           params(
             image: T.nilable(T::Boolean),
@@ -510,9 +447,6 @@ module AgUiProtocol
       # Modalities the agent can produce as output.
       #
       # Clients use this to anticipate rich content in the agent's response.
-      #
-      # @param image [Boolean] Set +true+ if the agent can generate images as part of its response.
-      # @param audio [Boolean] Set +true+ if the agent can produce audio output (text-to-speech, audio files).
       class MultimodalOutputCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :image
@@ -520,6 +454,8 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :audio
 
+        # @param image [Boolean, nil] Set `true` if the agent can generate images as part of its response.
+        # @param audio [Boolean, nil] Set `true` if the agent can produce audio output (text-to-speech, audio files).
         sig do
           params(
             image: T.nilable(T::Boolean),
@@ -542,11 +478,8 @@ module AgUiProtocol
 
       # Multimodal input and output support.
       #
-      # Organized into +input+ and +output+ sub-objects so clients can independently query
+      # Organized into `input` and `output` sub-objects so clients can independently query
       # what the agent accepts versus what it produces.
-      #
-      # @param input [MultimodalInputCapabilities] Modalities the agent can accept as input (images, audio, video, PDFs, files).
-      # @param output [MultimodalOutputCapabilities] Modalities the agent can produce as output (images, audio).
       class MultimodalCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(MultimodalInputCapabilities)) }
         attr_reader :input
@@ -554,6 +487,8 @@ module AgUiProtocol
         sig { returns(T.nilable(MultimodalOutputCapabilities)) }
         attr_reader :output
 
+        # @param input [MultimodalInputCapabilities, nil] Modalities the agent can accept as input (images, audio, video, PDFs, files).
+        # @param output [MultimodalOutputCapabilities, nil] Modalities the agent can produce as output (images, audio).
         sig do
           params(
             input: T.nilable(MultimodalInputCapabilities),
@@ -578,11 +513,6 @@ module AgUiProtocol
       #
       # Declare these so clients can set expectations about how long or how many steps an
       # agent run might take.
-      #
-      # @param code_execution [Boolean] Set +true+ if the agent can execute code (e.g., Python, JavaScript) during a run.
-      # @param sandboxed [Boolean] Set +true+ if code execution happens in a sandboxed/isolated environment. Only meaningful when +code_execution+ is +true+.
-      # @param max_iterations [Integer] Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations.
-      # @param max_execution_time [Integer] Maximum wall-clock time (in milliseconds) the agent will run before timing out.
       class ExecutionCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :code_execution
@@ -596,6 +526,10 @@ module AgUiProtocol
         sig { returns(T.nilable(Integer)) }
         attr_reader :max_execution_time
 
+        # @param code_execution [Boolean, nil] Set `true` if the agent can execute code (e.g., Python, JavaScript) during a run.
+        # @param sandboxed [Boolean, nil] Set `true` if code execution happens in a sandboxed/isolated environment. Only meaningful when `code_execution` is `true`.
+        # @param max_iterations [Integer, nil] Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations.
+        # @param max_execution_time [Integer, nil] Maximum wall-clock time (in milliseconds) the agent will run before timing out.
         sig do
           params(
             code_execution: T.nilable(T::Boolean),
@@ -629,13 +563,6 @@ module AgUiProtocol
       #
       # Enable these when your agent can pause execution to request human input, approval,
       # or feedback before continuing.
-      #
-      # @param supported [Boolean] Set +true+ if the agent supports any form of human-in-the-loop interaction.
-      # @param approvals [Boolean] Set +true+ if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data).
-      # @param interventions [Boolean] Set +true+ if the agent allows humans to intervene and modify its plan mid-execution.
-      # @param feedback [Boolean] Set +true+ if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session.
-      # @param interrupts [Boolean] Set +true+ if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]).
-      # @param approve_with_edits [Boolean] Set +true+ if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true.
       class HumanInTheLoopCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :supported
@@ -655,6 +582,12 @@ module AgUiProtocol
         sig { returns(T.nilable(T::Boolean)) }
         attr_reader :approve_with_edits
 
+        # @param supported [Boolean, nil] Set `true` if the agent supports any form of human-in-the-loop interaction.
+        # @param approvals [Boolean, nil] Set `true` if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data).
+        # @param interventions [Boolean, nil] Set `true` if the agent allows humans to intervene and modify its plan mid-execution.
+        # @param feedback [Boolean, nil] Set `true` if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session.
+        # @param interrupts [Boolean, nil] Set `true` if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]).
+        # @param approve_with_edits [Boolean, nil] Set `true` if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true.
         sig do
           params(
             supported: T.nilable(T::Boolean),
@@ -695,20 +628,8 @@ module AgUiProtocol
       # All fields are optional — agents only declare what they support. Omitted fields mean
       # the capability is not declared (unknown), not that it's unsupported.
       #
-      # The +custom+ field is an escape hatch for integration-specific capabilities that
+      # The `custom` field is an escape hatch for integration-specific capabilities that
       # don't fit into the standard categories.
-      #
-      # @param identity [IdentityCapabilities] Agent identity and metadata.
-      # @param transport [TransportCapabilities] Supported transport mechanisms (SSE, WebSocket, binary, etc.).
-      # @param tools [ToolsCapabilities] Tools the agent provides and tool calling configuration.
-      # @param output [OutputCapabilities] Output format support (structured output, MIME types).
-      # @param state [StateCapabilities] State and memory management (snapshots, deltas, persistence).
-      # @param multi_agent [MultiAgentCapabilities] Multi-agent coordination (delegation, handoffs, sub-agents).
-      # @param reasoning [ReasoningCapabilities] Reasoning and thinking support (chain-of-thought, encrypted thinking).
-      # @param multimodal [MultimodalCapabilities] Multimodal input/output support (images, audio, video, files).
-      # @param execution [ExecutionCapabilities] Execution control and limits (code execution, timeouts, iteration caps).
-      # @param human_in_the_loop [HumanInTheLoopCapabilities] Human-in-the-loop support (approvals, interventions, feedback).
-      # @param custom [Hash<String, Object>] Integration-specific capabilities not covered by the standard categories.
       class AgentCapabilities < AgUiProtocol::Core::Types::Model
         sig { returns(T.nilable(IdentityCapabilities)) }
         attr_reader :identity
@@ -740,9 +661,20 @@ module AgUiProtocol
         sig { returns(T.nilable(HumanInTheLoopCapabilities)) }
         attr_reader :human_in_the_loop
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
         attr_reader :custom
 
+        # @param identity [IdentityCapabilities, nil] Agent identity and metadata.
+        # @param transport [TransportCapabilities, nil] Supported transport mechanisms (SSE, WebSocket, binary, etc.).
+        # @param tools [ToolsCapabilities, nil] Tools the agent provides and tool calling configuration.
+        # @param output [OutputCapabilities, nil] Output format support (structured output, MIME types).
+        # @param state [StateCapabilities, nil] State and memory management (snapshots, deltas, persistence).
+        # @param multi_agent [MultiAgentCapabilities, nil] Multi-agent coordination (delegation, handoffs, sub-agents).
+        # @param reasoning [ReasoningCapabilities, nil] Reasoning and thinking support (chain-of-thought, encrypted thinking).
+        # @param multimodal [MultimodalCapabilities, nil] Multimodal input/output support (images, audio, video, files).
+        # @param execution [ExecutionCapabilities, nil] Execution control and limits (code execution, timeouts, iteration caps).
+        # @param human_in_the_loop [HumanInTheLoopCapabilities, nil] Human-in-the-loop support (approvals, interventions, feedback).
+        # @param custom [Hash{String, Symbol => Object}, nil] Integration-specific capabilities not covered by the standard categories. String or Symbol keys are both accepted.
         sig do
           params(
             identity: T.nilable(IdentityCapabilities),
@@ -755,7 +687,7 @@ module AgUiProtocol
             multimodal: T.nilable(MultimodalCapabilities),
             execution: T.nilable(ExecutionCapabilities),
             human_in_the_loop: T.nilable(HumanInTheLoopCapabilities),
-            custom: T.nilable(T::Hash[String, T.untyped])
+            custom: T.nilable(T::Hash[T.any(String, Symbol), T.untyped])
           ).void
         end
         def initialize(

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/capabilities.rb
@@ -1,0 +1,798 @@
+# typed: true
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require_relative "types"
+
+module AgUiProtocol
+  module Core
+    # Agent capabilities define what an agent can do. They are declared by the agent
+    # implementation and communicated to the client during a run.
+    #
+    # All fields are optional — agents only declare what they support. Omitted fields mean
+    # the capability is not declared (unknown), not that it's unsupported.
+    #
+    # ## SubAgentInfo
+    #
+    # Describes a sub-agent that can be invoked by a parent agent.
+    #
+    # ## IdentityCapabilities
+    #
+    # Basic metadata about the agent.
+    #
+    # ## TransportCapabilities
+    #
+    # Declares which transport mechanisms the agent supports.
+    #
+    # ## ToolsCapabilities
+    #
+    # Tool calling capabilities.
+    #
+    # ## OutputCapabilities
+    #
+    # Output format support.
+    #
+    # ## StateCapabilities
+    #
+    # State and memory management capabilities.
+    #
+    # ## MultiAgentCapabilities
+    #
+    # Multi-agent coordination capabilities.
+    #
+    # ## ReasoningCapabilities
+    #
+    # Reasoning and thinking capabilities.
+    #
+    # ## MultimodalInputCapabilities
+    #
+    # Modalities the agent can accept as input.
+    #
+    # ## MultimodalOutputCapabilities
+    #
+    # Modalities the agent can produce as output.
+    #
+    # ## MultimodalCapabilities
+    #
+    # Multimodal input and output support.
+    #
+    # ## ExecutionCapabilities
+    #
+    # Execution control and limits.
+    #
+    # ## HumanInTheLoopCapabilities
+    #
+    # Human-in-the-loop interaction support.
+    #
+    # ## AgentCapabilities
+    #
+    # A categorized snapshot of an agent's current capabilities.
+    module Capabilities
+      # Describes a sub-agent that can be invoked by a parent agent.
+      #
+      # @param name [String] Unique name or identifier of the sub-agent.
+      # @param description [String] What this sub-agent specializes in. Helps clients build agent selection UIs.
+      class SubAgentInfo < AgUiProtocol::Core::Types::Model
+        sig { returns(String) }
+        attr_reader :name
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :description
+
+        sig do
+          params(
+            name: String,
+            description: T.nilable(String)
+          ).void
+        end
+        def initialize(name:, description: nil)
+          @name = name
+          @description = description
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            name: @name,
+            description: @description
+          }
+        end
+      end
+
+      # Basic metadata about the agent.
+      #
+      # Useful for discovery UIs, agent marketplaces, and debugging. Set these when you want
+      # clients to display agent information or when multiple agents are available and users
+      # need to pick one.
+      #
+      # @param name [String] Human-readable name shown in UIs and agent selectors.
+      # @param type [String] The framework or platform powering this agent (e.g., \"langgraph\", \"mastra\", \"crewai\").
+      # @param description [String] What this agent does — helps users and routing logic decide when to use it.
+      # @param version [String] Semantic version of the agent (e.g., \"1.2.0\"). Useful for compatibility checks.
+      # @param provider [String] Organization or team that maintains this agent.
+      # @param documentation_url [String] URL to the agent's documentation or homepage.
+      # @param metadata [Hash<String, Object>] Arbitrary key-value pairs for integration-specific identity info.
+      class IdentityCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(String)) }
+        attr_reader :name
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :type
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :description
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :version
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :provider
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :documentation_url
+
+        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        attr_reader :metadata
+
+        sig do
+          params(
+            name: T.nilable(String),
+            type: T.nilable(String),
+            description: T.nilable(String),
+            version: T.nilable(String),
+            provider: T.nilable(String),
+            documentation_url: T.nilable(String),
+            metadata: T.nilable(T::Hash[String, T.untyped])
+          ).void
+        end
+        def initialize(
+          name: nil, type: nil, description: nil, version: nil,
+          provider: nil, documentation_url: nil, metadata: nil
+        )
+          @name = name
+          @type = type
+          @description = description
+          @version = version
+          @provider = provider
+          @documentation_url = documentation_url
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            name: @name,
+            type: @type,
+            description: @description,
+            version: @version,
+            provider: @provider,
+            documentation_url: @documentation_url,
+            metadata: @metadata
+          }
+        end
+      end
+
+      # Declares which transport mechanisms the agent supports.
+      #
+      # Clients use this to pick the best connection strategy. Only set flags to +true+ for
+      # transports your agent actually handles — omit or set +false+ for unsupported ones.
+      #
+      # @param streaming [Boolean] Set +true+ if the agent streams responses via SSE. Most agents enable this.
+      # @param websocket [Boolean] Set +true+ if the agent accepts persistent WebSocket connections.
+      # @param http_binary [Boolean] Set +true+ if the agent supports the AG-UI binary protocol (protobuf over HTTP).
+      # @param push_notifications [Boolean] Set +true+ if the agent can send async updates via webhooks after a run finishes.
+      # @param resumable [Boolean] Set +true+ if the agent supports resuming interrupted streams via sequence numbers.
+      class TransportCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :streaming
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :websocket
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :http_binary
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :push_notifications
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :resumable
+
+        sig do
+          params(
+            streaming: T.nilable(T::Boolean),
+            websocket: T.nilable(T::Boolean),
+            http_binary: T.nilable(T::Boolean),
+            push_notifications: T.nilable(T::Boolean),
+            resumable: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(
+          streaming: nil, websocket: nil, http_binary: nil,
+          push_notifications: nil, resumable: nil
+        )
+          @streaming = streaming
+          @websocket = websocket
+          @http_binary = http_binary
+          @push_notifications = push_notifications
+          @resumable = resumable
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            streaming: @streaming,
+            websocket: @websocket,
+            http_binary: @http_binary,
+            push_notifications: @push_notifications,
+            resumable: @resumable
+          }
+        end
+      end
+
+      # Tool calling capabilities.
+      #
+      # Distinguishes between tools the agent itself provides (listed in +items+) and tools
+      # the client passes at runtime via +RunAgentInput.tools+. Enable this when your agent
+      # can call functions, search the web, execute code, etc.
+      #
+      # @param supported [Boolean] Set +true+ if the agent can make tool calls at all. Set +false+ to explicitly signal tool calling is disabled even if items are present.
+      # @param items [Array<Tool>] The tools this agent provides on its own (full JSON Schema definitions). These are distinct from client-provided tools passed in RunAgentInput.tools.
+      # @param parallel_calls [Boolean] Set +true+ if the agent can invoke multiple tools concurrently within a single step.
+      # @param client_provided [Boolean] Set +true+ if the agent accepts and uses tools provided by the client at runtime.
+      class ToolsCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :supported
+
+        sig { returns(T.nilable(T::Array[AgUiProtocol::Core::Types::Tool])) }
+        attr_reader :items
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :parallel_calls
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :client_provided
+
+        sig do
+          params(
+            supported: T.nilable(T::Boolean),
+            items: T.nilable(T::Array[AgUiProtocol::Core::Types::Tool]),
+            parallel_calls: T.nilable(T::Boolean),
+            client_provided: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(
+          supported: nil, items: nil, parallel_calls: nil, client_provided: nil
+        )
+          @supported = supported
+          @items = items
+          @parallel_calls = parallel_calls
+          @client_provided = client_provided
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            supported: @supported,
+            items: @items,
+            parallel_calls: @parallel_calls,
+            client_provided: @client_provided
+          }
+        end
+      end
+
+      # Output format support.
+      #
+      # Enable +structured_output+ when your agent can return responses conforming to a
+      # JSON schema, which is useful for programmatic consumption.
+      #
+      # @param structured_output [Boolean] Set +true+ if the agent can produce structured JSON output matching a provided schema.
+      # @param supported_mime_types [Array<String>] MIME types the agent can produce (e.g., [\"text/plain\", \"application/json\"]). Omit if the agent only produces plain text.
+      class OutputCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :structured_output
+
+        sig { returns(T.nilable(T::Array[String])) }
+        attr_reader :supported_mime_types
+
+        sig do
+          params(
+            structured_output: T.nilable(T::Boolean),
+            supported_mime_types: T.nilable(T::Array[String])
+          ).void
+        end
+        def initialize(structured_output: nil, supported_mime_types: nil)
+          @structured_output = structured_output
+          @supported_mime_types = supported_mime_types
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            structured_output: @structured_output,
+            supported_mime_types: @supported_mime_types
+          }
+        end
+      end
+
+      # State and memory management capabilities.
+      #
+      # These tell the client how the agent handles shared state and whether conversation
+      # context persists across runs.
+      #
+      # @param snapshots [Boolean] Set +true+ if the agent emits STATE_SNAPSHOT events (full state replacement).
+      # @param deltas [Boolean] Set +true+ if the agent emits STATE_DELTA events (JSON Patch incremental updates).
+      # @param memory [Boolean] Set +true+ if the agent has long-term memory beyond the current thread (e.g., vector store, knowledge base, or cross-session recall).
+      # @param persistent_state [Boolean] Set +true+ if state is preserved across multiple runs within the same thread. When +false+, state resets on each run.
+      class StateCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :snapshots
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :deltas
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :memory
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :persistent_state
+
+        sig do
+          params(
+            snapshots: T.nilable(T::Boolean),
+            deltas: T.nilable(T::Boolean),
+            memory: T.nilable(T::Boolean),
+            persistent_state: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(snapshots: nil, deltas: nil, memory: nil, persistent_state: nil)
+          @snapshots = snapshots
+          @deltas = deltas
+          @memory = memory
+          @persistent_state = persistent_state
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            snapshots: @snapshots,
+            deltas: @deltas,
+            memory: @memory,
+            persistent_state: @persistent_state
+          }
+        end
+      end
+
+      # Multi-agent coordination capabilities.
+      #
+      # Enable these when your agent can orchestrate or hand off work to other agents.
+      #
+      # @param supported [Boolean] Set +true+ if the agent participates in any form of multi-agent coordination.
+      # @param delegation [Boolean] Set +true+ if the agent can delegate subtasks to other agents while retaining control.
+      # @param handoffs [Boolean] Set +true+ if the agent can transfer the conversation entirely to another agent.
+      # @param sub_agents [Array<SubAgentInfo>] List of sub-agents this agent can invoke. Helps clients build agent selection UIs.
+      class MultiAgentCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :supported
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :delegation
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :handoffs
+
+        sig { returns(T.nilable(T::Array[SubAgentInfo])) }
+        attr_reader :sub_agents
+
+        sig do
+          params(
+            supported: T.nilable(T::Boolean),
+            delegation: T.nilable(T::Boolean),
+            handoffs: T.nilable(T::Boolean),
+            sub_agents: T.nilable(T::Array[SubAgentInfo])
+          ).void
+        end
+        def initialize(
+          supported: nil, delegation: nil, handoffs: nil, sub_agents: nil
+        )
+          @supported = supported
+          @delegation = delegation
+          @handoffs = handoffs
+          @sub_agents = sub_agents
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            supported: @supported,
+            delegation: @delegation,
+            handoffs: @handoffs,
+            sub_agents: @sub_agents
+          }
+        end
+      end
+
+      # Reasoning and thinking capabilities.
+      #
+      # Enable these when your agent exposes its internal thought process (e.g.,
+      # chain-of-thought, extended thinking).
+      #
+      # @param supported [Boolean] Set +true+ if the agent produces reasoning/thinking tokens visible to the client.
+      # @param streaming [Boolean] Set +true+ if reasoning tokens are streamed incrementally (vs. returned all at once).
+      # @param encrypted [Boolean] Set +true+ if reasoning content is encrypted (zero-data-retention mode). Clients should expect opaque +encrypted_value+ fields instead of readable content.
+      class ReasoningCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :supported
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :streaming
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :encrypted
+
+        sig do
+          params(
+            supported: T.nilable(T::Boolean),
+            streaming: T.nilable(T::Boolean),
+            encrypted: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(supported: nil, streaming: nil, encrypted: nil)
+          @supported = supported
+          @streaming = streaming
+          @encrypted = encrypted
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            supported: @supported,
+            streaming: @streaming,
+            encrypted: @encrypted
+          }
+        end
+      end
+
+      # Modalities the agent can accept as input.
+      #
+      # Clients use this to show/hide file upload buttons, audio recorders, image pickers, etc.
+      #
+      # @param image [Boolean] Set +true+ if the agent can process image inputs (e.g., screenshots, photos).
+      # @param audio [Boolean] Set +true+ if the agent can process audio inputs (speech, recordings).
+      # @param video [Boolean] Set +true+ if the agent can process video inputs.
+      # @param pdf [Boolean] Set +true+ if the agent can process PDF documents.
+      # @param file [Boolean] Set +true+ if the agent can process arbitrary file uploads.
+      class MultimodalInputCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :image
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :audio
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :video
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :pdf
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :file
+
+        sig do
+          params(
+            image: T.nilable(T::Boolean),
+            audio: T.nilable(T::Boolean),
+            video: T.nilable(T::Boolean),
+            pdf: T.nilable(T::Boolean),
+            file: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(image: nil, audio: nil, video: nil, pdf: nil, file: nil)
+          @image = image
+          @audio = audio
+          @video = video
+          @pdf = pdf
+          @file = file
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            image: @image,
+            audio: @audio,
+            video: @video,
+            pdf: @pdf,
+            file: @file
+          }
+        end
+      end
+
+      # Modalities the agent can produce as output.
+      #
+      # Clients use this to anticipate rich content in the agent's response.
+      #
+      # @param image [Boolean] Set +true+ if the agent can generate images as part of its response.
+      # @param audio [Boolean] Set +true+ if the agent can produce audio output (text-to-speech, audio files).
+      class MultimodalOutputCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :image
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :audio
+
+        sig do
+          params(
+            image: T.nilable(T::Boolean),
+            audio: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(image: nil, audio: nil)
+          @image = image
+          @audio = audio
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            image: @image,
+            audio: @audio
+          }
+        end
+      end
+
+      # Multimodal input and output support.
+      #
+      # Organized into +input+ and +output+ sub-objects so clients can independently query
+      # what the agent accepts versus what it produces.
+      #
+      # @param input [MultimodalInputCapabilities] Modalities the agent can accept as input (images, audio, video, PDFs, files).
+      # @param output [MultimodalOutputCapabilities] Modalities the agent can produce as output (images, audio).
+      class MultimodalCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(MultimodalInputCapabilities)) }
+        attr_reader :input
+
+        sig { returns(T.nilable(MultimodalOutputCapabilities)) }
+        attr_reader :output
+
+        sig do
+          params(
+            input: T.nilable(MultimodalInputCapabilities),
+            output: T.nilable(MultimodalOutputCapabilities)
+          ).void
+        end
+        def initialize(input: nil, output: nil)
+          @input = input
+          @output = output
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            input: @input,
+            output: @output
+          }
+        end
+      end
+
+      # Execution control and limits.
+      #
+      # Declare these so clients can set expectations about how long or how many steps an
+      # agent run might take.
+      #
+      # @param code_execution [Boolean] Set +true+ if the agent can execute code (e.g., Python, JavaScript) during a run.
+      # @param sandboxed [Boolean] Set +true+ if code execution happens in a sandboxed/isolated environment. Only meaningful when +code_execution+ is +true+.
+      # @param max_iterations [Integer] Maximum number of tool-call/reasoning iterations the agent will perform per run. Helps clients display progress or set timeout expectations.
+      # @param max_execution_time [Integer] Maximum wall-clock time (in milliseconds) the agent will run before timing out.
+      class ExecutionCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :code_execution
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :sandboxed
+
+        sig { returns(T.nilable(Integer)) }
+        attr_reader :max_iterations
+
+        sig { returns(T.nilable(Integer)) }
+        attr_reader :max_execution_time
+
+        sig do
+          params(
+            code_execution: T.nilable(T::Boolean),
+            sandboxed: T.nilable(T::Boolean),
+            max_iterations: T.nilable(Integer),
+            max_execution_time: T.nilable(Integer)
+          ).void
+        end
+        def initialize(
+          code_execution: nil, sandboxed: nil,
+          max_iterations: nil, max_execution_time: nil
+        )
+          @code_execution = code_execution
+          @sandboxed = sandboxed
+          @max_iterations = max_iterations
+          @max_execution_time = max_execution_time
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            code_execution: @code_execution,
+            sandboxed: @sandboxed,
+            max_iterations: @max_iterations,
+            max_execution_time: @max_execution_time
+          }
+        end
+      end
+
+      # Human-in-the-loop interaction support.
+      #
+      # Enable these when your agent can pause execution to request human input, approval,
+      # or feedback before continuing.
+      #
+      # @param supported [Boolean] Set +true+ if the agent supports any form of human-in-the-loop interaction.
+      # @param approvals [Boolean] Set +true+ if the agent can pause and request explicit approval before performing sensitive actions (e.g., sending emails, deleting data).
+      # @param interventions [Boolean] Set +true+ if the agent allows humans to intervene and modify its plan mid-execution.
+      # @param feedback [Boolean] Set +true+ if the agent can incorporate user feedback (thumbs up/down, corrections) to improve its behavior within the current session.
+      # @param interrupts [Boolean] Set +true+ if the agent participates in the AG-UI interrupt protocol (emits RUN_FINISHED with interrupt outcome, accepts resume[]).
+      # @param approve_with_edits [Boolean] Set +true+ if tool-call interrupts accept editedArgs in the resume payload. Only meaningful when interrupts is true.
+      class HumanInTheLoopCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :supported
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :approvals
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :interventions
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :feedback
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :interrupts
+
+        sig { returns(T.nilable(T::Boolean)) }
+        attr_reader :approve_with_edits
+
+        sig do
+          params(
+            supported: T.nilable(T::Boolean),
+            approvals: T.nilable(T::Boolean),
+            interventions: T.nilable(T::Boolean),
+            feedback: T.nilable(T::Boolean),
+            interrupts: T.nilable(T::Boolean),
+            approve_with_edits: T.nilable(T::Boolean)
+          ).void
+        end
+        def initialize(
+          supported: nil, approvals: nil, interventions: nil,
+          feedback: nil, interrupts: nil, approve_with_edits: nil
+        )
+          @supported = supported
+          @approvals = approvals
+          @interventions = interventions
+          @feedback = feedback
+          @interrupts = interrupts
+          @approve_with_edits = approve_with_edits
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            supported: @supported,
+            approvals: @approvals,
+            interventions: @interventions,
+            feedback: @feedback,
+            interrupts: @interrupts,
+            approve_with_edits: @approve_with_edits
+          }
+        end
+      end
+
+      # A categorized snapshot of an agent's current capabilities.
+      #
+      # All fields are optional — agents only declare what they support. Omitted fields mean
+      # the capability is not declared (unknown), not that it's unsupported.
+      #
+      # The +custom+ field is an escape hatch for integration-specific capabilities that
+      # don't fit into the standard categories.
+      #
+      # @param identity [IdentityCapabilities] Agent identity and metadata.
+      # @param transport [TransportCapabilities] Supported transport mechanisms (SSE, WebSocket, binary, etc.).
+      # @param tools [ToolsCapabilities] Tools the agent provides and tool calling configuration.
+      # @param output [OutputCapabilities] Output format support (structured output, MIME types).
+      # @param state [StateCapabilities] State and memory management (snapshots, deltas, persistence).
+      # @param multi_agent [MultiAgentCapabilities] Multi-agent coordination (delegation, handoffs, sub-agents).
+      # @param reasoning [ReasoningCapabilities] Reasoning and thinking support (chain-of-thought, encrypted thinking).
+      # @param multimodal [MultimodalCapabilities] Multimodal input/output support (images, audio, video, files).
+      # @param execution [ExecutionCapabilities] Execution control and limits (code execution, timeouts, iteration caps).
+      # @param human_in_the_loop [HumanInTheLoopCapabilities] Human-in-the-loop support (approvals, interventions, feedback).
+      # @param custom [Hash<String, Object>] Integration-specific capabilities not covered by the standard categories.
+      class AgentCapabilities < AgUiProtocol::Core::Types::Model
+        sig { returns(T.nilable(IdentityCapabilities)) }
+        attr_reader :identity
+
+        sig { returns(T.nilable(TransportCapabilities)) }
+        attr_reader :transport
+
+        sig { returns(T.nilable(ToolsCapabilities)) }
+        attr_reader :tools
+
+        sig { returns(T.nilable(OutputCapabilities)) }
+        attr_reader :output
+
+        sig { returns(T.nilable(StateCapabilities)) }
+        attr_reader :state
+
+        sig { returns(T.nilable(MultiAgentCapabilities)) }
+        attr_reader :multi_agent
+
+        sig { returns(T.nilable(ReasoningCapabilities)) }
+        attr_reader :reasoning
+
+        sig { returns(T.nilable(MultimodalCapabilities)) }
+        attr_reader :multimodal
+
+        sig { returns(T.nilable(ExecutionCapabilities)) }
+        attr_reader :execution
+
+        sig { returns(T.nilable(HumanInTheLoopCapabilities)) }
+        attr_reader :human_in_the_loop
+
+        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        attr_reader :custom
+
+        sig do
+          params(
+            identity: T.nilable(IdentityCapabilities),
+            transport: T.nilable(TransportCapabilities),
+            tools: T.nilable(ToolsCapabilities),
+            output: T.nilable(OutputCapabilities),
+            state: T.nilable(StateCapabilities),
+            multi_agent: T.nilable(MultiAgentCapabilities),
+            reasoning: T.nilable(ReasoningCapabilities),
+            multimodal: T.nilable(MultimodalCapabilities),
+            execution: T.nilable(ExecutionCapabilities),
+            human_in_the_loop: T.nilable(HumanInTheLoopCapabilities),
+            custom: T.nilable(T::Hash[String, T.untyped])
+          ).void
+        end
+        def initialize(
+          identity: nil, transport: nil, tools: nil, output: nil,
+          state: nil, multi_agent: nil, reasoning: nil, multimodal: nil,
+          execution: nil, human_in_the_loop: nil, custom: nil
+        )
+          @identity = identity
+          @transport = transport
+          @tools = tools
+          @output = output
+          @state = state
+          @multi_agent = multi_agent
+          @reasoning = reasoning
+          @multimodal = multimodal
+          @execution = execution
+          @human_in_the_loop = human_in_the_loop
+          @custom = custom
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            identity: @identity,
+            transport: @transport,
+            tools: @tools,
+            output: @output,
+            state: @state,
+            multi_agent: @multi_agent,
+            reasoning: @reasoning,
+            multimodal: @multimodal,
+            execution: @execution,
+            human_in_the_loop: @human_in_the_loop,
+            custom: @custom
+          }
+        end
+      end
+    end
+  end
+end

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
@@ -22,6 +22,16 @@ module AgUiProtocol
     #
     # These events represent the lifecycle of tool calls made by agents.
     #
+    # ## Thinking Events
+    #
+    # These events represent the lifecycle of an agent's thinking steps, conveying
+    # intermediate reasoning to the frontend without contributing to the final message.
+    #
+    # ## Reasoning Events
+    #
+    # These events convey structured reasoning blocks emitted by an agent, including
+    # streaming reasoning messages and encrypted reasoning values.
+    #
     # ## State Management Events
     #
     # These events are used to manage agent state.
@@ -30,7 +40,7 @@ module AgUiProtocol
       # Valid values for the role attribute of a text message.
       TEXT_MESSAGE_ROLE_VALUES = ["developer", "system", "assistant", "user", "reasoning"].freeze
 
-      # The `EventType` module defines all possible event types in the system
+      # The `EventType` module defines all possible event types in the system.
       module EventType
         TEXT_MESSAGE_START = "TEXT_MESSAGE_START"
         TEXT_MESSAGE_CONTENT = "TEXT_MESSAGE_CONTENT"
@@ -67,8 +77,10 @@ module AgUiProtocol
         REASONING_ENCRYPTED_VALUE = "REASONING_ENCRYPTED_VALUE"
       end
 
-      # All events inherit from the `BaseEvent` class, which provides common properties
-      # shared across all event types.
+      # All event classes inherit from `BaseEvent`, which provides common properties
+      # shared across all event types. Value types in this module
+      # (RunFinishedSuccessOutcome, RunFinishedInterruptOutcome) inherit directly from
+      # `Model` — they are payload types referenced by events, not events themselves.
       # ```ruby
       #
       # event = AgUiProtocol::Core::Events::BaseEvent.new(
@@ -129,13 +141,16 @@ module AgUiProtocol
         attr_reader :role
 
         # @param message_id [String] Unique identifier for the message
+        # @param role [String] Must be one of TEXT_MESSAGE_ROLE_VALUES; defaults to "assistant"
         # @param timestamp [Time] Timestamp when the event was created
         # @param raw_event [Object] Original event data if this event was transformed
-        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
-        def initialize(message_id:, timestamp: nil, raw_event: nil)
+        sig { params(message_id: String, role: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, role: "assistant", timestamp: nil, raw_event: nil)
+          raise ArgumentError, "role must be one of #{TEXT_MESSAGE_ROLE_VALUES.join(", ")}, got #{role}" unless TEXT_MESSAGE_ROLE_VALUES.include?(role)
+
           super(type: EventType::TEXT_MESSAGE_START, timestamp: timestamp, raw_event: raw_event)
           @message_id = message_id
-          @role = 'assistant'
+          @role = role
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -242,18 +257,18 @@ module AgUiProtocol
         # @param delta [String] Text content chunk
         # @param timestamp [Time] Timestamp when the event was created
         # @param raw_event [Object] Original event data if this event was transformed
-        sig do 
+        sig do
           params(
             message_id: T.nilable(String),
             role: T.nilable(String),
             delta: T.nilable(String),
             timestamp: T.nilable(Time),
             raw_event: T.untyped,
-          ).void 
+          ).void
         end
         def initialize(message_id: nil, role: nil, delta: nil, timestamp: nil, raw_event: nil)
           raise ArgumentError, "role must be one of #{TEXT_MESSAGE_ROLE_VALUES.join(", ")}, got #{role}" if !role.nil? && !TEXT_MESSAGE_ROLE_VALUES.include?(role)
-          
+
           super(type: EventType::TEXT_MESSAGE_CHUNK, timestamp: timestamp, raw_event: raw_event)
           @message_id = message_id
           @role = role
@@ -530,8 +545,8 @@ module AgUiProtocol
           ).void
         end
         def initialize(message_id:, tool_call_id:, content:, role: nil, timestamp: nil, raw_event: nil)
-          raise ArgumentError, "role must be tool, got #{role}" if !role.nil? && role != "tool"
-          
+          raise ArgumentError, "role must be \"tool\", got #{role.inspect}" if !role.nil? && role != "tool"
+
           super(type: EventType::TOOL_CALL_RESULT, timestamp: timestamp, raw_event: raw_event)
           @message_id = message_id
           @tool_call_id = tool_call_id
@@ -647,7 +662,9 @@ module AgUiProtocol
       # Provides a snapshot of all messages in a conversation.
       #
       # ```ruby
-      # event = AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(messages: [{ "id" => "m1", "content" => "hi" }])
+      # event = AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(
+      #   messages: [AgUiProtocol::Core::Types::UserMessage.new(id: "m1", content: "hi")]
+      # )
       # ```
       #
       # @category State Management Events
@@ -655,13 +672,13 @@ module AgUiProtocol
         sig { returns(T::Array[T.untyped]) }
         attr_reader :messages
 
-        # @param messages [Array<AgUiProtocol::Core::Types::BaseMessage>] Array of message objects
+        # @param messages [Array<AgUiProtocol::Core::Types::BaseMessage, AgUiProtocol::Core::Types::ActivityMessage>] Array of message objects. Accepts both BaseMessage subclasses and ActivityMessage for parity with RunAgentInput.
         # @param timestamp [Time] Timestamp when the event was created
         # @param raw_event [Object] Original event data if this event was transformed
-        sig { params(messages: T::Array[AgUiProtocol::Core::Types::BaseMessage], timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        sig { params(messages: T::Array[T.any(AgUiProtocol::Core::Types::BaseMessage, AgUiProtocol::Core::Types::ActivityMessage)], timestamp: T.nilable(Time), raw_event: T.untyped).void }
         def initialize(messages:, timestamp: nil, raw_event: nil)
-          unless messages.is_a?(Array) && messages.all? { |m| m.is_a?(AgUiProtocol::Core::Types::BaseMessage) }
-            raise ArgumentError, "messages must be an Array of BaseMessage"
+          unless messages.is_a?(Array) && messages.all? { |m| m.is_a?(AgUiProtocol::Core::Types::BaseMessage) || m.is_a?(AgUiProtocol::Core::Types::ActivityMessage) }
+            raise ArgumentError, "messages must be an Array of BaseMessage or ActivityMessage"
           end
 
           super(type: EventType::MESSAGES_SNAPSHOT, timestamp: timestamp, raw_event: raw_event)
@@ -871,6 +888,8 @@ module AgUiProtocol
         # @param run_id [String] ID of the run
         # @param parent_run_id [String] Lineage pointer for branching/time travel. If present, refers to a prior run within the same thread
         # @param input [Object] The exact agent input payload sent to the agent for this run. May omit messages already in history
+        # @param timestamp [Time, nil] Timestamp when the event was created
+        # @param raw_event [Object, nil] Original event data if this event was transformed
         sig do
           params(
             thread_id: String,
@@ -900,7 +919,74 @@ module AgUiProtocol
         end
       end
 
-      # Signals the successful completion of an agent run.
+      # Represents a successful outcome for a run.
+      #
+      # The `type` discriminator is enforced — only "success" is accepted (or nil for default).
+      # The optional `type:` kwarg exists to support round-trip deserialization from `to_h`
+      # output (which emits `type: "success"`); supplying any other value raises ArgumentError.
+      #
+      # ```ruby
+      # outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+      # ```
+      class RunFinishedSuccessOutcome < AgUiProtocol::Core::Types::Model
+        sig { returns(String) }
+        attr_reader :type
+
+        # @param type [String, nil] Optional. Must be "success" if provided. Always stored as "success"; the kwarg exists to support round-trip deserialization from `to_h` output.
+        sig { params(type: T.nilable(String)).void }
+        def initialize(type: nil)
+          if !type.nil? && type != "success"
+            raise ArgumentError, "RunFinishedSuccessOutcome.type must be \"success\""
+          end
+
+          @type = "success"
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          { type: @type }
+        end
+      end
+
+      # Represents an interrupt outcome for a run.
+      #
+      # ```ruby
+      # outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
+      #   interrupts: [
+      #     AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
+      #   ]
+      # )
+      # ```
+      class RunFinishedInterruptOutcome < AgUiProtocol::Core::Types::Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T::Array[AgUiProtocol::Core::Types::Interrupt]) }
+        attr_reader :interrupts
+
+        # @param interrupts [Array<AgUiProtocol::Core::Types::Interrupt>] List of interrupts
+        # @param type [String, nil] Optional. Must be "interrupt" if provided. Always stored as "interrupt"; the kwarg exists to support round-trip deserialization from `to_h` output.
+        sig { params(interrupts: T::Array[AgUiProtocol::Core::Types::Interrupt], type: T.nilable(String)).void }
+        def initialize(interrupts:, type: nil)
+          unless interrupts.is_a?(Array) && interrupts.all? { |i| i.is_a?(AgUiProtocol::Core::Types::Interrupt) }
+            raise ArgumentError, "interrupts must be an Array of Interrupt"
+          end
+
+          if !type.nil? && type != "interrupt"
+            raise ArgumentError, "RunFinishedInterruptOutcome.type must be \"interrupt\""
+          end
+
+          @type = "interrupt"
+          @interrupts = interrupts
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          { type: @type, interrupts: @interrupts }
+        end
+      end
+
+      # Signals the completion of an agent run. The `outcome` field discriminates between success and interrupt: provide either a `RunFinishedSuccessOutcome` or `RunFinishedInterruptOutcome` (or use the legacy `result` field; the two are mutually exclusive).
       #
       # ```ruby
       #
@@ -924,10 +1010,11 @@ module AgUiProtocol
 
         # @param thread_id [String] ID of the conversation thread
         # @param run_id [String] ID of the run
-        # @param result [Object] Result data from the agent run
-        # @param outcome [RunFinishedSuccessOutcome, RunFinishedInterruptOutcome] Outcome of the run
+        # @param result [Object] Result data from the agent run. Mutually exclusive with `outcome`.
+        # @param outcome [RunFinishedSuccessOutcome, RunFinishedInterruptOutcome] Outcome of the run. Mutually exclusive with `result`.
         # @param timestamp [Time] Timestamp when the event was created
         # @param raw_event [Object] Original event data if this event was transformed
+        # @raise [ArgumentError] when both `result` and `outcome` are non-nil. Callers must choose one.
         sig do
           params(
             thread_id: String,
@@ -939,6 +1026,10 @@ module AgUiProtocol
           ).void
         end
         def initialize(thread_id:, run_id:, result: nil, outcome: nil, timestamp: nil, raw_event: nil)
+          if !result.nil? && !outcome.nil?
+            raise ArgumentError, "result and outcome are mutually exclusive; provide one or the other, not both"
+          end
+
           super(type: EventType::RUN_FINISHED, timestamp: timestamp, raw_event: raw_event)
           @thread_id = thread_id
           @run_id = run_id
@@ -1041,9 +1132,6 @@ module AgUiProtocol
         end
       end
 
-      # Valid values for reasoning encrypted value subtype.
-      ReasoningEncryptedValueSubtype = T.type_alias { T.any(String, T.nilable(String)) }
-
       # Signals the start of a reasoning block.
       #
       # ```ruby
@@ -1072,6 +1160,10 @@ module AgUiProtocol
 
       # Signals the start of a reasoning message within a reasoning block.
       #
+      # The `role` is always "reasoning" (enforced). The optional `role:` kwarg exists
+      # to support round-trip deserialization from `to_h` output (which emits
+      # `role: "reasoning"`); supplying any other value raises ArgumentError.
+      #
       # ```ruby
       # event = AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id: "reason_msg_1")
       # ```
@@ -1085,12 +1177,18 @@ module AgUiProtocol
         attr_reader :role
 
         # @param message_id [String] Unique identifier
+        # @param role [String, nil] Optional. Must be "reasoning" if provided. Always stored as "reasoning"; the kwarg exists to support round-trip deserialization from `to_h` output.
         # @param timestamp [Time] Timestamp when the event was created
         # @param raw_event [Object] Original event data if this event was transformed
-        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
-        def initialize(message_id:, timestamp: nil, raw_event: nil)
+        sig { params(message_id: String, role: T.nilable(String), timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, role: nil, timestamp: nil, raw_event: nil)
+          if !role.nil? && role != "reasoning"
+            raise ArgumentError, "ReasoningMessageStartEvent.role must be \"reasoning\""
+          end
+
           super(type: EventType::REASONING_MESSAGE_START, timestamp: timestamp, raw_event: raw_event)
           @message_id = message_id
+          # Role is always "reasoning" for ReasoningMessageStartEvent.
           @role = "reasoning"
         end
 
@@ -1245,7 +1343,7 @@ module AgUiProtocol
         sig { returns(String) }
         attr_reader :encrypted_value
 
-        # @param subtype [String] Subtype ("tool-call" or "message")
+        # @param subtype [String] free-form string; protocol values are "tool-call" or "message" but not enforced by this SDK
         # @param entity_id [String] ID of the entity being encrypted
         # @param encrypted_value [String] The encrypted value
         # @param timestamp [Time] Timestamp when the event was created
@@ -1272,55 +1370,6 @@ module AgUiProtocol
         end
       end
 
-      # Represents a successful outcome for a run.
-      #
-      # ```ruby
-      # outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
-      # ```
-      class RunFinishedSuccessOutcome < AgUiProtocol::Core::Types::Model
-        sig { returns(String) }
-        attr_reader :type
-
-        sig { params(type: String).void }
-        def initialize(type: "success")
-          @type = type
-        end
-
-        sig { returns(T::Hash[Symbol, T.untyped]) }
-        def to_h
-          { type: @type }
-        end
-      end
-
-      # Represents an interrupt outcome for a run.
-      #
-      # ```ruby
-      # outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
-      #   interrupts: [
-      #     AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
-      #   ]
-      # )
-      # ```
-      class RunFinishedInterruptOutcome < AgUiProtocol::Core::Types::Model
-        sig { returns(String) }
-        attr_reader :type
-
-        sig { returns(T::Array[AgUiProtocol::Core::Types::Interrupt]) }
-        attr_reader :interrupts
-
-        # @param interrupts [Array<AgUiProtocol::Core::Types::Interrupt>] List of interrupts
-        # @param type [String] Outcome type
-        sig { params(interrupts: T::Array[AgUiProtocol::Core::Types::Interrupt], type: String).void }
-        def initialize(interrupts:, type: "interrupt")
-          @type = type
-          @interrupts = interrupts
-        end
-
-        sig { returns(T::Hash[Symbol, T.untyped]) }
-        def to_h
-          { type: @type, interrupts: @interrupts }
-        end
-      end
     end
   end
 end

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
@@ -28,7 +28,7 @@ module AgUiProtocol
     #
     module Events
       # Valid values for the role attribute of a text message.
-      TEXT_MESSAGE_ROLE_VALUES = ["developer", "system", "assistant", "user"].freeze
+      TEXT_MESSAGE_ROLE_VALUES = ["developer", "system", "assistant", "user", "reasoning"].freeze
 
       # The `EventType` module defines all possible event types in the system
       module EventType
@@ -58,6 +58,13 @@ module AgUiProtocol
         RUN_ERROR = "RUN_ERROR"
         STEP_STARTED = "STEP_STARTED"
         STEP_FINISHED = "STEP_FINISHED"
+        REASONING_START = "REASONING_START"
+        REASONING_MESSAGE_START = "REASONING_MESSAGE_START"
+        REASONING_MESSAGE_CONTENT = "REASONING_MESSAGE_CONTENT"
+        REASONING_MESSAGE_END = "REASONING_MESSAGE_END"
+        REASONING_MESSAGE_CHUNK = "REASONING_MESSAGE_CHUNK"
+        REASONING_END = "REASONING_END"
+        REASONING_ENCRYPTED_VALUE = "REASONING_ENCRYPTED_VALUE"
       end
 
       # All events inherit from the `BaseEvent` class, which provides common properties
@@ -912,22 +919,36 @@ module AgUiProtocol
         sig { returns(T.untyped) }
         attr_reader :result
 
+        sig { returns(T.nilable(T.any(RunFinishedSuccessOutcome, RunFinishedInterruptOutcome))) }
+        attr_reader :outcome
+
         # @param thread_id [String] ID of the conversation thread
         # @param run_id [String] ID of the run
         # @param result [Object] Result data from the agent run
-          # @param timestamp [Time] Timestamp when the event was created
-          # @param raw_event [Object] Original event data if this event was transformed
-        sig { params(thread_id: String, run_id: String, result: T.untyped, timestamp: T.nilable(Time), raw_event: T.untyped).void }
-        def initialize(thread_id:, run_id:, result: nil, timestamp: nil, raw_event: nil)
+        # @param outcome [RunFinishedSuccessOutcome, RunFinishedInterruptOutcome] Outcome of the run
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig do
+          params(
+            thread_id: String,
+            run_id: String,
+            result: T.untyped,
+            outcome: T.nilable(T.any(RunFinishedSuccessOutcome, RunFinishedInterruptOutcome)),
+            timestamp: T.nilable(Time),
+            raw_event: T.untyped
+          ).void
+        end
+        def initialize(thread_id:, run_id:, result: nil, outcome: nil, timestamp: nil, raw_event: nil)
           super(type: EventType::RUN_FINISHED, timestamp: timestamp, raw_event: raw_event)
           @thread_id = thread_id
           @run_id = run_id
           @result = result
+          @outcome = outcome
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          super.merge(thread_id: @thread_id, run_id: @run_id, result: @result)
+          super.merge(thread_id: @thread_id, run_id: @run_id, result: @result, outcome: @outcome)
         end
       end
 
@@ -1017,6 +1038,287 @@ module AgUiProtocol
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
           super.merge(step_name: @step_name)
+        end
+      end
+
+      # Valid values for reasoning encrypted value subtype.
+      ReasoningEncryptedValueSubtype = T.type_alias { T.any(String, T.nilable(String)) }
+
+      # Signals the start of a reasoning block.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningStartEvent.new(message_id: "reason_1")
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningStartEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :message_id
+
+        # @param message_id [String] Unique identifier for the reasoning message
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_START, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id)
+        end
+      end
+
+      # Signals the start of a reasoning message within a reasoning block.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id: "reason_msg_1")
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningMessageStartEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :message_id
+
+        sig { returns(String) }
+        attr_reader :role
+
+        # @param message_id [String] Unique identifier
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_MESSAGE_START, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+          @role = "reasoning"
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id, role: @role)
+        end
+      end
+
+      # Represents a chunk of content in a streaming reasoning message.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningMessageContentEvent.new(message_id: "reason_msg_1", delta: "step 1...")
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningMessageContentEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :message_id
+
+        sig { returns(String) }
+        attr_reader :delta
+
+        # @param message_id [String] Matches the ID from ReasoningMessageStartEvent
+        # @param delta [String] Reasoning content chunk
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig { params(message_id: String, delta: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, delta:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_MESSAGE_CONTENT, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+          @delta = delta
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id, delta: @delta)
+        end
+      end
+
+      # Signals the end of a reasoning message.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningMessageEndEvent.new(message_id: "reason_msg_1")
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningMessageEndEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :message_id
+
+        # @param message_id [String] Matches the ID from ReasoningMessageStartEvent
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_MESSAGE_END, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id)
+        end
+      end
+
+      # Convenience event for reasoning messages without manually emitting start/end.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningMessageChunkEvent.new(
+      #   message_id: "reason_msg_1",
+      #   delta: "step 1..."
+      # )
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningMessageChunkEvent < BaseEvent
+        sig { returns(T.nilable(String)) }
+        attr_reader :message_id
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :delta
+
+        # @param message_id [String] Optional on first chunk
+        # @param delta [String] Optional reasoning content chunk
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig do
+          params(
+            message_id: T.nilable(String),
+            delta: T.nilable(String),
+            timestamp: T.nilable(Time),
+            raw_event: T.untyped
+          ).void
+        end
+        def initialize(message_id: nil, delta: nil, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_MESSAGE_CHUNK, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+          @delta = delta
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id, delta: @delta)
+        end
+      end
+
+      # Signals the end of a reasoning block.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningEndEvent.new(message_id: "reason_1")
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningEndEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :message_id
+
+        # @param message_id [String] Matches the ID from ReasoningStartEvent
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig { params(message_id: String, timestamp: T.nilable(Time), raw_event: T.untyped).void }
+        def initialize(message_id:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_END, timestamp: timestamp, raw_event: raw_event)
+          @message_id = message_id
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(message_id: @message_id)
+        end
+      end
+
+      # Event containing an encrypted value within a reasoning block.
+      #
+      # ```ruby
+      # event = AgUiProtocol::Core::Events::ReasoningEncryptedValueEvent.new(
+      #   subtype: "tool-call",
+      #   entity_id: "tc_1",
+      #   encrypted_value: "encrypted..."
+      # )
+      # ```
+      #
+      # @category Reasoning Events
+      class ReasoningEncryptedValueEvent < BaseEvent
+        sig { returns(String) }
+        attr_reader :subtype
+
+        sig { returns(String) }
+        attr_reader :entity_id
+
+        sig { returns(String) }
+        attr_reader :encrypted_value
+
+        # @param subtype [String] Subtype ("tool-call" or "message")
+        # @param entity_id [String] ID of the entity being encrypted
+        # @param encrypted_value [String] The encrypted value
+        # @param timestamp [Time] Timestamp when the event was created
+        # @param raw_event [Object] Original event data if this event was transformed
+        sig do
+          params(
+            subtype: String,
+            entity_id: String,
+            encrypted_value: String,
+            timestamp: T.nilable(Time),
+            raw_event: T.untyped
+          ).void
+        end
+        def initialize(subtype:, entity_id:, encrypted_value:, timestamp: nil, raw_event: nil)
+          super(type: EventType::REASONING_ENCRYPTED_VALUE, timestamp: timestamp, raw_event: raw_event)
+          @subtype = subtype
+          @entity_id = entity_id
+          @encrypted_value = encrypted_value
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          super.merge(subtype: @subtype, entity_id: @entity_id, encrypted_value: @encrypted_value)
+        end
+      end
+
+      # Represents a successful outcome for a run.
+      #
+      # ```ruby
+      # outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+      # ```
+      class RunFinishedSuccessOutcome < AgUiProtocol::Core::Types::Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { params(type: String).void }
+        def initialize(type: "success")
+          @type = type
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          { type: @type }
+        end
+      end
+
+      # Represents an interrupt outcome for a run.
+      #
+      # ```ruby
+      # outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(
+      #   interrupts: [
+      #     AgUiProtocol::Core::Types::Interrupt.new(id: "int_1", reason: "input_required")
+      #   ]
+      # )
+      # ```
+      class RunFinishedInterruptOutcome < AgUiProtocol::Core::Types::Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T::Array[AgUiProtocol::Core::Types::Interrupt]) }
+        attr_reader :interrupts
+
+        # @param interrupts [Array<AgUiProtocol::Core::Types::Interrupt>] List of interrupts
+        # @param type [String] Outcome type
+        sig { params(interrupts: T::Array[AgUiProtocol::Core::Types::Interrupt], type: String).void }
+        def initialize(interrupts:, type: "interrupt")
+          @type = type
+          @interrupts = interrupts
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          { type: @type, interrupts: @interrupts }
         end
       end
     end

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/events.rb
@@ -629,7 +629,8 @@ module AgUiProtocol
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          super.merge(snapshot: @snapshot)
+          # `snapshot` is the agent's user-defined state object — preserve keys verbatim.
+          super.merge(snapshot: @snapshot.nil? ? nil : AgUiProtocol::Util::Opaque.new(@snapshot))
         end
       end
 
@@ -655,7 +656,10 @@ module AgUiProtocol
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          super.merge(delta: @delta)
+          # `delta` is an array of JSON Patch ops; each op's `value` may carry
+          # arbitrary user-defined keys (RFC 6902). Preserve the array
+          # contents verbatim on the wire.
+          super.merge(delta: @delta.nil? ? nil : AgUiProtocol::Util::Opaque.new(@delta))
         end
       end
 
@@ -813,7 +817,8 @@ module AgUiProtocol
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          super.merge(event: @event, source: @source)
+          # `event` is the raw upstream event payload — preserve keys verbatim.
+          super.merge(event: @event.nil? ? nil : AgUiProtocol::Util::Opaque.new(@event), source: @source)
         end
       end
 
@@ -844,7 +849,8 @@ module AgUiProtocol
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          super.merge(name: @name, value: @value)
+          # `value` is an application-specific payload — preserve keys verbatim.
+          super.merge(name: @name, value: @value.nil? ? nil : AgUiProtocol::Util::Opaque.new(@value))
         end
       end
 

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
@@ -25,7 +25,7 @@ module AgUiProtocol
       #
       # ```
       # @category Message Types
-      Role = ["developer", "system", "assistant", "user", "tool", "activity"].freeze
+      Role = ["developer", "system", "assistant", "user", "tool", "activity", "reasoning"].freeze
 
       # Base model for protocol entities.
       #
@@ -119,14 +119,19 @@ module AgUiProtocol
         sig { returns(FunctionCall) }
         attr_reader :function
 
+        sig { returns(T.nilable(String)) }
+        attr_reader :encrypted_value
+
         # @param id [String] Unique identifier for the tool call
         # @param function [FunctionCall, Hash] Function name and arguments
         # @param type [String] Type of the tool call
-        sig { params(id: String, function: T.untyped, type: String).void }
-        def initialize(id:, function:, type: 'function')
+        # @param encrypted_value [String] Encrypted tool call value for zero-data-retention mode
+        sig { params(id: String, function: T.untyped, type: String, encrypted_value: T.nilable(String)).void }
+        def initialize(id:, function:, type: 'function', encrypted_value: nil)
           @id = id
           @type = type
           @function = function.is_a?(FunctionCall) ? function : FunctionCall.new(**function)
+          @encrypted_value = encrypted_value
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -134,7 +139,8 @@ module AgUiProtocol
           {
             id: @id,
             type: @type,
-            function: @function
+            function: @function,
+            encrypted_value: @encrypted_value
           }
         end
       end
@@ -147,22 +153,35 @@ module AgUiProtocol
         sig { returns(String) }
         attr_reader :role
 
-        sig { returns(T.nilable(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)]))) }
+        sig { returns(T.nilable(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)]))) }
         attr_reader :content
 
         sig { returns(T.nilable(String)) }
         attr_reader :name
 
+        sig { returns(T.nilable(String)) }
+        attr_reader :encrypted_value
+
         # @param id [String] Unique identifier for the message
         # @param role [String] Role of the message sender
         # @param content [Object] Text content of the message
         # @param name [String] Optional name of the sender
-        sig { params(id: String, role: String, content: T.nilable(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)])), name: T.nilable(String)).void }
-        def initialize(id:, role:, content: nil, name: nil)
+        # @param encrypted_value [String] Encrypted content for zero-data-retention mode
+        sig do
+          params(
+            id: String,
+            role: String,
+            content: T.nilable(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)])),
+            name: T.nilable(String),
+            encrypted_value: T.nilable(String)
+          ).void
+        end
+        def initialize(id:, role:, content: nil, name: nil, encrypted_value: nil)
           @id = id
           @role = role
           @content = content
           @name = name
+          @encrypted_value = encrypted_value
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -171,7 +190,8 @@ module AgUiProtocol
             id: @id,
             role: @role,
             content: @content,
-            name: @name
+            name: @name,
+            encrypted_value: @encrypted_value
           }
         end
       end
@@ -390,21 +410,31 @@ module AgUiProtocol
         sig { returns(String) }
         attr_reader :role
 
-        sig { returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)])) }
+        sig { returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)])) }
         attr_reader :content
 
         sig { returns(T.nilable(String)) }
         attr_reader :name
 
         # @param id [String] Unique identifier for the message
-        # @param content [String, Array<TextInputContent | BinaryInputContent>] Either a plain text string or an ordered list of multimodal fragments
+        # @param content [String, Array<TextInputContent | BinaryInputContent | ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent>] Either a plain text string or an ordered list of multimodal fragments
         # @param name [String] Optional name of the sender
-        sig { params(id: String, content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)]), name: T.nilable(String)).void }
+        sig do
+          params(
+            id: String,
+            content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)]),
+            name: T.nilable(String)
+          ).void
+        end
         def initialize(id:, content:, name: nil)
           super(id: id, role: "user", content: normalize_user_content(content), name: name)
         end
 
-        sig { params(content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)])).returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent)])) }
+        sig do
+          params(
+            content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)])
+          ).returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)]))
+        end
         def normalize_user_content(content)
           if content.is_a?(Array)
             content.map do |c|
@@ -422,6 +452,14 @@ module AgUiProtocol
                     data: c[:data] || c["data"],
                     filename: c[:filename] || c["filename"]
                   )
+                when "image"
+                  ImageInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
+                when "audio"
+                  AudioInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
+                when "video"
+                  VideoInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
+                when "document"
+                  DocumentInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
                 else
                   c
                 end
@@ -473,15 +511,20 @@ module AgUiProtocol
         sig { returns(T.nilable(String)) }
         attr_reader :error
 
+        sig { returns(T.nilable(String)) }
+        attr_reader :encrypted_value
+
         # @param id [String] Unique identifier for the message.
         # @param content [String] Tool result content.
         # @param tool_call_id [String] ID of the tool call this message responds to.
         # @param error [String] Error payload if the tool call failed.
-        sig { params(id: String, content: String, tool_call_id: String, error: T.nilable(String)).void }
-        def initialize(id:, content:, tool_call_id:, error: nil)
+        # @param encrypted_value [String] Encrypted tool message value for zero-data-retention mode
+        sig { params(id: String, content: String, tool_call_id: String, error: T.nilable(String), encrypted_value: T.nilable(String)).void }
+        def initialize(id:, content:, tool_call_id:, error: nil, encrypted_value: nil)
           super(id: id, role: "tool", content: content)
           @tool_call_id = tool_call_id
           @error = error
+          @encrypted_value = encrypted_value
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -491,7 +534,8 @@ module AgUiProtocol
             role: @role,
             content: @content,
             tool_call_id: @tool_call_id,
-            error: @error
+            error: @error,
+            encrypted_value: @encrypted_value
           }
         end
       end
@@ -615,6 +659,466 @@ module AgUiProtocol
         end
       end
 
+      # Represents a data source for multimodal input content using base64-encoded data.
+      #
+      # ```ruby
+      #
+      # source = AgUiProtocol::Core::Types::InputContentDataSource.new(
+      #   value: "base64encoded...",
+      #   mime_type: "image/png"
+      # )
+      #
+      # ```
+      class InputContentDataSource < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(String) }
+        attr_reader :value
+
+        sig { returns(String) }
+        attr_reader :mime_type
+
+        # @param value [String] Base64 encoded content
+        # @param mime_type [String] MIME type of the content
+        # @param type [String] Identifies the source type
+        sig { params(value: String, mime_type: String, type: String).void }
+        def initialize(value:, mime_type:, type: "data")
+          @type = type
+          @value = value
+          @mime_type = mime_type
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            value: @value,
+            mime_type: @mime_type
+          }
+        end
+      end
+
+      # Represents a URL source for multimodal input content.
+      #
+      # ```ruby
+      #
+      # source = AgUiProtocol::Core::Types::InputContentUrlSource.new(
+      #   value: "https://example.com/image.png",
+      #   mime_type: "image/png"
+      # )
+      #
+      # ```
+      class InputContentUrlSource < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(String) }
+        attr_reader :value
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :mime_type
+
+        # @param value [String] URL string
+        # @param mime_type [String] Optional MIME type
+        # @param type [String] Identifies the source type
+        sig { params(value: String, mime_type: T.nilable(String), type: String).void }
+        def initialize(value:, mime_type: nil, type: "url")
+          @type = type
+          @value = value
+          @mime_type = mime_type
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            value: @value,
+            mime_type: @mime_type
+          }
+        end
+      end
+
+      # Represents an image content fragment inside a multimodal user message.
+      #
+      # ```ruby
+      #
+      # content = AgUiProtocol::Core::Types::ImageInputContent.new(
+      #   source: { type: "url", value: "https://example.com/cat.png", mime_type: "image/png" }
+      # )
+      #
+      # ```
+      class ImageInputContent < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T.any(InputContentDataSource, InputContentUrlSource)) }
+        attr_reader :source
+
+        sig { returns(T.untyped) }
+        attr_reader :metadata
+
+        # @param source [InputContentDataSource, InputContentUrlSource, Hash] Content source
+        # @param metadata [Object] Optional metadata
+        # @param type [String] Identifies the fragment type
+        sig { params(source: T.untyped, metadata: T.untyped, type: String).void }
+        def initialize(source:, metadata: nil, type: "image")
+          @type = type
+          @source = source.is_a?(Hash) ? build_source(source) : source
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            source: @source,
+            metadata: @metadata
+          }
+        end
+
+        private
+
+        def build_source(hash)
+          src_type = hash[:type] || hash["type"]
+          case src_type
+          when "data"
+            InputContentDataSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          when "url"
+            InputContentUrlSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          else
+            hash
+          end
+        end
+      end
+
+      # Represents an audio content fragment inside a multimodal user message.
+      #
+      # ```ruby
+      #
+      # content = AgUiProtocol::Core::Types::AudioInputContent.new(
+      #   source: { type: "url", value: "https://example.com/audio.mp3", mime_type: "audio/mp3" }
+      # )
+      #
+      # ```
+      class AudioInputContent < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T.any(InputContentDataSource, InputContentUrlSource)) }
+        attr_reader :source
+
+        sig { returns(T.untyped) }
+        attr_reader :metadata
+
+        # @param source [InputContentDataSource, InputContentUrlSource, Hash] Content source
+        # @param metadata [Object] Optional metadata
+        # @param type [String] Identifies the fragment type
+        sig { params(source: T.untyped, metadata: T.untyped, type: String).void }
+        def initialize(source:, metadata: nil, type: "audio")
+          @type = type
+          @source = source.is_a?(Hash) ? build_source(source) : source
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            source: @source,
+            metadata: @metadata
+          }
+        end
+
+        private
+
+        def build_source(hash)
+          src_type = hash[:type] || hash["type"]
+          case src_type
+          when "data"
+            InputContentDataSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          when "url"
+            InputContentUrlSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          else
+            hash
+          end
+        end
+      end
+
+      # Represents a video content fragment inside a multimodal user message.
+      #
+      # ```ruby
+      #
+      # content = AgUiProtocol::Core::Types::VideoInputContent.new(
+      #   source: { type: "url", value: "https://example.com/video.mp4", mime_type: "video/mp4" }
+      # )
+      #
+      # ```
+      class VideoInputContent < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T.any(InputContentDataSource, InputContentUrlSource)) }
+        attr_reader :source
+
+        sig { returns(T.untyped) }
+        attr_reader :metadata
+
+        # @param source [InputContentDataSource, InputContentUrlSource, Hash] Content source
+        # @param metadata [Object] Optional metadata
+        # @param type [String] Identifies the fragment type
+        sig { params(source: T.untyped, metadata: T.untyped, type: String).void }
+        def initialize(source:, metadata: nil, type: "video")
+          @type = type
+          @source = source.is_a?(Hash) ? build_source(source) : source
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            source: @source,
+            metadata: @metadata
+          }
+        end
+
+        private
+
+        def build_source(hash)
+          src_type = hash[:type] || hash["type"]
+          case src_type
+          when "data"
+            InputContentDataSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          when "url"
+            InputContentUrlSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          else
+            hash
+          end
+        end
+      end
+
+      # Represents a document content fragment inside a multimodal user message.
+      #
+      # ```ruby
+      #
+      # content = AgUiProtocol::Core::Types::DocumentInputContent.new(
+      #   source: { type: "url", value: "https://example.com/doc.pdf", mime_type: "application/pdf" }
+      # )
+      #
+      # ```
+      class DocumentInputContent < Model
+        sig { returns(String) }
+        attr_reader :type
+
+        sig { returns(T.any(InputContentDataSource, InputContentUrlSource)) }
+        attr_reader :source
+
+        sig { returns(T.untyped) }
+        attr_reader :metadata
+
+        # @param source [InputContentDataSource, InputContentUrlSource, Hash] Content source
+        # @param metadata [Object] Optional metadata
+        # @param type [String] Identifies the fragment type
+        sig { params(source: T.untyped, metadata: T.untyped, type: String).void }
+        def initialize(source:, metadata: nil, type: "document")
+          @type = type
+          @source = source.is_a?(Hash) ? build_source(source) : source
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            type: @type,
+            source: @source,
+            metadata: @metadata
+          }
+        end
+
+        private
+
+        def build_source(hash)
+          src_type = hash[:type] || hash["type"]
+          case src_type
+          when "data"
+            InputContentDataSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          when "url"
+            InputContentUrlSource.new(
+              value: hash[:value] || hash["value"],
+              mime_type: hash[:mime_type] || hash["mime_type"]
+            )
+          else
+            hash
+          end
+        end
+      end
+
+      # Represents a reasoning message from an agent with chain-of-thought content.
+      #
+      # ```ruby
+      #
+      # msg = AgUiProtocol::Core::Types::ReasoningMessage.new(
+      #   id: "reason_1",
+      #   content: "Let me think through this step by step...",
+      #   encrypted_value: nil
+      # )
+      #
+      # ```
+      class ReasoningMessage < BaseMessage
+
+        sig { returns(String) }
+        attr_reader :content
+
+        # @param id [String] Unique identifier for the message
+        # @param content [String] Reasoning content (plaintext when not encrypted)
+        # @param encrypted_value [String] Encrypted reasoning content when in zero-data-retention mode
+        sig { params(id: String, content: String, encrypted_value: T.nilable(String)).void }
+        def initialize(id:, content:, encrypted_value: nil)
+          super(id: id, role: "reasoning", content: content, encrypted_value: encrypted_value)
+        end
+      end
+
+      # Represents an interrupt that occurred during agent execution for human-in-the-loop workflows.
+      #
+      # ```ruby
+      #
+      # interrupt = AgUiProtocol::Core::Types::Interrupt.new(
+      #   id: "int_1",
+      #   reason: "input_required",
+      #   message: "Please provide additional information"
+      # )
+      #
+      # ```
+      class Interrupt < Model
+        sig { returns(String) }
+        attr_reader :id
+
+        sig { returns(String) }
+        attr_reader :reason
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :message
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :tool_call_id
+
+        sig { returns(T.untyped) }
+        attr_reader :response_schema
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :expires_at
+
+        sig { returns(T.untyped) }
+        attr_reader :metadata
+
+        # @param id [String] Unique identifier
+        # @param reason [String] Reason for the interrupt
+        # @param message [String] Human-readable message
+        # @param tool_call_id [String] Associated tool call if applicable
+        # @param response_schema [Object] JSON schema for response
+        # @param expires_at [String] ISO timestamp when interrupt expires
+        # @param metadata [Object] Arbitrary metadata
+        sig do
+          params(
+            id: String,
+            reason: String,
+            message: T.nilable(String),
+            tool_call_id: T.nilable(String),
+            response_schema: T.untyped,
+            expires_at: T.nilable(String),
+            metadata: T.untyped
+          ).void
+        end
+        def initialize(id:, reason:, message: nil, tool_call_id: nil, response_schema: nil, expires_at: nil, metadata: nil)
+          @id = id
+          @reason = reason
+          @message = message
+          @tool_call_id = tool_call_id
+          @response_schema = response_schema
+          @expires_at = expires_at
+          @metadata = metadata
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            id: @id,
+            reason: @reason,
+            message: @message,
+            tool_call_id: @tool_call_id,
+            response_schema: @response_schema,
+            expires_at: @expires_at,
+            metadata: @metadata
+          }
+        end
+      end
+
+      # Valid values for resume status in interrupt resolution.
+      ResumeStatus = T.type_alias { T.any(String, T.nilable(String)) }
+
+      # Represents an entry for resuming an interrupted run.
+      #
+      # ```ruby
+      #
+      # entry = AgUiProtocol::Core::Types::ResumeEntry.new(
+      #   interrupt_id: "int_1",
+      #   status: "resolved",
+      #   payload: { "answer" => "42" }
+      # )
+      #
+      # ```
+      class ResumeEntry < Model
+        sig { returns(String) }
+        attr_reader :interrupt_id
+
+        sig { returns(ResumeStatus) }
+        attr_reader :status
+
+        sig { returns(T.untyped) }
+        attr_reader :payload
+
+        # @param interrupt_id [String] ID of the interrupt being resolved
+        # @param status [String] Resolution status ("resolved" or "cancelled")
+        # @param payload [Object] Response payload for the interrupt
+        sig { params(interrupt_id: String, status: String, payload: T.untyped).void }
+        def initialize(interrupt_id:, status:, payload:)
+          @interrupt_id = interrupt_id
+          @status = status
+          @payload = payload
+        end
+
+        sig { returns(T::Hash[Symbol, T.untyped]) }
+        def to_h
+          {
+            interrupt_id: @interrupt_id,
+            status: @status,
+            payload: @payload
+          }
+        end
+      end
+
       # Input parameters for running an agent. In the HTTP API, this is the body of the `POST` request.
       #
       # ```ruby
@@ -656,6 +1160,9 @@ module AgUiProtocol
         sig { returns(T.untyped) }
         attr_reader :forwarded_props
 
+        sig { returns(T.nilable(T::Array[ResumeEntry])) }
+        attr_reader :resume
+
         # @param thread_id [String] ID of the conversation thread
         # @param run_id [String] ID of the current run
         # @param state [Object] Current state of the agent
@@ -664,6 +1171,7 @@ module AgUiProtocol
         # @param context [Array<Context>] List of context objects provided to the agent
         # @param forwarded_props [Object] Additional properties forwarded to the agent
         # @param parent_run_id [String] Lineage pointer for branching/time travel
+        # @param resume [Array<ResumeEntry>] Entries for resuming interrupted runs
         # @raise [ArgumentError] if messages is not an Array of BaseMessage
         sig do
           params(
@@ -674,10 +1182,11 @@ module AgUiProtocol
             tools: T::Array[Tool],
             context: T::Array[Context],
             forwarded_props: T.untyped,
-            parent_run_id: T.nilable(String)
+            parent_run_id: T.nilable(String),
+            resume: T.nilable(T::Array[ResumeEntry])
           ).void.checked(:always)
         end
-        def initialize(thread_id:, run_id:, state:, messages:, tools:, context:, forwarded_props:, parent_run_id: nil)
+        def initialize(thread_id:, run_id:, state:, messages:, tools:, context:, forwarded_props:, parent_run_id: nil, resume: nil)
           unless messages.is_a?(Array) && messages.all? { |m| m.is_a?(BaseMessage) }
             raise ArgumentError, "messages must be an Array of BaseMessage"
           end
@@ -696,6 +1205,7 @@ module AgUiProtocol
           @tools = tools
           @context = context
           @forwarded_props = forwarded_props
+          @resume = resume
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -708,7 +1218,8 @@ module AgUiProtocol
             messages: @messages,
             tools: @tools,
             context: @context,
-            forwarded_props: @forwarded_props
+            forwarded_props: @forwarded_props,
+            resume: @resume
           }
         end
       end

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
@@ -21,10 +21,9 @@ module AgUiProtocol
       # ```ruby
       #
       # AgUiProtocol::Core::Types::Role
-      # # => ["developer", "system", "assistant", "user", "tool", "activity"]
+      # # => ["developer", "system", "assistant", "user", "tool", "activity", "reasoning"]
       #
       # ```
-      # @category Message Types
       Role = ["developer", "system", "assistant", "user", "tool", "activity", "reasoning"].freeze
 
       # Base model for protocol entities.
@@ -41,7 +40,7 @@ module AgUiProtocol
         # @return [Hash<Symbol, Object>, raise NotImplementedError]
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          raise NotImplementedError, 'Implement this method by concrect class'
+          raise NotImplementedError, "Implement this method in a concrete subclass"
         end
 
         # Returns a JSON-ready representation.
@@ -130,7 +129,11 @@ module AgUiProtocol
         def initialize(id:, function:, type: 'function', encrypted_value: nil)
           @id = id
           @type = type
-          @function = function.is_a?(FunctionCall) ? function : FunctionCall.new(**function)
+          @function = if function.is_a?(FunctionCall)
+                       function
+                     else
+                       FunctionCall.new(**function.transform_keys(&:to_sym))
+                     end
           @encrypted_value = encrypted_value
         end
 
@@ -267,13 +270,23 @@ module AgUiProtocol
 
         # @param id [String] Unique identifier for the message
         # @param content [Object] Text content of the message
-        # @param tool_calls [Array<ToolCall, Hash>] Tool calls made in this message
+        # @param tool_calls [Array<ToolCall, Hash>] Tool calls made in this message; Hashes are normalized to ToolCall instances.
         # @param name [String] Name of the sender
-        sig { params(id: String, content: T.untyped, tool_calls: T.nilable(T::Array[ToolCall]), name: T.nilable(String)).void }
-        def initialize(id:, content: nil, tool_calls: nil, name: nil)
-          super(id: id, role: "assistant", content: content, name: name)
+        # @param encrypted_value [String] Encrypted content for zero-data-retention mode
+        sig do
+          params(
+            id: String,
+            content: T.untyped,
+            tool_calls: T.nilable(T::Array[T.any(ToolCall, T::Hash[T.any(Symbol, String), T.untyped])]),
+            name: T.nilable(String),
+            encrypted_value: T.nilable(String)
+          ).void
+        end
+        def initialize(id:, content: nil, tool_calls: nil, name: nil, encrypted_value: nil)
+          super(id: id, role: "assistant", content: content, name: name, encrypted_value: encrypted_value)
           @tool_calls = tool_calls&.map do |tc|
-            tc.is_a?(ToolCall) ? tc : ToolCall.new(**tc)
+            next tc if tc.is_a?(ToolCall)
+            ToolCall.new(**tc.transform_keys(&:to_sym))
           end
         end
 
@@ -364,8 +377,8 @@ module AgUiProtocol
           ).void
         end
         def initialize(mime_type:, type: "binary", id: nil, url: nil, data: nil, filename: nil)
-          if [id, url, data].all?(&:nil?)
-            raise ArgumentError, "BinaryInputContent requires id, url, or data to be provided."
+          if [id, url, data].none? { |v| v.is_a?(String) && !v.empty? }
+            raise ArgumentError, "BinaryInputContent requires at least one of id, url, or data to be a non-empty string"
           end
 
           @type = type
@@ -404,35 +417,37 @@ module AgUiProtocol
       # ```
       # @category Message Types
       class UserMessage < BaseMessage
-        sig { returns(String) }
-        attr_reader :id
-
-        sig { returns(String) }
-        attr_reader :role
-
-        sig { returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)])) }
-        attr_reader :content
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :name
-
         # @param id [String] Unique identifier for the message
-        # @param content [String, Array<TextInputContent | BinaryInputContent | ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent>] Either a plain text string or an ordered list of multimodal fragments
+        # @param content [String, Array<TextInputContent | BinaryInputContent | ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent | Hash>] Accepted shapes: a String for plain text, or an Array whose elements are either *InputContent Models (TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent) OR Hashes with a `type:` key (`text`, `binary`, `image`, `audio`, `video`, `document`); Hash entries are normalized internally to the corresponding Model.
         # @param name [String] Optional name of the sender
+        # @param encrypted_value [String] Encrypted content for zero-data-retention mode
         sig do
           params(
             id: String,
-            content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)]),
-            name: T.nilable(String)
+            content: T.any(
+              String,
+              T::Array[T.any(
+                TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent,
+                T::Hash[T.any(Symbol, String), T.untyped]
+              )]
+            ),
+            name: T.nilable(String),
+            encrypted_value: T.nilable(String)
           ).void
         end
-        def initialize(id:, content:, name: nil)
-          super(id: id, role: "user", content: normalize_user_content(content), name: name)
+        def initialize(id:, content:, name: nil, encrypted_value: nil)
+          super(id: id, role: "user", content: normalize_user_content(content), name: name, encrypted_value: encrypted_value)
         end
 
         sig do
           params(
-            content: T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)])
+            content: T.any(
+              String,
+              T::Array[T.any(
+                TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent,
+                T::Hash[T.any(Symbol, String), T.untyped]
+              )]
+            )
           ).returns(T.any(String, T::Array[T.any(TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent)]))
         end
         def normalize_user_content(content)
@@ -441,7 +456,8 @@ module AgUiProtocol
               if c.is_a?(Model)
                 c
               elsif c.is_a?(Hash)
-                case c[:type] || c["type"]
+                src_type = c[:type] || c["type"]
+                case src_type
                 when "text"
                   TextInputContent.new(text: c[:text] || c["text"])
                 when "binary"
@@ -450,7 +466,7 @@ module AgUiProtocol
                     id: c[:id] || c["id"],
                     url: c[:url] || c["url"],
                     data: c[:data] || c["data"],
-                    filename: c[:filename] || c["filename"]
+                    filename: c[:filename] || c["filename"] || c[:fileName] || c["fileName"]
                   )
                 when "image"
                   ImageInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
@@ -461,10 +477,10 @@ module AgUiProtocol
                 when "document"
                   DocumentInputContent.new(source: c[:source] || c["source"], metadata: c[:metadata] || c["metadata"])
                 else
-                  c
+                  raise ArgumentError, "Unknown content type: #{src_type.inspect}"
                 end
               else
-                c
+                raise ArgumentError, "Unknown content type: #{c.class}"
               end
             end
           else
@@ -472,15 +488,6 @@ module AgUiProtocol
           end
         end
 
-        sig { returns(T::Hash[Symbol, T.untyped]) }
-        def to_h
-          {
-            id: @id,
-            role: @role,
-            content: @content,
-            name: @name
-          }
-        end
       end
 
       # Tool result message.
@@ -497,22 +504,10 @@ module AgUiProtocol
       # @category Message Types
       class ToolMessage < BaseMessage
         sig { returns(String) }
-        attr_reader :id
-
-        sig { returns(String) }
-        attr_reader :role
-
-        sig { returns(String) }
-        attr_reader :content
-
-        sig { returns(String) }
         attr_reader :tool_call_id
 
         sig { returns(T.nilable(String)) }
         attr_reader :error
-
-        sig { returns(T.nilable(String)) }
-        attr_reader :encrypted_value
 
         # @param id [String] Unique identifier for the message.
         # @param content [String] Tool result content.
@@ -521,26 +516,26 @@ module AgUiProtocol
         # @param encrypted_value [String] Encrypted tool message value for zero-data-retention mode
         sig { params(id: String, content: String, tool_call_id: String, error: T.nilable(String), encrypted_value: T.nilable(String)).void }
         def initialize(id:, content:, tool_call_id:, error: nil, encrypted_value: nil)
-          super(id: id, role: "tool", content: content)
+          super(id: id, role: "tool", content: content, encrypted_value: encrypted_value)
           @tool_call_id = tool_call_id
           @error = error
-          @encrypted_value = encrypted_value
         end
 
         sig { returns(T::Hash[Symbol, T.untyped]) }
         def to_h
-          {
-            id: @id,
-            role: @role,
-            content: @content,
+          super.merge(
             tool_call_id: @tool_call_id,
-            error: @error,
-            encrypted_value: @encrypted_value
-          }
+            error: @error
+          )
         end
       end
 
       # Represents structured activity progress emitted between chat messages.
+      #
+      # ActivityMessage intentionally does NOT inherit from BaseMessage because its
+      # `content` is a structured Hash rather than text/multimodal, which is
+      # incompatible with BaseMessage#content's type. It still appears alongside
+      # other messages in the stream but is modeled as its own shape.
       #
       # ```ruby
       #
@@ -552,7 +547,7 @@ module AgUiProtocol
       #
       # ```
       # @category Message Types
-      class ActivityMessage < BaseMessage
+      class ActivityMessage < Model
         sig { returns(String) }
         attr_reader :id
 
@@ -571,7 +566,7 @@ module AgUiProtocol
         sig { params(id: String, activity_type: String, content: T::Hash[T.any(Symbol, String), T.untyped]).void }
         def initialize(id:, activity_type:, content:)
           @id = id
-          @role = 'activity'
+          @role = "activity"
           @activity_type = activity_type
           @content = content
         end
@@ -781,19 +776,15 @@ module AgUiProtocol
 
         def build_source(hash)
           src_type = hash[:type] || hash["type"]
+          value = hash[:value] || hash["value"]
+          mime_type = hash[:mime_type] || hash["mime_type"] || hash[:mimeType] || hash["mimeType"]
           case src_type
           when "data"
-            InputContentDataSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentDataSource.new(value: value, mime_type: mime_type)
           when "url"
-            InputContentUrlSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentUrlSource.new(value: value, mime_type: mime_type)
           else
-            hash
+            raise ArgumentError, "Unknown source type: #{src_type.inspect}"
           end
         end
       end
@@ -840,19 +831,15 @@ module AgUiProtocol
 
         def build_source(hash)
           src_type = hash[:type] || hash["type"]
+          value = hash[:value] || hash["value"]
+          mime_type = hash[:mime_type] || hash["mime_type"] || hash[:mimeType] || hash["mimeType"]
           case src_type
           when "data"
-            InputContentDataSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentDataSource.new(value: value, mime_type: mime_type)
           when "url"
-            InputContentUrlSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentUrlSource.new(value: value, mime_type: mime_type)
           else
-            hash
+            raise ArgumentError, "Unknown source type: #{src_type.inspect}"
           end
         end
       end
@@ -899,19 +886,15 @@ module AgUiProtocol
 
         def build_source(hash)
           src_type = hash[:type] || hash["type"]
+          value = hash[:value] || hash["value"]
+          mime_type = hash[:mime_type] || hash["mime_type"] || hash[:mimeType] || hash["mimeType"]
           case src_type
           when "data"
-            InputContentDataSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentDataSource.new(value: value, mime_type: mime_type)
           when "url"
-            InputContentUrlSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentUrlSource.new(value: value, mime_type: mime_type)
           else
-            hash
+            raise ArgumentError, "Unknown source type: #{src_type.inspect}"
           end
         end
       end
@@ -958,19 +941,15 @@ module AgUiProtocol
 
         def build_source(hash)
           src_type = hash[:type] || hash["type"]
+          value = hash[:value] || hash["value"]
+          mime_type = hash[:mime_type] || hash["mime_type"] || hash[:mimeType] || hash["mimeType"]
           case src_type
           when "data"
-            InputContentDataSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentDataSource.new(value: value, mime_type: mime_type)
           when "url"
-            InputContentUrlSource.new(
-              value: hash[:value] || hash["value"],
-              mime_type: hash[:mime_type] || hash["mime_type"]
-            )
+            InputContentUrlSource.new(value: value, mime_type: mime_type)
           else
-            hash
+            raise ArgumentError, "Unknown source type: #{src_type.inspect}"
           end
         end
       end
@@ -1075,9 +1054,6 @@ module AgUiProtocol
         end
       end
 
-      # Valid values for resume status in interrupt resolution.
-      ResumeStatus = T.type_alias { T.any(String, T.nilable(String)) }
-
       # Represents an entry for resuming an interrupted run.
       #
       # ```ruby
@@ -1093,17 +1069,18 @@ module AgUiProtocol
         sig { returns(String) }
         attr_reader :interrupt_id
 
-        sig { returns(ResumeStatus) }
+        # Free-form string; protocol values are "resolved" or "cancelled" but not enforced by this SDK.
+        sig { returns(T.nilable(String)) }
         attr_reader :status
 
         sig { returns(T.untyped) }
         attr_reader :payload
 
         # @param interrupt_id [String] ID of the interrupt being resolved
-        # @param status [String] Resolution status ("resolved" or "cancelled")
+        # @param status [String] Resolution status (free-form; protocol values are "resolved" or "cancelled")
         # @param payload [Object] Response payload for the interrupt
-        sig { params(interrupt_id: String, status: String, payload: T.untyped).void }
-        def initialize(interrupt_id:, status:, payload:)
+        sig { params(interrupt_id: String, status: T.nilable(String), payload: T.untyped).void }
+        def initialize(interrupt_id:, status: nil, payload: nil)
           @interrupt_id = interrupt_id
           @status = status
           @payload = payload
@@ -1148,7 +1125,7 @@ module AgUiProtocol
         sig { returns(T.untyped) }
         attr_reader :state
 
-        sig { returns(T::Array[BaseMessage]) }
+        sig { returns(T::Array[T.any(BaseMessage, ActivityMessage)]) }
         attr_reader :messages
 
         sig { returns(T::Array[Tool]) }
@@ -1166,19 +1143,19 @@ module AgUiProtocol
         # @param thread_id [String] ID of the conversation thread
         # @param run_id [String] ID of the current run
         # @param state [Object] Current state of the agent
-        # @param messages [Array<BaseMessage>] List of messages in the conversation
+        # @param messages [Array<BaseMessage, ActivityMessage>] List of messages in the conversation
         # @param tools [Array<Tool>] List of tools available to the agent
         # @param context [Array<Context>] List of context objects provided to the agent
         # @param forwarded_props [Object] Additional properties forwarded to the agent
         # @param parent_run_id [String] Lineage pointer for branching/time travel
         # @param resume [Array<ResumeEntry>] Entries for resuming interrupted runs
-        # @raise [ArgumentError] if messages is not an Array of BaseMessage
+        # @raise [ArgumentError] if messages is not an Array of BaseMessage or ActivityMessage
         sig do
           params(
             thread_id: String,
             run_id: String,
             state: T.untyped,
-            messages: T::Array[BaseMessage],
+            messages: T::Array[T.any(BaseMessage, ActivityMessage)],
             tools: T::Array[Tool],
             context: T::Array[Context],
             forwarded_props: T.untyped,
@@ -1187,14 +1164,17 @@ module AgUiProtocol
           ).void.checked(:always)
         end
         def initialize(thread_id:, run_id:, state:, messages:, tools:, context:, forwarded_props:, parent_run_id: nil, resume: nil)
-          unless messages.is_a?(Array) && messages.all? { |m| m.is_a?(BaseMessage) }
-            raise ArgumentError, "messages must be an Array of BaseMessage"
+          unless messages.is_a?(Array) && messages.all? { |m| m.is_a?(BaseMessage) || m.is_a?(ActivityMessage) }
+            raise ArgumentError, "messages must be an Array of BaseMessage or ActivityMessage"
           end
           unless tools.is_a?(Array) && tools.all? { |m| m.is_a?(Tool) }
             raise ArgumentError, "tools must be an Array of Tool"
           end
           unless context.is_a?(Array) && context.all? { |m| m.is_a?(Context) }
             raise ArgumentError, "context must be an Array of Context"
+          end
+          unless resume.nil? || (resume.is_a?(Array) && resume.all? { |r| r.is_a?(ResumeEntry) })
+            raise ArgumentError, "resume must be an Array of ResumeEntry"
           end
 
           @thread_id = thread_id

--- a/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/core/types.rb
@@ -577,7 +577,8 @@ module AgUiProtocol
             id: @id,
             role: @role,
             activity_type: @activity_type,
-            content: @content
+            # `content` is an arbitrary user-supplied payload — preserve keys verbatim on the wire.
+            content: @content.nil? ? nil : AgUiProtocol::Util::Opaque.new(@content)
           }
         end
       end
@@ -649,7 +650,8 @@ module AgUiProtocol
           {
             name: @name,
             description: @description,
-            parameters: @parameters
+            # `parameters` is a JSON Schema document supplied by the user — preserve keys verbatim.
+            parameters: @parameters.nil? ? nil : AgUiProtocol::Util::Opaque.new(@parameters)
           }
         end
       end
@@ -1047,9 +1049,11 @@ module AgUiProtocol
             reason: @reason,
             message: @message,
             tool_call_id: @tool_call_id,
-            response_schema: @response_schema,
+            # `response_schema` is a JSON Schema document supplied by the user — preserve keys verbatim.
+            response_schema: @response_schema.nil? ? nil : AgUiProtocol::Util::Opaque.new(@response_schema),
             expires_at: @expires_at,
-            metadata: @metadata
+            # `metadata` is arbitrary user-defined key/value data — preserve keys verbatim.
+            metadata: @metadata.nil? ? nil : AgUiProtocol::Util::Opaque.new(@metadata)
           }
         end
       end
@@ -1091,7 +1095,8 @@ module AgUiProtocol
           {
             interrupt_id: @interrupt_id,
             status: @status,
-            payload: @payload
+            # `payload` is the user's resume response — preserve keys verbatim.
+            payload: @payload.nil? ? nil : AgUiProtocol::Util::Opaque.new(@payload)
           }
         end
       end
@@ -1194,11 +1199,13 @@ module AgUiProtocol
             thread_id: @thread_id,
             run_id: @run_id,
             parent_run_id: @parent_run_id,
-            state: @state,
+            # `state` is the agent's user-defined state object — preserve keys verbatim.
+            state: @state.nil? ? nil : AgUiProtocol::Util::Opaque.new(@state),
             messages: @messages,
             tools: @tools,
             context: @context,
-            forwarded_props: @forwarded_props,
+            # `forwarded_props` is arbitrary user-defined key/value data — preserve keys verbatim.
+            forwarded_props: @forwarded_props.nil? ? nil : AgUiProtocol::Util::Opaque.new(@forwarded_props),
             resume: @resume
           }
         end

--- a/sdks/community/ruby/lib/ag_ui_protocol/encoder/event_encoder.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/encoder/event_encoder.rb
@@ -39,11 +39,10 @@ module AgUiProtocol
     # ### Implementation Details
     #
     # Internally, the encoder converts events to JSON and formats them as Server-Sent
-    # Events with the following structure:
+    # Events with the following structure (each event terminated by two literal
+    # newline characters, shown here as escape sequences):
     #
-    # ```
-    # data: {json-serialized event}\n\n
-    # ```
+    #   data: {json-serialized event}\n\n
     #
     # This format allows clients to receive a continuous stream of events and process
     # them as they arrive.

--- a/sdks/community/ruby/lib/ag_ui_protocol/util.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/util.rb
@@ -8,13 +8,43 @@ module AgUiProtocol
   # Utility methods for encoding events.
   module Util
     extend T::Sig
+
+    # Marks a value as opaque user-supplied payload that MUST pass through
+    # serialization unchanged — no key camelization, no nil compaction, no
+    # recursive normalization.
+    #
+    # Use this for fields where the AG-UI protocol carries arbitrary
+    # user-defined Hash content (e.g., `metadata`, `custom`, `response_schema`,
+    # JSON Patch op payloads, raw upstream events). Schema-typed fields whose
+    # keys are part of the protocol contract MUST NOT be wrapped — those still
+    # need camelCase rewriting on the wire.
+    #
+    # The wrapper unwraps to its original `value` at the camelization boundary
+    # in {Util.deep_transform_keys_to_camel}. Keys inside the wrapped value
+    # (and any nested Hashes/Arrays within it) are preserved verbatim.
+    class Opaque
+      extend T::Sig
+
+      sig { returns(T.untyped) }
+      attr_reader :value
+
+      sig { params(value: T.untyped).void }
+      def initialize(value)
+        @value = value
+      end
+    end
+
     module_function
 
     # @param value [Object]
     # @return [Object]
     sig { params(value: T.untyped).returns(T.untyped) }
     def normalize_value(value)
-      if value.is_a?(AgUiProtocol::Core::Types::Model)
+      case value
+      when Opaque
+        # Preserve the wrapper so downstream stages can recognize and skip it.
+        value
+      when AgUiProtocol::Core::Types::Model
         value.to_h
       else
         value
@@ -38,6 +68,10 @@ module AgUiProtocol
     def deep_compact(value)
       value = normalize_value(value)
       case value
+      when Opaque
+        # Opaque payloads are pass-through: do not recurse into their content
+        # and do not strip nils. The wrapper is unwrapped during camelization.
+        value
       when Hash
         value.transform_values { |v| deep_compact(v) unless v.nil? }.tap(&:compact!)
       when Array
@@ -55,6 +89,10 @@ module AgUiProtocol
     def deep_transform_keys_to_camel(value)
       value = normalize_value(value)
       case value
+      when Opaque
+        # Unwrap and emit the inner value verbatim — keys (including nested
+        # Hash keys and Array elements) are preserved as supplied by the user.
+        value.value
       when Hash
         value.each_with_object({}) do |(k, v), acc|
           acc[camelize_key(k)] = deep_transform_keys_to_camel(v)

--- a/sdks/community/ruby/lib/ag_ui_protocol/util.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/util.rb
@@ -44,6 +44,11 @@ module AgUiProtocol
       when Opaque
         # Preserve the wrapper so downstream stages can recognize and skip it.
         value
+      when Time
+        # AG-UI protocol wire format for BaseEvent.timestamp is epoch
+        # milliseconds (matches Python SDK `Optional[int]` and TypeScript
+        # `z.number().optional()`).
+        (value.to_f * 1000).to_i
       when AgUiProtocol::Core::Types::Model
         value.to_h
       else

--- a/sdks/community/ruby/lib/ag_ui_protocol/version.rb
+++ b/sdks/community/ruby/lib/ag_ui_protocol/version.rb
@@ -2,5 +2,5 @@
 
 module AgUiProtocol
   # The version of the protocol.
-  VERSION = "0.1.5"
+  VERSION = "0.2.0"
 end

--- a/sdks/community/ruby/templates/default/fulldoc/markdown/setup.rb
+++ b/sdks/community/ruby/templates/default/fulldoc/markdown/setup.rb
@@ -23,6 +23,12 @@ TARGET_PAGES = {
     title: "Overview",
     document_title: "Event Encoder",
     description: "Documentation for encoding Agent User Interaction Protocol events (Ruby SDK)"
+  },
+  "AgUiProtocol::Core::Capabilities" => {
+    path: "core/capabilities",
+    title: "Capabilities",
+    document_title: "Agent Capabilities",
+    description: "Documentation for agent capability declarations in the Agent User Interaction Protocol (Ruby SDK)"
   }
 }.freeze
 
@@ -747,6 +753,8 @@ def serialize(object)
     serialize_types_page
   when "AgUiProtocol::Encoder"
     serialize_encoder_page
+  when "AgUiProtocol::Core::Capabilities"
+    serialize_capabilities_page
   else
     ""
   end
@@ -942,6 +950,51 @@ def serialize_types_page
   out << "## State\n\n"
   out << "`State` is represented as `Any`.\n\n"
   out << "The state type is flexible and can hold any data structure needed by the agent implementation.\n"
+
+  out
+end
+
+def serialize_capabilities_page
+  capabilities_module = Registry.at("AgUiProtocol::Core::Capabilities")
+  out = +""
+  page_header(out, "AgUiProtocol::Core::Capabilities")
+  return out unless capabilities_module
+
+  module_doc = rdoc_to_md(capabilities_module.docstring).to_s.strip
+  preamble_doc, _section_docs, section_order = extract_virtual_sections(module_doc)
+  out << "#{preamble_doc}\n\n" unless preamble_doc.empty?
+
+  classes = capabilities_module.children.grep(CodeObjects::ClassObject).sort_by { |c| c.name.to_s }
+
+  rendered = Set.new
+  section_order.each do |title|
+    klass = classes.find { |c| c.name.to_s == title }
+    next unless klass
+    next if rendered.include?(klass.path)
+
+    rendered << klass.path
+    out << "## #{klass.name}\n\n"
+    out << "#{inline_code(klass.path)}\n\n"
+
+    append_doc(out, klass.docstring)
+    append_tags(out, klass)
+
+    table = render_params_table_for(klass)
+    out << table unless table.empty?
+  end
+
+  classes.each do |klass|
+    next if rendered.include?(klass.path)
+
+    out << "## #{klass.name}\n\n"
+    out << "#{inline_code(klass.path)}\n\n"
+
+    append_doc(out, klass.docstring)
+    append_tags(out, klass)
+
+    table = render_params_table_for(klass)
+    out << table unless table.empty?
+  end
 
   out
 end

--- a/sdks/community/ruby/templates/default/fulldoc/markdown/setup.rb
+++ b/sdks/community/ruby/templates/default/fulldoc/markdown/setup.rb
@@ -50,10 +50,13 @@ def init
 
     begin
       Templates::Engine.with_serializer(object, options.serializer) { serialize(object) }
-    rescue => e
+    rescue StandardError => e
       path = options.serializer.serialized_path(object)
       log.error "Exception occurred while generating '#{path}'"
       log.backtrace(e)
+      # Target pages MUST succeed — re-raise so YARD exits non-zero rather
+      # than silently shipping an empty or partial documentation page.
+      raise if TARGET_PAGES.key?(object.path)
     end
   end
 end
@@ -64,8 +67,8 @@ def define_custom_tags
   begin
     YARD::Tags::Library.define_tag("Category", :category)
     YARD::Tags::Library.define_tag("Document Title", :document_title)
-  rescue
-    nil
+  rescue NoMethodError, ArgumentError => e
+    log.warn "ag_ui_protocol YARD template: failed to define custom tags: #{e.message}"
   end
 end
 
@@ -160,17 +163,85 @@ def parse_param_tags_from_source(file, line)
   start_idx = [line.to_i - 2, lines.size - 1].min
   return [] if start_idx < 0
 
+  # Scan backward through the comment block preceding the method
+  # declaration, walking past any Sorbet `sig do ... end` block(s) that sit
+  # between the @param comments and `def initialize`. Stop at real
+  # declaration boundaries (`class `/`module `/`def `) so @param tags from
+  # a previous class/method never leak in.
+  #
+  # YARD's `line` for a multi-line `def initialize(...)` points at the
+  # opening `def` line, so `start_idx = line - 2` lands us EITHER on the
+  # closing `end` of the sig block, OR somewhere inside the sig body
+  # (e.g. `).void`) when the def signature itself is multi-line. We track
+  # sig-block depth so both shapes are handled: each `end` we encounter
+  # walking back opens a depth, and the matching `sig do`/`sig {`/`sig`
+  # closes it. While inside a sig block, all body lines are silently
+  # skipped — including DSL content like `).void`, `params(`, identifier
+  # lines, etc.
   search_window = 120
   first_param_idx = nil
 
   idx = start_idx
   min_idx = [0, start_idx - search_window].max
+  sig_depth = 0
   while idx >= min_idx
     stripped = lines[idx].to_s.strip
-    if stripped.match?(/^#\s*@param\b/)
-      first_param_idx = idx
+
+    # Hard boundary: never cross into a different class/module/def.
+    if stripped.start_with?("class ", "module ", "def ") || stripped == "class" || stripped == "module"
       break
     end
+
+    # Bare `end` walking backward: open a sig-block depth. (Method bodies
+    # don't legally sit between @param tags and the method they describe,
+    # so this is unambiguous in our codebase — boundary check above keeps
+    # us from drifting into a previous declaration.)
+    if stripped == "end"
+      sig_depth += 1
+      idx -= 1
+      next
+    end
+
+    # Sig openers — close the current sig block if we have one open, or
+    # treat as a single-line sig to walk past.
+    is_sig_opener = stripped.start_with?("sig ", "sig{", "sig do") || stripped == "sig"
+    if is_sig_opener
+      sig_depth -= 1 if sig_depth > 0
+      idx -= 1
+      next
+    end
+
+    # Inside a sig block: skip body content unconditionally — BUT still
+    # respect class/module/def boundaries. A bare `end` walking backward
+    # might have actually closed a def/class/module above us; if we see
+    # such a declaration line while sig_depth > 0, stop here so a previous
+    # method's @param tags can't leak in.
+    if sig_depth > 0
+      idx -= 1
+      next
+    end
+
+    # attr_reader/attr_writer/attr_accessor lines may live between the
+    # @param doc block and `def initialize`. Walk past them transparently.
+    if stripped.start_with?("attr_reader", "attr_writer", "attr_accessor")
+      idx -= 1
+      next
+    end
+
+    # Outside any sig block: comments and blanks are walkable. @param hit
+    # ends the search. Anything else (stray code, or sig DSL leftovers
+    # like `).void` from a sig block whose closing `end` we passed before
+    # entering this scope) is also walked past — common when YARD points
+    # at the OPENING line of a multi-line `def initialize(...)` and
+    # start_idx lands inside the sig body just below its opener. The
+    # class/module/def boundary check above is what actually bounds us.
+    if stripped.start_with?("#") || stripped.empty?
+      if stripped.match?(/^#\s*@param\b/)
+        first_param_idx = idx
+        break
+      end
+    end
+
     idx -= 1
   end
 
@@ -331,7 +402,8 @@ end
 
 def safe_tags(object)
   object.tags
-rescue
+rescue NoMethodError => e
+  log.warn "ag_ui_protocol YARD template: tags lookup failed for #{object.respond_to?(:path) ? object.path : object.inspect}: #{e.message}"
   []
 end
 
@@ -457,14 +529,21 @@ def render_params_table_for(object)
     display_types = non_nil_types.empty? ? type_values : non_nil_types
 
     is_optional = optional_param?(types: type_values, default: defaults[name])
-    type = display_types.any? ? "`#{display_types.join(" , ")}`" : ""
+    type = display_types.any? ? "`#{display_types.join(", ")}`" : ""
     type = "#{type} (optional)" if is_optional
     desc = param_tag_text(t).to_s.strip
 
     default = defaults[name]
     if default && !default.empty?
-      suffix = ", Default: `#{default}`."
-      desc = desc.empty? ? suffix : "#{desc} #{suffix}".strip
+      if desc.empty?
+        desc = "Default: `#{default}`."
+      else
+        # Strip a trailing period/whitespace from the description so the
+        # rendered cell is "<text>. Default: `nil`." instead of the stray
+        # "<text>. , Default: `nil`." artifact.
+        clean_desc = desc.sub(/[.\s]+\z/, "")
+        desc = "#{clean_desc}. Default: `#{default}`."
+      end
     end
 
     prop_cell = "`#{name}`"
@@ -507,7 +586,8 @@ def locate_method_line_in_file(file, method_name)
   rx = /^\s*def\s+#{Regexp.escape(method_name)}(\b|\s*\(|\s*$)/
   idx = lines.find_index { |l| l.to_s.match?(rx) }
   idx ? (idx + 1) : nil
-rescue
+rescue Errno::ENOENT, IOError => e
+  log.warn "ag_ui_protocol YARD template: locate_method_line_in_file failed for #{file}/#{method_name}: #{e.message}"
   nil
 end
 
@@ -535,7 +615,8 @@ def method_param_tags(method_object, owner: nil)
 
   parsed = parse_method_doc_from_source(file, line)
   parsed.fetch(:params, [])
-rescue
+rescue NoMethodError, Errno::ENOENT, IOError => e
+  log.warn "ag_ui_protocol YARD template: method_param_tags failed for #{method_object.respond_to?(:path) ? method_object.path : method_object.inspect}: #{e.message}"
   []
 end
 
@@ -548,7 +629,8 @@ def method_return_tag(method_object, owner: nil)
 
   parsed = parse_method_doc_from_source(file, line)
   parsed[:return]
-rescue
+rescue NoMethodError, Errno::ENOENT, IOError => e
+  log.warn "ag_ui_protocol YARD template: method_return_tag failed for #{method_object.respond_to?(:path) ? method_object.path : method_object.inspect}: #{e.message}"
   nil
 end
 
@@ -558,7 +640,8 @@ def method_description_from_source(method_object, owner: nil)
 
   parsed = parse_method_doc_from_source(file, line)
   parsed.fetch(:description, "").to_s.strip
-rescue
+rescue NoMethodError, Errno::ENOENT, IOError => e
+  log.warn "ag_ui_protocol YARD template: method_description_from_source failed for #{method_object.respond_to?(:path) ? method_object.path : method_object.inspect}: #{e.message}"
   ""
 end
 
@@ -588,6 +671,7 @@ def parse_method_doc_from_source(file, line)
   collected = []
   scanned = 0
   max_scan = 80
+  sig_depth = 0
 
   while idx >= 0 && scanned < max_scan
     scanned += 1
@@ -596,13 +680,52 @@ def parse_method_doc_from_source(file, line)
 
     stripped = raw.strip
 
+    # Inside a multi-line `sig do ... end` block — skip body unconditionally
+    # until we reach the `sig do`/`sig` opener that closes the depth.
+    #
+    # However, a real def/class/module boundary line ALWAYS stops traversal.
+    # A bare `end` walking backward isn't necessarily a sig closer — it could
+    # be closing a `def`/`class`/`module`. If we hit one of those declaration
+    # keywords while sig_depth > 0, the `end` we treated as a sig closer was
+    # actually a def/class/module closer, so we must stop here to avoid
+    # leaking another method's docstring into this one.
+    if sig_depth > 0
+      if stripped.start_with?("class ", "module ", "def ") || stripped == "class" || stripped == "module"
+        break
+      end
+      if stripped.start_with?("sig ", "sig{", "sig do") || stripped == "sig"
+        sig_depth -= 1
+      end
+      idx -= 1
+      next
+    end
+
     if stripped.start_with?("#") || stripped.empty?
       collected << stripped
       idx -= 1
       next
     end
 
-    if stripped.start_with?("sig") || stripped == "end" || stripped.include?("params(") || stripped.include?("returns(") || stripped.end_with?(".void") || stripped.include?("T.nilable")
+    # Hard boundaries: never cross into a different class/module/def. These
+    # mark territory belonging to another declaration and leaking across
+    # them produces cross-method doc contamination.
+    if stripped.start_with?("class ", "module ", "def ") || stripped == "class" || stripped == "module"
+      break
+    end
+
+    # `end` walking backward closes a sig block above us (a comment-or-code
+    # bound region directly above the method we're documenting).
+    if stripped == "end"
+      sig_depth += 1
+      idx -= 1
+      next
+    end
+
+    # Single-line sig (`sig { ... }`) — strip cleanly. Use start-of-line
+    # checks, not substring matching, so comment text mentioning sig DSL
+    # tokens (e.g. a `# @param ... T.nilable(String)`) is never mistaken
+    # for actual sig code.
+    if stripped.start_with?("sig ", "sig{", "sig do") || stripped == "sig"
       idx -= 1
       next
     end
@@ -648,13 +771,65 @@ end
 
 def method_signature_for(method_object, owner: nil)
   name = method_object.name(false).to_s
-  tags = method_param_tags(method_object, owner: owner)
-  params = tags.map { |t| normalize_param_name(param_tag_name(t)) }.join(", ")
-  sig = params.empty? ? name : "#{name}(#{params})"
 
-  return sig if name == "initialize"
+  # Prefer YARD's parameter introspection so we render keyword args with
+  # their trailing colon AND default value (e.g. `initialize(accept: nil)`
+  # rather than `initialize(accept)`). YARD's `.parameters` returns an
+  # array of `[raw_name, default_or_nil]` pairs where `raw_name` retains
+  # the syntactic decoration that distinguishes parameter kinds:
+  #
+  #   positional required:  ["name", nil]
+  #   positional optional:  ["name", "default"]
+  #   keyword required:     ["name:", nil]
+  #   keyword optional:     ["name:", "default"]
+  #   rest:                 ["*args", nil]
+  #   keyrest:              ["**opts", nil]
+  #   block:                ["&block", nil]
+  #
+  # Render each part as `raw_name` (positional required, splat, block,
+  # keyword required) or `raw_name <sep> default` where `<sep>` is `: `
+  # for keyword args (the name already ends in `:`) and ` = ` for
+  # positional optionals.
+  params = nil
+  if method_object.respond_to?(:parameters) && method_object.parameters.is_a?(Array)
+    parts = method_object.parameters.map do |param|
+      raw_name, default = if param.is_a?(Array)
+        [param[0].to_s, param[1]]
+      else
+        s = param.to_s
+        if s.include?("=")
+          n, d = s.split("=", 2)
+          [n.to_s, d.to_s.strip]
+        else
+          [s, nil]
+        end
+      end
 
-  sig
+      raw_name = raw_name.to_s.strip
+      next nil if raw_name.empty?
+
+      default_str = default.to_s.strip
+      if default_str.empty?
+        raw_name
+      elsif raw_name.end_with?(":")
+        "#{raw_name} #{default_str}"
+      else
+        "#{raw_name} = #{default_str}"
+      end
+    end.compact
+
+    params = parts.join(", ")
+  end
+
+  # Fall back to @param tag names (legacy path) when YARD didn't expose
+  # parameters — keeps signatures rendering for objects whose source we
+  # can't introspect.
+  if params.nil?
+    tags = method_param_tags(method_object, owner: owner)
+    params = tags.map { |t| normalize_param_name(param_tag_name(t)) }.join(", ")
+  end
+
+  params.empty? ? name : "#{name}(#{params})"
 end
 
 def render_params_table_for_method(method_object, owner: nil)
@@ -673,7 +848,7 @@ def render_params_table_for_method(method_object, owner: nil)
     display_types = non_nil_types.empty? ? type_values : non_nil_types
 
     is_optional = optional_param?(types: type_values, default: nil)
-    type = display_types.any? ? "`#{display_types.join(" , ")}`" : ""
+    type = display_types.any? ? "`#{display_types.join(", ")}`" : ""
     type = "#{type} (optional)" if is_optional
     desc = param_tag_text(t).to_s.strip
 
@@ -756,7 +931,10 @@ def serialize(object)
   when "AgUiProtocol::Core::Capabilities"
     serialize_capabilities_page
   else
-    ""
+    # Fail-loud: if TARGET_PAGES gains a new entry but the dispatcher isn't
+    # updated, we want to know immediately rather than silently emit an
+    # empty page.
+    raise "ag_ui_protocol YARD template: no serialize_* dispatch case for #{object.path}. Update setup.rb#serialize to add one."
   end
 end
 
@@ -773,14 +951,33 @@ def serialize_events_page
   preamble_doc, section_docs, section_order = extract_virtual_sections(module_doc)
   out << "#{preamble_doc}\n\n" unless preamble_doc.empty?
 
-  classes = events_module.children.grep(CodeObjects::ClassObject)
-  classes = classes.reject { |c| c.path == "AgUiProtocol::Core::Events::BaseEvent" }
+  all_classes = events_module.children.grep(CodeObjects::ClassObject)
+  all_classes = all_classes.reject { |c| c.path == "AgUiProtocol::Core::Events::BaseEvent" }
+
+  # Outcome classes live in the Events module but are value types (subclasses
+  # of Types::Model), not events. Keep them separate so they don't get
+  # mis-bucketed into "Lifecycle Events" (their names start with "Run").
+  outcomes, classes = all_classes.partition do |c|
+    name = c.name.to_s
+    name.end_with?("Outcome")
+  end
 
   lifecycle = classes.select { |c| c.name.to_s.start_with?("Run", "Step") }
-  text = classes.select { |c| c.name.to_s.start_with?("TextMessage", "Thinking") }
+  text = classes.select { |c| c.name.to_s.start_with?("TextMessage") }
+  thinking = classes.select { |c| c.name.to_s.start_with?("Thinking") }
   tool = classes.select { |c| c.name.to_s.start_with?("ToolCall") }
   state = classes.select { |c| c.name.to_s.start_with?("State", "Messages", "Activity") }
+  reasoning = classes.select { |c| c.name.to_s.start_with?("Reasoning") }
   special = classes.select { |c| c.name.to_s.start_with?("Raw", "Custom") }
+
+  # Fail-loud: every event class must land in exactly one bucket. If a new
+  # event class is added upstream and no bucket matches, we want a noisy
+  # failure rather than silently dropping it from the docs.
+  bucketed = (lifecycle + text + thinking + tool + state + reasoning + special).map(&:path).to_set
+  orphans = classes.reject { |c| bucketed.include?(c.path) }.map { |c| c.name.to_s }
+  unless orphans.empty?
+    raise "ag_ui_protocol YARD template: event classes not assigned to any group: #{orphans.join(", ")}. Update setup.rb groups[] to include them."
+  end
 
   if event_type_module
     out << "## EventType\n\n"
@@ -810,8 +1007,10 @@ def serialize_events_page
   groups = [
     ["Lifecycle Events", lifecycle],
     ["Text Message Events", text],
+    ["Thinking Events", thinking],
     ["Tool Call Events", tool],
     ["State Management Events", state],
+    ["Reasoning Events", reasoning],
     ["Special Events", special]
   ]
 
@@ -833,6 +1032,23 @@ def serialize_events_page
     out << "#{section_doc}\n\n" unless section_doc.empty?
 
     list.sort_by { |c| c.name.to_s }.each do |klass|
+      out << "### #{klass.name}\n\n"
+      out << "#{inline_code(klass.path)}\n\n"
+
+      append_doc(out, klass.docstring)
+      append_tags(out, klass)
+
+      table = render_params_table_for(klass)
+      out << table unless table.empty?
+    end
+  end
+
+  # Render outcome value types (used by RunFinishedEvent.outcome) in a
+  # dedicated section, NOT bucketed with events.
+  unless outcomes.empty?
+    out << "## Run Outcome Types\n\n"
+    out << "Value types referenced by `RunFinishedEvent.outcome`.\n\n"
+    outcomes.sort_by { |c| c.name.to_s }.each do |klass|
       out << "### #{klass.name}\n\n"
       out << "#{inline_code(klass.path)}\n\n"
 
@@ -954,6 +1170,47 @@ def serialize_types_page
   out
 end
 
+# Curated semantic order for capability sections. Used when the
+# Capabilities module docstring does NOT provide its own `## Heading`
+# section order. Matches overview.mdx ordering so the rendered page
+# reads top-to-bottom in roughly increasing specialization.
+CAPABILITY_SECTION_ORDER = %w[
+  AgentCapabilities
+  IdentityCapabilities
+  TransportCapabilities
+  ToolsCapabilities
+  OutputCapabilities
+  StateCapabilities
+  MultiAgentCapabilities
+  ReasoningCapabilities
+  MultimodalCapabilities
+  MultimodalInputCapabilities
+  MultimodalOutputCapabilities
+  ExecutionCapabilities
+  HumanInTheLoopCapabilities
+].freeze
+
+# Fallback hardcoded list of value-type class names in the Capabilities
+# module. Classes are recognized as value types iff they carry an explicit
+# `@category Value Types` tag (preferred) OR appear in this list. Any new
+# class in the module that is neither a *Capabilities suffix class nor
+# tagged/listed here will raise — see capability_value_type? below.
+CAPABILITY_VALUE_TYPES = %w[SubAgentInfo].freeze
+
+def capability_value_type?(klass)
+  category = category_for(klass).to_s.strip
+  return true if category == "Value Types"
+
+  name = klass.name.to_s
+  return true if CAPABILITY_VALUE_TYPES.include?(name)
+
+  unless name.end_with?("Capabilities")
+    raise "ag_ui_protocol YARD template: class #{klass.path} is not a *Capabilities class and has no `@category Value Types` tag. Tag it explicitly so setup.rb knows whether to render it as a top-level capability or a value type (or add it to CAPABILITY_VALUE_TYPES in setup.rb)."
+  end
+
+  false
+end
+
 def serialize_capabilities_page
   capabilities_module = Registry.at("AgUiProtocol::Core::Capabilities")
   out = +""
@@ -964,10 +1221,20 @@ def serialize_capabilities_page
   preamble_doc, _section_docs, section_order = extract_virtual_sections(module_doc)
   out << "#{preamble_doc}\n\n" unless preamble_doc.empty?
 
-  classes = capabilities_module.children.grep(CodeObjects::ClassObject).sort_by { |c| c.name.to_s }
+  all_classes = capabilities_module.children.grep(CodeObjects::ClassObject).sort_by { |c| c.name.to_s }
+
+  # Value types (e.g. SubAgentInfo) are referenced by capability classes but
+  # are not themselves capabilities. Pull them out so they don't appear as
+  # peers of AgentCapabilities/MultiAgentCapabilities at the top level.
+  value_types, classes = all_classes.partition { |c| capability_value_type?(c) }
+
+  # Section ordering: prefer `## Heading` order from the module docstring
+  # (template flexibility) when present; otherwise fall back to the curated
+  # CAPABILITY_SECTION_ORDER which matches overview.mdx semantic order.
+  effective_order = section_order.any? ? section_order : CAPABILITY_SECTION_ORDER
 
   rendered = Set.new
-  section_order.each do |title|
+  effective_order.each do |title|
     klass = classes.find { |c| c.name.to_s == title }
     next unless klass
     next if rendered.include?(klass.path)
@@ -994,6 +1261,21 @@ def serialize_capabilities_page
 
     table = render_params_table_for(klass)
     out << table unless table.empty?
+  end
+
+  unless value_types.empty?
+    out << "## Value Types\n\n"
+    out << "Value types referenced by capability classes.\n\n"
+    value_types.each do |klass|
+      out << "### #{klass.name}\n\n"
+      out << "#{inline_code(klass.path)}\n\n"
+
+      append_doc(out, klass.docstring)
+      append_tags(out, klass)
+
+      table = render_params_table_for(klass)
+      out << table unless table.empty?
+    end
   end
 
   out
@@ -1048,12 +1330,120 @@ end
 ##
 # Converts rdoc to markdown.
 #
-# I didn't found a way to detect yard/rdoc docstrings, so we're running docstrings through rdoc to markdown converter in all cases. If it's yard docstring, it doesn't seem to have any negative effect on end results. But absense of bugs, doesn't mean that there are no issues.
+# I didn't find a way to detect yard/rdoc docstrings, so we're running docstrings through rdoc to markdown converter in all cases. If it's yard docstring, it doesn't seem to have any negative effect on end results. But absence of bugs doesn't mean that there are no issues.
 #
 # @param docstring [String, YARD::Docstring]
 # @return [String] markdown formatted string
 def rdoc_to_md(docstring)
-  RDoc::Markup::ToMarkdown.new.convert(docstring)
+  md = RDoc::Markup::ToMarkdown.new.convert(docstring).to_s
+  md = ensure_fences_on_own_lines(md)
+  md = convert_verbatim_plus_to_code(md)
+  md
+end
+
+# RDoc::Markup::ToMarkdown sometimes collapses blank lines around triple
+# backtick fences, producing output like `prose. ```ruby code``` more prose`
+# on a single line. Split fences onto their own lines so MDX renders the
+# code block correctly. Avoid introducing double-blank lines.
+def ensure_fences_on_own_lines(md)
+  return md if md.nil? || md.empty?
+
+  # 1. Force any ``` token that is not already at line-start onto its own
+  #    line. This handles `prose ```ruby` style runons.
+  result = md.gsub(/([^\n])(```)/, "\\1\n\\2")
+
+  # 2. If a fence line has a language tag followed by content on the same
+  #    line (e.g. "```ruby code = 1"), split the language and content.
+  #    For closing fences (bare "```"), split anything after the tag.
+  result = result.split("\n", -1).flat_map do |line|
+    stripped = line.lstrip
+    next [line] unless stripped.start_with?("```")
+
+    indent = line[0...(line.length - stripped.length)]
+    rest = stripped[3..].to_s
+
+    if rest.empty?
+      [line]
+    else
+      # rest may be "<lang>" alone, or "<lang> <content>", or "<content>"
+      # for a closing fence. Pull off the first whitespace-delimited token
+      # as the language tag iff it's all word characters; otherwise treat
+      # the whole rest as content following a bare ``` (closing fence
+      # case).
+      m = rest.match(/\A(\w+)(\s+)(.+)\z/m)
+      if m
+        ["#{indent}```#{m[1]}", m[3]]
+      elsif rest.match?(/\A\w+\z/)
+        # Just a language tag with no trailing content — leave alone.
+        [line]
+      else
+        # Closing fence (or odd content) with stuff after it.
+        ["#{indent}```", rest]
+      end
+    end
+  end.join("\n")
+
+  # 3. Ensure a blank line BEFORE an OPENING fence when the previous line
+  #    is non-empty. Track fence parity line-by-line so we only act on
+  #    transitions out→in (opening fences). Critically: NEVER insert a
+  #    blank between an opening fence and the first code line, nor between
+  #    the last code line and the closing fence — that lives INSIDE a
+  #    fence and would corrupt the rendered code block.
+  out_lines = []
+  prev = nil
+  in_fence_pre = false
+  result.split("\n", -1).each do |line|
+    is_fence = line.lstrip.start_with?("```")
+    is_opening = is_fence && !in_fence_pre
+    if is_opening && prev && !prev.strip.empty? && !prev.lstrip.start_with?("```")
+      out_lines << ""
+    end
+    out_lines << line
+    in_fence_pre = !in_fence_pre if is_fence
+    prev = line
+  end
+
+  # 4. Ensure a blank line AFTER a CLOSING fence when the next line is
+  #    non-empty and not another fence. Track fence parity from the start
+  #    of the document so we know exactly which fence is closing.
+  final = []
+  in_fence_post = false
+  out_lines.each_with_index do |line, i|
+    final << line
+    is_fence = line.lstrip.start_with?("```")
+    if is_fence
+      was_in_fence = in_fence_post
+      in_fence_post = !in_fence_post
+      # Closing fence = transition from inside → outside.
+      is_closing = was_in_fence && !in_fence_post
+      next_line = out_lines[i + 1]
+      if is_closing && next_line && !next_line.strip.empty? && !next_line.lstrip.start_with?("```")
+        final << ""
+      end
+    end
+  end
+
+  final.join("\n")
+end
+
+# RDoc's +verbatim+ markup is not converted to backtick code spans by
+# ToMarkdown, so terms like `+true+` and `+nil+` render literally. Convert
+# `+text+` to `` `text` `` but only outside of fenced code blocks (where
+# arithmetic expressions could legitimately use `+`).
+def convert_verbatim_plus_to_code(md)
+  return md if md.nil? || md.empty?
+
+  in_fence = false
+  md.split("\n", -1).map do |line|
+    if line.lstrip.start_with?("```")
+      in_fence = !in_fence
+      next line
+    end
+    next line if in_fence
+
+    # +word+ where word starts with non-space non-+ and contains no +.
+    line.gsub(/\+([^+\s][^+]*?)\+/, '`\1`')
+  end.join("\n")
 end
 
 ##
@@ -1073,14 +1463,21 @@ def render_tags(object)
   examples = []
 
   object.tags.each do |tag|
-    next if %w[attr_reader param document_title].include?(tag.tag_name)
+    # Skip tags consumed elsewhere (params, document_title, attr_reader) or
+    # tags used purely for bucketing (category). Without this skip, every
+    # class with a @category tag rendered a stray "**@category** [] <name>"
+    # line in the docs.
+    next if %w[attr_reader param document_title category].include?(tag.tag_name)
 
     if tag.tag_name == "example"
       examples << tag
       next
     end
 
-    result << "**@#{tag.tag_name}** [#{tag.types&.join(', ')}] #{tag.text}\n\n"
+    types_arr = tag.respond_to?(:types) ? tag.types : nil
+    type_part = (types_arr && !types_arr.empty?) ? " [#{types_arr.join(", ")}]" : ""
+    text_part = tag.text.to_s
+    result << "**@#{tag.tag_name}**#{type_part}#{text_part.empty? ? "" : " #{text_part}"}\n\n"
   end
 
   examples.each do |tag|

--- a/sdks/community/ruby/test/ag_ui_protocol/core/capabilities_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/capabilities_test.rb
@@ -1,0 +1,326 @@
+require "test_helper"
+require "json"
+
+class CapabilitiesTest < Minitest::Test
+  context "AgUiProtocol::Core::Capabilities" do
+    context "SubAgentInfo" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::SubAgentInfo.new(
+          name: "search-agent",
+          description: "Handles web search"
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal "search-agent", payload["name"]
+        assert_equal "Handles web search", payload["description"]
+      end
+
+      should "omit nil description" do
+        obj = AgUiProtocol::Core::Capabilities::SubAgentInfo.new(name: "search-agent")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "search-agent", payload["name"]
+        refute payload.key?("description")
+      end
+    end
+
+    context "IdentityCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::IdentityCapabilities.new(
+          name: "MyAgent",
+          type: "langgraph",
+          description: "A helpful agent",
+          version: "1.0.0",
+          provider: "ACME Corp",
+          documentation_url: "https://example.com/docs",
+          metadata: { "key" => "val" }
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal "MyAgent", payload["name"]
+        assert_equal "langgraph", payload["type"]
+        assert_equal "A helpful agent", payload["description"]
+        assert_equal "1.0.0", payload["version"]
+        assert_equal "ACME Corp", payload["provider"]
+        assert_equal "https://example.com/docs", payload["documentationUrl"]
+        assert_equal "val", payload["metadata"]["key"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::IdentityCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "TransportCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::TransportCapabilities.new(
+          streaming: true, websocket: false
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["streaming"]
+        assert_equal false, payload["websocket"]
+      end
+
+      should "include only set fields" do
+        obj = AgUiProtocol::Core::Capabilities::TransportCapabilities.new(
+          streaming: true
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["streaming"]
+        refute payload.key?("websocket")
+        refute payload.key?("httpBinary")
+        refute payload.key?("pushNotifications")
+        refute payload.key?("resumable")
+      end
+    end
+
+    context "ToolsCapabilities" do
+      should "serialize to JSON with camelCase" do
+        tool = AgUiProtocol::Core::Types::Tool.new(
+          name: "search", description: "Web search",
+          parameters: { type: "object", properties: {} }
+        )
+        obj = AgUiProtocol::Core::Capabilities::ToolsCapabilities.new(
+          supported: true, items: [tool], parallel_calls: true, client_provided: false
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["supported"]
+        assert_equal "search", payload["items"][0]["name"]
+        assert_equal true, payload["parallelCalls"]
+        assert_equal false, payload["clientProvided"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::ToolsCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "OutputCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::OutputCapabilities.new(
+          structured_output: true,
+          supported_mime_types: ["text/plain", "application/json"]
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["structuredOutput"]
+        assert_equal ["text/plain", "application/json"], payload["supportedMimeTypes"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::OutputCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "StateCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::StateCapabilities.new(
+          snapshots: true, deltas: false, memory: true, persistent_state: true
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["snapshots"]
+        assert_equal false, payload["deltas"]
+        assert_equal true, payload["memory"]
+        assert_equal true, payload["persistentState"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::StateCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "MultiAgentCapabilities" do
+      should "serialize to JSON with camelCase" do
+        sub = AgUiProtocol::Core::Capabilities::SubAgentInfo.new(
+          name: "research", description: "Research agent"
+        )
+        obj = AgUiProtocol::Core::Capabilities::MultiAgentCapabilities.new(
+          supported: true, delegation: true, handoffs: false, sub_agents: [sub]
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["supported"]
+        assert_equal true, payload["delegation"]
+        assert_equal false, payload["handoffs"]
+        assert_equal "research", payload["subAgents"][0]["name"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::MultiAgentCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "ReasoningCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::ReasoningCapabilities.new(
+          supported: true, streaming: true, encrypted: false
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["supported"]
+        assert_equal true, payload["streaming"]
+        assert_equal false, payload["encrypted"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::ReasoningCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "MultimodalInputCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities.new(
+          image: true, audio: false, video: true
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["image"]
+        assert_equal false, payload["audio"]
+        assert_equal true, payload["video"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "MultimodalOutputCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities.new(
+          image: true, audio: true
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["image"]
+        assert_equal true, payload["audio"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "MultimodalCapabilities" do
+      should "serialize to JSON with camelCase" do
+        input = AgUiProtocol::Core::Capabilities::MultimodalInputCapabilities.new(
+          image: true, audio: true
+        )
+        output = AgUiProtocol::Core::Capabilities::MultimodalOutputCapabilities.new(
+          image: false
+        )
+        obj = AgUiProtocol::Core::Capabilities::MultimodalCapabilities.new(
+          input: input, output: output
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["input"]["image"]
+        assert_equal true, payload["input"]["audio"]
+        assert_equal false, payload["output"]["image"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::MultimodalCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "ExecutionCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::ExecutionCapabilities.new(
+          code_execution: true, sandboxed: true,
+          max_iterations: 10, max_execution_time: 30000
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["codeExecution"]
+        assert_equal true, payload["sandboxed"]
+        assert_equal 10, payload["maxIterations"]
+        assert_equal 30000, payload["maxExecutionTime"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::ExecutionCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "HumanInTheLoopCapabilities" do
+      should "serialize to JSON with camelCase" do
+        obj = AgUiProtocol::Core::Capabilities::HumanInTheLoopCapabilities.new(
+          supported: true, approvals: true, interventions: false,
+          feedback: true, interrupts: false, approve_with_edits: true
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["supported"]
+        assert_equal true, payload["approvals"]
+        assert_equal false, payload["interventions"]
+        assert_equal true, payload["feedback"]
+        assert_equal false, payload["interrupts"]
+        assert_equal true, payload["approveWithEdits"]
+      end
+
+      should "omit nil fields" do
+        obj = AgUiProtocol::Core::Capabilities::HumanInTheLoopCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+    end
+
+    context "AgentCapabilities" do
+      should "serialize empty to JSON" do
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new
+        payload = JSON.parse(obj.to_json)
+        assert_equal({}, payload)
+      end
+
+      should "include sub-capabilities" do
+        identity = AgUiProtocol::Core::Capabilities::IdentityCapabilities.new(
+          name: "Agent", version: "1"
+        )
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new(identity: identity)
+        payload = JSON.parse(obj.to_json)
+        assert_equal "Agent", payload["identity"]["name"]
+      end
+
+      should "include nested capabilities" do
+        transport = AgUiProtocol::Core::Capabilities::TransportCapabilities.new(
+          streaming: true
+        )
+        reasoning = AgUiProtocol::Core::Capabilities::ReasoningCapabilities.new(
+          supported: true
+        )
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new(
+          transport: transport, reasoning: reasoning
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["transport"]["streaming"]
+        assert_equal true, payload["reasoning"]["supported"]
+      end
+
+      should "serialize custom field" do
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new(
+          custom: { "featureX" => { "enabled" => true } }
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["custom"]["featureX"]["enabled"]
+      end
+
+      should "include output capabilities" do
+        output = AgUiProtocol::Core::Capabilities::OutputCapabilities.new(
+          structured_output: true
+        )
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new(output: output)
+        payload = JSON.parse(obj.to_json)
+        assert_equal true, payload["output"]["structuredOutput"]
+      end
+    end
+  end
+end

--- a/sdks/community/ruby/test/ag_ui_protocol/core/capabilities_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/capabilities_test.rb
@@ -48,6 +48,17 @@ class CapabilitiesTest < Minitest::Test
         payload = JSON.parse(obj.to_json)
         assert_equal({}, payload)
       end
+
+      should "preserve user-supplied metadata keys verbatim (no camelCase rewriting)" do
+        obj = AgUiProtocol::Core::Capabilities::IdentityCapabilities.new(
+          metadata: { "agent_id" => "x", "feature_flag" => true, "nested_thing" => { "user_key" => "raw" } }
+        )
+        payload = JSON.parse(obj.to_json)
+        # metadata is an opaque user-defined Hash; inner keys must NOT be camelized.
+        assert_equal "x", payload["metadata"]["agent_id"]
+        assert_equal true, payload["metadata"]["feature_flag"]
+        assert_equal "raw", payload["metadata"]["nested_thing"]["user_key"]
+      end
     end
 
     context "TransportCapabilities" do
@@ -311,6 +322,16 @@ class CapabilitiesTest < Minitest::Test
         )
         payload = JSON.parse(obj.to_json)
         assert_equal true, payload["custom"]["featureX"]["enabled"]
+      end
+
+      should "preserve user-supplied custom keys verbatim (no camelCase rewriting)" do
+        obj = AgUiProtocol::Core::Capabilities::AgentCapabilities.new(
+          custom: { "agent_id" => "x", "feature_flag" => { "deep_key" => 1 } }
+        )
+        payload = JSON.parse(obj.to_json)
+        # `custom` is the explicit escape hatch; inner keys must NOT be camelized.
+        assert_equal "x", payload["custom"]["agent_id"]
+        assert_equal 1, payload["custom"]["feature_flag"]["deep_key"]
       end
 
       should "include output capabilities" do

--- a/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
@@ -376,6 +376,34 @@ class EventsTest < Minitest::Test
           AgUiProtocol::Core::Events::RunFinishedEvent.new(run_id: "r1")
         end
       end
+
+      should "support success outcome" do
+        outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+        event = AgUiProtocol::Core::Events::RunFinishedEvent.new(
+          thread_id: "t1", run_id: "r1", outcome: outcome
+        )
+        assert_event_payload(
+          event,
+          { "type" => "RUN_FINISHED", "threadId" => "t1", "runId" => "r1", "outcome" => { "type" => "success" } }
+        )
+      end
+
+      should "support interrupt outcome" do
+        interrupt = AgUiProtocol::Core::Types::Interrupt.new(id: "int1", reason: "input_required")
+        outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(interrupts: [interrupt])
+        event = AgUiProtocol::Core::Events::RunFinishedEvent.new(
+          thread_id: "t1", run_id: "r1", outcome: outcome
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal "interrupt", payload["outcome"]["type"]
+        assert_equal "int1", payload["outcome"]["interrupts"][0]["id"]
+      end
+
+      should "omit outcome when nil" do
+        event = AgUiProtocol::Core::Events::RunFinishedEvent.new(thread_id: "t1", run_id: "r1")
+        payload = JSON.parse(event.to_json)
+        refute payload.key?("outcome")
+      end
     end
 
     context "RunErrorEvent" do
@@ -414,6 +442,158 @@ class EventsTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Events::StepFinishedEvent.new
         end
+      end
+    end
+
+    context "ReasoningStartEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningStartEvent.new(message_id: "r1")
+        assert_event_payload(event, { "type" => "REASONING_START", "messageId" => "r1" })
+      end
+
+      should "raise when message_id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningStartEvent.new
+        end
+      end
+    end
+
+    context "ReasoningMessageStartEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id: "rm1")
+        assert_event_payload(
+          event,
+          { "type" => "REASONING_MESSAGE_START", "messageId" => "rm1", "role" => "reasoning" }
+        )
+      end
+
+      should "raise when message_id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new
+        end
+      end
+    end
+
+    context "ReasoningMessageContentEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageContentEvent.new(message_id: "rm1", delta: "step 1")
+        assert_event_payload(
+          event,
+          { "type" => "REASONING_MESSAGE_CONTENT", "messageId" => "rm1", "delta" => "step 1" }
+        )
+      end
+
+      should "raise when delta is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningMessageContentEvent.new(message_id: "rm1")
+        end
+      end
+    end
+
+    context "ReasoningMessageEndEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageEndEvent.new(message_id: "rm1")
+        assert_event_payload(event, { "type" => "REASONING_MESSAGE_END", "messageId" => "rm1" })
+      end
+
+      should "raise when message_id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningMessageEndEvent.new
+        end
+      end
+    end
+
+    context "ReasoningMessageChunkEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageChunkEvent.new(message_id: "rm1", delta: "step 1")
+        assert_event_payload(
+          event,
+          { "type" => "REASONING_MESSAGE_CHUNK", "messageId" => "rm1", "delta" => "step 1" }
+        )
+      end
+
+      should "work with nil fields" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageChunkEvent.new
+        assert_event_payload(event, { "type" => "REASONING_MESSAGE_CHUNK" })
+      end
+    end
+
+    context "ReasoningEndEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningEndEvent.new(message_id: "r1")
+        assert_event_payload(event, { "type" => "REASONING_END", "messageId" => "r1" })
+      end
+
+      should "raise when message_id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningEndEvent.new
+        end
+      end
+    end
+
+    context "ReasoningEncryptedValueEvent" do
+      should "serialize with type" do
+        event = AgUiProtocol::Core::Events::ReasoningEncryptedValueEvent.new(
+          subtype: "tool-call", entity_id: "tc1", encrypted_value: "enc"
+        )
+        assert_event_payload(
+          event,
+          { "type" => "REASONING_ENCRYPTED_VALUE", "subtype" => "tool-call", "entityId" => "tc1", "encryptedValue" => "enc" }
+        )
+      end
+
+      should "raise when subtype is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningEncryptedValueEvent.new(entity_id: "tc1", encrypted_value: "enc")
+        end
+      end
+    end
+
+    context "RunFinishedSuccessOutcome" do
+      should "serialize with type" do
+        outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+        payload = JSON.parse(outcome.to_json)
+        assert_equal "success", payload["type"]
+      end
+    end
+
+    context "RunFinishedInterruptOutcome" do
+      should "serialize with type" do
+        interrupt = AgUiProtocol::Core::Types::Interrupt.new(id: "int1", reason: "input_required")
+        outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(interrupts: [interrupt])
+        payload = JSON.parse(outcome.to_json)
+        assert_equal "interrupt", payload["type"]
+        assert_equal "int1", payload["interrupts"][0]["id"]
+      end
+
+      should "raise when interrupts is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new
+        end
+      end
+    end
+
+    context "EventType" do
+      should "include reasoning constants" do
+        assert_equal "REASONING_START", AgUiProtocol::Core::Events::EventType::REASONING_START
+        assert_equal "REASONING_MESSAGE_START", AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_START
+        assert_equal "REASONING_MESSAGE_CONTENT", AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_CONTENT
+        assert_equal "REASONING_MESSAGE_END", AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_END
+        assert_equal "REASONING_MESSAGE_CHUNK", AgUiProtocol::Core::Events::EventType::REASONING_MESSAGE_CHUNK
+        assert_equal "REASONING_END", AgUiProtocol::Core::Events::EventType::REASONING_END
+        assert_equal "REASONING_ENCRYPTED_VALUE", AgUiProtocol::Core::Events::EventType::REASONING_ENCRYPTED_VALUE
+      end
+    end
+
+    context "TEXT_MESSAGE_ROLE_VALUES" do
+      should "include reasoning" do
+        assert_includes AgUiProtocol::Core::Events::TEXT_MESSAGE_ROLE_VALUES, "reasoning"
+      end
+    end
+
+    context "ReasoningEncryptedValueSubtype" do
+      should "be defined" do
+        refute_nil AgUiProtocol::Core::Events::ReasoningEncryptedValueSubtype
       end
     end
   end

--- a/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
@@ -14,6 +14,38 @@ class EventsTest < Minitest::Test
           AgUiProtocol::Core::Events::BaseEvent.new
         end
       end
+
+      should "serialize Time timestamp as epoch milliseconds (Integer)" do
+        t = Time.utc(2026, 5, 26, 12, 0, 0)
+        event = AgUiProtocol::Core::Events::BaseEvent.new(
+          type: AgUiProtocol::Core::Events::EventType::RAW, timestamp: t
+        )
+        payload = JSON.parse(event.to_json)
+        assert_kind_of Integer, payload["timestamp"]
+        assert_equal 1779796800000, payload["timestamp"]
+      end
+
+      should "serialize non-UTC Time as the equivalent epoch milliseconds" do
+        t = Time.new(2026, 5, 26, 5, 0, 0, "-07:00") # equivalent to 12:00 UTC
+        event = AgUiProtocol::Core::Events::BaseEvent.new(
+          type: AgUiProtocol::Core::Events::EventType::RAW, timestamp: t
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal 1779796800000, payload["timestamp"]
+      end
+
+      should "serialize timestamp on a concrete event subclass (RunStartedEvent)" do
+        input = AgUiProtocol::Core::Types::RunAgentInput.new(
+          thread_id: "t1", run_id: "r1", state: {},
+          messages: [], tools: [], context: [], forwarded_props: {}
+        )
+        event = AgUiProtocol::Core::Events::RunStartedEvent.new(
+          thread_id: "t1", run_id: "r1", input: input,
+          timestamp: Time.utc(2026, 5, 26, 12, 0, 0)
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal 1779796800000, payload["timestamp"]
+      end
     end
 
     context "TextMessageStartEvent" do

--- a/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
@@ -257,6 +257,20 @@ class EventsTest < Minitest::Test
           AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(messages: [1])
         end
       end
+
+      should "accept ActivityMessage entries alongside BaseMessage" do
+        base = AgUiProtocol::Core::Types::DeveloperMessage.new(id: "d1", content: "hi")
+        activity = AgUiProtocol::Core::Types::ActivityMessage.new(
+          id: "a1", activity_type: "progress", content: { "pct" => 10 }
+        )
+        event = AgUiProtocol::Core::Events::MessagesSnapshotEvent.new(messages: [base, activity])
+        payload = JSON.parse(event.to_json)
+        assert_equal "MESSAGES_SNAPSHOT", payload["type"]
+        assert_equal 2, payload["messages"].length
+        assert_equal "d1", payload["messages"][0]["id"]
+        assert_equal "a1", payload["messages"][1]["id"]
+        assert_equal "activity", payload["messages"][1]["role"]
+      end
     end
 
     context "ActivitySnapshotEvent" do
@@ -404,6 +418,15 @@ class EventsTest < Minitest::Test
         payload = JSON.parse(event.to_json)
         refute payload.key?("outcome")
       end
+
+      should "raise when both result and outcome are set" do
+        outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::RunFinishedEvent.new(
+            thread_id: "t1", run_id: "r1", result: { "ok" => true }, outcome: outcome
+          )
+        end
+      end
     end
 
     context "RunErrorEvent" do
@@ -470,6 +493,17 @@ class EventsTest < Minitest::Test
       should "raise when message_id is missing" do
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new
+        end
+      end
+
+      should "accept role: \"reasoning\" for round-trip compatibility" do
+        event = AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id: "rm1", role: "reasoning")
+        assert_equal "reasoning", event.role
+      end
+
+      should "raise when role is not \"reasoning\"" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::ReasoningMessageStartEvent.new(message_id: "rm1", role: "user")
         end
       end
     end
@@ -555,6 +589,17 @@ class EventsTest < Minitest::Test
         payload = JSON.parse(outcome.to_json)
         assert_equal "success", payload["type"]
       end
+
+      should "accept type: \"success\" for round-trip compatibility" do
+        outcome = AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new(type: "success")
+        assert_equal "success", outcome.type
+      end
+
+      should "raise when type is not \"success\"" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::RunFinishedSuccessOutcome.new(type: "interrupt")
+        end
+      end
     end
 
     context "RunFinishedInterruptOutcome" do
@@ -569,6 +614,27 @@ class EventsTest < Minitest::Test
       should "raise when interrupts is missing" do
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new
+        end
+      end
+
+      should "accept type: \"interrupt\" for round-trip compatibility" do
+        interrupt = AgUiProtocol::Core::Types::Interrupt.new(id: "int1", reason: "input_required")
+        outcome = AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(interrupts: [interrupt], type: "interrupt")
+        assert_equal "interrupt", outcome.type
+      end
+
+      should "raise when type is not \"interrupt\"" do
+        interrupt = AgUiProtocol::Core::Types::Interrupt.new(id: "int1", reason: "input_required")
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(interrupts: [interrupt], type: "success")
+        end
+      end
+
+      should "raise when interrupts contains non-Interrupt entries" do
+        # sorbet-runtime catches T::Array[Interrupt] violations with a TypeError;
+        # accept either ArgumentError (our runtime check) or TypeError (sig check).
+        assert_raises(ArgumentError, TypeError) do
+          AgUiProtocol::Core::Events::RunFinishedInterruptOutcome.new(interrupts: ["not_an_interrupt"])
         end
       end
     end
@@ -591,11 +657,6 @@ class EventsTest < Minitest::Test
       end
     end
 
-    context "ReasoningEncryptedValueSubtype" do
-      should "be defined" do
-        refute_nil AgUiProtocol::Core::Events::ReasoningEncryptedValueSubtype
-      end
-    end
   end
 
   def assert_event_payload(event, expected)

--- a/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/events_test.rb
@@ -218,6 +218,16 @@ class EventsTest < Minitest::Test
           AgUiProtocol::Core::Events::StateSnapshotEvent.new
         end
       end
+
+      should "preserve user-supplied keys verbatim in snapshot" do
+        event = AgUiProtocol::Core::Events::StateSnapshotEvent.new(
+          snapshot: { "user_state" => { "agent_id" => "x", "feature_flag" => true } }
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal "x", payload["snapshot"]["user_state"]["agent_id"]
+        assert_equal true, payload["snapshot"]["user_state"]["feature_flag"]
+        refute payload["snapshot"].key?("userState")
+      end
     end
 
     context "StateDeltaEvent" do
@@ -233,6 +243,22 @@ class EventsTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Events::StateDeltaEvent.new
         end
+      end
+
+      should "preserve user-supplied keys verbatim inside JSON Patch op values" do
+        # RFC 6902 JSON Patch ops may carry arbitrary user payloads in `value`;
+        # nested keys must NOT be camelized on the wire.
+        event = AgUiProtocol::Core::Events::StateDeltaEvent.new(
+          delta: [
+            { "op" => "replace", "path" => "/user_state", "value" => { "agent_id" => "x", "feature_flag" => true } }
+          ]
+        )
+        payload = JSON.parse(event.to_json)
+        op = payload["delta"][0]
+        assert_equal "replace", op["op"]
+        assert_equal "/user_state", op["path"]
+        assert_equal "x", op["value"]["agent_id"]
+        assert_equal true, op["value"]["feature_flag"]
       end
     end
 
@@ -323,6 +349,17 @@ class EventsTest < Minitest::Test
           AgUiProtocol::Core::Events::RawEvent.new
         end
       end
+
+      should "preserve user-supplied keys verbatim in event payload" do
+        event = AgUiProtocol::Core::Events::RawEvent.new(
+          event: { "upstream_id" => "abc", "raw_data" => { "deep_key" => 1 } },
+          source: "openai"
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal "abc", payload["event"]["upstream_id"]
+        assert_equal 1, payload["event"]["raw_data"]["deep_key"]
+        refute payload["event"].key?("upstreamId")
+      end
     end
 
     context "CustomEvent" do
@@ -335,6 +372,17 @@ class EventsTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Events::CustomEvent.new(name: "custom")
         end
+      end
+
+      should "preserve user-supplied keys verbatim in value payload" do
+        event = AgUiProtocol::Core::Events::CustomEvent.new(
+          name: "my_event",
+          value: { "user_data" => { "agent_id" => "x", "feature_flag" => true } }
+        )
+        payload = JSON.parse(event.to_json)
+        assert_equal "x", payload["value"]["user_data"]["agent_id"]
+        assert_equal true, payload["value"]["user_data"]["feature_flag"]
+        refute payload["value"].key?("userData")
       end
     end
 

--- a/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
@@ -373,6 +373,20 @@ class TypesTest < Minitest::Test
         assert_equal "progress", payload["activityType"]
         assert_equal 10, payload["content"]["pct"]
       end
+
+      should "preserve user-supplied keys verbatim in content" do
+        msg = AgUiProtocol::Core::Types::ActivityMessage.new(
+          id: "am1",
+          activity_type: "progress",
+          content: { "step_name" => "indexing", "items_done" => 7 }
+        )
+        payload = JSON.parse(msg.to_json)
+        # `content` is arbitrary user-defined activity payload; keys preserved verbatim.
+        assert_equal "indexing", payload["content"]["step_name"]
+        assert_equal 7, payload["content"]["items_done"]
+        refute payload["content"].key?("stepName")
+        refute payload["content"].key?("itemsDone")
+      end
     end
 
     context "Context" do
@@ -401,6 +415,31 @@ class TypesTest < Minitest::Test
           AgUiProtocol::Core::Types::Tool.new(name: "t", description: "d")
         end
       end
+
+      should "preserve user-supplied JSON Schema keys verbatim in parameters" do
+        # JSON Schema fields like `properties` contain user-named keys that MUST
+        # NOT be camelized on the wire.
+        obj = AgUiProtocol::Core::Types::Tool.new(
+          name: "search",
+          description: "Web search",
+          parameters: {
+            "type" => "object",
+            "properties" => {
+              "search_query" => { "type" => "string" },
+              "max_results" => { "type" => "integer" }
+            },
+            "required" => ["search_query"]
+          }
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal "object", payload["parameters"]["type"]
+        # Inner schema keys are preserved exactly.
+        assert payload["parameters"]["properties"].key?("search_query")
+        assert payload["parameters"]["properties"].key?("max_results")
+        refute payload["parameters"]["properties"].key?("searchQuery")
+        assert_equal "string", payload["parameters"]["properties"]["search_query"]["type"]
+        assert_equal ["search_query"], payload["parameters"]["required"]
+      end
     end
 
     context "Interrupt" do
@@ -417,6 +456,28 @@ class TypesTest < Minitest::Test
         end
       end
 
+      should "preserve user-supplied keys verbatim in response_schema and metadata" do
+        obj = AgUiProtocol::Core::Types::Interrupt.new(
+          id: "int1",
+          reason: "input_required",
+          response_schema: {
+            "type" => "object",
+            "properties" => {
+              "user_answer" => { "type" => "string" }
+            }
+          },
+          metadata: { "trace_id" => "abc", "client_flag" => true }
+        )
+        payload = JSON.parse(obj.to_json)
+        # response_schema is JSON Schema; inner keys must be preserved.
+        assert payload["responseSchema"]["properties"].key?("user_answer")
+        refute payload["responseSchema"]["properties"].key?("userAnswer")
+        # metadata is arbitrary user data; inner keys must be preserved.
+        assert_equal "abc", payload["metadata"]["trace_id"]
+        assert_equal true, payload["metadata"]["client_flag"]
+        refute payload["metadata"].key?("traceId")
+      end
+
       should "include optional fields in to_h" do
         obj = AgUiProtocol::Core::Types::Interrupt.new(
           id: "int1", reason: "input_required",
@@ -427,9 +488,14 @@ class TypesTest < Minitest::Test
         hash = obj.to_h
         assert_equal "Please provide input", hash[:message]
         assert_equal "tc1", hash[:tool_call_id]
-        assert_equal "object", hash[:response_schema]["type"]
         assert_equal "2026-01-01T00:00:00Z", hash[:expires_at]
-        assert_equal "val", hash[:metadata]["key"]
+        # response_schema and metadata are user-supplied opaque payloads; to_h
+        # wraps them in Util::Opaque so the serializer preserves their keys
+        # verbatim (no camelCase rewriting, no nil compaction).
+        assert_kind_of AgUiProtocol::Util::Opaque, hash[:response_schema]
+        assert_equal({ "type" => "object" }, hash[:response_schema].value)
+        assert_kind_of AgUiProtocol::Util::Opaque, hash[:metadata]
+        assert_equal({ "key" => "val" }, hash[:metadata].value)
       end
     end
 
@@ -453,6 +519,19 @@ class TypesTest < Minitest::Test
         assert_equal "int1", payload["interruptId"]
         refute payload.key?("status")
         refute payload.key?("payload")
+      end
+
+      should "preserve user-supplied keys verbatim in payload" do
+        obj = AgUiProtocol::Core::Types::ResumeEntry.new(
+          interrupt_id: "int1",
+          status: "resolved",
+          payload: { "user_answer" => "42", "extra_info" => { "deep_key" => true } }
+        )
+        wire = JSON.parse(obj.to_json)
+        assert_equal "42", wire["payload"]["user_answer"]
+        assert_equal true, wire["payload"]["extra_info"]["deep_key"]
+        refute wire["payload"].key?("userAnswer")
+        refute wire["payload"].key?("extraInfo")
       end
     end
 
@@ -590,6 +669,25 @@ class TypesTest < Minitest::Test
             resume: [{ interrupt_id: "int1", status: "resolved", payload: {} }]
           )
         end
+      end
+
+      should "preserve user-supplied keys verbatim in state and forwarded_props" do
+        obj = AgUiProtocol::Core::Types::RunAgentInput.new(
+          thread_id: "t1",
+          run_id: "r1",
+          state: { "user_state_key" => { "deep_key" => 1 } },
+          messages: [],
+          tools: [],
+          context: [],
+          forwarded_props: { "client_token" => "abc", "feature_flag" => true }
+        )
+        payload = JSON.parse(obj.to_json)
+        # state and forwardedProps are opaque user payloads — keys preserved verbatim.
+        assert_equal 1, payload["state"]["user_state_key"]["deep_key"]
+        refute payload["state"].key?("userStateKey")
+        assert_equal "abc", payload["forwardedProps"]["client_token"]
+        assert_equal true, payload["forwardedProps"]["feature_flag"]
+        refute payload["forwardedProps"].key?("clientToken")
       end
     end
 

--- a/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
@@ -17,6 +17,12 @@ class TypesTest < Minitest::Test
       end
     end
 
+    context "Role" do
+      should "include reasoning in Role values" do
+        assert_includes AgUiProtocol::Core::Types::Role, "reasoning"
+      end
+    end
+
     context "FunctionCall" do
       should "serialize to JSON" do
         obj = AgUiProtocol::Core::Types::FunctionCall.new(name: "f", arguments: "{}")
@@ -128,6 +134,29 @@ class TypesTest < Minitest::Test
           AgUiProtocol::Core::Types::AssistantMessage.new(id: "a1", tool_calls: [{ id: "tc1" }])
         end
       end
+
+      should "support encrypted_value" do
+        obj = AgUiProtocol::Core::Types::AssistantMessage.new(id: "a1", content: "hi", encrypted_value: "enc")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "omit encrypted_value when nil" do
+        obj = AgUiProtocol::Core::Types::AssistantMessage.new(id: "a1", content: "hi")
+        payload = JSON.parse(obj.to_json)
+        refute payload.key?("encryptedValue")
+      end
+
+      should "accept tool_calls hash with string keys" do
+        obj = AgUiProtocol::Core::Types::AssistantMessage.new(
+          id: "a1",
+          content: "hi",
+          tool_calls: [{ "id" => "tc1", "function" => { "name" => "f", "arguments" => "{}" } }]
+        )
+        assert_kind_of AgUiProtocol::Core::Types::ToolCall, obj.tool_calls[0]
+        assert_equal "tc1", obj.tool_calls[0].id
+        assert_equal "f", obj.tool_calls[0].function.name
+      end
     end
 
     context "TextInputContent" do
@@ -148,6 +177,12 @@ class TypesTest < Minitest::Test
       should "raise when no source is provided" do
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::BinaryInputContent.new(mime_type: "image/png")
+        end
+      end
+
+      should "raise when all source fields are empty strings" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::BinaryInputContent.new(mime_type: "image/png", url: "", data: "", id: "")
         end
       end
 
@@ -181,6 +216,27 @@ class TypesTest < Minitest::Test
         end
       end
 
+      should "support encrypted_value" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(id: "u1", content: "hello", encrypted_value: "enc")
+        payload = JSON.parse(msg.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "omit encrypted_value when nil" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(id: "u1", content: "hello")
+        payload = JSON.parse(msg.to_json)
+        refute payload.key?("encryptedValue")
+      end
+
+      should "raise on unknown content type in array" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::UserMessage.new(
+            id: "u1",
+            content: [{ type: "mystery", value: "nope" }]
+          )
+        end
+      end
+
       should "normalize array content into typed input content models" do
         msg = AgUiProtocol::Core::Types::UserMessage.new(
           id: "u1",
@@ -211,6 +267,33 @@ class TypesTest < Minitest::Test
         assert_kind_of AgUiProtocol::Core::Types::AudioInputContent, msg.content[2]
         assert_kind_of AgUiProtocol::Core::Types::VideoInputContent, msg.content[3]
         assert_kind_of AgUiProtocol::Core::Types::DocumentInputContent, msg.content[4]
+      end
+
+      should "accept camelCase mimeType in multimodal image source" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(
+          id: "u1",
+          content: [
+            { type: "image", source: { type: "url", value: "https://example.com/a.png", mimeType: "image/png" } }
+          ]
+        )
+
+        assert_kind_of AgUiProtocol::Core::Types::ImageInputContent, msg.content[0]
+        assert_kind_of AgUiProtocol::Core::Types::InputContentUrlSource, msg.content[0].source
+        assert_equal "image/png", msg.content[0].source.mime_type
+      end
+
+      should "accept camelCase fileName in binary content normalization" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(
+          id: "u1",
+          content: [
+            { type: "binary", mimeType: "image/png", url: "https://example.com/a.png", fileName: "x.png" }
+          ]
+        )
+
+        assert_kind_of AgUiProtocol::Core::Types::BinaryInputContent, msg.content[0]
+        assert_equal "x.png", msg.content[0].filename
+        assert_equal "image/png", msg.content[0].mime_type
+        assert_equal "https://example.com/a.png", msg.content[0].url
       end
 
       should "normalize multimodal content with data source" do
@@ -282,6 +365,13 @@ class TypesTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::ActivityMessage.new(id: "am1", content: { "pct" => 10 })
         end
+      end
+
+      should "serialize structured content payload" do
+        msg = AgUiProtocol::Core::Types::ActivityMessage.new(id: "am1", activity_type: "progress", content: { "pct" => 10 })
+        payload = JSON.parse(msg.to_json)
+        assert_equal "progress", payload["activityType"]
+        assert_equal 10, payload["content"]["pct"]
       end
     end
 
@@ -355,6 +445,14 @@ class TypesTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::ResumeEntry.new(status: "resolved", payload: {})
         end
+      end
+
+      should "allow omitting status and payload" do
+        obj = AgUiProtocol::Core::Types::ResumeEntry.new(interrupt_id: "int1")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "int1", payload["interruptId"]
+        refute payload.key?("status")
+        refute payload.key?("payload")
       end
     end
 
@@ -483,6 +581,16 @@ class TypesTest < Minitest::Test
         payload = JSON.parse(obj.to_json)
         refute payload.key?("resume")
       end
+
+      should "raise when resume contains a non-ResumeEntry element" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::RunAgentInput.new(
+            thread_id: "t1", run_id: "r1", state: {},
+            messages: [], tools: [], context: [], forwarded_props: {},
+            resume: [{ interrupt_id: "int1", status: "resolved", payload: {} }]
+          )
+        end
+      end
     end
 
     should "work with array content" do
@@ -520,17 +628,17 @@ class TypesTest < Minitest::Test
         AgUiProtocol::Core::Types::FunctionCall.new(name: "f", arguments: "{}"),
         AgUiProtocol::Core::Types::ToolCall.new(id: "tc1", function: { name: "f", arguments: "{}" }),
       ]
-      
+
       assert_raises(ArgumentError) do
-        obj = AgUiProtocol::Core::Types::RunAgentInput.new(
-        thread_id: "t1",
-        run_id: "r1",
-        state: {},
-        messages: messages,
-        tools: [],
-        context: [],
-        forwarded_props: {}
-      )
+        AgUiProtocol::Core::Types::RunAgentInput.new(
+          thread_id: "t1",
+          run_id: "r1",
+          state: {},
+          messages: messages,
+          tools: [],
+          context: [],
+          forwarded_props: {}
+        )
       end
     end
   end

--- a/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/core/types_test.rb
@@ -44,6 +44,18 @@ class TypesTest < Minitest::Test
           AgUiProtocol::Core::Types::ToolCall.new(id: "tc1")
         end
       end
+
+      should "support encrypted_value" do
+        obj = AgUiProtocol::Core::Types::ToolCall.new(id: "tc1", function: { name: "f", arguments: "{}" }, encrypted_value: "enc")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "omit encrypted_value when nil" do
+        obj = AgUiProtocol::Core::Types::ToolCall.new(id: "tc1", function: { name: "f", arguments: "{}" })
+        payload = JSON.parse(obj.to_json)
+        refute payload.key?("encryptedValue")
+      end
     end
 
     context "BaseMessage" do
@@ -57,6 +69,18 @@ class TypesTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::BaseMessage.new(id: "m1")
         end
+      end
+
+      should "support encrypted_value" do
+        obj = AgUiProtocol::Core::Types::BaseMessage.new(id: "m1", role: "assistant", content: "hi", encrypted_value: "enc")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "omit encrypted_value when nil" do
+        obj = AgUiProtocol::Core::Types::BaseMessage.new(id: "m1", role: "assistant", content: "hi")
+        payload = JSON.parse(obj.to_json)
+        refute payload.key?("encryptedValue")
       end
     end
 
@@ -171,6 +195,36 @@ class TypesTest < Minitest::Test
         assert_kind_of AgUiProtocol::Core::Types::BinaryInputContent, msg.content[1]
       end
 
+      should "normalize multimodal content types" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(
+          id: "u1",
+          content: [
+            { type: "text", text: "describe this" },
+            { type: "image", source: { type: "url", value: "https://example.com/a.png", mime_type: "image/png" } },
+            { type: "audio", source: { type: "url", value: "https://example.com/a.mp3", mime_type: "audio/mp3" } },
+            { type: "video", source: { type: "url", value: "https://example.com/a.mp4", mime_type: "video/mp4" } },
+            { type: "document", source: { type: "url", value: "https://example.com/a.pdf", mime_type: "application/pdf" } }
+          ]
+        )
+
+        assert_kind_of AgUiProtocol::Core::Types::ImageInputContent, msg.content[1]
+        assert_kind_of AgUiProtocol::Core::Types::AudioInputContent, msg.content[2]
+        assert_kind_of AgUiProtocol::Core::Types::VideoInputContent, msg.content[3]
+        assert_kind_of AgUiProtocol::Core::Types::DocumentInputContent, msg.content[4]
+      end
+
+      should "normalize multimodal content with data source" do
+        msg = AgUiProtocol::Core::Types::UserMessage.new(
+          id: "u1",
+          content: [
+            { type: "image", source: { type: "data", value: "base64data", mime_type: "image/png" } }
+          ]
+        )
+
+        assert_kind_of AgUiProtocol::Core::Types::ImageInputContent, msg.content[0]
+        assert_kind_of AgUiProtocol::Core::Types::InputContentDataSource, msg.content[0].source
+      end
+
       should "serialize content with camelCase keys" do
         msg = AgUiProtocol::Core::Types::UserMessage.new(
           id: "u1",
@@ -202,6 +256,18 @@ class TypesTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::ToolMessage.new(id: "tm1", content: "ok")
         end
+      end
+
+      should "support encrypted_value" do
+        msg = AgUiProtocol::Core::Types::ToolMessage.new(id: "tm1", content: "ok", tool_call_id: "tc1", encrypted_value: "enc")
+        payload = JSON.parse(msg.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "omit encrypted_value when nil" do
+        msg = AgUiProtocol::Core::Types::ToolMessage.new(id: "tm1", content: "ok", tool_call_id: "tc1")
+        payload = JSON.parse(msg.to_json)
+        refute payload.key?("encryptedValue")
       end
     end
 
@@ -247,6 +313,134 @@ class TypesTest < Minitest::Test
       end
     end
 
+    context "Interrupt" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::Interrupt.new(id: "int1", reason: "input_required")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "int1", payload["id"]
+        assert_equal "input_required", payload["reason"]
+      end
+
+      should "raise when id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::Interrupt.new(reason: "input_required")
+        end
+      end
+
+      should "include optional fields in to_h" do
+        obj = AgUiProtocol::Core::Types::Interrupt.new(
+          id: "int1", reason: "input_required",
+          message: "Please provide input", tool_call_id: "tc1",
+          response_schema: { "type" => "object" }, expires_at: "2026-01-01T00:00:00Z",
+          metadata: { "key" => "val" }
+        )
+        hash = obj.to_h
+        assert_equal "Please provide input", hash[:message]
+        assert_equal "tc1", hash[:tool_call_id]
+        assert_equal "object", hash[:response_schema]["type"]
+        assert_equal "2026-01-01T00:00:00Z", hash[:expires_at]
+        assert_equal "val", hash[:metadata]["key"]
+      end
+    end
+
+    context "ResumeEntry" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::ResumeEntry.new(interrupt_id: "int1", status: "resolved", payload: { "ok" => true })
+        payload = JSON.parse(obj.to_json)
+        assert_equal "int1", payload["interruptId"]
+        assert_equal "resolved", payload["status"]
+      end
+
+      should "raise when interrupt_id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::ResumeEntry.new(status: "resolved", payload: {})
+        end
+      end
+    end
+
+    context "InputContentDataSource" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::InputContentDataSource.new(value: "base64data", mime_type: "image/png")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "data", payload["type"]
+        assert_equal "base64data", payload["value"]
+        assert_equal "image/png", payload["mimeType"]
+      end
+    end
+
+    context "InputContentUrlSource" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::InputContentUrlSource.new(value: "https://example.com/a.png", mime_type: "image/png")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "url", payload["type"]
+        assert_equal "https://example.com/a.png", payload["value"]
+        assert_equal "image/png", payload["mimeType"]
+      end
+    end
+
+    context "ImageInputContent" do
+      should "serialize to JSON" do
+        source = AgUiProtocol::Core::Types::InputContentUrlSource.new(value: "https://example.com/a.png", mime_type: "image/png")
+        obj = AgUiProtocol::Core::Types::ImageInputContent.new(source: source)
+        payload = JSON.parse(obj.to_json)
+        assert_equal "image", payload["type"]
+        assert_equal "url", payload["source"]["type"]
+      end
+
+      should "accept hash source" do
+        obj = AgUiProtocol::Core::Types::ImageInputContent.new(source: { type: "url", value: "https://example.com/a.png", mime_type: "image/png" })
+        assert_kind_of AgUiProtocol::Core::Types::InputContentUrlSource, obj.source
+      end
+    end
+
+    context "AudioInputContent" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::AudioInputContent.new(source: { type: "url", value: "https://example.com/a.mp3", mime_type: "audio/mp3" })
+        payload = JSON.parse(obj.to_json)
+        assert_equal "audio", payload["type"]
+        assert_equal "url", payload["source"]["type"]
+      end
+    end
+
+    context "VideoInputContent" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::VideoInputContent.new(source: { type: "url", value: "https://example.com/a.mp4", mime_type: "video/mp4" })
+        payload = JSON.parse(obj.to_json)
+        assert_equal "video", payload["type"]
+        assert_equal "url", payload["source"]["type"]
+      end
+    end
+
+    context "DocumentInputContent" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::DocumentInputContent.new(source: { type: "url", value: "https://example.com/a.pdf", mime_type: "application/pdf" })
+        payload = JSON.parse(obj.to_json)
+        assert_equal "document", payload["type"]
+        assert_equal "url", payload["source"]["type"]
+      end
+    end
+
+    context "ReasoningMessage" do
+      should "serialize to JSON" do
+        obj = AgUiProtocol::Core::Types::ReasoningMessage.new(id: "r1", content: "step 1")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "reasoning", payload["role"]
+        assert_equal "step 1", payload["content"]
+      end
+
+      should "support encrypted_value" do
+        obj = AgUiProtocol::Core::Types::ReasoningMessage.new(id: "r1", content: "step 1", encrypted_value: "enc")
+        payload = JSON.parse(obj.to_json)
+        assert_equal "enc", payload["encryptedValue"]
+      end
+
+      should "raise when id is missing" do
+        assert_raises(ArgumentError) do
+          AgUiProtocol::Core::Types::ReasoningMessage.new(content: "step 1")
+        end
+      end
+    end
+
     context "RunAgentInput" do
       should "serialize to JSON" do
         obj = AgUiProtocol::Core::Types::RunAgentInput.new(
@@ -266,6 +460,28 @@ class TypesTest < Minitest::Test
         assert_raises(ArgumentError) do
           AgUiProtocol::Core::Types::RunAgentInput.new(thread_id: "t1", run_id: "r1", state: {}, messages: [], tools: [], context: [])
         end
+      end
+
+      should "support resume field" do
+        resume = [
+          AgUiProtocol::Core::Types::ResumeEntry.new(interrupt_id: "int1", status: "resolved", payload: {})
+        ]
+        obj = AgUiProtocol::Core::Types::RunAgentInput.new(
+          thread_id: "t1", run_id: "r1", state: {},
+          messages: [], tools: [], context: [], forwarded_props: {},
+          resume: resume
+        )
+        payload = JSON.parse(obj.to_json)
+        assert_equal "int1", payload["resume"][0]["interruptId"]
+      end
+
+      should "omit resume when nil" do
+        obj = AgUiProtocol::Core::Types::RunAgentInput.new(
+          thread_id: "t1", run_id: "r1", state: {},
+          messages: [], tools: [], context: [], forwarded_props: {}
+        )
+        payload = JSON.parse(obj.to_json)
+        refute payload.key?("resume")
       end
     end
 

--- a/sdks/community/ruby/test/ag_ui_protocol/util_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/util_test.rb
@@ -62,4 +62,19 @@ class UtilTest < Minitest::Test
       assert_equal({ "user_key" => "raw" }, result[1])
     end
   end
+
+  context "AgUiProtocol::Util.normalize_value (Time)" do
+    should "convert Time to epoch milliseconds (Integer)" do
+      t = Time.utc(2026, 5, 26, 12, 0, 0)
+      result = AgUiProtocol::Util.normalize_value(t)
+      assert_kind_of Integer, result
+      # 2026-05-26T12:00:00Z == 1779796800 seconds since epoch == 1779796800000 ms
+      assert_equal 1779796800000, result
+    end
+
+    should "preserve sub-second precision when converting Time to epoch milliseconds" do
+      t = Time.utc(2026, 5, 26, 12, 0, 0, 500_000)
+      assert_equal 1779796800500, AgUiProtocol::Util.normalize_value(t)
+    end
+  end
 end

--- a/sdks/community/ruby/test/ag_ui_protocol/util_test.rb
+++ b/sdks/community/ruby/test/ag_ui_protocol/util_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+require "json"
+
+class UtilTest < Minitest::Test
+  context "AgUiProtocol::Util::Opaque" do
+    should "expose its wrapped value via #value" do
+      wrapped = AgUiProtocol::Util::Opaque.new({ "agent_id" => "x" })
+      assert_equal({ "agent_id" => "x" }, wrapped.value)
+    end
+  end
+
+  context "AgUiProtocol::Util.deep_compact" do
+    should "leave Opaque wrappers untouched (no recursion, no nil pruning)" do
+      payload = { "agent_id" => "x", "feature_flag" => nil, "nested" => { "user_key" => nil } }
+      result = AgUiProtocol::Util.deep_compact(AgUiProtocol::Util::Opaque.new(payload))
+      assert_kind_of AgUiProtocol::Util::Opaque, result
+      # Inner Hash is the same identity-preserved Hash; nils are NOT stripped.
+      assert_equal payload, result.value
+      assert_nil result.value["feature_flag"]
+      assert_nil result.value["nested"]["user_key"]
+    end
+
+    should "not recurse into Opaque-wrapped values inside a Hash" do
+      input = {
+        keep_me: nil,
+        opaque_field: AgUiProtocol::Util::Opaque.new({ "user_key" => nil, "other" => 1 })
+      }
+      result = AgUiProtocol::Util.deep_compact(input)
+      refute result.key?(:keep_me) # outer nils are still pruned
+      assert_kind_of AgUiProtocol::Util::Opaque, result[:opaque_field]
+      assert_equal({ "user_key" => nil, "other" => 1 }, result[:opaque_field].value)
+    end
+  end
+
+  context "AgUiProtocol::Util.deep_transform_keys_to_camel" do
+    should "unwrap Opaque and return inner value verbatim (no key camelization)" do
+      wrapped = AgUiProtocol::Util::Opaque.new({ "agent_id" => "x", "feature_flag" => true })
+      result = AgUiProtocol::Util.deep_transform_keys_to_camel(wrapped)
+      assert_equal({ "agent_id" => "x", "feature_flag" => true }, result)
+    end
+
+    should "preserve Opaque-wrapped values inside an enclosing Hash while camelizing the outer keys" do
+      input = {
+        outer_key: "v",
+        opaque_field: AgUiProtocol::Util::Opaque.new({ "nested_key" => { "deep_key" => 1 } })
+      }
+      result = AgUiProtocol::Util.deep_transform_keys_to_camel(input)
+      assert_equal "v", result["outerKey"]
+      # opaque inner Hash keys remain snake_case.
+      assert_equal({ "nested_key" => { "deep_key" => 1 } }, result["opaqueField"])
+    end
+
+    should "preserve Opaque values inside an Array" do
+      arr = [
+        { "outer_one" => 1 },
+        AgUiProtocol::Util::Opaque.new({ "user_key" => "raw" })
+      ]
+      result = AgUiProtocol::Util.deep_transform_keys_to_camel(arr)
+      # Element 0 is a normal Hash — keys ARE camelized (snake_case → camelCase).
+      assert_equal({ "outerOne" => 1 }, result[0])
+      # Element 1 is Opaque — keys preserved verbatim.
+      assert_equal({ "user_key" => "raw" }, result[1])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two bucket-d follow-ons to #1783 that surfaced during its CR but are out of scope for that PR's subject (Ruby SDK core types + reasoning events + capabilities). Both are cross-language interop fixes in `lib/ag_ui_protocol/util.rb` plus per-field opt-ins at the use sites.

**Stacked on #1783.** Until #1783 merges, this PR's diff vs main will include both #1783's changes and the new commits here. After #1783 merges, the diff narrows to only the 2 hardening commits.

## Fix 1: Preserve user-supplied opaque hash keys (`e1f676f6`)

`Model#as_json` runs `to_h` through `Util.deep_transform_keys_to_camel`, which recursively rewrites every Hash key as camelCase. Correct for schema-typed fields; wrong for fields that hold arbitrary user-controlled payloads.

Concrete impact: a user passing `metadata: { "agent_id" => "a1", "feature_flag" => true }` to `IdentityCapabilities` would see their keys silently rewritten to `agentId` / `featureFlag` over the wire. Same for `Interrupt#response_schema` (a JSON Schema — `properties` is user-defined), `Tool#parameters`, `RunAgentInput#forwarded_props`/`#state`, `StateSnapshotEvent#snapshot`, `StateDeltaEvent#delta`, `CustomEvent#value`, `RawEvent#event`, `ActivityMessage#content`, `AgentCapabilities#custom`, and others.

**Approach:** introduce `Util::Opaque` — a sentinel wrapper. `deep_compact` and `deep_transform_keys_to_camel` recognize it and emit the wrapped `value` verbatim (no key rewriting, no nil compaction). Each affected `to_h` site wraps the field as `Util::Opaque.new(raw_value)`.

**Affected fields wrapped:**
- `Interrupt#response_schema`, `Interrupt#metadata`
- `ResumeEntry#payload`
- `Tool#parameters`
- `ActivityMessage#content`
- `RunAgentInput#state`, `RunAgentInput#forwarded_props`
- `StateSnapshotEvent#snapshot`, `StateDeltaEvent#delta`
- `CustomEvent#value`
- `RawEvent#event`
- `IdentityCapabilities#metadata`
- `AgentCapabilities#custom`

## Fix 2: Serialize `BaseEvent.timestamp` as epoch milliseconds (`4d6c0ee6`)

`BaseEvent#timestamp` is typed `T.nilable(Time)`. Stdlib `JSON.generate` falls back to `Time#to_s`, producing strings like `"2026-05-26 12:00:00 -0700"`. Python types this as `Optional[int]` (epoch ms); TS types as `z.number().optional()` — both expect an integer.

Without this fix, every Ruby-emitted event with a non-nil timestamp is misread by Python/TS consumers.

**Fix:** `Util.normalize_value` adds a `Time` case → `(time.to_f * 1000).to_i`. Matches Python/TS encoding.

## Test plan

- [x] Baseline #1783 tests still pass (194 → 216, +22 new, 1 updated)
- [x] Opaque field round-trip preserves snake_case for: `metadata`, `custom`, `response_schema`, `forwarded_props`, `snapshot`, `value`, `event`, `content`
- [x] Sibling Hash fields that are NOT opaque (e.g., normal message fields) still camelize correctly
- [x] `RunStartedEvent.new(..., timestamp: Time.utc(...)).to_json` emits epoch ms integer
- [x] `nil` timestamp still omitted via `deep_compact`
- [x] Test that previously asserted into the inner structure of `response_schema`/`metadata` (predating the opaque contract) was updated with red-green discipline to assert via `Util::Opaque#value`

## Files

8 files changed, +302/-16 in commit 1; 3 files changed, +52 in commit 2.