### PR TITLE
test(langgraph): regression test for LG 0.6.0 configurable+context HTTP 400

### DIFF
--- a/integrations/langgraph/typescript/src/__tests__/agent.test.ts
+++ b/integrations/langgraph/typescript/src/__tests__/agent.test.ts
@@ -287,6 +287,79 @@ describe("prepareStream payload partitioning", () => {
     expect(payload.context).toBeUndefined();
   });
 
+  // Regression: langgraph-api 0.6.0+ rejects requests with HTTP 400
+  // "Cannot specify both configurable and context" when BOTH fields are
+  // present and non-empty in the run-create payload. See langgraph_api
+  // models/run.py (the run-create validator). The partition logic in
+  // prepareStream guarantees these two fields are mutually exclusive at
+  // the payload level. This test asserts that invariant across the four
+  // scenarios that mirror real-world Runtime usage.
+  it("test 6b: payload never carries both populated configurable AND populated context (LG 0.6.0 invariant)", async () => {
+    const scenarios: Array<{
+      name: string;
+      configurable: Record<string, unknown>;
+      contextSchema: string[];
+    }> = [
+      {
+        name: "headers-only (no context_schema)",
+        configurable: { copilotkit_forwarded_headers: { "x-trace": "1" } },
+        contextSchema: [],
+      },
+      {
+        name: "headers + ctx key (header dropped, ctx wins)",
+        configurable: {
+          copilotkit_forwarded_headers: { "x-trace": "1" },
+          my_ctx: "v",
+        },
+        contextSchema: ["my_ctx"],
+      },
+      {
+        name: "only ctx keys (all moved to context)",
+        configurable: { my_ctx: "v" },
+        contextSchema: ["my_ctx"],
+      },
+      {
+        name: "only non-ctx keys (all stay in configurable)",
+        configurable: { thread_scoped: "v" },
+        contextSchema: [],
+      },
+    ];
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    for (const scenario of scenarios) {
+      const { agent, capturedPayload } = buildMockedAgent(
+        { assistantConfig: { configurable: scenario.configurable } },
+        {
+          config: Object.keys(scenario.configurable),
+          context: scenario.contextSchema,
+        },
+      );
+
+      await runPrepareStream(agent);
+
+      const payload = capturedPayload.value!;
+      const cfgKeys =
+        (payload.config as any)?.configurable &&
+        Object.keys((payload.config as any).configurable).length > 0
+          ? Object.keys((payload.config as any).configurable)
+          : [];
+      const ctxKeys =
+        payload.context && Object.keys(payload.context as object).length > 0
+          ? Object.keys(payload.context as object)
+          : [];
+
+      // LG 0.6.0 invariant: not both fields populated simultaneously.
+      const bothPopulated = cfgKeys.length > 0 && ctxKeys.length > 0;
+      expect(
+        bothPopulated,
+        `scenario "${scenario.name}" populated both configurable (${cfgKeys.join(",")}) AND context (${ctxKeys.join(",")}) — would trigger LG 0.6.0 HTTP 400`,
+      ).toBe(false);
+    }
+
+    warnSpy.mockRestore();
+  });
+
   it("test 7: mergeConfigs preserves context_schema keys in allowlist", async () => {
     const { agent } = buildMockedAgent(
       {},


### PR DESCRIPTION
## Summary

Adds a regression test asserting the LangGraph 0.6.0+ invariant that the outbound run-create payload never carries both populated `config.configurable` AND populated `context` simultaneously. LG 0.6.0's `langgraph_api/models/run.py` rejects such requests with HTTP 400 "Cannot specify both configurable and context".

The functional fix was already shipped in commit 10aced42 ("feat(langgraph): per-request header forwarding via onRequest hook and context partition in mergeConfigs", 2026-05-22), which added `schemaKeys.context` to the merge allowlist and implemented the partition logic in `prepareStream` that ensures mutual exclusivity at the payload level. Published in `@ag-ui/langgraph` 0.0.33.

Existing tests 1-7 cover individual partition scenarios (configurable-only, context-only, context-wins data loss, key overlap, warning emission, mergeConfigs allowlist). This PR adds **test 6b** which asserts the LG 0.6.0 invariant directly across four real-world Runtime configurations:

1. headers-only (no context_schema)
2. headers + ctx key (header dropped, ctx wins)
3. only ctx keys (all moved to context)
4. only non-ctx keys (all stay in configurable)

In each scenario, the test fails the run if both `config.configurable` and `context` end up populated.

## Why this matters

Without this assertion, a future refactor of the partition logic in `prepareStream` could silently regress the invariant for some configurations — the existing tests only check individual aspects (does context contain key X, does configurable lack key Y), not the cross-field exclusivity that LG 0.6.0 explicitly enforces.

## Red-green verification

Confirmed RED by replacing the strip branch in `agent.ts` with `const configForPayload = finalConfig`. Scenario "headers + ctx key" failed with:

> scenario "headers + ctx key (header dropped, ctx wins)" populated both configurable (copilotkit_forwarded_headers) AND context (my_ctx) — would trigger LG 0.6.0 HTTP 400

Restored the original strip branch — test passes.

## Test plan

- [x] `pnpm test` in `integrations/langgraph/typescript` — 155 passing, 2 todo
- [x] `pnpm build` — clean (26.58 kB ESM, 16.45 kB CJS)
- [x] Format check via `prettier --write` — no changes
- [x] Red-green verified with bug reintroduced and restored