### PR TITLE
fix(langgraph): round-trip reasoning content losslessly across turns

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -16,6 +16,7 @@ from ag_ui.core import (
     AssistantMessage as AGUIAssistantMessage,
     SystemMessage as AGUISystemMessage,
     ToolMessage as AGUIToolMessage,
+    ReasoningMessage as AGUIReasoningMessage,
     ToolCall as AGUIToolCall,
     FunctionCall as AGUIFunctionCall,
     TextInputContent,
@@ -112,6 +113,79 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
                     ))
     return agui_content
 
+def _reasoning_block_summary_text(block: Dict[str, Any]) -> str:
+    """Extract the human-readable reasoning text from a LangChain reasoning
+    content block (OpenAI Responses ``responses/v1`` shape)."""
+    summary = block.get("summary")
+    if isinstance(summary, list):
+        parts = [
+            s.get("text", "")
+            for s in summary
+            if isinstance(s, dict) and s.get("text")
+        ]
+        if parts:
+            # Join multi-part summaries with a newline so the parts stay
+            # legible instead of being mashed together ("A\nB", not "AB").
+            return "\n".join(parts)
+    # Fallbacks for non-OpenAI shapes that still carry a flat text field.
+    for key in ("reasoning", "text"):
+        val = block.get(key)
+        if isinstance(val, str) and val:
+            return val
+    return ""
+
+
+def _reasoning_block_to_agui_message(
+    block: Dict[str, Any], assistant_id: str, index: int = 0
+) -> "AGUIReasoningMessage | None":
+    """Turn a LangChain reasoning content block into an AG-UI
+    ReasoningMessage, preserving the block id (so it round-trips back to the
+    provider as the same reasoning item) and any encrypted content (needed when
+    the provider is run statelessly with ``store=False``).
+
+    Returns ``None`` for a block with neither text nor encrypted content — there
+    is nothing the client could render or round-trip.
+    """
+    text = _reasoning_block_summary_text(block)
+    encrypted = block.get("encrypted_content")
+    block_id = block.get("id")
+    # The provider id (e.g. OpenAI ``rs_…``) is the round-trip handle: under
+    # ``store=True`` the summary/encrypted content are empty and the id alone is
+    # what lets the next request reference the stored reasoning. So emit whenever
+    # we have an id, text, or encrypted content; only a wholly empty block is
+    # dropped (nothing to render or round-trip).
+    if not block_id and not text and not encrypted:
+        return None
+    # Fall back to a deterministic id derived from the owning assistant message
+    # when the provider didn't supply one. Include the block index so multiple
+    # id-less reasoning blocks on one message don't collide on the same id.
+    block_id = block_id or f"{assistant_id}-reasoning-{index}"
+    return AGUIReasoningMessage(
+        id=str(block_id),
+        role="reasoning",
+        content=text,
+        encrypted_value=encrypted,
+    )
+
+
+def _agui_reasoning_message_to_block(message: AGUIReasoningMessage) -> Dict[str, Any]:
+    """Rebuild the LangChain reasoning content block from an AG-UI
+    ReasoningMessage so it can be re-attached to the adjacent assistant message
+    (the inverse of :func:`_reasoning_block_to_agui_message`)."""
+    block: Dict[str, Any] = {
+        "type": "reasoning",
+        "id": message.id,
+        "summary": (
+            [{"type": "summary_text", "text": message.content}]
+            if message.content
+            else []
+        ),
+    }
+    if getattr(message, "encrypted_value", None):
+        block["encrypted_content"] = message.encrypted_value
+    return block
+
+
 def langchain_messages_to_agui(messages: List[BaseMessage]) -> List[AGUIMessage]:
     agui_messages: List[AGUIMessage] = []
     for message in messages:
@@ -129,6 +203,19 @@ def langchain_messages_to_agui(messages: List[BaseMessage]) -> List[AGUIMessage]
                 name=message.name,
             ))
         elif isinstance(message, AIMessage):
+            # Surface reasoning content blocks as standalone
+            # ReasoningMessages placed BEFORE the assistant message (matching
+            # streaming-event ordering), so a client with no persistent
+            # checkpoint can round-trip them back to the model.
+            if isinstance(message.content, list):
+                for index, block in enumerate(message.content):
+                    if isinstance(block, dict) and block.get("type") == "reasoning":
+                        reasoning_msg = _reasoning_block_to_agui_message(
+                            block, str(message.id), index
+                        )
+                        if reasoning_msg is not None:
+                            agui_messages.append(reasoning_msg)
+
             tool_calls = None
             if message.tool_calls:
                 tool_calls = [
@@ -233,17 +320,32 @@ def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List
 
 def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]:
     langchain_messages = []
