### PR TITLE
docs(sdk): mark THINKING_* events deprecated in go/kotlin/ruby mirrors

### DIFF
--- a/docs/sdk/go/core/events.mdx
+++ b/docs/sdk/go/core/events.mdx
@@ -35,7 +35,7 @@ const (
     EventTypeStepStarted        EventType = "STEP_STARTED"
     EventTypeStepFinished       EventType = "STEP_FINISHED"
     
-    // Thinking events for reasoning phase support
+    // Thinking events (DEPRECATED — use the REASONING_* events below; removed in 1.0.0)
     EventTypeThinkingStart              EventType = "THINKING_START"
     EventTypeThinkingEnd                EventType = "THINKING_END"
     EventTypeThinkingTextMessageStart   EventType = "THINKING_TEXT_MESSAGE_START"
@@ -456,9 +456,27 @@ delta := []events.JSONPatchOperation{
 event := events.NewStateDeltaEvent(delta)
 ```
 
-## Thinking Events
+## Thinking Events (Deprecated)
+
+<Warning>
+  The `THINKING_*` events are deprecated and will be removed in version 1.0.0.
+  New implementations should use `REASONING_*` events instead.
+</Warning>
 
 These events support reasoning/thinking phases where the agent shows its thought process.
+
+The following event types are deprecated:
+
+| Deprecated Event                | Replacement                 |
+| ------------------------------- | --------------------------- |
+| `THINKING_START`                | `REASONING_START`           |
+| `THINKING_END`                  | `REASONING_END`             |
+| `THINKING_TEXT_MESSAGE_START`   | `REASONING_MESSAGE_START`   |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
+
+See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+for detailed migration guidance.
 
 ### ThinkingStartEvent
 

--- a/docs/sdk/kotlin/core/events.mdx
+++ b/docs/sdk/kotlin/core/events.mdx
@@ -89,8 +89,27 @@ data class TextMessageChunkEvent(
 ) : BaseEvent()
 ```
 
-### Thinking Events (5)
+### Thinking Events (5) (Deprecated)
+
+<Warning>
+  The `THINKING_*` events are deprecated and will be removed in version 1.0.0.
+  New implementations should use `REASONING_*` events instead.
+</Warning>
+
 Handle agent internal reasoning processes.
+
+The following event types are deprecated:
+
+| Deprecated Event                | Replacement                 |
+| ------------------------------- | --------------------------- |
+| `THINKING_START`                | `REASONING_START`           |
+| `THINKING_END`                  | `REASONING_END`             |
+| `THINKING_TEXT_MESSAGE_START`   | `REASONING_MESSAGE_START`   |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
+
+See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+for detailed migration guidance.
 
 #### ThinkingStartEvent
 Agent begins internal reasoning.

--- a/docs/sdk/ruby/core/events.mdx
+++ b/docs/sdk/ruby/core/events.mdx
@@ -433,11 +433,29 @@ event = AgUiProtocol::Core::Events::ToolCallStartEvent.new(
 | `timestamp`         | `Time` (optional)   | Timestamp when the event was created. Default: `nil`.              |
 | `raw_event`         | `Object` (optional) | Original event data if this event was transformed. Default: `nil`. |
 
-## Thinking Events
+## Thinking Events (Deprecated)
+
+<Warning>
+  The `THINKING_*` events are deprecated and will be removed in version 1.0.0.
+  New implementations should use the `REASONING_*` events instead.
+</Warning>
 
 These events represent the lifecycle of an agent's thinking steps, conveying
 intermediate reasoning to the frontend without contributing to the final
 message.
+
+The following event types are deprecated:
+
+| Deprecated Event                | Replacement                 |
+| ------------------------------- | --------------------------- |
+| `THINKING_START`                | `REASONING_START`           |
+| `THINKING_END`                  | `REASONING_END`             |
+| `THINKING_TEXT_MESSAGE_START`   | `REASONING_MESSAGE_START`   |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
+
+See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+for detailed migration guidance.
 
 ### ThinkingEndEvent
 


### PR DESCRIPTION
## Summary
Mark the `THINKING_*` events as deprecated in the **go**, **kotlin**, and **ruby** SDK mirror docs (`docs/sdk/{go,kotlin,ruby}/core/events.mdx`) and document the `REASONING_*` replacements — matching the canonical TypeScript SDK (`@deprecated Use REASONING_* instead. Will be removed in 1.0.0`) and the existing js/python doc pattern.

## Why
A Pathfinder docs-analytics gap analysis surfaced that the go/kotlin/ruby event docs still presented `THINKING_*` as current, while the TS/Python SDKs and the js/python docs already mark them deprecated in favor of `REASONING_*`. This brings the three lagging mirrors in line.

## Notes
- Docs-only. Both event families still exist (THINKING is deprecated-but-present until 1.0.0), so the existing enum listings are intentionally retained.
- The migration cross-reference `/concepts/reasoning#migration-from-thinking-events` resolves to an existing heading and is already used by the js/python/events docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)