### PR TITLE
chore(release): prepare @ag-ui/adk for first npm publish (proposal)

### DIFF
--- a/integrations/adk-middleware/typescript/README.md
+++ b/integrations/adk-middleware/typescript/README.md
@@ -14,8 +14,8 @@ pnpm add @ag-ui/adk
 
 ### Peer Dependencies
 
-- `@ag-ui/client` (>=0.0.37)
-- `@ag-ui/core` (>=0.0.37)
+- `@ag-ui/client` (>=0.0.55)
+- `@ag-ui/core` (>=0.0.55)
 - `rxjs` (7.8.1)
 
 ## TypeScript Client Usage
@@ -25,15 +25,26 @@ pnpm add @ag-ui/adk
 ```typescript
 import { ADKAgent } from "@ag-ui/adk";
 
+// `threadId` and `initialMessages` are constructor options (AgentConfig),
+// not run-time parameters.
 const agent = new ADKAgent({
   url: "http://localhost:8000/chat",
+  threadId: "thread-123",
+  initialMessages: [{ id: "1", role: "user", content: "Hello!" }],
 });
 
+// `run(input)` returns an RxJS Observable of AG-UI events. It takes a full
+// `RunAgentInput`, so reuse the agent's `threadId`/`messages`/`state` and
+// supply the remaining required fields.
 agent
-  .runAgent({
-    threadId: "thread-123",
+  .run({
+    threadId: agent.threadId,
     runId: "run-456",
-    messages: [{ id: "1", role: "user", content: "Hello!" }],
+    messages: agent.messages,
+    state: agent.state,
+    tools: [],
+    context: [],
+    forwardedProps: {},
   })
   .subscribe({
     next: (event) => {
@@ -46,11 +57,12 @@ agent
           break;
       }
     },
+    error: (err) => console.error("Run failed:", err),
     complete: () => console.log("Done"),
   });
 ```
 
-`ADKAgent` accepts the same configuration as `HttpAgent` (`url`, `headers`, `agentId`, etc.) and exposes the standard `runAgent(...)` / `run(...)` Observable API.
+`ADKAgent` accepts the same configuration as `HttpAgent` (`url`, `headers`, `agentId`, `threadId`, `initialMessages`, etc.). Only `run(input)` is the Observable API — it takes a full `RunAgentInput` and returns an `Observable<BaseEvent>`. The Promise-based `runAgent(parameters?, subscriber?)` is the alternative: it manages `threadId`/`messages`/`state` for you, accepts only `runId`/`tools`/`context`/`forwardedProps`/`resume`, and resolves to a `RunAgentResult` (it is not subscribable).
 
 ### Discover agent capabilities
 

--- a/integrations/adk-middleware/typescript/README.md
+++ b/integrations/adk-middleware/typescript/README.md
@@ -97,7 +97,7 @@ To use this integration you need to:
     cd integrations/adk-middleware/python
     ```
 
-3. Install the `adk-middleware` package from the local directory.  For example,
+3. Install the `ag_ui_adk` package from the local directory.  For example,
 
     ```bash
     pip install .
@@ -110,17 +110,12 @@ To use this integration you need to:
     ```
 
     This installs the package from the current directory which contains:
-    - `src/adk_middleware/` - The middleware source code
+    - `src/ag_ui_adk/` - The middleware source code
     - `examples/` - Example servers and agents
     - `tests/` - Test suite
 
-4. Install the requirements for the `examples`, for example:
-
-    ```bash
-    uv pip install -r requirements.txt
-    ```
-
-5. Run the example fast_api server.
+4. Run the example FastAPI server. The example project pulls in its own
+   dependencies (including the local middleware) via `uv sync`.
 
     ```bash
     export GOOGLE_API_KEY=<My API Key>
@@ -129,42 +124,31 @@ To use this integration you need to:
     uv run dev
     ```
 
-6. Open another terminal in the root directory of the ag-ui repository clone.
+5. Open another terminal in the root directory of the ag-ui repository clone.
 
-7. Start the integration ag-ui dojo:
+6. Start the integration ag-ui dojo:
 
     ```bash
     pnpm install && pnpm run dev
     ```
 
-8. Visit [http://localhost:3000/adk-middleware](http://localhost:3000/adk-middleware).
+7. Visit [http://localhost:3000/adk-middleware](http://localhost:3000/adk-middleware).
 
-9. Select View `ADK Middleware` from the sidebar.
+8. Select View `ADK Middleware` from the sidebar.
 
 ### Development Setup
 
-If you want to contribute to ADK Middleware development, you'll need to take some additional steps.  You can either use the following script of the manual development setup.
+If you want to contribute to ADK Middleware development, install the package in
+editable mode with its dev dependencies:
 
 ```bash
