### PR TITLE
feat(langgraph): forward agent.headers into config.configurable.copilotkit_forwarded_headers

### DIFF
--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/langgraph",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"

--- a/integrations/langgraph/typescript/src/__tests__/agent.test.ts
+++ b/integrations/langgraph/typescript/src/__tests__/agent.test.ts
@@ -469,6 +469,110 @@ describe("header forwarding via onRequest hook", () => {
   });
 });
 
+// ─── Part C: forwarded-headers payload injection ─────────────────────────────
+//
+// CopilotKit Runtime writes per-request x-* headers (correlation IDs, x-aimock-context,
+// etc.) onto `agent.headers`. The Python LangGraph middleware reads them out of
+// payload.config.configurable.copilotkit_forwarded_headers (see
+// _extract_forwarded_headers_from_config in copilotkit_lg_middleware.py). The TS
+// adapter must serialize agent.headers into that exact path or downstream
+// extraction returns {}.
+//
+
+describe("forwarded headers injected into payload.config.configurable", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("test 15: x-* headers from agent.headers land in config.configurable.copilotkit_forwarded_headers", async () => {
+    const { agent, capturedPayload } = buildMockedAgent();
+    agent.headers = {
+      "x-aimock-context": "langgraph-typescript",
+      "x-correlation-id": "abc-123",
+      "x-request-id": "req-xyz",
+    };
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    expect(payload.config).toBeDefined();
+    const configurable = (payload.config as any)?.configurable;
+    expect(configurable).toBeDefined();
+    expect(configurable.copilotkit_forwarded_headers).toEqual({
+      "x-aimock-context": "langgraph-typescript",
+      "x-correlation-id": "abc-123",
+      "x-request-id": "req-xyz",
+    });
+  });
+
+  it("test 16: non-x-* headers are filtered out of copilotkit_forwarded_headers", async () => {
+    const { agent, capturedPayload } = buildMockedAgent();
+    agent.headers = {
+      "x-aimock-context": "langgraph-typescript",
+      authorization: "Bearer secret",
+      "content-type": "application/json",
+    };
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    const forwarded = (payload.config as any)?.configurable
+      ?.copilotkit_forwarded_headers;
+    expect(forwarded).toEqual({
+      "x-aimock-context": "langgraph-typescript",
+    });
+    expect(forwarded).not.toHaveProperty("authorization");
+    expect(forwarded).not.toHaveProperty("content-type");
+  });
+
+  it("test 17: empty agent.headers does not add copilotkit_forwarded_headers", async () => {
+    const { agent, capturedPayload } = buildMockedAgent();
+    agent.headers = {};
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    const configurable = (payload.config as any)?.configurable;
+    if (configurable) {
+      expect(configurable).not.toHaveProperty("copilotkit_forwarded_headers");
+    }
+  });
+
+  it("test 18: forwarded headers survive context-wins path (configurable stripped)", async () => {
+    // Scenario: context_schema present and assistantConfig populates a context
+    // key. The partition strips configurable in favor of context. The forwarded
+    // headers MUST still ride along — they are infrastructure metadata, not
+    // graph-context, and the Python middleware reads them from config.configurable.
+    const { agent, capturedPayload } = buildMockedAgent(
+      {
+        assistantConfig: {
+          configurable: { my_app_key: "val" },
+        },
+      },
+      { config: ["my_app_key"], context: ["my_app_key"] },
+    );
+    agent.headers = {
+      "x-aimock-context": "langgraph-typescript",
+    };
+
+    // Silence the data-loss warning that fires when context wins
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await runPrepareStream(agent);
+
+    const payload = capturedPayload.value!;
+    expect(payload.context).toEqual({ my_app_key: "val" });
+    // configurable should still exist solely to carry forwarded headers
+    const configurable = (payload.config as any)?.configurable;
+    expect(configurable).toBeDefined();
+    expect(configurable.copilotkit_forwarded_headers).toEqual({
+      "x-aimock-context": "langgraph-typescript",
+    });
+    // The graph-context key must NOT leak back into configurable
+    expect(configurable).not.toHaveProperty("my_app_key");
+  });
+});
+
 // ─── Integration tests (skipped without LANGGRAPH_API_URL) ───────────────────
 
 describe("integration tests (require LANGGRAPH_API_URL)", () => {

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -581,7 +581,7 @@ export class LangGraphAgent extends AbstractAgent {
 
     // Strip configurable cleanly using destructuring to avoid leaving an
     // explicit `configurable: undefined` key in the serialized payload.
-    const configForPayload = (() => {
+    const configForPayloadBase = (() => {
       if (!finalConfig) return undefined;
       if (hasConfigurable && !hasContext) return finalConfig; // old-style: configurable only
       const { configurable: _stripped, ...configSansConfigurable } =
@@ -590,6 +590,32 @@ export class LangGraphAgent extends AbstractAgent {
         ? configSansConfigurable
         : undefined;
     })();
+
+    // Forward x-* request headers into payload.config.configurable so the
+    // Python middleware can extract them via _extract_forwarded_headers_from_config.
+    // This is infrastructure metadata (correlation IDs, x-aimock-context, etc.),
+    // NOT graph context, so it must ride in configurable regardless of whether
+    // context_schema wins. Only x-* headers are forwarded; auth/content-type
+    // headers stay on the HTTP wire via the onRequest hook.
+    const forwardedHeaders = Object.fromEntries(
+      Object.entries(this.headers ?? {}).filter(([k]) =>
+        k.toLowerCase().startsWith("x-"),
+      ),
+    );
+    const configForPayload =
+      Object.keys(forwardedHeaders).length > 0
+        ? {
+            ...(configForPayloadBase ?? {}),
+            configurable: {
+              ...((
+                configForPayloadBase as {
+                  configurable?: Record<string, unknown>;
+                }
+              )?.configurable ?? {}),
+              copilotkit_forwarded_headers: forwardedHeaders,
+            },
+          }
+        : configForPayloadBase;
 
     const payload: Record<string, unknown> = {
       ...restProps,


### PR DESCRIPTION
## Summary

`@ag-ui/langgraph@0.0.33` accepts per-request headers via `agent.headers` and forwards them on the HTTP wire via the `onRequest` hook, but never serializes them into the `runs.stream` payload. As a result, the Python LangGraph middleware (`_extract_forwarded_headers_from_config` in `copilotkit_lg_middleware.py`) reads an empty map from `config.configurable.copilotkit_forwarded_headers`, and downstream consumers — most notably aimock context routing in D6 testing — see no headers.

This PR serializes the `x-*` subset of `agent.headers` into `payload.config.configurable.copilotkit_forwarded_headers` at the exact path the Python middleware consumes.

## Root cause (verified)

Two independent investigation agents confirmed via runtime trace against `showcase-langgraph-typescript`:

- `this.headers` is populated with 8 keys (including `x-aimock-context`) at the `runAgentStream` call site.
- `payload.config` and `payload.context` arrive at `runs.stream(...)` as `null`.
- The `agent.ts` class has only two references to `this.headers`: the constructor (`this.headers = {}`) and `clone()` (`headers: { ...this.headers }`). No code path reads `this.headers` into the outbound payload.

## Fix shape

After the existing configurable/context partition resolves which payload shape to emit, inject `copilotkit_forwarded_headers` into the resulting `config.configurable`:

- If forwarded headers are non-empty, ensure `config.configurable.copilotkit_forwarded_headers` is set, creating `config` and/or `configurable` if needed. This works even when the partition has stripped `configurable` because `context_schema` won (langgraph-api >= 0.7.x).
- If forwarded headers are empty, the payload shape is unchanged.
- Only keys whose lowercased name starts with `x-` are forwarded. Authorization/Cookie/Content-Type stay on the HTTP wire via the existing `onRequest` hook.

Forwarded headers are infrastructure metadata (correlation IDs, `x-aimock-context`, etc.) — they are NOT graph context, so they must ride in `configurable` regardless of whether `context_schema` wins.

## Regression tests added

`integrations/langgraph/typescript/src/__tests__/agent.test.ts`, new describe block:

- **test 15** — x-* headers from `agent.headers` land in `config.configurable.copilotkit_forwarded_headers`.
- **test 16** — non-x-* headers (Authorization, Content-Type) are filtered out of the forwarded set.
- **test 17** — empty `agent.headers` leaves the payload unchanged (no `copilotkit_forwarded_headers` key).
- **test 18** — forwarded headers survive the context-wins partition path: `payload.context` carries the `context_schema` key, AND `payload.config.configurable.copilotkit_forwarded_headers` carries the x-* headers, AND the graph-context key does NOT leak back into `configurable`.

All four tests fail RED on the pre-fix source and pass GREEN after the change. The entire existing suite (154 tests across 10 files) continues to pass.

Related: regression test in PR #1797 hits the same boundary from the test side. This PR fixes the producer.

## Test plan

- [x] `pnpm test` (all 158 tests pass; 4 new + 154 existing)
- [x] `pnpm build` (clean build)
- [ ] CI: `dojo / langgraph-typescript` green — exercises the fix end-to-end
- [ ] User merge after CI green

## Notes

- Pre-existing TypeScript errors in the package (`agent.ts:71`, `messages-tuple.test.ts:17`, `state-merging.test.ts`, `state-streaming.ts:62`, `utils.ts:187`) were verified against `main` and are unaffected by this change.