### PR TITLE
chore(release): guard config↔manifest package names; flag deferred hardening

### DIFF
--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -92,3 +92,21 @@ jobs:
           persist-credentials: false
       - name: Verify release scope dropdowns match release.config.json
         run: bash scripts/release/verify-release-scope-dropdowns.sh
+
+  release-config-manifest-names:
+    # Verifies each release.config.json package `name` matches the actual name
+    # in its on-disk manifest (package.json / pyproject.toml). Catches drift
+    # like langroid's config name being the underscore form `ag_ui_langroid`
+    # while its pyproject (and PyPI distribution) is `ag-ui-langroid` — harmless
+    # for resolution but wrong in PR bodies, release notes and human summaries.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Verify config package names match manifests
+        run: bash scripts/release/verify-config-manifest-names.sh

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -150,7 +150,7 @@
       "description": "Langroid integration (Python)",
       "sharedVersion": false,
       "packages": [
-        { "name": "ag_ui_langroid", "path": "integrations/langroid/python", "ecosystem": "python", "buildSystem": "uv" }
+        { "name": "ag-ui-langroid", "path": "integrations/langroid/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
     "integration-llama-index": {

--- a/scripts/release/verify-config-manifest-names.sh
+++ b/scripts/release/verify-config-manifest-names.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/release/verify-config-manifest-names.sh
+#
+# Verifies that the `name` declared for each package in
+# scripts/release/release.config.json matches the actual package name in that
+# package's on-disk manifest (package.json for TypeScript, pyproject.toml for
+# Python — either PEP 621 `[project]` or poetry `[tool.poetry]`).
+#
+# Why this matters: release.config.json is the single source of truth that the
+# version-bumper (prepare-release.ts), the dropdown guard, the nx allowlist
+# guard, and the notify-job ecosystem map all key off. The `name` field is used
+# in PR bodies, release-notes attribution and human-facing summaries. If it
+# drifts from the real published name nobody notices until a release ships with
+# the wrong label — exactly what happened with the langroid integration, whose
+# config `name` was the underscore form `ag_ui_langroid` while its pyproject
+# (and the actual PyPI distribution) is the hyphenated `ag-ui-langroid`.
+#
+# This guard cross-checks every config package `name` against its manifest at
+# `path` and fails CI on any divergence.
+#
+# Note on `path`: each package's `path` is also validated transitively here —
+# a missing/typo'd path surfaces as a missing manifest (loud failure below).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG="$REPO_ROOT/scripts/release/release.config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ERROR: $CONFIG not found" >&2
+  exit 1
+fi
+
+# Emit one TSV line per package: "<scope>\t<name>\t<path>\t<ecosystem>\t<buildSystem>".
+PACKAGES=$(jq -r '
+  .scopes | to_entries[]
+  | .key as $s
+  | .value.packages[]
+  | [$s, .name, .path, .ecosystem, (.buildSystem // "-")] | @tsv
+' "$CONFIG")
+
+rc=0
+while IFS=$'\t' read -r scope name path ecosystem build_system; do
+  [ -z "$scope" ] && continue
+
+  if [ "$ecosystem" = "typescript" ]; then
+    manifest="$REPO_ROOT/$path/package.json"
+    if [ ! -f "$manifest" ]; then
+      echo "ERROR: [$scope] $name: package.json not found at $path" >&2
+      rc=1
+      continue
+    fi
+    actual=$(jq -r '.name // empty' "$manifest")
+  else
+    manifest="$REPO_ROOT/$path/pyproject.toml"
+    if [ ! -f "$manifest" ]; then
+      echo "ERROR: [$scope] $name: pyproject.toml not found at $path" >&2
+      rc=1
+      continue
+    fi
+    # Extract the name using tomllib (3.11+) or the tomli backport, mirroring
+    # detect-py-version-changes.sh. uv/PEP 621 packages live under [project];
+    # poetry packages under [tool.poetry].
+    actual=$(MANIFEST="$manifest" BUILD_SYSTEM="$build_system" python3 -c "
+import os, sys
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open(os.environ['MANIFEST'], 'rb') as f:
+    cfg = tomllib.load(f)
+bs = os.environ['BUILD_SYSTEM']
+try:
+    if bs == 'poetry':
+        print(cfg['tool']['poetry']['name'])
+    else:
+        print(cfg['project']['name'])
+except KeyError as e:
+    print(f'ERROR: missing key {e} in {os.environ[\"MANIFEST\"]}', file=sys.stderr)
+    sys.exit(1)
+") || { echo "ERROR: [$scope] $name: could not read name from $path/pyproject.toml" >&2; rc=1; continue; }
+  fi
+
+  if [ -z "$actual" ]; then
+    echo "ERROR: [$scope] $name: manifest at $path has no package name" >&2
+    rc=1
+    continue
+  fi
+
+  if [ "$name" != "$actual" ]; then
+    echo "ERROR: [$scope] release.config.json name '$name' != manifest name '$actual' at $path" >&2
+    rc=1
+  fi
+done <<< "$PACKAGES"
+
+if [ "$rc" -ne 0 ]; then
+  echo "" >&2
+  echo "Fix: make each release.config.json package 'name' exactly match the name in" >&2
+  echo "its manifest (package.json '.name', or pyproject.toml [project]/[tool.poetry] name)." >&2
+  exit 1
+fi
+
+echo "OK: every release.config.json package name matches its on-disk manifest"
+exit 0


### PR DESCRIPTION
## Summary

Follow-up hardening on the release pipeline after #1869 (which synced the canary/release `scope` dropdowns to `release.config.json` and added a CI drift-guard + notify-job ecosystem-map fix). This PR closes the one clearly-safe gap that was deferred, and flags the rest.

## What this hardens

- **New guard `scripts/release/verify-config-manifest-names.sh`** — cross-checks every `name` in `release.config.json` against the actual package name in its on-disk manifest (`package.json` for TS, `pyproject.toml` `[project]`/`[tool.poetry]` for Python). The config `name` feeds PR-body labels, AI release notes and human summaries, but nothing enforced it matched the real published name.
  - Caught one real drift: `integration-langroid` config name was `ag_ui_langroid` (underscore) while its pyproject + PyPI distribution is `ag-ui-langroid` (hyphen). Fixed the config. (Harmless for resolution — `pkg.name` from config is only used for logging/labels in `prepare-release.ts`; file/registry resolution uses `path`/manifest — but wrong in human-facing output.)
  - `path` is validated transitively (a missing/typo'd path surfaces as a missing manifest → loud failure).
- **CI-wired** the new guard as a `release-config-manifest-names` job in `lint-release-workflows.yml`, alongside the existing dropdown / nx-allowlist guards, on the same `scripts/release/**` + workflow + `nx.json` path triggers.

### Red-green proof
- New guard RED on a deliberately-injected TS name typo (`@ag-ui/core-TYPO`) and on the real langroid drift; GREEN after the config fix and restore.
- `shellcheck --severity=warning` clean (matches the CI shellcheck job). `actions/setup-python` pinned to the same SHA the repo already uses.

## Audited and found already-adequate (no change needed)
- **Dropdown guard bidirectionality (#3):** `verify-release-scope-dropdowns.sh` uses exact sorted-set equality, so orphan options and missing options both fail. Already covers BOTH workflow dropdowns + the notify-job ecosystem `case` (explicit list AND full projection).
- **detect-*-version-changes.sh path coverage (#4):** both scripts derive their package set directly from `release.config.json` scopes, so every config path is covered by construction — no orphan paths.
- **CI wiring of existing guards (#5):** dropdown + nx-allowlist guards already run in `lint-release-workflows.yml`.

## Flagged for follow-up (deliberately NOT done — higher-risk / ambiguous)
- **Consolidating the four `verify-*`/`detect-*` config consumers behind one extractor** (or a single `verify-release-config.sh` umbrella) would reduce per-script `jq` duplication, but is a refactor with workflow blast-radius — out of scope for a safe hardening pass.
- **`ecosystem`/`buildSystem` value-domain validation** (e.g. assert ecosystem ∈ {typescript,python}, buildSystem ∈ {uv,poetry}): low value today (all consumers branch on exact strings and would fail loudly on an unknown value), but could be a cheap schema check if a JSON-schema for `release.config.json` is ever introduced. Flagging rather than hand-rolling a partial validator.
- **`versionSource` existence check** for shared-version scopes (`sdk-ts`): currently only `prepare-release.ts` would fail at run time if it drifted. Could be added to the manifest-name guard, but wanted to keep this guard single-purpose.

## Test plan
- [ ] `Lint Release Workflows` CI green (new `release-config-manifest-names` job + existing jobs)
- [ ] Confirm the new guard job triggers on this PR (it touches `scripts/release/**`)

DO NOT MERGE without maintainer review.