### PR TITLE
chore(release): republish TS a2ui recovery packages (OSS-162)

### DIFF
--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/langgraph",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"

--- a/middlewares/a2ui-middleware/package.json
+++ b/middlewares/a2ui-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ag-ui/a2ui-middleware",
   "author": "Markus Ecker",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"

--- a/sdks/typescript/packages/a2ui-toolkit/package.json
+++ b/sdks/typescript/packages/a2ui-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ag-ui/a2ui-toolkit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## Why

The TS `@ag-ui/a2ui-toolkit` recovery code **never reached npm**. The release bumped it `0.0.1-alpha.3 → 0.0.1`, which collided with the already-published stable `0.0.1`, so npm's `0.0.1` is still the **pre-recovery** build (zero recovery symbols). Both dependents then published **pinned to that dead version**:

- `@ag-ui/a2ui-middleware@0.0.7` → `@ag-ui/a2ui-toolkit@0.0.1` (imports `validateA2UIComponents`, which isn't there)
- `@ag-ui/langgraph@0.0.38` → `@ag-ui/a2ui-toolkit@0.0.1` (references `runA2UIGenerationWithRecovery`, which isn't there)

So the published TS recovery stack is broken at runtime.

## What this does

Version-only patch bumps to get past the collision so `publish-release` (which diffs `main` vs the registry) ships recovery-bearing versions, and the dependents re-pin the new toolkit via `workspace:*` at pack time:

| Package | from | to |
|---|---|---|
| `@ag-ui/a2ui-toolkit` | 0.0.1 | **0.0.2** (publishes the recovery toolkit) |
| `@ag-ui/a2ui-middleware` | 0.0.7 | **0.0.8** (re-pins toolkit `^0.0.2`) |
| `@ag-ui/langgraph` | 0.0.38 | **0.0.39** (re-pins toolkit `^0.0.2`) |

No `workspace:*` edits needed — they resolve to `0.0.2` at publish.

## Publish

After merge, run **`publish-release`** — it diffs `main` against npm and sweeps these three (main > registry), publishing in dependency order (toolkit first). No `prepare-release` dispatch (would double-bump).

## Not affected

Python is already in sync: `ag-ui-a2ui-toolkit@0.0.2` (PyPI) carries recovery and `ag-ui-langgraph@0.0.40` resolves it via its `>=` range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)