### PR TITLE
chore(adk-middleware): bump version to 0.6.5 (concurrency fix)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-05-28
+
+### Fixed
+
+- **FIX**: Revert the `AGUIToolset.bind()` delegation introduced in 0.6.4 (#1746)
+  and restore per-run `ClientProxyToolset` replacement (#1786). Thanks to
+  @jplikesbikes for catching the regression and driving the fix.
+  - **Impact**: 0.6.4 introduced a cross-user data leak under concurrent runs.
+    With `max_concurrent_executions=10` (default) and serialization only per
+    `(thread_id, user_id)`, two overlapping runs would share a single mutable
+    `_delegate` slot on the construction-time `AGUIToolset` placeholder.
+    Run A's `TOOL_CALL_START/ARGS/END` events could be emitted onto Run B's
+    `event_queue` (a confidentiality breach: tool-call arguments generated
+    from one user's conversation/state would land on another user's stream
+    and Run A would stall, never having been told about the call). A
+    secondary failure mode stranded any still-in-flight run with an empty
+    tool list when the first run's `finally` block unbound the shared
+    placeholder. Tool *results* (client → agent) were not affected — they
+    return via a separate `RunAgentInput` matched per `(thread_id, user)`.
+  - **Root cause of the 0.6.4 regression**: The #1746 rationale — that
+    ADK 2.0 `Runner.__init__` eagerly caches `get_tools()` results and
+    therefore the `AGUIToolset` object must be preserved by reference —
+    does not match the GA behavior. Verified against `google-adk` 1.16.0,
+    1.34.1, 2.0.0, and 2.1.0: `Runner.__init__` does *no* tool resolution;
+    `agent.canonical_tools` reads `self.tools` live per invocation
+    (`flows/llm_flows/base_llm_flow.py` caches on the per-`run_async`
+    `InvocationContext`, and the toolset-level cache in
+    `tools/base_toolset.py` is keyed by `invocation_id`). The actual #1389
+    failure mode on the pre-release `google-adk==2.0.0a2` was a separate
+    well-formed-`BaseToolset` issue: a toolset missing
+    `_use_invocation_cache` (i.e. not calling `BaseToolset.__init__`) is
+    silently dropped to `[]` by `llm_agent._convert_tool_union_to_tools`.
+    That fix — `super().__init__()` on `AGUIToolset` — is retained; only
+    the unnecessary `bind()` delegation that introduced the concurrency
+    hazard is reverted.
+  - **Fix**: `_update_agent_tools_recursive` once again replaces the
+    placeholder per-run with a fresh `ClientProxyToolset` inside the
+    per-run shallow-copied agent's own `tools` list. The construction-time
+    placeholder is never mutated; each run carries its own `input.tools`
+    and `event_queue`.
+  - **Tests added** (pass on both `google-adk==1.26.0` and
+    `google-adk==2.1.0`):
+    - `tests/test_agui_toolset_concurrency.py` — three tests asserting
+      per-run isolation, including a real concurrent-`asyncio`
+      reproduction with a barrier.
+    - `tests/test_adk_2_0_compat.py::TestAGUIToolsetReplacement::test_swapped_in_toolset_resolves_nonempty_via_get_tools_with_prefix`
+      — guards the real #1389 silent-drop path (via
+      `_use_invocation_cache`) so it cannot silently regress.
+  - **Compatibility note**: Pre-release `google-adk==2.0.0a2` snapshotted
+    toolset references at `LlmAgent` construction (via `model_post_init` →
+    `_build_nodes`) and would regress to an empty tool list under per-run
+    replacement; the supported install range `>=1.16.0,<3.0.0` never
+    resolves a pre-release.
+
 ## [0.6.4] - 2026-05-26
 
 ### Added

--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ag_ui_adk"
 description = "ADK Middleware for AG-UI Protocol"
-version = "0.6.4"
+version = "0.6.5"
 readme = "README.md"
 authors = [
     { name = "Mark Fogle", email = "mark@contextable.com" }


### PR DESCRIPTION
## Summary

Cuts **adk-middleware 0.6.5**, releasing the per-run `AGUIToolset` replacement restored in #1786 and closing the cross-user data leak that 0.6.4 (#1746) introduced.

Credit to @jplikesbikes for catching the regression, building the reproduction (including the alpha-vs-GA mechanism breakdown that explained why the original `bind()` rationale didn't apply on `google-adk` GA), and driving the fix in #1786.

## What's in this PR

- `integrations/adk-middleware/python/pyproject.toml`: `version = "0.6.4"` → `"0.6.5"`
- `integrations/adk-middleware/python/CHANGELOG.md`: new `[0.6.5] - 2026-05-28` entry under `### Fixed` documenting the leak, root cause, fix, added tests, and the pre-release-only `2.0.0a2` compatibility note

Not touched:
- `src/ag_ui_adk/__init__.py::__version__` — already stale at `"0.1.0"` since well before 0.6.4; left alone to keep this PR a pure release cut
- `uv.lock` — its self-entry was already stale at `0.6.2` before this bump; refreshing it here would pull unrelated dependency churn into a release-only PR

## Test plan

- [x] Full suite passes on `google-adk==1.26.0` (826 passed, 11 skipped, 0 failed)
- [x] Full suite passes on `google-adk==2.1.0` (833 passed, 4 skipped, 0 failed)
- [x] Concurrency-safety tests pass on both ADK majors (`test_agui_toolset_concurrency.py` — 3/3)
- [x] #1389 regression guard passes on both ADK majors (`TestAGUIToolsetReplacement::test_swapped_in_toolset_resolves_nonempty_via_get_tools_with_prefix`)
- [ ] After merge: tag `v0.6.5` and publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)