### PR TITLE
feat(kotlin-sdk): support AG-UI interrupts on RUN_FINISHED

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Interrupts** ([AG-UI spec](https://docs.ag-ui.com/concepts/interrupts)). The Kotlin SDK now models the interrupt protocol that the TypeScript and Python SDKs already ship. Without this change a Kotlin client connected to an interrupt-aware server would either fail polymorphic deserialization of `outcome` or silently drop the interrupt payload on a `RUN_FINISHED` event.
+  - New types in `com.agui.core.types`:
+    - `Interrupt(id, reason, message?, toolCallId?, responseSchema?, expiresAt?, metadata?)`
+    - `ResumeStatus` enum (`RESOLVED` → `"resolved"`, `CANCELLED` → `"cancelled"`)
+    - `ResumeEntry(interruptId, status, payload?)`
+    - Sealed `RunFinishedOutcome` with `@JsonClassDiscriminator("type")`:
+      - `RunFinishedSuccessOutcome` (`{"type":"success"}`)
+      - `RunFinishedInterruptOutcome(interrupts)` (`{"type":"interrupt","interrupts":[…]}`) — `interrupts` is validated non-empty at construction.
+  - `RunAgentInput` gains an optional `resume: List<ResumeEntry>?` field for resuming a previously interrupted run on the same `threadId`.
+  - `RunFinishedEvent` gains optional `result: JsonElement?` and `outcome: RunFinishedOutcome?` fields. Both default to `null`; legacy producers that omit them continue to decode unchanged, and Python `exclude_none=False` callers that emit explicit JSON `null` also decode to `null`.
+  - `AgUiSerializersModule` registers the two `RunFinishedOutcome` subclasses for polymorphic serialization.
+  - 13 new tests in `InterruptSerializationTest` covering minimal/full `Interrupt` round-trips, `ResumeEntry` status enum mapping and rejection of unknown statuses, object payloads, `RunAgentInput.resume` omit/round-trip, `RunFinishedInterruptOutcome` non-empty validation, and `RunFinishedEvent` round-trips for the legacy shape, the success outcome, the interrupt outcome (including a server-produced JSON shape), and explicit `null` outcome/result.
+
 ### Examples
 - Chatapp surfaces `REASONING_*` events as a transient "💭 Reasoning…" bubble (new `MessageRole.REASONING` + `EphemeralType.REASONING`), mirroring the existing tool-call / step ephemeral pattern. Clears on `RUN_FINISHED`, run cancel, or run error. Handles `REASONING_START` / `REASONING_END`, `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END`, and `REASONING_MESSAGE_CHUNK`.
 - Bump all Kotlin sample apps (chatapp, chatapp-java, chatapp-wearos, chatapp-swiftui, tools) from `agui-core 0.3.0` to `0.4.0` and consume the published artefacts from Maven by removing the `includeBuild("../../library")` + dependencySubstitution blocks from the four chatapp variants' settings files.

--- a/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/AgUiSerializersModule.kt
+++ b/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/AgUiSerializersModule.kt
@@ -45,5 +45,11 @@ val AgUiSerializersModule by lazy {
             subclass(UserMessage::class)
             subclass(ToolMessage::class)
         }
+
+        // Polymorphic serialization for RUN_FINISHED outcomes
+        polymorphic(RunFinishedOutcome::class) {
+            subclass(RunFinishedSuccessOutcome::class)
+            subclass(RunFinishedInterruptOutcome::class)
+        }
     }
 }

--- a/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Events.kt
+++ b/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Events.kt
@@ -200,6 +200,51 @@ sealed class BaseEvent {
     abstract val rawEvent: JsonElement?
 }
 
