### PR TITLE
fix(claude-agent-sdk): repair six source bugs in the Python AG-UI adapter (ships as 0.1.2)

### DIFF
--- a/integrations/claude-agent-sdk/python/.gitignore
+++ b/integrations/claude-agent-sdk/python/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.egg-info/

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -94,7 +94,8 @@ class ClaudeAgentAdapter:
         self._max_workers = max_workers
         self._worker_ttl_seconds = worker_ttl_seconds
         self._query_timeout_seconds = query_timeout_seconds
-        self._workers: Dict[str, Dict] = {}  # changed from Dict[str, SessionWorker]
+        # thread_id -> {"worker": SessionWorker, "last_used": datetime, "active": bool}
+        self._workers: Dict[str, Dict] = {}
         self._state_locks: Dict[str, asyncio.Lock] = {}
         self._per_thread_state: Dict[str, Any] = {}  # thread_id -> current state
         self._per_thread_result: Dict[str, Any] = {}  # thread_id -> last result data
@@ -140,6 +141,8 @@ class ClaudeAgentAdapter:
             task = asyncio.create_task(entry["worker"].stop())
             task.add_done_callback(lambda t: t.exception() and logger.warning(f"Worker eviction error: {t.exception()}"))
             self._state_locks.pop(oldest_tid, None)
+            self._per_thread_state.pop(oldest_tid, None)
+            self._per_thread_result.pop(oldest_tid, None)
 
     async def clear_session(self, thread_id: str) -> None:
         """Stop and remove the session worker for a thread."""
@@ -147,6 +150,8 @@ class ClaudeAgentAdapter:
         if entry:
             await entry["worker"].stop()
         self._state_locks.pop(thread_id, None)
+        self._per_thread_state.pop(thread_id, None)
+        self._per_thread_result.pop(thread_id, None)
 
     async def run(self, input_data: RunAgentInput) -> AsyncIterator[BaseEvent]:
         """Run the agent and yield AG-UI events."""
@@ -159,8 +164,22 @@ class ClaudeAgentAdapter:
         self._per_thread_result[thread_id] = None
         
         try:
-            # Get or create worker for this thread
+            # Get or create worker for this thread.
+            # Guard against a poisoned cache entry: if a previously-cached
+            # worker's background task has died (e.g. client.connect() failed),
+            # reusing it would hang forever on a queue nothing drains. Evict the
+            # dead worker and fall through to creating a fresh one.
             entry = self._workers.get(thread_id)
+            if entry is not None and not entry["worker"].is_alive():
+                logger.warning(
+                    f"Evicting dead worker for thread={thread_id} (task terminated); creating fresh worker"
+                )
+                dead_entry = self._workers.pop(thread_id, None)
+                if dead_entry is not None:
+                    await dead_entry["worker"].stop()
+                self._state_locks.pop(thread_id, None)
+                entry = None
+
             if entry is None:
                 options = self.build_options(input_data, thread_id=thread_id)
                 worker = SessionWorker(thread_id, options)
@@ -250,6 +269,8 @@ class ClaudeAgentAdapter:
             if broken_entry:
                 await broken_entry["worker"].stop()
             self._state_locks.pop(thread_id, None)
