### PR TITLE
chore(release): add middleware-mcp release scope

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,6 +34,7 @@ on:
           - integration-spring-ai
           - middleware-a2a
           - middleware-a2ui
+          - middleware-mcp
           - middleware-mcp-apps
           - sdk-py
           - sdk-ts

--- a/nx.json
+++ b/nx.json
@@ -28,7 +28,8 @@
       "@ag-ui/watsonx",
       "@ag-ui/a2a-middleware",
       "@ag-ui/a2ui-middleware",
-      "@ag-ui/mcp-apps-middleware"
+      "@ag-ui/mcp-apps-middleware",
+      "@ag-ui/mcp-middleware"
     ]
   },
   "namedInputs": {

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -173,6 +173,13 @@
       "packages": [
         { "name": "@ag-ui/mcp-apps-middleware", "path": "middlewares/mcp-apps-middleware", "ecosystem": "typescript" }
       ]
+    },
+    "middleware-mcp": {
+      "description": "MCP Middleware (TypeScript)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "@ag-ui/mcp-middleware", "path": "middlewares/mcp-middleware", "ecosystem": "typescript" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Adds a `middleware-mcp` release scope so the new `@ag-ui/mcp-middleware` package can be released through the standard tooling.

The package was merged in #1818 but was never wired into the release config, so it doesn't appear in the `release / create-pr` workflow's scope dropdown and can't be version-bumped/published.

## Changes

- **`scripts/release/release.config.json`** — add `middleware-mcp` scope mapping `@ag-ui/mcp-middleware` → `middlewares/mcp-middleware` (the source of truth the release script reads).
- **`.github/workflows/prepare-release.yml`** — add `middleware-mcp` to the `scope` dropdown options so it's selectable in the UI.

## Verification

Dry run on this branch:

```
[middleware-mcp] @ag-ui/mcp-middleware: 0.0.1 -> 0.0.2
```

> Note: the dropdown reads from `main`, so `middleware-mcp` will only appear in the workflow UI after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)