### PR TITLE
chore(kotlin-sdk): bump community SDK to 0.4.1

### DIFF
--- a/sdks/community/kotlin/CHANGELOG.md
+++ b/sdks/community/kotlin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-02
+
 ### Added
 - **Interrupts** ([AG-UI spec](https://docs.ag-ui.com/concepts/interrupts)). The Kotlin SDK now models the interrupt protocol that the TypeScript and Python SDKs already ship. Without this change a Kotlin client connected to an interrupt-aware server would either fail polymorphic deserialization of `outcome` or silently drop the interrupt payload on a `RUN_FINISHED` event.
   - New types in `com.agui.core.types`:
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Examples
 - Chatapp surfaces `REASONING_*` events as a transient "💭 Reasoning…" bubble (new `MessageRole.REASONING` + `EphemeralType.REASONING`), mirroring the existing tool-call / step ephemeral pattern. Clears on `RUN_FINISHED`, run cancel, or run error. Handles `REASONING_START` / `REASONING_END`, `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END`, and `REASONING_MESSAGE_CHUNK`.
-- Bump all Kotlin sample apps (chatapp, chatapp-java, chatapp-wearos, chatapp-swiftui, tools) from `agui-core 0.3.0` to `0.4.0` and consume the published artefacts from Maven by removing the `includeBuild("../../library")` + dependencySubstitution blocks from the four chatapp variants' settings files.
+- Bump all Kotlin sample apps (chatapp, chatapp-java, chatapp-wearos, chatapp-swiftui, tools) from `agui-core 0.3.0` to `0.4.1` and consume the published artefacts from Maven by removing the `includeBuild("../../library")` + dependencySubstitution blocks from the four chatapp variants' settings files.
 - Bump chatapp Kotlin `2.1.20 → 2.2.20` so the iOS targets can consume `com.mikepenz:multiplatform-markdown-renderer-m3:0.37.0` klibs (require ABI 2.2.0+).
 
 ## [0.4.0] - 2026-05-12

--- a/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-java/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.4.0"
+agui-core = "0.4.1"
 a2ui4k = "0.8.1"
 appcompat = "1.7.1"
 core = "1.6.1"

--- a/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-swiftui/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.4.0"
+agui-core = "0.4.1"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp-wearos/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.4.0"
+agui-core = "0.4.1"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/chatapp/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.4.0"
+agui-core = "0.4.1"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
+++ b/sdks/community/kotlin/examples/tools/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity-compose = "1.10.1"
-agui-core = "0.4.0"
+agui-core = "0.4.1"
 appcompat = "1.7.1"
 core = "1.6.1"
 core-ktx = "1.16.0"

--- a/sdks/community/kotlin/library/build.gradle.kts
+++ b/sdks/community/kotlin/library/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 //   - publish.sh script (reads dynamically)
 //   - GitHub Actions workflow (reads dynamically)
 // Only update these values here - they propagate automatically
-version = "0.4.0"
+version = "0.4.1"
 group = "com.ag-ui.community"
 
 allprojects {


### PR DESCRIPTION
## Summary

Bumps the community **Kotlin SDK** from `0.4.0` → `0.4.1` and cuts the pending CHANGELOG into a dated release.

- **Version** — `0.4.0` → `0.4.1` in `library/build.gradle.kts`, the single source of truth that `publish.sh`, the `publish-kotlin-sdk.yml` CI workflow, JReleaser, and all subprojects read dynamically. (The legacy `0.1.0` in the root `build.gradle.kts` is a separate, unused build and is left untouched.)
- **CHANGELOG** — the pending `[Unreleased]` section is cut into `## [0.4.1] - 2026-06-02`, leaving a fresh empty `[Unreleased]` placeholder. The release notes carry the **Interrupts** feature (#1802) plus the example/Reasoning updates already staged under `[Unreleased]`.
- **Examples** — all five sample-app version catalogs (chatapp, chatapp-java, chatapp-swiftui, chatapp-wearos, tools) now point `agui-core` at `0.4.1`. Each catalog uses a single `agui-core` version key that every `com.ag-ui.community:kotlin-*` module resolves through.

## ⚠️ Note

The examples now reference artifacts that don't exist yet — **they will not build until `0.4.1` is published to Maven Central.** This is expected for a pre-publish version bump.

## Files changed (7)

- `sdks/community/kotlin/library/build.gradle.kts` — version bump
- `sdks/community/kotlin/CHANGELOG.md` — 0.4.1 release cut
- `sdks/community/kotlin/examples/{chatapp,chatapp-java,chatapp-swiftui,chatapp-wearos,tools}/gradle/libs.versions.toml` — `agui-core` → 0.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)