### PR TITLE
fix: set repository metadata on published packages for npm provenance

### DIFF
--- a/integrations/aws-strands/typescript/package.json
+++ b/integrations/aws-strands/typescript/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@ag-ui/aws-strands",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "author": "AG-UI Contributors",
   "version": "0.1.0",
   "description": "AWS Strands Agents integration for the AG-UI protocol",

--- a/integrations/vercel-ai-sdk/typescript/package.json
+++ b/integrations/vercel-ai-sdk/typescript/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@ag-ui/vercel-ai-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "version": "0.0.2",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/middlewares/event-throttle-middleware/package.json
+++ b/middlewares/event-throttle-middleware/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@ag-ui/event-throttle-middleware",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "version": "0.0.1",
   "publishConfig": {
     "access": "public"

--- a/middlewares/mcp-middleware/package.json
+++ b/middlewares/mcp-middleware/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@ag-ui/mcp-middleware",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.1",
   "main": "./dist/index.js",

--- a/sdks/typescript/packages/a2ui-toolkit/package.json
+++ b/sdks/typescript/packages/a2ui-toolkit/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@ag-ui/a2ui-toolkit",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "version": "0.0.1-alpha.3",
   "description": "Framework-agnostic helpers for building A2UI subagent tools — op builders, prompt assembly, history walkers, and request/envelope orchestration shared across framework adapters.",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Problem

`npm publish --provenance` (used by prerelease canary publishing) rejects any package whose `package.json` `repository.url` does not match the repo. A canary of `@ag-ui/a2ui-toolkit` failed with:

```
Error verifying sigstore provenance bundle: package.json "repository.url" is "", expected to match "https://github.com/ag-ui-protocol/ag-ui"
```

The root cause: several published (`"private": false`) packages were missing the `repository` field entirely, so npm computed an empty `repository.url` and provenance verification failed.

## Fix

Added the canonical `repository` object — matching `@ag-ui/core` and the other correctly-configured published SDK packages:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/ag-ui-protocol/ag-ui.git"
}
```

to every published package that was missing it:

- `@ag-ui/a2ui-toolkit` (`sdks/typescript/packages/a2ui-toolkit`)
- `@ag-ui/aws-strands` (`integrations/aws-strands/typescript`)
- `@ag-ui/vercel-ai-sdk` (`integrations/vercel-ai-sdk/typescript`)
- `@ag-ui/event-throttle-middleware` (`middlewares/event-throttle-middleware`)
- `@ag-ui/mcp-middleware` (`middlewares/mcp-middleware`)

All other published packages already had a correct `repository` field. Private packages and example/docs packages were left untouched.

## Notes

- This PR is **stacked on #1874** (`codex/fix-prerelease-dispatch-agui`), which loosens the release workflow so branch prerelease dispatches are allowed — so this branch carries that workflow fix for the canary. **After #1874 merges, this branch should be rebased onto `main`.**
- The dominant convention in this repo does not use `repository.directory`, so it was intentionally omitted to match the canonical SDK packages exactly.