### PR TITLE
fix(langgraph): preserve multimodal input metadata

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -184,6 +184,16 @@ def _media_source_to_url(source: Union[InputContentDataSource, InputContentUrlSo
     return None
 
 
+def _attach_input_metadata(
+    content_block: Dict[str, Any],
+    item: AGUIContentItem,
+) -> Dict[str, Any]:
+    metadata = getattr(item, "metadata", None)
+    if metadata is not None:
+        content_block["metadata"] = metadata
+    return content_block
+
+
 def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List[Dict[str, Any]]:
     """Convert AG-UI multimodal content to LangChain's multimodal format.
 
@@ -195,17 +205,17 @@ def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List
     langchain_content: List[Dict[str, Any]] = []
     for item in content:
         if isinstance(item, TextInputContent):
-            langchain_content.append({
+            langchain_content.append(_attach_input_metadata({
                 "type": "text",
                 "text": item.text
-            })
+            }, item))
         elif isinstance(item, _MEDIA_CONTENT_TYPES):
             url = _media_source_to_url(item.source)
             if url:
-                langchain_content.append({
+                langchain_content.append(_attach_input_metadata({
                     "type": "image_url",
                     "image_url": {"url": url}
-                })
+                }, item))
             else:
                 logger.warning("Dropping %s content: source could not be converted to URL", type(item).__name__)
         elif isinstance(item, BinaryInputContent):

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -162,6 +162,29 @@ class TestMultimodalConversion(unittest.TestCase):
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
         )
 
+    def test_agui_input_metadata_to_langchain(self):
+        """Test preserving AG-UI InputContent metadata in LangChain blocks."""
+        content_list = [
+            TextInputContent(
+                type="text",
+                text="Describe this image",
+                metadata={"source": "prompt"},
+            ),
+            ImageInputContent(
+                type="image",
+                source=InputContentUrlSource(
+                    type="url",
+                    value="https://example.com/photo.jpg",
+                ),
+                metadata={"provider_hint": "vision"},
+            ),
+        ]
+
+        lc_content = convert_agui_multimodal_to_langchain(content_list)
+
+        self.assertEqual(lc_content[0]["metadata"], {"source": "prompt"})
+        self.assertEqual(lc_content[1]["metadata"], {"provider_hint": "vision"})
+
     # ── AudioInputContent ───────────────────────────────────────────────
 
     def test_agui_audio_url_source_to_langchain(self):


### PR DESCRIPTION
﻿## Summary

Preserve AG-UI `InputContent.metadata` when converting multimodal content into LangChain blocks.

The LangGraph adapter currently keeps the text/media payload but drops metadata attached to typed AG-UI input content. That loses provider hints and caller annotations before the message reaches LangChain.

## Changes

- copy `metadata` from `TextInputContent` and typed media input blocks into the LangChain content block
- add a regression test covering both text and image input metadata

## To verify

```bash
cd integrations/langgraph/python
uv run python -m pytest tests/test_multimodal.py -q
uv run python -m py_compile ag_ui_langgraph/utils.py tests/test_multimodal.py
```

Also ran `git diff --check` from the repo root.

Fixes #1809
