### PR TITLE
fix(ci): allow branch prerelease dispatches

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,12 +54,11 @@ on:
   # unrelated pushes don't even start the workflow, and any workflow run that
   # does fire still filters to enrolled packages before touching a registry.
   #
-  # We trigger on push-to-main (NOT pull_request: closed) so the workflow run's
-  # ref is refs/heads/main. The publish job pins `environment: npm`, whose
-  # deployment_branch_policy allows only main; a pull_request-triggered run
-  # executes in the PR merge-ref context (refs/pull/N/merge) and is rejected by
-  # that policy before any step runs. A merged release PR lands a commit on
-  # main, which fires this push trigger — so the automated lane still works.
+  # We trigger stable releases on push-to-main (NOT pull_request: closed) so
+  # the workflow run's ref is refs/heads/main. Prerelease dispatches are
+  # intentionally allowed from any selected branch; the npm GitHub Environment
+  # must therefore allow those deployment branches while stable branch safety is
+  # enforced by the build job's mode-aware guard below.
   push:
     branches: [main]
     paths:
@@ -133,13 +132,14 @@ permissions:
 
 jobs:
   build:
-    # Fires on push-to-main (stable; a merged release PR lands a commit here)
-    # OR on manual workflow_dispatch from main (stable retry / prerelease
-    # canary). The main-branch guard on workflow_dispatch prevents republishing
-    # from arbitrary branches; the `environment: npm` protected_branches policy
-    # on the publish job is the defense-in-depth backstop.
+    # Fires on push-to-main (stable; a merged release PR lands a commit here),
+    # on stable manual workflow_dispatch from main (retry escape hatch), or on
+    # prerelease manual workflow_dispatch from any selected branch. Canary
+    # publishes are intentionally branch-scoped so maintainers can push a
+    # button on feature work without merging first.
     if: >
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.mode == 'prerelease' || github.ref == 'refs/heads/main')) ||
       github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -178,11 +178,11 @@ jobs:
           echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
           echo "Detected mode: $MODE, scope: $SCOPE"
 
-      - name: Checkout merged main
+      - name: Checkout release ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ steps.meta.outputs.mode == 'prerelease' && github.ref || 'main' }}
           persist-credentials: false
 
       - name: Setup pnpm
@@ -580,16 +580,19 @@ jobs:
     # Renaming this file, this `environment:` value, or the workflow path
     # breaks npm publishing for every @ag-ui/* package silently until the
     # trusted-publisher config on npmjs.org is updated to match.
+    # The GitHub Environment's deployment branch policy must allow prerelease
+    # workflow_dispatch refs; stable releases remain main-only via the build
+    # job guard.
     environment: npm
     permissions:
       contents: write
       id-token: write
     steps:
-      - name: Checkout merged main
+      - name: Checkout release ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.build.outputs.mode == 'prerelease' && github.ref || 'main' }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
 


### PR DESCRIPTION
If we tried to make a pre-release on a non-main branch then CI would just skip it. This fixes that by not skipping non-main runs when pre-release mode is active.