+    # Reasoning AG-UI messages are display-only at the AG-UI layer, but
+    # at the LangChain layer reasoning lives as a content block ON the assistant
+    # AIMessage. To round-trip reasoning without loss (so a stateless client can
+    # hand the model back its own chain-of-thought), buffer each reasoning message and
+    # re-attach it as a content block on the assistant message that follows it
+    # (matching the order reasoning is streamed: reasoning first, then text).
+    # Developer messages stay dropped — they are configured on the agent itself.
+    #
+    # Reasoning that is NOT immediately followed by an assistant message (a
+    # trailing reasoning message, or one followed by a user/tool/system message)
+    # is intentionally discarded: there is no assistant to attach it to, and
+    # re-materializing it as a standalone message causes exponential message
+    # duplication and tool-call loops under the add_messages reducer. The
+    # snapshot side (langchain_messages_to_agui) only ever emits reasoning
+    # immediately before its assistant, so this drop never affects a real
+    # round-trip — only hand-crafted/ partial inputs.
+    pending_reasoning: list = []
     for message in messages:
         role = message.role
-        # Reasoning + developer AG-UI messages are display-only / handled
-        # elsewhere; their content is already represented in adjacent AIMessage
-        # content blocks (reasoning) or in the agent's configured system prompt
-        # (developer). Re-materializing them as standalone LangChain messages
-        # duplicates context on every turn and can drive the model into a
-        # tool-call loop.
-        if role in ("reasoning", "developer"):
+        if role == "reasoning":
+            pending_reasoning.append(_agui_reasoning_message_to_block(message))
+            continue
+        if role == "developer":
             continue
         if role == "user":
+            pending_reasoning = []
             # Handle multimodal content
             if isinstance(message.content, str):
                 content = message.content
@@ -267,19 +369,29 @@ def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]
                         "args": json.loads(tc.function.arguments) if hasattr(tc, "function") and tc.function.arguments else {},
                         "type": "tool_call",
                     })
+            # Fold any buffered reasoning blocks onto this assistant message.
+            if pending_reasoning:
+                content = list(pending_reasoning)
+                if message.content:
+                    content.append({"type": "text", "text": message.content})
+                pending_reasoning = []
+            else:
+                content = message.content or ""
             langchain_messages.append(AIMessage(
                 id=message.id,
-                content=message.content or "",
+                content=content,
                 tool_calls=tool_calls,
                 name=message.name,
             ))
         elif role == "system":
+            pending_reasoning = []
             langchain_messages.append(SystemMessage(
                 id=message.id,
                 content=message.content,
                 name=message.name,
             ))
         elif role == "tool":
