### PR TITLE
fix(mcp-apps): support nested UI resource metadata

### DIFF
--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -19,6 +19,7 @@ import {
   createTextMessageContentEvent,
   createTextMessageEndEvent,
   createMCPToolWithUI,
+  createMCPToolWithNestedUI,
   createMCPToolWithoutUI,
   createMCPToolWithEmptyMeta,
   createAssistantMessageWithToolCalls,
@@ -319,6 +320,25 @@ describe("MCPAppsMiddleware", () => {
       const enhancedTools = agent.runCalls[0].tools;
       expect(enhancedTools).toHaveLength(1);
       expect(enhancedTools[0].name).toBe("ui-tool");
+    });
+
+    it("accepts nested ui.resourceUri metadata", async () => {
+      mockListTools.mockResolvedValue({
+        tools: [
+          createMCPToolWithNestedUI("nested-ui-tool", "ui://server/nested"),
+          createMCPToolWithoutUI("non-ui-tool"),
+        ],
+      });
+
+      const middleware = new MCPAppsMiddleware({ mcpServers: [httpServerConfig] });
+      const agent = new MockAgent([createRunStartedEvent(), createRunFinishedEvent()]);
+
+      await collectEvents(middleware.run(createRunAgentInput(), agent));
+
+      const enhancedTools = agent.runCalls[0].tools;
+      expect(enhancedTools).toHaveLength(1);
+      expect(enhancedTools[0].name).toBe("nested-ui-tool");
+      expect(enhancedTools[0].description).toContain("[UI Resource: ui://server/nested]");
     });
 
     it("converts MCP tools to AG-UI Tool format correctly", async () => {
@@ -887,6 +907,25 @@ describe("MCPAppsMiddleware", () => {
       expect((activityEvent as any).content.resourceUri).toBe("ui://server/dashboard");
       // Should NOT have resource content (frontend fetches it)
       expect((activityEvent as any).content.resource).toBeUndefined();
+    });
+
+    it("uses nested resourceUri in activity snapshots", async () => {
+      const uiTool = createMCPToolWithNestedUI("ui-tool", "ui://server/nested-tool");
+      mockListTools.mockResolvedValue({ tools: [uiTool] });
+      mockCallTool.mockResolvedValue(createMCPToolCallResult([{ type: "text", text: "Result" }]));
+
+      const middleware = new MCPAppsMiddleware({ mcpServers: [httpServerConfig] });
+
+      const assistantMsg = createAssistantMessageWithToolCalls([{ name: "ui-tool", args: {}, id: "tc-1" }]);
+
+      const agent = new MockAgent([createRunStartedEvent(), createRunFinishedEvent()]);
+      const input = createRunAgentInput({ messages: [assistantMsg] });
+
+      const events = await collectEvents(middleware.run(input, agent));
+
+      const activityEvent = events.find((e) => e.type === EventType.ACTIVITY_SNAPSHOT);
+      expect(activityEvent).toBeDefined();
+      expect((activityEvent as any).content.resourceUri).toBe("ui://server/nested-tool");
     });
 
     it("does not call readResource during tool execution", async () => {

--- a/middlewares/mcp-apps-middleware/__tests__/test-utils.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/test-utils.ts
@@ -58,6 +58,19 @@ export function createMCPToolWithUI(
   };
 }
 
+export function createMCPToolWithNestedUI(
+  name: string,
+  resourceUri: string,
+  description?: string
+): MockMCPTool {
+  return {
+    name,
+    description: description || `Tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+    _meta: { ui: { resourceUri } },
+  };
+}
+
 /**
  * Create an MCP tool without UI resource
  */

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -103,8 +103,21 @@ export interface MCPAppsMiddlewareConfig {
 /**
  * Check if a tool has a UI resource attached (per SEP-1865)
  */
+function getUIResourceUri(tool: { _meta?: Record<string, unknown> }): string | undefined {
+  const uiMeta = tool._meta?.ui;
+  if (uiMeta && typeof uiMeta === "object" && !Array.isArray(uiMeta)) {
+    const resourceUri = (uiMeta as Record<string, unknown>).resourceUri;
+    if (typeof resourceUri === "string") {
+      return resourceUri;
+    }
+  }
+
+  const resourceUri = tool._meta?.["ui/resourceUri"];
+  return typeof resourceUri === "string" ? resourceUri : undefined;
+}
+
 function hasUIResource(tool: { _meta?: Record<string, unknown> }): boolean {
-  return typeof tool._meta?.["ui/resourceUri"] === "string";
+  return getUIResourceUri(tool) !== undefined;
 }
 
 /**
@@ -132,8 +145,8 @@ function convertMCPToolToAGUITool(mcpTool: {
 
   // Store UI resource URI in the description for now
   // TODO: Once AG-UI Tool type supports _meta, use that instead
-  const uiResourceUri = mcpTool._meta?.["ui/resourceUri"];
-  if (typeof uiResourceUri === "string") {
+  const uiResourceUri = getUIResourceUri(mcpTool);
+  if (uiResourceUri !== undefined) {
     tool.description = `${tool.description}\n[UI Resource: ${uiResourceUri}]`;
   }
 
@@ -601,7 +614,7 @@ export class MCPAppsMiddleware extends Middleware {
         .map((mcpTool) => ({
           tool: convertMCPToolToAGUITool(mcpTool),
           serverConfig,
-          resourceUri: mcpTool._meta!["ui/resourceUri"] as string,
+          resourceUri: getUIResourceUri(mcpTool)!,
         }));
 
       return uiTools;


### PR DESCRIPTION
﻿## Summary
- support MCP Apps tools that expose `ui.resourceUri` inside `_meta.ui`
- keep the existing `_meta["ui/resourceUri"]` form working
- use the resolved resource URI for both injected tool descriptions and activity snapshots

Fixes #1648.

## To verify
- `pnpm --filter @ag-ui/mcp-apps-middleware test -- __tests__/mcp-apps-middleware.test.ts`
- `pnpm --filter @ag-ui/mcp-apps-middleware build`
- `git diff --check`

## Notes
- `pnpm --filter @ag-ui/mcp-apps-middleware typecheck` currently fails on `src/index.ts(19,40)` because the existing `crypto` import is not covered by the package tsconfig types (`types` only includes `vitest/globals`). This is unrelated to this patch; build and the focused test suite pass.
