### PR TITLE
chore: pin langgraph examples pnpm

### DIFF
--- a/integrations/langgraph/python/examples/pyproject.toml
+++ b/integrations/langgraph/python/examples/pyproject.toml
@@ -20,18 +20,14 @@ dependencies = [
     "langgraph>=1.1.3,<2",
     # Pin: 0.7.97 requires DATABASE_URI at import time, breaking in-memory dev server
     "langgraph-api>=0.7.70,<0.7.97",
-    "ag-ui-langgraph",
-    "ag-ui-protocol",
+    "ag-ui-langgraph>=0.0.37",
+    "ag-ui-protocol>=0.1.18",
     "python-dotenv>=1.0.0",
     "fastapi>=0.115.12",
 ]
 
 [tool.uv]
 override-dependencies = ["langgraph>=1.1.3,<2"]
-
-[tool.uv.sources]
-ag-ui-langgraph = { path = "../", editable = true }
-ag-ui-protocol = { path = "../../../../sdks/python" }
 
 [project.scripts]
 dev = "agents.dojo:main"

--- a/integrations/langgraph/typescript/examples/package.json
+++ b/integrations/langgraph/typescript/examples/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "TypeScript examples for LangGraph agents with CopilotKit integration",
   "type": "module",
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "build": "tsc",
     "dev": "pnpx @langchain/langgraph-cli@1.1.13 dev",


### PR DESCRIPTION
Pins a bunch of versions to enable deploying these example agents