### PR TITLE
fix(langgraph): preserve multimodal metadata

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -184,6 +184,13 @@ def _media_source_to_url(source: Union[InputContentDataSource, InputContentUrlSo
     return None
 
 
+def _with_input_metadata(content: Dict[str, Any], item: AGUIContentItem) -> Dict[str, Any]:
+    metadata = getattr(item, "metadata", None)
+    if metadata is not None:
+        content["metadata"] = metadata
+    return content
+
+
 def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List[Dict[str, Any]]:
     """Convert AG-UI multimodal content to LangChain's multimodal format.
 
@@ -202,10 +209,10 @@ def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List
         elif isinstance(item, _MEDIA_CONTENT_TYPES):
             url = _media_source_to_url(item.source)
             if url:
-                langchain_content.append({
+                langchain_content.append(_with_input_metadata({
                     "type": "image_url",
                     "image_url": {"url": url}
-                })
+                }, item))
             else:
                 logger.warning("Dropping %s content: source could not be converted to URL", type(item).__name__)
         elif isinstance(item, BinaryInputContent):

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -135,6 +135,24 @@ class TestMultimodalConversion(unittest.TestCase):
         self.assertEqual(content[1]["type"], "image_url")
         self.assertEqual(content[1]["image_url"]["url"], "https://example.com/photo.jpg")
 
+    def test_agui_media_metadata_to_langchain(self):
+        content_list = [
+            ImageInputContent(
+                type="image",
+                source=InputContentUrlSource(
+                    type="url",
+                    value="https://example.com/photo.jpg",
+                ),
+                metadata={"filename": "photo.jpg", "source": "upload"},
+            ),
+        ]
+
+        lc_content = convert_agui_multimodal_to_langchain(content_list)
+
+        self.assertEqual(lc_content[0]["type"], "image_url")
+        self.assertEqual(lc_content[0]["image_url"]["url"], "https://example.com/photo.jpg")
+        self.assertEqual(lc_content[0]["metadata"], {"filename": "photo.jpg", "source": "upload"})
+
     def test_agui_image_data_source_to_langchain(self):
         """Test converting ImageInputContent with data source to LangChain."""
         agui_message = UserMessage(


### PR DESCRIPTION
﻿## Summary
- preserve metadata from typed AG-UI media content when converting to LangChain multimodal blocks
- keep the existing image_url mapping and legacy BinaryInputContent behavior unchanged
- add a regression for ImageInputContent metadata

Fixes #1809

## To verify
- `.\.venv\Scripts\python.exe -m py_compile ag_ui_langgraph\utils.py tests\test_multimodal.py`
- `.\.venv\Scripts\python.exe -m pytest tests\test_multimodal.py -q`
- `.\.venv\Scripts\python.exe -m pytest -q`
