### PR TITLE
docs(aws-strands): add TypeScript Strands service to Render deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -136,6 +136,24 @@ projects:
       autoDeployTrigger: commit
       rootDir: integrations/aws-strands/python/examples
     - type: web
+      name: ag-ui-dojo-strands-typescript
+      runtime: node
+      repo: https://github.com/ag-ui-protocol/ag-ui
+      plan: standard
+      scaling:
+        minInstances: 1
+        maxInstances: 3
+        targetMemoryPercent: 70
+        targetCPUPercent: 70
+      envVars:
+      - key: OPENAI_API_KEY
+        sync: false
+      region: virginia
+      buildCommand: cd ../../.. && npm install -g pnpm && pnpm install && npx nx run @ag-ui/aws-strands:build
+      startCommand: npx tsx examples/server/server.ts
+      autoDeployTrigger: commit
+      rootDir: integrations/aws-strands/typescript
+    - type: web
       name: ag-ui-dojo-agno
       runtime: python
       repo: https://github.com/ag-ui-protocol/ag-ui
@@ -445,6 +463,8 @@ projects:
         value: https://ag-ui-dojo-a2a-middleware-orchestrator.onrender.com
       - key: AWS_STRANDS_URL
         value: https://ag-ui-dojo-strands-python.onrender.com
+      - key: AWS_STRANDS_TYPESCRIPT_URL
+        value: https://ag-ui-dojo-strands-typescript.onrender.com
       - key: CLAUDE_AGENT_SDK_PYTHON_URL
         value: https://ag-ui-dojo-claude-agent-sdk-python.onrender.com
       - key: CLAUDE_AGENT_SDK_TYPESCRIPT_URL

--- a/render.yaml
+++ b/render.yaml
@@ -149,10 +149,10 @@ projects:
       - key: OPENAI_API_KEY
         sync: false
       region: virginia
-      buildCommand: cd ../../.. && npm install -g pnpm && pnpm install && npx nx run @ag-ui/aws-strands:build
-      startCommand: npx tsx examples/server/server.ts
+      buildCommand: cd ../../../.. && npm install -g pnpm && pnpm install && npx nx run @ag-ui/aws-strands:build
+      startCommand: npx tsx server/server.ts
       autoDeployTrigger: commit
-      rootDir: integrations/aws-strands/typescript
+      rootDir: integrations/aws-strands/typescript/examples
     - type: web
       name: ag-ui-dojo-agno
       runtime: python


### PR DESCRIPTION
## Summary

- Adds the `ag-ui-dojo-strands-typescript` Render service definition (Node.js, standard plan) to deploy the TypeScript Strands examples server
- Adds `AWS_STRANDS_TYPESCRIPT_URL` env var to the dojo app pointing to the new service

The dojo's `aws-strands-typescript` integration was broken in production because no backend service existed — the app fell back to `http://localhost:8022` which doesn't resolve on Render.

## Post-merge action

Set the `OPENAI_API_KEY` secret on the new `ag-ui-dojo-strands-typescript` service in the Render dashboard.

## Test plan

- [ ] Verify Render deploys the new service successfully
- [ ] Confirm https://dojo.ag-ui.com/aws-strands-typescript/feature/backend_tool_rendering loads and streams a response