### PR TITLE
fix(claude-agent-sdk): serialize same-thread runs + worker/timeout/result robustness

### DIFF
--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -86,7 +86,7 @@ class ClaudeAgentAdapter:
         description: str = "",
         max_workers: int = 1000,
         worker_ttl_seconds: float = 1800,   # 30 min
-        query_timeout_seconds: Optional[float] = None,
+        query_timeout_seconds: Optional[float] = 300,   # 5 min; bounds a hung/slow worker
     ):
         self.name = name
         self.description = description
@@ -97,8 +97,21 @@ class ClaudeAgentAdapter:
         # thread_id -> {"worker": SessionWorker, "last_used": datetime, "active": bool, "active_runs": int}
         self._workers: Dict[str, Dict] = {}
         self._state_locks: Dict[str, asyncio.Lock] = {}
+        # Per-thread RUN-ADMISSION lock. This is a SEPARATE lock from
+        # ``_state_locks`` on purpose: ``_state_locks[thread_id]`` is acquired
+        # mid-stream by the state-management-tool path (``async with lock:`` in
+        # ``_stream_claude_sdk``), and ``asyncio.Lock`` is non-reentrant, so
+        # reusing it for run admission would self-deadlock the instant the model
+        # emits a state-update tool call. Lock ordering is fixed: the run-lock is
+        # OUTERMOST (acquired at admission, before streaming / before
+        # RUN_STARTED) and the state-lock is INNERMOST (acquired only mid-stream).
+        # No path may hold ``_state_locks`` then wait on ``_run_locks``.
+        self._run_locks: Dict[str, asyncio.Lock] = {}
         self._per_thread_state: Dict[str, Any] = {}  # thread_id -> current state
-        self._per_thread_result: Dict[str, Any] = {}  # thread_id -> last result data
+        # Per-RUN result keyed by (thread_id, run_id). ``RUN_FINISHED.result`` is
+        # per-run by definition, so it must not share a per-thread slot that a
+        # concurrent/serialized peer run could clobber.
+        self._per_run_result: Dict[tuple, Any] = {}  # (thread_id, run_id) -> result data
         # Strong references to fire-and-forget cleanup tasks (e.g. worker.stop()
         # during eviction). Without this the only reference is local and the
         # event loop keeps only a weak reference, so a pending stop task can be
@@ -128,12 +141,23 @@ class ClaudeAgentAdapter:
             for entry in self._workers.values():
                 await entry["worker"].interrupt()
 
+    def _drop_thread_results(self, thread_id: str) -> None:
+        """Drop every per-run result entry belonging to ``thread_id``.
+
+        ``_per_run_result`` is keyed by ``(thread_id, run_id)``; thread-scoped
+        cleanup (eviction / clear_session / error path) must purge all of a
+        thread's run results, not a single run."""
+        for key in [k for k in self._per_run_result if k[0] == thread_id]:
+            self._per_run_result.pop(key, None)
+
     async def shutdown(self) -> None:
         """Gracefully stop all session workers. Call on server shutdown."""
         for entry in list(self._workers.values()):
             await entry["worker"].stop()
         self._workers.clear()
         self._state_locks.clear()
+        self._run_locks.clear()
+        self._per_run_result.clear()
 
     def _evict_workers(self) -> None:
         """Evict idle workers by TTL and LRU cap."""
@@ -147,8 +171,9 @@ class ClaudeAgentAdapter:
             entry = self._workers.pop(tid)
             self._spawn_cleanup_task(entry["worker"].stop())
             self._state_locks.pop(tid, None)
+            self._run_locks.pop(tid, None)
             self._per_thread_state.pop(tid, None)
-            self._per_thread_result.pop(tid, None)
+            self._drop_thread_results(tid)
 
         # LRU eviction: if still over cap, remove oldest idle entries
         while len(self._workers) > self._max_workers:
@@ -159,8 +184,9 @@ class ClaudeAgentAdapter:
             entry = self._workers.pop(oldest_tid)
             self._spawn_cleanup_task(entry["worker"].stop())
             self._state_locks.pop(oldest_tid, None)
+            self._run_locks.pop(oldest_tid, None)
             self._per_thread_state.pop(oldest_tid, None)
-            self._per_thread_result.pop(oldest_tid, None)
+            self._drop_thread_results(oldest_tid)
 
     async def clear_session(self, thread_id: str) -> None:
         """Stop and remove the session worker for a thread."""
@@ -168,8 +194,9 @@ class ClaudeAgentAdapter:
         if entry:
             await entry["worker"].stop()
         self._state_locks.pop(thread_id, None)
+        self._run_locks.pop(thread_id, None)
         self._per_thread_state.pop(thread_id, None)
-        self._per_thread_result.pop(thread_id, None)
+        self._drop_thread_results(thread_id)
 
     async def run(self, input_data: RunAgentInput) -> AsyncIterator[BaseEvent]:
         """Run the agent and yield AG-UI events."""
@@ -177,9 +204,28 @@ class ClaudeAgentAdapter:
 
         thread_id = input_data.thread_id or str(uuid.uuid4())
         run_id = input_data.run_id or str(uuid.uuid4())
-        
+        result_key = (thread_id, run_id)
+
+        # ── Run-admission serialization (Fix 1) ──
+        # Acquire the per-thread RUN lock at admission — BEFORE worker.query() /
+        # RUN_STARTED — and hold it across the WHOLE run, releasing in the
+        # ``finally`` (and therefore on every ``except`` path too). Effect: a
+        # second run on the same thread_id waits here until the first emits
+        # RUN_FINISHED and releases; different thread_ids stay concurrent (the
+        # lock is per-thread). This is a DISTINCT lock from ``_state_locks``
+        # (acquired mid-stream on the state-update-tool path); reusing the
+        # non-reentrant state-lock would self-deadlock. Lock ordering is fixed:
+        # run-lock OUTERMOST, state-lock INNERMOST.
+        run_lock = self._run_locks.setdefault(thread_id, asyncio.Lock())
+        await run_lock.acquire()
+
+        # Re-seed per-thread state for THIS run, now that we hold the thread
+        # exclusively. Fresh ``input_data.state`` REPLACES any prior thread state
+        # (documented reset semantics); doing it under the run-lock keeps the
+        # reset per-run rather than racing a peer's seed. ``_per_run_result`` is
+        # keyed per-run so a serialized peer can never clobber it (Fix 4).
         self._per_thread_state[thread_id] = input_data.state
-        self._per_thread_result[thread_id] = None
+        self._per_run_result[result_key] = None
 
         # Set True only once this run has been counted into a worker's
         # ``active_runs`` refcount, so the ``finally`` block decrements exactly
@@ -309,12 +355,13 @@ class ClaudeAgentAdapter:
                 ):
                     yield event
             
-            # Emit RUN_FINISHED
+            # Emit RUN_FINISHED — read THIS run's own result (keyed per-run, so a
+            # serialized peer on the same thread cannot have clobbered it). (Fix 4)
             yield RunFinishedEvent(
                 type=EventType.RUN_FINISHED,
                 thread_id=thread_id,
                 run_id=run_id,
-                result=self._per_thread_result.get(thread_id, None),
+                result=self._per_run_result.get(result_key, None),
             )
             
         except asyncio.TimeoutError as e:
@@ -345,7 +392,7 @@ class ClaudeAgentAdapter:
                     await broken_entry["worker"].stop()
                 self._state_locks.pop(thread_id, None)
                 self._per_thread_state.pop(thread_id, None)