-# From the adk-middleware directory
-chmod +x setup_dev.sh
-./setup_dev.sh
-```
-
-### Manual Development Setup
-
-```bash
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate
+# From the integrations/adk-middleware/python directory
 
 # Install this package in editable mode
 pip install -e .
 
 # For development (includes testing and linting tools)
 pip install -e ".[dev]"
-# OR
-pip install -r requirements-dev.txt
 ```
 
 This installs the ADK middleware in editable mode for development.
@@ -172,11 +156,11 @@ This installs the ADK middleware in editable mode for development.
 ## Testing
 
 ```bash
-# Run tests (271 comprehensive tests)
+# Run the test suite
 pytest
 
 # With coverage
-pytest --cov=src/adk_middleware
+pytest --cov=src/ag_ui_adk
 
 # Specific test file
 pytest tests/test_adk_agent.py
@@ -185,7 +169,7 @@ pytest tests/test_adk_agent.py
 
 ### Option 1: Direct Usage
 ```python
-from adk_middleware import ADKAgent
+from ag_ui_adk import ADKAgent
 from google.adk.agents import Agent
 
 # 1. Create your ADK agent
@@ -210,7 +194,7 @@ async for event in agent.run(input_data):
 
 ```python
 from fastapi import FastAPI
-from adk_middleware import ADKAgent, add_adk_fastapi_endpoint
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
 from google.adk.agents import Agent
 
 # 1. Create your ADK agent
@@ -233,18 +217,21 @@ add_adk_fastapi_endpoint(app, agent, path="/chat")
 # Run with: uvicorn your_module:app --host 0.0.0.0 --port 8000
 ```
 
-For detailed configuration options, see [CONFIGURATION.md](./CONFIGURATION.md)
+For detailed configuration options, see [CONFIGURATION.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/CONFIGURATION.md).
 
 
 ## Running the ADK Backend Server for Dojo App
 
-To run the ADK backend server that works with the Dojo app, use the following command:
+To run the ADK backend server that works with the Dojo app, run the example
+server from the `integrations/adk-middleware/python/examples` directory:
 
 ```bash
-python -m examples.fastapi_server
+cd examples
+uv sync
+uv run dev
 ```
 
-This will start a FastAPI server that connects your ADK middleware to the Dojo application.
+This starts a FastAPI server (the `server:main` entrypoint) that connects your ADK middleware to the Dojo application.
 
 ## Examples
 
@@ -252,7 +239,7 @@ This will start a FastAPI server that connects your ADK middleware to the Dojo a
 
 ```python
 import asyncio
-from adk_middleware import ADKAgent
+from ag_ui_adk import ADKAgent
 from google.adk.agents import Agent
 from ag_ui.core import RunAgentInput, UserMessage
 