+            self._per_thread_state.pop(thread_id, None)
+            self._per_thread_result.pop(thread_id, None)
             yield RunErrorEvent(
                 type=EventType.RUN_ERROR,
                 thread_id=thread_id,
@@ -735,7 +756,8 @@ class ClaudeAgentAdapter:
                         if tool_id and tool_id in processed_tool_ids:
                             continue
                         updated_state, tool_events = await handle_tool_use_block(
-                            block, message, thread_id, run_id, self._per_thread_state.get(thread_id)
+                            block, message, thread_id, run_id, self._per_thread_state.get(thread_id),
+                            parent_message_id=current_message_id,
                         )
                         if tool_id:
                             processed_tool_ids.add(tool_id)

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/handlers.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/handlers.py
@@ -31,28 +31,32 @@ async def handle_tool_use_block(
     thread_id: str,
     run_id: str,
     current_state: Optional[Any],
+    parent_message_id: Optional[str] = None,
 ) -> tuple[Optional[Any], AsyncIterator[BaseEvent]]:
     """
     Handle ToolUseBlock from Claude SDK.
-    
+
     Intercepts state management tool calls and emits STATE_SNAPSHOT.
     For regular tools, emits TOOL_CALL_START/ARGS events.
-    
+
     Args:
         block: ToolUseBlock from Claude SDK
         message: Parent message containing the block
         thread_id: Thread identifier
         run_id: Run identifier
         current_state: Current state for state management tools
-        
+        parent_message_id: ID of the assistant message that owns this tool
+            call. The streaming path uses the current assistant message id for
+            ``ToolCallStartEvent.parent_message_id``; this mirrors that
+            semantics on the non-streaming fallback path.
+
     Returns:
         Tuple of (updated_state, event_generator)
     """
     tool_name = getattr(block, 'name', '') or 'unknown'
     tool_input = getattr(block, 'input', {}) or {}
     tool_id = getattr(block, 'id', None) or str(uuid.uuid4())
-    parent_tool_use_id = getattr(message, 'parent_tool_use_id', None)
-    
+
     # Strip MCP prefix for client matching (same as streaming path)
     tool_display_name = strip_mcp_prefix(tool_name)
     if tool_display_name != tool_name:
@@ -77,13 +81,16 @@ async def handle_tool_use_block(
                     logger.debug("Parsed state_updates from JSON string")
                 except json.JSONDecodeError as e:
                     logger.warning(f"Failed to parse state_updates JSON: {e}")
-                    state_updates = {}
                     yield CustomEvent(
                         type=EventType.CUSTOM,
                         name="state_update_error",
                         value={"error": str(e)},
                     )
-            
+                    # Emit ONLY the error event — do not fall through and emit a
+                    # spurious STATE_SNAPSHOT with un-updated state. Mirrors the
+                    # streaming path (adapter.py), which emits the error alone.
+                    return
+
             # Update current state
             if isinstance(current_state, dict) and isinstance(state_updates, dict):
                 current_state = {**current_state, **state_updates}
@@ -109,7 +116,7 @@ async def handle_tool_use_block(
             run_id=run_id,
             tool_call_id=tool_id,
             tool_call_name=tool_display_name,  # Use unprefixed name
-            parent_message_id=parent_tool_use_id,
+            parent_message_id=parent_message_id,
         )
         
         if tool_input:
@@ -192,6 +199,16 @@ async def handle_tool_result_block(
             result_str = str(content)
 
     result_str = fix_surrogates(result_str)
+
+    # Propagate the SDK's error indication. AG-UI's ToolCallResultEvent has no
+    # dedicated error field, so a failed tool result would otherwise look
+    # identical to a successful one. Wrap the payload in an explicit error
+    # envelope (and log it) so downstream consumers can distinguish failures.
+    if is_error:
+        logger.warning(
+            f"Tool result for tool_use_id={tool_use_id} reported is_error=True"
+        )
+        result_str = json.dumps({"error": True, "content": result_str})
 
     if tool_use_id:
         # NOTE: Do NOT emit TOOL_CALL_END here — it was already emitted

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/handlers.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/handlers.py
@@ -63,52 +63,69 @@ async def handle_tool_use_block(
         logger.debug(f"Stripped MCP prefix in handler: {tool_name} -> {tool_display_name}")
     
     logger.debug(f"ToolUseBlock detected: {tool_name}")
-    
-    async def event_gen():
-        nonlocal current_state
-        
-        # Intercept state management tool calls (check both prefixed and unprefixed names)
-        if _is_state_management_tool(tool_name):
-            logger.debug("Intercepting ag_ui_update_state tool call")
-            
-            # Extract state updates from tool input
-            state_updates = tool_input.get("state_updates", {})
-            
-            # Parse if it's a JSON string
-            if isinstance(state_updates, str):
-                try:
-                    state_updates = json.loads(state_updates)
-                    logger.debug("Parsed state_updates from JSON string")
-                except json.JSONDecodeError as e:
-                    logger.warning(f"Failed to parse state_updates JSON: {e}")
-                    yield CustomEvent(
-                        type=EventType.CUSTOM,
-                        name="state_update_error",
-                        value={"error": str(e)},
-                    )
-                    # Emit ONLY the error event — do not fall through and emit a
-                    # spurious STATE_SNAPSHOT with un-updated state. Mirrors the
-                    # streaming path (adapter.py), which emits the error alone.
-                    return
 
+    # Compute the merged state SYNCHRONOUSLY, before building the generator, so
+    # the returned first element reflects the post-merge state. The adapter
+    # persists this returned value (self._per_thread_state[thread_id]) BEFORE it
+    # iterates the event generator, so a value computed inside event_gen() would
+    # not yet exist when the tuple is built — the adapter would persist the
+    # stale pre-merge state while the emitted STATE_SNAPSHOT carried the merged
+    # state. Computing here keeps the returned/persisted state == the snapshot.
+    merged_state = current_state
+    # When the state_updates JSON fails to parse we emit ONLY a CUSTOM error and
+    # must NOT mutate state nor emit a STATE_SNAPSHOT (mirrors the streaming
+    # path in adapter.py). This flag carries that decision out to the generator.
+    state_parse_error: Optional[str] = None
+
+    if _is_state_management_tool(tool_name):
+        logger.debug("Intercepting ag_ui_update_state tool call")
+
+        # Extract state updates from tool input
+        state_updates = tool_input.get("state_updates", {})
+
+        # Parse if it's a JSON string
+        if isinstance(state_updates, str):
+            try:
+                state_updates = json.loads(state_updates)
+                logger.debug("Parsed state_updates from JSON string")
+            except json.JSONDecodeError as e:
+                logger.warning(f"Failed to parse state_updates JSON: {e}")
+                state_parse_error = str(e)
+
+        if state_parse_error is None:
             # Update current state
-            if isinstance(current_state, dict) and isinstance(state_updates, dict):
-                current_state = {**current_state, **state_updates}
+            if isinstance(merged_state, dict) and isinstance(state_updates, dict):
+                merged_state = {**merged_state, **state_updates}
             else:
-                current_state = state_updates
+                merged_state = state_updates
 
             # Fix any UTF-16 surrogates before Pydantic serialisation
-            current_state = fix_surrogates_deep(current_state)
+            merged_state = fix_surrogates_deep(merged_state)
 
-            # Emit STATE_SNAPSHOT with updated state
+    async def event_gen():
+        # Intercept state management tool calls (check both prefixed and unprefixed names)
+        if _is_state_management_tool(tool_name):
+            if state_parse_error is not None:
+                yield CustomEvent(
+                    type=EventType.CUSTOM,
+                    name="state_update_error",
+                    value={"error": state_parse_error},
+                )
+                # Emit ONLY the error event — do not fall through and emit a
+                # spurious STATE_SNAPSHOT with un-updated state. Mirrors the
+                # streaming path (adapter.py), which emits the error alone.
+                return
+
+            # Emit STATE_SNAPSHOT with the SAME merged state we return below, so
+            # the persisted state and the snapshot never diverge.
             yield StateSnapshotEvent(
                 type=EventType.STATE_SNAPSHOT,
-                snapshot=current_state
+                snapshot=merged_state
             )
-            
+
             logger.debug(f"Emitted STATE_SNAPSHOT with updated state")
             return  # Skip normal tool call events
-        
+
         # Regular tool handling for non-state tools
         yield ToolCallStartEvent(
             type=EventType.TOOL_CALL_START,
@@ -140,7 +157,7 @@ async def handle_tool_use_block(
             tool_call_id=tool_id,
         )
 
-    return current_state, event_gen()
+    return merged_state, event_gen()
 
 
 async def handle_tool_result_block(
@@ -172,7 +189,12 @@ async def handle_tool_result_block(
     # Parse tool result content for frontend rendering
     # Claude SDK tools return: [{"type": "text", "text": "{json_data}"}]
     # Frontend expects just the parsed json_data
+    #
+    # We track both the final string AND, when the content is a JSON *object*,
+    # the parsed object. The error path (below) needs the parsed object so it
+    # can add an "error" marker WITHOUT double-encoding it into a string.
     result_str = ""
+    parsed_obj = None  # set only when the content is a JSON object (dict)
     if content is not None:
         try:
             # If content is a list of content blocks (Claude SDK format)
@@ -186,6 +208,8 @@ async def handle_tool_result_block(
                         parsed_json = json.loads(text_content)
                         # Use the parsed JSON directly so frontend can access fields
                         result_str = json.dumps(parsed_json)
+                        if isinstance(parsed_json, dict):
+                            parsed_obj = parsed_json
                     except (json.JSONDecodeError, ValueError):
                         # Not JSON, use as-is
                         result_str = text_content
@@ -198,17 +222,31 @@ async def handle_tool_result_block(
         except (TypeError, ValueError):
             result_str = str(content)
 
-    result_str = fix_surrogates(result_str)
-
     # Propagate the SDK's error indication. AG-UI's ToolCallResultEvent has no
     # dedicated error field, so a failed tool result would otherwise look
-    # identical to a successful one. Wrap the payload in an explicit error
-    # envelope (and log it) so downstream consumers can distinguish failures.
+    # identical to a successful one. Surface the error indicator (and log it)
+    # so downstream consumers can distinguish failures — but do it WITHOUT
+    # corrupting the payload:
+    #   * JSON-object content: add an "error": True key to the object and emit
+    #     the single-encoded object (consistent with the success shape).
+    #   * Plain-string content: wrap as {"error": True, "content": <string>}
+    #     exactly once (no nested re-encode).
+    #
+    # Surrogate repair must happen on the string VALUE *before* it is embedded
+    # in any json.dumps: json.dumps (ensure_ascii) escapes lone surrogates into
+    # literal "\ud83c" text, which fix_surrogates (a UTF-16 round-trip) cannot
+    # subsequently repair. So we fix the raw content first, then serialise, and
+    # do not re-escape the already-repaired value.
     if is_error:
         logger.warning(
             f"Tool result for tool_use_id={tool_use_id} reported is_error=True"
         )
-        result_str = json.dumps({"error": True, "content": result_str})
+        if parsed_obj is not None:
+            result_str = json.dumps(fix_surrogates_deep({**parsed_obj, "error": True}))
+        else:
+            result_str = json.dumps({"error": True, "content": fix_surrogates(result_str)})
+    else:
+        result_str = fix_surrogates(result_str)
 
     if tool_use_id:
         # NOTE: Do NOT emit TOOL_CALL_END here — it was already emitted

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
@@ -45,6 +45,16 @@ class SessionWorker:
             self._run(), name=f"session-worker-{self.thread_id}"
         )
 
+    def is_alive(self) -> bool:
+        """Return True if the background task is running and able to serve queries.
+
+        A worker whose ``_run`` task has finished (e.g. ``client.connect()``
+        failed and the task fell through its ``finally``) can no longer drain
+        the input queue, so reusing it would hang the next ``query()`` forever.
+        Callers must treat a non-alive worker as dead and create a fresh one.
+        """
+        return self._task is not None and not self._task.done()
+
     async def _run(self) -> None:
         """Main loop — runs entirely inside one stable async context."""
         from claude_agent_sdk import ClaudeSDKClient, SystemMessage

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/utils.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def fix_surrogates(s: str) -> str:
     """Re-assemble lone UTF-16 surrogate pairs into proper Unicode codepoints.
 
-    LLMock (JavaScript) chunks JSON via ``String.slice()`` which operates on
+    Streamed JSON chunked in JavaScript via ``String.slice()`` operates on
     16-bit code units.  Emoji outside the BMP (e.g. U+1F35D 🍝) are two code
     units in JS (a surrogate pair), and ``slice`` can split them.  When the
     chunks are reassembled in Python the string contains *paired* surrogates
@@ -356,18 +356,26 @@ def build_agui_assistant_message(
     Returns:
         AG-UI AssistantMessage, or None if no user-visible content.
     """
+    from claude_agent_sdk.types import TextBlock, ToolUseBlock
+
     content_blocks = getattr(sdk_message, "content", []) or []
 
     text_content = ""
     tool_calls: List[ToolCall] = []
 
     for block in content_blocks:
+        # Dispatch on the real SDK block classes. The genuine
+        # claude_agent_sdk TextBlock/ToolUseBlock dataclasses do NOT expose a
+        # ``.type`` attribute, so keying off ``getattr(block, "type", None)``
+        # silently dropped every real block. We keep a ``.type`` string
+        # fallback so dict-shaped / mock blocks that carry an explicit type
+        # still work.
         block_type = getattr(block, "type", None)
 
-        if block_type == "text":
+        if isinstance(block, TextBlock) or block_type == "text":
             text_content += getattr(block, "text", "")
 
-        elif block_type == "tool_use":
+        elif isinstance(block, ToolUseBlock) or block_type == "tool_use":
             raw_name = getattr(block, "name", "unknown")
 
             # Skip internal state management tool — not conversation history

--- a/integrations/claude-agent-sdk/python/pyproject.toml
+++ b/integrations/claude-agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag-ui-claude-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "AG-UI integration for Anthropic Claude Agent SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/claude-agent-sdk/python/pyproject.toml
+++ b/integrations/claude-agent-sdk/python/pyproject.toml
@@ -35,3 +35,6 @@ testpaths = ["tests"]
 requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["ag_ui_claude_sdk*"]
+

--- a/integrations/claude-agent-sdk/python/tests/test_adapter.py
+++ b/integrations/claude-agent-sdk/python/tests/test_adapter.py
@@ -262,3 +262,138 @@ class TestRunErrorPath:
         assert EventType.RUN_FINISHED not in types
         err = next(e for e in events if e.type == EventType.RUN_ERROR)
         assert "boom" in err.message
+
+    @pytest.mark.asyncio
+    async def test_error_path_cleans_all_three_dicts(self, make_input, monkeypatch):
+        # The run() error path must evict the worker AND drop per-thread state
+        # and result, not just the worker + lock. Otherwise an errored thread
+        # leaks _per_thread_state / _per_thread_result forever.
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _FakeFailingWorker)
+
+        inp = make_input(
+            thread_id="leaky",
+            state={"x": 1},
+            messages=[{"id": "1", "role": "user", "content": "hi"}],
+        )
+        _ = [e async for e in adapter.run(inp)]
+        assert "leaky" not in adapter._workers
+        assert "leaky" not in adapter._state_locks
+        assert "leaky" not in adapter._per_thread_state
+        assert "leaky" not in adapter._per_thread_result
+
+
+class _FakeAliveWorker:
+    """A SessionWorker stand-in that stays alive and is never queried."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def start(self):
+        pass
+
+    def is_alive(self):
+        return True
+
+    async def stop(self):
+        pass
+
+
+class _FakeDeadWorker:
+    """A SessionWorker stand-in whose background task has died."""
+
+    def __init__(self, *args, **kwargs):
+        self.stopped = False
+
+    async def start(self):
+        pass
+
+    def is_alive(self):
+        return False
+
+    def query(self, prompt, session_id="default"):
+        async def _gen():
+            # A dead worker can never serve a query; if reuse isn't guarded the
+            # real worker would hang here forever. Make the test fail loudly.
+            raise AssertionError("dead worker was reused for a query")
+            yield  # pragma: no cover
+
+        return _gen()
+
+    async def stop(self):
+        self.stopped = True
+
+
+class TestEviction:
+    @pytest.mark.asyncio
+    async def test_lru_eviction_cleans_all_three_dicts(self):
+        # LRU eviction must pop _per_thread_state and _per_thread_result, not
+        # just _workers + _state_locks. Cap at 1 worker, insert 2 idle entries.
+        # Async so _evict_workers' asyncio.create_task has a running loop.
+        import asyncio
+        from datetime import datetime, timedelta
+
+        adapter = ClaudeAgentAdapter(name="t", max_workers=1)
+        for i, tid in enumerate(["old", "new"]):
+            adapter._workers[tid] = {
+                "worker": _FakeAliveWorker(),
+                "last_used": datetime.now() + timedelta(seconds=i),
+                "active": False,
+            }
+            adapter._state_locks[tid] = asyncio.Lock()
+            adapter._per_thread_state[tid] = {"v": i}
+            adapter._per_thread_result[tid] = {"r": i}
+
+        adapter._evict_workers()
+
+        # "old" (lowest last_used) is evicted; all three dicts cleaned for it.
+        assert "old" not in adapter._workers
+        assert "old" not in adapter._state_locks
+        assert "old" not in adapter._per_thread_state
+        assert "old" not in adapter._per_thread_result
+        # "new" survives.
+        assert "new" in adapter._workers
+
+    @pytest.mark.asyncio
+    async def test_clear_session_cleans_all_three_dicts(self):
+        import asyncio
+
+        adapter = ClaudeAgentAdapter(name="t")
+        adapter._workers["s"] = {"worker": _FakeAliveWorker(), "last_used": None, "active": False}
+        adapter._state_locks["s"] = asyncio.Lock()
+        adapter._per_thread_state["s"] = {"v": 1}
+        adapter._per_thread_result["s"] = {"r": 1}
+
+        await adapter.clear_session("s")
+
+        assert "s" not in adapter._workers
+        assert "s" not in adapter._state_locks
+        assert "s" not in adapter._per_thread_state
+        assert "s" not in adapter._per_thread_result
+
+
+class TestPoisonedWorkerCache:
+    @pytest.mark.asyncio
+    async def test_dead_cached_worker_is_evicted_and_replaced(self, make_input, monkeypatch):
+        # A cached worker whose task has died must be evicted so the next run
+        # creates a fresh worker instead of reusing the dead one (which would
+        # hang forever waiting on a queue nothing drains).
+        adapter = ClaudeAgentAdapter(name="t")
+        dead = _FakeDeadWorker()
+        adapter._workers["th"] = {"worker": dead, "last_used": None, "active": False}
+
+        # The fresh worker created on the retry uses a fake that errors on query
+        # (so run still completes via RUN_ERROR rather than touching the LLM),
+        # but crucially the DEAD worker must NOT be the one queried.
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _FakeFailingWorker)
+
+        inp = make_input(thread_id="th", messages=[{"id": "1", "role": "user", "content": "hi"}])
+        events = [e async for e in adapter.run(inp)]
+        types = _types(events)
+        # Dead worker was stopped during eviction.
+        assert dead.stopped is True
+        # A fresh worker replaced it (RUN_ERROR comes from _FakeFailingWorker,
+        # NOT the AssertionError the dead worker would have raised).
+        assert EventType.RUN_ERROR in types
+        err = next(e for e in events if e.type == EventType.RUN_ERROR)
+        assert "boom" in err.message

--- a/integrations/claude-agent-sdk/python/tests/test_handlers.py
+++ b/integrations/claude-agent-sdk/python/tests/test_handlers.py
@@ -104,17 +104,30 @@ class TestHandleToolUseBlock:
         _, gen = await handle_tool_use_block(block, _Msg(), "th", "run", {})
         events = await collect(gen)
         types = [e.type for e in events]
-        # Exact current sequence: the parse error emits a CUSTOM event, then the
-        # handler STILL emits a STATE_SNAPSHOT (with the un-updated state). That
-        # trailing STATE_SNAPSHOT-after-error is a known handler bug deferred to
-        # the follow-up PR; we assert reality precisely here so the test is not
-        # vacuous (do NOT fix the handler logic in this PR).
-        assert types == [EventType.CUSTOM, EventType.STATE_SNAPSHOT]
+        # Invalid JSON emits ONLY a CUSTOM error event and returns early — no
+        # spurious STATE_SNAPSHOT with un-updated state (mirrors the streaming
+        # path in adapter.py).
+        assert types == [EventType.CUSTOM]
         custom = events[0]
         assert custom.name == "state_update_error"
         assert "error" in custom.value
-        # Invalid JSON -> updates discarded -> snapshot reflects the original {} state.
-        assert events[1].snapshot == {}
+
+
+class TestToolUseBlockParentMessageId:
+    @pytest.mark.asyncio
+    async def test_parent_message_id_uses_passed_assistant_message_id(self):
+        # The streaming path sets ToolCallStartEvent.parent_message_id to the
+        # current assistant message id. The non-streaming handler must mirror
+        # that — NOT the SDK's parent_tool_use_id (which lives on the message).
+        block = ToolUseBlock(id="tc1", name="get_weather", input={"city": "NYC"})
+        msg = _Msg(parent_tool_use_id="SHOULD_NOT_BE_USED")
+        _, gen = await handle_tool_use_block(
+            block, msg, "th", "run", None, parent_message_id="assistant-msg-1"
+        )
+        events = await collect(gen)
+        start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+        assert start.parent_message_id == "assistant-msg-1"
+        assert start.parent_message_id != "SHOULD_NOT_BE_USED"
 
 
 class TestHandleToolResultBlock:
@@ -129,6 +142,33 @@ class TestHandleToolResultBlock:
         assert events[0].type == EventType.TOOL_CALL_RESULT
         assert events[0].tool_call_id == "tc1"
         assert events[0].message_id == "tc1-result"
+        assert json.loads(events[0].content) == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_is_error_propagated_into_result_content(self):
+        # A failed tool result (is_error=True) must not look identical to a
+        # successful one. AG-UI's ToolCallResultEvent has no error field, so the
+        # error indication is surfaced inside the content envelope.
+        block = ToolResultBlock(
+            tool_use_id="tc1",
+            content=[{"type": "text", "text": "boom"}],
+            is_error=True,
+        )
+        events = await collect(handle_tool_result_block(block, "th", "run"))
+        assert len(events) == 1
+        payload = json.loads(events[0].content)
+        assert payload["error"] is True
+        assert payload["content"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_success_result_has_no_error_envelope(self):
+        block = ToolResultBlock(
+            tool_use_id="tc1",
+            content=[{"type": "text", "text": '{"ok": true}'}],
+            is_error=False,
+        )
+        events = await collect(handle_tool_result_block(block, "th", "run"))
+        # Successful result is the bare payload, not wrapped in an error envelope.
         assert json.loads(events[0].content) == {"ok": True}
 
     @pytest.mark.asyncio

--- a/integrations/claude-agent-sdk/python/tests/test_handlers.py
+++ b/integrations/claude-agent-sdk/python/tests/test_handlers.py
@@ -82,6 +82,10 @@ class TestHandleToolUseBlock:
         # Only a STATE_SNAPSHOT, no TOOL_CALL_* events
         assert [e.type for e in events] == [EventType.STATE_SNAPSHOT]
         assert events[0].snapshot == {"count": 5, "name": "a"}
+        # The RETURNED state must equal the merged snapshot, not the pre-merge
+        # state. The adapter persists this dict on the non-streaming path, so a
+        # pre-merge return regresses thread state.
+        assert new_state == {"count": 5, "name": "a"}
 
     @pytest.mark.asyncio
     async def test_state_management_tool_json_string_updates(self):
@@ -90,9 +94,14 @@ class TestHandleToolUseBlock:
             name=STATE_MANAGEMENT_TOOL_FULL_NAME,
             input={"state_updates": json.dumps({"count": 9})},
         )
-        _, gen = await handle_tool_use_block(block, _Msg(), "th", "run", {"count": 1})
+        new_state, gen = await handle_tool_use_block(
+            block, _Msg(), "th", "run", {"count": 1}
+        )
         events = await collect(gen)
         assert events[0].snapshot == {"count": 9}
+        # The returned state must equal the merged snapshot (pins the return on
+        # the JSON-string variant too).
+        assert new_state == {"count": 9}
 
     @pytest.mark.asyncio
     async def test_state_management_invalid_json_emits_custom_error(self):
@@ -159,6 +168,60 @@ class TestHandleToolResultBlock:
         payload = json.loads(events[0].content)
         assert payload["error"] is True
         assert payload["content"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_is_error_with_json_object_content_is_single_encoded(self):
+        # When the tool result content is itself a JSON object, the error path
+        # must stay consistent with the success shape: a single-encoded JSON
+        # object carrying an "error": true marker — NOT a double-encoded string
+        # nested under "content".
+        block = ToolResultBlock(
+            tool_use_id="tc1",
+            content=[{"type": "text", "text": '{"detail": "nope", "code": 42}'}],
+            is_error=True,
+        )
+        events = await collect(handle_tool_result_block(block, "th", "run"))
+        assert len(events) == 1
+        payload = json.loads(events[0].content)
+        # Single-encoded object: the original fields are top-level dict members,
+        # not a re-escaped JSON string under "content".
+        assert payload["detail"] == "nope"
+        assert payload["code"] == 42
+        assert payload["error"] is True
+        # Guard against the double-encode regression: "content" must not hold a
+        # stringified copy of the JSON object.
+        assert not isinstance(payload.get("content"), str)
+
+    @pytest.mark.asyncio
+    async def test_is_error_with_surrogate_content_is_repaired(self):
+        # A split UTF-16 surrogate pair in error content must be repaired in the
+        # emitted payload. The old envelope ran json.dumps over a string that
+        # already contained surrogates escaped to literal "\ud83c" text — so
+        # fix_surrogates (a UTF-16 round-trip) could not repair it, AND the
+        # whole thing got double-encoded under "content". Use JSON-object
+        # content carrying the surrogate so both defects are exercised.
+        #
+        # chr(0xD83C)+chr(0xDF5D) is the lone-surrogate-pair form of 🍝
+        # (U+1F35D), as produced when a JS String.slice splits the emoji across
+        # stream chunks.
+        split_pasta = chr(0xD83C) + chr(0xDF5D)
+        block = ToolResultBlock(
+            tool_use_id="tc1",
+            content=[{"type": "text", "text": json.dumps({"msg": split_pasta})}],
+            is_error=True,
+        )
+        events = await collect(handle_tool_result_block(block, "th", "run"))
+        assert len(events) == 1
+        payload = json.loads(events[0].content)
+        assert payload["error"] is True
+        # Single-encoded object: "msg" is a top-level field, not buried in a
+        # double-encoded "content" string.
+        assert "msg" in payload
+        assert not isinstance(payload.get("content"), str)
+        # The surrogate is repaired to the real codepoint, not left as a pair of
+        # lone surrogates that Pydantic would reject.
+        assert payload["msg"] == "\U0001f35d"
+        assert len(payload["msg"]) == 1
 
     @pytest.mark.asyncio
     async def test_success_result_has_no_error_envelope(self):

--- a/integrations/claude-agent-sdk/python/tests/test_utils.py
+++ b/integrations/claude-agent-sdk/python/tests/test_utils.py
@@ -244,29 +244,31 @@ class TestBuildAguiAssistantMessage:
 
         assert build_agui_assistant_message(Msg(), "m4") is None
 
-    @pytest.mark.xfail(
-        reason="build_agui_assistant_message dispatches on .type which real SDK blocks lack; deferred to follow-up",
-        strict=False,
-    )
     def test_real_sdk_blocks_build_assistant_message(self):
-        """Real Claude SDK TextBlock/ToolUseBlock SHOULD build a proper message.
+        """Real Claude SDK TextBlock/ToolUseBlock build a proper message.
 
         The real Claude SDK ``TextBlock``/``ToolUseBlock`` dataclasses do NOT
-        expose a ``.type`` attribute, but build_agui_assistant_message keys off
-        ``getattr(block, "type", None)``. The CORRECT behaviour is to produce a
-        populated AG-UI assistant message from genuine SDK blocks; the current
-        implementation instead returns None. Marked xfail so it documents the
-        defect now and flips to xpass once the follow-up fixes the dispatch.
+        expose a ``.type`` attribute. build_agui_assistant_message now
+        dispatches via ``isinstance`` against the real SDK block classes, so a
+        genuine ``TextBlock`` produces a populated AG-UI assistant message
+        instead of being silently dropped.
         """
-        from claude_agent_sdk.types import TextBlock
+        from claude_agent_sdk.types import TextBlock, ToolUseBlock
 
         class Msg:
-            content = [TextBlock(text="Hello")]
+            content = [
+                TextBlock(text="Hello"),
+                ToolUseBlock(id="tc1", name="mcp__ag_ui__search", input={"q": "x"}),
+            ]
 
         msg = build_agui_assistant_message(Msg(), "m5")
         assert msg is not None
         assert msg.content == "Hello"
         assert msg.id == "m5"
+        assert msg.tool_calls is not None
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "search"
+        assert json.loads(msg.tool_calls[0].function.arguments) == {"q": "x"}
 
 
 class TestBuildAguiToolMessage:

--- a/integrations/claude-agent-sdk/python/uv.lock
+++ b/integrations/claude-agent-sdk/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ag-ui-claude-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary

Fixes six confirmed source bugs in the `ag-ui-claude-sdk` Python integration (`integrations/claude-agent-sdk/python`). Each fix is covered by a red→green test. Ships as **0.1.2** on merge.

### Bugs fixed
1. **Dropped assistant messages** — `build_agui_assistant_message` dispatched on `getattr(block, "type")`, but real `claude_agent_sdk` `TextBlock`/`ToolUseBlock` have no `.type`, so every real block returned `None` and non-streamed assistant messages vanished from `MESSAGES_SNAPSHOT`. Now dispatches via `isinstance(...)` (keeps a `.type` fallback for dict/mock blocks). The previously-`xfail` test now passes as a plain assertion.
2. **Spurious STATE_SNAPSHOT after invalid state JSON** — the handler emitted a CUSTOM error then fell through and ALSO emitted a `STATE_SNAPSHOT` with un-updated state. Now `return`s after the error (mirrors the streaming path).
3. **Memory leaks** — only the TTL eviction branch cleaned all three per-thread dicts; LRU eviction, `clear_session`, and the `run()` error path leaked `_per_thread_state`/`_per_thread_result`. All four sites now pop the same three dicts.
4. **Poisoned-worker-cache hang** — a worker whose background task died (e.g. `client.connect()` failed) stayed cached; the next `run()` reused it and hung forever on a queue nothing drained. A dead worker is now detected (`SessionWorker.is_alive()`) and evicted so a fresh worker is created.
5. **`is_error` dropped** — `is_error` was read but never propagated; failed tool results looked successful. AG-UI's `ToolCallResultEvent` has no error field, so the indication is now surfaced inside the content envelope (and logged).
6. **`parent_tool_use_id` mis-passed** — the non-streaming handler used the SDK's `parent_tool_use_id` as `ToolCallStartEvent.parent_message_id`; it now uses the assistant message id, matching the streaming path.

### Investigated (#7) — left as-is, intentionally
The handlers.py tool events pass `thread_id`/`run_id` kwargs. AG-UI's `ToolCall*Event` types do **not** declare those fields, but `BaseEvent` uses `extra="allow"`, so they are accepted and serialized (not silently ignored, not a hard error). The streaming path in `adapter.py` passes them identically to every tool event, so this is consistent codebase-wide behavior the runtime tolerates. Pyright's `reportCallIssue` is technically correct, but removing the kwargs would change the emitted wire format across both paths — out of scope for a targeted bug-fix PR.

### Hygiene
- Fixed the `fix_surrogates` docstring (described a nonexistent "LLMock").
- Replaced the stale `_workers` comment with the actual value shape.
- Added a package `.gitignore` (`build/`, `dist/`, `*.egg-info/`).

## Lower-priority items — flagged, not fixed (behavior-change risk)
- handlers.py state-update unwrap defaults to `{}` while `adapter.py` falls back to the whole object (`state_updates.get("state_updates", state_updates)`). Only matters for unwrapped/malformed input; the tool schema nests under `state_updates`.
- `process_messages`' `has_pending_tool_result` flag is computed and logged but unused by `run()`.
- `MESSAGES_SNAPSHOT` / `RunStartedEvent.input` mix raw input dicts with Pydantic models (serialization hazard).
- Raw `str(e)` leaks into `RUN_ERROR.message`.

## Test plan
- [x] `uv sync` (no extras) then `uv run python -m pytest` → **62 passed** (the previously-xfailed test now passes; 0 xfailed)
- [x] Each fix verified red→green (stashed source, confirmed the 8 new/changed tests fail, restored, confirmed green)
- [x] `uv build` clean; wheel contains only `ag_ui_claude_sdk` (no tests/examples)