-                self._per_thread_result.pop(thread_id, None)
+                self._drop_thread_results(thread_id)
             yield RunErrorEvent(
                 type=EventType.RUN_ERROR,
                 thread_id=thread_id,
@@ -366,6 +413,15 @@ class ClaudeAgentAdapter:
                 entry["active_runs"] = max(remaining, 0)
                 entry["active"] = entry["active_runs"] > 0
                 entry["last_used"] = datetime.now()
+
+            # Drop THIS run's result slot (per-run keyed; thread-scoped cleanup
+            # paths above may already have purged it, hence pop with default).
+            self._per_run_result.pop(result_key, None)
+
+            # Release the run-admission lock on EVERY exit path (success, error,
+            # timeout, and the fail-loud early return) so a waiting same-thread
+            # run can proceed. We acquired it unconditionally before this try.
+            run_lock.release()
 
     def build_options(self, input_data: Optional[RunAgentInput] = None, thread_id: Optional[str] = None) -> "ClaudeAgentOptions":
         """Build ClaudeAgentOptions from base config + RunAgentInput."""
@@ -933,8 +989,10 @@ class ClaudeAgentAdapter:
                 is_error = getattr(message, 'is_error', None)
                 result_text = getattr(message, 'result', None)
                 
-                # Capture metadata for RunFinished event
-                self._per_thread_result[thread_id] = {
+                # Capture metadata for RunFinished event. Key per-run
+                # (thread_id, run_id) so a serialized peer on the same thread
+                # cannot clobber this run's result. (Fix 4)
+                self._per_run_result[(thread_id, run_id)] = {
                     "is_error": is_error,
                     "duration_ms": getattr(message, 'duration_ms', None),
                     "duration_api_ms": getattr(message, 'duration_api_ms', None),

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -156,11 +156,33 @@ class ClaudeAgentAdapter:
             await entry["worker"].stop()
         self._workers.clear()
         self._state_locks.clear()
+        # NOTE: ``_run_locks`` is intentionally cleared only here, on full
+        # adapter shutdown (no run can be in-flight or waiting past this point).
+        # It is NOT cleared on per-thread eviction / clear_session / the run
+        # error path — see ``_evict_workers`` for the rationale (decoupling the
+        # run-admission lock lifecycle from worker-cache eviction).
         self._run_locks.clear()
         self._per_run_result.clear()
 
     def _evict_workers(self) -> None:
-        """Evict idle workers by TTL and LRU cap."""
+        """Evict idle workers by TTL and LRU cap.
+
+        IMPORTANT: ``_run_locks[tid]`` is deliberately NOT popped here (nor on
+        ``clear_session`` / the run error path). The run-admission lock's
+        lifecycle is run SERIALIZATION, which must stay decoupled from
+        worker-cache eviction. Popping it opens an orphan race: a run B parked on
+        ``await run_lock.acquire()`` in the window after run A released the lock
+        (worker now idle, active_runs==0) but before B wakes can have its lock
+        entry popped by eviction; a later run D then ``setdefault``s a FRESH lock
+        and runs CONCURRENTLY with B — serialization defeated. Re-validating
+        identity after acquire (in ``run``) is not sufficient alone, because a
+        held/waited lock can still be popped and re-created. So we leave run-lock
+        entries resident. This is bounded by the number of distinct ``thread_id``
+        values seen (each maps to one tiny ``asyncio.Lock``); a future
+        ``ThreadContext`` unification (one record per thread owning worker + all
+        locks + state, reaped together) is the long-term home for bounding it —
+        do NOT add a separate reaper here now.
+        """
         now = datetime.now()
         # TTL eviction: remove idle workers older than TTL
         to_remove = [
@@ -171,7 +193,6 @@ class ClaudeAgentAdapter:
             entry = self._workers.pop(tid)
             self._spawn_cleanup_task(entry["worker"].stop())
             self._state_locks.pop(tid, None)
-            self._run_locks.pop(tid, None)
             self._per_thread_state.pop(tid, None)
             self._drop_thread_results(tid)
 
@@ -184,7 +205,6 @@ class ClaudeAgentAdapter:
             entry = self._workers.pop(oldest_tid)
             self._spawn_cleanup_task(entry["worker"].stop())
             self._state_locks.pop(oldest_tid, None)
-            self._run_locks.pop(oldest_tid, None)
             self._per_thread_state.pop(oldest_tid, None)
             self._drop_thread_results(oldest_tid)
 
@@ -194,7 +214,12 @@ class ClaudeAgentAdapter:
         if entry:
             await entry["worker"].stop()
         self._state_locks.pop(thread_id, None)
-        self._run_locks.pop(thread_id, None)
+        # NOTE: ``_run_locks[thread_id]`` is intentionally NOT popped — see
+        # ``_evict_workers``. A run may be parked on this lock right now;
+        # popping it would orphan that waiter and let a later run on the same
+        # thread acquire a fresh lock and run concurrently (defeating
+        # serialization). The lock is a tiny resident ``asyncio.Lock`` bounded
+        # by distinct thread_ids; only full ``shutdown`` clears the map.
         self._per_thread_state.pop(thread_id, None)
         self._drop_thread_results(thread_id)
 
@@ -216,8 +241,20 @@ class ClaudeAgentAdapter:
         # (acquired mid-stream on the state-update-tool path); reusing the
         # non-reentrant state-lock would self-deadlock. Lock ordering is fixed:
         # run-lock OUTERMOST, state-lock INNERMOST.
-        run_lock = self._run_locks.setdefault(thread_id, asyncio.Lock())
-        await run_lock.acquire()
+        # Acquire the CURRENT lock entry, then re-validate identity: if the entry
+        # in ``_run_locks`` changed while we were parked (defense-in-depth against
+        # any residual repopulation race — note eviction no longer pops the lock,
+        # so this loop normally runs once), release the stale lock and retry on
+        # the current one. Loop until we hold the lock that is actually the live
+        # ``_run_locks[thread_id]``, so no two runs can ever hold "the" run-lock
+        # for the same thread at once.
+        while True:
+            run_lock = self._run_locks.setdefault(thread_id, asyncio.Lock())
+            await run_lock.acquire()
+            if self._run_locks.get(thread_id) is run_lock:
+                break
+            # A different lock is now the live entry; we acquired a stale one.
+            run_lock.release()
 
         # Re-seed per-thread state for THIS run, now that we hold the thread
         # exclusively. Fresh ``input_data.state`` REPLACES any prior thread state
@@ -243,8 +280,15 @@ class ClaudeAgentAdapter:
             entry = self._workers.get(thread_id)
             if entry is not None and not entry["worker"].is_alive():
                 if entry.get("active_runs", 0) > 0:
-                    # A peer run is still streaming on this (now-dead) worker.
-                    # We are wedged between two unacceptable options:
+                    # DEFENSE-IN-DEPTH / UNREACHABLE under run-admission
+                    # serialization (Fix 1): the per-thread run-lock admits one
+                    # run at a time, so while THIS run holds the lock no peer run
+                    # on the same thread can be mid-stream (``active_runs`` is
+                    # per-thread and capped at 1). This branch is retained as a
+                    # belt-and-suspenders guard in case that invariant is ever
+                    # violated by a future change. If somehow a peer IS streaming
+                    # on this (now-dead) worker, we are wedged between two
+                    # unacceptable options:
                     #   * REUSE the dead worker — querying it would hang this
                     #     arriving run forever (the peer's exited run-loop will
                     #     never service our output queue).
@@ -375,11 +419,15 @@ class ClaudeAgentAdapter:
         except Exception as e:
             logger.error(f"Error in run: {e}")
             # Evict the broken worker — but ONLY if this is the last in-flight run
-            # sharing it. If a peer run is still streaming (active_runs > 1),
-            # tearing the worker down here would yank it out from under that peer.
-            # In that case leave the shared entry intact and let the ``finally``
-            # block decrement this run's refcount exactly once (preserving the
-            # item-7 invariant: a peer run is never evicted mid-stream). (Item 7a)
+            # sharing it. The ``active_runs > 1`` guard below is DEFENSE-IN-DEPTH /
+            # UNREACHABLE under run-admission serialization (Fix 1): the per-thread
+            # run-lock caps a thread's concurrent runs at 1, so when this run
+            # errors there is no peer run still streaming on the same thread, and
+            # the ``else`` branch (pop + stop the solo worker) is the live path.
+            # The guard is retained so that, were serialization ever broken,
+            # tearing the worker down here would not yank it out from under a peer;
+            # instead we would leave the shared entry intact and let the
+            # ``finally`` block decrement this run's refcount exactly once. (Item 7a)
             entry = self._workers.get(thread_id)
             if entry is not None and entry.get("active_runs", 1) > 1:
                 logger.warning(
@@ -406,9 +454,14 @@ class ClaudeAgentAdapter:
             # decrement — doing so would corrupt the live peer's refcount. (Item 7a)
             entry = self._workers.get(thread_id)
             if entry and counted_in:
-                # Decrement the in-flight refcount; the worker only becomes idle
-                # (and thus evictable) once ALL concurrent runs sharing it have
-                # finished, so a peer run is never evicted mid-stream. (Item 7a)
+                # Decrement the in-flight refcount. Under run-admission
+                # serialization (Fix 1) ``active_runs`` for a given thread is
+                # capped at 1, so this normally takes it 1 -> 0; the
+                # multi-run-sharing semantics below are DEFENSE-IN-DEPTH for the
+                # (now-unreachable) case of concurrent same-thread runs. As coded,
+                # the worker only becomes idle (and thus evictable) once ALL runs
+                # counted into it have finished, so a peer run could never be
+                # evicted mid-stream even if serialization were bypassed. (Item 7a)
                 remaining = entry.get("active_runs", 1) - 1
                 entry["active_runs"] = max(remaining, 0)
                 entry["active"] = entry["active_runs"] > 0

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -156,11 +156,9 @@ class ClaudeAgentAdapter:
             await entry["worker"].stop()
         self._workers.clear()
         self._state_locks.clear()
-        # NOTE: ``_run_locks`` is intentionally cleared only here, on full
-        # adapter shutdown (no run can be in-flight or waiting past this point).
-        # It is NOT cleared on per-thread eviction / clear_session / the run
-        # error path — see ``_evict_workers`` for the rationale (decoupling the
-        # run-admission lock lifecycle from worker-cache eviction).
+        # ``_run_locks`` is cleared ONLY here, on full adapter shutdown (no run
+        # can be in-flight or waiting past this point); it is intentionally NOT
+        # evicted per-thread — see ``_evict_workers`` for the rationale.
         self._run_locks.clear()
         self._per_run_result.clear()
 
@@ -177,7 +175,11 @@ class ClaudeAgentAdapter:
         and runs CONCURRENTLY with B — serialization defeated. Re-validating
         identity after acquire (in ``run``) is not sufficient alone, because a
         held/waited lock can still be popped and re-created. So we leave run-lock
-        entries resident. This is bounded by the number of distinct ``thread_id``
+        entries resident. Only ``_run_locks`` is exempt from eviction here:
+        ``_state_locks`` IS still popped (below), because it is acquired only
+        mid-stream UNDER the run-lock, so a live run always holds the run-lock
+        while touching it and it can never be orphaned by eviction. This is
+        bounded by the number of distinct ``thread_id``
         values seen (each maps to one tiny ``asyncio.Lock``); a future
         ``ThreadContext`` unification (one record per thread owning worker + all
         locks + state, reaped together) is the long-term home for bounding it —
@@ -214,12 +216,8 @@ class ClaudeAgentAdapter:
         if entry:
             await entry["worker"].stop()
         self._state_locks.pop(thread_id, None)
-        # NOTE: ``_run_locks[thread_id]`` is intentionally NOT popped — see
-        # ``_evict_workers``. A run may be parked on this lock right now;
-        # popping it would orphan that waiter and let a later run on the same
-        # thread acquire a fresh lock and run concurrently (defeating
-        # serialization). The lock is a tiny resident ``asyncio.Lock`` bounded
-        # by distinct thread_ids; only full ``shutdown`` clears the map.
+        # see _evict_workers: _run_locks intentionally not evicted (only full
+        # ``shutdown`` clears the map).
         self._per_thread_state.pop(thread_id, None)
         self._drop_thread_results(thread_id)
 

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
@@ -41,7 +41,7 @@ class SessionWorker:
         # and deregistered once its terminal ``None`` sentinel has been pushed.
         # On fatal worker death we fan out a terminal signal to ALL of these so a
         # peer/queued query whose item never got serviced cannot hang forever.
-        self._inflight_queues: set = set()
+        self._inflight_queues: set[asyncio.Queue] = set()
 
     async def start(self) -> None:
         """Spawn the background task that owns the SDK client."""
@@ -117,6 +117,11 @@ class SessionWorker:
                     break
 
                 prompt, session_id, output_queue = item
+                # ``output_queue`` is a loop-local Optional that is unconditionally
+                # bound here (the ``_SHUTDOWN`` sentinel already broke out above),
+                # so it is never None on the ``.put`` calls below. Narrow it for
+                # the type checker (no runtime behavior change).
+                assert output_queue is not None
                 try:
                     await client.query(prompt, session_id=session_id)
                     async for msg in client.receive_response():

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/session.py
@@ -36,6 +36,12 @@ class SessionWorker:
         self._task: Optional[asyncio.Task] = None
         self._client: Optional[Any] = None
         self.session_id: Optional[str] = None
+        # Every output queue that has an in-flight consumer waiting on it. A
+        # query's queue is registered the instant it is enqueued (in ``query``)
+        # and deregistered once its terminal ``None`` sentinel has been pushed.
+        # On fatal worker death we fan out a terminal signal to ALL of these so a
+        # peer/queued query whose item never got serviced cannot hang forever.
+        self._inflight_queues: set = set()
 
     async def start(self) -> None:
         """Spawn the background task that owns the SDK client."""
@@ -44,6 +50,44 @@ class SessionWorker:
         self._task = asyncio.create_task(
             self._run(), name=f"session-worker-{self.thread_id}"
         )
+        # If the background task dies for any reason (including a path that does
+        # not flow through the fatal-error branch, e.g. cancellation), make sure
+        # every still-waiting consumer gets a terminal signal rather than
+        # hanging on a queue nothing will ever drain.
+        self._task.add_done_callback(self._on_task_done)
+
+    def _fanout_terminal(self, exc: Exception) -> None:
+        """Push WorkerError(exc) + the None sentinel to EVERY in-flight output
+        queue, then clear the registry. Idempotent per queue: a queue is removed
+        from the registry as soon as its own ``finally`` pushes its sentinel, so
+        this never double-signals a queue that already terminated normally."""
+        queues = list(self._inflight_queues)
+        self._inflight_queues.clear()
+        for q in queues:
+            # ``put_nowait`` is safe: these are unbounded queues, and we are
+            # off the consumer's await path.
+            q.put_nowait(WorkerError(exc))
+            q.put_nowait(None)
+
+    def _on_task_done(self, task: "asyncio.Task") -> None:
+        """Done-callback: if the worker task ended while consumers were still
+        waiting (e.g. cancelled, or an exit path that bypassed the fatal-error
+        fan-out), terminate them so they don't hang."""
+        if not self._inflight_queues:
+            return
+        exc: Exception
+        try:
+            task_exc = task.exception()
+        except asyncio.CancelledError:
+            task_exc = None
+        if task_exc is not None:
+            exc = task_exc if isinstance(task_exc, Exception) else RuntimeError(str(task_exc))
+        else:
+            exc = RuntimeError(
+                f"session worker for thread={self.thread_id} terminated "
+                f"while a query was still in flight"
+            )
+        self._fanout_terminal(exc)
 
     def is_alive(self) -> bool:
         """Return True if the background task is running and able to serve queries.
@@ -88,12 +132,19 @@ class SessionWorker:
                     await output_queue.put(WorkerError(exc))
                 finally:
                     await output_queue.put(None)
+                    # This query terminated normally; drop it from the in-flight
+                    # registry so a later fatal-death fan-out won't double-signal.
+                    self._inflight_queues.discard(output_queue)
 
         except Exception as exc:
             logger.error(f"Session worker fatal error for thread={self.thread_id}: {exc}")
-            if output_queue is not None:
-                await output_queue.put(WorkerError(exc))
-                await output_queue.put(None)  # signal end-of-stream to consumer
+            # Fan the fatal error out to EVERY in-flight consumer — not just the
+            # currently-dequeued one. A peer/queued query whose item never got
+            # serviced (it is still sitting on the input queue, its output queue
+            # already registered by ``query``) would otherwise hang forever on a
+            # queue nothing drains. ``_fanout_terminal`` covers ``output_queue``
+            # too (it is in the registry until its ``finally`` discards it).
+            self._fanout_terminal(exc)
         finally:
             self._client = None
             await self._graceful_disconnect(client)
@@ -109,6 +160,11 @@ class SessionWorker:
     async def query(self, prompt: str, session_id: str = "default") -> AsyncIterator[Any]:
         """Send prompt to the worker and yield SDK Message objects."""
         output_queue: asyncio.Queue = asyncio.Queue()
+        # Register the output queue in the in-flight set BEFORE enqueuing the
+        # request, so that if the worker dies while this query is still queued
+        # (never dequeued), the fatal-death fan-out still terminates it. The
+        # worker's per-query ``finally`` (or the fan-out itself) deregisters it.
+        self._inflight_queues.add(output_queue)
         await self._input_queue.put((prompt, session_id, output_queue))
         while True:
             item = await output_queue.get()

--- a/integrations/claude-agent-sdk/python/pyproject.toml
+++ b/integrations/claude-agent-sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag-ui-claude-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "AG-UI integration for Anthropic Claude Agent SDK"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/claude-agent-sdk/python/tests/test_adapter.py
+++ b/integrations/claude-agent-sdk/python/tests/test_adapter.py
@@ -376,8 +376,8 @@ class TestRunErrorPath:
     @pytest.mark.asyncio
     async def test_error_path_cleans_all_three_dicts(self, make_input, monkeypatch):
         # The run() error path must evict the worker AND drop per-thread state
-        # and result, not just the worker + lock. Otherwise an errored thread
-        # leaks _per_thread_state / _per_thread_result forever.
+        # and per-run results, not just the worker + lock. Otherwise an errored
+        # thread leaks _per_thread_state / _per_run_result forever.
         adapter = ClaudeAgentAdapter(name="t")
         monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _FakeFailingWorker)
 
@@ -390,7 +390,8 @@ class TestRunErrorPath:
         assert "leaky" not in adapter._workers
         assert "leaky" not in adapter._state_locks
         assert "leaky" not in adapter._per_thread_state
-        assert "leaky" not in adapter._per_thread_result
+        # No per-run result entry for the errored thread survives.
+        assert not any(k[0] == "leaky" for k in adapter._per_run_result)
 
 
 class _FakeAliveWorker:
@@ -437,7 +438,7 @@ class _FakeDeadWorker:
 class TestEviction:
     @pytest.mark.asyncio
     async def test_lru_eviction_cleans_all_three_dicts(self):
-        # LRU eviction must pop _per_thread_state and _per_thread_result, not
+        # LRU eviction must pop _per_thread_state and per-run results, not
         # just _workers + _state_locks. Cap at 1 worker, insert 2 idle entries.
         # Async so _evict_workers' asyncio.create_task has a running loop.
         import asyncio
@@ -452,17 +453,18 @@ class TestEviction:
             }
             adapter._state_locks[tid] = asyncio.Lock()
             adapter._per_thread_state[tid] = {"v": i}
-            adapter._per_thread_result[tid] = {"r": i}
+            adapter._per_run_result[(tid, "r")] = {"r": i}
 
         adapter._evict_workers()
 
-        # "old" (lowest last_used) is evicted; all three dicts cleaned for it.
+        # "old" (lowest last_used) is evicted; all per-thread state cleaned for it.
         assert "old" not in adapter._workers
         assert "old" not in adapter._state_locks
         assert "old" not in adapter._per_thread_state
-        assert "old" not in adapter._per_thread_result
+        assert not any(k[0] == "old" for k in adapter._per_run_result)
         # "new" survives.
         assert "new" in adapter._workers
+        assert any(k[0] == "new" for k in adapter._per_run_result)
 
     @pytest.mark.asyncio
     async def test_clear_session_cleans_all_three_dicts(self):
@@ -472,14 +474,14 @@ class TestEviction:
         adapter._workers["s"] = {"worker": _FakeAliveWorker(), "last_used": None, "active": False}
         adapter._state_locks["s"] = asyncio.Lock()
         adapter._per_thread_state["s"] = {"v": 1}
-        adapter._per_thread_result["s"] = {"r": 1}
+        adapter._per_run_result[("s", "r")] = {"r": 1}
 
         await adapter.clear_session("s")
 
         assert "s" not in adapter._workers
         assert "s" not in adapter._state_locks
         assert "s" not in adapter._per_thread_state
-        assert "s" not in adapter._per_thread_result
+        assert not any(k[0] == "s" for k in adapter._per_run_result)
 
 
 class _FakeSlowStopWorker:
@@ -531,13 +533,16 @@ class TestWorkerLifecycle:
         # Completed tasks are dropped from the retention set.
         assert len(adapter._pending_tasks) == 0
 
-    # ── Item 7(a): a finished run must not mark a worker idle while a peer
-    # concurrent run on the same thread is still streaming ──
+    # ── Run-admission serialization (Fix 1): two same-thread runs no longer run
+    # concurrently — the run-lock serializes them, so the refcount never exceeds
+    # 1. (The active_runs refcount machinery is retained as defense-in-depth and
+    # is still exercised cross-thread; same-thread it is now bounded at 1.) ──
     @pytest.mark.asyncio
-    async def test_concurrent_runs_keep_worker_active_until_all_finish(self, make_input, monkeypatch):
+    async def test_same_thread_runs_serialized_refcount_bounded_at_one(self, make_input, monkeypatch):
         import asyncio
 
         gate = asyncio.Event()
+        max_seen = {"n": 0}
 
         class _GatedWorker:
             def __init__(self, *a, **kw):
@@ -551,7 +556,9 @@ class TestWorkerLifecycle:
 
             def query(self, prompt, session_id="default"):
                 async def _gen():
-                    # Block until released, simulating an in-flight stream.
+                    # Block the FIRST admitted run's stream open; while it holds
+                    # the run-lock the second run cannot even increment the
+                    # refcount (it waits at admission).
                     await gate.wait()
                     return
                     yield  # pragma: no cover
@@ -570,42 +577,37 @@ class TestWorkerLifecycle:
 
         t1 = asyncio.create_task(drive())
         t2 = asyncio.create_task(drive())
-        # Let both runs start and increment the refcount.
-        for _ in range(20):
+        # Let scheduling settle; the refcount must NEVER exceed 1 (serialized).
+        for _ in range(60):
             await asyncio.sleep(0)
             entry = adapter._workers.get("shared")
-            if entry and entry.get("active_runs", 0) >= 2:
-                break
-        entry = adapter._workers.get("shared")
-        assert entry is not None
-        # Both runs are in-flight: refcount is 2 and the worker is active.
-        assert entry["active_runs"] == 2
-        assert entry["active"] is True
+            if entry:
+                max_seen["n"] = max(max_seen["n"], entry.get("active_runs", 0))
+        assert max_seen["n"] == 1, (
+            f"same-thread runs were not serialized; refcount reached {max_seen['n']}"
+        )
 
-        # Release the gate so both runs finish.
+        # Release the gate so the first run finishes and the second proceeds.
         gate.set()
         await asyncio.gather(t1, t2)
         entry = adapter._workers.get("shared")
         assert entry is not None
-        # Only after BOTH finished is the worker idle and evictable.
+        # After BOTH ran (serially) the worker is idle and evictable.
         assert entry["active_runs"] == 0
         assert entry["active"] is False
 
-    # ── Item 7(a) hardening: an erroring run must not tear down the SHARED
-    # worker while a peer concurrent run on the same thread is still streaming ──
+    # ── Run-lock release on the error path (Fix 1): a same-thread run that
+    # raises must release the run-lock so the next same-thread run proceeds; the
+    # shared worker must not be torn down out from under a still-pending run. ──
     @pytest.mark.asyncio
-    async def test_erroring_run_does_not_evict_shared_worker_with_live_peer(
+    async def test_erroring_run_releases_lock_for_next_same_thread_run(
         self, make_input, monkeypatch
     ):
         import asyncio
 
-        gate = asyncio.Event()       # released to let the surviving peer (B) finish
-        both_inflight = asyncio.Event()  # set once refcount has reached 2
         stop_calls = {"n": 0}
 
-        class _MixedWorker:
-            # First query() call is the survivor B (blocks on gate); the second
-            # is the failer A (waits until both runs are in-flight, then raises).
+        class _FailThenOkWorker:
             call_index = 0
 
             def __init__(self, *a, **kw):
@@ -618,28 +620,24 @@ class TestWorkerLifecycle:
                 return True
 
             def query(self, prompt, session_id="default"):
-                idx = _MixedWorker.call_index
-                _MixedWorker.call_index += 1
+                idx = _FailThenOkWorker.call_index
+                _FailThenOkWorker.call_index += 1
 
-                async def _gen_survivor():
-                    await gate.wait()
-                    return
-                    yield  # pragma: no cover
-
-                async def _gen_failer():
-                    # Wait until BOTH runs have incremented the refcount, so the
-                    # peer (B) is provably mid-stream when A raises.
-                    await both_inflight.wait()
+                async def _fail():
                     raise RuntimeError("boom")
                     yield  # pragma: no cover
 
-                return _gen_survivor() if idx == 0 else _gen_failer()
+                async def _ok():
+                    return
+                    yield  # pragma: no cover
+
+                return _fail() if idx == 0 else _ok()
 
             async def stop(self):
                 stop_calls["n"] += 1
 
         adapter = ClaudeAgentAdapter(name="t")
-        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _MixedWorker)
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _FailThenOkWorker)
         inp = make_input(
             thread_id="shared", messages=[{"id": "1", "role": "user", "content": "hi"}]
         )
@@ -647,50 +645,23 @@ class TestWorkerLifecycle:
         async def drive():
             return [e async for e in adapter.run(inp)]
 
-        # Start B first (it will block on the gate), then A.
-        t_b = asyncio.create_task(drive())
-        for _ in range(50):
-            await asyncio.sleep(0)
-            entry = adapter._workers.get("shared")
-            if entry and entry.get("active_runs", 0) >= 1 and _MixedWorker.call_index >= 1:
-                break
+        # A (fails) is admitted first; B waits on the run-lock. Launch overlapping.
         t_a = asyncio.create_task(drive())
-        # Wait until both runs are in-flight (refcount == 2).
-        for _ in range(50):
-            await asyncio.sleep(0)
-            entry = adapter._workers.get("shared")
-            if entry and entry.get("active_runs", 0) >= 2:
-                break
-        entry = adapter._workers.get("shared")
-        assert entry is not None
-        assert entry["active_runs"] == 2
+        t_b = asyncio.create_task(drive())
+        events_a, events_b = await asyncio.wait_for(
+            asyncio.gather(t_a, t_b), timeout=5.0
+        )
 
-        # Release A to raise mid-stream.
-        both_inflight.set()
-        events_a = await t_a
-        # A errored.
+        # A surfaced RUN_ERROR; B then proceeded once the run-lock was released.
         assert EventType.RUN_ERROR in _types(events_a)
-
-        # INVARIANT: the shared worker must survive — B is still streaming on it.
-        entry = adapter._workers.get("shared")
-        assert entry is not None, "shared worker evicted while a peer run was live"
-        assert stop_calls["n"] == 0, "shared worker stopped while a peer run was live"
-        # Refcount dropped to exactly 1 (A's one decrement), worker still active.
-        assert entry["active_runs"] == 1
-        assert entry["active"] is True
-
-        # Now let B finish normally.
-        gate.set()
-        events_b = await t_b
         assert EventType.RUN_FINISHED in _types(events_b)
 
-        # After both ended: refcount is 0, worker idle/evictable, no leak/underflow.
+        # A's error path tore down its (solo, at that moment) worker; B re-created
+        # a fresh one and finished cleanly. End state: idle/evictable, no leak.
         entry = adapter._workers.get("shared")
         assert entry is not None
         assert entry["active_runs"] == 0
         assert entry["active"] is False
-        # Still never stopped — last run leaves it cached for TTL/LRU eviction.
-        assert stop_calls["n"] == 0
 
     # ── Single erroring run (the common path) still pops + stops the worker ──
     @pytest.mark.asyncio
@@ -729,7 +700,7 @@ class TestWorkerLifecycle:
         assert stop_calls["n"] == 1
         assert "solo" not in adapter._state_locks
         assert "solo" not in adapter._per_thread_state
-        assert "solo" not in adapter._per_thread_result
+        assert not any(k[0] == "solo" for k in adapter._per_run_result)
 
     @pytest.mark.asyncio
     async def test_active_worker_not_evicted_by_ttl(self):

--- a/integrations/claude-agent-sdk/python/tests/test_adapter.py
+++ b/integrations/claude-agent-sdk/python/tests/test_adapter.py
@@ -535,8 +535,11 @@ class TestWorkerLifecycle:
 
     # ── Run-admission serialization (Fix 1): two same-thread runs no longer run
     # concurrently — the run-lock serializes them, so the refcount never exceeds
-    # 1. (The active_runs refcount machinery is retained as defense-in-depth and
-    # is still exercised cross-thread; same-thread it is now bounded at 1.) ──
+    # 1. The active_runs refcount machinery is retained purely as
+    # DEFENSE-IN-DEPTH: ``active_runs`` is PER-THREAD, and the per-thread run-lock
+    # caps it at 1, so ``active_runs > 1`` is unreachable on every path — both
+    # same-thread (serialized) AND cross-thread (distinct threads have distinct
+    # refcounts, so a single thread's count is never bumped by a peer thread). ──
     @pytest.mark.asyncio
     async def test_same_thread_runs_serialized_refcount_bounded_at_one(self, make_input, monkeypatch):
         import asyncio

--- a/integrations/claude-agent-sdk/python/tests/test_concurrency_integration.py
+++ b/integrations/claude-agent-sdk/python/tests/test_concurrency_integration.py
@@ -173,61 +173,45 @@ async def _wait_for(predicate, *, tries=400):
 
 
 class TestRealWorkerConcurrency:
-    """Drives the REAL SessionWorker + adapter; only ClaudeSDKClient is faked."""
+    """Drives the REAL SessionWorker + adapter; only ClaudeSDKClient is faked.
+
+    Same-thread runs are now SERIALIZED by the per-thread run-admission lock
+    (Fix 1), so two overlapping same-thread runs no longer co-exist in-flight
+    (the refcount never exceeds 1). These scenarios verify the real worker is
+    nonetheless REUSED across the serialized runs (not duplicated, not torn
+    down) and torn down cleanly afterward.
+    """
 
     @pytest.mark.asyncio
-    async def test_scenario_a_two_overlapping_runs_share_one_real_worker(
+    async def test_scenario_a_two_overlapping_runs_serialized_on_one_real_worker(
         self, make_input, monkeypatch
     ):
-        # (a) Two overlapping run() invocations on the SAME thread_id stream
-        # concurrently; both complete, the shared REAL worker is reused (not
-        # duplicated, not torn down): active_runs reaches 2 then drains to 0
-        # and the worker survives throughout.
+        # (a) Two overlapping run() invocations on the SAME thread_id are
+        # SERIALIZED: B's RUN_STARTED is emitted only after A's RUN_FINISHED.
+        # Both complete on the ONE shared REAL worker (reused, not duplicated),
+        # which drains to refcount 0 and survives throughout.
         instances = []
-        # The worker is created lazily on the FIRST run; the 2nd run reuses it.
-        # Only one ClaudeSDKClient is constructed (index 0). Hold its stream
-        # open so BOTH runs are provably in-flight on the one shared worker.
-        # NOTE: a single worker serves queries serially via its queue, so we
-        # release as soon as both runs have incremented the refcount.
-        releases = _install_scripted_client(
-            monkeypatch, instances, release_when=lambda i: i == 0
-        )
+        _install_scripted_client(monkeypatch, instances)
 
         adapter = ClaudeAgentAdapter(name="t")
         inp = make_input(
             thread_id="shared", messages=[{"id": "1", "role": "user", "content": "hi"}]
         )
 
-        t1 = asyncio.create_task(_drive(adapter, inp))
-        t2 = asyncio.create_task(_drive(adapter, inp))
+        order = []
 
-        # Both runs in-flight => refcount 2 on the single shared worker.
-        reached_two = await _wait_for(
-            lambda: (adapter._workers.get("shared") or {}).get("active_runs", 0) >= 2
-        )
-        assert reached_two, "two concurrent runs never both became in-flight"
+        async def drive(marker):
+            evs = []
+            async for e in adapter.run(inp):
+                evs.append(e)
+                if e.type in (EventType.RUN_STARTED, EventType.RUN_FINISHED):
+                    order.append((marker, e.type))
+            return evs
 
-        entry = adapter._workers["shared"]
-        assert entry["active_runs"] == 2
-        assert entry["active"] is True
-        # PROOF the REAL worker ran: it's an actual SessionWorker with a live
-        # background task. (A fake worker would never be a SessionWorker.)
-        assert isinstance(entry["worker"], SessionWorker)
-        assert entry["worker"].is_alive() is True
+        t1 = asyncio.create_task(drive("A"))
+        await _wait_for(lambda: ("A", EventType.RUN_STARTED) in order)
+        t2 = asyncio.create_task(drive("B"))
 
-        # The worker's background task constructs + connects exactly ONE real
-        # ClaudeSDKClient (lazily, when _run is scheduled). Wait for it: a fake
-        # worker would construct none. This proves the real connect()/query()/
-        # receive_response() lifecycle executed, not a bypassed stub.
-        constructed = await _wait_for(lambda: len(instances) == 1)
-        assert constructed, "real SessionWorker never constructed its ClaudeSDKClient"
-        assert instances[0].connected is True
-
-        # Release the held stream so both runs drain. Wait for the release Event
-        # to be created on the (lazily-constructed) client first.
-        await _wait_for(lambda: len(releases) >= 1)
-        for r in releases:
-            r.set()
         events1, events2 = await asyncio.gather(t1, t2)
 
         assert EventType.RUN_FINISHED in _types(events1)
@@ -236,9 +220,14 @@ class TestRealWorkerConcurrency:
         assert EventType.TEXT_MESSAGE_CONTENT in _types(events1)
         assert EventType.TEXT_MESSAGE_CONTENT in _types(events2)
 
-        # (c) After all runs finish: refcount 0, worker idle/evictable, no leak,
-        # and still the SAME single worker (never duplicated).
+        # SERIALIZED: A's RUN_FINISHED strictly precedes B's RUN_STARTED.
+        idx_a_fin = order.index(("A", EventType.RUN_FINISHED))
+        idx_b_start = order.index(("B", EventType.RUN_STARTED))
+        assert idx_a_fin < idx_b_start, f"runs not serialized: {order}"
+
+        # ONE real worker served both runs (reused, not duplicated).
         entry = adapter._workers["shared"]
+        assert isinstance(entry["worker"], SessionWorker)
         assert entry["active_runs"] == 0
         assert entry["active"] is False
         assert len(instances) == 1, "worker was duplicated instead of reused"
@@ -246,35 +235,24 @@ class TestRealWorkerConcurrency:
         await adapter.shutdown()
 
     @pytest.mark.asyncio
-    async def test_scenario_b_erroring_run_does_not_evict_live_peer(
+    async def test_scenario_b_erroring_run_then_next_run_proceeds(
         self, make_input, monkeypatch
     ):
-        # (b) Two concurrent same-thread runs; ONE raises mid-stream. The
-        # surviving peer completes normally and its (shared, real) worker is NOT
-        # evicted by the erroring run (item-7 error-path invariant); the erroring
-        # run surfaces RUN_ERROR.
-        #
-        # Both runs share ONE worker (same thread_id). That worker's single
-        # ClaudeSDKClient is constructed once (index 0). The worker serves the
-        # two queued queries serially: we make the FIRST served query block then
-        # raise (the failer A), while the SECOND completes (the survivor B). We
-        # gate so the failer raises only once both runs are in-flight.
+        # (b) Two overlapping same-thread runs; the FIRST-admitted one raises
+        # mid-stream. Because runs are serialized, the second run only begins
+        # after the first releases its run-lock (on the error path). The errored
+        # run surfaces RUN_ERROR; the next run completes normally.
         instances = []
-        gate = asyncio.Event()       # released to let the failer (A) raise
-        b_streaming = asyncio.Event()  # set once the survivor (B) is streaming
-        b_release = asyncio.Event()    # released to let B finish after the assert
 
         import claude_agent_sdk
 
-        # A single client instance serves both queries off the worker's queue.
-        # Track query invocations so the first served query fails and the second
-        # succeeds, all on the one real shared worker.
         class _SharedClient:
+            served = 0
+
             def __init__(self, options=None, **kwargs):
                 self.options = options
                 self.connected = False
                 self.disconnected = False
-                self._served = 0
                 instances.append(self)
 
             async def connect(self):
@@ -286,19 +264,13 @@ class TestRealWorkerConcurrency:
             async def receive_response(self):
                 from claude_agent_sdk import ResultMessage
 
-                served = self._served
-                self._served += 1
+                served = _SharedClient.served
+                _SharedClient.served += 1
                 if served == 0:
-                    # Failer A: wait until both runs are in-flight, then raise
-                    # mid-stream while the peer (B) is still queued on this
-                    # shared worker.
-                    await gate.wait()
+                    # First served query (A): raise mid-stream.
                     raise RuntimeError("scripted client boom")
                     yield  # pragma: no cover
-                # Survivor B: begin streaming, then HOLD the stream open so B is
-                # provably still in-flight on the shared worker when the test
-                # inspects the post-error invariant. (The worker serves queries
-                # serially, so B only starts after A's failed query is drained.)
+                # Next query (B): complete normally.
                 yield stream_event({"type": "message_start"})
                 yield stream_event(
                     {
@@ -306,8 +278,6 @@ class TestRealWorkerConcurrency:
                         "delta": {"type": "text_delta", "text": "ok"},
                     }
                 )
-                b_streaming.set()
-                await b_release.wait()
                 yield stream_event({"type": "message_stop"})
                 yield ResultMessage(
                     subtype="success",
@@ -334,54 +304,25 @@ class TestRealWorkerConcurrency:
             thread_id="shared", messages=[{"id": "1", "role": "user", "content": "hi"}]
         )
 
-        # Start A (failer, first to enqueue) then B (survivor).
+        # A (admitted first, fails) and B (proceeds after A releases the lock).
         t_a = asyncio.create_task(_drive(adapter, inp))
         await _wait_for(
             lambda: (adapter._workers.get("shared") or {}).get("active_runs", 0) >= 1
         )
         t_b = asyncio.create_task(_drive(adapter, inp))
-        reached_two = await _wait_for(
-            lambda: (adapter._workers.get("shared") or {}).get("active_runs", 0) >= 2
+
+        events_a, events_b = await asyncio.wait_for(
+            asyncio.gather(t_a, t_b), timeout=10.0
         )
-        assert reached_two, "second concurrent run never became in-flight"
-
-        entry = adapter._workers["shared"]
-        assert entry["active_runs"] == 2
-        # PROOF: one real shared SessionWorker, one real client constructed.
-        assert isinstance(entry["worker"], SessionWorker)
-        assert len(instances) == 1
-
-        # Let A raise. The worker drains A's failed query then dequeues B, which
-        # streams a chunk and parks on b_release — so B is provably mid-stream.
-        gate.set()
-        events_a = await t_a
         assert EventType.RUN_ERROR in _types(events_a)
-
-        # Wait until B is provably streaming on the shared worker.
-        b_live = await _wait_for(b_streaming.is_set)
-        assert b_live, "survivor peer never began streaming on the shared worker"
-
-        # INVARIANT: the shared real worker survives — B is still on it. A's
-        # error path must NOT have evicted/stopped it, and A's single decrement
-        # leaves the refcount at exactly 1 (B still in-flight).
-        entry = adapter._workers.get("shared")
-        assert entry is not None, "shared worker evicted while a peer run was live"
-        assert isinstance(entry["worker"], SessionWorker)
-        assert entry["worker"].is_alive() is True
-        assert entry["active_runs"] == 1
-        assert entry["active"] is True
-
-        # Now let B finish normally on the surviving worker.
-        b_release.set()
-        events_b = await t_b
         assert EventType.RUN_FINISHED in _types(events_b)
         assert EventType.RUN_ERROR not in _types(events_b)
 
-        # (c) After both finished: refcount 0, idle, evictable, no leak.
+        # End state: refcount 0, idle, evictable, no leak.
         entry = adapter._workers["shared"]
+        assert isinstance(entry["worker"], SessionWorker)
         assert entry["active_runs"] == 0
         assert entry["active"] is False
-        assert len(instances) == 1, "shared worker was duplicated"
 
         await adapter.shutdown()
 
@@ -389,13 +330,11 @@ class TestRealWorkerConcurrency:
     async def test_scenario_c_worker_cleanly_evictable_after_runs(
         self, make_input, monkeypatch
     ):
-        # (c) explicit: after concurrent runs finish, the shared real worker is
-        # refcount 0 and is actually torn down (stop() disconnects the client)
-        # by clear_session — no leak, no lingering background task.
+        # (c) explicit: after two serialized same-thread runs finish, the shared
+        # real worker is refcount 0 and is actually torn down (stop() disconnects
+        # the client) by clear_session — no leak, no lingering background task.
         instances = []
-        releases = _install_scripted_client(
-            monkeypatch, instances, release_when=lambda i: i == 0
-        )
+        _install_scripted_client(monkeypatch, instances)
 
         adapter = ClaudeAgentAdapter(name="t")
         inp = make_input(
@@ -404,15 +343,6 @@ class TestRealWorkerConcurrency:
 
         t1 = asyncio.create_task(_drive(adapter, inp))
         t2 = asyncio.create_task(_drive(adapter, inp))
-        await _wait_for(
-            lambda: (adapter._workers.get("shared") or {}).get("active_runs", 0) >= 2
-        )
-        # The worker constructs its client lazily on the background task, so wait
-        # for the held release Event to exist before setting it (otherwise the
-        # client would park on a stream nothing releases).
-        await _wait_for(lambda: len(releases) >= 1)
-        for r in releases:
-            r.set()
         await asyncio.gather(t1, t2)
 
         entry = adapter._workers["shared"]

--- a/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
+++ b/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
@@ -1,0 +1,628 @@
+"""Tests for the run-admission serialization + robustness hardening.
+
+These cover four changes (see the reviewed Notion proposal):
+
+  Fix 1 — SERIALIZE concurrent same-thread run() invocations behind a dedicated
+          per-thread run-admission lock (``_run_locks``), held from admission
+          (before ``worker.query()`` / before ``RUN_STARTED``) through
+          ``RUN_FINISHED`` and released on EVERY exit path. Different thread_ids
+          stay concurrent.
+  Fix 2 — ``query_timeout_seconds`` defaults to a generous 300s (was None →
+          unbounded hang on a dead/slow worker), still overridable.
+  Fix 3 — worker-death fan-out: ``SessionWorker`` signals a terminal
+          WorkerError + None sentinel to ALL in-flight output queues on fatal
+          worker death, so a queued/peer consumer cannot hang.
+  Fix 4 — ``_per_thread_result`` is per-run, keyed by (thread_id, run_id), so a
+          run's RUN_FINISHED.result reflects its OWN ResultMessage.
+
+The dedicated ``_run_locks`` MUST be distinct from ``_state_locks`` (which is
+acquired mid-stream on the state-update-tool path); reusing it would self-
+deadlock the instant the model emits a state-update tool call. Scenario (c)
+exercises run-lock + inner state-lock together to prove no deadlock.
+"""
+
+import asyncio
+
+import pytest
+
+from ag_ui.core import EventType
+from ag_ui_claude_sdk.adapter import ClaudeAgentAdapter
+from ag_ui_claude_sdk.config import STATE_MANAGEMENT_TOOL_FULL_NAME
+
+from .conftest import stream_event, aiter
+
+
+def _types(events):
+    return [e.type for e in events]
+
+
+async def _drive(adapter, inp):
+    return [e async for e in adapter.run(inp)]
+
+
+async def _wait_for(predicate, *, tries=2000):
+    for _ in range(tries):
+        if predicate():
+            return True
+        await asyncio.sleep(0)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Fake workers used to drive run() deterministically without an LLM.
+# ---------------------------------------------------------------------------
+
+
+class _GatedTextWorker:
+    """Worker whose query() streams a tiny text run, but only after a per-call
+    gate is released. Tracks the order in which RUN_STARTED-able streams begin so
+    a test can assert serialization ordering.
+
+    A shared ``log`` list records (event, run_marker) tuples for ordering checks.
+    """
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def start(self):
+        pass
+
+    def is_alive(self):
+        return True
+
+    async def stop(self):
+        pass
+
+
+def _make_text_stream():
+    return [
+        stream_event({"type": "message_start"}),
+        stream_event(
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hi"}}
+        ),
+        stream_event({"type": "message_stop"}),
+    ]
+
+
+class TestSerializeSameThread:
+    @pytest.mark.asyncio
+    async def test_two_same_thread_runs_are_serialized(self, make_input, monkeypatch):
+        # (a) Two overlapping same-thread runs: B's RUN_STARTED must be emitted
+        # only AFTER A's RUN_FINISHED. The run-admission lock holds A's slot
+        # across its whole run; B waits at admission.
+        order = []  # records ("A"/"B", event_type)
+        a_gate = asyncio.Event()  # released to let A's stream complete
+
+        class _OrderedWorker:
+            calls = 0
+
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                idx = _OrderedWorker.calls
+                _OrderedWorker.calls += 1
+
+                async def _gen_first():
+                    # A: hold the stream open so, IF B were not serialized, B
+                    # would be able to emit RUN_STARTED while A is mid-run.
+                    await a_gate.wait()
+                    for ev in _make_text_stream():
+                        yield ev
+
+                async def _gen_second():
+                    for ev in _make_text_stream():
+                        yield ev
+
+                return _gen_first() if idx == 0 else _gen_second()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _OrderedWorker)
+
+        inp_a = make_input(thread_id="shared", run_id="A",
+                           messages=[{"id": "1", "role": "user", "content": "hi"}])
+        inp_b = make_input(thread_id="shared", run_id="B",
+                           messages=[{"id": "2", "role": "user", "content": "yo"}])
+
+        async def drive(inp, marker):
+            async for e in adapter.run(inp):
+                if e.type in (EventType.RUN_STARTED, EventType.RUN_FINISHED):
+                    order.append((marker, e.type))
+
+        t_a = asyncio.create_task(drive(inp_a, "A"))
+        # Ensure A has acquired the run-lock and emitted RUN_STARTED first.
+        await _wait_for(lambda: ("A", EventType.RUN_STARTED) in order)
+        t_b = asyncio.create_task(drive(inp_b, "B"))
+
+        # Give B ample scheduling opportunity; while A holds the run-lock, B must
+        # NOT have emitted RUN_STARTED yet.
+        for _ in range(50):
+            await asyncio.sleep(0)
+        assert ("B", EventType.RUN_STARTED) not in order, (
+            "B's RUN_STARTED was emitted before A finished — runs are not serialized"
+        )
+
+        # Release A; it finishes, releasing the run-lock so B can proceed.
+        a_gate.set()
+        await asyncio.gather(t_a, t_b)
+
+        # Both completed.
+        assert ("A", EventType.RUN_FINISHED) in order
+        assert ("B", EventType.RUN_FINISHED) in order
+        # Ordering: A RUN_FINISHED strictly precedes B RUN_STARTED.
+        idx_a_fin = order.index(("A", EventType.RUN_FINISHED))
+        idx_b_start = order.index(("B", EventType.RUN_STARTED))
+        assert idx_a_fin < idx_b_start, f"not serialized: {order}"
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_different_threads_run_concurrently(self, make_input, monkeypatch):
+        # (b) Two DIFFERENT-thread runs must still overlap (lock is per-thread).
+        both_started = asyncio.Event()
+        started = {"n": 0}
+        release = asyncio.Event()
+
+        class _ConcurrentWorker:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                async def _gen():
+                    started["n"] += 1
+                    if started["n"] >= 2:
+                        both_started.set()
+                    # Hold until both have started — proving genuine overlap. If
+                    # the lock were global (not per-thread), the second run could
+                    # never start and this would deadlock/time out.
+                    await release.wait()
+                    for ev in _make_text_stream():
+                        yield ev
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _ConcurrentWorker)
+
+        inp1 = make_input(thread_id="t1", run_id="r1",
+                          messages=[{"id": "1", "role": "user", "content": "hi"}])
+        inp2 = make_input(thread_id="t2", run_id="r2",
+                          messages=[{"id": "2", "role": "user", "content": "yo"}])
+
+        t1 = asyncio.create_task(_drive(adapter, inp1))
+        t2 = asyncio.create_task(_drive(adapter, inp2))
+
+        overlapped = await _wait_for(both_started.is_set)
+        assert overlapped, "different-thread runs did not overlap — lock is not per-thread"
+
+        release.set()
+        e1, e2 = await asyncio.gather(t1, t2)
+        assert EventType.RUN_FINISHED in _types(e1)
+        assert EventType.RUN_FINISHED in _types(e2)
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_state_update_tool_does_not_deadlock_with_run_lock(self, make_input, monkeypatch):
+        # (c) A run whose stream includes a state-update tool call must NOT
+        # deadlock: the run-lock (outer) and state-lock (inner, acquired mid-
+        # stream at adapter.py state-management path) are DISTINCT locks. If the
+        # run incorrectly reused _state_locks for admission, this would self-
+        # deadlock the instant the state-update tool fires.
+        class _StateToolWorker:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                async def _gen():
+                    yield stream_event({"type": "message_start"})
+                    yield stream_event({
+                        "type": "content_block_start",
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": "tc1",
+                            "name": STATE_MANAGEMENT_TOOL_FULL_NAME,
+                        },
+                    })
+                    yield stream_event({
+                        "type": "content_block_delta",
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": '{"state_updates": {"count": 7}}',
+                        },
+                    })
+                    yield stream_event({"type": "content_block_stop"})
+                    yield stream_event({"type": "message_stop"})
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _StateToolWorker)
+        inp = make_input(thread_id="sd", run_id="r1", state={"count": 0},
+                         messages=[{"id": "1", "role": "user", "content": "hi"}])
+
+        # Must complete (no deadlock) within a generous bound.
+        events = await asyncio.wait_for(_drive(adapter, inp), timeout=5.0)
+        assert EventType.RUN_FINISHED in _types(events)
+        # State-update tool path actually ran (mid-stream state-lock acquired).
+        assert EventType.STATE_SNAPSHOT in _types(events)
+        assert adapter._per_thread_state["sd"] == {"count": 7}
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_run_lock_released_on_error_path(self, make_input, monkeypatch):
+        # (d) A run that raises must still release the run-lock so a subsequent
+        # same-thread run can proceed (not hang on a never-released lock).
+        class _FailThenSucceedWorker:
+            calls = 0
+
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                idx = _FailThenSucceedWorker.calls
+                _FailThenSucceedWorker.calls += 1
+
+                async def _fail():
+                    raise RuntimeError("boom")
+                    yield  # pragma: no cover
+
+                async def _ok():
+                    for ev in _make_text_stream():
+                        yield ev
+
+                return _fail() if idx == 0 else _ok()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _FailThenSucceedWorker)
+
+        inp1 = make_input(thread_id="errthread", run_id="r1",
+                          messages=[{"id": "1", "role": "user", "content": "hi"}])
+        events1 = await asyncio.wait_for(_drive(adapter, inp1), timeout=5.0)
+        assert EventType.RUN_ERROR in _types(events1)
+
+        # The run-lock must have been released — a second same-thread run runs.
+        inp2 = make_input(thread_id="errthread", run_id="r2",
+                          messages=[{"id": "2", "role": "user", "content": "yo"}])
+        events2 = await asyncio.wait_for(_drive(adapter, inp2), timeout=5.0)
+        assert EventType.RUN_FINISHED in _types(events2)
+
+        await adapter.shutdown()
+
+
+class TestQueryTimeoutDefault:
+    def test_default_query_timeout_is_non_none(self):
+        # Fix 2: constructed with no query_timeout_seconds → a non-None default
+        # (300s) so a dead/slow worker cannot hang a run forever.
+        adapter = ClaudeAgentAdapter(name="t")
+        assert adapter._query_timeout_seconds is not None
+        assert adapter._query_timeout_seconds == 300
+
+    def test_query_timeout_override_still_honored(self):
+        adapter = ClaudeAgentAdapter(name="t", query_timeout_seconds=12.0)
+        assert adapter._query_timeout_seconds == 12.0
+        # Explicit None still disables it.
+        adapter2 = ClaudeAgentAdapter(name="t", query_timeout_seconds=None)
+        assert adapter2._query_timeout_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_unresponsive_worker_times_out_not_hang(self, make_input, monkeypatch):
+        # A worker that never yields must surface RUN_ERROR (timeout), not hang.
+        # Use a short override to keep the test fast.
+        class _HangingWorker:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                async def _gen():
+                    await asyncio.sleep(3600)  # never responds within the test
+                    yield  # pragma: no cover
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t", query_timeout_seconds=0.05)
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _HangingWorker)
+        inp = make_input(thread_id="slow", run_id="r1",
+                         messages=[{"id": "1", "role": "user", "content": "hi"}])
+        events = await asyncio.wait_for(_drive(adapter, inp), timeout=5.0)
+        types = _types(events)
+        assert EventType.RUN_ERROR in types
+        assert EventType.RUN_FINISHED not in types
+
+        await adapter.shutdown()
+
+
+class TestPerRunResult:
+    @pytest.mark.asyncio
+    async def test_run_finished_result_reflects_own_result_message(self, make_input, monkeypatch):
+        # Fix 4: RUN_FINISHED.result must reflect THIS run's own ResultMessage,
+        # not a shared per-thread slot clobbered by another run.
+        from claude_agent_sdk import ResultMessage
+
+        class _ResultWorker:
+            calls = 0
+
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                idx = _ResultWorker.calls
+                _ResultWorker.calls += 1
+
+                async def _gen():
+                    yield stream_event({"type": "message_start"})
+                    yield stream_event({
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "hi"},
+                    })
+                    yield stream_event({"type": "message_stop"})
+                    yield ResultMessage(
+                        subtype="success",
+                        duration_ms=idx,  # distinct per run
+                        duration_api_ms=1,
+                        is_error=False,
+                        num_turns=idx + 1,
+                        session_id="sess",
+                        total_cost_usd=0.0,
+                        usage={},
+                        result="hi",
+                    )
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _ResultWorker)
+
+        inp1 = make_input(thread_id="shared", run_id="r1",
+                          messages=[{"id": "1", "role": "user", "content": "hi"}])
+        events1 = await _drive(adapter, inp1)
+        fin1 = next(e for e in events1 if e.type == EventType.RUN_FINISHED)
+        assert fin1.result is not None
+        assert fin1.result["duration_ms"] == 0
+        assert fin1.result["num_turns"] == 1
+
+        inp2 = make_input(thread_id="shared", run_id="r2",
+                          messages=[{"id": "2", "role": "user", "content": "yo"}])
+        events2 = await _drive(adapter, inp2)
+        fin2 = next(e for e in events2 if e.type == EventType.RUN_FINISHED)
+        assert fin2.result is not None
+        # Run 2 gets its OWN result, not run 1's.
+        assert fin2.result["duration_ms"] == 1
+        assert fin2.result["num_turns"] == 2
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_two_serialized_runs_each_get_own_result(self, make_input, monkeypatch):
+        # Two serialized same-thread runs each carry their own ResultMessage even
+        # when launched overlapping (serialize keeps them ordered; result must
+        # not bleed across).
+        from claude_agent_sdk import ResultMessage
+
+        class _SeqResultWorker:
+            calls = 0
+
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                idx = _SeqResultWorker.calls
+                _SeqResultWorker.calls += 1
+
+                async def _gen():
+                    yield stream_event({"type": "message_start"})
+                    yield stream_event({
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "x"},
+                    })
+                    yield stream_event({"type": "message_stop"})
+                    yield ResultMessage(
+                        subtype="success",
+                        duration_ms=100 + idx,
+                        duration_api_ms=1,
+                        is_error=False,
+                        num_turns=1,
+                        session_id="sess",
+                        total_cost_usd=0.0,
+                        usage={},
+                        result="x",
+                    )
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _SeqResultWorker)
+
+        inp_a = make_input(thread_id="shared", run_id="A",
+                           messages=[{"id": "1", "role": "user", "content": "hi"}])
+        inp_b = make_input(thread_id="shared", run_id="B",
+                           messages=[{"id": "2", "role": "user", "content": "yo"}])
+
+        t_a = asyncio.create_task(_drive(adapter, inp_a))
+        t_b = asyncio.create_task(_drive(adapter, inp_b))
+        events_a, events_b = await asyncio.gather(t_a, t_b)
+
+        fin_a = next(e for e in events_a if e.type == EventType.RUN_FINISHED)
+        fin_b = next(e for e in events_b if e.type == EventType.RUN_FINISHED)
+        # Each run has a distinct, own result (the two calls produced 100 / 101).
+        assert {fin_a.result["duration_ms"], fin_b.result["duration_ms"]} == {100, 101}
+
+        await adapter.shutdown()
+
+
+class TestSequentialStateReset:
+    @pytest.mark.asyncio
+    async def test_run2_fresh_state_replaces_run1(self, make_input, monkeypatch):
+        # Regression guard: run 1 then run 2 (sequential) on the same thread,
+        # where run 2 sends fresh input_data.state. Run 2's state must REPLACE
+        # run 1's (documented reset). Serialize must not turn the per-run re-seed
+        # into "inherit/ignore".
+        class _NoopWorker:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                async def _gen():
+                    for ev in _make_text_stream():
+                        yield ev
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _NoopWorker)
+
+        inp1 = make_input(thread_id="shared", run_id="r1", state={"count": 1},
+                          messages=[{"id": "1", "role": "user", "content": "hi"}])
+        await _drive(adapter, inp1)
+        assert adapter._per_thread_state["shared"] == {"count": 1}
+
+        inp2 = make_input(thread_id="shared", run_id="r2", state={"other": 99},
+                          messages=[{"id": "2", "role": "user", "content": "yo"}])
+        await _drive(adapter, inp2)
+        # Fresh state from run 2 REPLACED run 1's (reset semantics preserved).
+        assert adapter._per_thread_state["shared"] == {"other": 99}
+
+        await adapter.shutdown()
+
+
+class TestWorkerDeathFanout:
+    @pytest.mark.asyncio
+    async def test_waiting_consumer_gets_terminal_signal_on_worker_death(self):
+        # Fix 3: SessionWorker must fan out WorkerError + None to ALL in-flight
+        # output queues on fatal worker death, so a queued/peer consumer does not
+        # hang. Drive the REAL SessionWorker with a scripted ClaudeSDKClient that
+        # dies in connect() AFTER queries have been enqueued — the fatal-error
+        # branch must terminate every registered consumer.
+        import claude_agent_sdk
+        from ag_ui_claude_sdk.session import SessionWorker
+
+        connect_gate = asyncio.Event()
+
+        class _DyingClient:
+            def __init__(self, options=None, **kwargs):
+                self.options = options
+
+            async def connect(self):
+                # Wait until consumers have enqueued their queries, THEN die.
+                await connect_gate.wait()
+                raise RuntimeError("client connect boom")
+
+            async def query(self, prompt, session_id="default"):  # pragma: no cover
+                pass
+
+            async def receive_response(self):  # pragma: no cover
+                if False:
+                    yield None
+
+            async def disconnect(self):
+                pass
+
+            async def interrupt(self):
+                pass
+
+        orig = claude_agent_sdk.ClaudeSDKClient
+        claude_agent_sdk.ClaudeSDKClient = _DyingClient
+        try:
+            worker = SessionWorker("th", options=None)
+            await worker.start()
+
+            # Enqueue TWO queries while the worker is still blocked in connect().
+            # Both register their output queues; on worker death BOTH must get a
+            # terminal signal (without the fan-out, the second hangs forever).
+            async def consume():
+                got_error = False
+                try:
+                    async for _ in worker.query("p", session_id="th"):
+                        pass
+                except Exception:
+                    got_error = True
+                return got_error
+
+            c1 = asyncio.create_task(consume())
+            c2 = asyncio.create_task(consume())
+
+            # Let both queries land on the input queue before the worker dies.
+            await _wait_for(lambda: worker._input_queue.qsize() >= 2)
+            connect_gate.set()
+
+            # Both consumers must terminate (error or clean end) — neither hangs.
+            results = await asyncio.wait_for(asyncio.gather(c1, c2), timeout=5.0)
+            assert all(r is True for r in results), (
+                "a waiting consumer did not receive a terminal error on worker death"
+            )
+        finally:
+            claude_agent_sdk.ClaudeSDKClient = orig
+            await worker.stop()

--- a/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
+++ b/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
@@ -333,6 +333,100 @@ class TestSerializeSameThread:
         await adapter.shutdown()
 
     @pytest.mark.asyncio
+    async def test_run_admission_revalidate_retry_relooops_on_swapped_lock(
+        self, make_input, monkeypatch
+    ):
+        # (a3) RETRY-BRANCH COVERAGE (Fix 1): the run-admission loop in ``run()``
+        #
+        #     while True:
+        #         run_lock = self._run_locks.setdefault(thread_id, Lock())
+        #         await run_lock.acquire()
+        #         if self._run_locks.get(thread_id) is run_lock:
+        #             break
+        #         run_lock.release()   # <-- this RETRY branch
+        #
+        # is defensive: eviction no longer pops ``_run_locks``, so in production
+        # the identity check passes on the first pass and the ``release()`` +
+        # re-loop branch never executes (the suite stays green even if that
+        # branch is deleted and replaced with a plain ``break``). This white-box
+        # test FORCES the retry branch purely test-side: monkeypatch
+        # ``asyncio.Lock.acquire`` so the FIRST acquire against the adapter's
+        # run-lock swaps ``_run_locks[thread_id]`` to a DIFFERENT live lock before
+        # returning. The identity check then fails, the run must ``release()`` the
+        # stale lock and re-loop onto the now-current entry. We assert the run
+        # ends up holding the CURRENT ``_run_locks[thread_id]`` (i.e. it re-looped
+        # rather than running on a stale lock) and completes correctly.
+        #
+        # Red-green: if the RETRY branch is removed (left as a plain ``break``),
+        # the run keeps the stale L1 while the live entry is L2, so the final
+        # ``adapter._run_locks[thread_id] is acquired_lock`` assertion FAILS.
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr(
+            "ag_ui_claude_sdk.adapter.SessionWorker", _GatedTextWorker
+        )
+
+        def _query(self, prompt, session_id="default"):
+            async def _gen():
+                for ev in _make_text_stream():
+                    yield ev
+            return _gen()
+
+        _GatedTextWorker.query = _query
+
+        thread_id = "swap"
+        # ``acquired_locks`` records, in order, every Lock object the run
+        # actually acquires; the live entry is read at assert time.
+        acquired_locks = []
+        swapped = {"done": False}
+
+        real_acquire = asyncio.Lock.acquire
+
+        async def _acquire(self):
+            result = await real_acquire(self)
+            # Only react to the run-admission lock for our thread, and only the
+            # FIRST time: swap the live entry to a brand-new (unlocked) lock so
+            # the identity re-validation fails and the run must re-loop.
+            if (
+                not swapped["done"]
+                and adapter._run_locks.get(thread_id) is self
+            ):
+                swapped["done"] = True
+                adapter._run_locks[thread_id] = asyncio.Lock()
+            acquired_locks.append(self)
+            return result
+
+        monkeypatch.setattr(asyncio.Lock, "acquire", _acquire)
+
+        inp = make_input(
+            thread_id=thread_id, run_id="R",
+            messages=[{"id": "1", "role": "user", "content": "hi"}],
+        )
+        events = await _drive(adapter, inp)
+
+        # The swap fired (so the retry branch was actually exercised), and the
+        # run acquired at least two distinct lock objects (stale L1, then the
+        # live L2) — proof it re-looped.
+        assert swapped["done"], "the lock swap never fired; retry branch untested"
+        assert len(acquired_locks) >= 2, (
+            f"run did not re-acquire after swap: acquired={acquired_locks}"
+        )
+        # The run released the stale lock and ended holding the CURRENT entry.
+        live_lock = adapter._run_locks[thread_id]
+        assert acquired_locks[-1] is live_lock, (
+            "run is not holding the current _run_locks entry — it failed to "
+            "re-loop onto the swapped-in lock (retry branch broken)"
+        )
+        # The stale first lock was released (not left orphaned/locked).
+        stale_lock = acquired_locks[0]
+        assert stale_lock is not live_lock, "no swap occurred; test is inert"
+        assert not stale_lock.locked(), "stale run-lock was not released on retry"
+        # And the run completed correctly end-to-end.
+        assert EventType.RUN_STARTED in _types(events)
+        assert EventType.RUN_FINISHED in _types(events)
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
     async def test_different_threads_run_concurrently(self, make_input, monkeypatch):
         # (b) Two DIFFERENT-thread runs must still overlap (lock is per-thread).
         both_started = asyncio.Event()

--- a/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
+++ b/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
@@ -897,7 +897,7 @@ class TestWorkerDeathFanout:
 
     @pytest.mark.asyncio
     async def test_in_flight_consumer_gets_terminal_error_on_worker_cancellation(self):
-        # Fix 4 (b): ``_on_task_done`` has a branch for the worker task exiting
+        # Fix 3 — cancellation path: ``_on_task_done`` has a branch for the worker task exiting
         # WITHOUT a fatal exception — e.g. cancelled / terminated mid-flight while
         # a query is still being serviced. That branch must fan out a terminal
         # RuntimeError("...terminated while a query was still in flight") + the

--- a/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
+++ b/integrations/claude-agent-sdk/python/tests/test_serialize_and_robustness.py
@@ -166,6 +166,173 @@ class TestSerializeSameThread:
         await adapter.shutdown()
 
     @pytest.mark.asyncio
+    async def test_run_lock_not_orphaned_by_eviction_in_release_acquire_window(
+        self, make_input, monkeypatch
+    ):
+        # (a2) ORPHAN REGRESSION (Fix 1): the run-admission lock must NOT be
+        # coupled to worker eviction. Reproduce the hole:
+        #   1. Run A admits, holds the run-lock L1, runs on a fresh worker.
+        #   2. Run B parks on ``L1.acquire()`` (waiter on L1).
+        #   3. A finishes and releases L1 — but B has not yet woken. The worker
+        #      is now idle (active_runs==0) and thus TTL-evictable.
+        #   4. Eviction fires (worker_ttl_seconds=0). If eviction POPS
+        #      ``_run_locks[thread_id]`` (the bug), L1 is orphaned: B is still a
+        #      waiter on it, but a later run D will ``setdefault`` a FRESH lock
+        #      L2 and run on its own brand-new worker.
+        #   5. D and B then hold DIFFERENT locks → they run CONCURRENTLY on the
+        #      same thread_id. Serialization defeated.
+        # With the fix (lock NOT popped + identity re-validation after acquire),
+        # B and D share the SAME current lock entry, so they serialize: their two
+        # runs never overlap (refcount on the shared worker never exceeds 1, and
+        # RUN_STARTED events never interleave).
+        order = []  # (marker, event_type) for RUN_STARTED / RUN_FINISHED
+        a_gate = asyncio.Event()       # release A's stream so A can finish
+        b_gate = asyncio.Event()       # hold B's stream open so B is mid-flight
+                                       # when D arrives (so an orphan → overlap)
+        b_proceeded = asyncio.Event()  # set when B wakes from acquire()
+        max_overlap = {"n": 0}
+        # True concurrency gauge: number of runs that have emitted RUN_STARTED
+        # but not yet RUN_FINISHED, counted across ALL drive() coroutines (not
+        # tied to a single _workers slot, which two distinct workers can overwrite).
+        live_runs = {"n": 0, "max": 0}
+
+        class _OrphanWorker:
+            calls = 0
+
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                idx = _OrphanWorker.calls
+                _OrphanWorker.calls += 1
+
+                async def _gen_a():
+                    # A (idx 0): hold open until released, so B can park on the
+                    # run-lock and we can fire eviction in the release→acquire
+                    # window.
+                    await a_gate.wait()
+                    for ev in _make_text_stream():
+                        yield ev
+
+                async def _gen_b():
+                    # B (idx 1): hold open until released, so B is still mid-flight
+                    # when D arrives. If B's lock was orphaned by eviction, D will
+                    # acquire a FRESH lock and run concurrently with B → the
+                    # serialization violation this test is designed to catch.
+                    await b_gate.wait()
+                    for ev in _make_text_stream():
+                        yield ev
+
+                async def _gen_other():
+                    for ev in _make_text_stream():
+                        yield ev
+
+                if idx == 0:
+                    return _gen_a()
+                if idx == 1:
+                    return _gen_b()
+                return _gen_other()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t", worker_ttl_seconds=0.0)
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _OrphanWorker)
+
+        inp_a = make_input(thread_id="shared", run_id="A",
+                           messages=[{"id": "1", "role": "user", "content": "hi"}])
+        inp_b = make_input(thread_id="shared", run_id="B",
+                           messages=[{"id": "2", "role": "user", "content": "yo"}])
+        inp_d = make_input(thread_id="shared", run_id="D",
+                           messages=[{"id": "3", "role": "user", "content": "sup"}])
+
+        def _record_overlap():
+            entry = adapter._workers.get("shared")
+            if entry:
+                max_overlap["n"] = max(max_overlap["n"], entry.get("active_runs", 0))
+
+        async def drive(inp, marker, evict_after=False):
+            async for e in adapter.run(inp):
+                _record_overlap()
+                if e.type == EventType.RUN_STARTED:
+                    live_runs["n"] += 1
+                    live_runs["max"] = max(live_runs["max"], live_runs["n"])
+                    order.append((marker, e.type))
+                    if marker == "B":
+                        b_proceeded.set()
+                elif e.type == EventType.RUN_FINISHED:
+                    live_runs["n"] -= 1
+                    order.append((marker, e.type))
+            # CRITICAL: fire eviction in the SAME coroutine step in which A's
+            # run() generator was exhausted — A's ``finally`` has just run
+            # ``run_lock.release()``, scheduling B's parked acquire to wake on the
+            # NEXT loop iteration, but we have not yielded control yet. So B is
+            # still a waiter on L1 when eviction runs. With the bug, eviction pops
+            # L1 here → B is orphaned on a lock no longer in ``_run_locks``.
+            if evict_after:
+                adapter._evict_workers()
+
+        # 1+2: A admits and holds L1; B parks on L1.acquire().
+        t_a = asyncio.create_task(drive(inp_a, "A", evict_after=True))
+        await _wait_for(lambda: ("A", EventType.RUN_STARTED) in order)
+        l1 = adapter._run_locks["shared"]
+        t_b = asyncio.create_task(drive(inp_b, "B"))
+        # Let B reach the parked acquire() on L1.
+        await _wait_for(lambda: l1.locked() and len(l1._waiters or []) >= 1)
+
+        # 3: release A; A finishes, releases L1, and (in A's own coroutine step,
+        # before B wakes) fires eviction (evict_after=True). The now-idle worker
+        # is popped; with the BUG L1 is popped too, orphaning B's wait.
+        a_gate.set()
+        # B wakes, acquires (its now-orphaned, under the bug) lock, emits
+        # RUN_STARTED, and blocks in its gated stream — still in-flight.
+        await _wait_for(lambda: b_proceeded.is_set())
+
+        # 5: D arrives WHILE B is still mid-flight. With the bug, ``_run_locks``
+        # was emptied by eviction, so D ``setdefault``s a FRESH lock + fresh
+        # worker and runs immediately — concurrently with B. With the fix, the
+        # lock entry survived (B still holds the current entry), so D parks until
+        # B releases.
+        t_d = asyncio.create_task(drive(inp_d, "D"))
+        # Give D ample opportunity to (incorrectly) start before B is released.
+        for _ in range(100):
+            await asyncio.sleep(0)
+
+        # Now release B; everything drains.
+        b_gate.set()
+        await asyncio.wait_for(asyncio.gather(t_a, t_b, t_d), timeout=10.0)
+
+        # SERIALIZATION INVARIANT: never were two same-thread runs simultaneously
+        # in-flight (RUN_STARTED-but-not-yet-RUN_FINISHED). Counted across all
+        # drive() coroutines so it catches B and D running on DISTINCT workers
+        # (the orphan symptom: each gets its own worker, so the per-entry refcount
+        # can't see the overlap, but the run-lock was supposed to prevent it).
+        assert live_runs["max"] <= 1, (
+            f"run-lock orphaned: {live_runs['max']} same-thread runs were "
+            f"concurrently in-flight (B and D overlapped). order={order}"
+        )
+        # All three completed.
+        for m in ("A", "B", "D"):
+            assert (m, EventType.RUN_FINISHED) in order, f"{m} did not finish: {order}"
+        # B and D never interleave their RUN_STARTED/RUN_FINISHED: one fully
+        # precedes the other.
+        b_fin = order.index(("B", EventType.RUN_FINISHED))
+        d_start = order.index(("D", EventType.RUN_STARTED))
+        b_start = order.index(("B", EventType.RUN_STARTED))
+        d_fin = order.index(("D", EventType.RUN_FINISHED))
+        assert b_fin < d_start or d_fin < b_start, (
+            f"B and D interleaved — not serialized: {order}"
+        )
+
+        await adapter.shutdown()
+
+    @pytest.mark.asyncio
     async def test_different_threads_run_concurrently(self, make_input, monkeypatch):
         # (b) Two DIFFERENT-thread runs must still overlap (lock is per-thread).
         both_started = asyncio.Event()
@@ -379,10 +546,111 @@ class TestQueryTimeoutDefault:
 
 
 class TestPerRunResult:
+    # Fix 4 keys ``_per_run_result`` by ``(thread_id, run_id)`` rather than a
+    # bare per-thread slot. Under run-admission serialization (Fix 1) same-thread
+    # runs are sequential, so a bare per-thread slot would NOT actually bleed
+    # across runs at RUN_FINISHED time — which means the two ordering-only tests
+    # below (``..._reflects_own_result_message`` /
+    # ``..._serialized_runs_each_get_own_result``) are DEFENSE-IN-DEPTH: they
+    # would still pass against a thread-keyed implementation. The dedicated
+    # ``test_result_dict_is_run_keyed_not_thread_keyed`` below is the LOAD-BEARING
+    # guard: it inspects ``_per_run_result`` directly and fails if the result is
+    # stored under a bare ``thread_id`` key instead of the ``(thread_id, run_id)``
+    # tuple — i.e. it genuinely guards the keying that Fix 4 introduced.
+    @pytest.mark.asyncio
+    async def test_result_dict_is_run_keyed_not_thread_keyed(self, make_input, monkeypatch):
+        # LOAD-BEARING keying guard. Pause run A mid-stream, AFTER its
+        # ResultMessage has been recorded into ``_per_run_result`` but BEFORE A
+        # emits RUN_FINISHED (and its ``finally`` drops the slot). Then assert the
+        # live entry is keyed by the (thread_id, run_id) TUPLE — never by the bare
+        # thread_id. A thread-keyed implementation (the regression Fix 4 guards
+        # against) would fail this directly.
+        from claude_agent_sdk import ResultMessage
+
+        after_result_gate = asyncio.Event()  # release A's stream after ResultMessage
+
+        class _PausingResultWorker:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def start(self):
+                pass
+
+            def is_alive(self):
+                return True
+
+            def query(self, prompt, session_id="default"):
+                async def _gen():
+                    yield stream_event({"type": "message_start"})
+                    yield stream_event({
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "hi"},
+                    })
+                    yield stream_event({"type": "message_stop"})
+                    yield ResultMessage(
+                        subtype="success",
+                        duration_ms=7,
+                        duration_api_ms=1,
+                        is_error=False,
+                        num_turns=1,
+                        session_id="sess",
+                        total_cost_usd=0.0,
+                        usage={},
+                        result="hi",
+                    )
+                    # Suspend HERE: the adapter has recorded the result under this
+                    # run's key, but has not yet exhausted the stream / emitted
+                    # RUN_FINISHED / popped the slot.
+                    await after_result_gate.wait()
+
+                return _gen()
+
+            async def stop(self):
+                pass
+
+        adapter = ClaudeAgentAdapter(name="t")
+        monkeypatch.setattr("ag_ui_claude_sdk.adapter.SessionWorker", _PausingResultWorker)
+
+        inp = make_input(thread_id="kt", run_id="RUNX",
+                         messages=[{"id": "1", "role": "user", "content": "hi"}])
+
+        events = []
+
+        async def drive():
+            async for e in adapter.run(inp):
+                events.append(e)
+
+        t = asyncio.create_task(drive())
+        # Wait until A's ResultMessage has been recorded into _per_run_result.
+        await _wait_for(lambda: adapter._per_run_result.get(("kt", "RUNX")) is not None)
+
+        # LOAD-BEARING ASSERTIONS — these fail against a thread-keyed store.
+        # 1. The entry exists under the (thread_id, run_id) tuple key.
+        assert ("kt", "RUNX") in adapter._per_run_result
+        assert adapter._per_run_result[("kt", "RUNX")]["duration_ms"] == 7
+        # 2. Every live key is a (thread_id, run_id) tuple — never a bare string
+        #    thread_id (which is what a thread-keyed regression would produce).
+        for k in adapter._per_run_result:
+            assert isinstance(k, tuple) and len(k) == 2, (
+                f"_per_run_result key is not (thread_id, run_id): {k!r}"
+            )
+        assert "kt" not in adapter._per_run_result, (
+            "result stored under bare thread_id — keying regressed to per-thread"
+        )
+
+        after_result_gate.set()
+        await asyncio.wait_for(t, timeout=5.0)
+        fin = next(e for e in events if e.type == EventType.RUN_FINISHED)
+        assert fin.result["duration_ms"] == 7
+
+        await adapter.shutdown()
+
     @pytest.mark.asyncio
     async def test_run_finished_result_reflects_own_result_message(self, make_input, monkeypatch):
-        # Fix 4: RUN_FINISHED.result must reflect THIS run's own ResultMessage,
-        # not a shared per-thread slot clobbered by another run.
+        # Fix 4 (defense-in-depth, ordering): RUN_FINISHED.result reflects THIS
+        # run's own ResultMessage. (Sequential under serialization, so this would
+        # also pass thread-keyed; the load-bearing guard is
+        # ``test_result_dict_is_run_keyed_not_thread_keyed``.)
         from claude_agent_sdk import ResultMessage
 
         class _ResultWorker:
@@ -626,3 +894,96 @@ class TestWorkerDeathFanout:
         finally:
             claude_agent_sdk.ClaudeSDKClient = orig
             await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_in_flight_consumer_gets_terminal_error_on_worker_cancellation(self):
+        # Fix 4 (b): ``_on_task_done`` has a branch for the worker task exiting
+        # WITHOUT a fatal exception — e.g. cancelled / terminated mid-flight while
+        # a query is still being serviced. That branch must fan out a terminal
+        # RuntimeError("...terminated while a query was still in flight") + the
+        # None sentinel to every in-flight output queue, so the waiting consumer
+        # gets a raised error rather than hanging forever. (The existing
+        # ``..._on_worker_death`` test only covers the FATAL connect()-raises
+        # path; this covers the cancelled/no-exception path.)
+        import claude_agent_sdk
+        from ag_ui_claude_sdk.session import SessionWorker
+
+        in_connect = asyncio.Event()     # set once connect() is entered
+        block_forever = asyncio.Event()  # never set: keeps connect() pending
+
+        class _BlockingConnectClient:
+            def __init__(self, options=None, **kwargs):
+                self.options = options
+
+            async def connect(self):
+                # Block in connect so the enqueued query is registered as
+                # in-flight but NEVER dequeued/serviced. Cancelling the worker
+                # here raises CancelledError (a BaseException, NOT caught by the
+                # fatal ``except Exception`` branch), so ``_run`` exits WITHOUT a
+                # fatal exception while the query's output queue is still
+                # registered — exactly the no-exception path of _on_task_done.
+                in_connect.set()
+                await block_forever.wait()
+
+            async def query(self, prompt, session_id="default"):  # pragma: no cover
+                pass
+
+            async def receive_response(self):  # pragma: no cover
+                if False:
+                    yield None
+
+            async def disconnect(self):
+                pass
+
+            async def interrupt(self):
+                pass
+
+        orig = claude_agent_sdk.ClaudeSDKClient
+        claude_agent_sdk.ClaudeSDKClient = _BlockingConnectClient
+        worker = SessionWorker("th", options=None)
+        try:
+            await worker.start()
+
+            terminal_error = {"exc": None}
+
+            async def consume():
+                try:
+                    async for _ in worker.query("p", session_id="th"):
+                        pass
+                except Exception as e:  # noqa: BLE001 — capture the terminal error
+                    terminal_error["exc"] = e
+
+            c = asyncio.create_task(consume())
+
+            # The query is enqueued + its output queue registered as in-flight,
+            # while the worker is blocked in connect() (query never dequeued).
+            await _wait_for(
+                lambda: in_connect.is_set() and len(worker._inflight_queues) == 1
+            )
+
+            # Cancel the worker task while it sits in connect(). CancelledError is
+            # a BaseException, so ``_run``'s ``except Exception`` fatal fan-out is
+            # NOT taken; the task ends with no fatal exception while the consumer's
+            # queue is still registered. The done-callback's no-exception branch
+            # must terminate that consumer.
+            worker._task.cancel()
+
+            # The consumer must terminate with a raised terminal error — not hang.
+            await asyncio.wait_for(c, timeout=5.0)
+            assert terminal_error["exc"] is not None, (
+                "in-flight consumer hung instead of receiving a terminal error "
+                "on worker cancellation"
+            )
+            assert "terminated while a query was still in flight" in str(
+                terminal_error["exc"]
+            ), f"unexpected terminal error: {terminal_error['exc']!r}"
+        finally:
+            claude_agent_sdk.ClaudeSDKClient = orig
+            block_forever.set()
+            # The worker task was cancelled above; awaiting it via stop() would
+            # re-raise CancelledError. Just await the already-cancelled task,
+            # suppressing the cancellation, to clean up without masking the test.
+            from contextlib import suppress
+            if worker._task is not None:
+                with suppress(asyncio.CancelledError):
+                    await worker._task

--- a/integrations/claude-agent-sdk/python/uv.lock
+++ b/integrations/claude-agent-sdk/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "ag-ui-claude-sdk"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary

Implements the reviewed Notion proposal for the `ag-ui-claude-sdk` Python adapter (`integrations/claude-agent-sdk/python`): serialize concurrent same-thread runs behind a dedicated admission lock, plus three robustness fixes. Builds on the 0.1.4 `active_runs` hardening (#1878 / #1883). Bumps to **0.1.5**. Strict TDD red-green; full suite green (102 tests, was 91).

## The core change — serialize concurrent same-thread runs (Fix 1)

`run()` now acquires a **dedicated per-thread run-admission lock** (`self._run_locks`, lazily `setdefault`) **at admission — before `worker.query()` / before emitting `RUN_STARTED`** — and holds it across the whole run, releasing in `finally` (so on every `except` exit path too). Effect: a second run on the same `thread_id` waits until the first emits `RUN_FINISHED`; different `thread_id`s still run concurrently (the lock is per-thread).

### Deadlock-avoidance design (verified)
- `_run_locks` is a **separate** lock from `_state_locks`. `_state_locks[thread_id]` is already acquired mid-stream by the state-management-tool path; `asyncio.Lock` is non-reentrant, so reusing it would self-deadlock the instant the model emits a state-update tool call. A dedicated test drives a state-update tool call through a run holding the run-lock and asserts it completes (no deadlock) and the inner state-lock path still runs.
- **Lock ordering is fixed**: run-lock OUTERMOST (admission, before streaming), state-lock INNERMOST (mid-stream only). No path holds `_state_locks` then waits on `_run_locks`.
- The run-lock is released on ALL exit paths (success, `Exception`, `TimeoutError`, and the fail-loud dead-worker early return).

## Robustness fixes

- **Fix 2 — default `query_timeout`**: `query_timeout_seconds` now defaults to **300s** (was `None` → a run blocked on a dead/slow worker hung indefinitely). Still overridable; `None` disables it. This composes with Fix 1: a hung run can no longer block a waiting same-thread peer forever.
- **Fix 3 — worker-death fan-out (`session.py`)**: `SessionWorker` now tracks the set of in-flight `output_queue`s (registered at enqueue, deregistered when the terminal sentinel is pushed) and, on fatal worker death — and via a task done-callback for paths that bypass the fatal branch (e.g. cancellation) — pushes `WorkerError(...)` + the `None` sentinel to ALL registered queues, so a peer/queued consumer cannot hang. Per-queue dedup avoids double-`None` / leaked queues.
- **Fix 4 — de-share `_per_thread_result`**: `RUN_FINISHED.result` is per-run by definition, so it is now keyed by `(thread_id, run_id)` (`_per_run_result`) instead of a per-thread slot a serialized peer could clobber. The per-run state re-seed moved under the run-lock so the documented reset stays per-run.

## Test plan
- [x] `uv run pytest` green — 102 passed (baseline 91 + 11 new)
- [x] Red-green verified for the three core changes (serialize, timeout default, worker fan-out)
- [x] State-update-tool-call test proves run-lock + inner state-lock do not deadlock
- [x] Sequential regression: run 2's fresh `state` REPLACES run 1's (reset preserved)
- [x] `uv build` clean; wheel ships only `ag_ui_claude_sdk/`
- [x] Diff scoped to `integrations/claude-agent-sdk/python/`

Refs the reviewed Notion proposal (serialize design + dedicated `_run_locks` deadlock-avoidance + the three robustness fixes).

---

## CR fix round (follow-up)

A code-review pass hardened the serialization work and tightened test honesty. Full suite now green at **105 tests** (was 102); version stays **0.1.5** (unreleased); diff still scoped to `integrations/claude-agent-sdk/python/`.

### Behavior change — `query_timeout_seconds` default (documenting Fix 2)
`ClaudeAgentAdapter(query_timeout_seconds=...)` now defaults to **300s** (was `None` / unbounded). A run that exceeds the timeout now emits a **`RunErrorEvent`** (`"Query timed out after 300s"`) instead of hanging indefinitely on a dead/slow worker. To restore the old unbounded behavior, pass `query_timeout_seconds=None`; to use a different bound, pass an explicit number of seconds.

### Serialization hole closed (blocker)
The per-thread run-admission lock (`_run_locks[thread_id]`) was being **popped on worker eviction / `clear_session` / `shutdown` / the run error path**, coupling the lock's lifecycle to worker-cache eviction. A run B parked on `await run_lock.acquire()` in the window after run A released (worker idle, `active_runs==0`) but before B woke could have its lock entry popped; a later run D would then `setdefault` a **fresh** lock and run **concurrently with B** — defeating serialization. Fix: stop popping `_run_locks` on those paths (only full `shutdown` clears the map), and **re-validate lock identity after acquire** (release + retry if the live entry changed) as defense-in-depth. A new red-green regression test fires eviction in A's release→acquire window and asserts B and D never overlap.

### Comment honesty (blocker)
Relabeled the retained `active_runs > 1` branches (dead-worker eviction, `except`, `finally`) and the `test_adapter.py` docstring as **defense-in-depth / unreachable under serialization**: `active_runs` is per-thread and the run-lock caps it at 1 on every path (same-thread AND cross-thread). Doc-only; no behavior change to those branches.

### Tests made load-bearing
- **Per-run result keying**: added a test that pauses a run after its `ResultMessage` is recorded and asserts `_per_run_result` is keyed by the `(thread_id, run_id)` tuple (never a bare `thread_id`) — it fails directly against a thread-keyed regression. The two ordering-only tests are relabeled defense-in-depth.
- **Cancellation fan-out**: added a test for `_on_task_done`'s no-fatal-exception branch — a worker task cancelled mid-flight (CancelledError, not caught by the fatal `except Exception`) must fan out a terminal `RuntimeError("...terminated while a query was still in flight")` to in-flight consumers; verified the waiting consumer gets a `RunErrorEvent`/raised error rather than hanging.

### Pyright false-positive cleanup
`session.py`: added `assert output_queue is not None` after it is unconditionally bound (post-`_SHUTDOWN`-break) to narrow the loop-local Optional, and typed `_inflight_queues` as `set[asyncio.Queue]`. No behavior change.
