### PR TITLE
fix(strands): bundle replayed tool results

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -190,8 +190,30 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
     than a fresh prompt that re-fires the same tool every turn.
     """
     out: List[Dict[str, Any]] = []
+    pending_tool_results: List[Dict[str, Any]] = []
+
+    def flush_tool_results() -> None:
+        if not pending_tool_results:
+            return
+        out.append({"role": "user", "content": list(pending_tool_results)})
+        pending_tool_results.clear()
+
     for msg in input_messages or []:
         role = getattr(msg, "role", None)
+        if role == "tool":
+            pending_tool_results.append(
+                {
+                    "toolResult": {
+                        "toolUseId": getattr(msg, "tool_call_id", "") or "",
+                        "content": [{"text": _coerce_text(msg.content)}],
+                        "status": "success",
+                    }
+                }
+            )
+            continue
+
+        flush_tool_results()
+
         if role == "user":
             content = msg.content
             if isinstance(content, list):
@@ -238,21 +260,8 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
             if not blocks:
                 blocks = [{"text": ""}]
             out.append({"role": "assistant", "content": blocks})
-        elif role == "tool":
-            out.append(
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "toolResult": {
-                                "toolUseId": getattr(msg, "tool_call_id", "") or "",
-                                "content": [{"text": _coerce_text(msg.content)}],
-                                "status": "success",
-                            }
-                        }
-                    ],
-                }
-            )
+
+    flush_tool_results()
     return out
 
 

--- a/integrations/aws-strands/python/tests/test_parallel_tool_call_handling.py
+++ b/integrations/aws-strands/python/tests/test_parallel_tool_call_handling.py
@@ -38,7 +38,7 @@ from ag_ui.core import (
 )
 from strands.tools.registry import ToolRegistry
 
-from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.agent import StrandsAgent, _build_strands_history
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 
 
@@ -96,6 +96,51 @@ def _run_input(
 
 async def _collect(agent: StrandsAgent, inp: RunAgentInput) -> list:
     return [e async for e in agent.run(inp)]
+
+
+def test_strands_history_bundles_parallel_tool_results():
+    messages = [
+        UserMessage(id="u1", role="user", content="hi"),
+        AssistantMessage(
+            id="a1",
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="tooluse_1",
+                    type="function",
+                    function=FunctionCall(name="my_tool", arguments="{}"),
+                ),
+                ToolCall(
+                    id="tooluse_2",
+                    type="function",
+                    function=FunctionCall(name="my_tool", arguments="{}"),
+                ),
+                ToolCall(
+                    id="tooluse_3",
+                    type="function",
+                    function=FunctionCall(name="my_tool", arguments="{}"),
+                ),
+            ],
+        ),
+        ToolMessage(id="t1", role="tool", tool_call_id="tooluse_1", content='{"ok":1}'),
+        ToolMessage(id="t2", role="tool", tool_call_id="tooluse_2", content='{"ok":2}'),
+        ToolMessage(id="t3", role="tool", tool_call_id="tooluse_3", content='{"ok":3}'),
+    ]
+
+    native = _build_strands_history(messages)
+
+    assert len(native) == 3
+    assert native[2]["role"] == "user"
+    tool_results = [
+        block["toolResult"] for block in native[2]["content"] if "toolResult" in block
+    ]
+    assert len(tool_results) == 3
+    assert {result["toolUseId"] for result in tool_results} == {
+        "tooluse_1",
+        "tooluse_2",
+        "tooluse_3",
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1847.

When AG-UI history is replayed into Strands, each AG-UI tool message currently becomes its own Strands user message. That breaks Bedrock Converse for parallel tool calls: after one assistant message with multiple toolUse blocks, Bedrock expects the matching toolResult blocks in one following user message.

This changes `_build_strands_history()` to accumulate consecutive AG-UI tool messages and flush them as one Strands user message. Non-tool messages still flush pending results before being converted, so the message order is preserved.

Validation:
- .venv\Scripts\python.exe -m pytest tests\test_parallel_tool_call_handling.py -q -k "bundles_parallel_tool_results"
- .venv\Scripts\python.exe -m pytest tests\test_parallel_tool_call_handling.py -q
- .venv\Scripts\python.exe -m py_compile src\ag_ui_strands\agent.py tests\test_parallel_tool_call_handling.py
- git diff --check

Notes:
- `ruff check src\ag_ui_strands\agent.py tests\test_parallel_tool_call_handling.py` is blocked by existing baseline issues on main: E402 import ordering in `agent.py`, an unrelated unused `e` at `agent.py:1558`, and an existing unused `pytest` import in the test file.
- `ruff format --check ...` would reformat broad pre-existing sections of these files, so I did not run whole-file formatting for this scoped fix.