+            pending_reasoning = []
             langchain_messages.append(ToolMessage(
                 id=message.id,
                 content=message.content,

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -134,11 +134,12 @@ class TestAguiMessagesToLangchain:
         assert isinstance(result[1], AIMessage)
         assert isinstance(result[2], HumanMessage)
 
-    def test_reasoning_messages_dropped(self):
-        # Reasoning content is already represented inside the assistant
-        # AIMessage's content blocks at the LangChain layer; emitting a
-        # separate LangGraph message would duplicate context on the next turn
-        # and can drive the model into a tool-call loop.
+    def test_reasoning_messages_folded_into_assistant(self):
+        # Reasoning belongs as a content block ON the assistant AIMessage at the
+        # LangChain layer. It is not emitted as a standalone LangChain
+        # message — that would duplicate context and can drive a tool-call loop —
+        # but it must not be dropped either, or the model loses its
+        # chain-of-thought on a stateless round-trip.
         msgs = [
             AGUIUserMessage(id="u1", role="user", content="Hi"),
             AGUIReasoningMessage(id="r1", role="reasoning", content="thinking..."),
@@ -148,6 +149,13 @@ class TestAguiMessagesToLangchain:
         assert len(result) == 2
         assert isinstance(result[0], HumanMessage)
         assert isinstance(result[1], AIMessage)
+        # Reasoning is folded onto the assistant, not dropped.
+        reasoning_blocks = [
+            b for b in result[1].content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert len(reasoning_blocks) == 1
+        assert reasoning_blocks[0]["id"] == "r1"
 
     def test_developer_messages_dropped(self):
         # Developer prompts are configured on the agent itself, not round-tripped.
@@ -349,3 +357,223 @@ class TestEdgeCases:
         result = agui_messages_to_langchain([msg])
         assert isinstance(result[0], AIMessage)
         assert result[0].tool_calls == []
+
+
+class TestReasoningRoundTrip:
+    """Reasoning must survive AG-UI <-> LangChain conversion losslessly.
+
+    An OpenAI reasoning model (Responses API) emits reasoning as a
+    content block on the assistant AIMessage. AG-UI carries it as a separate
+    ``role:"reasoning"`` message. Without a lossless converter pair, a stateless
+    round-trip (no checkpoint to retain the block) drops the reasoning, so the
+    model loses its own chain-of-thought on the next turn.
+    """
+
+    def test_reasoning_message_reattached_to_adjacent_assistant(self):
+        """AG-UI -> LangChain: a reasoning message is folded into the following
+        assistant AIMessage as a content block (not dropped, not a standalone
+        message)."""
+        msgs = [
+            AGUIUserMessage(id="u1", role="user", content="Hi"),
+            AGUIReasoningMessage(
+                id="rs_abc", role="reasoning", content="step 1; step 2",
+                encrypted_value="ENC123",
+            ),
+            AGUIAssistantMessage(id="a1", role="assistant", content="Hello"),
+        ]
+        result = agui_messages_to_langchain(msgs)
+
+        # No standalone reasoning message — it's folded into the assistant.
+        assert len(result) == 2
+        assert isinstance(result[0], HumanMessage)
+        assert isinstance(result[1], AIMessage)
+
+        content = result[1].content
+        assert isinstance(content, list), "assistant content should be a block list"
+        reasoning_blocks = [
+            b for b in content if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert len(reasoning_blocks) == 1
+        rb = reasoning_blocks[0]
+        assert rb["id"] == "rs_abc"
+        assert rb.get("encrypted_content") == "ENC123"
+        summary_text = " ".join(
+            s.get("text", "") for s in rb.get("summary", []) if isinstance(s, dict)
+        )
+        assert "step 1" in summary_text
+        # The assistant's own text is preserved alongside the reasoning block.
+        text_blocks = [
+            b for b in content
+            if isinstance(b, dict) and b.get("type") == "text" and b.get("text") == "Hello"
+        ]
+        assert len(text_blocks) == 1
+
+    def test_ai_reasoning_block_emitted_as_reasoning_message(self):
+        """LangChain -> AG-UI: a reasoning content block becomes a ReasoningMessage
+        placed before the assistant message, carrying the block id + encrypted
+        content so it is stable across snapshots."""
+        msg = AIMessage(
+            id="a1",
+            content=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_abc",
+                    "summary": [{"type": "summary_text", "text": "step 1; step 2"}],
+                    "encrypted_content": "ENC123",
+                },
+                {"type": "text", "text": "Hello"},
+            ],
+        )
+        result = langchain_messages_to_agui([msg])
+
+        assert len(result) == 2
+        reasoning, assistant = result[0], result[1]
+        assert reasoning.role == "reasoning"
+        assert reasoning.id == "rs_abc"
+        assert reasoning.content == "step 1; step 2"
+        assert reasoning.encrypted_value == "ENC123"
+        assert assistant.role == "assistant"
+        assert assistant.content == "Hello"
+
+    def test_reasoning_block_with_only_id_is_preserved(self):
+        """Real OpenAI Responses (store=True) persists the reasoning block as
+        just an ``rs_`` id with empty summary/content. The id is the round-trip
+        handle, so it must still be surfaced and re-attached."""
+        msg = AIMessage(
+            id="a1",
+            content=[
+                {"type": "reasoning", "id": "rs_only", "summary": [], "content": []},
+                {"type": "text", "text": "Done."},
+            ],
+        )
+        agui = langchain_messages_to_agui([msg])
+        reasoning_msgs = [m for m in agui if m.role == "reasoning"]
+        assert len(reasoning_msgs) == 1
+        assert reasoning_msgs[0].id == "rs_only"
+
+        back = agui_messages_to_langchain(agui)
+        blocks = [
+            b for b in back[0].content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert len(blocks) == 1
+        assert blocks[0]["id"] == "rs_only"
+
+    def test_reasoning_round_trips_losslessly(self):
+        """langchain -> agui -> langchain preserves the reasoning block id and
+        encrypted content on the assistant AIMessage."""
+        original = AIMessage(
+            id="a1",
+            content=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_abc",
+                    "summary": [{"type": "summary_text", "text": "because X implies Y"}],
+                    "encrypted_content": "ENC123",
+                },
+                {"type": "text", "text": "The answer is 42."},
+            ],
+        )
+        agui = langchain_messages_to_agui([original])
+        back = agui_messages_to_langchain(agui)
+
+        assert len(back) == 1
+        assert isinstance(back[0], AIMessage)
+        reasoning_blocks = [
+            b for b in back[0].content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert len(reasoning_blocks) == 1
+        assert reasoning_blocks[0]["id"] == "rs_abc"
+        assert reasoning_blocks[0].get("encrypted_content") == "ENC123"
+        # The summary text (the human-readable chain-of-thought) must survive too,
+        # not just the id/encrypted handle.
+        summary_text = "".join(
+            s.get("text", "") for s in reasoning_blocks[0].get("summary", [])
+            if isinstance(s, dict)
+        )
+        assert "because X implies Y" in summary_text
+        # The assistant's own text block survives alongside the reasoning.
+        assert any(
+            isinstance(b, dict) and b.get("type") == "text"
+            and b.get("text") == "The answer is 42."
+            for b in back[0].content
+        )
+
+    def test_multipart_summary_text_survives_round_trip(self):
+        """A reasoning block with multiple summary parts keeps every part's text
+        on the round-trip (joined, not dropped)."""
+        original = AIMessage(
+            id="a1",
+            content=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_multi",
+                    "summary": [
+                        {"type": "summary_text", "text": "first part"},
+                        {"type": "summary_text", "text": "second part"},
+                    ],
+                },
+                {"type": "text", "text": "Answer."},
+            ],
+        )
+        back = agui_messages_to_langchain(langchain_messages_to_agui([original]))
+        block = next(
+            b for b in back[0].content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        )
+        text = "".join(
+            s.get("text", "") for s in block.get("summary", []) if isinstance(s, dict)
+        )
+        assert "first part" in text
+        assert "second part" in text
+
+    def test_multiple_idless_reasoning_blocks_get_distinct_ids(self):
+        """Two reasoning blocks on one message that lack a provider id must not
+        collapse onto a single shared fallback id."""
+        msg = AIMessage(
+            id="a1",
+            content=[
+                {"type": "reasoning", "summary": [{"text": "alpha"}]},
+                {"type": "reasoning", "summary": [{"text": "beta"}]},
+                {"type": "text", "text": "Done."},
+            ],
+        )
+        reasoning_msgs = [m for m in langchain_messages_to_agui([msg]) if m.role == "reasoning"]
+        assert len(reasoning_msgs) == 2
+        assert reasoning_msgs[0].id != reasoning_msgs[1].id
+
+    def test_two_reasoning_blocks_fold_onto_one_assistant(self):
+        """Two reasoning messages buffered before a single assistant both fold
+        onto it (exercises multi-block accumulation, not just one)."""
+        msgs = [
+            AGUIReasoningMessage(id="rs_1", role="reasoning", content="first"),
+            AGUIReasoningMessage(id="rs_2", role="reasoning", content="second"),
+            AGUIAssistantMessage(id="a1", role="assistant", content="Hello"),
+        ]
+        result = agui_messages_to_langchain(msgs)
+        assert len(result) == 1
+        reasoning_ids = [
+            b["id"] for b in result[0].content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert reasoning_ids == ["rs_1", "rs_2"]
+
+    def test_orphan_reasoning_without_following_assistant_is_dropped(self):
+        """Reasoning not immediately followed by an assistant has no message to
+        attach to; it is intentionally dropped rather than materialized as a
+        standalone message (which would loop under add_messages). This locks in
+        that deliberate behavior."""
+        # Trailing reasoning (no following assistant).
+        trailing = agui_messages_to_langchain([
+            AGUIUserMessage(id="u1", role="user", content="Hi"),
+            AGUIReasoningMessage(id="rs_x", role="reasoning", content="orphan"),
+        ])
+        assert [type(m).__name__ for m in trailing] == ["HumanMessage"]
+
+        # Reasoning followed by a non-assistant message.
+        followed_by_user = agui_messages_to_langchain([
+            AGUIReasoningMessage(id="rs_y", role="reasoning", content="orphan"),
+            AGUIUserMessage(id="u1", role="user", content="Hi"),
+        ])
+        assert [type(m).__name__ for m in followed_by_user] == ["HumanMessage"]

--- a/integrations/langgraph/typescript/src/message-conversion.test.ts
+++ b/integrations/langgraph/typescript/src/message-conversion.test.ts
@@ -4,8 +4,28 @@
  */
 
 import { Message as LangGraphMessage } from "@langchain/langgraph-sdk";
-import { Message } from "@ag-ui/client";
+import { Message, ReasoningMessage } from "@ag-ui/client";
 import { aguiMessagesToLangChain, langchainMessagesToAgui } from "./utils";
+
+// Runtime shape of a reasoning content block on a LangChain assistant message
+// (not part of the LangGraph SDK's typed content union).
+type ReasoningBlock = {
+  type?: string;
+  id?: string;
+  text?: string;
+  encrypted_content?: string;
+  summary?: { text?: string }[];
+};
+
+// The LangGraph SDK's MessageContent type models only string | (text|image)
+// blocks, so a reasoning content block has no place in it. These two helpers
+// centralize the single unavoidable cast at that boundary — building a fixture
+// AIMessage whose content carries reasoning blocks, and reading those blocks
+// back out — so the test bodies stay cast-free.
+const aiMessageWithBlocks = (id: string, content: unknown[]): LangGraphMessage =>
+  ({ id, type: "ai", content }) as unknown as LangGraphMessage;
+const contentBlocksOf = (message: LangGraphMessage): ReasoningBlock[] =>
+  message.content as unknown as ReasoningBlock[];
 
 describe("Message Conversion - All Types", () => {
   describe("aguiMessagesToLangChain", () => {
@@ -78,10 +98,10 @@ describe("Message Conversion - All Types", () => {
       expect(result[2].type).toBe("human");
     });
 
-    it("should drop reasoning messages (display-only)", () => {
-      // Reasoning content already lives inside the assistant AIMessage's
-      // content blocks at the LangChain layer; emitting a separate LangGraph
-      // message would duplicate context on the next turn.
+    it("should fold reasoning messages onto the adjacent assistant (not drop)", () => {
+      // Reasoning belongs as a content block ON the assistant AIMessage — not a
+      // standalone message (would duplicate context), but not dropped either
+      // (the model would lose its chain-of-thought on a stateless turn).
       const msgs: Message[] = [
         { id: "u1", role: "user", content: "Hi" },
         { id: "r1", role: "reasoning", content: "thinking..." },
@@ -91,6 +111,9 @@ describe("Message Conversion - All Types", () => {
       expect(result).toHaveLength(2);
       expect(result[0].type).toBe("human");
       expect(result[1].type).toBe("ai");
+      const reasoningBlocks = contentBlocksOf(result[1]).filter((b) => b.type === "reasoning");
+      expect(reasoningBlocks).toHaveLength(1);
+      expect(reasoningBlocks[0].id).toBe("r1");
     });
 
     it("should drop developer messages (handled by agent system prompt)", () => {
@@ -277,6 +300,163 @@ describe("Message Conversion - All Types", () => {
       expect(back[0].role).toBe("tool");
       expect(back[0].content).toBe("done");
       expect(back[0].toolCallId).toBe("tc1");
+    });
+  });
+
+  // Reasoning must survive AG-UI <-> LangChain conversion losslessly so a
+  // stateless client can hand a reasoning model back its own chain-of-thought.
+  describe("reasoning round-trip", () => {
+    it("should fold a reasoning message onto the adjacent assistant message", () => {
+      const msgs: Message[] = [
+        { id: "u1", role: "user", content: "Hi" },
+        { id: "rs_abc", role: "reasoning", content: "step 1; step 2", encryptedValue: "ENC123" },
+        { id: "a1", role: "assistant", content: "Hello" },
+      ];
+      const result = aguiMessagesToLangChain(msgs);
+
+      expect(result).toHaveLength(2); // reasoning folded in, not standalone
+      expect(result[0].type).toBe("human");
+      expect(result[1].type).toBe("ai");
+      const blocks = contentBlocksOf(result[1]);
+      const reasoningBlocks = blocks.filter((b) => b.type === "reasoning");
+      expect(reasoningBlocks).toHaveLength(1);
+      expect(reasoningBlocks[0].id).toBe("rs_abc");
+      expect(reasoningBlocks[0].encrypted_content).toBe("ENC123");
+      expect(blocks.some((b) => b.type === "text" && b.text === "Hello")).toBe(true);
+    });
+
+    it("should emit a reasoning message for an AI reasoning content block", () => {
+      const msg = aiMessageWithBlocks("a1", [
+        { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "step 1; step 2" }], encrypted_content: "ENC123" },
+        { type: "text", text: "Hello" },
+      ]);
+      const result = langchainMessagesToAgui([msg]);
+
+      expect(result).toHaveLength(2);
+      const reasoning = result[0] as ReasoningMessage;
+      expect(reasoning.role).toBe("reasoning");
+      expect(reasoning.id).toBe("rs_abc");
+      expect(reasoning.content).toBe("step 1; step 2");
+      expect(reasoning.encryptedValue).toBe("ENC123");
+      expect(result[1].role).toBe("assistant");
+      expect(result[1].content).toBe("Hello");
+    });
+
+    it("should preserve a reasoning block that carries only an id (store=true)", () => {
+      // Real OpenAI Responses (store=true) persists reasoning as just an rs_ id
+      // with empty summary; the id is the round-trip handle.
+      const msg = aiMessageWithBlocks("a1", [
+        { type: "reasoning", id: "rs_only", summary: [], content: [] },
+        { type: "text", text: "Done." },
+      ]);
+      const agui = langchainMessagesToAgui([msg]);
+      const reasoning = agui.filter((m) => m.role === "reasoning");
+      expect(reasoning).toHaveLength(1);
+      expect(reasoning[0].id).toBe("rs_only");
+
+      const back = aguiMessagesToLangChain(agui);
+      const blocks = contentBlocksOf(back[0]).filter((b) => b.type === "reasoning");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].id).toBe("rs_only");
+    });
+
+    it("should round-trip reasoning losslessly (langchain -> agui -> langchain)", () => {
+      const original = aiMessageWithBlocks("a1", [
+        { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "because X" }], encrypted_content: "ENC123" },
+        { type: "text", text: "The answer is 42." },
+      ]);
+      const agui = langchainMessagesToAgui([original]);
+      const back = aguiMessagesToLangChain(agui);
+
+      expect(back).toHaveLength(1);
+      const allBlocks = contentBlocksOf(back[0]);
+      const blocks = allBlocks.filter((b) => b.type === "reasoning");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].id).toBe("rs_abc");
+      expect(blocks[0].encrypted_content).toBe("ENC123");
+      // The summary text and the assistant's own text must survive too.
+      const summaryText = (blocks[0].summary ?? []).map((s) => s.text).join("");
+      expect(summaryText).toContain("because X");
+      expect(allBlocks.some((b) => b.type === "text" && b.text === "The answer is 42.")).toBe(true);
+    });
+
+    it("should preserve every part of a multi-part summary on round-trip", () => {
+      const original = aiMessageWithBlocks("a1", [
+        { type: "reasoning", id: "rs_multi", summary: [{ text: "first part" }, { text: "second part" }] },
+        { type: "text", text: "Answer." },
+      ]);
+      const back = aguiMessagesToLangChain(langchainMessagesToAgui([original]));
+      const block = contentBlocksOf(back[0]).find((b) => b.type === "reasoning")!;
+      const text = (block.summary ?? []).map((s) => s.text).join("");
+      expect(text).toContain("first part");
+      expect(text).toContain("second part");
+    });
+
+    it("should give multiple id-less reasoning blocks distinct ids", () => {
+      const msg = aiMessageWithBlocks("a1", [
+        { type: "reasoning", summary: [{ text: "alpha" }] },
+        { type: "reasoning", summary: [{ text: "beta" }] },
+        { type: "text", text: "Done." },
+      ]);
+      const reasoning = langchainMessagesToAgui([msg]).filter((m) => m.role === "reasoning");
+      expect(reasoning).toHaveLength(2);
+      expect(reasoning[0].id).not.toBe(reasoning[1].id);
+    });
+
+    it("should fold two buffered reasoning messages onto one assistant", () => {
+      const msgs: Message[] = [
+        { id: "rs_1", role: "reasoning", content: "first" },
+        { id: "rs_2", role: "reasoning", content: "second" },
+        { id: "a1", role: "assistant", content: "Hello" },
+      ];
+      const result = aguiMessagesToLangChain(msgs);
+      expect(result).toHaveLength(1);
+      const ids = contentBlocksOf(result[0]).filter((b) => b.type === "reasoning").map((b) => b.id);
+      expect(ids).toEqual(["rs_1", "rs_2"]);
+    });
+
+    it("should drop reasoning that is not immediately followed by an assistant", () => {
+      // No assistant to attach to; materializing standalone loops under
+      // add_messages, so the drop is deliberate. Lock in the behavior.
+      const trailing = aguiMessagesToLangChain([
+        { id: "u1", role: "user", content: "Hi" },
+        { id: "rs_x", role: "reasoning", content: "orphan" },
+      ]);
+      expect(trailing.map((m) => m.type)).toEqual(["human"]);
+
+      const followedByUser = aguiMessagesToLangChain([
+        { id: "rs_y", role: "reasoning", content: "orphan" },
+        { id: "u1", role: "user", content: "Hi" },
+      ]);
+      expect(followedByUser.map((m) => m.type)).toEqual(["human"]);
+    });
+  });
+
+  // Tool-call argument handling must match the Python converter (no crash on
+  // empty arguments; no `undefined` emitted for missing args).
+  describe("tool-call argument robustness", () => {
+    it("should not throw on an assistant tool call with empty arguments", () => {
+      const msg: Message = {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "tc1", type: "function", function: { name: "noargs", arguments: "" } }],
+      };
+      const result = aguiMessagesToLangChain([msg]);
+      const ai = result[0] as { tool_calls?: { args: unknown }[] };
+      expect(ai.tool_calls?.[0].args).toEqual({});
+    });
+
+    it("should emit \"{}\" (not undefined) for a tool call with no args", () => {
+      const msg = {
+        id: "a1",
+        type: "ai",
+        content: "",
+        tool_calls: [{ id: "tc1", name: "noargs" }],
+      } as unknown as LangGraphMessage;
+      const result = langchainMessagesToAgui([msg]);
+      const assistant = result[0] as { toolCalls?: { function: { arguments: string } }[] };
+      expect(assistant.toolCalls?.[0].function.arguments).toBe("{}");
     });
   });
 });

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -2,6 +2,7 @@ import { Message as LangGraphMessage } from "@langchain/langgraph-sdk";
 import { State, SchemaKeys, LangGraphReasoning } from "./types";
 import {
   Message,
+  ReasoningMessage,
   ToolCall,
   TextInputContent,
   ImageInputContent,
@@ -167,10 +168,87 @@ function convertAguiMultimodalToLangchain(
   return langchainContent;
 }
 
+// A reasoning content block as it appears on a LangChain assistant message
+// (OpenAI Responses `responses/v1` shape). It is not part of the LangGraph SDK's
+// typed content union, so it is declared here for narrowing.
+interface ReasoningSummaryEntry {
+  type?: string;
+  text?: string;
+}
+
+interface ReasoningContentBlock {
+  type: "reasoning";
+  id?: string;
+  summary?: ReasoningSummaryEntry[];
+  encrypted_content?: string;
+  // Flat-text shapes emitted by some non-OpenAI providers.
+  reasoning?: string;
+  text?: string;
+}
+
+function isReasoningBlock(block: unknown): block is ReasoningContentBlock {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { type?: unknown }).type === "reasoning"
+  );
+}
+
+// Extract the human-readable reasoning text from a reasoning content block.
+function reasoningBlockSummaryText(block: ReasoningContentBlock): string {
+  if (Array.isArray(block.summary)) {
+    const parts = block.summary
+      .map((entry) => entry?.text)
+      .filter((text): text is string => Boolean(text));
+    // Join multi-part summaries with a newline so the parts stay legible
+    // instead of being mashed together ("A\nB", not "AB").
+    if (parts.length) return parts.join("\n");
+  }
+  return block.reasoning ?? block.text ?? "";
+}
+
+// Turn a LangChain reasoning content block into an AG-UI ReasoningMessage,
+// preserving the block id (the provider's `rs_…` handle — under store=true it is
+// the only round-trip key) and any encrypted content (needed for store=false).
+// Returns null only for a wholly empty block (nothing to render or round-trip).
+function reasoningBlockToAguiMessage(
+  block: ReasoningContentBlock,
+  assistantId: string,
+  index = 0,
+): ReasoningMessage | null {
+  const text = reasoningBlockSummaryText(block);
+  const encrypted = block.encrypted_content;
+  if (!block.id && !text && !encrypted) return null;
+  const message: ReasoningMessage = {
+    // Include the block index in the fallback id so multiple id-less reasoning
+    // blocks on one message don't collide on the same id.
+    id: String(block.id ?? `${assistantId}-reasoning-${index}`),
+    role: "reasoning",
+    content: text,
+  };
+  if (encrypted) message.encryptedValue = encrypted;
+  return message;
+}
+
+// Rebuild the LangChain reasoning content block from an AG-UI ReasoningMessage
+// (inverse of reasoningBlockToAguiMessage).
+function aguiReasoningMessageToBlock(message: ReasoningMessage): ReasoningContentBlock {
+  const block: ReasoningContentBlock = {
+    type: "reasoning",
+    id: message.id,
+    summary: message.content
+      ? [{ type: "summary_text", text: message.content }]
+      : [],
+  };
+  if (message.encryptedValue) block.encrypted_content = message.encryptedValue;
+  return block;
+}
+
 export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[] {
-  return messages.map((message) => {
+  const out: Message[] = [];
+  for (const message of messages) {
     switch (message.type) {
-      case "human":
+      case "human": {
         // Handle multimodal content
         let userContent: string | InputContent[];
         if (Array.isArray(message.content)) {
@@ -179,15 +257,28 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
           userContent = stringifyIfNeeded(resolveMessageContent(message.content));
         }
 
-        return {
+        out.push({
           id: message.id!,
           role: "user",
           content: userContent,
-        };
+        });
+        break;
+      }
       case "generic":
-      case "ai":
-        const aiContent = resolveMessageContent(message.content)
-        return {
+      case "ai": {
+        // Surface reasoning content blocks as standalone ReasoningMessages
+        // placed BEFORE the assistant message (matching streaming order), so a
+        // client with no persistent checkpoint can round-trip them.
+        if (Array.isArray(message.content)) {
+          message.content.forEach((block, index) => {
+            if (isReasoningBlock(block)) {
+              const reasoningMsg = reasoningBlockToAguiMessage(block, message.id!, index);
+              if (reasoningMsg) out.push(reasoningMsg);
+            }
+          });
+        }
+        const aiContent = resolveMessageContent(message.content);
+        out.push({
           id: message.id!,
           role: "assistant",
           content: aiContent ? stringifyIfNeeded(aiContent) : '',
@@ -196,41 +287,62 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
             type: "function",
             function: {
               name: tc.name,
-              arguments: JSON.stringify(tc.args),
+              // Default missing args to "{}" (parity with the Python side);
+              // JSON.stringify(undefined) would emit an invalid `undefined`.
+              arguments: JSON.stringify(tc.args ?? {}),
             },
           })),
-        };
+        });
+        break;
+      }
       case "system":
-        return {
+        out.push({
           id: message.id!,
           role: "system",
           content: stringifyIfNeeded(resolveMessageContent(message.content)),
-        };
+        });
+        break;
       case "tool":
-        return {
+        out.push({
           id: message.id!,
           role: "tool",
           content: stringifyIfNeeded(resolveMessageContent(message.content)),
           toolCallId: message.tool_call_id,
-        };
+        });
+        break;
       default:
         throw new Error("message type returned from LangGraph is not supported.");
     }
-  });
+  }
+  return out;
 }
 
 export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[] {
-  return messages
-    // Reasoning AG-UI messages are display-only — their content already lives
-    // inside the corresponding assistant AIMessage's content blocks
-    // (langchain-openai writes them there for the Responses API). Developer
-    // messages are part of the agent's configured system prompt. Re-materializing
-    // either as standalone LangChain messages duplicates context on every turn
-    // and can drive the model into a tool-call loop.
-    .filter((message) => message.role !== "reasoning" && message.role !== "developer")
-    .map((message, index) => {
+  const out: LangGraphMessage[] = [];
+  // Reasoning is display-only at the AG-UI layer but lives as a content block ON
+  // the assistant AIMessage at the LangChain layer. To round-trip reasoning
+  // without loss (so a stateless client can hand the model back its own
+  // chain-of-thought), buffer reasoning messages and re-attach them as content
+  // blocks on the assistant that follows (matching streaming order). Developer
+  // messages stay dropped — they are configured on the agent itself.
+  //
+  // Reasoning that is NOT immediately followed by an assistant message (trailing,
+  // or followed by a user/tool/system message) is intentionally discarded: there
+  // is no assistant to attach it to, and re-materializing it as a standalone
+  // message causes exponential message duplication and tool-call loops under the
+  // add_messages reducer. The snapshot side (langchainMessagesToAgui) only ever
+  // emits reasoning immediately before its assistant, so this drop never affects
+  // a real round-trip — only hand-crafted / partial inputs.
+  let pendingReasoning: ReasoningContentBlock[] = [];
+  for (const message of messages) {
     switch (message.role) {
-      case "user":
+      case "reasoning":
+        pendingReasoning.push(aguiReasoningMessageToBlock(message));
+        continue;
+      case "developer":
+        continue;
+      case "user": {
+        pendingReasoning = [];
         // Handle multimodal content
         let content: UserMessage['content'];
         if (typeof message.content === "string") {
@@ -241,45 +353,68 @@ export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[]
           content = String(message.content);
         }
 
-        return {
+        out.push({
           id: message.id,
           role: message.role,
           content,
           type: "human",
-        } as LangGraphMessage;
-      case "assistant":
-        return {
+        } as LangGraphMessage);
+        break;
+      }
+      case "assistant": {
+        // Fold any buffered reasoning blocks onto this assistant message.
+        let content: string | Array<ReasoningContentBlock | { type: "text"; text: string }>;
+        if (pendingReasoning.length) {
+          const blocks: Array<ReasoningContentBlock | { type: "text"; text: string }> = [
+            ...pendingReasoning,
+          ];
+          if (message.content) blocks.push({ type: "text", text: message.content });
+          content = blocks;
+          pendingReasoning = [];
+        } else {
+          content = message.content ?? "";
+        }
+        out.push({
           id: message.id,
           type: "ai",
           role: message.role,
-          content: message.content ?? "",
+          content,
           tool_calls: (message.toolCalls ?? []).map((tc: ToolCall) => ({
             id: tc.id,
             name: tc.function.name,
-            args: JSON.parse(tc.function.arguments),
+            // Guard empty/absent arguments (parity with the Python side):
+            // JSON.parse("") throws and would abort the whole conversion.
+            args: tc.function.arguments ? JSON.parse(tc.function.arguments) : {},
             type: "tool_call",
           })),
-        };
+        } as LangGraphMessage);
+        break;
+      }
       case "system":
-        return {
+        pendingReasoning = [];
+        out.push({
           id: message.id,
           role: message.role,
           content: message.content,
           type: "system",
-        };
+        } as LangGraphMessage);
+        break;
       case "tool":
-        return {
+        pendingReasoning = [];
+        out.push({
           content: message.content,
           role: message.role,
           type: message.role,
           tool_call_id: message.toolCallId,
           id: message.id,
-        };
+        } as LangGraphMessage);
+        break;
       default:
-        console.error(`Message role ${message.role} is not implemented`);
+        console.error(`Message role ${(message as { role: string }).role} is not implemented`);
         throw new Error("message role is not supported.");
     }
-  });
+  }
+  return out;
 }
 
 function stringifyIfNeeded(item: any) {


### PR DESCRIPTION
## What

Make the AG-UI ↔ LangChain message converters round-trip reasoning content losslessly, in both the Python (`ag_ui_langgraph`) and TypeScript (`@ag-ui/langgraph`) SDKs.

## Why

Reasoning lives in two shapes: a content block on the assistant `AIMessage` (LangChain) vs. a standalone `role:"reasoning"` message (AG-UI). The converters **dropped** reasoning on the way back to LangChain. With a server checkpoint that's harmless, but on a **stateless** turn (no checkpoint to retain it) the model gets zero prior reasoning items back — a reasoning model loses its own chain-of-thought across turns.

## Changes

- **LangChain → AG-UI:** emit a `ReasoningMessage` per reasoning block, before its assistant message, preserving the provider id (`rs_…`) and `encrypted_content`. Blocks that carry only an id (the real `store=true` shape) are still surfaced.
- **AG-UI → LangChain:** re-attach reasoning messages as content blocks on the adjacent assistant message instead of dropping them. Reasoning with no following assistant is intentionally dropped (no anchor; standalone materialization loops under `add_messages`).
- Minor parity hardening of the rewritten converters: TS no longer crashes on an empty tool-call `arguments`, and no longer emits `undefined` for missing `args`.

## Testing

- New round-trip test suites in both languages (Python `42 passed`, TS `36 passed`); red-green verified.
- End-to-end against a LangGraph FastAPI app + an OpenAI reasoning model (Responses API): a stateless turn-2 request now carries the turn-1 reasoning item (previously absent). Checkpointed deployments unchanged.