### PR TITLE
fix: skip missing-payload chunks instead of aborting stream (#1635)

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/edge-cases.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/edge-cases.test.ts
@@ -639,5 +639,74 @@ describe("event emission details (fake-only)", () => {
 
       warnSpy.mockRestore();
     });
+
+    it("recognizes text-start / text-end / tool-output without warning (#1635, #836)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const agent = makeLocalMastraAgent({
+        streamChunks: [
+          { type: "text-start", payload: { id: "t1" } },
+          { type: "text-delta", payload: { text: "Hi" } },
+          { type: "text-end", payload: { id: "t1" } },
+          { type: "tool-output", payload: { output: "interim" } },
+          { type: "finish", payload: { finishReason: "stop" } },
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput());
+
+      // Text still flows and the run completes.
+      expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+      const joinedText = events
+        .filter(
+          (e): e is TextMessageChunkEvent =>
+            e.type === EventType.TEXT_MESSAGE_CHUNK,
+        )
+        .map((e) => e.delta ?? "")
+        .join("");
+      expect(joinedText).toContain("Hi");
+
+      // None of these recognized types hit the `default:` warn flood.
+      const warnedTypes = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(
+        warnedTypes.some(
+          (m) =>
+            m.includes("Unrecognized stream chunk type") &&
+            (m.includes("text-start") ||
+              m.includes("text-end") ||
+              m.includes("tool-output")),
+        ),
+      ).toBe(false);
+
+      warnSpy.mockRestore();
+    });
+
+    it("warns at most once per payload-less chunk type (no log flood)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const agent = makeLocalMastraAgent({
+        streamChunks: [
+          { type: "data-workspace-metadata", data: { n: 1 } },
+          { type: "data-workspace-metadata", data: { n: 2 } },
+          { type: "data-workspace-metadata", data: { n: 3 } },
+          { type: "finish", payload: { finishReason: "stop" } },
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput());
+
+      expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+
+      const skipWarns = warnSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter(
+          (m) =>
+            m.includes("Skipping stream chunk without payload") &&
+            m.includes("data-workspace-metadata"),
+        );
+      expect(skipWarns).toHaveLength(1);
+
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/integrations/mastra/typescript/src/__tests__/edge-cases.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/edge-cases.test.ts
@@ -603,4 +603,41 @@ describe("event emission details (fake-only)", () => {
     // Step 1 and Step 3 text must have distinct messageIds
     expect(textChunks[0].messageId).not.toBe(textChunks[1].messageId);
   });
+
+  describe("custom-data / missing-payload chunks (#1635)", () => {
+    it("skips a custom-data chunk lacking a payload instead of aborting the stream", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const agent = makeLocalMastraAgent({
+        streamChunks: [
+          { type: "text-delta", payload: { text: "Hello" } },
+          // Mastra 1.31 custom-data chunk: carries `data`, no `payload`.
+          {
+            type: "data-workspace-metadata",
+            data: { workspaceId: "ws-1", title: "My Workspace" },
+          },
+          { type: "text-delta", payload: { text: " world" } },
+          { type: "finish", payload: { finishReason: "stop" } },
+        ],
+      });
+
+      const events = await collectEvents(agent, makeInput());
+
+      // The stream must NOT abort: RUN_FINISHED is still emitted.
+      expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+
+      // Both text deltas (before and after the custom-data chunk) flow through.
+      const joinedText = events
+        .filter(
+          (e): e is TextMessageChunkEvent =>
+            e.type === EventType.TEXT_MESSAGE_CHUNK,
+        )
+        .map((e) => e.delta ?? "")
+        .join("");
+      expect(joinedText).toContain("Hello");
+      expect(joinedText).toContain("world");
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
@@ -879,29 +879,42 @@ describe("interrupt bridge: tool-call buffering", () => {
     expect(JSON.parse((customEvents[1] as any).value).toolCallId).toBe("tc-y");
   });
 
-  it("errors with descriptive message when chunk has no payload", async () => {
+  it("skips (does not abort on) a chunk with no payload (#1635)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const agent = makeLocalMastraAgent({
       streamChunks: [
         { type: "text-delta" }, // missing payload
+        { type: "finish", payload: { finishReason: "stop" } },
       ],
     });
 
-    const { error, events } = await collectError(agent, makeInput());
+    const events = await collectEvents(agent, makeInput());
 
-    expect(error.message).toContain("Malformed stream chunk");
-    expect(error.message).toContain("text-delta");
     expect(events[0]?.type).toBe(EventType.RUN_STARTED);
+    expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping stream chunk without payload"),
+    );
+    warnSpy.mockRestore();
   });
 
-  it("errors with descriptive message when chunk is null", async () => {
+  it("skips (does not abort on) a null chunk (#1635)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const agent = makeLocalMastraAgent({
-      streamChunks: [null],
+      streamChunks: [
+        null,
+        { type: "finish", payload: { finishReason: "stop" } },
+      ],
     });
 
-    const { error, events } = await collectError(agent, makeInput());
+    const events = await collectEvents(agent, makeInput());
 
-    expect(error.message).toContain("Malformed stream chunk");
     expect(events[0]?.type).toBe(EventType.RUN_STARTED);
+    expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping stream chunk without payload"),
+    );
+    warnSpy.mockRestore();
   });
 
   it("errors when tool-call-suspended payload is missing toolCallId", async () => {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -1226,6 +1226,19 @@ export class MastraAgent extends AbstractAgent {
     const streamedStarted = new Set<string>();
     const streamedEnded = new Set<string>();
 
+    // Skipped / unrecognized chunk types warn at most once each. Mastra 1.31+
+    // custom-data streams (e.g. `data-*` via context.writer.custom) can emit
+    // the same payload-less type at high frequency; a per-chunk warn would
+    // flood the log (#1635). Dedupe by type so integrators still see the
+    // message without the spam.
+    const warnedChunkTypes = new Set<string>();
+    const warnOnce = (type: string | undefined, message: string) => {
+      const key = type ?? "undefined";
+      if (warnedChunkTypes.has(key)) return;
+      warnedChunkTypes.add(key);
+      console.warn(`[MastraAgent] ${message}: type=${key}`);
+    };
+
     const startStreamedToolCall = (toolCallId: string, toolName: string) => {
       if (!streamedStarted.has(toolCallId)) {
         streamedStarted.add(toolCallId);
@@ -1320,9 +1333,7 @@ export class MastraAgent extends AbstractAgent {
       // return false) so the rest of the stream — including RUN_FINISHED —
       // still flows, rather than aborting the run.
       if (!chunk || !chunk.payload) {
-        console.warn(
-          `[MastraAgent] Skipping stream chunk without payload: type=${chunk?.type ?? "undefined"}`,
-        );
+        warnOnce(chunk?.type, "Skipping stream chunk without payload");
         return false;
       }
       switch (chunk.type) {
@@ -1340,6 +1351,21 @@ export class MastraAgent extends AbstractAgent {
         }
         case "reasoning-signature":
         case "redacted-reasoning":
+          break;
+        // Mastra 1.31+ text lifecycle markers bracket the `text-delta` chunks.
+        // AG-UI streams text via TEXT_MESSAGE_CHUNK and derives message
+        // boundaries from start/finish + messageId rotation, so these markers
+        // need no action — recognize them so they don't hit the `default:`
+        // warning flood (#1635, #836).
+        case "text-start":
+        case "text-end":
+          break;
+        // A standalone (non-background) `tool-output` streams intermediate tool
+        // output. The bridge surfaces completed tool results via `tool-result`;
+        // there is no AG-UI mapping for interim output, so ignore it. (Task
+        // output under a backgrounded tool is consumed inside
+        // `background-task-output`, not here.) Recognized to avoid the warn.
+        case "tool-output":
           break;
         case "text-delta": {
           flush();
@@ -1729,9 +1755,7 @@ export class MastraAgent extends AbstractAgent {
           break;
         }
         default: {
-          console.warn(
-            `[MastraAgent] Unrecognized stream chunk type: ${chunk.type}`,
-          );
+          warnOnce(chunk.type, "Unrecognized stream chunk type");
           break;
         }
       }

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -1313,13 +1313,17 @@ export class MastraAgent extends AbstractAgent {
     };
 
     const handleChunk = (chunk: any): boolean => {
+      // Chunks without a `payload` are not fatal. Mastra 1.31+ emits
+      // custom-data chunks (e.g. `data-*` types via context.writer.custom)
+      // that carry `data` instead of `payload`, plus new lifecycle chunk
+      // types this switch doesn't recognize. Skip them gracefully (warn,
+      // return false) so the rest of the stream — including RUN_FINISHED —
+      // still flows, rather than aborting the run.
       if (!chunk || !chunk.payload) {
-        callbacks.onError(
-          new Error(
-            `Malformed stream chunk: type=${chunk?.type ?? "undefined"}, missing payload`,
-          ),
+        console.warn(
+          `[MastraAgent] Skipping stream chunk without payload: type=${chunk?.type ?? "undefined"}`,
         );
-        return true;
+        return false;
       }
       switch (chunk.type) {
         case "reasoning-start": {


### PR DESCRIPTION
Fixes #1635

## Root cause

In `integrations/mastra/typescript/src/mastra.ts`, `createChunkProcessor` → `handleChunk` had an early guard that ran **before** the chunk-type `switch`:

```ts
if (!chunk || !chunk.payload) {
  callbacks.onError(new Error(`Malformed stream chunk: ... missing payload`));
  return true; // return true == abort the stream
}
```

Mastra 1.31+ emits custom-data chunks (e.g. type `data-workspace-metadata` produced via `context.writer.custom`) that carry `data` instead of `payload`, plus new lifecycle chunk types the `switch` doesn't recognize. Because the guard ran first, any such chunk caused `onError` + abort — terminating the SSE stream before subsequent valid events (including `RUN_FINISHED`) could flow. The `default:` case (which already does `console.warn` + skip) was never reached.

## Fix

Make a missing `payload` non-fatal: warn and skip the chunk (`return false`) instead of `onError` + abort, so the rest of the stream still flows and `RUN_FINISHED` is emitted. Known Mastra chunk types always carry a `payload`, so their behavior is unchanged. Genuinely fatal cases (`error` chunks, malformed `tool-call-suspended`) remain fatal — they are handled inside the `switch` and are untouched.

## Tests added

- `edge-cases.test.ts` — new test feeding `text-delta("Hello")` → a `data-workspace-metadata` chunk with `{ data }` and no `payload` → `text-delta(" world")` → `finish`. Asserts the stream does **not** abort: `RUN_FINISHED` is emitted and the joined text contains both `"Hello"` and `"world"`. (Red before the fix, green after.)
- `interrupt-bridge.test.ts` — the two existing tests that asserted the old fatal-abort behavior for missing-payload / null chunks were updated to assert the corrected graceful-skip behavior (warns, stream completes with `RUN_FINISHED`).

Full `@ag-ui/mastra` suite: **126 passed (7 files)**. Package builds clean (`nx run @ag-ui/mastra:build`).

## Checklist

- [x] Failing test written first, passes after fix
- [x] Full package test suite passes (126/126)
- [x] Minimal, scoped change — no refactoring, no dep/CI changes
- [x] Formatter run; package builds
- [x] No AI attribution in commits