### PR TITLE
fix(strands): detect private session manager

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -60,6 +60,13 @@ def _extract_agent_kwargs(agent: StrandsAgentCore) -> dict:
     return kwargs
 
 
+def _has_strands_session_manager(agent: Any) -> bool:
+    return (
+        getattr(agent, "session_manager", None) is not None
+        or getattr(agent, "_session_manager", None) is not None
+    )
+
+
 logger = logging.getLogger(__name__)
 from ag_ui.core import (
     AssistantMessage,
@@ -692,7 +699,7 @@ class StrandsAgent:
             # Strands manages history itself, so we leave it alone.
             replay_history = (
                 self.config.replay_history_into_strands
-                and getattr(strands_agent, "session_manager", None) is None
+                and not _has_strands_session_manager(strands_agent)
             )
             if replay_history:
                 native_history = _build_strands_history(input_data.messages)

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from strands.session import SessionManager
 
-from ag_ui.core import EventType, RunAgentInput
+from ag_ui.core import EventType, RunAgentInput, UserMessage
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig
 
@@ -21,12 +21,16 @@ def _mock_session_manager() -> MagicMock:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_run_input(thread_id: str | None = "thread-1", run_id: str = "run-1") -> RunAgentInput:
+def _make_run_input(
+    thread_id: str | None = "thread-1",
+    run_id: str = "run-1",
+    messages=None,
+) -> RunAgentInput:
     return RunAgentInput(
         thread_id=thread_id,
         run_id=run_id,
         state={},
-        messages=[],
+        messages=messages or [],
         tools=[],
         context=[],
         forwarded_props={},
@@ -65,6 +69,19 @@ def _make_mock_instance():
     instance.tool_registry.registry = {}
     instance.stream_async = MagicMock(side_effect=lambda _: _empty_async_gen())
     return instance
+
+
+class _MockStrandsAgentWithPrivateSessionManager:
+    def __init__(self, session_manager):
+        self._session_manager = session_manager
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.stream_prompts = []
+
+    async def stream_async(self, prompt):
+        self.stream_prompts.append(prompt)
+        return
+        yield  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------
@@ -236,3 +253,20 @@ class TestSessionManagerProvider:
         event_types = [e.type for e in events]
         assert EventType.RUN_FINISHED in event_types
         assert any("returned None" in msg for msg in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_private_session_manager_disables_replay_history(self):
+        mock_session_manager = _mock_session_manager()
+        provider = MagicMock(return_value=mock_session_manager)
+        agent = _make_base_agent(session_manager_provider=provider)
+        input_data = _make_run_input(
+            messages=[UserMessage(id="u1", content="hello from user")]
+        )
+
+        instance = _MockStrandsAgentWithPrivateSessionManager(mock_session_manager)
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert instance.stream_prompts == ["hello from user"]
+        assert not hasattr(instance, "messages")


### PR DESCRIPTION
﻿## Summary
- treat Strands' private `_session_manager` as an active session manager when deciding whether to replay AG-UI history
- keep support for objects that expose a public `session_manager`
- add a regression test for the `session_manager_provider` path where Strands stores the manager privately

Fixes #1823.

## Test plan
- python -m venv .venv
- .\.venv\Scripts\python.exe -m pip install -e . pytest pytest-asyncio
- .\.venv\Scripts\python.exe -m py_compile src\ag_ui_strands\agent.py tests\test_session_manager.py
- .\.venv\Scripts\python.exe -m pytest tests\test_session_manager.py -q
- .\.venv\Scripts\python.exe -m pytest -q
