### PR TITLE
fix(strands): detect private session manager

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -690,10 +690,11 @@ class StrandsAgent:
             # turn and the LLM re-fires the same tool every run, producing
             # the "chart loops forever" symptom. With a session manager,
             # Strands manages history itself, so we leave it alone.
-            replay_history = (
-                self.config.replay_history_into_strands
-                and getattr(strands_agent, "session_manager", None) is None
+            has_session_manager = (
+                getattr(strands_agent, "session_manager", None) is not None
+                or getattr(strands_agent, "_session_manager", None) is not None
             )
+            replay_history = self.config.replay_history_into_strands and not has_session_manager
             if replay_history:
                 native_history = _build_strands_history(input_data.messages)
                 # Apply ``state_context_builder`` to the last user-text

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from strands.session import SessionManager
 
-from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core import EventType, RunAgentInput, UserMessage
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig
 
@@ -21,12 +21,16 @@ def _mock_session_manager() -> MagicMock:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_run_input(thread_id: str | None = "thread-1", run_id: str = "run-1") -> RunAgentInput:
+def _make_run_input(
+    thread_id: str | None = "thread-1",
+    run_id: str = "run-1",
+    messages: list | None = None,
+) -> RunAgentInput:
     return RunAgentInput(
         thread_id=thread_id,
         run_id=run_id,
         state={},
-        messages=[],
+        messages=[] if messages is None else messages,
         tools=[],
         context=[],
         forwarded_props={},
@@ -65,6 +69,20 @@ def _make_mock_instance():
     instance.tool_registry.registry = {}
     instance.stream_async = MagicMock(side_effect=lambda _: _empty_async_gen())
     return instance
+
+
+class _CoreWithPrivateSessionManager:
+    def __init__(self, session_manager):
+        self._session_manager = session_manager
+        self.state = MagicMock()
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.stream_inputs = []
+
+    async def stream_async(self, message):
+        self.stream_inputs.append(message)
+        if False:
+            yield
 
 
 # ---------------------------------------------------------------------------
@@ -236,3 +254,21 @@ class TestSessionManagerProvider:
         event_types = [e.type for e in events]
         assert EventType.RUN_FINISHED in event_types
         assert any("returned None" in msg for msg in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_private_session_manager_disables_history_replay(self):
+        """Strands Agent stores SessionManager on _session_manager."""
+        mock_session_manager = _mock_session_manager()
+        provider = MagicMock(return_value=mock_session_manager)
+        agent = _make_base_agent(session_manager_provider=provider)
+        input_data = _make_run_input(
+            thread_id="private-sm",
+            messages=[UserMessage(id="u1", content="hello")],
+        )
+        instance = _CoreWithPrivateSessionManager(mock_session_manager)
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=instance):
+            events = await _collect_events(agent, input_data)
+
+        assert EventType.RUN_FINISHED in [event.type for event in events]
+        assert instance.stream_inputs == ["hello"]


### PR DESCRIPTION
﻿### Summary

Fixes #1823.

`ag_ui_strands` only checked `strands_agent.session_manager` before deciding whether to replay AG-UI history into the Strands agent. The single-agent Strands path stores the manager as `_session_manager`, so the adapter replayed history even when a per-thread `SessionManager` was wired.

This change treats both forms as an active session manager:

- `session_manager` for Graph / Swarm-style agents
- `_session_manager` for the regular Strands `Agent`

When either exists, the adapter leaves history ownership to Strands and passes the current user message to `stream_async(...)` instead of `None`.

### To verify

- `python -m py_compile src/ag_ui_strands/agent.py tests/test_session_manager.py`
- `uv run pytest tests/test_session_manager.py -q`
- `uv run pytest tests -q`
- `git diff --check`