+// ============== Run Outcomes (2) ==============
+
+/**
+ * Discriminated union describing how a run terminated. Carried in the optional
+ * [RunFinishedEvent.outcome] field. The wire-level `"type"` field discriminates
+ * between successful completion ([RunFinishedSuccessOutcome]) and an
+ * interrupt-driven pause ([RunFinishedInterruptOutcome]).
+ *
+ * Producers written before the interrupt-aware run lifecycle simply omit the
+ * `outcome` field on `RunFinishedEvent`; newer producers set it explicitly.
+ *
+ * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("type")
+sealed class RunFinishedOutcome
+
+/**
+ * Outcome variant signalling that a run completed normally.
+ */
+@Serializable
+@SerialName("success")
+data object RunFinishedSuccessOutcome : RunFinishedOutcome()
+
+/**
+ * Outcome variant signalling that a run paused on one or more interrupts.
+ *
+ * The client resumes by addressing every open interrupt in
+ * [RunAgentInput.resume] of the next request, reusing the same `threadId`.
+ *
+ * @param interrupts The pending interrupts; must be non-empty.
+ */
+@Serializable
+@SerialName("interrupt")
+data class RunFinishedInterruptOutcome(
+    val interrupts: List<Interrupt>
+) : RunFinishedOutcome() {
+    init {
+        require(interrupts.isNotEmpty()) {
+            "outcome 'interrupt' requires at least one interrupt"
+        }
+    }
+}
+
 // ============== Lifecycle Events (5) ==============
 
 /**
@@ -227,21 +272,31 @@ data class RunStartedEvent(
 }
 
 /**
- * Event indicating that an agent run has completed successfully.
- * 
- * This event is emitted when an agent has finished processing a run request
- * and has generated all output. It signals the end of the execution lifecycle.
- * 
- * @param threadId The identifier for the conversation thread
- * @param runId The unique identifier for the completed run
- * @param timestamp Optional timestamp when the run finished
- * @param rawEvent Optional raw JSON representation of the event
+ * Event indicating that an agent run has completed.
+ *
+ * This event is emitted when an agent has finished processing a run request.
+ * Whether the run completed successfully or paused on interrupts is signalled
+ * by the optional [outcome] field. Producers written before the interrupt-aware
+ * run lifecycle simply omit [outcome] (legacy back-compat); newer producers set
+ * it to [RunFinishedSuccessOutcome] or [RunFinishedInterruptOutcome].
+ *
+ * @param threadId The identifier for the conversation thread.
+ * @param runId The unique identifier for the completed run.
+ * @param result Optional terminal value produced by the run.
+ * @param outcome Optional discriminated outcome of the run; see [RunFinishedOutcome].
+ * @param timestamp Optional timestamp when the run finished.
+ * @param rawEvent Optional raw JSON representation of the event.
+ *
+ * @see RunFinishedOutcome
+ * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
  */
 @Serializable
 @SerialName("RUN_FINISHED")
 data class RunFinishedEvent(
     val threadId: String,
     val runId: String,
+    val result: JsonElement? = null,
+    val outcome: RunFinishedOutcome? = null,
     override val timestamp: Long? = null,
     override val rawEvent: JsonElement? = null
 ) : BaseEvent () {

--- a/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Types.kt
+++ b/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Types.kt
@@ -433,5 +433,79 @@ data class RunAgentInput(
     val messages: List<Message> = emptyList(),
     val tools: List<Tool> = emptyList(),
     val context: List<Context> = emptyList(),
-    val forwardedProps: JsonElement = JsonObject(emptyMap())
+    val forwardedProps: JsonElement = JsonObject(emptyMap()),
+    /**
+     * Per-interrupt responses sent when resuming a previously interrupted run.
+     *
+     * Each entry addresses an [Interrupt] from the prior `RunFinishedEvent` whose
+     * `outcome` was a [com.agui.core.types.RunFinishedInterruptOutcome]. The same
+     * `threadId` must be reused. Omitted when not resuming.
+     *
+     * @see Interrupt
+     * @see ResumeEntry
+     * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
+     */
+    val resume: List<ResumeEntry>? = null
+)
+
+// ============== Interrupts ==============
+
+/**
+ * A pause carried inside [com.agui.core.types.RunFinishedInterruptOutcome] when a
+ * run finishes on one or more interrupts. The client resumes by addressing this
+ * interrupt in the [RunAgentInput.resume] array of the next request, using the
+ * same `threadId`.
+ *
+ * @param id Stable identifier of this interrupt; echoed back as [ResumeEntry.interruptId].
+ * @param reason Machine-readable reason describing why the agent paused
+ *               (e.g. `"tool_call"`, `"human_approval"`).
+ * @param message Optional human-readable explanation suitable for surfacing to the user.
+ * @param toolCallId Optional tool-call this interrupt is associated with.
+ * @param responseSchema Optional JSON Schema describing the expected shape of
+ *                       [ResumeEntry.payload]. Agents MAY validate the payload against this.
+ * @param expiresAt Optional ISO-8601 timestamp after which a resume MUST NOT be submitted.
+ * @param metadata Optional opaque metadata for the agent / UI to use.
+ *
+ * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
+ */
+@Serializable
+data class Interrupt(
+    val id: String,
+    val reason: String,
+    val message: String? = null,
+    val toolCallId: String? = null,
+    val responseSchema: JsonElement? = null,
+    val expiresAt: String? = null,
+    val metadata: JsonElement? = null
+)
+
+/**
+ * Status of a [ResumeEntry].
+ *
+ * - [RESOLVED]: the user provided a response (typically with a `payload`).
+ * - [CANCELLED]: the user abandoned the interrupt without providing input.
+ */
+@Serializable
+enum class ResumeStatus {
+    @SerialName("resolved")
+    RESOLVED,
+    @SerialName("cancelled")
+    CANCELLED
+}
+
+/**
+ * A per-interrupt response in [RunAgentInput.resume].
+ *
+ * @param interruptId The [Interrupt.id] this entry resolves.
+ * @param status See [ResumeStatus].
+ * @param payload Optional response value. Shape is dictated by the originating
+ *                interrupt's [Interrupt.responseSchema] (if any).
+ *
+ * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
+ */
+@Serializable
+data class ResumeEntry(
+    val interruptId: String,
+    val status: ResumeStatus,
+    val payload: JsonElement? = null
 )

--- a/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InterruptSerializationTest.kt
+++ b/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InterruptSerializationTest.kt
@@ -213,6 +213,8 @@ class InterruptSerializationTest {
         val jsonString = json.encodeToString<BaseEvent>(event)
         val outcomeObj = json.parseToJsonElement(jsonString).jsonObject["outcome"]?.jsonObject
         assertNotNull(outcomeObj)
+        // Schema is exactly `{ type: "success" }` — discriminator only, no extra keys.
+        assertEquals(setOf("type"), outcomeObj.keys)
         assertEquals("success", outcomeObj["type"]?.jsonPrimitive?.content)
 
         val decoded = json.decodeFromString<BaseEvent>(jsonString)

--- a/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InterruptSerializationTest.kt
+++ b/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InterruptSerializationTest.kt
@@ -1,0 +1,313 @@
+package com.agui.tests
+
+import com.agui.core.types.*
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+/**
+ * Coverage for the AG-UI interrupt protocol additions:
+ * - [Interrupt], [ResumeStatus], [ResumeEntry]
+ * - [RunAgentInput.resume]
+ * - [RunFinishedEvent.outcome] / [RunFinishedEvent.result]
+ * - [RunFinishedOutcome] discriminated union ([RunFinishedSuccessOutcome] / [RunFinishedInterruptOutcome])
+ *
+ * Mirrors TS (`sdks/typescript/packages/core/src/__tests__/interrupts.test.ts`)
+ * and Python interrupt tests.
+ *
+ * @see <a href="https://docs.ag-ui.com/concepts/interrupts">AG-UI Interrupts</a>
+ */
+class InterruptSerializationTest {
+
+    private val json = AgUiJson
+
+    // ========== Interrupt ==========
+
+    @Test
+    fun testInterruptMinimalRoundTrip() {
+        val interrupt = Interrupt(id = "int-1", reason = "tool_call")
+
+        val jsonString = json.encodeToString(Interrupt.serializer(), interrupt)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("int-1", jsonObj["id"]?.jsonPrimitive?.content)
+        assertEquals("tool_call", jsonObj["reason"]?.jsonPrimitive?.content)
+        // explicitNulls = false → optional null fields must be omitted
+        assertFalse(jsonObj.containsKey("message"))
+        assertFalse(jsonObj.containsKey("toolCallId"))
+        assertFalse(jsonObj.containsKey("responseSchema"))
+        assertFalse(jsonObj.containsKey("expiresAt"))
+        assertFalse(jsonObj.containsKey("metadata"))
+
+        val decoded = json.decodeFromString(Interrupt.serializer(), jsonString)
+        assertEquals(interrupt, decoded)
+    }
+
+    @Test
+    fun testInterruptFullRoundTrip() {
+        val schema = buildJsonObject {
+            put("type", "object")
+            put("properties", buildJsonObject {
+                put("approved", buildJsonObject { put("type", "boolean") })
+            })
+        }
+        val metadata = buildJsonObject {
+            put("priority", "high")
+            put("retries", 0)
+        }
+        val interrupt = Interrupt(
+            id = "int-1",
+            reason = "human_approval",
+            message = "Please confirm before sending the email.",
+            toolCallId = "call-42",
+            responseSchema = schema,
+            expiresAt = "2026-05-27T12:00:00Z",
+            metadata = metadata
+        )
+
+        val jsonString = json.encodeToString(Interrupt.serializer(), interrupt)
+        val decoded = json.decodeFromString(Interrupt.serializer(), jsonString)
+        assertEquals(interrupt, decoded)
+    }
+
+    // ========== ResumeEntry / ResumeStatus ==========
+
+    @Test
+    fun testResumeEntryResolvedRoundTrip() {
+        val entry = ResumeEntry(
+            interruptId = "int-1",
+            status = ResumeStatus.RESOLVED,
+            payload = JsonPrimitive("ok")
+        )
+
+        val jsonString = json.encodeToString(ResumeEntry.serializer(), entry)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("int-1", jsonObj["interruptId"]?.jsonPrimitive?.content)
+        assertEquals("resolved", jsonObj["status"]?.jsonPrimitive?.content)
+        assertEquals("ok", jsonObj["payload"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(ResumeEntry.serializer(), jsonString)
+        assertEquals(entry, decoded)
+    }
+
+    @Test
+    fun testResumeEntryCancelledRoundTrip() {
+        val entry = ResumeEntry(
+            interruptId = "int-1",
+            status = ResumeStatus.CANCELLED
+        )
+
+        val jsonString = json.encodeToString(ResumeEntry.serializer(), entry)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("cancelled", jsonObj["status"]?.jsonPrimitive?.content)
+        assertFalse(jsonObj.containsKey("payload"))
+
+        val decoded = json.decodeFromString(ResumeEntry.serializer(), jsonString)
+        assertEquals(entry, decoded)
+    }
+
+    @Test
+    fun testResumeEntryRejectsUnknownStatus() {
+        val malformed = """{"interruptId":"int-1","status":"denied"}"""
+        assertFailsWith<SerializationException> {
+            json.decodeFromString(ResumeEntry.serializer(), malformed)
+        }
+    }
+
+    @Test
+    fun testResumeEntryAcceptsObjectPayload() {
+        val payload = buildJsonObject {
+            put("approved", true)
+            put("note", "looks good")
+        }
+        val entry = ResumeEntry(
+            interruptId = "int-1",
+            status = ResumeStatus.RESOLVED,
+            payload = payload
+        )
+
+        val jsonString = json.encodeToString(ResumeEntry.serializer(), entry)
+        val decoded = json.decodeFromString(ResumeEntry.serializer(), jsonString)
+        assertEquals(payload, decoded.payload)
+    }
+
+    // ========== RunAgentInput.resume ==========
+
+    @Test
+    fun testRunAgentInputResumeOmittedWhenNull() {
+        val input = RunAgentInput(threadId = "t", runId = "r")
+
+        val jsonString = json.encodeToString(input)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        // explicitNulls = false → resume must not appear when null
+        assertFalse(jsonObj.containsKey("resume"))
+
+        val decoded = json.decodeFromString<RunAgentInput>(jsonString)
+        assertNull(decoded.resume)
+    }
+
+    @Test
+    fun testRunAgentInputResumeRoundTrip() {
+        val input = RunAgentInput(
+            threadId = "t",
+            runId = "r",
+            resume = listOf(
+                ResumeEntry("int-1", ResumeStatus.RESOLVED, JsonPrimitive("yes")),
+                ResumeEntry("int-2", ResumeStatus.CANCELLED)
+            )
+        )
+
+        val jsonString = json.encodeToString(input)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+        val resumeArr = jsonObj["resume"]?.jsonArray
+        assertNotNull(resumeArr)
+        assertEquals(2, resumeArr.size)
+        assertEquals("int-1", resumeArr[0].jsonObject["interruptId"]?.jsonPrimitive?.content)
+        assertEquals("resolved", resumeArr[0].jsonObject["status"]?.jsonPrimitive?.content)
+        assertEquals("cancelled", resumeArr[1].jsonObject["status"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<RunAgentInput>(jsonString)
+        assertEquals(input, decoded)
+    }
+
+    // ========== RunFinishedOutcome ==========
+
+    @Test
+    fun testRunFinishedInterruptOutcomeRejectsEmptyList() {
+        assertFailsWith<IllegalArgumentException> {
+            RunFinishedInterruptOutcome(interrupts = emptyList())
+        }
+    }
+
+    // ========== RunFinishedEvent.outcome ==========
+
+    @Test
+    fun testRunFinishedEventLegacyShapeRoundTrip() {
+        // Legacy producer: no result, no outcome.
+        val event = RunFinishedEvent(threadId = "t", runId = "r")
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val jsonObj = json.parseToJsonElement(jsonString).jsonObject
+
+        assertEquals("RUN_FINISHED", jsonObj["type"]?.jsonPrimitive?.content)
+        assertFalse(jsonObj.containsKey("outcome"))
+        assertFalse(jsonObj.containsKey("result"))
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is RunFinishedEvent)
+        assertNull(decoded.outcome)
+        assertNull(decoded.result)
+    }
+
+    @Test
+    fun testRunFinishedEventSuccessOutcomeSerialization() {
+        val event = RunFinishedEvent(
+            threadId = "t",
+            runId = "r",
+            outcome = RunFinishedSuccessOutcome
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val outcomeObj = json.parseToJsonElement(jsonString).jsonObject["outcome"]?.jsonObject
+        assertNotNull(outcomeObj)
+        assertEquals("success", outcomeObj["type"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is RunFinishedEvent)
+        assertEquals(RunFinishedSuccessOutcome, decoded.outcome)
+    }
+
+    @Test
+    fun testRunFinishedEventInterruptOutcomeSerialization() {
+        val interrupts = listOf(
+            Interrupt(id = "int-1", reason = "tool_call"),
+            Interrupt(id = "int-2", reason = "human_approval", message = "ok?")
+        )
+        val event = RunFinishedEvent(
+            threadId = "t",
+            runId = "r",
+            outcome = RunFinishedInterruptOutcome(interrupts)
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val outcomeObj = json.parseToJsonElement(jsonString).jsonObject["outcome"]?.jsonObject
+        assertNotNull(outcomeObj)
+        assertEquals("interrupt", outcomeObj["type"]?.jsonPrimitive?.content)
+        val emittedInterrupts = outcomeObj["interrupts"]?.jsonArray
+        assertNotNull(emittedInterrupts)
+        assertEquals(2, emittedInterrupts.size)
+        assertEquals("int-1", emittedInterrupts[0].jsonObject["id"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is RunFinishedEvent)
+        val outcome = decoded.outcome
+        assertTrue(outcome is RunFinishedInterruptOutcome)
+        assertEquals(interrupts, outcome.interrupts)
+    }
+
+    @Test
+    fun testRunFinishedEventWithResultRoundTrip() {
+        val result = buildJsonObject {
+            put("answer", 42)
+            put("note", "ok")
+        }
+        val event = RunFinishedEvent(
+            threadId = "t",
+            runId = "r",
+            result = result,
+            outcome = RunFinishedSuccessOutcome
+        )
+
+        val jsonString = json.encodeToString<BaseEvent>(event)
+        val decoded = json.decodeFromString<BaseEvent>(jsonString)
+        assertTrue(decoded is RunFinishedEvent)
+        assertEquals(result, decoded.result)
+        assertEquals(RunFinishedSuccessOutcome, decoded.outcome)
+    }
+
+    @Test
+    fun testRunFinishedEventAcceptsExplicitNullOutcome() {
+        // Python `exclude_none=False` callers serialize the optional outcome as
+        // JSON `null`. The Kotlin SDK must accept that and normalize to null.
+        val rawJson = """{
+            "type":"RUN_FINISHED",
+            "threadId":"t",
+            "runId":"r",
+            "outcome":null,
+            "result":null
+        }""".trimIndent()
+
+        val decoded = json.decodeFromString<BaseEvent>(rawJson)
+        assertTrue(decoded is RunFinishedEvent)
+        assertNull(decoded.outcome)
+        assertNull(decoded.result)
+    }
+
+    @Test
+    fun testRunFinishedEventDecodesServerProducedInterruptShape() {
+        // Sanity check that the JSON shape a TS/Python server emits decodes
+        // cleanly through the polymorphic BaseEvent dispatch.
+        val rawJson = """{
+            "type":"RUN_FINISHED",
+            "threadId":"t",
+            "runId":"r",
+            "outcome":{
+                "type":"interrupt",
+                "interrupts":[
+                    {"id":"i1","reason":"tool_call"}
+                ]
+            }
+        }""".trimIndent()
+
+        val decoded = json.decodeFromString<BaseEvent>(rawJson)
+        assertTrue(decoded is RunFinishedEvent)
+        val outcome = decoded.outcome
+        assertTrue(outcome is RunFinishedInterruptOutcome)
+        assertEquals(1, outcome.interrupts.size)
+        assertEquals("i1", outcome.interrupts[0].id)
+        assertEquals("tool_call", outcome.interrupts[0].reason)
+    }
+}


### PR DESCRIPTION
## Summary

  Brings the community Kotlin SDK up to parity with the TypeScript and Python
  SDKs for the **Interrupts** protocol
  ([spec](https://docs.ag-ui.com/concepts/interrupts)).

  Without this change a Kotlin client connected to an interrupt-aware server
  would either fail polymorphic deserialization of the new `outcome` field or
  silently drop the interrupt payload on `RUN_FINISHED`.

  Scope is intentionally narrow: **types + serialization only**. No new
  `AgentSubscriber` callback, no high-level resume helper — consumers detect
  interrupts via the existing `onEvent` hook and inspect
  `RunFinishedEvent.outcome`.

  ## Changes

  New types in `com.agui.core.types`:

  - `Interrupt(id, reason, message?, toolCallId?, responseSchema?, expiresAt?, metadata?)`
  - `ResumeStatus` enum (`RESOLVED` → `"resolved"`, `CANCELLED` → `"cancelled"`)
  - `ResumeEntry(interruptId, status, payload?)`
  - Sealed `RunFinishedOutcome` with `@JsonClassDiscriminator("type")`:
    - `RunFinishedSuccessOutcome` → `{"type":"success"}`
    - `RunFinishedInterruptOutcome(interrupts)` → `{"type":"interrupt","interrupts":[…]}` — validated non-empty at construction

  Schema additions:

  - `RunAgentInput.resume: List<ResumeEntry>? = null` — for resuming a previously
    interrupted run on the same `threadId`.
  - `RunFinishedEvent.result: JsonElement? = null` (was missing in Kotlin; TS/Python
    both have it).
  - `RunFinishedEvent.outcome: RunFinishedOutcome? = null`.

  ## Backwards compatibility

  All new fields are optional and default to `null`. The serializer uses
  `explicitNulls = false`, so:

  - Legacy producers that **omit** `outcome` / `result` continue to decode
    unchanged — `outcome == null`, `result == null`.
  - Python `exclude_none=False` callers that emit explicit JSON `null` for
    `outcome` / `result` also decode to `null` (verified by test).
  - The wire shape for the `"success"` variant is exactly `{"type":"success"}`
    with no extra keys (verified by test).

Fixes #1801