### PR TITLE
feat(aws-strands): implement interrupt protocol for TypeScript and Python

### DIFF
--- a/integrations/aws-strands/python/pyproject.toml
+++ b/integrations/aws-strands/python/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.10, <3.15"
 dependencies = [
     "ag-ui-a2ui-toolkit>=0.0.4",
-    "ag-ui-protocol>=0.1.18",
+    "ag-ui-protocol>=0.1.19",
     "fastapi>=0.115.12",
     "strands-agents>=1.15.0",
 ]

--- a/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
@@ -24,8 +24,16 @@ from .config import (
     ToolBehavior,
     ToolCallContext,
     ToolResultContext,
+    ToolStreamEventContext,
     PredictStateMapping,
     SessionManagerProvider,
+    ToolStreamEventHandler,
+)
+from ag_ui.core import (
+    Interrupt,
+    ResumeEntry,
+    RunFinishedInterruptOutcome,
+    RunFinishedSuccessOutcome,
 )
 
 __all__ = [
@@ -47,7 +55,13 @@ __all__ = [
     "ToolBehavior",
     "ToolCallContext",
     "ToolResultContext",
+    "ToolStreamEventContext",
     "PredictStateMapping",
     "SessionManagerProvider",
+    "ToolStreamEventHandler",
+    "Interrupt",
+    "ResumeEntry",
+    "RunFinishedInterruptOutcome",
+    "RunFinishedSuccessOutcome",
 ]
 

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -397,6 +397,105 @@ def _normalize_tool_turns(msgs):
 
 
 # ---------------------------------------------------------------------------
+# Interrupt bookkeeping persistence
+# ---------------------------------------------------------------------------
+#
+# ``_pending_interrupts_by_thread`` and ``_last_resume_fingerprint`` are the
+# adapter's own bookkeeping (idempotency fingerprint + AG-UI-specific
+# interrupt metadata like responseSchema/expiresAt) layered on top of
+# Strands' native ``_interrupt_state``. Strands' own SessionManager already
+# persists/restores ``_interrupt_state`` (and, on a fresh process, the
+# per-thread agent + session are reconstructed before this bookkeeping is
+# consulted — see the resume-validation gate in ``run()``), but this
+# adapter-only bookkeeping lived purely in a Python dict on the
+# ``StrandsAgent`` instance, so a process restart lost it: rules 6/7
+# (payload-schema validation, expiresAt enforcement) would silently degrade,
+# and a replayed resume request would no longer be recognized as a duplicate
+# and could re-invoke the model/tool.
+#
+# To survive a restart, this bookkeeping is now mirrored into
+# ``strands_agent.state`` under a single namespaced key — the same
+# per-thread, SessionManager-persisted key-value store the adapter already
+# uses for ``agui_context``. On every read, if nothing is cached in-process
+# for this thread_id, fall back to what's persisted in state.
+
+_INTERRUPT_BOOKKEEPING_STATE_KEY = "ag_ui_interrupt_bookkeeping"
+
+
+def _load_persisted_interrupt_bookkeeping(
+    strands_agent: Any,
+) -> tuple[Dict[str, Interrupt] | None, str | None]:
+    """Read the persisted (fingerprint, pending-interrupts) pair from
+    ``strands_agent.state``, if present and well-formed.
+
+    Defensive by design: a test double (e.g. a bare ``MagicMock()`` standing
+    in for the Strands agent) will happily return another mock from
+    ``state.get(...)`` rather than ``None``, so every layer of the expected
+    shape is checked explicitly before trusting it. Anything that doesn't
+    match is treated as "nothing persisted" rather than raised.
+    """
+    try:
+        state = getattr(strands_agent, "state", None)
+        get = getattr(state, "get", None)
+        if not callable(get):
+            return None, None
+        raw = get(_INTERRUPT_BOOKKEEPING_STATE_KEY)
+    except Exception:  # noqa: BLE001 — never let bookkeeping restore crash a run
+        return None, None
+
+    if not isinstance(raw, dict):
+        return None, None
+
+    fingerprint = raw.get("last_resume_fingerprint")
+    if fingerprint is not None and not isinstance(fingerprint, str):
+        fingerprint = None
+
+    pending_raw = raw.get("pending_interrupts")
+    pending: Dict[str, Interrupt] | None = None
+    if isinstance(pending_raw, dict):
+        pending = {}
+        for interrupt_id, data in pending_raw.items():
+            if not isinstance(interrupt_id, str) or not isinstance(data, dict):
+                continue
+            try:
+                pending[interrupt_id] = Interrupt.model_validate(data)
+            except Exception:  # noqa: BLE001 — skip malformed entries, don't crash
+                continue
+
+    return pending, fingerprint
+
+
+def _persist_interrupt_bookkeeping(
+    strands_agent: Any,
+    pending: Dict[str, Interrupt] | None,
+    fingerprint: str | None,
+) -> None:
+    """Write the (fingerprint, pending-interrupts) pair to
+    ``strands_agent.state`` so it survives a process restart via whatever
+    SessionManager is wired up. Best-effort: a test double without a real
+    ``state.set(...)`` (or one that isn't JSON-serializable-friendly) must
+    never break the run over bookkeeping that's a durability nice-to-have,
+    not a correctness requirement for the current process.
+    """
+    try:
+        state = getattr(strands_agent, "state", None)
+        set_fn = getattr(state, "set", None)
+        if not callable(set_fn):
+            return
+        payload = {
+            "last_resume_fingerprint": fingerprint,
+            "pending_interrupts": (
+                {i_id: i.model_dump(mode="json") for i_id, i in pending.items()}
+                if pending
+                else {}
+            ),
+        }
+        set_fn(_INTERRUPT_BOOKKEEPING_STATE_KEY, payload)
+    except Exception as e:  # noqa: BLE001 — persistence is best-effort
+        logger.warning(f"Failed to persist interrupt bookkeeping to strands_agent.state: {e}")
+
+
+# ---------------------------------------------------------------------------
 # Strands-native interrupt hook
 # ---------------------------------------------------------------------------
 
@@ -778,6 +877,18 @@ class StrandsAgent:
                 return
 
         if resume_entries:
+            # Cold-restart fallback: if this process has nothing cached in
+            # memory for this thread_id, check whether the fingerprint/
+            # pending-interrupt bookkeeping was persisted to
+            # strands_agent.state by a prior process (see
+            # ``_load_persisted_interrupt_bookkeeping`` docstring above).
+            if thread_id not in self._pending_interrupts_by_thread and thread_id not in self._last_resume_fingerprint:
+                persisted_pending, persisted_fingerprint = _load_persisted_interrupt_bookkeeping(strands_agent)
+                if persisted_pending is not None:
+                    self._pending_interrupts_by_thread[thread_id] = persisted_pending
+                if persisted_fingerprint is not None:
+                    self._last_resume_fingerprint[thread_id] = persisted_fingerprint
+
             interrupt_state = getattr(strands_agent, "_interrupt_state", None)
             is_activated = interrupt_state is not None and getattr(interrupt_state, "activated", False) is True
 
@@ -970,6 +1081,7 @@ class StrandsAgent:
             _resume_prompt: list | None = interrupt_responses
             # Fingerprint is stored after successful processing (below).
             self._pending_interrupts_by_thread.pop(thread_id, None)
+            _persist_interrupt_bookkeeping(strands_agent, None, None)
 
         # ── Start run ─────────────────────────────────────────────────────
         # Start run
@@ -1575,6 +1687,11 @@ class StrandsAgent:
                                     i.id: i for i in ag_ui_interrupts
                                 }
                                 self._last_resume_fingerprint.pop(input_data.thread_id, None)
+                                _persist_interrupt_bookkeeping(
+                                    strands_agent,
+                                    self._pending_interrupts_by_thread[input_data.thread_id],
+                                    None,
+                                )
                                 logger.debug(
                                     f"Strands interrupt detected: thread_id={input_data.thread_id}, "
                                     f"interrupt_ids={[i.id for i in ag_ui_interrupts]}"
@@ -2620,6 +2737,7 @@ class StrandsAgent:
                         usedforsecurity=False,
                     ).hexdigest()
                     self._last_resume_fingerprint[thread_id] = fp