@@ -312,7 +299,7 @@ creative_agent_wrapper = ADKAgent(
 
 # Use different endpoints for each agent
 from fastapi import FastAPI
-from adk_middleware import add_adk_fastapi_endpoint
+from ag_ui_adk import add_adk_fastapi_endpoint
 
 app = FastAPI()
 add_adk_fastapi_endpoint(app, general_agent_wrapper, path="/agents/general")
@@ -324,11 +311,13 @@ add_adk_fastapi_endpoint(app, creative_agent_wrapper, path="/agents/creative")
 
 The middleware provides complete bidirectional tool support, enabling AG-UI Protocol tools to execute within Google ADK agents. All tools supplied by the client are currently implemented as long-running tools that emit events to the client for execution and can be combined with backend tools provided by the agent to create a hybrid combined toolset.
 
-For detailed information about tool support, see [TOOLS.md](./TOOLS.md).
+For detailed information about tool support, see [TOOLS.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/TOOLS.md).
 
 ## Additional Documentation
 
-- **[CONFIGURATION.md](./CONFIGURATION.md)** - Complete configuration guide
-- **[TOOLS.md](./TOOLS.md)** - Tool support documentation
-- **[USAGE.md](./USAGE.md)** - Usage examples and patterns
-- **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Technical architecture and design details
+These guides live in the companion Python middleware directory:
+
+- **[CONFIGURATION.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/CONFIGURATION.md)** - Complete configuration guide
+- **[TOOLS.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/TOOLS.md)** - Tool support documentation
+- **[USAGE.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/USAGE.md)** - Usage examples and patterns
+- **[ARCHITECTURE.md](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/ARCHITECTURE.md)** - Technical architecture and design details

--- a/integrations/adk-middleware/typescript/README.md
+++ b/integrations/adk-middleware/typescript/README.md
@@ -1,4 +1,77 @@
-# ADK Middleware for AG-UI Protocol
+# @ag-ui/adk
+
+AG-UI integration for [Google ADK](https://google.github.io/adk-docs/) (Agent Development Kit). This package ships a thin TypeScript client, `ADKAgent`, that connects an AG-UI front end to an ADK-backed agent endpoint served by the companion Python middleware (`ag_ui_adk`).
+
+`ADKAgent` extends `HttpAgent` from `@ag-ui/client`, so it speaks the full AG-UI protocol over HTTP/SSE out of the box. On top of that it adds a `getCapabilities()` method that fetches and validates the agent's advertised capabilities.
+
+## Installation
+
+```bash
+npm install @ag-ui/adk
+# or
+pnpm add @ag-ui/adk
+```
+
+### Peer Dependencies
+
+- `@ag-ui/client` (>=0.0.37)
+- `@ag-ui/core` (>=0.0.37)
+- `rxjs` (7.8.1)
+
+## TypeScript Client Usage
+
+### Connect to an ADK-backed agent
+
+```typescript
+import { ADKAgent } from "@ag-ui/adk";
+
+const agent = new ADKAgent({
+  url: "http://localhost:8000/chat",
+});
+
+agent
+  .runAgent({
+    threadId: "thread-123",
+    runId: "run-456",
+    messages: [{ id: "1", role: "user", content: "Hello!" }],
+  })
+  .subscribe({
+    next: (event) => {
+      switch (event.type) {
+        case "TEXT_MESSAGE_CONTENT":
+          process.stdout.write(event.delta);
+          break;
+        case "TOOL_CALL_START":
+          console.log("Calling tool:", event.toolCallName);
+          break;
+      }
+    },
+    complete: () => console.log("Done"),
+  });
+```
+
+`ADKAgent` accepts the same configuration as `HttpAgent` (`url`, `headers`, `agentId`, etc.) and exposes the standard `runAgent(...)` / `run(...)` Observable API.
+
+### Discover agent capabilities
+
+`getCapabilities()` issues a `GET` against the agent's `/capabilities` endpoint (derived from the configured `url`), parses the JSON response, and validates it against the AG-UI `AgentCapabilitiesSchema`. It rejects on HTTP errors, unparseable bodies, or schema-invalid responses.
+
+```typescript
+import { ADKAgent } from "@ag-ui/adk";
+
+const agent = new ADKAgent({ url: "http://localhost:8000/chat" });
+
+const capabilities = await agent.getCapabilities();
+console.log(capabilities);
+```
+
+To customize how capabilities are fetched (auth, headers, credentials, or the URL itself), subclass `ADKAgent` and override the protected `capabilitiesUrl()` and/or `capabilitiesRequestInit()` methods.
+
+---
+
+The remainder of this document covers the companion **Python middleware** (`ag_ui_adk`) that serves the ADK agent endpoint the TypeScript client above connects to.
+
+## Python Middleware
 
 This Python middleware enables [Google ADK](https://google.github.io/adk-docs/) agents to be used with the AG-UI Protocol, providing a bridge between the two frameworks.
 

--- a/integrations/adk-middleware/typescript/package.json
+++ b/integrations/adk-middleware/typescript/package.json
@@ -1,13 +1,22 @@
 {
   "name": "@ag-ui/adk",
-  "author": "Mark Fogle <mark@contextable.com>",
   "version": "0.0.1",
+  "description": "AG-UI integration for Google ADK (Agent Development Kit) - thin TypeScript client for ADK-backed AG-UI agents",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist/**"
+    "dist/**",
+    "README.md"
+  ],
+  "keywords": [
+    "ag-ui",
+    "adk",
+    "google",
+    "agent-development-kit",
+    "agents",
+    "ai"
   ],
   "scripts": {
     "build": "tsdown",
@@ -35,6 +44,17 @@
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
     "vitest": "^4.0.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ag-ui-protocol/ag-ui.git",
+    "directory": "integrations/adk-middleware/typescript"
+  },
+  "author": "Mark Fogle <mark@contextable.com>",
+  "license": "MIT",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
   },
   "exports": {
     ".": {

--- a/integrations/adk-middleware/typescript/package.json
+++ b/integrations/adk-middleware/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/adk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "AG-UI integration for Google ADK (Agent Development Kit) - thin TypeScript client for ADK-backed AG-UI agents",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -31,8 +31,8 @@
     "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
-    "@ag-ui/core": ">=0.0.37",
-    "@ag-ui/client": ">=0.0.37",
+    "@ag-ui/core": ">=0.0.55",
+    "@ag-ui/client": ">=0.0.55",
     "rxjs": "7.8.1"
   },
   "devDependencies": {

--- a/nx.json
+++ b/nx.json
@@ -15,6 +15,7 @@
       "@ag-ui/proto",
       "create-ag-ui-app",
       "@ag-ui/a2a",
+      "@ag-ui/adk",
       "@ag-ui/ag2",
       "@ag-ui/agno",
       "@ag-ui/claude-agent-sdk",

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -27,7 +27,14 @@
         { "name": "@ag-ui/a2a", "path": "integrations/a2a/typescript", "ecosystem": "typescript" }
       ]
     },
-    "integration-adk": {
+    "integration-adk-ts": {
+      "description": "ADK integration (TypeScript)",
+      "sharedVersion": false,
+      "packages": [
+        { "name": "@ag-ui/adk", "path": "integrations/adk-middleware/typescript", "ecosystem": "typescript" }
+      ]
+    },
+    "integration-adk-py": {
       "description": "ADK Middleware integration (Python)",
       "sharedVersion": false,
       "packages": [


### PR DESCRIPTION
## Proposal — prepares `@ag-ui/adk` for its first npm publish; awaiting maintainer (Mark Fogle) consent before publish + merge.

`@ag-ui/adk` (`integrations/adk-middleware/typescript`, **v0.0.1**) is a real but **never-published** thin TypeScript client — `ADKAgent` (extends `HttpAgent`) plus a `getCapabilities()` method with Zod validation, 8 passing tests. It is backed by the mature, already-published Python middleware `ag_ui_adk@0.6.5`. It was not publish-ready (missing packaging metadata) and not enrolled in the release pipeline. This PR fixes both, using `@ag-ui/cloudflare-agents` as the reference convention.

### What changed

**`integrations/adk-middleware/typescript/package.json`** — added publish metadata mirroring the cloudflare-agents sibling:
- `repository` → `git+https://github.com/ag-ui-protocol/ag-ui.git` (directory `integrations/adk-middleware/typescript`) — required for npm provenance (the E422 trap; must match `ag-ui-protocol/ag-ui`)
- `license: "MIT"`, `private: false`, `publishConfig.access: "public"`
- `description` + `keywords` (Google ADK = Agent Development Kit)
- `README.md` added to `files` so it ships in the tarball
- Version unchanged (`0.0.1`); `name`/`main`/`module`/`types`/`exports` left as-is

**`integrations/adk-middleware/typescript/README.md`** — added a primary TypeScript-client usage section (install, peer deps, `ADKAgent` connect, `getCapabilities()`), keeping the existing Python middleware docs below.

**Release pipeline** — split the Python-only `integration-adk` scope into `integration-adk-ts` (`@ag-ui/adk`) + `integration-adk-py` (`ag_ui_adk`) per the `-ts`/`-py` convention; added `@ag-ui/adk` to `nx.json` `release.projects` to keep `verify-nx-release-allowlist.sh` green.

### Red → Green verification

`scripts/release/detect-ts-version-changes.sh`:
- **Before:** `SKIP (not in release.config.json): @ag-ui/adk`
- **After:** `NEW (unpublished): @ag-ui/adk@0.0.1 at integrations/adk-middleware/typescript` → emitted in the publish JSON array

`scripts/release/verify-nx-release-allowlist.sh`: `OK: nx.json release.projects matches release.config.json TypeScript packages` (exit 0).

`npx nx build @ag-ui/adk`: success — emits `dist/index.js`, `index.mjs`, `index.d.ts`, `index.d.mts`. Tests 8/8 pass; `publint --strict` clean; `attw` all-green (node10/node16/bundler).

### NOTE on merge order

The actual **bootstrap-publish (manual OTP)** of `@ag-ui/adk@0.0.1` plus the **npm trusted-publisher binding** must happen **before** this PR is merged — mirroring how `@ag-ui/cloudflare-agents` was done. Merge order:

> **consent → bootstrap-publish + trusted-publisher binding → merge**

**Do not publish and do not merge until Mark Fogle consents.**