### PR TITLE
fix: set repository metadata on published packages for npm provenance

### DIFF
--- a/integrations/aws-strands/typescript/package.json
+++ b/integrations/aws-strands/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/aws-strands",
   "author": "AG-UI Contributors",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "description": "AWS Strands Agents integration for the AG-UI protocol",
   "publishConfig": {
     "access": "public"

--- a/integrations/vercel-ai-sdk/typescript/package.json
+++ b/integrations/vercel-ai-sdk/typescript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/vercel-ai-sdk",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/middlewares/event-throttle-middleware/package.json
+++ b/middlewares/event-throttle-middleware/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/event-throttle-middleware",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/middlewares/mcp-middleware/package.json
+++ b/middlewares/mcp-middleware/package.json
@@ -2,6 +2,10 @@
   "name": "@ag-ui/mcp-middleware",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/packages/a2ui-toolkit/package.json
+++ b/sdks/typescript/packages/a2ui-toolkit/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@ag-ui/a2ui-toolkit",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ag-ui-protocol/ag-ui.git"
+  },
   "description": "Framework-agnostic helpers for building A2UI subagent tools — op builders, prompt assembly, history walkers, and request/envelope orchestration shared across framework adapters.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Problem

Five published TypeScript packages are missing a `repository` field in their `package.json`. An empty/missing `repository.url` breaks `npm publish --provenance` (the canary publish of `@ag-ui/a2ui-toolkit` failed with E422 for exactly this reason).

## Fix

Add the canonical `repository` block used by the rest of the repo's packages (e.g. `@ag-ui/core`) to the five affected published packages:

- `@ag-ui/a2ui-toolkit` (`sdks/typescript/packages/a2ui-toolkit`)
- `@ag-ui/aws-strands` (`integrations/aws-strands/typescript`)
- `@ag-ui/vercel-ai-sdk` (`integrations/vercel-ai-sdk/typescript`)
- `@ag-ui/event-throttle-middleware` (`middlewares/event-throttle-middleware`)
- `@ag-ui/mcp-middleware` (`middlewares/mcp-middleware`)

```json
"repository": {
  "type": "git",
  "url": "https://github.com/ag-ui-protocol/ag-ui.git"
}
```

Each change is purely additive — no `version` or other field is touched.

Supersedes auto-closed #1884 (which was stacked on #1874; #1874 has since merged to `main`).