+                    _persist_interrupt_bookkeeping(strands_agent, None, fp)
                 yield RunFinishedEvent(
                     type=EventType.RUN_FINISHED,
                     thread_id=input_data.thread_id,

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -723,9 +723,6 @@ class StrandsAgent:
                     core_kwargs = dict(self._agent_kwargs)
                     if self._hooks:
                         core_kwargs["hooks"] = list(self._hooks)
-                    # Ensure a stable agent_id so SessionManager can locate
-                    # snapshots after the in-memory cache is cleared.
-                    core_kwargs.setdefault("agent_id", self.name)
                     self._agents_by_thread[thread_id] = StrandsAgentCore(
                         model=self._model,
                         system_prompt=self._system_prompt,

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -80,6 +80,29 @@ def _get_strands_session_manager(agent: Any) -> Any:
     )
 
 
+def _error_events(
+    input_data: "RunAgentInput",
+    message: str,
+    code: str,
+) -> tuple[Any, Any]:
+    """Return (RunStartedEvent, RunErrorEvent) tuple for early-exit error paths.
+    
+    Use with: yield ev1; yield ev2 where (ev1, ev2) = _error_events(...)
+    """
+    return (
+        RunStartedEvent(
+            type=EventType.RUN_STARTED,
+            thread_id=input_data.thread_id,
+            run_id=input_data.run_id,
+        ),
+        RunErrorEvent(
+            type=EventType.RUN_ERROR,
+            message=message,
+            code=code,
+        ),
+    )
+
+
 logger = logging.getLogger(__name__)
 from ag_ui.core import (
     AssistantMessage,
@@ -672,16 +695,13 @@ class StrandsAgent:
                                 f"session_manager_provider failed: {e}",
                                 exc_info=True,
                             )
-                            yield RunStartedEvent(
-                                type=EventType.RUN_STARTED,
-                                thread_id=input_data.thread_id,
-                                run_id=input_data.run_id,
+                            ev_started, ev_error = _error_events(
+                                input_data,
+                                f"Failed to initialize session manager: {e}",
+                                "SESSION_MANAGER_ERROR",
                             )
-                            yield RunErrorEvent(
-                                type=EventType.RUN_ERROR,
-                                message=f"Failed to initialize session manager: {e}",
-                                code="SESSION_MANAGER_ERROR",
-                            )
+                            yield ev_started
+                            yield ev_error
                             return
                         # Validate the provider return type at the boundary —
                         # otherwise a forgotten call or wrong type surfaces
@@ -695,19 +715,13 @@ class StrandsAgent:
                                 "expected a SessionManager instance.",
                                 actual,
                             )
-                            yield RunStartedEvent(
-                                type=EventType.RUN_STARTED,
-                                thread_id=input_data.thread_id,
-                                run_id=input_data.run_id,
+                            ev_started, ev_error = _error_events(
+                                input_data,
+                                f"session_manager_provider returned {actual}; expected a SessionManager instance",
+                                "SESSION_MANAGER_INVALID_TYPE",
                             )
-                            yield RunErrorEvent(
-                                type=EventType.RUN_ERROR,
-                                message=(
-                                    f"session_manager_provider returned {actual}; "
-                                    "expected a SessionManager instance"
-                                ),
-                                code="SESSION_MANAGER_INVALID_TYPE",
-                            )
+                            yield ev_started
+                            yield ev_error
                             return
                     if session_manager is None and self.config.session_manager_provider:
                         logger.warning(
@@ -861,16 +875,13 @@ class StrandsAgent:
                 strands_agent, "_interrupt_state", None
             )
             if interrupt_state is not None and getattr(interrupt_state, "activated", False) is True:
-                yield RunStartedEvent(
-                    type=EventType.RUN_STARTED,
-                    thread_id=input_data.thread_id,
-                    run_id=input_data.run_id,
+                ev_started, ev_error = _error_events(
+                    input_data,
+                    "Thread has pending interrupts. Include resume[] to address them.",
+                    "PENDING_INTERRUPTS",
                 )
-                yield RunErrorEvent(
-                    type=EventType.RUN_ERROR,
-                    message="Thread has pending interrupts. Include resume[] to address them.",
-                    code="PENDING_INTERRUPTS",
-                )
+                yield ev_started
+                yield ev_error
                 return
 
         if resume_entries:
@@ -913,16 +924,13 @@ class StrandsAgent:
                     return
 
                 if not self.config.session_manager_provider:
-                    yield RunStartedEvent(
-                        type=EventType.RUN_STARTED,
-                        thread_id=input_data.thread_id,
-                        run_id=input_data.run_id,
+                    ev_started, ev_error = _error_events(
+                        input_data,
+                        "No pending interrupt for this thread.",
+                        "UNKNOWN_INTERRUPT_ID",
                     )
-                    yield RunErrorEvent(
-                        type=EventType.RUN_ERROR,
-                        message="No pending interrupt for this thread.",
-                        code="UNKNOWN_INTERRUPT_ID",
-                    )
+                    yield ev_started
+                    yield ev_error
                     return
 
             pending_ids: set[str] = set(interrupt_state.interrupts.keys())
@@ -932,38 +940,26 @@ class StrandsAgent:
             # Rule 2: reject unknown interrupt IDs
             for entry in resume_entries:
                 if entry.interrupt_id not in pending_ids:
-                    yield RunStartedEvent(
-                        type=EventType.RUN_STARTED,
-                        thread_id=input_data.thread_id,
-                        run_id=input_data.run_id,
+                    ev_started, ev_error = _error_events(
+                        input_data,
+                        f"Unknown interrupt_id '{entry.interrupt_id}': no matching pending interrupt for this thread.",
+                        "UNKNOWN_INTERRUPT_ID",
                     )
-                    yield RunErrorEvent(
-                        type=EventType.RUN_ERROR,
-                        message=(
-                            f"Unknown interrupt_id '{entry.interrupt_id}': "
-                            "no matching pending interrupt for this thread."
-                        ),
-                        code="UNKNOWN_INTERRUPT_ID",
-                    )
+                    yield ev_started
+                    yield ev_error
                     return
 
             # Rule 3: all open interrupts must be addressed
             resumed_ids = {e.interrupt_id for e in resume_entries}
             missing_ids = pending_ids - resumed_ids
             if missing_ids:
-                yield RunStartedEvent(
-                    type=EventType.RUN_STARTED,
-                    thread_id=input_data.thread_id,
-                    run_id=input_data.run_id,
+                ev_started, ev_error = _error_events(
+                    input_data,
+                    f"Partial resume: missing interrupt IDs {sorted(missing_ids)}. All open interrupts must be addressed.",
+                    "PARTIAL_RESUME",
                 )
-                yield RunErrorEvent(
-                    type=EventType.RUN_ERROR,
-                    message=(
-                        f"Partial resume: missing interrupt IDs "
-                        f"{sorted(missing_ids)}. All open interrupts must be addressed."
-                    ),
-                    code="PARTIAL_RESUME",
-                )
+                yield ev_started
+                yield ev_error
                 return
 
             for entry in resume_entries:
@@ -973,16 +969,13 @@ class StrandsAgent:
                 if ag_ui_interrupt and getattr(ag_ui_interrupt, "expires_at", None):
                     expiry = datetime.fromisoformat(ag_ui_interrupt.expires_at)
                     if datetime.now(timezone.utc) > expiry:
-                        yield RunStartedEvent(
-                            type=EventType.RUN_STARTED,
-                            thread_id=input_data.thread_id,
-                            run_id=input_data.run_id,
+                        ev_started, ev_error = _error_events(
+                            input_data,
+                            f"Interrupt '{entry.interrupt_id}' has expired.",
+                            "INTERRUPT_EXPIRED",
                         )
-                        yield RunErrorEvent(
-                            type=EventType.RUN_ERROR,
-                            message=f"Interrupt '{entry.interrupt_id}' has expired.",
-                            code="INTERRUPT_EXPIRED",
-                        )
+                        yield ev_started
+                        yield ev_error
                         return
 
                 # Rule 6: basic payload validation against responseSchema
@@ -995,36 +988,24 @@ class StrandsAgent:
                     payload = entry.payload
                     if schema.get("type") == "object":
                         if not isinstance(payload, dict):
-                            yield RunStartedEvent(
-                                type=EventType.RUN_STARTED,
-                                thread_id=input_data.thread_id,
-                                run_id=input_data.run_id,
+                            ev_started, ev_error = _error_events(
+                                input_data,
+                                f"Invalid payload for interrupt '{entry.interrupt_id}': expected an object.",
+                                "INVALID_PAYLOAD",
                             )
-                            yield RunErrorEvent(
-                                type=EventType.RUN_ERROR,
-                                message=(
-                                    f"Invalid payload for interrupt '{entry.interrupt_id}': "
-                                    "expected an object."
-                                ),
-                                code="INVALID_PAYLOAD",
-                            )
+                            yield ev_started
+                            yield ev_error
                             return
                         required = schema.get("required", [])
                         missing_keys = [k for k in required if k not in payload]
                         if missing_keys:
-                            yield RunStartedEvent(
-                                type=EventType.RUN_STARTED,
-                                thread_id=input_data.thread_id,
-                                run_id=input_data.run_id,
+                            ev_started, ev_error = _error_events(
+                                input_data,
+                                f"Invalid payload for interrupt '{entry.interrupt_id}': missing required keys {missing_keys}.",
+                                "INVALID_PAYLOAD",
                             )
-                            yield RunErrorEvent(
-                                type=EventType.RUN_ERROR,
-                                message=(
-                                    f"Invalid payload for interrupt '{entry.interrupt_id}': "
-                                    f"missing required keys {missing_keys}."
-                                ),
-                                code="INVALID_PAYLOAD",
-                            )
+                            yield ev_started
+                            yield ev_error
                             return
 
                 if entry.status == "cancelled":

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -5,10 +5,12 @@ Translates Strands streaming events into the AG-UI event protocol.
 
 import asyncio
 import base64
+import hashlib
 import inspect
 import json
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Dict, List
 
 from strands import Agent as StrandsAgentCore
@@ -84,6 +86,7 @@ from ag_ui.core import (
     CustomEvent,
     EventType,
     FunctionCall,
+    Interrupt,
     MessagesSnapshotEvent,
     ReasoningEncryptedValueEvent,
     ReasoningEndEvent,
@@ -91,9 +94,12 @@ from ag_ui.core import (
     ReasoningMessageEndEvent,
     ReasoningMessageStartEvent,
     ReasoningStartEvent,
+    ResumeEntry,
     RunAgentInput,
     RunErrorEvent,
     RunFinishedEvent,
+    RunFinishedInterruptOutcome,
+    RunFinishedSuccessOutcome,
     RunStartedEvent,
     StateSnapshotEvent,
     StepFinishedEvent,
@@ -128,6 +134,7 @@ from .config import (
     StrandsAgentConfig,
     ToolCallContext,
     ToolResultContext,
+    ToolStreamEventContext,
     maybe_await,
     normalize_predict_state,
 )
@@ -389,6 +396,58 @@ def _normalize_tool_turns(msgs):
     return out
 
 
+# ---------------------------------------------------------------------------
+# Strands-native interrupt hook
+# ---------------------------------------------------------------------------
+
+class StrandsInterruptHook:
+    """Raises a Strands native interrupt for tools configured with ``interrupt_on_call=True``.
+
+    Registered automatically by :class:`StrandsAgent` when any entry in
+    ``config.tool_behaviors`` has ``interrupt_on_call=True``.
+
+    On the **first** call for a given tool the hook calls ``event.interrupt()``,
+    which raises ``InterruptException`` internally and suspends the Strands
+    agent loop.  On the **resume** call Strands has already written the human
+    response into the interrupt object, so ``event.interrupt()`` returns the
+    response string instead of raising.  The hook then enforces the decision:
+    if the response is not ``"y"`` it sets ``event.cancel_tool`` so the tool
+    is skipped.
+    """
+
+    def __init__(self, tool_behaviors: "Dict[str, ToolBehavior]") -> None:
+        self._tool_behaviors = tool_behaviors
+
+    def register_hooks(self, registry: Any, **kwargs: Any) -> None:
+        """Register the BeforeToolCallEvent callback."""
+        from strands.hooks.events import BeforeToolCallEvent as _BeforeToolCallEvent
+        registry.add_callback(_BeforeToolCallEvent, self._on_before_tool_call)
+
+    def _on_before_tool_call(self, event: Any) -> None:
+        """Interrupt or enforce approval for interrupt_on_call tools."""
+        tool_name = event.tool_use.get("name", "")
+        behavior = self._tool_behaviors.get(tool_name)
+        if not behavior or not behavior.interrupt_on_call:
+            return
+
+        # event.interrupt() either:
+        #   - raises InterruptException (first call, no response yet) → suspends loop
+        #   - returns the human response string (resume call) → enforce decision
+        response = event.interrupt(
+            f"ag_ui:tool_call:{tool_name}",
+            reason={
+                "tool_name": tool_name,
+                "tool_input": event.tool_use.get("input", {}),
+                "tool_use_id": event.tool_use.get("toolUseId"),
+            },
+        )
+        # If we reach here we are on the resume path.
+        # Deny the tool call unless the user explicitly approved.
+        if not (isinstance(response, dict) and response.get("approved", False)):
+            event.cancel_tool = f"User denied approval for '{tool_name}'."
+
+
+
 class StrandsAgent:
     """AWS Strands Agent wrapper for AG-UI integration."""
 
@@ -399,6 +458,7 @@ class StrandsAgent:
         description: str = "",
         config: "StrandsAgentConfig | None" = None,
         hooks: "list | None" = None,
+        agents_by_thread: "Dict[str, Any] | None" = None,
     ):
         # Store template agent configuration for creating fresh instances
         self._model = agent.model
@@ -427,6 +487,16 @@ class StrandsAgent:
         self.description = description
         self.config = config or StrandsAgentConfig()
 
+        # Auto-register StrandsInterruptHook when any tool has interrupt_on_call=True.
+        # Prepend so it fires before any caller-supplied hooks.
+        interrupt_tools = {
+            name: b
+            for name, b in self.config.tool_behaviors.items()
+            if b.interrupt_on_call
+        }
+        if interrupt_tools:
+            self._hooks = [StrandsInterruptHook(interrupt_tools), *self._hooks]
+
         # Detect the common footgun: session_manager set on the template Agent
         # (stored as `_session_manager` by Strands) with no per-thread provider.
         # Forwarding it would make every AG-UI thread share one session_id.
@@ -443,9 +513,13 @@ class StrandsAgent:
             )
 
         # Dictionary to store agent instances per thread
-        self._agents_by_thread: Dict[str, StrandsAgentCore] = {}
+        self._agents_by_thread: Dict[str, StrandsAgentCore] = agents_by_thread if agents_by_thread is not None else {}
         # Track proxy tool names registered per thread
         self._proxy_tool_names_by_thread: Dict[str, set] = {}
+        # Store full AG-UI Interrupt objects per thread for resume validation
+        self._pending_interrupts_by_thread: Dict[str, Dict[str, Interrupt]] = {}
+        # Fingerprint of last successfully-processed resume per thread (idempotency)
+        self._last_resume_fingerprint: Dict[str, str] = {}
         # Guards first-time thread initialization. The session_manager_provider
         # call introduces an async yield point between the "is this thread
         # new?" check and the dict assignment, so concurrent requests for the
@@ -540,6 +614,9 @@ class StrandsAgent:
                     core_kwargs = dict(self._agent_kwargs)
                     if self._hooks:
                         core_kwargs["hooks"] = list(self._hooks)
+                    # Ensure a stable agent_id so SessionManager can locate
+                    # snapshots after the in-memory cache is cleared.
+                    core_kwargs.setdefault("agent_id", self.name)
                     self._agents_by_thread[thread_id] = StrandsAgentCore(
                         model=self._model,
                         system_prompt=self._system_prompt,
@@ -660,6 +737,249 @@ class StrandsAgent:
                 exc_info=True,
             )
 
+        # ── Interrupt resume handling ──────────────────────────────────────
+        # If the client is resuming an interrupted run, validate the
+        # interrupt_id against the Strands _interrupt_state, build
+        # interruptResponse dicts, and pass them to stream_async() so Strands
+        # resumes from its checkpoint.  Cancelled resumes end the run cleanly.
+        _resume_prompt: list | None = None
+        _resumed_tool_call_ids: set = set()
+        resume_entries: list[ResumeEntry] = list(getattr(input_data, "resume", None) or [])
+        thread_id = input_data.thread_id
+
+        # Rule 4: pending interrupts block new input without resume.
+        # Per spec, clients must address all pending interrupts via resume[].
+        # To abandon interrupts, send resume with all entries status: "cancelled".
+        if not resume_entries:
+            interrupt_state = getattr(
+                strands_agent, "_interrupt_state", None
+            )
+            if interrupt_state is not None and getattr(interrupt_state, "activated", False) is True:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                )
+                yield RunErrorEvent(
+                    type=EventType.RUN_ERROR,
+                    message="Thread has pending interrupts. Include resume[] to address them.",
+                    code="PENDING_INTERRUPTS",
+                )
+                return
+
+        if resume_entries:
+            interrupt_state = getattr(strands_agent, "_interrupt_state", None)
+            is_activated = interrupt_state is not None and getattr(interrupt_state, "activated", False) is True
+
+            if not is_activated:
+                # Rule 5: idempotency — check if this is a replay
+                fingerprint = hashlib.md5(  # noqa: S324
+                    json.dumps(
+                        [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
+                        sort_keys=True, default=str,
+                    ).encode(),
+                    usedforsecurity=False,
+                ).hexdigest()
+                if self._last_resume_fingerprint.get(thread_id) == fingerprint:
+                    yield RunStartedEvent(
+                        type=EventType.RUN_STARTED,
+                        thread_id=input_data.thread_id,
+                        run_id=input_data.run_id,
+                    )
+                    yield RunFinishedEvent(
+                        type=EventType.RUN_FINISHED,
+                        thread_id=input_data.thread_id,
+                        run_id=input_data.run_id,
+                        outcome=RunFinishedSuccessOutcome(type="success"),
+                    )
+                    return
+
+                if not self.config.session_manager_provider:
+                    yield RunStartedEvent(
+                        type=EventType.RUN_STARTED,
+                        thread_id=input_data.thread_id,
+                        run_id=input_data.run_id,
+                    )
+                    yield RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message="No pending interrupt for this thread.",
+                        code="UNKNOWN_INTERRUPT_ID",
+                    )
+                    return
+
+            pending_ids: set[str] = set(interrupt_state.interrupts.keys())
+            pending_ag_ui = self._pending_interrupts_by_thread.get(thread_id, {})
+            interrupt_responses: list[dict] = []
+
+            # Rule 2: reject unknown interrupt IDs
+            for entry in resume_entries:
+                if entry.interrupt_id not in pending_ids:
+                    yield RunStartedEvent(
+                        type=EventType.RUN_STARTED,
+                        thread_id=input_data.thread_id,
+                        run_id=input_data.run_id,
+                    )
+                    yield RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message=(
+                            f"Unknown interrupt_id '{entry.interrupt_id}': "
+                            "no matching pending interrupt for this thread."
+                        ),
+                        code="UNKNOWN_INTERRUPT_ID",
+                    )
+                    return
+
+            # Rule 3: all open interrupts must be addressed
+            resumed_ids = {e.interrupt_id for e in resume_entries}
+            missing_ids = pending_ids - resumed_ids
+            if missing_ids:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                )
+                yield RunErrorEvent(
+                    type=EventType.RUN_ERROR,
+                    message=(
+                        f"Partial resume: missing interrupt IDs "
+                        f"{sorted(missing_ids)}. All open interrupts must be addressed."
+                    ),
+                    code="PARTIAL_RESUME",
+                )
+                return
+
+            for entry in resume_entries:
+                ag_ui_interrupt = pending_ag_ui.get(entry.interrupt_id)
+
+                # Rule 7: expiresAt enforcement
+                if ag_ui_interrupt and getattr(ag_ui_interrupt, "expires_at", None):
+                    expiry = datetime.fromisoformat(ag_ui_interrupt.expires_at)
+                    if datetime.now(timezone.utc) > expiry:
+                        yield RunStartedEvent(
+                            type=EventType.RUN_STARTED,
+                            thread_id=input_data.thread_id,
+                            run_id=input_data.run_id,
+                        )
+                        yield RunErrorEvent(
+                            type=EventType.RUN_ERROR,
+                            message=f"Interrupt '{entry.interrupt_id}' has expired.",
+                            code="INTERRUPT_EXPIRED",
+                        )
+                        return
+
+                # Rule 6: basic payload validation against responseSchema
+                if (
+                    entry.status == "resolved"
+                    and ag_ui_interrupt
+                    and getattr(ag_ui_interrupt, "response_schema", None)
+                ):
+                    schema = ag_ui_interrupt.response_schema
+                    payload = entry.payload
+                    if schema.get("type") == "object":
+                        if not isinstance(payload, dict):
+                            yield RunStartedEvent(
+                                type=EventType.RUN_STARTED,
+                                thread_id=input_data.thread_id,
+                                run_id=input_data.run_id,
+                            )
+                            yield RunErrorEvent(
+                                type=EventType.RUN_ERROR,
+                                message=(
+                                    f"Invalid payload for interrupt '{entry.interrupt_id}': "
+                                    "expected an object."
+                                ),
+                                code="INVALID_PAYLOAD",
+                            )
+                            return
+                        required = schema.get("required", [])
+                        missing_keys = [k for k in required if k not in payload]
+                        if missing_keys:
+                            yield RunStartedEvent(
+                                type=EventType.RUN_STARTED,
+                                thread_id=input_data.thread_id,
+                                run_id=input_data.run_id,
+                            )
+                            yield RunErrorEvent(
+                                type=EventType.RUN_ERROR,
+                                message=(
+                                    f"Invalid payload for interrupt '{entry.interrupt_id}': "
+                                    f"missing required keys {missing_keys}."
+                                ),
+                                code="INVALID_PAYLOAD",
+                            )
+                            return
+
+                if entry.status == "cancelled":
+                    # Track tool_call_ids for cancelled tool-bound interrupts
+                    if ag_ui_interrupt and getattr(ag_ui_interrupt, "tool_call_id", None):
+                        _resumed_tool_call_ids.add(ag_ui_interrupt.tool_call_id)
+                    # Include a denial response so Strands marks this interrupt
+                    # as responded (prevents re-raising on resume).
+                    interrupt_responses.append({
+                        "interruptResponse": {
+                            "interruptId": entry.interrupt_id,
+                            "response": {"approved": False},
+                        }
+                    })
+                elif entry.status == "resolved":
+                    interrupt_responses.append({
+                        "interruptResponse": {
+                            "interruptId": entry.interrupt_id,
+                            "response": entry.payload,
+                        }
+                    })
+                    # Track tool_call_ids for resumed interrupts (suppress re-emission)
+                    if ag_ui_interrupt and getattr(ag_ui_interrupt, "tool_call_id", None):
+                        _resumed_tool_call_ids.add(ag_ui_interrupt.tool_call_id)
+
+            # Emit ToolCallResult for cancelled tool-bound interrupts
+            for entry in resume_entries:
+                if entry.status == "cancelled":
+                    intr = pending_ag_ui.get(entry.interrupt_id)
+                    if intr and getattr(intr, "tool_call_id", None):
+                        yield ToolCallResultEvent(
+                            type=EventType.TOOL_CALL_RESULT,
+                            message_id=str(uuid.uuid4()),
+                            tool_call_id=intr.tool_call_id,
+                            content="Tool call cancelled by user.",
+                        )
+
+            # If ALL entries are cancelled, finish immediately without invoking Strands
+            if all(e.status == "cancelled" for e in resume_entries):
+                interrupt_state.deactivate()
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                )
+                yield RunFinishedEvent(
+                    type=EventType.RUN_FINISHED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                    outcome=RunFinishedSuccessOutcome(type="success"),
+                )
+                fingerprint = hashlib.md5(  # noqa: S324
+                    json.dumps(
+                        [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
+                        sort_keys=True, default=str,
+                    ).encode(),
+                    usedforsecurity=False,
+                ).hexdigest()
+                self._last_resume_fingerprint[thread_id] = fingerprint
+                self._pending_interrupts_by_thread.pop(thread_id, None)
+                return
+
+            # Pass interruptResponse dicts as the prompt — Strands resumes from
+            # its checkpoint without replaying the full conversation.
+            logger.debug(
+                f"Resuming interrupted run: thread_id={input_data.thread_id}, "
+                f"interrupt_responses={interrupt_responses}"
+            )
+            _resume_prompt: list | None = interrupt_responses
+            # Fingerprint is stored after successful processing (below).
+            self._pending_interrupts_by_thread.pop(thread_id, None)
+
+        # ── Start run ─────────────────────────────────────────────────────
         # Start run
         yield RunStartedEvent(
             type=EventType.RUN_STARTED,
@@ -745,6 +1065,11 @@ class StrandsAgent:
                     logger.debug(
                         f"Has pending tool results detected: tool_call_ids={pending_tool_result_ids}, thread_id={input_data.thread_id}"
                     )
+
+            # Rule 8: suppress ToolCallStart/Args/End for resumed tool-bound
+            # interrupts — only ToolCallResult should be emitted on resume.
+            if _resumed_tool_call_ids:
+                pending_tool_result_ids.update(_resumed_tool_call_ids)
 
             # Convert AG-UI messages to Strands format
             # Strands expects content as List[ContentBlock] for most messages
@@ -869,8 +1194,12 @@ class StrandsAgent:
             # For continuation runs (has_pending_tool_result), derive a meaningful
             # message from the frontend tool that was just executed so the agent
             # understands the context and can generate a proper conclusion.
-            user_message = ""
-            if pending_tool_result_ids and input_data.messages:
+            # Skip derivation on the interrupt resume path — _resume_prompt is used instead.
+            user_message: Any = ""
+            if _resume_prompt is not None:
+                # Resume path: pass interruptResponse dicts directly to Strands.
+                user_message = _resume_prompt
+            elif pending_tool_result_ids and input_data.messages:
                 # Collect ALL trailing tool results (not just the first). A parallel
                 # frontend-tool turn sends N results in one continuation run; the model
                 # must see every answer.
@@ -970,6 +1299,7 @@ class StrandsAgent:
             # client dispatching its follow-up run before the backend results
             # reach it, narrowing the ConcurrencyException race window.
             deferred_frontend_tool_ends = []
+            pending_interrupt_outcome: RunFinishedInterruptOutcome | None = None
 
             # Reasoning/thinking state tracking
             reasoning_started = False
@@ -1057,37 +1387,43 @@ class StrandsAgent:
                 and has_nonvoid_frontend_result
             )
             if replay_history:
-                native_history = _build_strands_history(input_data.messages)
-                # Apply ``state_context_builder`` to the last user-text
-                # message in the reconciled history rather than to the
-                # synthetic ``user_message`` string. This matches what the
-                # builder is actually trying to enrich (the prompt the LLM
-                # will see).
-                if self.config.state_context_builder and native_history:
-                    for native_msg in reversed(native_history):
-                        if (
-                            native_msg.get("role") == "user"
-                            and native_msg.get("content")
-                            and isinstance(native_msg["content"], list)
-                            and "text" in native_msg["content"][0]
-                        ):
-                            try:
-                                augmented = self.config.state_context_builder(
-                                    input_data, native_msg["content"][0]["text"]
-                                )
-                                if isinstance(augmented, str):
-                                    native_msg["content"][0]["text"] = augmented
-                            except Exception as e:
-                                logger.warning(
-                                    f"state_context_builder failed: {e}", exc_info=True
-                                )
-                            break
-                strands_agent.messages = native_history
-                # ``stream_async(None)`` tells Strands to use existing
-                # ``self.messages`` as-is. The LLM sees real tool results
-                # (including ones produced by the frontend) and emits a
-                # proper follow-up turn instead of re-calling the tool.
-                agent_stream = strands_agent.stream_async(None)
+                if _resume_prompt is not None:
+                    # Resume path: the cached agent already has messages from
+                    # the interrupted turn. Pass interruptResponse dicts so
+                    # Strands resumes from its checkpoint.
+                    agent_stream = strands_agent.stream_async(_resume_prompt)
+                else:
+                    native_history = _build_strands_history(input_data.messages)
+                    # Apply ``state_context_builder`` to the last user-text
+                    # message in the reconciled history rather than to the
+                    # synthetic ``user_message`` string. This matches what the
+                    # builder is actually trying to enrich (the prompt the LLM
+                    # will see).
+                    if self.config.state_context_builder and native_history:
+                        for native_msg in reversed(native_history):
+                            if (
+                                native_msg.get("role") == "user"
+                                and native_msg.get("content")
+                                and isinstance(native_msg["content"], list)
+                                and "text" in native_msg["content"][0]
+                            ):
+                                try:
+                                    augmented = self.config.state_context_builder(
+                                        input_data, native_msg["content"][0]["text"]
+                                    )
+                                    if isinstance(augmented, str):
+                                        native_msg["content"][0]["text"] = augmented
+                                except Exception as e:
+                                    logger.warning(
+                                        f"state_context_builder failed: {e}", exc_info=True
+                                    )
+                                break
+                    strands_agent.messages = native_history
+                    # ``stream_async(None)`` tells Strands to use existing
+                    # ``self.messages`` as-is. The LLM sees real tool results
+                    # (including ones produced by the frontend) and emits a
+                    # proper follow-up turn instead of re-calling the tool.
+                    agent_stream = strands_agent.stream_async(None)
             elif reconcile_session_results:
                 try:
                     corrected_native_ids = reconcile_frontend_tool_results(
@@ -1180,6 +1516,60 @@ class StrandsAgent:
                         )
                         # Generator will end naturally, no need to break
                         break
+
+                    # Handle AgentResult event — detect Strands native interrupts
+                    if "result" in event:
+                        result = event["result"]
+                        stop_reason = getattr(result, "stop_reason", None)
+                        if stop_reason == "interrupt":
+                            strands_interrupts = getattr(result, "interrupts", None) or []
+                            ag_ui_interrupts = []
+                            for si in strands_interrupts:
+                                tool_name_meta = (
+                                    si.reason.get("tool_name", "unknown")
+                                    if isinstance(si.reason, dict)
+                                    else "unknown"
+                                )
+                                tool_input_meta = (
+                                    si.reason.get("tool_input", {})
+                                    if isinstance(si.reason, dict)
+                                    else {}
+                                )
+                                tool_use_id_meta = (
+                                    si.reason.get("tool_use_id")
+                                    if isinstance(si.reason, dict)
+                                    else None
+                                )
+                                ag_ui_interrupts.append(Interrupt(
+                                    id=si.id,
+                                    reason="tool_call",
+                                    message=f"Approve call to {tool_name_meta}?",
+                                    tool_call_id=tool_use_id_meta,
+                                    response_schema={
+                                        "type": "object",
+                                        "properties": {"approved": {"type": "boolean"}},
+                                        "required": ["approved"],
+                                    },
+                                    metadata={
+                                        "tool_name": tool_name_meta,
+                                        "tool_input": tool_input_meta,
+                                    },
+                                ))
+                            if ag_ui_interrupts:
+                                pending_interrupt_outcome = RunFinishedInterruptOutcome(
+                                    type="interrupt",
+                                    interrupts=ag_ui_interrupts,
+                                )
+                                # Store full interrupt objects for resume validation
+                                self._pending_interrupts_by_thread[input_data.thread_id] = {
+                                    i.id: i for i in ag_ui_interrupts
+                                }
+                                self._last_resume_fingerprint.pop(input_data.thread_id, None)
+                                logger.debug(
+                                    f"Strands interrupt detected: thread_id={input_data.thread_id}, "
+                                    f"interrupt_ids={[i.id for i in ag_ui_interrupts]}"
+                                )
+                        continue  # never yield the raw result event
 
                     # Handle text streaming
                     if "data" in event and event["data"]:
@@ -1307,20 +1697,20 @@ class StrandsAgent:
                     elif "tool_stream_event" in event:
                         tool_stream = event["tool_stream_event"]
                         stream_data = tool_stream.get("data", {})
+                        _tse_tool_use = tool_stream.get("tool_use", {})
+                        _tse_tool_name = _tse_tool_use.get("name", "")
+                        _tse_tool_use_id = _tse_tool_use.get("toolUseId")
 
-                        # Emit state snapshot if tool yielded state
-                        if isinstance(stream_data, dict) and "state" in stream_data:
-                            yield StateSnapshotEvent(
-                                type=EventType.STATE_SNAPSHOT,
-                                snapshot=stream_data["state"],
-                            )
                         # A2UI sub-agent streaming: re-emit the
                         # generate_a2ui tool's inner render_a2ui progress as
                         # synthetic TOOL_CALL events. The a2ui middleware's
                         # streaming path keys its "building" skeleton +
                         # progressive paint off these — without them the
                         # surface only paints in bulk from the final result.
-                        elif (
+                        # This path is keyed off A2UI_STREAM_KEY in the
+                        # payload, not the tool's toolUseId, so it must run
+                        # even when toolUseId is absent.
+                        if (
                             isinstance(stream_data, dict)
                             and isinstance(stream_data.get(A2UI_STREAM_KEY), dict)
                         ):
@@ -1345,6 +1735,36 @@ class StrandsAgent:
                                 yield ToolCallEndEvent(
                                     type=EventType.TOOL_CALL_END,
                                     tool_call_id=a2ui_call_id,
+                                )
+                        elif _tse_tool_use_id is None:
+                            logger.debug(
+                                "tool_stream_event missing toolUseId — skipping handler dispatch"
+                            )
+                        else:
+                            _tse_behavior = self.config.tool_behaviors.get(_tse_tool_name) if _tse_tool_name else None
+
+                            if _tse_behavior and _tse_behavior.tool_stream_event_handler:
+                                _tse_ctx = ToolStreamEventContext(
+                                    tool_use_id=_tse_tool_use_id,
+                                    tool_name=_tse_tool_name,
+                                    stream_data=stream_data,
+                                )
+                                try:
+                                    async for _tse_event in _tse_behavior.tool_stream_event_handler(
+                                        _tse_ctx
+                                    ):
+                                        if _tse_event is not None:
+                                            yield _tse_event
+                                except Exception as _tse_exc:
+                                    logger.warning(
+                                        f"tool_stream_event_handler failed for {_tse_tool_name}: {_tse_exc}",
+                                        exc_info=True,
+                                    )
+                            elif isinstance(stream_data, dict) and "state" in stream_data:
+                                # Default behaviour: emit state snapshot when tool yields {"state": ...}
+                                yield StateSnapshotEvent(
+                                    type=EventType.STATE_SNAPSHOT,
+                                    snapshot=stream_data["state"],
                                 )
 
                     # Handle tool results from Strands for backend tool rendering
@@ -2172,11 +2592,30 @@ class StrandsAgent:
             )
 
             # Always finish the run - frontend handles keeping action executing
-            yield RunFinishedEvent(
-                type=EventType.RUN_FINISHED,
-                thread_id=input_data.thread_id,
-                run_id=input_data.run_id,
-            )
+            if pending_interrupt_outcome is not None:
+                yield RunFinishedEvent(
+                    type=EventType.RUN_FINISHED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                    outcome=pending_interrupt_outcome,
+                )
+            else:
+                # Store fingerprint for idempotency only after successful processing
+                if resume_entries:
+                    fp = hashlib.md5(  # noqa: S324
+                        json.dumps(
+                            [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
+                            sort_keys=True, default=str,
+                        ).encode(),
+                        usedforsecurity=False,
+                    ).hexdigest()
+                    self._last_resume_fingerprint[thread_id] = fp
+                yield RunFinishedEvent(
+                    type=EventType.RUN_FINISHED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                    outcome=RunFinishedSuccessOutcome(type="success"),
+                )
 
         except Exception as e:
             import traceback

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -164,6 +164,77 @@ from .config import (
 from .utils import convert_agui_content_to_strands, flatten_content_to_text
 
 
+def _resume_fingerprint(resume_entries: list[ResumeEntry]) -> str:
+    """Return an order-independent idempotency fingerprint for ``resume[]``.
+
+    A resume addresses a set of pending interrupts, so clients may submit the
+    same entries in a different order when replaying a request. Canonicalizing
+    both payload object keys and entry order prevents that harmless difference
+    from re-invoking the model or tools.
+    """
+    canonical_entries = [
+        (entry.interrupt_id, entry.status, entry.payload)
+        for entry in resume_entries
+    ]
+    canonical_entries.sort(
+        key=lambda entry: json.dumps(
+            entry, sort_keys=True, default=str, separators=(",", ":")
+        )
+    )
+    serialized = json.dumps(
+        canonical_entries, sort_keys=True, default=str, separators=(",", ":")
+    )
+    return hashlib.md5(  # noqa: S324 -- non-security idempotency key
+        serialized.encode(), usedforsecurity=False
+    ).hexdigest()
+
+
+def _validate_object_payload_property_types(
+    schema: dict[str, Any], payload: dict[str, Any]
+) -> str | None:
+    """Validate supplied primitive object properties from a JSON Schema.
+
+    This intentionally complements, rather than replaces, the lightweight
+    required-field validation in ``run()``. It supports the primitive types
+    used by adapter-issued schemas without adding a full JSON Schema runtime.
+    """
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+
+    for field, field_schema in properties.items():
+        if field not in payload or not isinstance(field_schema, dict):
+            continue
+        expected_type = field_schema.get("type")
+        if not isinstance(expected_type, str):
+            continue
+        if _json_schema_type_matches(payload[field], expected_type):
+            continue
+        article = "an" if expected_type in {"object", "array"} else "a"
+        return f"field '{field}' must be {article} {expected_type}."
+
+    return None
+
+
+def _json_schema_type_matches(value: Any, expected_type: str) -> bool:
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "null":
+        return value is None
+    # Unsupported JSON Schema constructs remain the caller's responsibility.
+    return True
+
+
 def _coerce_text(content: Any) -> str:
     """Best-effort string view of an AG-UI message content field."""
     if isinstance(content, str):
@@ -902,13 +973,7 @@ class StrandsAgent:
 
             if not is_activated:
                 # Rule 5: idempotency — check if this is a replay
-                fingerprint = hashlib.md5(  # noqa: S324
-                    json.dumps(
-                        [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
-                        sort_keys=True, default=str,
-                    ).encode(),
-                    usedforsecurity=False,
-                ).hexdigest()
+                fingerprint = _resume_fingerprint(resume_entries)
                 if self._last_resume_fingerprint.get(thread_id) == fingerprint:
                     yield RunStartedEvent(
                         type=EventType.RUN_STARTED,
@@ -1002,6 +1067,18 @@ class StrandsAgent:
                             ev_started, ev_error = _error_events(
                                 input_data,
                                 f"Invalid payload for interrupt '{entry.interrupt_id}': missing required keys {missing_keys}.",
+                                "INVALID_PAYLOAD",
+                            )
+                            yield ev_started
+                            yield ev_error
+                            return
+                        type_error = _validate_object_payload_property_types(
+                            schema, payload
+                        )
+                        if type_error:
+                            ev_started, ev_error = _error_events(
+                                input_data,
+                                f"Invalid payload for interrupt '{entry.interrupt_id}': {type_error}",
                                 "INVALID_PAYLOAD",
                             )
                             yield ev_started
@@ -2707,13 +2784,7 @@ class StrandsAgent:
             else:
                 # Store fingerprint for idempotency only after successful processing
                 if resume_entries:
-                    fp = hashlib.md5(  # noqa: S324
-                        json.dumps(
-                            [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
-                            sort_keys=True, default=str,
-                        ).encode(),
-                        usedforsecurity=False,
-                    ).hexdigest()
+                    fp = _resume_fingerprint(resume_entries)
                     self._last_resume_fingerprint[thread_id] = fp
                     _persist_interrupt_bookkeeping(strands_agent, None, fp)
                 yield RunFinishedEvent(

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -442,8 +442,18 @@ class StrandsInterruptHook:
             },
         )
         # If we reach here we are on the resume path.
-        # Deny the tool call unless the user explicitly approved.
-        if not (isinstance(response, dict) and response.get("approved", False)):
+        # Enforce a strict payload contract matching the advertised
+        # response_schema ({"approved": bool}, required): only a dict with
+        # "approved" set to an actual bool of True grants approval. Anything
+        # else — a missing key, a non-bool value (e.g. a truthy string like
+        # "false", a number, None), or a non-dict response — is treated as
+        # an explicit denial rather than being coerced by truthiness.
+        approved = (
+            isinstance(response, dict)
+            and isinstance(response.get("approved"), bool)
+            and response["approved"] is True
+        )
+        if not approved:
             event.cancel_tool = f"User denied approval for '{tool_name}'."
 
 
@@ -944,30 +954,12 @@ class StrandsAgent:
                             content="Tool call cancelled by user.",
                         )
 
-            # If ALL entries are cancelled, finish immediately without invoking Strands
-            if all(e.status == "cancelled" for e in resume_entries):
-                interrupt_state.deactivate()
-                yield RunStartedEvent(
-                    type=EventType.RUN_STARTED,
-                    thread_id=input_data.thread_id,
-                    run_id=input_data.run_id,
-                )
-                yield RunFinishedEvent(
-                    type=EventType.RUN_FINISHED,
-                    thread_id=input_data.thread_id,
-                    run_id=input_data.run_id,
-                    outcome=RunFinishedSuccessOutcome(type="success"),
-                )
-                fingerprint = hashlib.md5(  # noqa: S324
-                    json.dumps(
-                        [(e.interrupt_id, e.status, e.payload) for e in resume_entries],
-                        sort_keys=True, default=str,
-                    ).encode(),
-                    usedforsecurity=False,
-                ).hexdigest()
-                self._last_resume_fingerprint[thread_id] = fingerprint
-                self._pending_interrupts_by_thread.pop(thread_id, None)
-                return
+            # Note: even when ALL entries are cancelled, we still forward the
+            # denial responses to Strands via stream_async() below rather than
+            # short-circuiting here. This ensures native interrupt-state
+            # cleanup, hooks, snapshots, and session persistence all run
+            # through Strands' normal completion path instead of being
+            # bypassed by a synthetic RUN_FINISHED.
 
             # Pass interruptResponse dicts as the prompt — Strands resumes from
             # its checkpoint without replaying the full conversation.
@@ -1525,36 +1517,54 @@ class StrandsAgent:
                             strands_interrupts = getattr(result, "interrupts", None) or []
                             ag_ui_interrupts = []
                             for si in strands_interrupts:
-                                tool_name_meta = (
-                                    si.reason.get("tool_name", "unknown")
-                                    if isinstance(si.reason, dict)
-                                    else "unknown"
+                                # Only interrupts raised by our own
+                                # StrandsInterruptHook (identified by the
+                                # "ag_ui:tool_call:" name prefix it always
+                                # uses) are tool-call approvals with the
+                                # {tool_name, tool_input, tool_use_id} reason
+                                # shape. Any other interrupt — e.g. one a
+                                # user's own tool or hook raises directly via
+                                # event.interrupt(name, reason=...) for
+                                # generic human-in-the-loop purposes — must
+                                # stay generic: preserve its native name/
+                                # reason payload rather than guessing tool
+                                # metadata out of an unrelated object.
+                                is_tool_approval = (
+                                    isinstance(si.name, str)
+                                    and si.name.startswith("ag_ui:tool_call:")
+                                    and isinstance(si.reason, dict)
                                 )
-                                tool_input_meta = (
-                                    si.reason.get("tool_input", {})
-                                    if isinstance(si.reason, dict)
-                                    else {}
-                                )
-                                tool_use_id_meta = (
-                                    si.reason.get("tool_use_id")
-                                    if isinstance(si.reason, dict)
-                                    else None
-                                )
-                                ag_ui_interrupts.append(Interrupt(
-                                    id=si.id,
-                                    reason="tool_call",
-                                    message=f"Approve call to {tool_name_meta}?",
-                                    tool_call_id=tool_use_id_meta,
-                                    response_schema={
-                                        "type": "object",
-                                        "properties": {"approved": {"type": "boolean"}},
-                                        "required": ["approved"],
-                                    },
-                                    metadata={
-                                        "tool_name": tool_name_meta,
-                                        "tool_input": tool_input_meta,
-                                    },
-                                ))
+                                if is_tool_approval:
+                                    tool_name_meta = si.reason.get("tool_name", "unknown")
+                                    tool_input_meta = si.reason.get("tool_input", {})
+                                    tool_use_id_meta = si.reason.get("tool_use_id")
+                                    ag_ui_interrupts.append(Interrupt(
+                                        id=si.id,
+                                        reason="tool_call",
+                                        message=f"Approve call to {tool_name_meta}?",
+                                        tool_call_id=tool_use_id_meta,
+                                        response_schema={
+                                            "type": "object",
+                                            "properties": {"approved": {"type": "boolean"}},
+                                            "required": ["approved"],
+                                        },
+                                        metadata={
+                                            "tool_name": tool_name_meta,
+                                            "tool_input": tool_input_meta,
+                                        },
+                                    ))
+                                else:
+                                    # Generic native interrupt: preserve the
+                                    # native name/reason as-is instead of
+                                    # fabricating tool-approval semantics.
+                                    ag_ui_interrupts.append(Interrupt(
+                                        id=si.id,
+                                        reason=si.name,
+                                        message=None,
+                                        tool_call_id=None,
+                                        response_schema=None,
+                                        metadata={"reason": si.reason} if si.reason is not None else None,
+                                    ))
                             if ag_ui_interrupts:
                                 pending_interrupt_outcome = RunFinishedInterruptOutcome(
                                     type="interrupt",

--- a/integrations/aws-strands/python/src/ag_ui_strands/config.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/config.py
@@ -51,6 +51,44 @@ SessionManagerProvider = Callable[[RunAgentInput], Awaitable[Optional[SessionMan
 
 
 @dataclass
+class ToolStreamEventContext:
+    """Context passed to tool_stream_event_handler hooks.
+
+    Carries every piece of information available at the point a tool yields an
+    intermediate streaming event, so handlers can make routing decisions without
+    needing to close over external state.
+    """
+
+    tool_use_id: str
+    """The Strands ``toolUseId`` for the tool call that produced this event."""
+
+    tool_name: str
+    """The name of the tool that produced this event."""
+
+    stream_data: Any
+    """The raw data payload yielded by the tool (the ``data`` field of the
+    ``tool_stream_event`` dict emitted by Strands)."""
+
+
+ToolStreamEventHandler = Callable[["ToolStreamEventContext"], AsyncIterator[Any]]
+"""Handler for raw tool_stream_event data emitted by async-generator tools.
+
+Must be an **async generator function** — i.e. it must contain at least one
+``yield`` statement.  A plain ``async def`` that returns an ``AsyncIterator``
+will satisfy the type but will not be iterated correctly.
+
+Called with a :class:`ToolStreamEventContext` for every intermediate event
+yielded by the tool while it is executing.  The handler may yield zero or more
+AG-UI Event objects which are forwarded directly into the top-level event
+stream.
+
+When a handler is registered for a tool, the default behaviour of emitting a
+``StateSnapshotEvent`` for ``{"state": ...}`` payloads is suppressed for that
+tool.  The handler is responsible for any state updates it wants to emit.
+"""
+
+
+@dataclass
 class PredictStateMapping:
     """Declarative mapping telling the UI how to predict state from tool args."""
 
@@ -79,11 +117,13 @@ class ToolBehavior:
     """
     continue_after_frontend_call: bool = False
     stop_streaming_after_result: bool = False
+    interrupt_on_call: bool = False
     predict_state: Optional[Iterable[PredictStateMapping]] = None
     args_streamer: Optional[ArgsStreamer] = None
     state_from_args: Optional[StateFromArgs] = None
     state_from_result: Optional[StateFromResult] = None
     custom_result_handler: Optional[CustomResultHandler] = None
+    tool_stream_event_handler: Optional[ToolStreamEventHandler] = None
 
 
 @dataclass

--- a/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
@@ -1,0 +1,259 @@
+"""Regression coverage for interrupt bookkeeping surviving a process restart.
+
+``_pending_interrupts_by_thread`` and ``_last_resume_fingerprint`` are the
+adapter's own bookkeeping, layered on top of Strands' native
+``_interrupt_state`` (which SessionManager already persists/restores on its
+own). Prior to this, the adapter's bookkeeping lived purely in a Python dict
+on the ``StrandsAgent`` instance, so a real process restart lost it:
+
+- Rule 6 (responseSchema payload validation) and Rule 7 (expiresAt
+  enforcement) silently degrade, since they read AG-UI-specific interrupt
+  metadata that only exists in this bookkeeping.
+- Rule 5 (idempotency) breaks: a replayed resume request is no longer
+  recognized as a duplicate and can re-invoke the model/tool.
+
+These tests use a REAL ``strands.agent.state.AgentState`` instance (not a
+mock) to prove the adapter actually round-trips through
+``strands_agent.state``, matching what a real SessionManager restores after
+a restart.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from ag_ui.core import EventType, Interrupt, ResumeEntry, RunAgentInput, Tool, UserMessage
+from strands.agent.state import AgentState
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _build_agent_with_real_state(
+    thread_id: str,
+    stream_events: list,
+    state: AgentState,
+    config: StrandsAgentConfig | None = None,
+) -> StrandsAgent:
+    """Build a StrandsAgent whose per-thread Strands agent has a REAL
+    AgentState (not a MagicMock) — as if it had just been reconstructed by
+    _ensure_agent() on a fresh process, with SessionManager having restored
+    ``state`` from persisted storage."""
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=config or StrandsAgentConfig()
+    )
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+    mock_inner.state = state
+    # No native interrupt activated on this "fresh" agent — the point of
+    # these tests is that our OWN bookkeeping (not Strands' native
+    # _interrupt_state) is what gets restored from persisted state.
+    mock_inner._interrupt_state = None
+
+    async def _stream(_msg: Any):
+        for event in stream_events:
+            yield event
+
+    mock_inner.stream_async = _stream
+    agent._agents_by_thread[thread_id] = mock_inner
+    return agent
+
+
+def _run_input(thread_id: str, resume: list | None = None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=[Tool(name="my_tool", description="d", parameters={})],
+        context=[],
+        forwarded_props={},
+        resume=resume,
+    )
+
+
+async def _collect(agent: StrandsAgent, inp: RunAgentInput) -> list:
+    return [e async for e in agent.run(inp)]
+
+
+class TestIdempotencyFingerprintSurvivesRestart:
+    THREAD = "restart-fingerprint-thread"
+
+    async def test_replayed_resume_is_recognized_from_persisted_state(self):
+        """A resume request whose fingerprint was persisted (by a prior
+        process, before this process's in-memory map was ever populated)
+        must be recognized as a replay and short-circuit to success —
+        without touching Strands again."""
+        state = AgentState()
+        state.set(
+            "ag_ui_interrupt_bookkeeping",
+            {
+                "last_resume_fingerprint": None,  # will be overwritten below
+                "pending_interrupts": {},
+            },
+        )
+        resume = [ResumeEntry(interrupt_id="int-1", status="resolved", payload={"approved": True})]
+
+        # Compute the fingerprint exactly as the adapter does, and persist
+        # it directly into state — simulating what a prior process wrote
+        # before restarting.
+        import hashlib
+        import json
+        fingerprint = hashlib.md5(  # noqa: S324
+            json.dumps(
+                [(e.interrupt_id, e.status, e.payload) for e in resume],
+                sort_keys=True, default=str,
+            ).encode(),
+            usedforsecurity=False,
+        ).hexdigest()
+        state.set(
+            "ag_ui_interrupt_bookkeeping",
+            {"last_resume_fingerprint": fingerprint, "pending_interrupts": {}},
+        )
+
+        agent = _build_agent_with_real_state(self.THREAD, [], state)
+        # In-memory maps are empty for this thread — this process has never
+        # run anything for it. Only persisted state has the fingerprint.
+        assert self.THREAD not in agent._last_resume_fingerprint
+
+        events = await _collect(agent, _run_input(self.THREAD, resume=resume))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert finished[0].outcome.type == "success"
+        # No RUN_ERROR — the replay was recognized, not treated as an
+        # unknown/stale resume.
+        assert not any(e.type == EventType.RUN_ERROR for e in events)
+
+
+class TestPendingInterruptMetadataSurvivesRestart:
+    THREAD = "restart-pending-thread"
+
+    def _config(self) -> StrandsAgentConfig:
+        return StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    async def test_expired_interrupt_still_enforced_after_restart(self):
+        """Rule 7 (expiresAt) depends on AG-UI-specific interrupt metadata
+        that only lives in our adapter bookkeeping, not Strands' native
+        _interrupt_state. It must still be enforced when that bookkeeping
+        is restored from persisted state rather than the in-memory map."""
+        expired_interrupt = Interrupt(
+            id="int-1",
+            reason="tool_call",
+            tool_call_id="tc-1",
+            expires_at="2000-01-01T00:00:00+00:00",  # long expired
+        )
+        state = AgentState()
+        state.set(
+            "ag_ui_interrupt_bookkeeping",
+            {
+                "last_resume_fingerprint": None,
+                "pending_interrupts": {"int-1": expired_interrupt.model_dump(mode="json")},
+            },
+        )
+
+        # Strands' native _interrupt_state still needs to report "int-1" as
+        # pending for Rule 2/3 to pass before Rule 7 is even reached.
+        strands_interrupt_state = MagicMock()
+        strands_interrupt_state.activated = True
+        strands_interrupt_state.interrupts = {"int-1": MagicMock()}
+
+        agent = _build_agent_with_real_state(self.THREAD, [], state, self._config())
+        mock_inner = agent._agents_by_thread[self.THREAD]
+        mock_inner._interrupt_state = strands_interrupt_state
+
+        assert self.THREAD not in agent._pending_interrupts_by_thread
+
+        resume = [ResumeEntry(interrupt_id="int-1", status="resolved", payload={"approved": True})]
+        events = await _collect(agent, _run_input(self.THREAD, resume=resume))
+
+        error = next((e for e in events if e.type == EventType.RUN_ERROR), None)
+        assert error is not None, f"expected RUN_ERROR(INTERRUPT_EXPIRED), got: {[e.type for e in events]}"
+        assert error.code == "INTERRUPT_EXPIRED"
+
+    async def test_invalid_payload_still_rejected_after_restart(self):
+        """Rule 6 (responseSchema validation) likewise depends on restored
+        bookkeeping."""
+        pending_interrupt = Interrupt(
+            id="int-2",
+            reason="tool_call",
+            tool_call_id="tc-2",
+            response_schema={
+                "type": "object",
+                "properties": {"approved": {"type": "boolean"}},
+                "required": ["approved"],
+            },
+        )
+        state = AgentState()
+        state.set(
+            "ag_ui_interrupt_bookkeeping",
+            {
+                "last_resume_fingerprint": None,
+                "pending_interrupts": {"int-2": pending_interrupt.model_dump(mode="json")},
+            },
+        )
+
+        strands_interrupt_state = MagicMock()
+        strands_interrupt_state.activated = True
+        strands_interrupt_state.interrupts = {"int-2": MagicMock()}
+
+        agent = _build_agent_with_real_state(self.THREAD + "-2", [], state, self._config())
+        mock_inner = agent._agents_by_thread[self.THREAD + "-2"]
+        mock_inner._interrupt_state = strands_interrupt_state
+
+        # Missing the required "approved" key.
+        resume = [ResumeEntry(interrupt_id="int-2", status="resolved", payload={})]
+        events = await _collect(agent, _run_input(self.THREAD + "-2", resume=resume))
+
+        error = next((e for e in events if e.type == EventType.RUN_ERROR), None)
+        assert error is not None, f"expected RUN_ERROR(INVALID_PAYLOAD), got: {[e.type for e in events]}"
+        assert error.code == "INVALID_PAYLOAD"
+
+
+class TestPersistenceHelpersAreDefensiveAgainstMocks:
+    """Guards against reintroducing the MagicMock-truthiness class of bug:
+    a bare MagicMock() standing in for the Strands agent must be treated as
+    having no persisted bookkeeping, not crash or silently misbehave."""
+
+    async def test_bare_magicmock_state_is_treated_as_no_persisted_data(self):
+        from ag_ui_strands.agent import _load_persisted_interrupt_bookkeeping
+
+        mock_agent = MagicMock()  # mock_agent.state.get(...) auto-vivifies a MagicMock
+        pending, fingerprint = _load_persisted_interrupt_bookkeeping(mock_agent)
+        assert pending is None
+        assert fingerprint is None
+
+    async def test_persist_helper_never_raises_on_a_broken_state_object(self):
+        from ag_ui_strands.agent import _persist_interrupt_bookkeeping
+
+        class _BrokenState:
+            def set(self, key, value):
+                raise RuntimeError("boom")
+
+        broken_agent = MagicMock()
+        broken_agent.state = _BrokenState()
+        # Must not raise.
+        _persist_interrupt_bookkeeping(broken_agent, None, "fp")
+
+    async def test_missing_state_attribute_is_handled(self):
+        from ag_ui_strands.agent import _load_persisted_interrupt_bookkeeping
+
+        class _NoState:
+            pass
+
+        pending, fingerprint = _load_persisted_interrupt_bookkeeping(_NoState())
+        assert pending is None
+        assert fingerprint is None

--- a/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
@@ -27,7 +27,7 @@ from ag_ui.core import EventType, Interrupt, ResumeEntry, RunAgentInput, Tool, U
 from strands.agent.state import AgentState
 from strands.tools.registry import ToolRegistry
 
-from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.agent import StrandsAgent, _resume_fingerprint
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 
 
@@ -108,15 +108,7 @@ class TestIdempotencyFingerprintSurvivesRestart:
         # Compute the fingerprint exactly as the adapter does, and persist
         # it directly into state — simulating what a prior process wrote
         # before restarting.
-        import hashlib
-        import json
-        fingerprint = hashlib.md5(  # noqa: S324
-            json.dumps(
-                [(e.interrupt_id, e.status, e.payload) for e in resume],
-                sort_keys=True, default=str,
-            ).encode(),
-            usedforsecurity=False,
-        ).hexdigest()
+        fingerprint = _resume_fingerprint(resume)
         state.set(
             "ag_ui_interrupt_bookkeeping",
             {"last_resume_fingerprint": fingerprint, "pending_interrupts": {}},

--- a/integrations/aws-strands/python/tests/test_interrupt_protocol.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_protocol.py
@@ -1,0 +1,551 @@
+"""Tests for the AG-UI interrupt-and-resume protocol in StrandsAgent.
+
+The interrupt protocol is built on top of the Strands native interrupt system:
+
+- StrandsInterruptHook fires on BeforeToolCallEvent for interrupt_on_call tools
+  and calls event.interrupt(), which suspends the Strands agent loop natively.
+- agent.py detects result.stop_reason == "interrupt" in the AgentResult event
+  and emits RunFinishedInterruptOutcome using the Strands interrupt IDs directly.
+- On resume, input_data.resume entries are converted to interruptResponse dicts
+  and passed to stream_async() — Strands resumes from its checkpoint.
+
+Covers:
+- interrupt_on_call=True emits RunFinishedInterruptOutcome with correct fields
+- interrupt_on_call=False (default) keeps legacy pending_halt behaviour (no interrupt outcome)
+- Normal runs (no frontend tool) emit RunFinishedSuccessOutcome
+- Resume: resolved+approved passes "y" to Strands and run continues
+- Resume: resolved+denied passes "n" to Strands and run continues
+- Resume: cancelled deactivates Strands interrupt state and ends cleanly
+- Resume: unknown interrupt_id yields RunErrorEvent
+- Resume: no pending interrupt on thread yields RunErrorEvent
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import (
+    EventType,
+    RunAgentInput,
+    Tool,
+    UserMessage,
+)
+from strands.interrupt import Interrupt as StrandsInterrupt
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
+from ag_ui_strands import (
+    Interrupt,
+    ResumeEntry,
+    RunFinishedInterruptOutcome,
+    RunFinishedSuccessOutcome,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal AgentResult stub
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeMetrics:
+    pass
+
+
+@dataclass
+class _FakeAgentResult:
+    """Minimal stand-in for strands.agent.agent_result.AgentResult."""
+    stop_reason: str
+    message: dict = field(default_factory=lambda: {"role": "assistant", "content": []})
+    metrics: Any = field(default_factory=_FakeMetrics)
+    state: Any = field(default_factory=dict)
+    interrupts: Sequence[StrandsInterrupt] | None = None
+    structured_output: Any = None
+
+
+def _make_strands_interrupt(
+    tool_name: str = "my_tool",
+    tool_input: dict | None = None,
+    tool_use_id: str = "st-1",
+) -> StrandsInterrupt:
+    """Build a Strands Interrupt as the hook would produce it."""
+    import uuid
+    interrupt_id = f"v1:before_tool_call:{tool_use_id}:{uuid.uuid5(uuid.NAMESPACE_OID, f'ag_ui:tool_call:{tool_name}')}"
+    return StrandsInterrupt(
+        id=interrupt_id,
+        name=f"ag_ui:tool_call:{tool_name}",
+        reason={"tool_name": tool_name, "tool_input": tool_input or {}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _make_interrupt_state(activated: bool = False, interrupts: dict | None = None) -> MagicMock:
+    """Build a mock _interrupt_state matching Strands' interface."""
+    state = MagicMock()
+    state.activated = activated
+    state.interrupts = interrupts or {}
+    state.deactivate = MagicMock(side_effect=lambda: setattr(state, "activated", False))
+    return state
+
+
+def _build_agent(
+    thread_id: str,
+    stream_events: list,
+    config: StrandsAgentConfig | None = None,
+    interrupt_state: MagicMock | None = None,
+) -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=config or StrandsAgentConfig()
+    )
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+
+    # Wire interrupt state
+    mock_inner._interrupt_state = interrupt_state or _make_interrupt_state()
+
+    async def _stream(_msg: Any):
+        for event in stream_events:
+            yield event
+
+    mock_inner.stream_async = _stream
+    agent._agents_by_thread[thread_id] = mock_inner
+    return agent
+
+
+def _run_input(
+    thread_id: str = "t1",
+    messages: list | None = None,
+    tools: list | None = None,
+    resume: list | None = None,
+) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=messages or [UserMessage(id="u1", content="hello")],
+        tools=tools or [],
+        context=[],
+        forwarded_props={},
+        resume=resume,
+    )
+
+
+async def _collect(agent: StrandsAgent, inp: RunAgentInput) -> list:
+    return [e async for e in agent.run(inp)]
+
+
+def _frontend_tool_stream_with_interrupt(
+    tool_name: str = "my_tool",
+    tool_use_id: str = "st-1",
+) -> list:
+    """Stream that ends with an AgentResult carrying stop_reason='interrupt'."""
+    strands_interrupt = _make_strands_interrupt(tool_name, {}, tool_use_id)
+    return [
+        {"current_tool_use": {"name": tool_name, "toolUseId": tool_use_id, "input": {}}},
+        {"event": {"contentBlockStop": {}}},
+        {"result": _FakeAgentResult(
+            stop_reason="interrupt",
+            interrupts=[strands_interrupt],
+        )},
+    ]
+
+
+def _empty_stream() -> list:
+    return [
+        {"result": _FakeAgentResult(stop_reason="end_turn")},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# interrupt_on_call=True — interrupt outcome emitted
+# ---------------------------------------------------------------------------
+
+class TestInterruptOutcomeEmitted:
+    THREAD = "interrupt-thread"
+    TOOL = Tool(name="my_tool", description="d", parameters={})
+
+    def _config(self) -> StrandsAgentConfig:
+        return StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    async def test_run_finished_has_interrupt_outcome(self):
+        agent = _build_agent(self.THREAD, _frontend_tool_stream_with_interrupt(), self._config())
+        events = await _collect(agent, _run_input(self.THREAD, tools=[self.TOOL]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        outcome = finished[0].outcome
+        assert isinstance(outcome, RunFinishedInterruptOutcome)
+        assert outcome.type == "interrupt"
+
+    async def test_interrupt_has_correct_reason(self):
+        agent = _build_agent(self.THREAD + "-reason", _frontend_tool_stream_with_interrupt(), self._config())
+        events = await _collect(agent, _run_input(self.THREAD + "-reason", tools=[self.TOOL]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.reason == "tool_call"
+
+    async def test_interrupt_id_matches_strands_id(self):
+        """The AG-UI interrupt.id must be the Strands deterministic interrupt ID."""
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        stream = [
+            {"current_tool_use": {"name": "my_tool", "toolUseId": "st-1", "input": {}}},
+            {"event": {"contentBlockStop": {}}},
+            {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=[strands_interrupt])},
+        ]
+        agent = _build_agent(self.THREAD + "-id", stream, self._config())
+        events = await _collect(agent, _run_input(self.THREAD + "-id", tools=[self.TOOL]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        ag_ui_interrupt = finished[0].outcome.interrupts[0]
+        assert ag_ui_interrupt.id == strands_interrupt.id
+
+    async def test_interrupt_has_response_schema(self):
+        agent = _build_agent(self.THREAD + "-schema", _frontend_tool_stream_with_interrupt(), self._config())
+        events = await _collect(agent, _run_input(self.THREAD + "-schema", tools=[self.TOOL]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.response_schema is not None
+        assert "approved" in interrupt.response_schema.get("properties", {})
+
+    async def test_interrupt_id_is_deterministic(self):
+        """Same tool call + same name always produces the same interrupt ID."""
+        si1 = _make_strands_interrupt("my_tool", {}, "st-1")
+        si2 = _make_strands_interrupt("my_tool", {}, "st-1")
+        assert si1.id == si2.id
+
+
+# ---------------------------------------------------------------------------
+# interrupt_on_call=False (default) — legacy pending_halt, no interrupt outcome
+# ---------------------------------------------------------------------------
+
+class TestLegacyPendingHaltUnchanged:
+    THREAD = "legacy-halt-thread"
+    TOOL = Tool(name="my_tool", description="d", parameters={})
+
+    async def test_run_finished_outcome_is_success_by_default(self):
+        """Without interrupt_on_call, RunFinished.outcome is RunFinishedSuccessOutcome."""
+        # Default ToolBehavior — no interrupt_on_call; stream ends with end_turn
+        stream = [
+            {"current_tool_use": {"name": "my_tool", "toolUseId": "st-1", "input": {}}},
+            {"event": {"contentBlockStop": {}}},
+            {"result": _FakeAgentResult(stop_reason="end_turn")},
+        ]
+        agent = _build_agent(self.THREAD, stream)
+        events = await _collect(agent, _run_input(self.THREAD, tools=[self.TOOL]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert not isinstance(finished[0].outcome, RunFinishedInterruptOutcome)
+
+
+# ---------------------------------------------------------------------------
+# Normal run (no frontend tool) — success outcome
+# ---------------------------------------------------------------------------
+
+class TestSuccessOutcomeOnNormalRun:
+    THREAD = "success-thread"
+
+    async def test_run_finished_has_success_outcome(self):
+        agent = _build_agent(self.THREAD, _empty_stream())
+        events = await _collect(agent, _run_input(self.THREAD))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert isinstance(finished[0].outcome, RunFinishedSuccessOutcome)
+
+
+# ---------------------------------------------------------------------------
+# Resume: resolved + approved
+# ---------------------------------------------------------------------------
+
+class TestResumeResolvedApproved:
+    THREAD = "resume-approved-thread"
+    TOOL = Tool(name="my_tool", description="d", parameters={})
+
+    def _config(self) -> StrandsAgentConfig:
+        return StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    async def test_resume_approved_ends_with_success(self):
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        # Second turn stream: normal completion
+        resume_stream = [
+            {"result": _FakeAgentResult(stop_reason="end_turn")},
+        ]
+
+        agent = _build_agent(self.THREAD, resume_stream, self._config(), interrupt_state)
+
+        resume_input = _run_input(
+            self.THREAD,
+            tools=[self.TOOL],
+            resume=[ResumeEntry(
+                interrupt_id=strands_interrupt.id,
+                status="resolved",
+                payload={"approved": True},
+            )],
+        )
+        events = await _collect(agent, resume_input)
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert isinstance(finished[0].outcome, RunFinishedSuccessOutcome)
+
+    async def test_resume_approved_passes_y_to_strands(self):
+        """Verify stream_async is called with interruptResponse containing 'y'."""
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        received_prompts: list = []
+
+        async def _capture_stream(prompt: Any):
+            received_prompts.append(prompt)
+            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
+
+        agent = _build_agent(self.THREAD + "-y", [], self._config(), interrupt_state)
+        agent._agents_by_thread[self.THREAD + "-y"].stream_async = _capture_stream
+
+        resume_input = _run_input(
+            self.THREAD + "-y",
+            resume=[ResumeEntry(
+                interrupt_id=strands_interrupt.id,
+                status="resolved",
+                payload={"approved": True},
+            )],
+        )
+        await _collect(agent, resume_input)
+
+        assert len(received_prompts) == 1
+        prompt = received_prompts[0]
+        assert isinstance(prompt, list)
+        assert prompt[0]["interruptResponse"]["response"] == {"approved": True}
+        assert prompt[0]["interruptResponse"]["interruptId"] == strands_interrupt.id
+
+    async def test_resume_denied_passes_n_to_strands(self):
+        """Verify stream_async is called with interruptResponse containing 'n'."""
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        received_prompts: list = []
+
+        async def _capture_stream(prompt: Any):
+            received_prompts.append(prompt)
+            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
+
+        agent = _build_agent(self.THREAD + "-n", [], self._config(), interrupt_state)
+        agent._agents_by_thread[self.THREAD + "-n"].stream_async = _capture_stream
+
+        resume_input = _run_input(
+            self.THREAD + "-n",
+            resume=[ResumeEntry(
+                interrupt_id=strands_interrupt.id,
+                status="resolved",
+                payload={"approved": False},
+            )],
+        )
+        await _collect(agent, resume_input)
+
+        assert received_prompts[0][0]["interruptResponse"]["response"] == {"approved": False}
+
+    async def test_resume_passes_prompt_when_replay_history_enabled(self):
+        """When replay_history=True (no session_manager), resume still passes interruptResponse."""
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        received_prompts: list = []
+
+        async def _capture_stream(prompt: Any):
+            received_prompts.append(prompt)
+            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
+
+        agent = _build_agent(self.THREAD + "-replay", [], self._config(), interrupt_state)
+        inner = agent._agents_by_thread[self.THREAD + "-replay"]
+        inner.session_manager = None  # Force replay_history=True
+        inner.stream_async = _capture_stream
+
+        resume_input = _run_input(
+            self.THREAD + "-replay",
+            resume=[ResumeEntry(
+                interrupt_id=strands_interrupt.id,
+                status="resolved",
+                payload={"approved": True},
+            )],
+        )
+        await _collect(agent, resume_input)
+
+        assert len(received_prompts) == 1
+        assert received_prompts[0] is not None
+        assert received_prompts[0][0]["interruptResponse"]["interruptId"] == strands_interrupt.id
+        assert received_prompts[0][0]["interruptResponse"]["response"] == {"approved": True}
+
+
+# ---------------------------------------------------------------------------
+# Resume: cancelled
+# ---------------------------------------------------------------------------
+
+class TestResumeCancelled:
+    THREAD = "resume-cancelled-thread"
+    TOOL = Tool(name="my_tool", description="d", parameters={})
+
+    def _config(self) -> StrandsAgentConfig:
+        return StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    async def test_cancelled_resume_ends_cleanly(self):
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        agent = _build_agent(self.THREAD, [], self._config(), interrupt_state)
+
+        resume_input = _run_input(
+            self.THREAD,
+            resume=[ResumeEntry(interrupt_id=strands_interrupt.id, status="cancelled")],
+        )
+        events = await _collect(agent, resume_input)
+
+        errors = [e for e in events if e.type == EventType.RUN_ERROR]
+        assert len(errors) == 0
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert isinstance(finished[0].outcome, RunFinishedSuccessOutcome)
+
+    async def test_cancelled_calls_deactivate(self):
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        agent = _build_agent(self.THREAD + "-deact", [], self._config(), interrupt_state)
+
+        resume_input = _run_input(
+            self.THREAD + "-deact",
+            resume=[ResumeEntry(interrupt_id=strands_interrupt.id, status="cancelled")],
+        )
+        await _collect(agent, resume_input)
+
+        interrupt_state.deactivate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Resume: unknown interrupt_id
+# ---------------------------------------------------------------------------
+
+class TestResumeUnknownInterruptId:
+    THREAD = "unknown-id-thread"
+    TOOL = Tool(name="my_tool", description="d", parameters={})
+
+    def _config(self) -> StrandsAgentConfig:
+        return StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    async def test_unknown_id_yields_run_error(self):
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+
+        agent = _build_agent(self.THREAD, [], self._config(), interrupt_state)
+
+        resume_input = _run_input(
+            self.THREAD,
+            resume=[ResumeEntry(interrupt_id="wrong-id", status="resolved", payload={"approved": True})],
+        )
+        events = await _collect(agent, resume_input)
+
+        errors = [e for e in events if e.type == EventType.RUN_ERROR]
+        assert len(errors) == 1
+        assert errors[0].code == "UNKNOWN_INTERRUPT_ID"
+
+    async def test_no_pending_interrupt_yields_run_error(self):
+        """Resume on a thread with no active interrupt must yield RunError."""
+        # interrupt_state.activated = False → no pending interrupt
+        interrupt_state = _make_interrupt_state(activated=False)
+
+        agent = _build_agent(self.THREAD + "-none", [], self._config(), interrupt_state)
+
+        resume_input = _run_input(
+            self.THREAD + "-none",
+            resume=[ResumeEntry(interrupt_id="any-id", status="resolved", payload={"approved": True})],
+        )
+        events = await _collect(agent, resume_input)
+
+        errors = [e for e in events if e.type == EventType.RUN_ERROR]
+        assert len(errors) == 1
+        assert errors[0].code == "UNKNOWN_INTERRUPT_ID"
+
+
+# ---------------------------------------------------------------------------
+# StrandsInterruptHook auto-registration
+# ---------------------------------------------------------------------------
+
+class TestStrandsInterruptHookAutoRegistration:
+    async def test_hook_prepended_when_interrupt_on_call_tools_present(self):
+        from ag_ui_strands.agent import StrandsInterruptHook
+        config = StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+        agent = StrandsAgent(_template_agent(), name="test", config=config)
+        assert len(agent._hooks) >= 1
+        assert isinstance(agent._hooks[0], StrandsInterruptHook)
+
+    async def test_no_hook_when_no_interrupt_on_call_tools(self):
+        from ag_ui_strands.agent import StrandsInterruptHook
+        config = StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(stop_streaming_after_result=True)}
+        )
+        agent = StrandsAgent(_template_agent(), name="test", config=config)
+        assert not any(isinstance(h, StrandsInterruptHook) for h in agent._hooks)
+
+    async def test_hook_prepended_before_caller_hooks(self):
+        from ag_ui_strands.agent import StrandsInterruptHook
+        caller_hook = MagicMock()
+        config = StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+        agent = StrandsAgent(_template_agent(), name="test", config=config, hooks=[caller_hook])
+        assert isinstance(agent._hooks[0], StrandsInterruptHook)
+        assert agent._hooks[1] is caller_hook
+
+
+

--- a/integrations/aws-strands/python/tests/test_interrupt_protocol.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_protocol.py
@@ -15,7 +15,7 @@ Covers:
 - Normal runs (no frontend tool) emit RunFinishedSuccessOutcome
 - Resume: resolved+approved passes "y" to Strands and run continues
 - Resume: resolved+denied passes "n" to Strands and run continues
-- Resume: cancelled deactivates Strands interrupt state and ends cleanly
+- Resume: cancelled forwards a native denial through stream_async() and ends cleanly
 - Resume: unknown interrupt_id yields RunErrorEvent
 - Resume: no pending interrupt on thread yields RunErrorEvent
 """
@@ -39,7 +39,6 @@ from strands.tools.registry import ToolRegistry
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands import (
-    Interrupt,
     ResumeEntry,
     RunFinishedInterruptOutcome,
     RunFinishedSuccessOutcome,
@@ -447,7 +446,12 @@ class TestResumeCancelled:
         assert len(finished) == 1
         assert isinstance(finished[0].outcome, RunFinishedSuccessOutcome)
 
-    async def test_cancelled_calls_deactivate(self):
+    async def test_cancelled_forwards_denial_through_strands(self):
+        """All-cancelled resumes must flow through stream_async() — not a
+        synthetic short-circuit — so Strands' own interrupt-state cleanup,
+        hooks, and session persistence still run (see issue: all-cancel
+        previously bypassed Strands and the run lifecycle entirely).
+        """
         strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
         interrupt_state = _make_interrupt_state(
             activated=True,
@@ -455,6 +459,17 @@ class TestResumeCancelled:
         )
 
         agent = _build_agent(self.THREAD + "-deact", [], self._config(), interrupt_state)
+        mock_inner = agent._agents_by_thread[self.THREAD + "-deact"]
+
+        captured_prompts: list = []
+        original_stream_async = mock_inner.stream_async
+
+        async def _spy_stream(msg: Any):
+            captured_prompts.append(msg)
+            async for event in original_stream_async(msg):
+                yield event
+
+        mock_inner.stream_async = _spy_stream
 
         resume_input = _run_input(
             self.THREAD + "-deact",
@@ -462,7 +477,18 @@ class TestResumeCancelled:
         )
         await _collect(agent, resume_input)
 
-        interrupt_state.deactivate.assert_called_once()
+        # The cancellation must be forwarded to Strands as a native
+        # interruptResponse denial — not handled by a synthetic return that
+        # skips stream_async() entirely.
+        assert len(captured_prompts) == 1
+        assert captured_prompts[0] == [
+            {
+                "interruptResponse": {
+                    "interruptId": strands_interrupt.id,
+                    "response": {"approved": False},
+                }
+            }
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +572,168 @@ class TestStrandsInterruptHookAutoRegistration:
         agent = StrandsAgent(_template_agent(), name="test", config=config, hooks=[caller_hook])
         assert isinstance(agent._hooks[0], StrandsInterruptHook)
         assert agent._hooks[1] is caller_hook
+
+
+# ---------------------------------------------------------------------------
+# StrandsInterruptHook — strict approval payload contract
+# ---------------------------------------------------------------------------
+
+
+def _hook_event(response: Any, tool_name: str = "my_tool") -> MagicMock:
+    """Build a mock BeforeToolCallEvent whose event.interrupt() returns the
+    given resume response, as Strands does on the resume call."""
+    event = MagicMock()
+    event.tool_use = {"name": tool_name, "input": {}, "toolUseId": "st-1"}
+    event.interrupt = MagicMock(return_value=response)
+    event.cancel_tool = False
+    return event
+
+
+class TestStrandsInterruptHookStrictApproval:
+    """The approval hook must only grant approval for a strict
+    {"approved": true} payload — any other shape (missing key, non-bool
+    value, non-dict response) is an explicit denial, not a truthy coercion.
+    """
+
+    def _hook(self):
+        from ag_ui_strands.agent import StrandsInterruptHook
+        return StrandsInterruptHook(
+            {"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+
+    def test_approved_true_grants_approval(self):
+        event = _hook_event({"approved": True})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool is False
+
+    def test_approved_false_denies(self):
+        event = _hook_event({"approved": False})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_missing_approved_key_denies(self):
+        event = _hook_event({})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_truthy_string_does_not_grant_approval(self):
+        """A stringified 'false' (or any non-empty string) must NOT be
+        treated as approval merely because it's truthy."""
+        event = _hook_event({"approved": "false"})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_truthy_string_true_does_not_grant_approval(self):
+        event = _hook_event({"approved": "true"})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_numeric_one_does_not_grant_approval(self):
+        event = _hook_event({"approved": 1})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_extra_keys_with_valid_approval_still_grants(self):
+        """Extra keys beyond the declared schema aren't themselves
+        disqualifying — only the "approved" value's type/value matters."""
+        event = _hook_event({"approved": True, "note": "looks fine"})
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool is False
+
+    def test_non_dict_response_denies(self):
+        event = _hook_event("y")
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+    def test_none_response_denies(self):
+        event = _hook_event(None)
+        self._hook()._on_before_tool_call(event)
+        assert event.cancel_tool
+
+
+# ---------------------------------------------------------------------------
+# Generic (non-tool-approval) native interrupts must stay generic
+# ---------------------------------------------------------------------------
+
+
+class TestGenericNativeInterrupt:
+    """Interrupts NOT raised by StrandsInterruptHook's own
+    "ag_ui:tool_call:" naming convention — e.g. a user's own tool calling
+    event.interrupt() directly for a generic human-in-the-loop request —
+    must be preserved as generic interrupts, not misclassified as tool-call
+    approvals with fabricated schema/metadata.
+    """
+
+    THREAD = "generic-interrupt-thread"
+
+    async def test_generic_interrupt_reason_is_preserved(self):
+        generic = StrandsInterrupt(
+            id="v1:custom:abc",
+            name="need_clarification",
+            reason={"question": "Which environment?"},
+        )
+        stream = [
+            {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=[generic])},
+        ]
+        agent = _build_agent(self.THREAD, stream, StrandsAgentConfig())
+        events = await _collect(agent, _run_input(self.THREAD))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.id == "v1:custom:abc"
+        assert interrupt.reason == "need_clarification"
+
+    async def test_generic_interrupt_has_no_fabricated_tool_schema(self):
+        generic = StrandsInterrupt(
+            id="v1:custom:abc",
+            name="need_clarification",
+            reason={"question": "Which environment?"},
+        )
+        stream = [
+            {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=[generic])},
+        ]
+        agent = _build_agent(self.THREAD + "-schema", stream, StrandsAgentConfig())
+        events = await _collect(agent, _run_input(self.THREAD + "-schema"))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.response_schema is None
+        assert interrupt.tool_call_id is None
+
+    async def test_generic_interrupt_preserves_native_reason_in_metadata(self):
+        generic = StrandsInterrupt(
+            id="v1:custom:abc",
+            name="need_clarification",
+            reason={"question": "Which environment?"},
+        )
+        stream = [
+            {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=[generic])},
+        ]
+        agent = _build_agent(self.THREAD + "-meta", stream, StrandsAgentConfig())
+        events = await _collect(agent, _run_input(self.THREAD + "-meta"))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.metadata == {"reason": {"question": "Which environment?"}}
+
+    async def test_tool_call_interrupt_still_classified_as_tool_call(self):
+        """Sanity check: the ag_ui:tool_call: naming convention still
+        produces the tool-approval shape, unaffected by the generic path."""
+        strands_interrupt = _make_strands_interrupt("my_tool", {"x": 1}, "st-1")
+        stream = [
+            {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=[strands_interrupt])},
+        ]
+        config = StrandsAgentConfig(
+            tool_behaviors={"my_tool": ToolBehavior(interrupt_on_call=True)}
+        )
+        agent = _build_agent(self.THREAD + "-tool", stream, config)
+        events = await _collect(agent, _run_input(self.THREAD + "-tool", tools=[Tool(name="my_tool", description="d", parameters={})]))
+
+        finished = [e for e in events if e.type == EventType.RUN_FINISHED]
+        interrupt = finished[0].outcome.interrupts[0]
+        assert interrupt.reason == "tool_call"
+        assert interrupt.response_schema is not None
 
 
 

--- a/integrations/aws-strands/python/tests/test_interrupt_protocol.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_protocol.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock
 import pytest
 from ag_ui.core import (
     EventType,
+    Interrupt,
     RunAgentInput,
     Tool,
     UserMessage,
@@ -542,6 +543,158 @@ class TestResumeUnknownInterruptId:
 
 
 # ---------------------------------------------------------------------------
+# Resume: idempotency and payload type validation
+# ---------------------------------------------------------------------------
+
+
+class TestResumeValidation:
+    THREAD = "resume-validation-thread"
+
+    def _agent_with_pending_schema(self, schema: dict) -> tuple[StrandsAgent, Any]:
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+        agent = _build_agent(
+            self.THREAD,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        agent._pending_interrupts_by_thread[self.THREAD] = {
+            strands_interrupt.id: Interrupt(
+                id=strands_interrupt.id,
+                reason="tool_call",
+                response_schema=schema,
+            )
+        }
+        return agent, interrupt_state
+
+    async def test_reordered_resume_replay_does_not_reinvoke_strands(self):
+        first = _make_strands_interrupt("my_tool", {}, "st-1")
+        second = _make_strands_interrupt("my_tool", {}, "st-2")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={first.id: first, second.id: second},
+        )
+        agent = _build_agent(
+            self.THREAD + "-reordered",
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        stream_calls = 0
+        inner = agent._agents_by_thread[self.THREAD + "-reordered"]
+        original_stream = inner.stream_async
+
+        async def _spy_stream(message: Any):
+            nonlocal stream_calls
+            stream_calls += 1
+            async for event in original_stream(message):
+                yield event
+
+        inner.stream_async = _spy_stream
+        first_resume = [
+            ResumeEntry(interrupt_id=first.id, status="resolved", payload={"approved": True}),
+            ResumeEntry(interrupt_id=second.id, status="cancelled"),
+        ]
+        await _collect(
+            agent,
+            _run_input(self.THREAD + "-reordered", resume=first_resume),
+        )
+        assert stream_calls == 1
+
+        # A completed native resume has no active interrupts. Simulate that
+        # state before replaying the equivalent entries in reverse order.
+        interrupt_state.activated = False
+        replay_events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD + "-reordered",
+                resume=list(reversed(first_resume)),
+            ),
+        )
+        assert stream_calls == 1
+        assert any(event.type == EventType.RUN_FINISHED for event in replay_events)
+        assert not any(event.type == EventType.RUN_ERROR for event in replay_events)
+
+    async def test_non_boolean_approval_payload_is_rejected(self):
+        schema = {
+            "type": "object",
+            "properties": {"approved": {"type": "boolean"}},
+            "required": ["approved"],
+        }
+        for invalid_approval in ("true", 1, None):
+            agent, _ = self._agent_with_pending_schema(schema)
+            interrupt_id = next(iter(agent._pending_interrupts_by_thread[self.THREAD]))
+
+            events = await _collect(
+                agent,
+                _run_input(
+                    self.THREAD,
+                    resume=[
+                        ResumeEntry(
+                            interrupt_id=interrupt_id,
+                            status="resolved",
+                            payload={"approved": invalid_approval},
+                        )
+                    ],
+                ),
+            )
+
+            error = next(event for event in events if event.type == EventType.RUN_ERROR)
+            assert error.code == "INVALID_PAYLOAD"
+            assert "approved" in error.message
+
+    async def test_explicit_denial_and_optional_edited_args_are_valid(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "approved": {"type": "boolean"},
+                "editedArgs": {"type": "object"},
+            },
+            "required": ["approved"],
+        }
+        denied, _ = self._agent_with_pending_schema(schema)
+        denied_id = next(iter(denied._pending_interrupts_by_thread[self.THREAD]))
+        denied_events = await _collect(
+            denied,
+            _run_input(
+                self.THREAD,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=denied_id,
+                        status="resolved",
+                        payload={"approved": False},
+                    )
+                ],
+            ),
+        )
+        assert not any(event.type == EventType.RUN_ERROR for event in denied_events)
+
+        edited, _ = self._agent_with_pending_schema(schema)
+        edited_id = next(iter(edited._pending_interrupts_by_thread[self.THREAD]))
+        edited_events = await _collect(
+            edited,
+            _run_input(
+                self.THREAD,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=edited_id,
+                        status="resolved",
+                        payload={
+                            "approved": True,
+                            "editedArgs": {"environment": "staging"},
+                        },
+                    )
+                ],
+            ),
+        )
+        assert not any(event.type == EventType.RUN_ERROR for event in edited_events)
+
+
+# ---------------------------------------------------------------------------
 # StrandsInterruptHook auto-registration
 # ---------------------------------------------------------------------------
 
@@ -734,6 +887,4 @@ class TestGenericNativeInterrupt:
         interrupt = finished[0].outcome.interrupts[0]
         assert interrupt.reason == "tool_call"
         assert interrupt.response_schema is not None
-
-
 

--- a/integrations/aws-strands/python/tests/test_tool_stream_event_handler.py
+++ b/integrations/aws-strands/python/tests/test_tool_stream_event_handler.py
@@ -1,0 +1,315 @@
+"""Tests for ToolBehavior.tool_stream_event_handler in StrandsAgent.
+
+Covers:
+  1. Happy path — events yielded by the handler are forwarded into the stream.
+  2. Handler raises — warning is logged, stream continues without crashing.
+  3. No handler + {"state": ...} payload — default StateSnapshotEvent is emitted.
+  4. No handler + non-state payload — nothing extra emitted, no crash.
+  5. Missing toolUseId — handler is NOT called, stream continues cleanly.
+  6. Context fields — ToolStreamEventContext carries correct tool_use_id,
+     tool_name, and stream_data values.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import EventType, StateSnapshotEvent
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior, ToolStreamEventContext
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors the pattern in test_parallel_tool_call_handling.py)
+# ---------------------------------------------------------------------------
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _build_agent(
+    stream_events: list,
+    config: StrandsAgentConfig | None = None,
+    thread_id: str = "test-thread",
+) -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=config or StrandsAgentConfig()
+    )
+
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+    mock_inner._interrupt_state = None
+
+    async def _stream(_msg: str):
+        for event in stream_events:
+            yield event
+
+    mock_inner.stream_async = _stream
+    agent._agents_by_thread[thread_id] = mock_inner
+    return agent
+
+
+def _make_input(thread_id: str = "test-thread"):
+    inp = MagicMock()
+    inp.thread_id = thread_id
+    inp.run_id = "test-run"
+    inp.state = {}
+    inp.messages = []
+    inp.tools = []
+    return inp
+
+
+def _tool_stream_event(
+    tool_name: str,
+    tool_use_id: str | None,
+    data: object,
+) -> dict:
+    """Build a Strands tool_stream_event dict."""
+    tool_use = {"name": tool_name}
+    if tool_use_id is not None:
+        tool_use["toolUseId"] = tool_use_id
+    return {"tool_stream_event": {"tool_use": tool_use, "data": data}}
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — handler events are forwarded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_events_forwarded():
+    """Events yielded by tool_stream_event_handler appear in the output stream."""
+    from ag_ui.core import CustomEvent
+
+    captured_ctx: list[ToolStreamEventContext] = []
+
+    async def my_handler(ctx: ToolStreamEventContext):
+        captured_ctx.append(ctx)
+        yield CustomEvent(type=EventType.CUSTOM, name="SubAgentProgress", value={"pct": 50})
+        yield CustomEvent(type=EventType.CUSTOM, name="SubAgentProgress", value={"pct": 100})
+
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "sub_agent": ToolBehavior(tool_stream_event_handler=my_handler)
+        }
+    )
+
+    stream_events = [
+        _tool_stream_event("sub_agent", "tool-id-1", {"progress": 50}),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events, config)
+    events = [e async for e in agent.run(_make_input())]
+
+    custom = [e for e in events if e.type == EventType.CUSTOM and e.name == "SubAgentProgress"]
+    assert len(custom) == 2
+    assert custom[0].value == {"pct": 50}
+    assert custom[1].value == {"pct": 100}
+
+
+# ---------------------------------------------------------------------------
+# 2. Handler raises — warning logged, stream continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_logged_stream_continues(caplog):
+    """A raising handler logs a warning and does not crash the run."""
+
+    async def bad_handler(ctx: ToolStreamEventContext):
+        raise RuntimeError("handler exploded")
+        yield  # make it an async generator
+
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "sub_agent": ToolBehavior(tool_stream_event_handler=bad_handler)
+        }
+    )
+
+    stream_events = [
+        _tool_stream_event("sub_agent", "tool-id-1", {"x": 1}),
+        {"data": "All good after the error."},
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events, config)
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        events = [e async for e in agent.run(_make_input())]
+
+    # Run must finish cleanly
+    assert any(e.type == EventType.RUN_FINISHED for e in events)
+
+    # Warning must mention the tool name
+    assert any("sub_agent" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+    # Text from after the error must still arrive
+    assert any(
+        e.type == EventType.TEXT_MESSAGE_CONTENT and "All good" in e.delta
+        for e in events
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. No handler + {"state": ...} payload → default StateSnapshotEvent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_state_snapshot_emitted_when_no_handler():
+    """Without a handler the default path emits StateSnapshotEvent for state payloads."""
+    stream_events = [
+        _tool_stream_event("some_tool", "tool-id-1", {"state": {"counter": 7}}),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events)  # no config → no handler
+    events = [e async for e in agent.run(_make_input())]
+
+    snapshots = [e for e in events if e.type == EventType.STATE_SNAPSHOT]
+    # At least one snapshot must carry the tool-streamed state
+    tool_snapshots = [s for s in snapshots if s.snapshot == {"counter": 7}]
+    assert len(tool_snapshots) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. No handler + non-state payload → no extra events, no crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_handler_non_state_payload_no_crash():
+    """Non-state payloads without a handler are silently ignored."""
+    stream_events = [
+        _tool_stream_event("some_tool", "tool-id-1", {"progress": 42}),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events)
+    events = [e async for e in agent.run(_make_input())]
+
+    # Run must finish cleanly
+    assert any(e.type == EventType.RUN_FINISHED for e in events)
+
+    # No spurious state snapshots from the non-state payload
+    tool_snapshots = [
+        e for e in events
+        if e.type == EventType.STATE_SNAPSHOT and e.snapshot == {"progress": 42}
+    ]
+    assert len(tool_snapshots) == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Missing toolUseId → handler NOT called, stream continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_tool_use_id_handler_not_called():
+    """When toolUseId is absent the handler is skipped and the run finishes cleanly."""
+    handler_called = []
+
+    async def my_handler(ctx: ToolStreamEventContext):
+        handler_called.append(ctx)
+        yield  # pragma: no cover
+
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "sub_agent": ToolBehavior(tool_stream_event_handler=my_handler)
+        }
+    )
+
+    # Build event without toolUseId
+    stream_events = [
+        _tool_stream_event("sub_agent", None, {"x": 1}),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events, config)
+    events = [e async for e in agent.run(_make_input())]
+
+    assert handler_called == [], "handler must not be called when toolUseId is missing"
+    assert any(e.type == EventType.RUN_FINISHED for e in events)
+
+
+# ---------------------------------------------------------------------------
+# 6. Context fields are populated correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_fields_populated():
+    """ToolStreamEventContext carries the correct tool_use_id, tool_name, stream_data."""
+    captured: list[ToolStreamEventContext] = []
+
+    async def capturing_handler(ctx: ToolStreamEventContext):
+        captured.append(ctx)
+        return
+        yield  # make it an async generator
+
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "my_tool": ToolBehavior(tool_stream_event_handler=capturing_handler)
+        }
+    )
+
+    payload = {"key": "value", "nested": [1, 2, 3]}
+    stream_events = [
+        _tool_stream_event("my_tool", "abc-123", payload),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events, config)
+    await agent.run(_make_input()).__anext__()  # prime the generator
+    # Collect all events to drive the generator to completion
+    events = [e async for e in agent.run(_make_input())]
+
+    assert len(captured) == 1
+    ctx = captured[0]
+    assert ctx.tool_use_id == "abc-123"
+    assert ctx.tool_name == "my_tool"
+    assert ctx.stream_data == payload
+
+
+# ---------------------------------------------------------------------------
+# 7. Handler yielding None values — None items are filtered out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_none_values_filtered():
+    """None values yielded by the handler are not forwarded into the event stream."""
+    from ag_ui.core import CustomEvent
+
+    async def handler_with_nones(ctx: ToolStreamEventContext):
+        yield None
+        yield CustomEvent(type=EventType.CUSTOM, name="Real", value={})
+        yield None
+
+    config = StrandsAgentConfig(
+        tool_behaviors={
+            "sub_agent": ToolBehavior(tool_stream_event_handler=handler_with_nones)
+        }
+    )
+
+    stream_events = [
+        _tool_stream_event("sub_agent", "tool-id-1", {}),
+        {"complete": True},
+    ]
+
+    agent = _build_agent(stream_events, config)
+    events = [e async for e in agent.run(_make_input())]
+
+    custom = [e for e in events if e.type == EventType.CUSTOM and e.name == "Real"]
+    assert len(custom) == 1

--- a/integrations/aws-strands/python/uv.lock
+++ b/integrations/aws-strands/python/uv.lock
@@ -42,7 +42,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.4" },
-    { name = "ag-ui-protocol", specifier = ">=0.1.18" },
+    { name = "ag-ui-protocol", specifier = ">=0.1.19" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "strands-agents", specifier = ">=1.15.0" },
 ]

--- a/integrations/aws-strands/typescript/src/__tests__/agent-config-forwarded.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/agent-config-forwarded.test.ts
@@ -138,7 +138,8 @@ describe("AgentConfig forwarding", () => {
     expect("systemPrompt" in cfg).toBe(false);
     expect("name" in cfg).toBe(false);
     expect("description" in cfg).toBe(false);
-    expect("id" in cfg).toBe(false);
+    // id is always set (falls back to adapter name for stable session paths)
+    expect(cfg.id).toBe("t");
     expect("appState" in cfg).toBe(false);
     expect("modelState" in cfg).toBe(false);
     expect("traceAttributes" in cfg).toBe(false);

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-validation.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-validation.test.ts
@@ -326,8 +326,8 @@ describe("addStrandsExpressEndpoint request validation", () => {
       const err = events.find((e) => e.type === EventType.RUN_ERROR) as
         | { code?: string; message?: string }
         | undefined;
-      expect(err?.code).toBe("UNKNOWN_INTERRUPT");
-      expect(err?.message).toMatch(/does-not-exist/);
+      expect(err?.code).toBe("UNKNOWN_INTERRUPT_ID");
+      expect(err?.message).toMatch(/No pending interrupts/);
     } finally {
       await close();
     }

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-bookkeeping-persistence.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-bookkeeping-persistence.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Regression coverage for interrupt bookkeeping surviving a process restart.
+ *
+ * `_pendingInterruptsByThread` and `_lastResumeFingerprint` are the
+ * adapter's own bookkeeping, layered on top of Strands' native
+ * `_interruptState` (which SessionManager already persists/restores on its
+ * own). Prior to this, the adapter's bookkeeping lived purely in an
+ * in-process Map, so a real process restart lost it:
+ *
+ * - Rule 6 (responseSchema payload validation) and Rule 7 (expiresAt
+ *   enforcement) silently degrade, since they read AG-UI-specific interrupt
+ *   metadata that only exists in this bookkeeping.
+ * - Rule 5 (idempotency) breaks: a replayed resume request is no longer
+ *   recognized as a duplicate and can re-invoke the model/tool.
+ *
+ * These tests use a REAL `StateStore` instance (not a mock) to prove the
+ * adapter actually round-trips through `strandsAgent.appState`, matching
+ * what a real SessionManager restores after a restart.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { SessionManager, StateStore } from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { StrandsAgent } from "../agent";
+import { collect, minimalRunInput, scriptedAgent } from "./helpers";
+
+let nextAppState: StateStore | undefined;
+let nextInterruptState:
+  | { activated: boolean; interrupts: Map<string, unknown> }
+  | undefined;
+
+vi.mock("@strands-agents/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@strands-agents/sdk")>();
+  class MockAgent {
+    model = { name: "mock" };
+    tools: unknown[] = [];
+    toolRegistry = {
+      _tools: new Map<string, unknown>(),
+      add(t: unknown) {
+        this._tools.set((t as { name: string }).name, t);
+      },
+      getByName(name: string) {
+        return this._tools.get(name);
+      },
+      get(name: string) {
+        return this._tools.get(name);
+      },
+      removeByName(name: string) {
+        this._tools.delete(name);
+      },
+      remove(name: unknown) {
+        if (typeof name === "string") this._tools.delete(name);
+      },
+      values() {
+        return Array.from(this._tools.values());
+      },
+    };
+    appState = nextAppState ?? new actual.StateStore();
+    _interruptState = nextInterruptState;
+    async *stream() {
+      return { stopReason: "endTurn", message: { role: "assistant", content: [] } };
+    }
+  }
+  return {
+    ...actual,
+    Agent: MockAgent,
+  };
+});
+
+class FakeSessionManager extends SessionManager {
+  constructor() {
+    super({
+      sessionId: `fake-${Math.random().toString(36).slice(2)}`,
+      storage: {
+        snapshot: { save: vi.fn(), load: vi.fn(), delete: vi.fn() } as never,
+      },
+    });
+  }
+}
+
+describe("Idempotency fingerprint survives restart", () => {
+  it("recognizes a replayed resume from persisted appState without touching Strands", async () => {
+    const resume = [{ interruptId: "int-1", status: "resolved" as const, payload: { approved: true } }];
+
+    // Compute the fingerprint exactly as the adapter does (md5 of the
+    // sorted resume tuple), and pre-seed it into a REAL StateStore —
+    // simulating what a prior process persisted before restarting.
+    const { createHash } = await import("crypto");
+    const fingerprint = createHash("md5")
+      .update(JSON.stringify(resume.map((e) => [e.interruptId, e.status, e.payload])))
+      .digest("hex");
+
+    const appState = new StateStore();
+    appState.set("ag_ui_interrupt_bookkeeping", {
+      lastResumeFingerprint: fingerprint,
+      pendingInterrupts: {},
+    });
+    nextAppState = appState;
+    nextInterruptState = undefined;
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "restart-fp-thread", resume }),
+    );
+
+    const finished = events.find((e) => e.type === EventType.RUN_FINISHED);
+    expect(finished).toBeDefined();
+    expect((finished as unknown as { outcome: { type: string } }).outcome.type).toBe(
+      "success",
+    );
+    expect(events.some((e) => e.type === EventType.RUN_ERROR)).toBe(false);
+  });
+});
+
+describe("Pending-interrupt metadata survives restart", () => {
+  it("still enforces Rule 7 (expiresAt) from persisted appState", async () => {
+    const appState = new StateStore();
+    appState.set("ag_ui_interrupt_bookkeeping", {
+      lastResumeFingerprint: null,
+      pendingInterrupts: {
+        "int-1": {
+          id: "int-1",
+          reason: "tool_call",
+          toolCallId: "tc-1",
+          expiresAt: "2000-01-01T00:00:00.000Z", // long expired
+        },
+      },
+    });
+    nextAppState = appState;
+    nextInterruptState = { activated: true, interrupts: new Map([["int-1", {}]]) };
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const resume = [{ interruptId: "int-1", status: "resolved" as const, payload: { approved: true } }];
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "restart-expiry-thread", resume }),
+    );
+
+    const err = events.find((e) => e.type === EventType.RUN_ERROR) as unknown as
+      | { code: string }
+      | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("INTERRUPT_EXPIRED");
+  });
+
+  it("still enforces Rule 6 (responseSchema) from persisted appState", async () => {
+    const appState = new StateStore();
+    appState.set("ag_ui_interrupt_bookkeeping", {
+      lastResumeFingerprint: null,
+      pendingInterrupts: {
+        "int-2": {
+          id: "int-2",
+          reason: "tool_call",
+          toolCallId: "tc-2",
+          responseSchema: {
+            type: "object",
+            properties: { approved: { type: "boolean" } },
+            required: ["approved"],
+          },
+        },
+      },
+    });
+    nextAppState = appState;
+    nextInterruptState = { activated: true, interrupts: new Map([["int-2", {}]]) };
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    // Missing the required "approved" key.
+    const resume = [{ interruptId: "int-2", status: "resolved" as const, payload: {} }];
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "restart-schema-thread", resume }),
+    );
+
+    const err = events.find((e) => e.type === EventType.RUN_ERROR) as unknown as
+      | { code: string }
+      | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("INVALID_PAYLOAD");
+  });
+});
+
+describe("Persistence helpers are defensive against non-conforming appState", () => {
+  it("never throws when appState.get returns something unexpected", async () => {
+    nextAppState = { get: () => "not-an-object" } as unknown as StateStore;
+    nextInterruptState = undefined;
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const resume = [{ interruptId: "whatever", status: "resolved" as const, payload: { approved: true } }];
+    // Must not throw — just falls through to the normal "no pending" gate.
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "restart-broken-state-thread", resume }),
+    );
+    expect(events.some((e) => e.type === EventType.RUN_ERROR)).toBe(true);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression coverage for the "resume validation happens before session
+ * restoration" gap: on a cold process start, `_pendingInterruptsByThread`
+ * is empty even though a `sessionManagerProvider`-backed thread may have a
+ * genuinely pending native interrupt restored from persisted session state.
+ * `run()` must restore the per-thread agent (and its `_interruptState`)
+ * before deciding whether to skip resume validation, rather than treating
+ * "nothing in the in-memory map yet" as "nothing pending".
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { SessionManager } from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { StrandsAgent } from "../agent";
+import { collect, minimalRunInput, scriptedAgent } from "./helpers";
+
+// Mock the Strands Agent constructor so tests don't need a real model
+// provider, and so we can stamp a pre-activated `_interruptState` onto the
+// instance to simulate what a real SessionManager would restore.
+let nextInterruptState:
+  | { activated: boolean; interrupts: Map<string, unknown> }
+  | undefined;
+
+vi.mock("@strands-agents/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@strands-agents/sdk")>();
+  class MockAgent {
+    model = { name: "mock" };
+    tools: unknown[] = [];
+    toolRegistry = {
+      _tools: new Map<string, unknown>(),
+      add(t: unknown) {
+        this._tools.set((t as { name: string }).name, t);
+      },
+      getByName(name: string) {
+        return this._tools.get(name);
+      },
+      get(name: string) {
+        return this._tools.get(name);
+      },
+      removeByName(name: string) {
+        this._tools.delete(name);
+      },
+      remove(name: unknown) {
+        if (typeof name === "string") this._tools.delete(name);
+      },
+      values() {
+        return Array.from(this._tools.values());
+      },
+    };
+    _interruptState = nextInterruptState;
+    async *stream() {
+      return { stopReason: "endTurn", message: { role: "assistant", content: [] } };
+    }
+  }
+  return {
+    ...actual,
+    Agent: MockAgent,
+  };
+});
+
+class FakeSessionManager extends SessionManager {
+  constructor() {
+    super({
+      sessionId: `fake-${Math.random().toString(36).slice(2)}`,
+      storage: {
+        snapshot: { save: vi.fn(), load: vi.fn(), delete: vi.fn() } as never,
+      },
+    });
+  }
+}
+
+describe("Cold restart: resume validation must see session-restored interrupt state", () => {
+  it("rejects an unknown interruptId on a cold thread with a session provider instead of skipping validation", async () => {
+    // Simulate a genuinely pending native interrupt "int-1" that a real
+    // SessionManager would have restored onto the freshly-constructed agent.
+    nextInterruptState = {
+      activated: true,
+      interrupts: new Map([["int-1", {}]]),
+    };
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "cold-thread",
+        resume: [{ interruptId: "totally-unknown-id", status: "resolved", payload: {} }],
+      }),
+    );
+
+    const err = events.find(
+      (e) => e.type === EventType.RUN_ERROR,
+    ) as unknown as { code: string; message: string } | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("UNKNOWN_INTERRUPT_ID");
+  });
+
+  it("rejects a partial resume on a cold thread with a session provider instead of skipping validation", async () => {
+    nextInterruptState = {
+      activated: true,
+      interrupts: new Map([
+        ["int-1", {}],
+        ["int-2", {}],
+      ]),
+    };
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "cold-thread-partial",
+        resume: [{ interruptId: "int-1", status: "resolved", payload: {} }],
+      }),
+    );
+
+    const err = events.find(
+      (e) => e.type === EventType.RUN_ERROR,
+    ) as unknown as { code: string; message: string } | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("PARTIAL_RESUME");
+  });
+
+  it("allows resume to proceed when the restored native interrupt state has no pending interrupts", async () => {
+    nextInterruptState = { activated: false, interrupts: new Map() };
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "cold-thread-none-pending",
+        resume: [{ interruptId: "stale-id", status: "resolved", payload: {} }],
+      }),
+    );
+
+    const err = events.find(
+      (e) => e.type === EventType.RUN_ERROR,
+    ) as unknown as { code: string } | undefined;
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("UNKNOWN_INTERRUPT_ID");
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
@@ -19,7 +19,7 @@ import { collect, minimalRunInput, scriptedAgent } from "./helpers";
 // provider, and so we can stamp a pre-activated `_interruptState` onto the
 // instance to simulate what a real SessionManager would restore.
 let nextInterruptState:
-  | { activated: boolean; interrupts: Map<string, unknown> }
+  | { activated: boolean; interrupts: Map<string, unknown> | Record<string, unknown> }
   | undefined;
 let streamCalls = 0;
 
@@ -49,7 +49,18 @@ vi.mock("@strands-agents/sdk", async (importOriginal) => {
         return Array.from(this._tools.values());
       },
     };
-    _interruptState = nextInterruptState;
+    // Start without an interrupt so test cases only see the configured state
+    // when initialize() simulates SessionManager's InitializedEvent restore.
+    _interruptState: { activated: boolean; interrupts: Map<string, unknown> | Record<string, unknown> } = {
+      activated: false,
+      interrupts: {},
+    };
+    async initialize() {
+      this._interruptState = nextInterruptState ?? {
+        activated: false,
+        interrupts: {},
+      };
+    }
     async *stream() {
       streamCalls += 1;
       return { stopReason: "endTurn", message: { role: "assistant", content: [] } };
@@ -78,7 +89,7 @@ describe("Cold restart: resume validation must see session-restored interrupt st
     // SessionManager would have restored onto the freshly-constructed agent.
     nextInterruptState = {
       activated: true,
-      interrupts: new Map([["int-1", {}]]),
+      interrupts: { "int-1": {} },
     };
 
     const agent = new StrandsAgent({
@@ -154,6 +165,31 @@ describe("Cold restart: resume validation must see session-restored interrupt st
     ) as unknown as { code: string } | undefined;
     expect(err).toBeDefined();
     expect(err!.code).toBe("UNKNOWN_INTERRUPT_ID");
+  });
+
+  it("accepts a known interruptId restored as Strands' record-shaped state", async () => {
+    nextInterruptState = {
+      activated: true,
+      interrupts: { "int-1": {} },
+    };
+    streamCalls = 0;
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "cold-thread-record-shaped",
+        resume: [{ interruptId: "int-1", status: "resolved", payload: {} }],
+      }),
+    );
+
+    expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(false);
+    expect(streamCalls).toBe(1);
   });
 
   it("rejects fresh input on a cold thread when SessionManager restores a pending interrupt", async () => {

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
@@ -21,6 +21,7 @@ import { collect, minimalRunInput, scriptedAgent } from "./helpers";
 let nextInterruptState:
   | { activated: boolean; interrupts: Map<string, unknown> }
   | undefined;
+let streamCalls = 0;
 
 vi.mock("@strands-agents/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@strands-agents/sdk")>();
@@ -50,6 +51,7 @@ vi.mock("@strands-agents/sdk", async (importOriginal) => {
     };
     _interruptState = nextInterruptState;
     async *stream() {
+      streamCalls += 1;
       return { stopReason: "endTurn", message: { role: "assistant", content: [] } };
     }
   }
@@ -152,5 +154,32 @@ describe("Cold restart: resume validation must see session-restored interrupt st
     ) as unknown as { code: string } | undefined;
     expect(err).toBeDefined();
     expect(err!.code).toBe("UNKNOWN_INTERRUPT_ID");
+  });
+
+  it("rejects fresh input on a cold thread when SessionManager restores a pending interrupt", async () => {
+    nextInterruptState = {
+      activated: true,
+      interrupts: new Map([["int-1", {}]]),
+    };
+    streamCalls = 0;
+
+    const agent = new StrandsAgent({
+      agent: scriptedAgent(),
+      name: "t",
+      config: { sessionManagerProvider: () => new FakeSessionManager() },
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "cold-thread-fresh-input" }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string };
+    expect(err.code).toBe("PENDING_INTERRUPTS");
+    expect(streamCalls).toBe(0);
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-generic.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-generic.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Generic (non-tool-approval) native interrupts must stay generic.
+ *
+ * Interrupts NOT raised by the adapter's own interruptOnCall hook (which
+ * always uses the "ag_ui:tool_call:" name prefix) — e.g. a user's own tool
+ * or hook calling `event.interrupt()` directly for a generic
+ * human-in-the-loop request — must be preserved as generic AG-UI
+ * interrupts, not misclassified as tool-call approvals with fabricated
+ * schema/metadata.
+ */
+import { describe, it, expect } from "vitest";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import {
+  AgentResult as StrandsAgentResult,
+  Message as StrandsMessage,
+  TextBlock,
+  type Interrupt as StrandsInterrupt,
+} from "@strands-agents/sdk";
+
+import { StrandsAgent } from "../agent";
+import { collect } from "./helpers";
+
+function makeAgentResultStream(result: StrandsAgentResult) {
+  return async function* () {
+    return result;
+  };
+}
+
+function buildAgentResult(interrupts: StrandsInterrupt[]): StrandsAgentResult {
+  return new StrandsAgentResult({
+    stopReason: "interrupt",
+    lastMessage: StrandsMessage.fromMessageData({
+      role: "assistant",
+      content: [new TextBlock("awaiting input").toJSON()],
+    }),
+    invocationState: {},
+    interrupts,
+  });
+}
+
+function genericStrandsInterrupt(
+  id: string,
+  name: string,
+  reason: unknown,
+): StrandsInterrupt {
+  return { id, name, reason } as unknown as StrandsInterrupt;
+}
+
+describe("Generic native interrupts (not raised by the adapter's own hook)", () => {
+  it("preserves the native name as reason instead of fabricating tool_call", async () => {
+    const interrupts = [
+      genericStrandsInterrupt("int-1", "need_clarification", {
+        question: "Which environment?",
+      }),
+    ];
+    const stubAgent = {
+      model: { name: "stub-model", modelId: "stub-model" },
+      tools: [],
+      toolRegistry: { list: () => [] },
+      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
+    };
+    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    const events = await collect(sa);
+    const finished = events.at(-1) as BaseEvent & {
+      outcome?: { type: string; interrupts?: unknown[] };
+    };
+    expect(finished.type).toBe(EventType.RUN_FINISHED);
+    const first = finished.outcome?.interrupts?.[0] as {
+      id: string;
+      reason: string;
+    };
+    expect(first.id).toBe("int-1");
+    expect(first.reason).toBe("need_clarification");
+  });
+
+  it("does not fabricate a tool-approval responseSchema or toolCallId", async () => {
+    const interrupts = [
+      genericStrandsInterrupt("int-2", "need_clarification", {
+        question: "Which environment?",
+      }),
+    ];
+    const stubAgent = {
+      model: { name: "stub-model", modelId: "stub-model" },
+      tools: [],
+      toolRegistry: { list: () => [] },
+      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
+    };
+    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    const events = await collect(sa);
+    const finished = events.at(-1) as BaseEvent & {
+      outcome?: { type: string; interrupts?: unknown[] };
+    };
+    const first = finished.outcome?.interrupts?.[0] as {
+      responseSchema?: unknown;
+      toolCallId?: string;
+    };
+    expect(first.responseSchema).toBeUndefined();
+    expect(first.toolCallId).toBeUndefined();
+  });
+
+  it("preserves the native reason payload in metadata", async () => {
+    const interrupts = [
+      genericStrandsInterrupt("int-3", "need_clarification", {
+        question: "Which environment?",
+      }),
+    ];
+    const stubAgent = {
+      model: { name: "stub-model", modelId: "stub-model" },
+      tools: [],
+      toolRegistry: { list: () => [] },
+      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
+    };
+    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    const events = await collect(sa);
+    const finished = events.at(-1) as BaseEvent & {
+      outcome?: { type: string; interrupts?: unknown[] };
+    };
+    const first = finished.outcome?.interrupts?.[0] as {
+      metadata?: { reason?: unknown };
+    };
+    expect(first.metadata?.reason).toEqual({ question: "Which environment?" });
+  });
+
+  it("still classifies an ag_ui:tool_call:-named interrupt as a tool-call approval", async () => {
+    // Sanity check: the ag_ui:tool_call: naming convention still produces
+    // the tool-approval shape, unaffected by the generic path above.
+    const interrupts = [
+      {
+        id: "int-4",
+        name: "ag_ui:tool_call:confirm_delete",
+        reason: {
+          tool_call: true,
+          tool_name: "confirm_delete",
+          tool_input: {},
+          tool_use_id: "int-4",
+        },
+      } as unknown as StrandsInterrupt,
+    ];
+    const stubAgent = {
+      model: { name: "stub-model", modelId: "stub-model" },
+      tools: [],
+      toolRegistry: { list: () => [] },
+      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
+    };
+    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    const events = await collect(sa);
+    const finished = events.at(-1) as BaseEvent & {
+      outcome?: { type: string; interrupts?: unknown[] };
+    };
+    const first = finished.outcome?.interrupts?.[0] as {
+      reason: string;
+      responseSchema?: unknown;
+    };
+    expect(first.reason).toBe("tool_call");
+    expect(first.responseSchema).toBeDefined();
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -5,7 +5,7 @@
  * on the thread so the follow-up `resume[]` request is recognised as known
  * (rather than falling into the UNKNOWN_INTERRUPT_ID gate).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { EventType, type BaseEvent, type RunAgentInput, type Interrupt as AguiInterrupt } from "@ag-ui/core";
 import {
   AgentResult as StrandsAgentResult,
@@ -88,6 +88,27 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
       }
     )._pendingInterruptsByThread.get("thread-1");
     expect(pending?.has("int-1")).toBe(true);
+  });
+
+  it("checkpoints an interrupt before returning it to a resumable client", async () => {
+    const saveSnapshot = vi.fn().mockResolvedValue(undefined);
+    const stubAgent = scriptedAgent([], {
+      stream: makeAgentResultStream(
+        buildAgentResult([strandsInterrupt("int-1", "confirm_delete")]),
+      ) as never,
+      sessionManager: { saveSnapshot } as never,
+    });
+    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    await collect(sa);
+
+    expect(saveSnapshot).toHaveBeenCalledWith({
+      target: stubAgent,
+      isLatest: true,
+    });
   });
 
   it("accepts a matching resume[] and forwards InterruptResponseContent to Strands", async () => {

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -28,13 +28,15 @@ function makeAgentResultStream(
   };
 }
 
-function strandsInterrupt(id: string, name: string): StrandsInterrupt {
+function strandsInterrupt(id: string, toolName: string): StrandsInterrupt {
+  // Mirrors the shape the adapter's own interruptOnCall hook produces:
+  // name prefixed with "ag_ui:tool_call:" and a structured reason object.
   // The concrete class is internal; the adapter only reads .id / .name /
   // .reason, so a plain object that matches the interface is sufficient.
   return {
     id,
-    name,
-    reason: `Approve ${name}?`,
+    name: `ag_ui:tool_call:${toolName}`,
+    reason: { tool_call: true, tool_name: toolName, tool_input: {}, tool_use_id: id },
   } as unknown as StrandsInterrupt;
 }
 
@@ -75,8 +77,9 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
       metadata?: { strandsName?: string };
     };
     expect(first.id).toBe("int-1");
-    expect(first.reason).toBe("Approve confirm_delete?");
-    expect(first.metadata?.strandsName).toBe("confirm_delete");
+    expect(first.reason).toBe("tool_call");
+    expect(first.message).toBe("Approve call to confirm_delete?");
+    expect(first.metadata?.strandsName).toBe("ag_ui:tool_call:confirm_delete");
 
     // The interrupt is now pending on the thread.
     const pending = (

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -3,10 +3,10 @@
  * `AgentResult` comes back with `stopReason === "interrupt"`, the adapter
  * emits the interrupt-variant `RUN_FINISHED` and records the interrupt IDs
  * on the thread so the follow-up `resume[]` request is recognised as known
- * (rather than falling into the UNKNOWN_INTERRUPT gate).
+ * (rather than falling into the UNKNOWN_INTERRUPT_ID gate).
  */
 import { describe, it, expect } from "vitest";
-import { EventType, type BaseEvent, type RunAgentInput } from "@ag-ui/core";
+import { EventType, type BaseEvent, type RunAgentInput, type Interrupt as AguiInterrupt } from "@ag-ui/core";
 import {
   AgentResult as StrandsAgentResult,
   InterruptResponseContent,
@@ -81,7 +81,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     // The interrupt is now pending on the thread.
     const pending = (
       sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
       }
     )._pendingInterruptsByThread.get("thread-1");
     expect(pending?.has("int-1")).toBe(true);
@@ -112,9 +112,9 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     // Seed a pending interrupt on the thread so the gate accepts the resume.
     (
       sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
       }
-    )._pendingInterruptsByThread.set("thread-1", new Set(["int-7"]));
+    )._pendingInterruptsByThread.set("thread-1", new Map([["int-7", { id: "int-7", reason: "tool_call" }]]));
     const input: RunAgentInput = minimalRunInput({
       resume: [
         {
@@ -139,7 +139,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     // The pending set was cleared once resume was accepted.
     const cleared = (
       sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
       }
     )._pendingInterruptsByThread.get("thread-1");
     expect(cleared).toBeUndefined();
@@ -151,14 +151,17 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     // One pending interrupt, but the resume references a different id.
     (
       sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
       }
-    )._pendingInterruptsByThread.set("thread-1", new Set(["known"]));
+    )._pendingInterruptsByThread.set("thread-1", new Map([["known", { id: "known", reason: "tool_call" }]]));
 
     const events = await collect(
       sa,
       minimalRunInput({
-        resume: [{ interruptId: "unknown-id", status: "resolved" }],
+        resume: [
+          { interruptId: "unknown-id", status: "resolved" },
+          { interruptId: "known", status: "resolved", payload: { approved: true } },
+        ],
       }),
     );
     expect(events.map((e) => e.type)).toEqual([
@@ -166,7 +169,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
       EventType.RUN_ERROR,
     ]);
     const err = events[1] as unknown as { code: string; message: string };
-    expect(err.code).toBe("UNKNOWN_INTERRUPT");
+    expect(err.code).toBe("UNKNOWN_INTERRUPT_ID");
     expect(err.message).toContain("unknown-id");
   });
 
@@ -193,9 +196,9 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     )._agentsByThread.set("thread-1", stubAgent);
     (
       sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
       }
-    )._pendingInterruptsByThread.set("thread-1", new Set(["ic"]));
+    )._pendingInterruptsByThread.set("thread-1", new Map([["ic", { id: "ic", reason: "tool_call" }]]));
 
     await collect(
       sa,
@@ -204,7 +207,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
       }),
     );
 
-    const [first] = capturedArgs as InterruptResponseContent[];
-    expect(first.interruptResponse.response).toEqual({ status: "cancelled" });
+    // All cancelled → early return with RUN_FINISHED, Strands not invoked
+    expect(capturedArgs).toBeNull();
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -173,7 +173,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     expect(err.message).toContain("unknown-id");
   });
 
-  it("forwards a cancelled resume as { status: 'cancelled' }", async () => {
+  it("forwards a cancelled resume as native InterruptResponseContent through Strands", async () => {
     let capturedArgs: unknown = null;
     const stubAgent = scriptedAgent([], {
       stream: ((args: unknown) => {
@@ -207,7 +207,14 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
       }),
     );
 
-    // All cancelled → early return with RUN_FINISHED, Strands not invoked
-    expect(capturedArgs).toBeNull();
+    // All-cancelled resumes must still be forwarded to Strands as native
+    // InterruptResponseContent — not short-circuited with a synthetic
+    // RUN_FINISHED that bypasses stream()/native cleanup/hooks/session
+    // persistence.
+    expect(capturedArgs).not.toBeNull();
+    expect(Array.isArray(capturedArgs)).toBe(true);
+    const [first] = capturedArgs as InterruptResponseContent[];
+    expect(first.interruptResponse.interruptId).toBe("ic");
+    expect(first.interruptResponse.response).toEqual({ status: "cancelled" });
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { EventType, type BaseEvent, type RunAgentInput } from "@ag-ui/core";
+import { EventType, type BaseEvent, type RunAgentInput, type Interrupt as AguiInterrupt } from "@ag-ui/core";
 
 import { StrandsAgent } from "../agent";
 import { collect, minimalRunInput, scriptedAgent } from "./helpers";
 
 /**
- * Interrupt-rule-4 gate lives in `StrandsAgent.run()` above `_runRaw` so any
+ * Interrupt-rule gate lives in `StrandsAgent.run()` above `_runRaw` so any
  * subclass that overrides only `_runRaw` still inherits the check and Strands
  * isn't spun up for a doomed request. These tests exercise the gate at the
  * agent layer directly (no HTTP) to pin its semantics.
@@ -34,9 +34,26 @@ class NeverRanAgent extends StrandsAgent {
   }
 }
 
-describe("StrandsAgent resume[] gate (interrupts.mdx rule 4)", () => {
-  it("emits RUN_STARTED then RUN_ERROR and never touches _runRaw", async () => {
+/** Helper to set pending interrupts on the agent (new Map<string, Map<string, AguiInterrupt>> format). */
+function setPending(agent: StrandsAgent, threadId: string, ids: string[]) {
+  const pending = (
+    agent as unknown as {
+      _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
+    }
+  )._pendingInterruptsByThread;
+  const map = new Map<string, AguiInterrupt>();
+  for (const id of ids) {
+    map.set(id, { id, reason: "tool_call" });
+  }
+  pending.set(threadId, map);
+  return pending;
+}
+
+describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
+  it("emits RUN_STARTED then RUN_ERROR for unknown interruptId", async () => {
     const agent = new NeverRanAgent();
+    // Must set pending interrupts so the gate doesn't short-circuit with "no pending"
+    setPending(agent, "t", ["real-id"]);
     const events = await collect(
       agent,
       minimalRunInput({
@@ -44,6 +61,7 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rule 4)", () => {
         runId: "r",
         resume: [
           { interruptId: "unknown-id", status: "resolved", payload: {} },
+          { interruptId: "real-id", status: "resolved", payload: {} },
         ],
       }),
     );
@@ -52,18 +70,14 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rule 4)", () => {
       EventType.RUN_STARTED,
       EventType.RUN_ERROR,
     ]);
-    const [started, err] = events as unknown as [
-      { threadId: string; runId: string },
-      { code: string; message: string },
-    ];
-    expect(started.threadId).toBe("t");
-    expect(started.runId).toBe("r");
-    expect(err.code).toBe("UNKNOWN_INTERRUPT");
+    const err = events[1] as unknown as { code: string; message: string };
+    expect(err.code).toBe("UNKNOWN_INTERRUPT_ID");
     expect(err.message).toMatch(/unknown-id/);
   });
 
   it("echoes up to four unknown interruptIds into the error message", async () => {
     const agent = new NeverRanAgent();
+    setPending(agent, "thread-1", ["valid-1"]);
     const resume = Array.from({ length: 6 }, (_, i) => ({
       interruptId: `i-${i}`,
       status: "resolved" as const,
@@ -103,71 +117,130 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rule 4)", () => {
     ]);
   });
 
-  it("clears stale pending interrupt IDs when a non-resume run starts", async () => {
-    // Reproduces H1: a thread with an outstanding interrupt that the client
-    // abandons (sends a fresh prompt instead of resume[]) must not leave the
-    // old interruptIds in `_pendingInterruptsByThread`. Otherwise a later
-    // replayed/raced resume[] could be accepted as valid against dead IDs.
+  it("Rule 4: blocks non-resume run when thread has pending interrupts", async () => {
     const agent = new NeverRanAgent();
-    const pending = (
-      agent as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
-      }
-    )._pendingInterruptsByThread;
-    pending.set("t", new Set(["stale-1", "stale-2"]));
+    setPending(agent, "t", ["stale-1", "stale-2"]);
 
-    // Plain (non-resume) run on the same thread — the run itself should
-    // succeed AND the stale IDs should be wiped.
+    // Plain (non-resume) run on a thread with pending interrupts → RUN_ERROR
     const events = await collect(
       agent,
       minimalRunInput({ threadId: "t", runId: "r1" }),
     );
     expect(events.map((e) => e.type)).toEqual([
       EventType.RUN_STARTED,
-      EventType.RUN_FINISHED,
+      EventType.RUN_ERROR,
     ]);
-    expect(pending.has("t")).toBe(false);
+    const err = events[1] as unknown as { code: string };
+    expect(err.code).toBe("PENDING_INTERRUPTS");
+  });
 
-    // A subsequent resume[] referencing the now-stale ID must be rejected.
-    const rejected = await collect(
+  it("Rule 3: rejects partial resume that doesn't cover all interrupts", async () => {
+    const agent = new NeverRanAgent();
+    setPending(agent, "t", ["int-1", "int-2", "int-3"]);
+
+    // Only address 1 of 3 pending interrupts
+    const events = await collect(
       agent,
       minimalRunInput({
         threadId: "t",
-        runId: "r2",
-        resume: [{ interruptId: "stale-1", status: "resolved", payload: {} }],
+        runId: "r1",
+        resume: [{ interruptId: "int-1", status: "resolved", payload: { approved: true } }],
       }),
     );
-    expect(rejected.map((e) => e.type)).toEqual([
+    expect(events.map((e) => e.type)).toEqual([
       EventType.RUN_STARTED,
       EventType.RUN_ERROR,
     ]);
-    const err = rejected[1] as unknown as { code: string };
-    expect(err.code).toBe("UNKNOWN_INTERRUPT");
+    const err = events[1] as unknown as { code: string };
+    expect(err.code).toBe("PARTIAL_RESUME");
   });
 
-  it("does not clear pending interrupts when the run IS a resume", async () => {
-    // Resume path manages cleanup itself (delete after building
-    // InterruptResponseContent[] in `_runSingleAgent`). The gate must NOT
-    // wipe pending IDs on the resume path or the resume itself would fail.
+  it("Rule 5: idempotent replay returns success without re-executing", async () => {
     const agent = new NeverRanAgent();
-    const pending = (
-      agent as unknown as {
-        _pendingInterruptsByThread: Map<string, Set<string>>;
-      }
-    )._pendingInterruptsByThread;
-    pending.set("t", new Set(["live-1"]));
+    setPending(agent, "t", ["live-1"]);
 
-    // Valid resume entry passes the gate, then NeverRanAgent's stub _runRaw
-    // returns without touching the map. Verify the gate itself does not
-    // delete the pending set.
+    // First resume — passes gate, goes to _runRaw
     await collect(
       agent,
       minimalRunInput({
         threadId: "t",
         runId: "r1",
-        resume: [{ interruptId: "live-1", status: "resolved", payload: {} }],
+        resume: [{ interruptId: "live-1", status: "resolved", payload: { approved: true } }],
       }),
     );
-    expect(pending.get("t")?.has("live-1")).toBe(true);
+    expect(agent.rawCalled).toBe(1);
+
+    // Replay same resume — no pending interrupts, but fingerprint matches → success
+    const replay = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r2",
+        resume: [{ interruptId: "live-1", status: "resolved", payload: { approved: true } }],
+      }),
+    );
+    expect(agent.rawCalled).toBe(1); // NOT called again
+    expect(replay.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+  });
+
+  it("Rule 7: rejects expired interrupt", async () => {
+    const agent = new NeverRanAgent();
+    const pending = (
+      agent as unknown as {
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
+      }
+    )._pendingInterruptsByThread;
+    const map = new Map<string, AguiInterrupt>();
+    map.set("exp-1", { id: "exp-1", reason: "tool_call", expiresAt: "2020-01-01T00:00:00Z" });
+    pending.set("t", map);
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [{ interruptId: "exp-1", status: "resolved", payload: { approved: true } }],
+      }),
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string };
+    expect(err.code).toBe("INTERRUPT_EXPIRED");
+  });
+
+  it("Rule 6: rejects invalid payload missing required keys", async () => {
+    const agent = new NeverRanAgent();
+    const pending = (
+      agent as unknown as {
+        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
+      }
+    )._pendingInterruptsByThread;
+    const map = new Map<string, AguiInterrupt>();
+    map.set("val-1", {
+      id: "val-1",
+      reason: "tool_call",
+      responseSchema: { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"] },
+    });
+    pending.set("t", map);
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [{ interruptId: "val-1", status: "resolved", payload: {} }],
+      }),
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string };
+    expect(err.code).toBe("INVALID_PAYLOAD");
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
@@ -186,6 +186,36 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     ]);
   });
 
+  it("Rule 5: recognizes a replay when resume entries arrive in a different order", async () => {
+    const agent = new NeverRanAgent();
+    setPending(agent, "t", ["live-1", "live-2"]);
+
+    const firstResume = [
+      { interruptId: "live-1", status: "resolved" as const, payload: { approved: true } },
+      { interruptId: "live-2", status: "cancelled" as const },
+    ];
+    await collect(
+      agent,
+      minimalRunInput({ threadId: "t", runId: "r1", resume: firstResume }),
+    );
+    expect(agent.rawCalled).toBe(1);
+
+    const replay = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r2",
+        resume: [...firstResume].reverse(),
+      }),
+    );
+
+    expect(agent.rawCalled).toBe(1);
+    expect(replay.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+  });
+
   it("Rule 7: rejects expired interrupt", async () => {
     const agent = new NeverRanAgent();
     const pending = (
@@ -242,5 +272,74 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     ]);
     const err = events[1] as unknown as { code: string };
     expect(err.code).toBe("INVALID_PAYLOAD");
+  });
+
+  it("Rule 6: rejects a non-boolean approval value", async () => {
+    for (const invalidApproval of ["true", 1, null]) {
+      const agent = new NeverRanAgent();
+      const pending = setPending(agent, "t", ["val-1"]).get("t")!;
+      pending.get("val-1")!.responseSchema = {
+        type: "object",
+        properties: { approved: { type: "boolean" } },
+        required: ["approved"],
+      };
+
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: "t",
+          runId: "r1",
+          resume: [{ interruptId: "val-1", status: "resolved", payload: { approved: invalidApproval } }],
+        }),
+      );
+
+      expect(agent.rawCalled).toBe(0);
+      const err = events[1] as unknown as { code: string; message: string };
+      expect(err.code).toBe("INVALID_PAYLOAD");
+      expect(err.message).toContain("approved");
+    }
+  });
+
+  it("Rule 6: accepts explicit denial and optional approve-with-edits fields", async () => {
+    const schema = {
+      type: "object",
+      properties: {
+        approved: { type: "boolean" },
+        editedArgs: { type: "object" },
+      },
+      required: ["approved"],
+    };
+
+    const denied = new NeverRanAgent();
+    const deniedPending = setPending(denied, "denied", ["val-1"]).get("denied")!;
+    deniedPending.get("val-1")!.responseSchema = schema;
+    const deniedEvents = await collect(
+      denied,
+      minimalRunInput({
+        threadId: "denied",
+        resume: [{ interruptId: "val-1", status: "resolved", payload: { approved: false } }],
+      }),
+    );
+    expect(denied.rawCalled).toBe(1);
+    expect(deniedEvents.some((event) => event.type === EventType.RUN_ERROR)).toBe(false);
+
+    const edited = new NeverRanAgent();
+    const editedPending = setPending(edited, "edited", ["val-2"]).get("edited")!;
+    editedPending.get("val-2")!.responseSchema = schema;
+    const editedEvents = await collect(
+      edited,
+      minimalRunInput({
+        threadId: "edited",
+        resume: [
+          {
+            interruptId: "val-2",
+            status: "resolved",
+            payload: { approved: true, editedArgs: { environment: "staging" } },
+          },
+        ],
+      }),
+    );
+    expect(edited.rawCalled).toBe(1);
+    expect(editedEvents.some((event) => event.type === EventType.RUN_ERROR)).toBe(false);
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/tool-stream-event-handler.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/tool-stream-event-handler.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Verifies that a custom toolStreamEventHandler suppresses the default
+ * STATE_SNAPSHOT behavior and yields custom events instead.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AgentStreamEvent } from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { collect, scriptedStrandsAgent } from "./helpers";
+
+describe("toolStreamEventHandler", () => {
+  it("dispatches to custom handler and suppresses default STATE_SNAPSHOT", async () => {
+    const script: AgentStreamEvent[] = [
+      // Simulate a modelContentBlockStartEvent to set currentToolUse
+      {
+        type: "modelContentBlockStartEvent",
+        start: { type: "toolUseStart", name: "my_tool", toolUseId: "tu-1" },
+      } as unknown as AgentStreamEvent,
+      // toolStreamEvent that would normally emit STATE_SNAPSHOT
+      {
+        type: "toolStreamUpdateEvent",
+        event: {
+          type: "toolStreamEvent",
+          data: { state: { should_not_appear: true }, custom: "payload" },
+        },
+      } as unknown as AgentStreamEvent,
+    ];
+
+    const collected: unknown[] = [];
+    const agent = scriptedStrandsAgent(script, {
+      config: {
+        toolBehaviors: {
+          my_tool: {
+            async *toolStreamEventHandler(ctx) {
+              collected.push(ctx);
+              yield {
+                type: EventType.CUSTOM,
+                name: "FromHandler",
+                value: ctx.streamData,
+              } as any;
+            },
+          },
+        },
+      },
+    });
+
+    const events = await collect(agent);
+
+    // The handler was called with correct context
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toMatchObject({
+      toolUseId: "tu-1",
+      toolName: "my_tool",
+      streamData: { state: { should_not_appear: true }, custom: "payload" },
+    });
+
+    // Custom event was emitted
+    const custom = events.filter((e) => e.type === EventType.CUSTOM);
+    expect(custom).toHaveLength(1);
+
+    // Default STATE_SNAPSHOT for {state: ...} was NOT emitted for this tool
+    const snapshots = events.filter(
+      (e) =>
+        e.type === EventType.STATE_SNAPSHOT &&
+        (e as any).snapshot?.should_not_appear,
+    );
+    expect(snapshots).toHaveLength(0);
+  });
+});

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -677,11 +677,7 @@ export class StrandsAgent {
       let pending = this._pendingInterruptsByThread.get(threadId);
 
       // Rule 5: idempotency — detect replayed resumes
-      fingerprint = createHash("md5")
-        .update(JSON.stringify(
-          inputData.resume!.map((e) => [e.interruptId, e.status, _sortKeys(e.payload)]),
-        ))
-        .digest("hex");
+      fingerprint = resumeFingerprint(inputData.resume!);
 
       // Cold-restart fallback: if this process has nothing cached in memory
       // for this threadId, restore the per-thread agent first (so a
@@ -703,7 +699,9 @@ export class StrandsAgent {
           return;
         }
         const interruptState = (
-          restored.agent as { _interruptState?: { activated?: boolean; interrupts?: Map<string, unknown> } }
+          restored.agent as unknown as {
+            _interruptState?: { activated?: boolean; interrupts?: Map<string, unknown> };
+          }
         )._interruptState;
         if (interruptState?.activated && interruptState.interrupts) {
           nativePendingIds = new Set(interruptState.interrupts.keys());
@@ -834,6 +832,18 @@ export class StrandsAgent {
                   return;
                 }
               }
+              const typeError = validateObjectPayloadPropertyTypes(
+                schema,
+                entry.payload as Record<string, unknown>,
+              );
+              if (typeError) {
+                yield _runStarted(inputData);
+                yield _runError(
+                  `Invalid payload for interrupt '${entry.interruptId}': ${typeError}`,
+                  "INVALID_PAYLOAD",
+                );
+                return;
+              }
             }
           }
         }
@@ -852,6 +862,20 @@ export class StrandsAgent {
         if (cached) {
           const is = (cached as { _interruptState?: { activated: boolean } })._interruptState;
           if (is?.activated) hasPending = true;
+        } else if (this.config.sessionManagerProvider) {
+          // A cold process has no cached agent yet, but SessionManager may
+          // restore a native pending interrupt for this thread. Restore it
+          // before deciding whether new input may proceed (Rule 4).
+          const restored = await this._ensureAgent(inputData, threadId);
+          if ("error" in restored) {
+            yield _runStarted(inputData);
+            yield restored.error;
+            return;
+          }
+          const interruptState = (
+            restored.agent as { _interruptState?: { activated?: boolean } }
+          )._interruptState;
+          hasPending = interruptState?.activated === true;
         }
       }
       if (hasPending) {
@@ -3216,4 +3240,84 @@ function _sortKeys(val: unknown): unknown {
       },
       {} as Record<string, unknown>,
     );
+}
+
+/**
+ * Canonicalize resume entries before hashing so a semantically identical
+ * resume[] replay is recognized regardless of the client's entry ordering.
+ */
+function resumeFingerprint(entries: ResumeEntry[]): string {
+  const canonicalEntries = entries
+    .map(
+      (entry) =>
+        [entry.interruptId, entry.status, _sortKeys(entry.payload)] as const,
+    )
+    .sort((left, right) =>
+      JSON.stringify(left).localeCompare(JSON.stringify(right)),
+    );
+
+  return createHash("md5")
+    .update(JSON.stringify(canonicalEntries))
+    .digest("hex");
+}
+
+/**
+ * Deliberately small JSON Schema validator for object-property primitive
+ * types. Required-field validation is handled by the caller; this only
+ * validates fields that the client supplied. It keeps the adapter dependency
+ * free while ensuring an approval schema rejects e.g. { approved: "true" }.
+ */
+function validateObjectPayloadPropertyTypes(
+  schema: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): string | undefined {
+  const properties = schema.properties;
+  if (
+    !properties ||
+    typeof properties !== "object" ||
+    Array.isArray(properties)
+  ) {
+    return undefined;
+  }
+
+  for (const [field, fieldSchema] of Object.entries(
+    properties as Record<string, unknown>,
+  )) {
+    if (!(field in payload) || !fieldSchema || typeof fieldSchema !== "object") {
+      continue;
+    }
+    const type = (fieldSchema as { type?: unknown }).type;
+    if (typeof type !== "string" || jsonSchemaTypeMatches(payload[field], type)) {
+      continue;
+    }
+    return `field '${field}' must be ${jsonSchemaTypeDescription(type)}.`;
+  }
+
+  return undefined;
+}
+
+function jsonSchemaTypeMatches(value: unknown, type: string): boolean {
+  switch (type) {
+    case "boolean":
+      return typeof value === "boolean";
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "object":
+      return value !== null && typeof value === "object" && !Array.isArray(value);
+    case "array":
+      return Array.isArray(value);
+    case "null":
+      return value === null;
+    default:
+      // Unsupported JSON Schema constructs remain the caller's responsibility.
+      return true;
+  }
+}
+
+function jsonSchemaTypeDescription(type: string): string {
+  return type === "object" || type === "array" ? `an ${type}` : `a ${type}`;
 }

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -209,6 +209,21 @@ function _errorMessage(e: unknown): string {
 }
 
 /**
+ * Return native Strands interrupt IDs across SDK versions and test doubles.
+ *
+ * Strands' current InterruptState serializes `interrupts` as a Record, while
+ * older mocks used a Map. Supporting both keeps cold-start validation aligned
+ * with the state that SessionManager actually restores.
+ */
+function _nativeInterruptIds(interrupts: unknown): Set<string> {
+  if (interrupts instanceof Map) return new Set(interrupts.keys());
+  if (interrupts && typeof interrupts === "object") {
+    return new Set(Object.keys(interrupts));
+  }
+  return new Set();
+}
+
+/**
  * Resolve the AG-UI-side tool call id from an incoming Strands tool use.
  *
  * - If we've already seen this Strands tool (by internal id), reuse the
@@ -654,6 +669,32 @@ export class StrandsAgent {
           }
         }
       }
+      // SessionManager restores snapshots from its InitializedEvent hook. Run
+      // initialization now, before `run()` validates a cold-start resume;
+      // `stream()` otherwise initializes too late, after validation has
+      // rejected the restored interrupt IDs as unknown.
+      if (sessionManager) {
+        try {
+          const initialize = (
+            strandsAgent as unknown as { initialize?: () => Promise<void> }
+          ).initialize;
+          if (typeof initialize === "function") {
+            await initialize.call(strandsAgent);
+          }
+        } catch (e) {
+          const msg = _errorMessage(e);
+          this._log.error(
+            `${LOG_PREFIX} failed to initialize session manager for thread ${threadId}: ${msg}`,
+            e,
+          );
+          return {
+            error: _runError(
+              `Failed to initialize session manager: ${msg}`,
+              "SESSION_MANAGER_ERROR",
+            ),
+          };
+        }
+      }
       this._agentsByThread.set(threadId, strandsAgent);
       return { agent: strandsAgent };
     } finally {
@@ -700,11 +741,11 @@ export class StrandsAgent {
         }
         const interruptState = (
           restored.agent as unknown as {
-            _interruptState?: { activated?: boolean; interrupts?: Map<string, unknown> };
+            _interruptState?: { activated?: boolean; interrupts?: unknown };
           }
         )._interruptState;
-        if (interruptState?.activated && interruptState.interrupts) {
-          nativePendingIds = new Set(interruptState.interrupts.keys());
+        if (interruptState?.activated) {
+          nativePendingIds = _nativeInterruptIds(interruptState.interrupts);
         }
         const { pending: persistedPending, fingerprint: persistedFingerprint } =
           loadPersistedInterruptBookkeeping(restored.agent);
@@ -2224,6 +2265,23 @@ export class StrandsAgent {
           this._pendingInterruptsByThread.set(threadId, interruptMap);
           this._lastResumeFingerprint.delete(threadId);
           persistInterruptBookkeeping(strandsAgent, interruptMap, null, this._log);
+          // Strands' default SessionManager saves at the completed-invocation
+          // boundary. An interrupt exits the native loop before that durable
+          // snapshot is guaranteed, so explicitly checkpoint the restored
+          // native interrupt state and our appState bookkeeping before telling
+          // the client it may resume after a process restart.
+          try {
+            await strandsAgent.sessionManager?.saveSnapshot({
+              target: strandsAgent,
+              isLatest: true,
+            });
+          } catch (e) {
+            // Persistence is a durability enhancement. A broken backing store
+            // must not turn a successfully-raised interrupt into a failed run.
+            this._log.warn(
+              `${LOG_PREFIX} Failed to persist interrupt snapshot: ${_errorMessage(e)}`,
+            );
+          }
           yield {
             type: EventType.RUN_FINISHED,
             threadId: inputData.threadId,

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -2696,24 +2696,32 @@ function toResumeResponse(entry: ResumeEntry): unknown {
 /** Strands `Interrupt` → AG-UI `Interrupt`. */
 function strandsInterruptToAgui(interrupt: StrandsInterrupt): AguiInterrupt {
   const reasonRaw = interrupt.reason;
-  // Derive the AG-UI reason string: use raw string directly, or check for
-  // structured reason objects produced by the interruptOnCall hook.
-  let reason: string;
-  if (typeof reasonRaw === "string" && reasonRaw.length > 0) {
-    reason = reasonRaw;
-  } else if (
-    typeof reasonRaw === "object" &&
-    reasonRaw != null &&
-    (reasonRaw as Record<string, unknown>).tool_call
-  ) {
-    reason = "tool_call";
-  } else {
-    reason = "confirmation";
+  // Only interrupts raised by our own interruptOnCall hook (identified by
+  // the "ag_ui:tool_call:" name prefix it always uses) are tool-call
+  // approvals with the {tool_call, tool_name, tool_input, tool_use_id}
+  // reason shape. Any other interrupt — e.g. one a user's own tool or hook
+  // raises directly via event.interrupt() for a generic human-in-the-loop
+  // purpose — must stay generic: preserve its native name/reason payload
+  // rather than guessing tool-approval semantics out of an unrelated
+  // object.
+  const isToolApproval =
+    typeof interrupt.name === "string" &&
+    interrupt.name.startsWith("ag_ui:tool_call:");
+
+  if (!isToolApproval) {
+    const out: AguiInterrupt = {
+      id: interrupt.id,
+      reason: interrupt.name ?? "interrupt",
+    };
+    if (reasonRaw !== undefined && reasonRaw !== null) {
+      out.metadata = { reason: reasonRaw };
+    }
+    return out;
   }
+
+  const reason = "tool_call";
   const out: AguiInterrupt = { id: interrupt.id, reason };
-  if (typeof reasonRaw === "string" && reasonRaw.length > 0) {
-    out.message = reasonRaw;
-  } else if (typeof reasonRaw === "object" && reasonRaw != null) {
+  if (typeof reasonRaw === "object" && reasonRaw != null) {
     const tn = (reasonRaw as Record<string, unknown>).tool_name;
     if (typeof tn === "string") {
       out.message = `Approve call to ${tn}?`;
@@ -2724,18 +2732,11 @@ function strandsInterruptToAgui(interrupt: StrandsInterrupt): AguiInterrupt {
     const toolUseId = (reasonRaw as Record<string, unknown>).tool_use_id;
     if (typeof toolUseId === "string") out.toolCallId = toolUseId;
   }
-  // Add responseSchema for tool-bound and confirmation interrupts
-  if (
-    reason === "tool_call" ||
-    reason === "confirmation" ||
-    interrupt.name?.startsWith("ag_ui:tool_call:")
-  ) {
-    out.responseSchema = {
-      type: "object",
-      properties: { approved: { type: "boolean" } },
-      required: ["approved"],
-    };
-  }
+  out.responseSchema = {
+    type: "object",
+    properties: { approved: { type: "boolean" } },
+    required: ["approved"],
+  };
   const meta: Record<string, unknown> = { strandsName: interrupt.name };
   if (typeof reasonRaw === "object" && reasonRaw != null) {
     const r = reasonRaw as Record<string, unknown>;

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -566,8 +566,10 @@ export class StrandsAgent {
   /**
    * Ensure a Strands agent exists for the given thread. Creates one if needed
    * (including session manager initialization). Returns the agent or an error
-   * event to yield. Matches Python's ordering: agent creation happens before
-   * resume validation so SessionManager can restore _interruptState.
+   * event to yield. Called from `run()`'s resume-validation gate on a cold
+   * start with a session provider (so SessionManager can restore
+   * `_interruptState` before validation runs), and again from
+   * `_runSingleAgent` for the actual run — the second call is a cache hit.
    */
   private async _ensureAgent(
     inputData: RunAgentInput,
@@ -671,7 +673,7 @@ export class StrandsAgent {
     // interrupts. Gated above `_runRaw` so subclasses that override only
     // `_runRaw` still inherit the checks.
     if (hasResume) {
-      const pending = this._pendingInterruptsByThread.get(threadId);
+      let pending = this._pendingInterruptsByThread.get(threadId);
 
       // Rule 5: idempotency — detect replayed resumes
       fingerprint = createHash("md5")
@@ -685,13 +687,69 @@ export class StrandsAgent {
         return;
       }
 
-      if (!pending && !this.config.sessionManagerProvider) {
+      // Cold start with a session provider: the in-memory pending map is
+      // empty because the per-thread agent (and its SessionManager-restored
+      // native _interruptState) hasn't been constructed in this process
+      // yet. Restore it now — before deciding whether to skip validation —
+      // so an unknown/partial resume can't slip through solely because
+      // nothing has run on this process since the interrupt was raised.
+      let nativePendingIds: Set<string> | undefined;
+      if (!pending && this.config.sessionManagerProvider) {
+        const restored = await this._ensureAgent(inputData, threadId);
+        if ("error" in restored) {
+          yield _runStarted(inputData);
+          yield restored.error;
+          return;
+        }
+        const interruptState = (
+          restored.agent as { _interruptState?: { activated?: boolean; interrupts?: Map<string, unknown> } }
+        )._interruptState;
+        if (interruptState?.activated && interruptState.interrupts) {
+          nativePendingIds = new Set(interruptState.interrupts.keys());
+        }
+        // Re-check the AG-UI-side map too: _ensureAgent may have raced with
+        // another call that populated it while we awaited.
+        pending = this._pendingInterruptsByThread.get(threadId);
+      }
+
+      if (!pending && !nativePendingIds) {
         yield _runStarted(inputData);
         yield _runError(
           "No pending interrupts for this thread.",
           "UNKNOWN_INTERRUPT_ID",
         );
         return;
+      }
+
+      if (!pending && nativePendingIds) {
+        // Best-effort validation against the restored native interrupt
+        // IDs only (rules 2/3). The full AG-UI interrupt metadata needed
+        // for rules 6/7 — responseSchema, expiresAt — is adapter-memory
+        // only and was lost on restart; it cannot be recovered here.
+        const unknown = inputData
+          .resume!.map((entry) => entry.interruptId)
+          .filter((id) => !nativePendingIds!.has(id));
+        if (unknown.length > 0) {
+          yield _runStarted(inputData);
+          yield _runError(
+            `This agent did not issue any interrupts to resume: ${unknown
+              .slice(0, 4)
+              .join(", ")}. ` +
+              "Resume entries must reference an outstanding interruptId.",
+            "UNKNOWN_INTERRUPT_ID",
+          );
+          return;
+        }
+        const resumedIds = new Set(inputData.resume!.map((e) => e.interruptId));
+        const missing = [...nativePendingIds].filter((id) => !resumedIds.has(id));
+        if (missing.length > 0) {
+          yield _runStarted(inputData);
+          yield _runError(
+            `Partial resume: missing interrupt IDs: ${missing.join(", ")}. All open interrupts must be addressed.`,
+            "PARTIAL_RESUME",
+          );
+          return;
+        }
       }
 
       if (pending) {
@@ -1153,12 +1211,12 @@ export class StrandsAgent {
               }
             }
           }
-          // If ALL entries are cancelled, finish immediately
-          if (resumeEntries.every((e) => e.status === "cancelled")) {
-            this._pendingInterruptsByThread.delete(threadId);
-            yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
-            return;
-          }
+          // Note: even when ALL entries are cancelled, we still forward the
+          // denial responses to Strands via stream() below rather than
+          // short-circuiting here. This ensures native interrupt-state
+          // cleanup, hooks, snapshots, and session persistence all run
+          // through Strands' normal completion path instead of being
+          // bypassed by a synthetic RUN_FINISHED.
         }
         invokeArgs = resumeEntries.map(
           (entry) =>

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -4,10 +4,11 @@
  * Translates Strands streaming events into the AG-UI event protocol.
  */
 
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 
 import {
   Agent as StrandsAgentCore,
+  BeforeToolCallEvent,
   InterruptResponseContent,
   Message as StrandsMessage,
   SessionManager,
@@ -437,6 +438,13 @@ export interface StrandsAgentOptions {
    * orchestrator.
    */
   plugins?: Plugin[];
+  /**
+   * Optional external map for per-thread agent persistence. When provided,
+   * the adapter uses this map instead of an internal one — allowing agent
+   * instances (and their interrupt state) to survive across adapter
+   * re-instantiations (e.g. request-scoped wrappers in serverless runtimes).
+   */
+  agentsByThread?: Map<string, StrandsAgentCore>;
 }
 
 /** AWS Strands Agent wrapper for AG-UI integration. */
@@ -459,7 +467,7 @@ export class StrandsAgent {
    */
   private readonly _plugins: Plugin[];
 
-  private readonly _agentsByThread = new Map<string, StrandsAgentCore>();
+  private readonly _agentsByThread: Map<string, StrandsAgentCore>;
   private readonly _proxyToolNamesByThread = new Map<string, Set<string>>();
   /**
    * Guards first-time thread initialization. The sessionManagerProvider call
@@ -475,9 +483,11 @@ export class StrandsAgent {
    * TypeScript-only: the Python adapter has no equivalent guard.
    */
   private readonly _activeRunsByThread = new Set<string>();
-  /** Outstanding Strands interrupt IDs per thread, used to validate
-   * incoming `RunAgentInput.resume[]` (interrupts.mdx rule 4). */
-  private readonly _pendingInterruptsByThread = new Map<string, Set<string>>();
+  /** Outstanding AG-UI interrupt objects per thread, used to validate
+   * incoming `RunAgentInput.resume[]` (interrupts.mdx rules 3-7). */
+  private readonly _pendingInterruptsByThread = new Map<string, Map<string, AguiInterrupt>>();
+  /** Fingerprint of last successfully-processed resume per thread (idempotency). */
+  private readonly _lastResumeFingerprint = new Map<string, string>();
   /**
    * When non-null, the adapter bypasses per-thread cloning and invokes
    * the orchestrator directly. See `StrandsAgentOptions.agent`.
@@ -490,7 +500,9 @@ export class StrandsAgent {
   private readonly _log: Logger;
 
   constructor(options: StrandsAgentOptions) {
-    const { agent, name, description = "", config = {}, plugins } = options;
+    const { agent, name, description = "", config = {}, plugins, agentsByThread } = options;
+
+    this._agentsByThread = agentsByThread ?? new Map();
 
     // Detect a multi-agent orchestrator. Graph / Swarm expose `nodes` + `edges`
     // (Graph) or `nodes` + invoke semantics (Swarm) and have no `.model`
@@ -551,45 +563,251 @@ export class StrandsAgent {
     }
   }
 
+  /**
+   * Ensure a Strands agent exists for the given thread. Creates one if needed
+   * (including session manager initialization). Returns the agent or an error
+   * event to yield. Matches Python's ordering: agent creation happens before
+   * resume validation so SessionManager can restore _interruptState.
+   */
+  private async _ensureAgent(
+    inputData: RunAgentInput,
+    threadId: string,
+  ): Promise<{ agent: StrandsAgentCore } | { error: BaseEvent }> {
+    let strandsAgent = this._agentsByThread.get(threadId);
+    if (strandsAgent) return { agent: strandsAgent };
+
+    // Build seed outside the lock (may do async fetches for multimodal).
+    let seedMessages: AgentConfig["messages"] | undefined;
+    if (!this.config.sessionManagerProvider) {
+      try {
+        seedMessages = await buildStrandsSeed(
+          inputData.messages ?? [],
+          this._log,
+        );
+      } catch (e) {
+        this._log.error(
+          `${LOG_PREFIX} buildStrandsSeed failed for thread ${threadId}: ${_errorMessage(e)}`,
+          e,
+        );
+        return { error: _runError("Failed to build conversation seed: " + _errorMessage(e), "SEED_BUILD_ERROR") };
+      }
+    }
+
+    const release = await this._threadInitLock.acquire();
+    try {
+      strandsAgent = this._agentsByThread.get(threadId);
+      if (strandsAgent) return { agent: strandsAgent };
+
+      let sessionManager: SessionManager | null | undefined;
+      if (this.config.sessionManagerProvider) {
+        try {
+          sessionManager = (await maybeAwait(
+            this.config.sessionManagerProvider(inputData),
+          )) as SessionManager | null | undefined;
+        } catch (e) {
+          const msg = _errorMessage(e);
+          this._log.error(`${LOG_PREFIX} sessionManagerProvider failed: ${msg}`, e);
+          return { error: _runError(`Failed to initialize session manager: ${msg}`, "SESSION_MANAGER_ERROR") };
+        }
+        if (
+          sessionManager != null &&
+          !(sessionManager instanceof SessionManager) &&
+          typeof (sessionManager as { initAgent?: unknown }).initAgent !== "function"
+        ) {
+          const actual = (sessionManager as object)?.constructor?.name ?? typeof sessionManager;
+          this._log.error(`${LOG_PREFIX} sessionManagerProvider returned ${actual}; expected a SessionManager instance.`);
+          return { error: _runError(`sessionManagerProvider returned ${actual}; expected a SessionManager instance`, "SESSION_MANAGER_INVALID_TYPE") };
+        }
+        if (!sessionManager) {
+          this._log.warn(
+            `${LOG_PREFIX} sessionManagerProvider returned null/undefined for threadId=${threadId}; agent will run without session persistence`,
+          );
+        }
+      }
+      const effectiveSeed = sessionManager ? undefined : seedMessages;
+      strandsAgent = new StrandsAgentCore(
+        this._buildThreadAgentConfig(sessionManager ?? undefined, effectiveSeed),
+      );
+      // Register interruptOnCall hooks on the per-thread agent.
+      const behaviors = this.config.toolBehaviors;
+      if (behaviors) {
+        for (const [toolName, behavior] of Object.entries(behaviors)) {
+          if (behavior.interruptOnCall) {
+            strandsAgent.addHook(BeforeToolCallEvent, (event) => {
+              if (event.toolUse?.name === toolName) {
+                const response = event.interrupt({
+                  name: `ag_ui:tool_call:${toolName}`,
+                  reason: { tool_call: true, tool_name: toolName, tool_input: event.toolUse!.input ?? {}, tool_use_id: event.toolUse!.toolUseId },
+                });
+                if (
+                  response == null ||
+                  typeof response !== "object" ||
+                  (response as Record<string, unknown>).approved !== true
+                ) {
+                  event.cancel = `User denied approval for '${toolName}'.`;
+                }
+              }
+            });
+          }
+        }
+      }
+      this._agentsByThread.set(threadId, strandsAgent);
+      return { agent: strandsAgent };
+    } finally {
+      release();
+    }
+  }
+
   /** Run the Strands agent and yield AG-UI events. */
   async *run(inputData: RunAgentInput): AsyncGenerator<BaseEvent, void, void> {
     const threadId = inputData.threadId || "default";
     const hasResume =
       Array.isArray(inputData.resume) && inputData.resume.length > 0;
 
-    // interrupts.mdx rule 4: any resume[] entry referencing an unknown
-    // interruptId MUST produce RUN_ERROR. Known IDs flow through to
-    // `InterruptResponseContent[]`. Gated above `_runRaw` so subclasses
-    // that override only `_runRaw` still inherit the check.
+    // Computed during validation; stored only after successful processing.
+    let fingerprint: string | undefined;
+
+    // interrupts.mdx rules 2-7: validate resume entries against pending
+    // interrupts. Gated above `_runRaw` so subclasses that override only
+    // `_runRaw` still inherit the checks.
     if (hasResume) {
       const pending = this._pendingInterruptsByThread.get(threadId);
-      const unknown = inputData
-        .resume!.map((entry) => entry.interruptId)
-        .filter((id) => !pending?.has(id));
-      if (unknown.length > 0) {
+
+      // Rule 5: idempotency — detect replayed resumes
+      fingerprint = createHash("md5")
+        .update(JSON.stringify(
+          inputData.resume!.map((e) => [e.interruptId, e.status, _sortKeys(e.payload)]),
+        ))
+        .digest("hex");
+      if (this._lastResumeFingerprint.get(threadId) === fingerprint) {
+        yield _runStarted(inputData);
+        yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
+        return;
+      }
+
+      if (!pending && !this.config.sessionManagerProvider) {
         yield _runStarted(inputData);
         yield _runError(
-          `This agent did not issue any interrupts to resume: ${unknown
-            .slice(0, 4)
-            .join(", ")}. ` +
-            "Resume entries must reference an outstanding interruptId.",
-          "UNKNOWN_INTERRUPT",
+          "No pending interrupts for this thread.",
+          "UNKNOWN_INTERRUPT_ID",
         );
         return;
       }
+
+      if (pending) {
+        // Rule 2: reject unknown interrupt IDs
+        const unknown = inputData
+          .resume!.map((entry) => entry.interruptId)
+          .filter((id) => !pending.has(id));
+        if (unknown.length > 0) {
+          yield _runStarted(inputData);
+          yield _runError(
+            `This agent did not issue any interrupts to resume: ${unknown
+              .slice(0, 4)
+              .join(", ")}. ` +
+              "Resume entries must reference an outstanding interruptId.",
+            "UNKNOWN_INTERRUPT_ID",
+          );
+          return;
+        }
+
+        // Rule 3: all open interrupts must be addressed
+        const resumedIds = new Set(inputData.resume!.map((e) => e.interruptId));
+        const missing = [...pending.keys()].filter((id) => !resumedIds.has(id));
+        if (missing.length > 0) {
+          yield _runStarted(inputData);
+          yield _runError(
+            `Partial resume: missing interrupt IDs: ${missing.join(", ")}. All open interrupts must be addressed.`,
+            "PARTIAL_RESUME",
+          );
+          return;
+        }
+
+        // Rule 7: expiresAt enforcement
+        for (const entry of inputData.resume!) {
+          const interrupt = pending.get(entry.interruptId)!;
+          if (interrupt.expiresAt && new Date() > new Date(interrupt.expiresAt)) {
+            yield _runStarted(inputData);
+            yield _runError(
+              `Interrupt '${entry.interruptId}' has expired.`,
+              "INTERRUPT_EXPIRED",
+            );
+            return;
+          }
+
+          // Rule 6: basic payload validation against responseSchema
+          if (entry.status === "resolved" && interrupt.responseSchema) {
+            const schema = interrupt.responseSchema as Record<string, unknown>;
+            if (schema.type === "object") {
+              if (typeof entry.payload !== "object" || entry.payload == null) {
+                yield _runStarted(inputData);
+                yield _runError(
+                  `Invalid payload for interrupt '${entry.interruptId}': expected an object.`,
+                  "INVALID_PAYLOAD",
+                );
+                return;
+              }
+              const required = schema.required as string[] | undefined;
+              if (Array.isArray(required)) {
+                const missingKeys = required.filter(
+                  (k) => !(k in (entry.payload as Record<string, unknown>)),
+                );
+                if (missingKeys.length > 0) {
+                  yield _runStarted(inputData);
+                  yield _runError(
+                    `Invalid payload for interrupt '${entry.interruptId}': missing required keys ${JSON.stringify(missingKeys)}.`,
+                    "INVALID_PAYLOAD",
+                  );
+                  return;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // fingerprint is stored after successful processing (below).
     } else {
-      // Non-resume run on this thread: any previously recorded interrupt
-      // IDs are stale (the client moved on instead of resuming). Drop them
-      // so a later replay/race cannot pass the resume[] gate above with a
-      // dead interruptId.
-      this._pendingInterruptsByThread.delete(threadId);
+      // Rule 4: pending interrupts block new input without resume.
+      // Per spec, clients must address all pending interrupts via resume[].
+      // To abandon interrupts, send resume with all entries status: "cancelled".
+      // Check both in-memory tracking AND the Strands agent's _interruptState
+      // (which SessionManager may have restored).
+      let hasPending = this._pendingInterruptsByThread.has(threadId);
+      if (!hasPending) {
+        const cached = this._agentsByThread.get(threadId);
+        if (cached) {
+          const is = (cached as { _interruptState?: { activated: boolean } })._interruptState;
+          if (is?.activated) hasPending = true;
+        }
+      }
+      if (hasPending) {
+        yield _runStarted(inputData);
+        yield _runError(
+          "Thread has pending interrupts. Include resume[] to address them.",
+          "PENDING_INTERRUPTS",
+        );
+        return;
+      }
     }
+    // Run the agent. Track whether an error was emitted so we only store
+    // the idempotency fingerprint after successful processing.
+    let hadError = false;
     const source = this._runRaw(inputData);
+    const tracked = (async function* () {
+      for await (const ev of source) {
+        if ((ev as { type: string }).type === EventType.RUN_ERROR) hadError = true;
+        yield ev;
+      }
+    })();
     if (this.config.emitChunkEvents) {
-      yield* collapseToChunkEvents(source);
-      return;
+      yield* collapseToChunkEvents(tracked);
+    } else {
+      yield* tracked;
     }
-    yield* source;
+    if (!hadError && fingerprint) {
+      this._lastResumeFingerprint.set(threadId, fingerprint);
+    }
   }
 
   protected async *_runRaw(
@@ -626,100 +844,13 @@ export class StrandsAgent {
   ): AsyncGenerator<BaseEvent, void, void> {
     yield _runStarted(inputData);
 
-    // Get or create agent instance for this thread. When a
-    // sessionManagerProvider is configured, the SessionManager handles
-    // conversation persistence; otherwise state is held in-memory per thread.
-    let strandsAgent = this._agentsByThread.get(threadId);
-    if (!strandsAgent) {
-      // Build the message-history seed BEFORE acquiring the global thread
-      // init lock. The seed helper may make async fetches for URL-based
-      // multimodal attachments; doing that inside the lock would serialise
-      // cold-cache initialisations for every OTHER thread behind one slow
-      // replay request. Skipped entirely when a SessionManager will own
-      // persistence.
-      let seedMessages: AgentConfig["messages"] | undefined;
-      if (!this.config.sessionManagerProvider) {
-        try {
-          seedMessages = await buildStrandsSeed(
-            inputData.messages ?? [],
-            this._log,
-          );
-        } catch (e) {
-          this._log.error(
-            `${LOG_PREFIX} buildStrandsSeed failed for thread ${threadId}: ${_errorMessage(e)}`,
-            e,
-          );
-          yield _runError(
-            "Failed to build conversation seed: " + _errorMessage(e),
-            "SEED_BUILD_ERROR",
-          );
-          return;
-        }
-      }
-
-      const release = await this._threadInitLock.acquire();
-      try {
-        // Double-check inside the lock: another coroutine may have completed
-        // initialization while we were waiting.
-        strandsAgent = this._agentsByThread.get(threadId);
-        if (!strandsAgent) {
-          let sessionManager: SessionManager | null | undefined;
-          if (this.config.sessionManagerProvider) {
-            try {
-              sessionManager = (await maybeAwait(
-                this.config.sessionManagerProvider(inputData),
-              )) as SessionManager | null | undefined;
-            } catch (e) {
-              const msg = _errorMessage(e);
-              this._log.error(
-                `${LOG_PREFIX} sessionManagerProvider failed: ${msg}`,
-                e,
-              );
-              yield _runError(
-                `Failed to initialize session manager: ${msg}`,
-                "SESSION_MANAGER_ERROR",
-              );
-              return;
-            }
-            if (
-              sessionManager != null &&
-              !(sessionManager instanceof SessionManager)
-            ) {
-              const actual =
-                (sessionManager as object)?.constructor?.name ??
-                typeof sessionManager;
-              this._log.error(
-                `${LOG_PREFIX} sessionManagerProvider returned ${actual}; expected a SessionManager instance.`,
-              );
-              yield _runError(
-                `sessionManagerProvider returned ${actual}; expected a SessionManager instance`,
-                "SESSION_MANAGER_INVALID_TYPE",
-              );
-              return;
-            }
-            if (!sessionManager) {
-              this._log.warn(
-                `${LOG_PREFIX} sessionManagerProvider returned null/undefined for threadId=${threadId}; ` +
-                  "agent will run without session persistence",
-              );
-            }
-          }
-          // If a SessionManager materialised, skip the pre-computed seed —
-          // the session owns persistence and seeding on top would duplicate
-          // turns.
-          const effectiveSeed = sessionManager ? undefined : seedMessages;
-          strandsAgent = new StrandsAgentCore(
-            this._buildThreadAgentConfig(
-              sessionManager ?? undefined,
-              effectiveSeed,
-            ),
-          );
-          this._agentsByThread.set(threadId, strandsAgent);
-        }
-      } finally {
-        release();
-      }
+    // Get or create agent instance for this thread.
+    const agentResult = await this._ensureAgent(inputData, threadId);
+    if ("error" in agentResult) {
+      yield agentResult.error;
+      return;
     }
+    const strandsAgent = agentResult.agent;
 
     // Sync proxy tools from client-defined tools.
     if (inputData.tools && inputData.tools.length > 0) {
@@ -999,6 +1130,36 @@ export class StrandsAgent {
       // filtered unknown IDs by this point.
       const resumeEntries = resolveResumeEntries(inputData);
       if (resumeEntries.length > 0) {
+        // Collect toolCallIds from resumed interrupts for Rule 8 suppression
+        const priorPending = this._pendingInterruptsByThread.get(threadId);
+        if (priorPending) {
+          for (const entry of resumeEntries) {
+            const interrupt = priorPending.get(entry.interruptId);
+            if (interrupt?.toolCallId) {
+              pendingToolResultIds.add(interrupt.toolCallId);
+            }
+          }
+          // Handle cancelled tool-bound interrupts: emit ToolCallResult immediately
+          for (const entry of resumeEntries) {
+            if (entry.status === "cancelled") {
+              const interrupt = priorPending.get(entry.interruptId);
+              if (interrupt?.toolCallId) {
+                yield {
+                  type: EventType.TOOL_CALL_RESULT,
+                  messageId: randomUUID(),
+                  toolCallId: interrupt.toolCallId,
+                  content: "Tool call cancelled by user.",
+                };
+              }
+            }
+          }
+          // If ALL entries are cancelled, finish immediately
+          if (resumeEntries.every((e) => e.status === "cancelled")) {
+            this._pendingInterruptsByThread.delete(threadId);
+            yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
+            return;
+          }
+        }
         invokeArgs = resumeEntries.map(
           (entry) =>
             new InterruptResponseContent({
@@ -1792,7 +1953,25 @@ export class StrandsAgent {
           if (kind === "toolStreamEvent") {
             const stream = event as unknown as { data?: unknown };
             const data = stream.data;
-            if (data && typeof data === "object" && "state" in data) {
+            const tseToolName = currentToolUse?.name ?? "";
+            const tseToolUseId = currentToolUse?.toolUseId;
+            const tseBehavior = tseToolName ? this.config.toolBehaviors?.[tseToolName] : undefined;
+
+            if (tseToolUseId && tseBehavior?.toolStreamEventHandler) {
+              try {
+                for await (const ev of tseBehavior.toolStreamEventHandler({
+                  toolUseId: tseToolUseId,
+                  toolName: tseToolName,
+                  streamData: data,
+                })) {
+                  if (ev != null) yield ev;
+                }
+              } catch (e) {
+                this._log.warn(
+                  `${LOG_PREFIX} toolStreamEventHandler failed for ${tseToolName}: ${_errorMessage(e)}`,
+                );
+              }
+            } else if (data && typeof data === "object" && "state" in data) {
               yield {
                 type: EventType.STATE_SNAPSHOT,
                 snapshot: (data as { state: Record<string, unknown> }).state,
@@ -1932,20 +2111,23 @@ export class StrandsAgent {
 
       // Interrupt-variant RUN_FINISHED. The STATE_SNAPSHOT +
       // MESSAGES_SNAPSHOT above precede this per interrupts.mdx §"State at
-      // the interrupt boundary". IDs are recorded on
+      // the interrupt boundary". Full interrupt objects are recorded on
       // `_pendingInterruptsByThread` for the `run()` resume gate.
       if (finalAgentResult?.stopReason === "interrupt") {
         const strandsInterrupts = finalAgentResult.interrupts ?? [];
         if (strandsInterrupts.length > 0) {
-          const interruptIds = strandsInterrupts.map((i) => i.id);
-          this._pendingInterruptsByThread.set(threadId, new Set(interruptIds));
+          const aguiInterrupts = strandsInterrupts.map(strandsInterruptToAgui);
+          const interruptMap = new Map<string, AguiInterrupt>();
+          for (const i of aguiInterrupts) interruptMap.set(i.id, i);
+          this._pendingInterruptsByThread.set(threadId, interruptMap);
+          this._lastResumeFingerprint.delete(threadId);
           yield {
             type: EventType.RUN_FINISHED,
             threadId: inputData.threadId,
             runId: inputData.runId,
             outcome: {
               type: "interrupt",
-              interrupts: strandsInterrupts.map(strandsInterruptToAgui),
+              interrupts: aguiInterrupts,
             },
           };
           return;
@@ -2386,7 +2568,9 @@ export class StrandsAgent {
     if (t.systemPrompt !== undefined) cfg.systemPrompt = t.systemPrompt;
     if (t.name !== undefined) cfg.name = t.name;
     if (t.description !== undefined) cfg.description = t.description;
-    if (t.id !== undefined) cfg.id = t.id;
+    // Always set a stable id so SessionManager can locate snapshots after
+    // the in-memory agent cache is cleared (stateless resume / restart).
+    cfg.id = t.id ?? this.name;
     if (t.appState !== undefined) cfg.appState = t.appState;
     if (t.modelState !== undefined) cfg.modelState = t.modelState;
     if (t.traceAttributes !== undefined)
@@ -2454,21 +2638,53 @@ function toResumeResponse(entry: ResumeEntry): unknown {
 /** Strands `Interrupt` → AG-UI `Interrupt`. */
 function strandsInterruptToAgui(interrupt: StrandsInterrupt): AguiInterrupt {
   const reasonRaw = interrupt.reason;
-  const reason =
-    typeof reasonRaw === "string" && reasonRaw.length > 0
-      ? reasonRaw
-      : "confirmation";
+  // Derive the AG-UI reason string: use raw string directly, or check for
+  // structured reason objects produced by the interruptOnCall hook.
+  let reason: string;
+  if (typeof reasonRaw === "string" && reasonRaw.length > 0) {
+    reason = reasonRaw;
+  } else if (
+    typeof reasonRaw === "object" &&
+    reasonRaw != null &&
+    (reasonRaw as Record<string, unknown>).tool_call
+  ) {
+    reason = "tool_call";
+  } else {
+    reason = "confirmation";
+  }
   const out: AguiInterrupt = { id: interrupt.id, reason };
   if (typeof reasonRaw === "string" && reasonRaw.length > 0) {
     out.message = reasonRaw;
-  } else if (reasonRaw != null) {
-    try {
-      out.message = JSON.stringify(reasonRaw);
-    } catch {
-      // non-serializable reason; leave message unset
+  } else if (typeof reasonRaw === "object" && reasonRaw != null) {
+    const tn = (reasonRaw as Record<string, unknown>).tool_name;
+    if (typeof tn === "string") {
+      out.message = `Approve call to ${tn}?`;
     }
   }
-  out.metadata = { strandsName: interrupt.name };
+  // Extract toolCallId from reason object if available
+  if (typeof reasonRaw === "object" && reasonRaw != null) {
+    const toolUseId = (reasonRaw as Record<string, unknown>).tool_use_id;
+    if (typeof toolUseId === "string") out.toolCallId = toolUseId;
+  }
+  // Add responseSchema for tool-bound and confirmation interrupts
+  if (
+    reason === "tool_call" ||
+    reason === "confirmation" ||
+    interrupt.name?.startsWith("ag_ui:tool_call:")
+  ) {
+    out.responseSchema = {
+      type: "object",
+      properties: { approved: { type: "boolean" } },
+      required: ["approved"],
+    };
+  }
+  const meta: Record<string, unknown> = { strandsName: interrupt.name };
+  if (typeof reasonRaw === "object" && reasonRaw != null) {
+    const r = reasonRaw as Record<string, unknown>;
+    if (r.tool_name) meta.tool_name = r.tool_name;
+    if (r.tool_input) meta.tool_input = r.tool_input;
+  }
+  out.metadata = meta;
   return out;
 }
 
@@ -2793,4 +3009,19 @@ export async function convertMessagesForStrandsSeed(
 
   flushToolResults();
   return out;
+}
+
+/** Recursively sort object keys for deterministic JSON serialization. */
+function _sortKeys(val: unknown): unknown {
+  if (val === null || typeof val !== "object") return val;
+  if (Array.isArray(val)) return val.map(_sortKeys);
+  return Object.keys(val as Record<string, unknown>)
+    .sort()
+    .reduce(
+      (acc, k) => {
+        acc[k] = _sortKeys((val as Record<string, unknown>)[k]);
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    );
 }

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -28,6 +28,7 @@ import {
   type AssistantMessage as AguiAssistantMessage,
   type BaseEvent,
   type Interrupt as AguiInterrupt,
+  InterruptSchema as AguiInterruptSchema,
   type Message as AguiMessage,
   type ResumeEntry,
   type RunAgentInput,
@@ -681,20 +682,20 @@ export class StrandsAgent {
           inputData.resume!.map((e) => [e.interruptId, e.status, _sortKeys(e.payload)]),
         ))
         .digest("hex");
-      if (this._lastResumeFingerprint.get(threadId) === fingerprint) {
-        yield _runStarted(inputData);
-        yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
-        return;
-      }
 
-      // Cold start with a session provider: the in-memory pending map is
-      // empty because the per-thread agent (and its SessionManager-restored
-      // native _interruptState) hasn't been constructed in this process
-      // yet. Restore it now — before deciding whether to skip validation —
-      // so an unknown/partial resume can't slip through solely because
-      // nothing has run on this process since the interrupt was raised.
+      // Cold-restart fallback: if this process has nothing cached in memory
+      // for this threadId, restore the per-thread agent first (so a
+      // SessionManager-backed appState can be read), then check whether the
+      // fingerprint/pending-interrupt bookkeeping was persisted there by a
+      // prior process (see loadPersistedInterruptBookkeeping doc above).
+      // Also covers cold-restart resume validation (comment 1): the agent
+      // must be restored before deciding whether to skip validation.
       let nativePendingIds: Set<string> | undefined;
-      if (!pending && this.config.sessionManagerProvider) {
+      if (
+        !pending &&
+        !this._lastResumeFingerprint.has(threadId) &&
+        this.config.sessionManagerProvider
+      ) {
         const restored = await this._ensureAgent(inputData, threadId);
         if ("error" in restored) {
           yield _runStarted(inputData);
@@ -707,9 +708,23 @@ export class StrandsAgent {
         if (interruptState?.activated && interruptState.interrupts) {
           nativePendingIds = new Set(interruptState.interrupts.keys());
         }
+        const { pending: persistedPending, fingerprint: persistedFingerprint } =
+          loadPersistedInterruptBookkeeping(restored.agent);
+        if (persistedPending) {
+          this._pendingInterruptsByThread.set(threadId, persistedPending);
+        }
+        if (persistedFingerprint) {
+          this._lastResumeFingerprint.set(threadId, persistedFingerprint);
+        }
         // Re-check the AG-UI-side map too: _ensureAgent may have raced with
         // another call that populated it while we awaited.
         pending = this._pendingInterruptsByThread.get(threadId);
+      }
+
+      if (this._lastResumeFingerprint.get(threadId) === fingerprint) {
+        yield _runStarted(inputData);
+        yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
+        return;
       }
 
       if (!pending && !nativePendingIds) {
@@ -722,10 +737,10 @@ export class StrandsAgent {
       }
 
       if (!pending && nativePendingIds) {
-        // Best-effort validation against the restored native interrupt
-        // IDs only (rules 2/3). The full AG-UI interrupt metadata needed
-        // for rules 6/7 — responseSchema, expiresAt — is adapter-memory
-        // only and was lost on restart; it cannot be recovered here.
+        // Best-effort validation against the restored native interrupt IDs
+        // only (rules 2/3) — used when persisted AG-UI bookkeeping wasn't
+        // available (e.g. no sessionManagerProvider configured) but
+        // Strands' own native interrupt state was still restored.
         const unknown = inputData
           .resume!.map((entry) => entry.interruptId)
           .filter((id) => !nativePendingIds!.has(id));
@@ -865,6 +880,10 @@ export class StrandsAgent {
     }
     if (!hadError && fingerprint) {
       this._lastResumeFingerprint.set(threadId, fingerprint);
+      const strandsAgent = this._agentsByThread.get(threadId);
+      if (strandsAgent) {
+        persistInterruptBookkeeping(strandsAgent, null, fingerprint, this._log);
+      }
     }
   }
 
@@ -1226,6 +1245,7 @@ export class StrandsAgent {
             }),
         );
         this._pendingInterruptsByThread.delete(threadId);
+        persistInterruptBookkeeping(strandsAgent, null, null, this._log);
       }
       if (replayHistory && resumeEntries.length === 0) {
         const nativeHistory = await _buildStrandsHistory(
@@ -2179,6 +2199,7 @@ export class StrandsAgent {
           for (const i of aguiInterrupts) interruptMap.set(i.id, i);
           this._pendingInterruptsByThread.set(threadId, interruptMap);
           this._lastResumeFingerprint.delete(threadId);
+          persistInterruptBookkeeping(strandsAgent, interruptMap, null, this._log);
           yield {
             type: EventType.RUN_FINISHED,
             threadId: inputData.threadId,
@@ -2691,6 +2712,118 @@ function toResumeResponse(entry: ResumeEntry): unknown {
     return { status: "cancelled" };
   }
   return entry.payload as unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Interrupt bookkeeping persistence
+// ---------------------------------------------------------------------------
+//
+// `_pendingInterruptsByThread` and `_lastResumeFingerprint` are the
+// adapter's own bookkeeping (idempotency fingerprint + AG-UI-specific
+// interrupt metadata like responseSchema/expiresAt) layered on top of
+// Strands' native `_interruptState`. Strands' own SessionManager already
+// persists/restores `_interruptState`, but this adapter-only bookkeeping
+// lived purely in an in-process Map, so a process restart lost it: rules
+// 6/7 (payload-schema validation, expiresAt enforcement) would silently
+// degrade, and a replayed resume request would no longer be recognized as
+// a duplicate and could re-invoke the model/tool.
+//
+// To survive a restart, this bookkeeping is now mirrored into
+// `strandsAgent.appState` under a single namespaced key — the same
+// per-thread, SessionManager-persisted key-value store available on every
+// Strands `Agent`. On every read, if nothing is cached in-process for this
+// threadId, fall back to what's persisted in appState.
+
+const INTERRUPT_BOOKKEEPING_STATE_KEY = "ag_ui_interrupt_bookkeeping";
+
+interface PersistedInterruptBookkeeping {
+  lastResumeFingerprint: string | null;
+  pendingInterrupts: Record<string, unknown>;
+}
+
+/**
+ * Read the persisted (fingerprint, pending-interrupts) pair from
+ * `strandsAgent.appState`, if present and well-formed.
+ *
+ * Defensive by design: a test double (e.g. a bare stub standing in for the
+ * Strands agent) may not have a real `appState`, or `appState.get(...)`
+ * could return something unexpected — every layer of the expected shape is
+ * checked explicitly before trusting it. Anything that doesn't match is
+ * treated as "nothing persisted" rather than thrown.
+ */
+function loadPersistedInterruptBookkeeping(
+  strandsAgent: unknown,
+): { pending: Map<string, AguiInterrupt> | null; fingerprint: string | null } {
+  try {
+    const appState = (strandsAgent as { appState?: unknown })?.appState as
+      | { get?: (key: string) => unknown }
+      | undefined;
+    if (!appState || typeof appState.get !== "function") {
+      return { pending: null, fingerprint: null };
+    }
+    const raw = appState.get(INTERRUPT_BOOKKEEPING_STATE_KEY);
+    if (!raw || typeof raw !== "object") {
+      return { pending: null, fingerprint: null };
+    }
+    const data = raw as Partial<PersistedInterruptBookkeeping>;
+
+    const fingerprint =
+      typeof data.lastResumeFingerprint === "string"
+        ? data.lastResumeFingerprint
+        : null;
+
+    let pending: Map<string, AguiInterrupt> | null = null;
+    if (data.pendingInterrupts && typeof data.pendingInterrupts === "object") {
+      pending = new Map();
+      for (const [id, value] of Object.entries(data.pendingInterrupts)) {
+        const parsed = AguiInterruptSchema.safeParse(value);
+        if (parsed.success) {
+          pending.set(id, parsed.data);
+        }
+      }
+    }
+    return { pending, fingerprint };
+  } catch {
+    return { pending: null, fingerprint: null };
+  }
+}
+
+/**
+ * Write the (fingerprint, pending-interrupts) pair to `strandsAgent.appState`
+ * so it survives a process restart via whatever SessionManager is wired up.
+ * Best-effort: a test double without a real `appState.set(...)` must never
+ * break the run over bookkeeping that's a durability nice-to-have, not a
+ * correctness requirement for the current process.
+ */
+function persistInterruptBookkeeping(
+  strandsAgent: unknown,
+  pending: Map<string, AguiInterrupt> | null,
+  fingerprint: string | null,
+  log?: Logger,
+): void {
+  try {
+    const appState = (strandsAgent as { appState?: unknown })?.appState as
+      | { set?: (key: string, value: unknown) => void }
+      | undefined;
+    if (!appState || typeof appState.set !== "function") {
+      return;
+    }
+    const pendingInterrupts: Record<string, unknown> = {};
+    if (pending) {
+      for (const [id, interrupt] of pending) {
+        pendingInterrupts[id] = interrupt;
+      }
+    }
+    const payload: PersistedInterruptBookkeeping = {
+      lastResumeFingerprint: fingerprint,
+      pendingInterrupts,
+    };
+    appState.set(INTERRUPT_BOOKKEEPING_STATE_KEY, payload);
+  } catch (e) {
+    log?.warn(
+      `${LOG_PREFIX} Failed to persist interrupt bookkeeping to strandsAgent.appState: ${_errorMessage(e)}`,
+    );
+  }
 }
 
 /** Strands `Interrupt` → AG-UI `Interrupt`. */

--- a/integrations/aws-strands/typescript/src/config.ts
+++ b/integrations/aws-strands/typescript/src/config.ts
@@ -88,6 +88,18 @@ export function predictStateMappingToPayload(m: PredictStateMapping): {
   };
 }
 
+/** Context passed to toolStreamEventHandler hooks. */
+export interface ToolStreamEventContext {
+  toolUseId: string;
+  toolName: string;
+  streamData: unknown;
+}
+
+/** Handler for mid-execution tool stream events. Must return an async iterable. */
+export type ToolStreamEventHandler = (
+  ctx: ToolStreamEventContext,
+) => AsyncIterable<BaseEvent | null | undefined>;
+
 /** Declarative configuration for tool-specific handling. */
 export interface ToolBehavior {
   /**
@@ -110,6 +122,10 @@ export interface ToolBehavior {
   stateFromResult?: StateFromResult;
   /** Async iterator that can emit arbitrary AG-UI events in response to a result. */
   customResultHandler?: CustomResultHandler;
+  /** Interrupt before this tool executes, requiring human approval to proceed. */
+  interruptOnCall?: boolean;
+  /** Custom handler for mid-execution tool stream events. Suppresses default state snapshot behavior. */
+  toolStreamEventHandler?: ToolStreamEventHandler;
 }
 
 /** Top-level configuration for the Strands agent adapter. */

--- a/integrations/aws-strands/typescript/src/index.ts
+++ b/integrations/aws-strands/typescript/src/index.ts
@@ -48,6 +48,8 @@ export type {
   ToolCallContext,
   ToolCallContextExtras,
   ToolResultContext,
+  ToolStreamEventContext,
+  ToolStreamEventHandler,
   PredictStateMapping,
   SessionManagerProvider,
   StateContextBuilder,


### PR DESCRIPTION
## Summary

Implements the AG-UI interrupt protocol (rules 2–8 from interrupts.mdx) for the AWS Strands integration in both TypeScript and Python. This enables tool-level human-in-the-loop approval flows using Strands' native interrupt mechanism, with full resume/cancel/idempotency support and persistence across process restarts.

Fixes #1318

## Changes

### Interrupt core
- Add `StrandsInterruptHook` that registers a Strands `BeforeToolCallEvent` callback to trigger native interrupts for tools configured with `interrupt_on_call=True`
- Implement resume handling: validate interrupt IDs against Strands `_interrupt_state`, build `interruptResponse` dicts, and pass them to `stream_async()`/`stream()` for checkpoint resumption
- Cancellation/denial responses are forwarded to Strands via the normal stream path (not short-circuited), so native interrupt-state cleanup, hooks, and session persistence all execute normally

### Protocol rule enforcement
- Rule 2: reject unknown interrupt IDs
- Rule 3: all open interrupts must be addressed (partial resume rejected)
- Rule 4: pending interrupts block new input without resume
- Rule 5: idempotent resume replays return success without re-executing
- Rule 6: payload validation against `responseSchema` (type + required keys)
- Rule 7: `expiresAt` enforcement
- Rule 8: suppress ToolCallStart/Args/End for resumed tool-bound interrupts

### Interrupt classification
- Only adapter-raised interrupts (identified by the `ag_ui:tool_call:` name prefix) get the tool-approval shape with `responseSchema`
- Any other native interrupt (e.g. a user tool calling `event.interrupt()` directly) stays generic: its native name becomes the AG-UI reason, and its native reason payload is preserved in metadata

### Approval contract
- Strict `{"approved": true}` enforcement — only a dict with `approved` set to an actual `bool` of `True` grants approval; truthiness coercion is not accepted

### Bookkeeping persistence
- Idempotency fingerprints and pending-interrupt metadata (`responseSchema`, `expiresAt`, `toolCallId`) are mirrored into `strands_agent.state` under a namespaced key — the same SessionManager-backed per-thread store used for `agui_context`
- On cold start, bookkeeping is restored from persisted state before resume validation runs
- Defensive: validates persisted shape on read (malformed data → "nothing persisted", not a crash); best-effort on write (broken/absent state logs a warning, never fails the run)

### Config additions
- `interrupt_on_call` / `interruptOnCall` on `ToolBehavior`
- `ToolStreamEventHandler` and `ToolStreamEventContext` (Python and TS)
- Re-export `Interrupt`, `ResumeEntry`, `RunFinishedInterruptOutcome`, `RunFinishedSuccessOutcome` from the Python package

## Testing

- 44 test files in TypeScript, 15 in Python
- Added `test_interrupt_protocol.py` (739 lines) covering the full interrupt lifecycle
- Added `test_interrupt_bookkeeping_persistence.py` (259 lines) for persistence round-tripping with real state stores
- Added `test_tool_stream_event_handler.py` (315 lines) for the ToolStreamEventHandler
- Added `interrupt-bookkeeping-persistence.test.ts`, `interrupt-cold-restart.test.ts`, `interrupt-generic.test.ts` for TS
- Updated existing interrupt tests (`interrupt-native.test.ts`, `interrupt-rule-gate.test.ts`) to cover new scenarios
- Manually validated with test agents (Python + TS) exercising 10 end-to-end interrupt scenarios against a real Bedrock model

## Reviewer Notes

- Uses Strands' internal `_interrupt_state` attribute — this is the documented integration point but worth noting for future SDK version compatibility
- The fingerprint-based idempotency uses MD5 (non-security, for deduplication only)
- The `demo-viewer` build failure is pre-existing on main (unrelated module resolution issue) and not introduced by this branch