### PR TITLE
feat(release): automated #engr Slack notification per release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1095,6 +1095,230 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Post-release #engr Slack notification. Ported from CopilotKit's `notify`
+  # job. Runs after build AND publish via always() so it fires on success,
+  # failure, OR a skipped publish — the pure builder
+  # (scripts/release/build-release-notification.ts) decides what (if anything)
+  # to post from the job results + the event-derived release intent.
+  #
+  # DIVERGENCE FROM CPK: ag-ui publishes BOTH npm and PyPI from the SINGLE
+  # `publish` job (CPK split them into `publish` + `publish-python`). So the
+  # npm-lane and PyPI-lane RESULT signals both read the shared
+  # needs.publish.result / needs.build.result; the two lanes are distinguished
+  # downstream by their published-package SETS (ts_packages vs py_packages),
+  # which the build job emits per-ecosystem. A publish-job failure pages
+  # whichever lane the event intended (npm and/or PyPI) — acceptable because
+  # both lanes share one publish process here.
+  notify:
+    needs: [build, publish]
+    # Run on every real-release context: a push-to-main (merged release PR /
+    # version-bump) or a non-dry-run workflow_dispatch. Skipped on dry-run
+    # dispatches (the builder also suppresses dry-run, but gating the job off
+    # avoids a needless runner). always() ensures we still notify when build
+    # or publish FAILED (the whole point of the failure arms).
+    if: >
+      always() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && inputs.dry_run != true))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    # SLACK_WEBHOOK MUST live at JOB level: GitHub Actions does NOT expose a
+    # step's own `env:` to that step's `if:` expression — only workflow- and
+    # job-level env is visible there. The `Post to #engr` and `Notifier
+    # self-watchdog` steps gate on `env.SLACK_WEBHOOK != ''`, so a step-level
+    # definition would make that guard ALWAYS false and the steps would never
+    # run, even with the secret set.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}
+    steps:
+      # Compute the event-derived release intent FIRST, before checkout/install,
+      # so its outputs survive an infra failure in a later step (this ordering
+      # was a fix on the CPK side: a checkout/install failure must not blind the
+      # failure arms). For a push we diff the compare-range; for a dispatch we
+      # derive intent from the mode/scope inputs.
+      - name: Compute release intent
+        id: intent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          SHA_BEFORE: ${{ github.event.before }}
+          SHA_AFTER: ${{ github.event.after }}
+          INPUT_SCOPE: ${{ inputs.scope }}
+        run: |
+          set -uo pipefail
+          NPM_INTENDED=false
+          PY_INTENDED=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # A stable dispatch intends the scope's lane. With no scope (full
+            # stable run) intend BOTH lanes. A prerelease dispatch is canary —
+            # canary (prerelease) is FULLY suppressed by the builder (mode ==
+            # "prerelease" → no post on EITHER lane). Intent is computed
+            # uniformly here regardless of mode, but a prerelease produces no
+            # notification on either lane. (INPUT_MODE is not read here: the
+            # builder applies the canary/stable suppression from MODE; this step
+            # only computes per-lane FAILURE intent.)
+            SCOPE="${INPUT_SCOPE:-}"
+            if [ -z "$SCOPE" ]; then
+              NPM_INTENDED=true
+              PY_INTENDED=true
+            else
+              # Map the dispatch scope to its ecosystem. The *-py glob catches
+              # the sdk-py / integration-*-py PyPI scopes; the explicit names
+              # cover the PyPI scopes that do NOT end in -py. Everything else is
+              # npm. This only affects FAILURE paging — success arms use the
+              # real published-package sets, not this heuristic.
+              case "$SCOPE" in
+                integration-adk|integration-agent-spec|integration-aws-strands|integration-langroid)
+                  PY_INTENDED=true ;;
+                *-py)
+                  PY_INTENDED=true ;;
+                *)
+                  NPM_INTENDED=true ;;
+              esac
+            fi
+          else
+            # push event: diff the compare-range for changed manifest files.
+            # Fail TOWARD paging (intended=true + ::warning::) on any API error
+            # so an outage never silently swallows a real release failure.
+            FILES=""
+            if [ -n "$SHA_BEFORE" ] && [ -n "$SHA_AFTER" ]; then
+              if ! FILES=$(gh api "repos/${REPO}/compare/${SHA_BEFORE}...${SHA_AFTER}" --jq '.files[].filename' 2>/dev/null); then
+                echo "::warning::Could not resolve changed files for ${SHA_BEFORE}...${SHA_AFTER} — failing toward paging (both lanes intended)."
+                NPM_INTENDED=true
+                PY_INTENDED=true
+                FILES=""
+              fi
+            else
+              echo "::warning::Missing before/after SHAs on push event — failing toward paging (both lanes intended)."
+              NPM_INTENDED=true
+              PY_INTENDED=true
+            fi
+            # Intent here means "the compare-range TOUCHED a package.json /
+            # pyproject.toml", NOT "a version was actually bumped". This signal
+            # is now the BUILD-FAILURE FALLBACK for the builder's failure arms,
+            # NOT the primary failure gate: the builder keys each failure arm off
+            # the DETECTED PACKAGE SET (ts_packages / py_packages) — the
+            # authoritative "this lane actually attempted a release" signal — and
+            # consults this intent ONLY when the build failed before detection
+            # could populate that set (so an early build failure on an intended
+            # release still pages, never toward silence). Because the success
+            # path and the primary failure path both key off the detected set,
+            # the old "manifest touched but version not bumped" false-positive
+            # (e.g. a dependabot dependency bump) no longer pages on a SUCCESSFUL
+            # build that detected no packages; it can only contribute via this
+            # fallback when the build itself failed.
+            if [ -n "$FILES" ]; then
+              # The GitHub compare endpoint returns AT MOST 300 files in .files
+              # and does NOT paginate them. On a large merge where a bumped
+              # package.json / pyproject.toml falls beyond file #300 it would be
+              # absent from this list, the grep would find nothing, and intent
+              # would compute false — which (combined with an early build failure
+              # before detection) could swallow a real release-failure page. So
+              # when the list is truncated (>= 300 filenames) fail TOWARD paging:
+              # intend BOTH lanes and warn, rather than trust an incomplete list.
+              FILE_COUNT=$(printf '%s\n' "$FILES" | grep -c .)
+              if [ "$FILE_COUNT" -ge 300 ]; then
+                echo "::warning::Compare response for ${SHA_BEFORE}...${SHA_AFTER} returned ${FILE_COUNT} files (>= the 300-file compare-API cap, which does not paginate) — failing toward paging (both lanes intended) since a manifest bump may be truncated out of the list."
+                NPM_INTENDED=true
+                PY_INTENDED=true
+              else
+                if echo "$FILES" | grep -qE '(^|/)package\.json$'; then
+                  NPM_INTENDED=true
+                fi
+                if echo "$FILES" | grep -qE '(^|/)pyproject\.toml$'; then
+                  PY_INTENDED=true
+                fi
+              fi
+            fi
+          fi
+
+          echo "npm_intended=$NPM_INTENDED" >> "$GITHUB_OUTPUT"
+          echo "py_intended=$PY_INTENDED" >> "$GITHUB_OUTPUT"
+          echo "npm_intended=$NPM_INTENDED py_intended=$PY_INTENDED"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: "10.33.4"
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Install dependencies (no lifecycle scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build release notification message
+        id: build_message
+        env:
+          MODE: ${{ needs.build.outputs.mode }}
+          NPM_RESULT: ${{ needs.publish.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          NPM_INTENDED: ${{ steps.intent.outputs.npm_intended }}
+          TS_PACKAGES: ${{ needs.build.outputs.ts_packages }}
+          TS_GROUPS: ${{ needs.build.outputs.ts_groups_json }}
+          PY_INTENDED: ${{ steps.intent.outputs.py_intended }}
+          PY_RESULT: ${{ needs.publish.result }}
+          PY_BUILD_RESULT: ${{ needs.build.result }}
+          PY_PACKAGES: ${{ needs.build.outputs.py_packages }}
+          SCOPE: ${{ needs.build.outputs.scope }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NPM_ORG_URL: https://www.npmjs.com/org/ag-ui
+          PY_BASE_URL: https://pypi.org/project
+        run: pnpm tsx scripts/release/build-release-notification.ts
+
+      - name: Post to #engr
+        # Guard so an unset webhook is a clean no-op rather than a failure: the
+        # secret is unset until the #engr incoming webhook is provisioned, and a
+        # release must not go red merely because alerting isn't wired yet.
+        if: steps.build_message.outputs.should_post == 'true' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGR }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ${{ toJSON(steps.build_message.outputs.message) }}
+            }
+
+      # Self-watchdog: if the notify job ITSELF failed (e.g. the message build
+      # or install step errored) on a real release attempt, best-effort ping
+      # #engr so a broken notifier doesn't fail silently. Gated off dry-run and
+      # only fires when the event intended a release on either lane.
+      - name: Notifier self-watchdog (best-effort)
+        # Fires unless intent is explicitly false on BOTH lanes, so an
+        # intent-step crash (empty outputs) still pages — never toward silence.
+        # Canary (prerelease) runs are FULLY suppressed on BOTH lanes — including
+        # this watchdog — so a notify-job failure during a prerelease dispatch
+        # never pings "notifier failed" on a canary run.
+        if: >
+          failure() &&
+          inputs.dry_run != true &&
+          needs.build.outputs.mode != 'prerelease' &&
+          (steps.intent.outputs.npm_intended != 'false' ||
+           steps.intent.outputs.py_intended != 'false') &&
+          env.SLACK_WEBHOOK != ''
+        continue-on-error: true
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_ENGR }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "⚠️ *ag-ui release notifier failed* — could not determine release status. Check the run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+
   # Dry-run summary — surfaces what WOULD have been published. Runs only
   # when dry_run=true on workflow_dispatch (stable detection still runs, but
   # the publish job is gated off; prerelease bump still runs in the build

--- a/scripts/release/build-release-notification.test.ts
+++ b/scripts/release/build-release-notification.test.ts
@@ -1,0 +1,855 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildReleaseNotification } from "./lib/build-release-notification";
+import type { BuildReleaseNotificationInput } from "./lib/build-release-notification";
+
+const RUN_URL = "https://github.com/ag-ui-protocol/ag-ui/actions/runs/123";
+const NPM_ORG_URL = "https://www.npmjs.com/org/ag-ui";
+const PY_BASE_URL = "https://pypi.org/project";
+
+// A neutral baseline where nothing has acted. Each test overrides only the
+// fields relevant to its truth-table row.
+function base(
+  overrides: Partial<BuildReleaseNotificationInput> = {},
+): BuildReleaseNotificationInput {
+  return {
+    mode: "",
+    npmResult: "skipped",
+    buildResult: "skipped",
+    npmIntended: "false",
+    tsPackages: [],
+    tsGroups: {},
+    pyIntended: "false",
+    pyResult: "skipped",
+    pyBuildResult: "skipped",
+    pyPackages: [],
+    scope: "",
+    dryRun: false,
+    runUrl: RUN_URL,
+    npmOrgUrl: NPM_ORG_URL,
+    pyBaseUrl: PY_BASE_URL,
+    ...overrides,
+  };
+}
+
+// Convenience builders for the published-package sets.
+function ts(...names: string[]): { name: string; version: string }[] {
+  return names.map((name) => ({ name, version: "0.0.41" }));
+}
+function py(...names: string[]): { name: string; version: string }[] {
+  return names.map((name) => ({ name, version: "0.0.11" }));
+}
+
+// ---- dry-run ----------------------------------------------------------------
+test("suppresses dry-run — no post", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { latest: ["@ag-ui/core"] },
+      dryRun: true,
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- npm lane: prerelease canary fully suppressed ---------------------------
+test("suppresses prerelease (canary) success — no post", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { canary: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("suppresses prerelease (canary) npm failure — no post", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "success",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("suppresses prerelease (canary) build failure — no post (would otherwise fire)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      npmIntended: "true",
+      npmResult: "skipped",
+      buildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("suppresses prerelease (canary) PyPI success — no post (both lanes suppressed)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("suppresses prerelease (canary) PyPI failure — no post (both lanes suppressed)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      pyIntended: "true",
+      pyResult: "failure",
+      pyBuildResult: "success",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- npm lane: stable success -----------------------------------------------
+test("stable npm success → concise npm success line (N packages + names + dist-tag)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core", "@ag-ui/client"),
+      tsGroups: { latest: ["@ag-ui/core", "@ag-ui/client"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    "🚀 *ag-ui release* · 2 npm packages published " +
+      "(`latest`: @ag-ui/core, @ag-ui/client) · " +
+      `<${NPM_ORG_URL}|npm>`,
+  );
+});
+
+test("single npm package → '1 npm package' (pluralization)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { latest: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /1 npm package /);
+  assert.ok(!/1 npm packages/.test(r.message));
+});
+
+test("npm dist-tags other than latest are rendered (alpha)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: [{ name: "@ag-ui/core", version: "1.0.0-alpha.0" }],
+      tsGroups: { alpha: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /`alpha`: @ag-ui\/core/);
+});
+
+test("npm success with multiple dist-tag groups → all groups rendered", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: [
+        { name: "@ag-ui/core", version: "1.0.0" },
+        { name: "@ag-ui/client", version: "1.0.0-beta.0" },
+      ],
+      tsGroups: { latest: ["@ag-ui/core"], beta: ["@ag-ui/client"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /`latest`: @ag-ui\/core/);
+  assert.match(r.message, /`beta`: @ag-ui\/client/);
+  assert.match(r.message, /2 npm packages published/);
+});
+
+// ---- npm lane: count/name agreement (FIX 3) ---------------------------------
+test("populated tsPackages + EMPTY tsGroups → flat name list (no dist-tag backticks)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core", "@ag-ui/client"),
+      tsGroups: {},
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /2 npm packages published/);
+  assert.match(r.message, /@ag-ui\/core, @ag-ui\/client/);
+  // Flat list: no dist-tag rendering (no backtick-wrapped tag labels).
+  assert.ok(!r.message.includes("`"));
+});
+
+test("tsGroups membership MISMATCHES tsPackages → falls back to flat list (count and names agree)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      // Three packages published...
+      tsPackages: ts("@ag-ui/core", "@ag-ui/client", "@ag-ui/encoder"),
+      // ...but the groups dropped one (degraded ts_groups_json). Count (3) from
+      // tsPackages would disagree with names (2) from tsGroups — must fall back.
+      tsGroups: { latest: ["@ag-ui/core", "@ag-ui/client"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /3 npm packages published/);
+  // Flat fallback lists all three published names (count and names agree).
+  assert.match(r.message, /@ag-ui\/core, @ag-ui\/client, @ag-ui\/encoder/);
+  // Degraded groups are NOT rendered as dist-tag groups.
+  assert.ok(!r.message.includes("`latest`"));
+});
+
+test("tsGroups listing a name NOT in tsPackages → falls back to flat list", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      // Group lists a phantom name absent from tsPackages → membership mismatch.
+      tsGroups: { latest: ["@ag-ui/core", "@ag-ui/phantom"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /1 npm package published/);
+  assert.ok(!r.message.includes("@ag-ui/phantom"));
+  assert.ok(!r.message.includes("`latest`"));
+});
+
+test("tsGroups with an EMPTY group array → falls back to flat list (no empty `tag`: fragment)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      // An empty-array group renders no names; total grouped count (1) still
+      // matches tsPackages.length (1) AND membership matches, but the empty
+      // group must never produce a malformed "`beta`: " fragment. The skip in
+      // renderNpmGroups drops it; here we additionally assert no empty fragment.
+      tsGroups: { latest: ["@ag-ui/core"], beta: [] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /1 npm package published/);
+  // No malformed empty dist-tag fragment for the empty `beta` group.
+  // renderNpmGroups structurally filters out empty groups, so the absence of
+  // any "`beta`" substring fully covers it (a separate "`beta`:" regex would be
+  // always-true here and imply coverage it cannot provide).
+  assert.ok(!r.message.includes("`beta`"));
+});
+
+test("tsGroups with a name duplicated across two groups → falls back to flat list (count/name agreement)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      // One published package...
+      tsPackages: ts("@ag-ui/core"),
+      // ...but it appears in TWO groups: deduped Set size (1) would match the
+      // package set, yet the TOTAL grouped count (2) disagrees with the count
+      // (1) from tsPackages. Must fall back to the flat list.
+      tsGroups: { latest: ["@ag-ui/core"], next: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /1 npm package published/);
+  // Flat fallback: no dist-tag grouping rendered, name listed exactly once.
+  assert.ok(!r.message.includes("`latest`"));
+  assert.ok(!r.message.includes("`next`"));
+  assert.equal(r.message.split("@ag-ui/core").length - 1, 1);
+});
+
+// ---- npm lane: failure (lane-level wording) ---------------------------------
+test("stable npm failure → lane-level red alert (NOT 'npm publish failed')", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "success",
+      // Detected package set is the authoritative "release attempted" signal:
+      // build succeeded and packages were detected, then publish failed.
+      tsPackages: ts("@ag-ui/core"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+  assert.ok(!r.message.includes("publish failed"));
+});
+
+test("npm result failure beats a populated package set → FAILURE line, NOT success (if/else ordering)", () => {
+  // A populated tsPackages set does NOT force a success line: the publish job
+  // can have packages yet end in `failure` (e.g. a later tag/release step
+  // broke). The success arm requires npmResult === "success".
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { latest: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+  assert.ok(!r.message.includes("🚀"));
+  assert.ok(!r.message.includes("published"));
+});
+
+test("build failure (mode='', npm skipped) → lane-level npm/build red alert", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "",
+      npmIntended: "true",
+      npmResult: "skipped",
+      buildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+  assert.ok(!r.message.includes("publish failed"));
+});
+
+test("npm publish failure with empty mode → lane-level red alert (no mode-coupling swallow)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "success",
+      // Packages were detected (build OK) then publish failed → authoritative.
+      tsPackages: ts("@ag-ui/core"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+// ---- npm lane: EVENT-DERIVED intent gate ------------------------------------
+test("npmIntended='true' + buildResult='failure' → npm red ALERT (intent gate open)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "",
+      npmIntended: "true",
+      npmResult: "skipped",
+      buildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("npmIntended='false' + buildResult='failure' → NEUTRAL (no npm release attempted)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "",
+      npmIntended: "false",
+      npmResult: "skipped",
+      buildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- FIX 1: failure arms gate on the DETECTED PACKAGE SET -------------------
+// The detected package set (tsPackages/pyPackages) is the authoritative "this
+// lane actually attempted a release" signal. Intent (compare-range) is only the
+// build-failure fallback.
+
+test("dependabot-style: build+publish success, NO detected npm packages, npmIntended true → NO npm line (no false positive)", () => {
+  // A dependabot dependency bump touches package.json without bumping the
+  // package's OWN version. Intent (manifest touched) is true, but the build
+  // detected no published packages. With a successful build there is nothing to
+  // page about → the lane stays quiet.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: [],
+      npmIntended: "true",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("early build failure on an intended npm release (no detected packages yet) → npm failure line (fail toward paging)", () => {
+  // The build FAILED before detection could populate tsPackages. The
+  // event-derived npmIntended is the fallback that keeps an early build failure
+  // on a genuine release from being swallowed.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      buildResult: "failure",
+      npmResult: "skipped",
+      tsPackages: [],
+      npmIntended: "true",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("detected npm packages + publish failure with npmIntended FALSE → npm failure line (detected set is authoritative)", () => {
+  // The detected package set pages on its own failure REGARDLESS of intent: the
+  // build succeeded and detected packages, then the publish job failed. Intent
+  // for this lane is false (e.g. the push touched only the other ecosystem),
+  // yet the real publish failure must still page.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "failure",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      npmIntended: "false",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("cross-lane stale PyPI bump: detected py packages + publish failure, pyIntended FALSE → PyPI failure line (closes the silent-swallow)", () => {
+  // detect_py diffs LOCAL manifests against the REGISTRY, so a push that only
+  // touched package.json can still re-detect a STALE unpublished PyPI bump from
+  // a prior failed release. The compare-range intent for the PyPI lane is
+  // false. Under the old intent-only gate that real publish failure was
+  // SILENTLY SWALLOWED; gating on the detected set closes it.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      pyResult: "failure",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+      pyIntended: "false",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui PyPI release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("build succeeded, NO detected PyPI packages, pyIntended true → NO PyPI line (no false positive)", () => {
+  // Symmetric with the dependabot npm case: a successful build that detected no
+  // PyPI packages does not page even though intent is true.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: [],
+      pyIntended: "true",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- PyPI lane: stable success (mode-gated, symmetric with npm) -------------
+test("PyPI success → only PyPI line", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    "🐍 *ag-ui release* · 1 PyPI package published (ag-ui-protocol) · " +
+      `<${PY_BASE_URL}/ag-ui-protocol/|PyPI>`,
+  );
+});
+
+test("PyPI success with multiple packages → count + names + org-style link to flagship", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol", "ag-ui-langgraph"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /2 PyPI packages published/);
+  assert.match(r.message, /ag-ui-protocol, ag-ui-langgraph/);
+});
+
+test("PyPI flagship link targets ag-ui-protocol even when it is NOT first in pyPackages", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyResult: "success",
+      pyBuildResult: "success",
+      mode: "stable",
+      // ag-ui-protocol is deliberately NOT at index 0 — nothing sorts
+      // pyPackages, so the flagship must be selected explicitly by name.
+      pyPackages: py("ag-ui-langgraph", "ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /2 PyPI packages published/);
+  // The link target is the flagship project page, ag-ui-protocol.
+  assert.match(
+    r.message,
+    /<https:\/\/pypi\.org\/project\/ag-ui-protocol\/\|PyPI>/,
+  );
+});
+
+test("PyPI flagship falls back to first package when ag-ui-protocol absent", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-langgraph", "ag-ui-mastra"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(
+    r.message,
+    /<https:\/\/pypi\.org\/project\/ag-ui-langgraph\/\|PyPI>/,
+  );
+});
+
+test("PyPI failure → lane-level PyPI red alert", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyIntended: "true",
+      pyResult: "failure",
+      pyBuildResult: "success",
+      // Build OK + packages detected, then publish failed → authoritative.
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui PyPI release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("build-python failure during a REAL Python release (publish skipped) → PyPI red alert", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyIntended: "true",
+      pyResult: "skipped",
+      pyBuildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui PyPI release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+test("build-python CANCELLED during a real Python release → NEUTRAL (no false red on deliberate cancel)", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyIntended: "true",
+      pyResult: "skipped",
+      pyBuildResult: "cancelled",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("build-python failure WITHOUT intent → NO post (routine PR flake)", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyIntended: "false",
+      pyResult: "skipped",
+      pyBuildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("python release intended (pyIntended='true', pyBuildResult='failure') → PyPI red ALERT", () => {
+  const r = buildReleaseNotification(
+    base({
+      pyIntended: "true",
+      pyResult: "skipped",
+      pyBuildResult: "failure",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui PyPI release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+// ---- prerelease + both lanes ------------------------------------------------
+test("prerelease + BOTH lanes failing → NO post (canary fully suppressed, both lanes)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "failure",
+      pyIntended: "true",
+      pyResult: "failure",
+      pyBuildResult: "success",
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("prerelease + python success → NO post (canary fully suppressed, both lanes)", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "prerelease",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { canary: ["@ag-ui/core"] },
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- cancelled is NEUTRAL everywhere ----------------------------------------
+test("npm cancelled (mode=stable) → no line (neutral, no false red)", () => {
+  const r = buildReleaseNotification(
+    base({ mode: "stable", npmResult: "cancelled", buildResult: "success" }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("build cancelled → no line (neutral)", () => {
+  const r = buildReleaseNotification(
+    base({ mode: "", npmResult: "skipped", buildResult: "cancelled" }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("PyPI cancelled → no line (neutral)", () => {
+  const r = buildReleaseNotification(
+    base({ pyResult: "cancelled", pyBuildResult: "success" }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- skipped lanes contribute nothing ---------------------------------------
+test("python-only run (npm lane skipped) → only PyPI line, NO false red", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "skipped",
+      buildResult: "skipped",
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.ok(!r.message.includes("🔴"));
+  assert.match(r.message, /🐍/);
+});
+
+test("npm-only run (PyPI lane not acting) → only npm line", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { latest: ["@ag-ui/core"] },
+      pyResult: "skipped",
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /🚀/);
+  assert.ok(!r.message.includes("🐍"));
+  assert.ok(!r.message.includes("🔴"));
+});
+
+// ---- both lanes -------------------------------------------------------------
+test("both lanes succeed → one message with both lines", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core", "@ag-ui/client"),
+      tsGroups: { latest: ["@ag-ui/core", "@ag-ui/client"] },
+      pyResult: "success",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  const expected =
+    "🚀 *ag-ui release* · 2 npm packages published " +
+    "(`latest`: @ag-ui/core, @ag-ui/client) · " +
+    `<${NPM_ORG_URL}|npm>\n` +
+    "🐍 *ag-ui release* · 1 PyPI package published (ag-ui-protocol) · " +
+    `<${PY_BASE_URL}/ag-ui-protocol/|PyPI>`;
+  assert.equal(r.message, expected);
+});
+
+test("both lanes fail → one message with both lane-level red lines", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmIntended: "true",
+      npmResult: "failure",
+      buildResult: "success",
+      // Both lanes detected packages (build OK) then the shared publish failed.
+      tsPackages: ts("@ag-ui/core"),
+      pyIntended: "true",
+      pyResult: "failure",
+      pyBuildResult: "success",
+      pyPackages: py("ag-ui-protocol"),
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.equal(
+    r.message,
+    `🔴 *ag-ui npm release failed* · <${RUN_URL}|View run>\n` +
+      `🔴 *ag-ui PyPI release failed* · <${RUN_URL}|View run>`,
+  );
+});
+
+// ---- nothing acted ----------------------------------------------------------
+test("nothing acted (npm skipped, PyPI not publishing) → no post, empty message", () => {
+  const r = buildReleaseNotification(base());
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- no-false-success guards ------------------------------------------------
+test("stable npm success with EMPTY package set → no npm success line (no false success)", () => {
+  // npmResult=success but no published packages is an anomalous state — do not
+  // claim success. With buildResult=success there is also no failure to report.
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: [],
+      tsGroups: {},
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("PyPI success with EMPTY package set → no PyPI success line (no false success)", () => {
+  const r = buildReleaseNotification(
+    base({ pyResult: "success", pyBuildResult: "success", pyPackages: [] }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+test("npm success but mode not stable (defensive) → no npm success line", () => {
+  const r = buildReleaseNotification(
+    base({
+      mode: "",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: ts("@ag-ui/core"),
+      tsGroups: { latest: ["@ag-ui/core"] },
+    }),
+  );
+  assert.equal(r.shouldPost, false);
+  assert.equal(r.message, "");
+});
+
+// ---- name-list truncation (keep the message concise) ------------------------
+test("npm success with many packages → name list truncates with '+N more'", () => {
+  const names = [
+    "@ag-ui/core",
+    "@ag-ui/client",
+    "@ag-ui/encoder",
+    "@ag-ui/proto",
+    "create-ag-ui-app",
+    "@ag-ui/langgraph",
+    "@ag-ui/mastra",
+  ];
+  const r = buildReleaseNotification(
+    base({
+      mode: "stable",
+      npmResult: "success",
+      buildResult: "success",
+      tsPackages: names.map((name) => ({ name, version: "1.0.0" })),
+      tsGroups: { latest: names },
+    }),
+  );
+  assert.equal(r.shouldPost, true);
+  assert.match(r.message, /7 npm packages published/);
+  // Concise: do not dump all 7 names; cap and summarize the remainder.
+  assert.match(r.message, /\+\d+ more/);
+});

--- a/scripts/release/build-release-notification.ts
+++ b/scripts/release/build-release-notification.ts
@@ -1,0 +1,292 @@
+#!/usr/bin/env -S pnpm tsx
+/**
+ * CLI wrapper for the post-release #engr Slack notification builder.
+ *
+ * Thin glue around the pure buildReleaseNotification() function in
+ * ./lib/build-release-notification.ts. The truth-table logic lives (and is
+ * unit-tested) there; this file only:
+ *   1. reads the release signals from env vars (set by the notify job from
+ *      needs.build.outputs / needs.publish.* results + workflow inputs +
+ *      the event-derived intent step),
+ *   2. parses the JSON package/group arrays defensively (a cosmetic parse
+ *      failure must never suppress a real alert),
+ *   3. calls the pure builder, and
+ *   4. writes `message=` and `should_post=` to GITHUB_OUTPUT.
+ *
+ * Env vars (all optional; absent → empty string / empty set):
+ *   MODE             needs.build.outputs.mode            ("stable" | "prerelease" | "")
+ *   NPM_RESULT       needs.publish.result                (shared publish job result)
+ *   BUILD_RESULT     needs.build.result                  (shared build job result)
+ *   NPM_INTENDED     notify-job event-derived npm release intent ("true" | ...)
+ *   TS_PACKAGES      needs.build.outputs.ts_packages     (JSON [{name,version,path}])
+ *   TS_GROUPS        needs.build.outputs.ts_groups_json  (JSON {tag: [name,...]})
+ *   PY_INTENDED      notify-job event-derived Python release intent ("true" | ...)
+ *   PY_RESULT        needs.publish.result                (SAME value as NPM_RESULT)
+ *   PY_BUILD_RESULT  needs.build.result                  (SAME value as BUILD_RESULT)
+ *   PY_PACKAGES      needs.build.outputs.py_packages     (JSON [{name,version,dir}])
+ *
+ *   NOTE: ag-ui runs ONE shared build job and ONE shared publish job spanning
+ *   BOTH lanes. The workflow wires BOTH BUILD_RESULT and PY_BUILD_RESULT to the
+ *   SAME needs.build.result, and BOTH NPM_RESULT and PY_RESULT to the SAME
+ *   needs.publish.result. These are NOT distinct per-lane signals. Lane
+ *   attribution comes from the detected package SETS (TS_PACKAGES vs
+ *   PY_PACKAGES) + the per-lane intent gates, NOT from distinct per-lane
+ *   build/publish results (see the lib interface doc, which says the same).
+ *   SCOPE            needs.build.outputs.scope
+ *   DRY_RUN          inputs.dry_run                      ("true" | "false" | "")
+ *   RUN_URL          this workflow run URL
+ *   NPM_ORG_URL      npm org page URL
+ *   PY_BASE_URL      PyPI project base URL
+ *
+ * Usage: pnpm tsx scripts/release/build-release-notification.ts
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { buildReleaseNotification } from "./lib/build-release-notification";
+import type {
+  ReleaseMode,
+  JobResult,
+  PublishedPackage,
+  DistTagGroups,
+  BuildReleaseNotificationResult,
+} from "./lib/build-release-notification";
+
+function env(name: string): string {
+  return process.env[name] ?? "";
+}
+
+const KNOWN_MODES: readonly ReleaseMode[] = ["stable", "prerelease", ""];
+
+const KNOWN_JOB_RESULTS: readonly JobResult[] = [
+  "success",
+  "failure",
+  "cancelled",
+  "skipped",
+  "",
+];
+
+/**
+ * Validate a raw GitHub Actions job-result env value against the known
+ * JobResult set, degrading LOUDLY to "failure" (page-on-uncertainty) on any
+ * unrecognized value. RESULT values drive FAILURE-gating; an unknown result is
+ * anomalous and must err toward PAGING. The failure arms are PACKAGE-SET-gated
+ * (the detected ts_packages/py_packages set is the primary gate; intent is only
+ * the build-failure fallback), so an unrecognized job-result value coerced to
+ * "failure" is the fail-toward-paging direction. In practice GitHub only ever
+ * emits success|failure|cancelled|skipped (plus "" when unset), so this
+ * coercion branch is defensive and not normally reached.
+ */
+export function resolveJobResultSafe(raw: string): JobResult {
+  if ((KNOWN_JOB_RESULTS as readonly string[]).includes(raw)) {
+    return raw as JobResult;
+  }
+  console.warn(
+    `::warning::resolveJobResultSafe: unrecognized job result "${raw}" (expected one of: success, failure, cancelled, skipped, or empty) — coercing to "failure" (page-on-uncertainty; the intent gates ensure this only pages on a real release).`,
+  );
+  return "failure";
+}
+
+/**
+ * Validate the raw MODE env value, degrading LOUDLY to "" (neutral "npm lane
+ * did not run") on any unrecognized value. MODE drives the npm SUCCESS-gating;
+ * degrading a typo to "stable" would FALSELY claim a publish, so MODE degrades
+ * to "" — never inventing a success. This does NOT swallow failures: the
+ * npm-failure arm keys off the event-derived intent + job RESULTS.
+ */
+export function resolveModeSafe(raw: string): ReleaseMode {
+  if ((KNOWN_MODES as readonly string[]).includes(raw)) {
+    return raw as ReleaseMode;
+  }
+  console.warn(
+    `::warning::resolveModeSafe: unrecognized MODE "${raw}" (expected one of: stable, prerelease, or empty) — coercing to "" (treated as "npm lane did not run").`,
+  );
+  return "";
+}
+
+/**
+ * Parse a JSON package array (ag-ui's ts_packages / py_packages output shape)
+ * into a clean PublishedPackage[], degrading to [] on ANY error or malformed
+ * entry. A cosmetic package set must NEVER throw and suppress a real alert.
+ * Entries missing a string `name` are dropped; `version` defaults to "".
+ */
+export function parsePackagesSafe(raw: string): PublishedPackage[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      // A non-empty raw input that parses to a non-array (e.g. an object) would
+      // otherwise silently yield no packages → no success line → no post, with
+      // no diagnostic. Warn before degrading to [] (mirrors the catch branch).
+      console.warn(
+        "::warning::parsePackagesSafe: package set parsed to a non-array — rendering without it.",
+      );
+      return [];
+    }
+    const out: PublishedPackage[] = [];
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object") {
+        const o = entry as Record<string, unknown>;
+        if (typeof o.name === "string" && o.name.length > 0) {
+          out.push({
+            name: o.name,
+            version: typeof o.version === "string" ? o.version : "",
+          });
+        }
+      }
+    }
+    return out;
+  } catch (err) {
+    console.warn(
+      `::warning::parsePackagesSafe: failed to parse package set — rendering without it. ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Parse the ts_groups_json dist-tag grouping object, degrading to {} on ANY
+ * error or non-object shape. Only string→string[] entries are kept.
+ */
+export function parseGroupsSafe(raw: string): DistTagGroups {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      // A non-empty raw input that parses to a non-object (e.g. an array or
+      // null) would otherwise silently yield no grouping with no diagnostic.
+      // Warn before degrading to {} (mirrors parsePackagesSafe's non-array
+      // branch and the catch branch below).
+      console.warn(
+        "::warning::parseGroupsSafe: dist-tag groups parsed to a non-object — rendering without grouping.",
+      );
+      return {};
+    }
+    const out: DistTagGroups = {};
+    for (const [tag, names] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (Array.isArray(names) && names.every((n) => typeof n === "string")) {
+        out[tag] = names as string[];
+      }
+    }
+    return out;
+  } catch (err) {
+    console.warn(
+      `::warning::parseGroupsSafe: failed to parse dist-tag groups — rendering without grouping. ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return {};
+  }
+}
+
+/**
+ * Serialize the builder result to a GITHUB_OUTPUT file using a per-write RANDOM
+ * heredoc delimiter (GitHub's documented pattern), so message content can never
+ * collide with / prematurely terminate the heredoc.
+ */
+export function writeGithubOutput(
+  outputPath: string,
+  result: BuildReleaseNotificationResult,
+): void {
+  const delimiter = `EOF_${randomBytes(8).toString("hex")}`;
+  // Build BOTH the message heredoc block AND the should_post line into a SINGLE
+  // string and write them with ONE appendFileSync. A prior two-call form could
+  // leave GITHUB_OUTPUT with `message` but no `should_post` if the second call
+  // threw — the Post step's `should_post == 'true'` guard would then be false
+  // and a real alert would silently vanish. One write keeps the pair atomic.
+  const payload =
+    `message<<${delimiter}\n${result.message}\n${delimiter}\n` +
+    `should_post=${result.shouldPost}\n`;
+  try {
+    fs.appendFileSync(outputPath, payload);
+  } catch (err) {
+    // Fail LOUD: a notifier that cannot persist its outputs is broken, and
+    // silently no-op'ing would swallow a real release alert. The ::error::
+    // annotation + non-zero exit routes to the workflow self-watchdog.
+    console.error(
+      `::error::Failed to write should_post/message to GITHUB_OUTPUT — cannot emit the release notification. ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    process.exit(1);
+  }
+}
+
+function main(): void {
+  const result = buildReleaseNotification({
+    mode: resolveModeSafe(env("MODE")),
+    npmResult: resolveJobResultSafe(env("NPM_RESULT")),
+    buildResult: resolveJobResultSafe(env("BUILD_RESULT")),
+    npmIntended: env("NPM_INTENDED"),
+    tsPackages: parsePackagesSafe(env("TS_PACKAGES")),
+    tsGroups: parseGroupsSafe(env("TS_GROUPS")),
+    pyIntended: env("PY_INTENDED"),
+    pyResult: resolveJobResultSafe(env("PY_RESULT")),
+    pyBuildResult: resolveJobResultSafe(env("PY_BUILD_RESULT")),
+    pyPackages: parsePackagesSafe(env("PY_PACKAGES")),
+    scope: env("SCOPE"),
+    dryRun: env("DRY_RUN") === "true",
+    runUrl: env("RUN_URL"),
+    npmOrgUrl: env("NPM_ORG_URL") || "https://www.npmjs.com/org/ag-ui",
+    pyBaseUrl: env("PY_BASE_URL") || "https://pypi.org/project",
+  });
+
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    writeGithubOutput(outputPath, result);
+  } else if (process.env.GITHUB_ACTIONS === "true") {
+    // A status notifier that cannot write its should_post/message outputs is
+    // broken: the Post step gates on those outputs, so silently no-op'ing would
+    // swallow a real release alert. Fail loud under Actions.
+    console.error(
+      "::error::GITHUB_OUTPUT is unset under GitHub Actions — cannot emit should_post/message for the release notification.",
+    );
+    process.exit(1);
+  }
+
+  // Console echo (always useful in logs; the sole output channel for an
+  // explicit local/no-Actions invocation).
+  console.log(`should_post=${result.shouldPost}`);
+  if (result.message) {
+    console.log(`message:\n${result.message}`);
+  }
+}
+
+// Only run when invoked directly as a CLI, not when imported by tests. Apply
+// fs.realpathSync to BOTH sides so a symlinked checkout can't make main()
+// silently not run. realpathSync THROWS (ENOENT) if argv[1] doesn't resolve on
+// disk, which would crash before main() and swallow a real alert — so guard it
+// with a path.resolve()-normalized compare on throw.
+function isInvokedDirectly(): boolean {
+  if (process.argv[1] == null) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return fs.realpathSync(modulePath) === fs.realpathSync(process.argv[1]);
+  } catch (err) {
+    // ENOENT is the documented case: argv[1] (or the module path) does not
+    // resolve on disk. For that, keep the weaker path.resolve() fallback.
+    // For ANY OTHER error under GitHub Actions (e.g. EACCES, ELOOP), a wrong
+    // `false` here would mean main() never runs → no $GITHUB_OUTPUT written →
+    // the alert silently vanishes. Fail LOUD instead so the self-watchdog sees
+    // it, rather than degrading to a compare that could also wrongly skip.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT" && process.env.GITHUB_ACTIONS === "true") {
+      console.error(
+        `::error::isInvokedDirectly: realpathSync failed (${
+          err instanceof Error ? err.message : String(err)
+        }) — cannot reliably determine direct invocation; refusing to silently skip the release notifier.`,
+      );
+      process.exit(1);
+    }
+    return path.resolve(modulePath) === path.resolve(process.argv[1]);
+  }
+}
+if (isInvokedDirectly()) {
+  main();
+}

--- a/scripts/release/build-release-notification.wrapper.test.ts
+++ b/scripts/release/build-release-notification.wrapper.test.ts
@@ -1,0 +1,431 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  writeGithubOutput,
+  resolveModeSafe,
+  resolveJobResultSafe,
+  parsePackagesSafe,
+  parseGroupsSafe,
+} from "./build-release-notification";
+
+const WRAPPER = join(
+  process.cwd(),
+  "scripts/release/build-release-notification.ts",
+);
+
+const RUN_URL = "https://github.com/ag-ui-protocol/ag-ui/actions/runs/123";
+
+function mkTmp(): string {
+  return mkdtempSync(join(tmpdir(), "release-notify-wrapper-"));
+}
+
+/**
+ * The release-signal / intent env vars the wrapper reads. The helper DELETES
+ * these from the inherited env before applying caller overrides, so each test
+ * controls them exactly (a real GITHUB_OUTPUT / GITHUB_ACTIONS / MODE etc. set
+ * on the runner — e.g. under GitHub Actions — must not leak in and pollute the
+ * fail-loud "GITHUB_OUTPUT unset" test or the DRY_RUN coercion cases). HOME /
+ * PATH / pnpm / corepack vars pass THROUGH so `pnpm tsx` works in any CI image.
+ */
+const CONTROLLED_ENV_KEYS = [
+  "GITHUB_OUTPUT",
+  "GITHUB_ACTIONS",
+  "DRY_RUN",
+  "MODE",
+  "NPM_RESULT",
+  "NPM_INTENDED",
+  "BUILD_RESULT",
+  "TS_PACKAGES",
+  "TS_GROUPS",
+  "PY_RESULT",
+  "PY_INTENDED",
+  "PY_BUILD_RESULT",
+  "PY_PACKAGES",
+  "SCOPE",
+  "RUN_URL",
+  "NPM_ORG_URL",
+  "PY_BASE_URL",
+] as const;
+
+/**
+ * Run the wrapper CLI as a subprocess; returns { status, stdout, stderr }.
+ *
+ * Starts from a COPY of process.env (so HOME / PATH / pnpm / corepack vars pass
+ * through — stripping them can make `pnpm tsx` fail in some CI images), DELETES
+ * the controlled release/intent keys (so the suite's own GitHub Actions env
+ * can't leak into a test), THEN applies the caller-supplied overrides.
+ */
+async function runWrapper(
+  env: Record<string, string | undefined>,
+): Promise<{ status: number; stdout: string; stderr: string }> {
+  const cleanEnv: Record<string, string | undefined> = { ...process.env };
+  for (const key of CONTROLLED_ENV_KEYS) {
+    delete cleanEnv[key];
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) cleanEnv[k] = v;
+    else delete cleanEnv[k];
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["tsx", WRAPPER], { env: cleanEnv });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", reject);
+    child.on("exit", (code) => resolve({ status: code ?? 0, stdout, stderr }));
+  });
+}
+
+// ---- writeGithubOutput (in-process) -----------------------------------------
+test("writeGithubOutput round-trips a multi-line message through the GITHUB_OUTPUT heredoc", () => {
+  const dir = mkTmp();
+  try {
+    const outputPath = join(dir, "out.txt");
+    writeFileSync(outputPath, "");
+    const message = "line one\nline two · <https://x|y>";
+
+    writeGithubOutput(outputPath, { message, shouldPost: true });
+
+    const raw = readFileSync(outputPath, "utf8");
+    const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    assert.notEqual(m, null);
+    assert.equal(m![2], message);
+    assert.ok(raw.includes("should_post=true"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeGithubOutput uses a per-write RANDOM delimiter (not a fixed sentinel)", () => {
+  const dir = mkTmp();
+  try {
+    const a = join(dir, "a.txt");
+    const b = join(dir, "b.txt");
+    writeFileSync(a, "");
+    writeFileSync(b, "");
+
+    writeGithubOutput(a, { message: "x", shouldPost: true });
+    writeGithubOutput(b, { message: "x", shouldPost: true });
+
+    const delimA = readFileSync(a, "utf8").match(/^message<<(\S+)/m)?.[1];
+    const delimB = readFileSync(b, "utf8").match(/^message<<(\S+)/m)?.[1];
+
+    assert.ok(delimA);
+    assert.ok(delimB);
+    // The real delimiter shape is EOF_<16-hex> (randomBytes(8).toString("hex")).
+    assert.match(delimA!, /^EOF_[0-9a-f]{16}$/);
+    assert.match(delimB!, /^EOF_[0-9a-f]{16}$/);
+    assert.notEqual(delimA, delimB);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeGithubOutput does not corrupt output when the message contains a heredoc-like token", () => {
+  const dir = mkTmp();
+  try {
+    const outputPath = join(dir, "out.txt");
+    writeFileSync(outputPath, "");
+    // Embed a token in the real delimiter shape (EOF_<16-hex>) so this actually
+    // exercises collision-safety against the implementation's format.
+    const message = "EOF_deadbeefdeadbeef\nstill the message";
+
+    writeGithubOutput(outputPath, { message, shouldPost: true });
+
+    const raw = readFileSync(outputPath, "utf8");
+    const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+    assert.notEqual(m, null);
+    assert.equal(m![2], message);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---- resolveModeSafe --------------------------------------------------------
+for (const mode of ["stable", "prerelease", ""] as const) {
+  test(`resolveModeSafe passes through the known mode "${mode}" unchanged`, () => {
+    assert.equal(resolveModeSafe(mode), mode);
+  });
+}
+
+test('resolveModeSafe coerces an unknown MODE (typo) to "" (degrade, no crash)', () => {
+  assert.doesNotThrow(() => resolveModeSafe("stabel"));
+  assert.equal(resolveModeSafe("stabel"), "");
+});
+
+// ---- resolveJobResultSafe ---------------------------------------------------
+for (const result of [
+  "success",
+  "failure",
+  "cancelled",
+  "skipped",
+  "",
+] as const) {
+  test(`resolveJobResultSafe passes through the known job result "${result}" unchanged`, () => {
+    assert.equal(resolveJobResultSafe(result), result);
+  });
+}
+
+test('resolveJobResultSafe coerces an unknown job result to "failure" (page-on-uncertainty)', () => {
+  assert.doesNotThrow(() => resolveJobResultSafe("succeeded"));
+  assert.equal(resolveJobResultSafe("succeeded"), "failure");
+});
+
+// ---- parsePackagesSafe ------------------------------------------------------
+test("parsePackagesSafe parses a valid JSON array of {name,version}", () => {
+  const parsed = parsePackagesSafe(
+    '[{"name":"@ag-ui/core","version":"1.0.0","path":"x"}]',
+  );
+  assert.deepEqual(parsed, [{ name: "@ag-ui/core", version: "1.0.0" }]);
+});
+
+test("parsePackagesSafe degrades to [] on empty / malformed JSON (cosmetic, never crashes)", () => {
+  assert.deepEqual(parsePackagesSafe(""), []);
+  assert.deepEqual(parsePackagesSafe("not json"), []);
+  assert.deepEqual(parsePackagesSafe("{}"), []);
+  // Entries missing a name are dropped.
+  assert.deepEqual(parsePackagesSafe('[{"version":"1.0.0"}]'), []);
+});
+
+// ---- parseGroupsSafe --------------------------------------------------------
+test("parseGroupsSafe parses a valid dist-tag grouping object", () => {
+  assert.deepEqual(parseGroupsSafe('{"latest":["@ag-ui/core"]}'), {
+    latest: ["@ag-ui/core"],
+  });
+});
+
+test("parseGroupsSafe degrades to {} on empty / malformed JSON", () => {
+  assert.deepEqual(parseGroupsSafe(""), {});
+  assert.deepEqual(parseGroupsSafe("not json"), {});
+  assert.deepEqual(parseGroupsSafe("[]"), {});
+});
+
+// ---- wrapper CLI fail-loud (subprocess) -------------------------------------
+test(
+  "fails loud (non-zero + ::error::) when running under Actions with GITHUB_OUTPUT unset",
+  { timeout: 30_000 },
+  async () => {
+    const { status, stderr } = await runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: undefined,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      BUILD_RESULT: "success",
+      TS_PACKAGES: '[{"name":"@ag-ui/core","version":"1.0.0"}]',
+      TS_GROUPS: '{"latest":["@ag-ui/core"]}',
+    });
+    assert.notEqual(status, 0);
+    assert.match(stderr, /::error::/);
+  },
+);
+
+test(
+  "writes output and exits 0 when GITHUB_OUTPUT is set",
+  { timeout: 30_000 },
+  async () => {
+    const dir = mkTmp();
+    try {
+      const out = join(dir, "gho.txt");
+      writeFileSync(out, "");
+      const { status } = await runWrapper({
+        GITHUB_ACTIONS: "true",
+        GITHUB_OUTPUT: out,
+        MODE: "stable",
+        NPM_RESULT: "success",
+        BUILD_RESULT: "success",
+        TS_PACKAGES: '[{"name":"@ag-ui/core","version":"1.0.0"}]',
+        TS_GROUPS: '{"latest":["@ag-ui/core"]}',
+      });
+      assert.equal(status, 0);
+      const raw = readFileSync(out, "utf8");
+      assert.ok(raw.includes("should_post=true"));
+      assert.match(raw, /^message<<\S+/m);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+// ---- wrapper CLI DRY_RUN string coercion (subprocess) -----------------------
+async function postFor(
+  dryRun: string,
+): Promise<{ status: number; raw: string }> {
+  const dir = mkTmp();
+  try {
+    const out = join(dir, "gho.txt");
+    writeFileSync(out, "");
+    const { status } = await runWrapper({
+      GITHUB_ACTIONS: "true",
+      GITHUB_OUTPUT: out,
+      MODE: "stable",
+      NPM_RESULT: "success",
+      BUILD_RESULT: "success",
+      TS_PACKAGES: '[{"name":"@ag-ui/core","version":"1.0.0"}]',
+      TS_GROUPS: '{"latest":["@ag-ui/core"]}',
+      DRY_RUN: dryRun,
+    });
+    return { status, raw: readFileSync(out, "utf8") };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test(
+  'DRY_RUN="true" → should_post=false (suppressed)',
+  { timeout: 30_000 },
+  async () => {
+    const { status, raw } = await postFor("true");
+    assert.equal(status, 0);
+    assert.ok(raw.includes("should_post=false"));
+  },
+);
+
+test(
+  'DRY_RUN="false" → posts on an otherwise-successful stable run',
+  { timeout: 30_000 },
+  async () => {
+    const { status, raw } = await postFor("false");
+    assert.equal(status, 0);
+    assert.ok(raw.includes("should_post=true"));
+  },
+);
+
+test(
+  'DRY_RUN="" (empty) → posts on an otherwise-successful stable run',
+  { timeout: 30_000 },
+  async () => {
+    const { status, raw } = await postFor("");
+    assert.equal(status, 0);
+    assert.ok(raw.includes("should_post=true"));
+  },
+);
+
+// ---- wrapper CLI end-to-end message rendering (subprocess) ------------------
+test(
+  "mixed lane: npm success + PyPI failure → one 🚀 line and one 🔴 line in one message",
+  { timeout: 30_000 },
+  async () => {
+    const dir = mkTmp();
+    try {
+      const out = join(dir, "gho.txt");
+      writeFileSync(out, "");
+      const { status } = await runWrapper({
+        GITHUB_ACTIONS: "true",
+        GITHUB_OUTPUT: out,
+        MODE: "stable",
+        NPM_RESULT: "success",
+        BUILD_RESULT: "success",
+        NPM_INTENDED: "true",
+        TS_PACKAGES: '[{"name":"@ag-ui/core","version":"1.0.0"}]',
+        TS_GROUPS: '{"latest":["@ag-ui/core"]}',
+        PY_INTENDED: "true",
+        PY_RESULT: "failure",
+        PY_BUILD_RESULT: "success",
+        // Build succeeded and detected a PyPI package, then the shared publish
+        // job failed: the detected package set is the authoritative
+        // "release attempted" signal the failure arm now gates on.
+        PY_PACKAGES: '[{"name":"ag-ui-protocol","version":"1.0.0"}]',
+        RUN_URL,
+      });
+      assert.equal(status, 0);
+      const m = readFileSync(out, "utf8").match(
+        /^message<<(\S+)\n([\s\S]*?)\n\1\n/m,
+      );
+      assert.notEqual(m, null);
+      const message = m![2];
+      assert.ok(message.includes("🚀"));
+      assert.ok(message.includes("🔴"));
+      assert.ok(message.includes("PyPI release failed"));
+      assert.equal(message.split("\n").length, 2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "PyPI build failure during a real release (PY_BUILD_RESULT=failure, publish skipped) → 🔴 PyPI alert",
+  { timeout: 30_000 },
+  async () => {
+    const dir = mkTmp();
+    try {
+      const out = join(dir, "gho.txt");
+      writeFileSync(out, "");
+      const { status } = await runWrapper({
+        GITHUB_ACTIONS: "true",
+        GITHUB_OUTPUT: out,
+        PY_INTENDED: "true",
+        PY_RESULT: "skipped",
+        PY_BUILD_RESULT: "failure",
+        RUN_URL,
+      });
+      assert.equal(status, 0);
+      const raw = readFileSync(out, "utf8");
+      assert.ok(raw.includes("should_post=true"));
+      const m = raw.match(/^message<<(\S+)\n([\s\S]*?)\n\1\n/m);
+      assert.notEqual(m, null);
+      assert.ok(m![2].includes("🔴"));
+      assert.ok(m![2].includes("PyPI release failed"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "routine merge (MODE='', no intent, build skipped) → should_post=false (no false red)",
+  { timeout: 30_000 },
+  async () => {
+    const dir = mkTmp();
+    try {
+      const out = join(dir, "gho.txt");
+      writeFileSync(out, "");
+      const { status } = await runWrapper({
+        GITHUB_ACTIONS: "true",
+        GITHUB_OUTPUT: out,
+        MODE: "",
+        BUILD_RESULT: "skipped",
+        NPM_RESULT: "skipped",
+        NPM_INTENDED: "false",
+        PY_INTENDED: "false",
+        PY_RESULT: "skipped",
+        PY_BUILD_RESULT: "skipped",
+        RUN_URL,
+      });
+      assert.equal(status, 0);
+      assert.ok(readFileSync(out, "utf8").includes("should_post=false"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "npm success with empty TS_PACKAGES (degraded) → no false success line",
+  { timeout: 30_000 },
+  async () => {
+    const dir = mkTmp();
+    try {
+      const out = join(dir, "gho.txt");
+      writeFileSync(out, "");
+      const { status } = await runWrapper({
+        GITHUB_ACTIONS: "true",
+        GITHUB_OUTPUT: out,
+        MODE: "stable",
+        NPM_RESULT: "success",
+        BUILD_RESULT: "success",
+        TS_PACKAGES: "",
+        TS_GROUPS: "",
+      });
+      assert.equal(status, 0);
+      assert.ok(readFileSync(out, "utf8").includes("should_post=false"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/scripts/release/lib/build-release-notification.ts
+++ b/scripts/release/lib/build-release-notification.ts
@@ -1,0 +1,406 @@
+/**
+ * Pure message-builder for the post-release #engr Slack notification.
+ *
+ * This is the load-bearing truth table for what (if anything) gets posted to
+ * Slack after the publish-release.yml workflow runs. It is deliberately a PURE
+ * function of its inputs so the full truth table can be unit-tested without any
+ * GitHub Actions / network involvement. The thin CLI wrapper
+ * (scripts/release/build-release-notification.ts) parses env vars, calls this
+ * function, and writes the result to GITHUB_OUTPUT.
+ *
+ * Ported from CopilotKit's scripts/release/lib/build-release-notification.ts.
+ * The truth table (suppression rules, lane independence, intent gating,
+ * cancelled-is-neutral, page-on-uncertainty) is preserved verbatim in spirit;
+ * the only divergence is the SUCCESS message shape. CopilotKit resolves a
+ * package COUNT from release.config.json and renders one summary line; ag-ui
+ * instead receives the actual published-package SETS from the build job's
+ * registry-diff outputs (ts_packages + ts_groups_json for npm, py_packages for
+ * PyPI), so the success line is rendered directly from those sets — count,
+ * package names, and (for npm) dist-tag grouping — as ONE concise message per
+ * lane, never one-per-package.
+ *
+ * Build/publish job topology — SINGLE SHARED JOBS (ag-ui divergence):
+ *
+ *   ag-ui runs ONE build job and ONE publish job spanning BOTH lanes. The
+ *   workflow wires BUILD_RESULT and PY_BUILD_RESULT both to needs.build.result,
+ *   and NPM_RESULT and PY_RESULT both to needs.publish.result. So the per-lane
+ *   build-vs-publish-skip distinction from CopilotKit (which had separate
+ *   build-python / publish-python jobs, where a build-stage failure skipped the
+ *   matching publish job and produced a distinct per-lane signal) does NOT apply
+ *   here — a build failure reds BOTH lanes' build signal, a publish failure reds
+ *   BOTH lanes' publish signal. Lane attribution therefore comes from the
+ *   published-package SETS (tsPackages vs pyPackages) — the AUTHORITATIVE
+ *   "this lane actually attempted a release" signal — with the event-derived
+ *   intent gates (npmIntended / pyIntended) used only as a BUILD-FAILURE
+ *   FALLBACK (when the build failed before detection could populate the set),
+ *   NOT from which job result is red.
+ *   (CopilotKit lineage: the buildResult/pyBuildResult split that once let a
+ *   single ecosystem's build failure page just that lane no longer applies.)
+ *   KNOWN LIMITATION: because npm and PyPI share ONE publish job, a single-lane
+ *   publish failure reds the shared result for BOTH lanes; if both lanes
+ *   detected packages, both red lines may show (safe over-report). True
+ *   per-lane attribution needs the publish job to emit per-lane outputs. The
+ *   shared BUILD job has the SAME coupling: a build failure in one ecosystem's
+ *   steps sets needs.build.result=failure for BOTH lanes, so a TS-only build
+ *   failure can red the PyPI lane (and vice-versa) when the other lane also
+ *   detected packages or was intended. Same safe over-report direction; true
+ *   per-lane attribution needs the build job to emit per-lane results.
+ *
+ * Failure model — TWO INDEPENDENT LANES (npm + PyPI):
+ *
+ *   - dry-run → no post (entirely suppressed).
+ *
+ *   - canary (mode === "prerelease") → no post AT ALL, BOTH lanes (success AND
+ *     failure). A canary run is fully suppressed: canaries are noise and we want
+ *     exactly one concise message per stable release, never canary spam. This
+ *     matches the npm-lane canary suppression and now extends it to the PyPI
+ *     lane, so a canary PyPI publish-failure never pages while a canary success
+ *     posts nothing — consistent silence on both lanes.
+ *
+ *   - npm lane (stable only — canary already short-circuited above):
+ *       • SUCCESS line when mode==stable && npmResult==success && ≥1 published
+ *         package. Rendered from tsPackages (count + names) grouped by dist-tag
+ *         via tsGroups. An EMPTY published set is anomalous (success result but
+ *         nothing published) and renders NO success line — never a false
+ *         success.
+ *       • FAILURE alert (lane-level, NOT step-level) when
+ *         (npmResult==failure || buildResult==failure) AND (tsPackages.length>0
+ *         OR (buildResult==failure && npmIntended)). PRIMARY gate is the
+ *         detected package set (tsPackages) — the authoritative attempted-a-
+ *         release signal; event-derived npmIntended is only the BUILD-FAILURE
+ *         FALLBACK so an early build failure (before detection ran) on an
+ *         intended release still pages. NOT additionally gated on mode==stable
+ *         (which would swallow a real stable publish failure whose mode output
+ *         came back empty). The publish step may have succeeded with a LATER
+ *         tag/release step failing, so the wording is "release failed", never
+ *         "publish failed".
+ *
+ *   - PyPI lane (stable only — canary already short-circuited above):
+ *       • SUCCESS line when mode==stable && pyResult==success && ≥1 published
+ *         package, rendered from pyPackages (count + names). Symmetric with the
+ *         npm SUCCESS arm: BOTH lanes require mode==="stable" so neither claims a
+ *         success on a degraded/empty MODE (the canary mode==="prerelease" case
+ *         is already fully suppressed by the early-return above; this gate guards
+ *         the mode==="" degraded case). py_packages is only populated on a stable
+ *         release, so this never suppresses a legitimate post.
+ *       • FAILURE alert when (pyResult==failure || pyBuildResult==failure) AND
+ *         (pyPackages.length>0 OR (pyBuildResult==failure && pyIntended)).
+ *         Symmetric with the npm lane: PRIMARY gate is the detected PyPI package
+ *         set (pyPackages); event-derived pyIntended is only the BUILD-FAILURE
+ *         FALLBACK. The pyBuildResult arm closes the gap where the build job
+ *         FAILS during a genuine release → publish is skipped → pyResult is
+ *         "skipped", so a bare pyResult check would post nothing. The
+ *         build-failure fallback to pyIntended catches a build failure that
+ *         never emitted publish outputs, and keeps routine non-Python merges
+ *         quiet.
+ *
+ *   - cancelled is NEUTRAL everywhere — never a failure line. (GitHub has no
+ *     timeout-specific result; a job hitting timeout-minutes reports
+ *     "cancelled", which correctly stays neutral.)
+ *
+ *   - a skipped lane contributes NOTHING (no false red).
+ *   - shouldPost is true iff ≥1 line (success OR failure) was emitted; an empty
+ *     message never posts.
+ *
+ * See build-release-notification.test.ts for the exhaustive truth table.
+ */
+
+export type ReleaseMode = "stable" | "prerelease" | "";
+
+/**
+ * GitHub Actions `result` values for a needed job. These are the ONLY values
+ * GitHub emits: success | failure | cancelled | skipped (plus "" when unset).
+ * We only treat "success" and "failure" as actionable;
+ * "skipped"/"cancelled"/"" are neutral.
+ */
+export type JobResult = "success" | "failure" | "skipped" | "cancelled" | "";
+
+/** A published package, as carried in the build job's package arrays. */
+export interface PublishedPackage {
+  name: string;
+  version: string;
+}
+
+/** dist-tag → package-name list (ag-ui's ts_groups_json shape). */
+export type DistTagGroups = Record<string, string[]>;
+
+export interface BuildReleaseNotificationInput {
+  /** needs.build.outputs.mode — "stable" | "prerelease" | "". */
+  mode: ReleaseMode;
+  /** needs.publish.result — the shared publish job result (npm lane view). */
+  npmResult: JobResult;
+  /**
+   * needs.build.result — the shared build job result (npm lane view). ag-ui has
+   * ONE build job spanning both lanes, so this is the SAME value as
+   * pyBuildResult (both wired to needs.build.result). The CopilotKit per-lane
+   * build-vs-publish distinction does NOT apply here. Catches build-stage
+   * failures on the npm side.
+   */
+  buildResult: JobResult;
+  /**
+   * NPM_INTENDED — "true" when the notify job determined an npm release was
+   * actually attempted (a push whose compare-range touched a package.json, or
+   * a workflow_dispatch stable lane). FALLBACK signal for the npm FAILURE arm:
+   * used only when the BUILD failed before the detected package set could be
+   * populated, so an early build failure on a genuine npm release still pages.
+   * The primary failure gate is the detected package set (tsPackages).
+   */
+  npmIntended: string;
+  /** needs.build.outputs.ts_packages — the published npm package set. */
+  tsPackages: PublishedPackage[];
+  /** needs.build.outputs.ts_groups_json — dist-tag groupings for the npm set. */
+  tsGroups: DistTagGroups;
+  /**
+   * PY_INTENDED — "true" when the notify job determined a Python release was
+   * intended (a push whose compare-range touched a pyproject.toml, or a
+   * workflow_dispatch stable lane). FALLBACK signal for the PyPI FAILURE arm:
+   * used only when the BUILD failed before the detected package set could be
+   * populated. The primary failure gate is the detected package set
+   * (pyPackages).
+   */
+  pyIntended: string;
+  /**
+   * needs.publish.result mapped to the PyPI lane. ag-ui publishes BOTH lanes
+   * from the SAME publish job, so this is the SAME value as npmResult.
+   */
+  pyResult: JobResult;
+  /**
+   * needs.build.result mapped to the PyPI lane. ag-ui has ONE build job, so
+   * this is the SAME value as buildResult. The CopilotKit lineage where a
+   * separate build-python failure pages only the PyPI lane no longer applies.
+   */
+  pyBuildResult: JobResult;
+  /** needs.build.outputs.py_packages — the published PyPI package set. */
+  pyPackages: PublishedPackage[];
+  /** needs.build.outputs.scope. Reserved for future use; not rendered today. */
+  scope: string;
+  /** inputs.dry_run — true on a dry-run dispatch. */
+  dryRun: boolean;
+  /** URL to this workflow run (for failure "View run" links). */
+  runUrl: string;
+  /** URL to the npm org page (https://www.npmjs.com/org/ag-ui). */
+  npmOrgUrl: string;
+  /** Base URL for PyPI project pages (https://pypi.org/project). */
+  pyBaseUrl: string;
+}
+
+export interface BuildReleaseNotificationResult {
+  /** The combined Slack message (mrkdwn). Empty when shouldPost is false. */
+  message: string;
+  /** True iff there is ≥1 success line OR ≥1 failure line. */
+  shouldPost: boolean;
+}
+
+/** Maximum package names to list inline before collapsing to "+N more". */
+const MAX_NAMES = 5;
+
+function pluralize(count: number, noun: string): string {
+  return count === 1 ? `1 ${noun}` : `${count} ${noun}s`;
+}
+
+/** Render a capped, comma-joined name list with a "+N more" overflow tail. */
+function renderNameList(names: string[]): string {
+  if (names.length <= MAX_NAMES) {
+    return names.join(", ");
+  }
+  const shown = names.slice(0, MAX_NAMES);
+  const remaining = names.length - MAX_NAMES;
+  return `${shown.join(", ")}, +${remaining} more`;
+}
+
+/**
+ * Render the npm dist-tag breakdown for the success line. Each group is shown
+ * as "`<tag>`: <name list>". Groups are sorted with "latest" first, then
+ * alphabetically, so the most common case reads naturally. Empty-array groups
+ * are skipped so a degraded ts_groups_json never renders a malformed "`tag`: "
+ * fragment with no names.
+ */
+function renderNpmGroups(groups: DistTagGroups): string {
+  const tags = Object.keys(groups)
+    .filter((tag) => groups[tag].length > 0)
+    .sort((a, b) => {
+      if (a === "latest") return -1;
+      if (b === "latest") return 1;
+      return a.localeCompare(b);
+    });
+  return tags
+    .map((tag) => `\`${tag}\`: ${renderNameList(groups[tag])}`)
+    .join(" · ");
+}
+
+/**
+ * Build the #engr Slack message for a release run. Pure function: same inputs
+ * always produce the same output.
+ */
+export function buildReleaseNotification(
+  input: BuildReleaseNotificationInput,
+): BuildReleaseNotificationResult {
+  const empty: BuildReleaseNotificationResult = {
+    message: "",
+    shouldPost: false,
+  };
+
+  // Dry-run never posts (no real publish happened on any lane).
+  if (input.dryRun) {
+    return empty;
+  }
+
+  // Canary (mode === "prerelease") is fully suppressed on BOTH lanes — success
+  // AND failure. Canaries are noise; we want exactly one concise message per
+  // stable release. This sits at the same level as the dry-run early-return so
+  // neither a success nor a failure line is produced for any canary run.
+  if (input.mode === "prerelease") {
+    return empty;
+  }
+
+  // Event-derived intent signals computed in the notify job. These are now the
+  // BUILD-FAILURE FALLBACK for each failure arm (used only when the build
+  // failed before the detected package set could populate); the PRIMARY failure
+  // gate is the detected package set (tsPackages / pyPackages).
+  const npmIntended = input.npmIntended === "true";
+  const pyIntended = input.pyIntended === "true";
+
+  const lines: string[] = [];
+
+  // --- npm lane (stable only — canary already short-circuited above) ------
+  if (
+    input.mode === "stable" &&
+    input.npmResult === "success" &&
+    input.tsPackages.length > 0
+  ) {
+    const count = input.tsPackages.length;
+    // Prefer the dist-tag grouping (carries tag context); fall back to a flat
+    // name list from tsPackages if groups came back empty/degraded. When groups
+    // ARE populated, validate that they agree with the tsPackages set on TWO
+    // axes, because the count (from tsPackages) and the rendered names (from
+    // tsGroups) must never disagree:
+    //   1. TOTAL count — the sum of grouped names ACROSS all groups, INCLUDING
+    //      duplicates, must equal tsPackages.length. A name appearing in two
+    //      groups would dedupe to the same Set size yet render more names than
+    //      the count claims, so a Set-only check would miss it.
+    //   2. Set membership — the deduped set of grouped names must exactly match
+    //      the tsPackages name set (catches a dropped group, or a phantom name
+    //      listed that isn't in tsPackages).
+    // On ANY mismatch, warn and fall back to the flat list so count and names
+    // always agree. (renderNpmGroups already skips empty-array groups; this
+    // total-count axis additionally catches the multi-group-duplicate case.)
+    let breakdown: string;
+    if (Object.keys(input.tsGroups).length > 0) {
+      const groupNames = new Set<string>();
+      let totalGroupedNames = 0;
+      for (const names of Object.values(input.tsGroups)) {
+        for (const n of names) {
+          groupNames.add(n);
+          totalGroupedNames += 1;
+        }
+      }
+      const packageNames = new Set(input.tsPackages.map((p) => p.name));
+      const sameTotalCount = totalGroupedNames === input.tsPackages.length;
+      const sameMembership =
+        groupNames.size === packageNames.size &&
+        [...groupNames].every((n) => packageNames.has(n));
+      if (sameTotalCount && sameMembership) {
+        breakdown = renderNpmGroups(input.tsGroups);
+      } else {
+        console.warn(
+          "::warning::npm dist-tag groups (ts_groups_json) disagree with the published package set (ts_packages) — falling back to a flat name list so the count and names agree.",
+        );
+        breakdown = renderNameList(input.tsPackages.map((p) => p.name));
+      }
+    } else {
+      breakdown = renderNameList(input.tsPackages.map((p) => p.name));
+    }
+    lines.push(
+      `🚀 *ag-ui release* · ${pluralize(count, "npm package")} published ` +
+        `(${breakdown}) · ` +
+        `<${input.npmOrgUrl}|npm>`,
+    );
+  } else if (
+    (input.npmResult === "failure" || input.buildResult === "failure") &&
+    (input.tsPackages.length > 0 ||
+      (input.buildResult === "failure" && npmIntended))
+  ) {
+    // FAILURE gating keys off the DETECTED PACKAGE SET, not the event-derived
+    // intent. The detected set (tsPackages.length > 0) is the authoritative
+    // "this lane actually attempted a release" signal → page on its failure
+    // regardless of which manifest the push touched. This closes a
+    // silent-swallow: detect_ts diffs LOCAL manifests against the REGISTRY, so
+    // a push that only touched the OTHER ecosystem's manifest can still
+    // re-detect a STALE unpublished bump from a prior failed release; intent
+    // (compare-range) for THIS lane is then false, which under the old
+    // intent-only gate would shut the arm and swallow a real publish failure.
+    // When the BUILD failed before detection could populate the package set, we
+    // fall back to the event-derived intent (npmIntended) so an early build
+    // failure on an intended release still pages — never toward silence. When
+    // the build SUCCEEDED but detected no packages (e.g. a dependabot dep bump
+    // that touched package.json without bumping the package's own version),
+    // this lane does NOT page (fixes the prior false-positive).
+    //
+    // KNOWN LIMITATION (out of scope — needs a publish-job change): npm and
+    // PyPI share ONE publish job, so npmResult and pyResult are both
+    // needs.publish.result. A single-lane publish failure therefore marks the
+    // shared result "failure"; if the OTHER lane also detected packages, both
+    // red lines may show. This is the safe over-report direction; true per-lane
+    // attribution requires the publish job to emit per-lane outputs. The shared
+    // BUILD job has the same coupling: buildResult is needs.build.result for
+    // BOTH lanes, so a TS-only build failure can red the PyPI lane (and
+    // vice-versa) when the other lane also detected packages or was intended.
+    //
+    // Lane-level wording: a later tag/release step may have failed while
+    // publish itself succeeded, so never say "npm publish failed".
+    lines.push(`🔴 *ag-ui npm release failed* · <${input.runUrl}|View run>`);
+  }
+  // cancelled / skipped on the npm lane are NEUTRAL → no line.
+
+  // --- PyPI lane (stable only — canary already short-circuited above) -----
+  if (
+    input.mode === "stable" &&
+    input.pyResult === "success" &&
+    input.pyPackages.length > 0
+  ) {
+    const count = input.pyPackages.length;
+    const names = renderNameList(input.pyPackages.map((p) => p.name));
+    // Link to the flagship project page. ag-ui's flagship is ag-ui-protocol;
+    // select it explicitly by name if present (nothing sorts pyPackages, so we
+    // must not assume index 0 is the flagship), else fall back to the first
+    // published package.
+    const flagship =
+      input.pyPackages.find((p) => p.name === "ag-ui-protocol")?.name ??
+      input.pyPackages[0].name;
+    lines.push(
+      `🐍 *ag-ui release* · ${pluralize(count, "PyPI package")} published ` +
+        `(${names}) · ` +
+        `<${input.pyBaseUrl}/${flagship}/|PyPI>`,
+    );
+  } else if (
+    (input.pyResult === "failure" || input.pyBuildResult === "failure") &&
+    (input.pyPackages.length > 0 ||
+      (input.pyBuildResult === "failure" && pyIntended))
+  ) {
+    // Symmetric with the npm failure arm: gate on the DETECTED PACKAGE SET
+    // (pyPackages.length > 0) as the authoritative "this lane attempted a
+    // release" signal → page on its failure regardless of which manifest the
+    // push touched (closes the stale-cross-lane silent-swallow where detect_py
+    // re-detects a stale unpublished bump on an npm-only push). When the BUILD
+    // failed before detection could populate the package set, fall back to the
+    // event-derived pyIntended so an early build failure on an intended release
+    // still pages. When the build SUCCEEDED but detected no packages, this lane
+    // does NOT page. Use pyBuildResult === "failure" (NOT "skipped"): a
+    // CANCELLED build reports "cancelled" and stays NEUTRAL, so a deliberate
+    // cancel never false-REDs.
+    //
+    // Same KNOWN LIMITATION as the npm arm: the shared publish job means a
+    // single-lane publish failure reds both lanes' result; safe over-report.
+    // The shared BUILD job has the same coupling: pyBuildResult is
+    // needs.build.result for BOTH lanes, so a PyPI-only build failure can red
+    // the npm lane (and vice-versa) when the other lane also detected packages
+    // or was intended.
+    lines.push(`🔴 *ag-ui PyPI release failed* · <${input.runUrl}|View run>`);
+  }
+
+  if (lines.length === 0) {
+    return empty;
+  }
+
+  return { message: lines.join("\n"), shouldPost: true };
+}


### PR DESCRIPTION
## Summary

Ports CopilotKit's release→Slack notification to ag-ui: a **single concise** post to **#engr** when a release publishes (or fails), covering both ecosystems (npm `@ag-ui/*` + PyPI). One message per release, not one per package.

- **New `notify` job** in `publish-release.yml` (`needs: [build, publish]`, `always()`, gated to a real release context). Posts via the existing `slackapi/slack-github-action` to `secrets.SLACK_WEBHOOK_ENGR`, guarded so an unset webhook is a clean no-op. Build/publish/dry_run_summary jobs are untouched.
- **Release intent is computed in the notify job** from the push compare-range (`gh api .../compare`) or dispatch inputs — independent of the build jobs, and **fails toward paging** on API error, missing SHAs, or a truncated (≥300-file) compare response, so a genuine failure is never swallowed.
- **Pure, unit-tested message builder** (`scripts/release/lib/build-release-notification.ts`) + CLI wrapper. The **failure arms gate on the detected package set** (`ts_packages`/`py_packages`) — the authoritative "a release was actually attempted" signal — with intent as the build-failure fallback. This closes a stale-cross-lane silent-swallow and avoids false pages on non-version manifest edits. Canary (`mode=prerelease`) and dry-runs are fully suppressed on both lanes (including the self-watchdog).
- Tests run via the repo idiom `node --test --import tsx` (**83 green**).

## Prerequisite to enable

`ag-ui-protocol` has no Slack secret yet. Add **`SLACK_WEBHOOK_ENGR`** as an org secret (visibility=all) or a repo secret. The workflow ships guarded, so it lands safely now and starts posting the moment the secret exists.

## Known limitation (documented in-code)

ag-ui uses a **single shared `publish` (and `build`) job** for both lanes, so `needs.publish.result`/`needs.build.result` are shared. On a *mixed* release where one lane fails, the other lane's red line may also show (safe over-report). Fully accurate per-lane attribution would require the publish job to emit per-lane `ts_failed`/`py_failed` outputs — a follow-up.

## Test plan

- [x] `node --test --import tsx scripts/release/*.test.ts` → 83 pass
- [x] `actionlint .github/workflows/publish-release.yml` → 0 findings
- [x] prettier clean; both secret-using steps webhook-guarded; watchdog gates on `mode != 'prerelease'`
- [ ] Provision `SLACK_WEBHOOK_ENGR` in the ag-ui-protocol org
- [ ] CI green on the PR
- [ ] Observe a real #engr post on the next release