### PR TITLE
chore(release): enroll @ag-ui/cloudflare-agents in release pipeline

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,6 +18,7 @@
       "@ag-ui/ag2",
       "@ag-ui/agno",
       "@ag-ui/claude-agent-sdk",
+      "@ag-ui/cloudflare-agents",
       "@ag-ui/crewai",
       "@ag-ui/langchain",
       "@ag-ui/langgraph",

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -69,6 +69,13 @@
         { "name": "@ag-ui/claude-agent-sdk", "path": "integrations/claude-agent-sdk/typescript", "ecosystem": "typescript" }
       ]
     },
+    "integration-cloudflare-agents": {
+      "description": "Cloudflare Agents integration (community, TypeScript)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "@ag-ui/cloudflare-agents", "path": "integrations/community/cloudflare-agents/typescript", "ecosystem": "typescript" }
+      ]
+    },
     "integration-crewai-ts": {
       "description": "CrewAI integration (TypeScript)",
       "sharedVersion": false,


### PR DESCRIPTION
## Summary

Enrolls the already-merged `@ag-ui/cloudflare-agents` package (v0.0.1, at `integrations/community/cloudflare-agents/typescript`) into the release pipeline so it can finally be published.

PR #1733 merged the package code but never wired it into the release allowlist, so the package is currently **invisible** to the publish workflow — `detect-ts-version-changes.sh` prints `SKIP (not in release.config.json): @ag-ui/cloudflare-agents` and the pipeline emits `[]` for it.

It was missing from **both** sources of truth, which must stay in sync (CI check `release-allowlist-sync` / `verify-nx-release-allowlist.sh`):

- `scripts/release/release.config.json` — added a new `integration-cloudflare-agents` scope, mirroring the existing `integration-spring-ai` community-integration shape (the only other `integrations/community/*` TS package).
- `nx.json` `release.projects` — added `@ag-ui/cloudflare-agents`.

This is a minimal 2-file enrollment change. No package source or version was modified.

## Red → Green proof (`bash scripts/release/detect-ts-version-changes.sh`)

**RED** (before, pristine `release.config.json`):
```
stderr: SKIP (not in release.config.json): @ag-ui/cloudflare-agents
stdout: []
```

**GREEN** (after enrollment):
```
stderr: NEW (unpublished): @ag-ui/cloudflare-agents@0.0.1 at integrations/community/cloudflare-agents/typescript
stdout: [{"name":"@ag-ui/cloudflare-agents","version":"0.0.1","path":"integrations/community/cloudflare-agents/typescript"}]
```

## Verification

- `bash scripts/release/verify-nx-release-allowlist.sh` → `OK: nx.json release.projects matches release.config.json TypeScript packages` (exit 0)
- `pnpm nx build @ag-ui/cloudflare-agents` → success, dist artifacts (CJS + ESM + d.ts) emitted

## Test plan

- [x] RED: detect script SKIPs the package before the change
- [x] GREEN: detect script reports it as publishable after the change
- [x] Sync verifier passes
- [x] Package builds clean