### PR TITLE
fix(release): upload spring-ai artifacts + add middleware-mcp to dispatch scope

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,6 +101,7 @@ on:
           - integration-watsonx-ts
           - middleware-a2a
           - middleware-a2ui
+          - middleware-mcp
           - middleware-mcp-apps
           - sdk-py
           - sdk-ts
@@ -373,6 +374,7 @@ jobs:
           path: |
             sdks/typescript/packages/*/dist/
             integrations/*/typescript/dist/
+            integrations/**/typescript/dist/
             middlewares/*/dist/
           retention-days: 1
 
@@ -507,9 +509,11 @@ jobs:
           path: |
             sdks/typescript/packages/*/dist/
             integrations/*/typescript/dist/
+            integrations/**/typescript/dist/
             middlewares/*/dist/
             sdks/typescript/packages/*/package.json
             integrations/*/typescript/package.json
+            integrations/**/typescript/package.json
             middlewares/*/package.json
           retention-days: 1
 


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the release pipeline (surfaced during a code review of `publish-release.yml`):

1. **`@ag-ui/spring-ai` build artifacts were never uploaded.** It lives at `integrations/community/spring-ai/typescript` (two levels under `integrations/`), but the TS upload-artifact globs only matched `integrations/*/typescript/` (one level). Result: a stable publish would `pnpm pack` against a missing `dist/` and ship a broken tarball (silent — only the canary lane fails loud, via the version-restore check). Added `integrations/**/typescript/{dist/,package.json}` to **both** the stable and prerelease upload steps.
2. **`middleware-mcp` (`@ag-ui/mcp-middleware`) was missing from the `workflow_dispatch` scope dropdown** — enrolled in `release.config.json` but not selectable, so it could not be canary-published. Added it; the option list now exactly matches `release.config.json` (25 = 25).

## Verification

- `actionlint .github/workflows/publish-release.yml` → 0 findings
- `verify-nx-release-allowlist.sh` → OK
- Scope-set diff (dropdown vs `release.config.json`) → exact match, zero drift
- Glob confirmed to match the nested `community/spring-ai` path without breaking existing single-level matches; the publish loop iterates the detected-package list (not the artifact tree), so the broader upload can't cause an unintended publish.

## Test plan
- [ ] CI green on the PR