### PR TITLE
fix(client): preserve compacted state across flushes

### DIFF
--- a/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
+++ b/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
@@ -390,6 +390,54 @@ describe("Event Compaction", () => {
       expect(compacted[5].type).toBe(EventType.RUN_FINISHED);
     });
 
+    it("should seed later state flushes from the previous compacted state", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { run_log: [] } },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "add", path: "/run_log/-", value: { kind: "token", text: "hi" } }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "add", path: "/run_log/-", value: { kind: "token", text: "there" } }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(6);
+      expect((compacted[1] as StateSnapshotEvent).snapshot).toEqual({
+        run_log: [{ kind: "token", text: "hi" }],
+      });
+      expect((compacted[4] as StateSnapshotEvent).snapshot).toEqual({
+        run_log: [
+          { kind: "token", text: "hi" },
+          { kind: "token", text: "there" },
+        ],
+      });
+    });
+
+    it("should let snapshots replace the running compacted state", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { stale: true } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { fresh: true } },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/extra", value: 1 }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const compacted = compactEvents(events);
+
+      expect(compacted).toHaveLength(6);
+      expect((compacted[4] as StateSnapshotEvent).snapshot).toEqual({ fresh: true, extra: 1 });
+    });
+
     it("should not emit state snapshot when no state events in run", () => {
       const events = [
         { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },

--- a/sdks/typescript/packages/client/src/compact/compact.ts
+++ b/sdks/typescript/packages/client/src/compact/compact.ts
@@ -47,6 +47,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
 
   // State compaction: collects state events, flushed at RUN_STARTED (pre-run/inter-run), RUN_FINISHED/RUN_ERROR (in-run), and at end (trailing)
   let stateEvents: (StateSnapshotEvent | StateDeltaEvent)[] = [];
+  let runningState: any = {};
 
   for (const event of events) {
     // Handle text message streaming events
@@ -138,21 +139,15 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       pendingToolCalls.delete(toolCallId);
     } else if (event.type === EventType.RUN_STARTED) {
       // Flush any pre-run state events before starting a new run
-      flushState(stateEvents, compacted);
+      runningState = flushState(stateEvents, compacted, runningState);
       stateEvents = [];
       compacted.push(event);
-    } else if (
-      event.type === EventType.RUN_FINISHED ||
-      event.type === EventType.RUN_ERROR
-    ) {
+    } else if (event.type === EventType.RUN_FINISHED || event.type === EventType.RUN_ERROR) {
       // Flush compacted state into output before the run boundary event
-      flushState(stateEvents, compacted);
+      runningState = flushState(stateEvents, compacted, runningState);
       stateEvents = [];
       compacted.push(event);
-    } else if (
-      event.type === EventType.STATE_SNAPSHOT ||
-      event.type === EventType.STATE_DELTA
-    ) {
+    } else if (event.type === EventType.STATE_SNAPSHOT || event.type === EventType.STATE_DELTA) {
       // Collect state events for compaction
       stateEvents.push(event as StateSnapshotEvent | StateDeltaEvent);
     } else {
@@ -199,7 +194,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
   }
 
   // Flush any remaining state events (incomplete run or events outside runs)
-  flushState(stateEvents, compacted);
+  flushState(stateEvents, compacted, runningState);
 
   return compacted;
 }
@@ -285,12 +280,13 @@ function flushToolCall(
 function flushState(
   stateEvents: (StateSnapshotEvent | StateDeltaEvent)[],
   compacted: BaseEvent[],
-): void {
+  initialState: any = {},
+): any {
   if (stateEvents.length === 0) {
-    return;
+    return initialState;
   }
 
-  let state: any = {};
+  let state: any = structuredClone_(initialState);
 
   for (const event of stateEvents) {
     if (event.type === EventType.STATE_SNAPSHOT) {
@@ -307,4 +303,5 @@ function flushState(
   };
 
   compacted.push(compactedSnapshot);
+  return state;
 }


### PR DESCRIPTION
﻿## Summary

Fixes #1720 by keeping the compacted state from the previous `flushState` call as the seed for the next one in the same `compactEvents` pass.

That keeps JSON Patch deltas like `add /run_log/-` valid when a stream is split across run boundaries or other flush points. An explicit `STATE_SNAPSHOT` still replaces the running state, so snapshot reset semantics stay the same.

## Tests

```
pnpm --filter @ag-ui/client test -- compact.test.ts
pnpm exec prettier --check sdks/typescript/packages/client/src/compact/compact.ts sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
git diff --check -- sdks/typescript/packages/client/src/compact/compact.ts sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
```

Also tried `pnpm --filter @ag-ui/client typecheck`; it currently fails on existing package-level test/global type setup and workspace type resolution (`describe`/`expect`, `@ag-ui/core`), outside these two changed files.
