### PR TITLE
fix(claude-agent-sdk): fail-loud dead worker + MESSAGES_SNAPSHOT encoding symmetry (#1878 fast-follows)

### DIFF
--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -180,7 +180,14 @@ class ClaudeAgentAdapter:
         
         self._per_thread_state[thread_id] = input_data.state
         self._per_thread_result[thread_id] = None
-        
+
+        # Set True only once this run has been counted into a worker's
+        # ``active_runs`` refcount, so the ``finally`` block decrements exactly
+        # the runs it incremented. The fail-loud dead-worker-with-live-peer path
+        # below returns WITHOUT counting itself in, so it must leave this False
+        # to avoid decrementing the peer's refcount. (Item 7a)
+        counted_in = False
+
         try:
             # Get or create worker for this thread.
             # Guard against a poisoned cache entry: if a previously-cached
@@ -191,15 +198,32 @@ class ClaudeAgentAdapter:
             if entry is not None and not entry["worker"].is_alive():
                 if entry.get("active_runs", 0) > 0:
                     # A peer run is still streaming on this (now-dead) worker.
-                    # Do NOT pop+stop the shared entry out from under it; that
-                    # would violate the item-7 invariant. Fall through and reuse
-                    # the existing entry so the refcount stays consistent — the
-                    # peer's own teardown (error or finally) handles eviction.
-                    logger.warning(
+                    # We are wedged between two unacceptable options:
+                    #   * REUSE the dead worker — querying it would hang this
+                    #     arriving run forever (the peer's exited run-loop will
+                    #     never service our output queue).
+                    #   * EVICT (pop+stop) the shared entry — that tears the
+                    #     worker out from under the live peer (item-7 violation).
+                    # So FAIL LOUD instead: surface a descriptive RunErrorEvent
+                    # and stop, leaving the peer's entry (and its refcount)
+                    # completely untouched. ``counted_in`` stays False so the
+                    # ``finally`` block does NOT decrement the peer's refcount.
+                    logger.error(
                         f"Worker for thread={thread_id} is dead but a peer run is "
                         f"still active (active_runs={entry.get('active_runs')}); "
-                        f"not evicting mid-stream"
+                        f"failing this run loudly rather than reusing (hang risk) "
+                        f"or evicting (would corrupt the live peer)"
                     )
+                    yield RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        thread_id=thread_id,
+                        run_id=run_id,
+                        message=(
+                            f"cannot start run on thread {thread_id}: its worker "
+                            f"has terminated while another run is still active"
+                        ),
+                    )
+                    return
                 else:
                     logger.warning(
                         f"Evicting dead worker for thread={thread_id} (task terminated); creating fresh worker"
@@ -222,10 +246,12 @@ class ClaudeAgentAdapter:
                 # count) for callers/tests that read it. (Item 7a)
                 entry = {"worker": worker, "last_used": datetime.now(), "active": True, "active_runs": 1}
                 self._workers[thread_id] = entry
+                counted_in = True
                 self._evict_workers()
                 logger.debug(f"Created worker for thread={thread_id}")
             else:
                 entry["active_runs"] = entry.get("active_runs", 0) + 1
+                counted_in = True
                 entry["active"] = True
                 entry["last_used"] = datetime.now()
                 worker = entry["worker"]
@@ -327,8 +353,12 @@ class ClaudeAgentAdapter:
                 message=str(e),
             )
         finally:
+            # Only decrement if THIS run was counted into the refcount. The
+            # fail-loud dead-worker-with-live-peer path returns early without
+            # counting itself in (``counted_in`` stays False), so it must not
+            # decrement — doing so would corrupt the live peer's refcount. (Item 7a)
             entry = self._workers.get(thread_id)
-            if entry:
+            if entry and counted_in:
                 # Decrement the in-flight refcount; the worker only becomes idle
                 # (and thus evictable) once ALL concurrent runs sharing it have
                 # finished, so a peer run is never evicted mid-stream. (Item 7a)

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/utils.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/utils.py
@@ -426,18 +426,36 @@ def build_agui_tool_message(
     Returns:
         AG-UI ToolMessage
     """
+    def _normalize_text(text: str) -> str:
+        """Canonical textual-payload encoding: parse JSON when possible (so the
+        frontend can access fields) else pass the raw text through UNQUOTED.
+
+        This mirrors ``handlers.py``'s ``_normalize_text`` for the live
+        TOOL_CALL_RESULT path (Item 5). Routing both the list-of-text-blocks
+        branch and the bare-string branch through here keeps MESSAGES_SNAPSHOT
+        encoding identical to TOOL_CALL_RESULT: the SAME logical tool result
+        reaches the frontend with the SAME encoding regardless of which SDK
+        shape (list vs. bare string) delivered it — in particular a bare string
+        is NOT json.dumps-quoted into '"plain"'."""
+        try:
+            return json.dumps(json.loads(text))
+        except (json.JSONDecodeError, ValueError):
+            # Not JSON — raw passthrough (NOT json.dumps, which would quote it
+            # and diverge from the list-text-block path).
+            return text
+
     result_str = ""
     try:
         if isinstance(content, list) and len(content) > 0:
             first_block = content[0]
             if isinstance(first_block, dict) and first_block.get("type") == "text":
-                text = first_block.get("text", "")
-                try:
-                    result_str = json.dumps(json.loads(text))
-                except (json.JSONDecodeError, ValueError):
-                    result_str = text
+                result_str = _normalize_text(first_block.get("text", ""))
             else:
                 result_str = json.dumps(content)
+        elif isinstance(content, str):
+            # Bare-string content: normalise identically to the inner text of a
+            # text block (Item 5) instead of json.dumps-quoting it.
+            result_str = _normalize_text(content)
         elif content is not None:
             result_str = json.dumps(content)
     except (TypeError, ValueError):

--- a/integrations/claude-agent-sdk/python/pyproject.toml
+++ b/integrations/claude-agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag-ui-claude-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "AG-UI integration for Anthropic Claude Agent SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/claude-agent-sdk/python/tests/test_adapter.py
+++ b/integrations/claude-agent-sdk/python/tests/test_adapter.py
@@ -775,18 +775,21 @@ class TestPoisonedWorkerCache:
         assert "boom" in err.message
 
     @pytest.mark.asyncio
-    async def test_dead_cached_worker_with_live_peer_is_not_evicted(self, make_input):
-        # The dead-worker eviction branch is refcount-aware: when a cached worker
-        # reports is_alive()==False BUT a concurrent peer still holds it
-        # (active_runs > 0), it must NOT pop+stop the shared entry out from under
-        # that peer. It leaves/reuses the entry so the peer isn't torn down
-        # mid-stream; the peer's own teardown handles eviction. (Item 7a)
+    async def test_dead_cached_worker_with_live_peer_fails_loud(self, make_input):
+        # The dead-worker branch is refcount-aware: when a cached worker reports
+        # is_alive()==False BUT a concurrent peer still holds it (active_runs > 0),
+        # the arriving NEW run must FAIL LOUD. It must neither reuse the dead
+        # worker (querying it would hang — the peer's exited run-loop will never
+        # service the new run's output queue) nor evict it (that would tear the
+        # worker out from under the live peer). Instead it emits a descriptive
+        # RunErrorEvent and stops WITHOUT disturbing the peer's entry. (Item 7a)
         stop_calls = {"n": 0}
+        query_calls = {"n": 0}
 
-        class _DeadWorkerWithCleanQuery:
-            """Reports dead, but serves a clean (empty) query stream so run()
-            completes normally — isolating the dead-worker branch as the only
-            place that could have popped+stopped the entry."""
+        class _DeadWorkerWithLivePeer:
+            """Reports dead. If the new run ever reuses it and calls query(),
+            that is the hang-risk bug — flag it loudly so the test catches a
+            regression to the reuse behavior."""
 
             def __init__(self, *args, **kwargs):
                 pass
@@ -798,8 +801,14 @@ class TestPoisonedWorkerCache:
                 return False
 
             def query(self, prompt, session_id="default"):
+                query_calls["n"] += 1
+
                 async def _gen():
-                    return
+                    # A real dead worker would hang here forever; raise instead
+                    # so a reuse regression fails fast rather than blocking.
+                    raise AssertionError(
+                        "dead worker was queried by the arriving run (hang risk)"
+                    )
                     yield  # pragma: no cover
 
                 return _gen()
@@ -808,7 +817,7 @@ class TestPoisonedWorkerCache:
                 stop_calls["n"] += 1
 
         adapter = ClaudeAgentAdapter(name="t")
-        worker = _DeadWorkerWithCleanQuery()
+        worker = _DeadWorkerWithLivePeer()
         # Pre-seed the cache as if a concurrent peer run already holds this
         # (now-dead) worker: active_runs=1 simulates the live peer.
         adapter._workers["shared"] = {
@@ -823,12 +832,23 @@ class TestPoisonedWorkerCache:
         )
         events = [e async for e in adapter.run(inp)]
 
-        # INVARIANT: the dead-worker branch must NOT evict a shared entry that a
-        # peer still holds. The entry survives and stop() is never called by the
-        # branch — the peer's worker is preserved mid-stream.
+        # LOUD FAILURE: the arriving run emits RUN_ERROR (never reuses → never
+        # queries the dead worker → no hang).
+        assert EventType.RUN_ERROR in _types(events), (
+            "arriving run on a dead-worker-with-live-peer must fail loud"
+        )
+        assert EventType.RUN_FINISHED not in _types(events)
+        assert query_calls["n"] == 0, "dead worker must not be queried (hang risk)"
+
+        # PEER UNTOUCHED: the shared entry survives, is not popped, not stopped.
         entry = adapter._workers.get("shared")
         assert entry is not None, "shared worker evicted while a peer run was live"
         assert entry["worker"] is worker
         assert stop_calls["n"] == 0, "shared worker stopped while a peer run was live"
-        # This run completed normally (no error/hang) on the reused entry.
-        assert EventType.RUN_FINISHED in _types(events)
+        # REFCOUNT INTACT: the peer's count must be exactly what it was (1). The
+        # arriving run must not increment-then-abandon, nor decrement the peer's
+        # count via the finally block.
+        assert entry["active_runs"] == 1, (
+            f"peer refcount corrupted: expected 1, got {entry['active_runs']}"
+        )
+        assert entry["active"] is True

--- a/integrations/claude-agent-sdk/python/tests/test_utils.py
+++ b/integrations/claude-agent-sdk/python/tests/test_utils.py
@@ -288,3 +288,25 @@ class TestBuildAguiToolMessage:
     def test_none_content(self):
         msg = build_agui_tool_message("tc1", None)
         assert msg.content == ""
+
+    def test_bare_string_not_double_quoted(self):
+        # A bare-string (non-JSON) result must be passed through unquoted, NOT
+        # json.dumps-quoted into '"plain"'. (Item 5 encoding symmetry)
+        msg = build_agui_tool_message("tc1", "plain")
+        assert msg.content == "plain"
+
+    def test_bare_string_matches_list_text_block(self):
+        # The MESSAGES_SNAPSHOT builder must encode a logical tool result the
+        # SAME way regardless of whether the SDK delivered it as a bare string
+        # or as a list of text blocks — mirroring the TOOL_CALL_RESULT path's
+        # canonical normalization (Item 5). Otherwise the same result renders
+        # differently depending on transport shape.
+        for raw in ("not json", '{"temp": 72}', "[1, 2, 3]", "42"):
+            bare = build_agui_tool_message("tc1", raw)
+            listed = build_agui_tool_message(
+                "tc1", [{"type": "text", "text": raw}]
+            )
+            assert bare.content == listed.content, (
+                f"asymmetric encoding for {raw!r}: "
+                f"bare={bare.content!r} list={listed.content!r}"
+            )

--- a/integrations/claude-agent-sdk/python/uv.lock
+++ b/integrations/claude-agent-sdk/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ag-ui-claude-sdk"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
Two documented fast-follow fixes to the `ag-ui-claude-sdk` Python integration, following the #1878 adapter hardening. Both are scoped to `integrations/claude-agent-sdk/python/`.

## Fix 1 — dead worker with a live peer fails loud (concurrency edge)

After #1878, the per-thread worker cache is refcounted (`active_runs`). When a cached worker reports `is_alive()==False` (its run-loop exited = dead) BUT `active_runs > 0` (a concurrent peer run still holds it), the previous code *reused* the dead worker.

That reuse is a **hang risk**: querying a dead worker blocks the arriving run forever on an output queue the peer's exited run-loop will never service. Evicting it instead is also wrong — that tears the worker out from under the live peer (the item-7 invariant).

**New behavior:** in that specific state, the arriving run now **fails loud** — it emits a descriptive `RunErrorEvent` (`cannot start run on thread {thread_id}: its worker has terminated while another run is still active`) and stops, leaving the peer's entry and refcount completely untouched. The single-run case (`active_runs == 0`) still evicts + replaces with a fresh worker, exactly as before.

**Refcount care:** a `counted_in` flag tracks whether the arriving run was added to a worker's `active_runs`. The fail-loud path returns *without* counting itself in, and the `finally` block only decrements when `counted_in` is true — so the peer's refcount is never corrupted (no increment-then-abandon, no spurious decrement).

## Fix 2 — encoding symmetry in `build_agui_tool_message` (MESSAGES_SNAPSHOT path)

`build_agui_tool_message` `json.dumps`-quoted a **bare-string** `content` (so `"plain"` became `'"plain"'`) while passing list-of-text-block content through unquoted. This is the same asymmetry #1878 item 5 fixed in `handlers.py` for the live TOOL_CALL_RESULT path.

Both shapes now route through a canonical text normalizer (try-JSON → else raw passthrough), mirroring `handlers.py`, so the same logical tool result produces the SAME MESSAGES_SNAPSHOT encoding regardless of SDK shape — and a bare string is no longer double-quoted.

## Tests

TDD red-green for both fixes. Full suite: **91 passed** (89 baseline + 2 new). Version bumped `0.1.3` → `0.1.4` (+ `uv.lock`). `uv build` succeeds; wheel ships only `ag_ui_claude_sdk/`.