### PR TITLE
chore(OSS-162): remove temp scaffolding now that recovery packages are published

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 minimum-release-age=1440
+minimum-release-age-exclude[]=@ag-ui/langgraph
+minimum-release-age-exclude[]=@ag-ui/a2ui-middleware
+minimum-release-age-exclude[]=@ag-ui/a2ui-toolkit
 block-exotic-subdeps=true

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -19,13 +19,6 @@ dependencies = [
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.115.12"]
 
-# Dev-only: resolve the sibling A2UI toolkit from local source so monorepo
-# changes (e.g. the OSS-162 recovery loop) are picked up without publishing.
-# uv strips [tool.uv.sources] from the built wheel, so the published package
-# still depends on `ag-ui-a2ui-toolkit>=0.0.1a0` from PyPI.
-[tool.uv.sources]
-ag-ui-a2ui-toolkit = { path = "../../../sdks/python/a2ui_toolkit", editable = true }
-
 [tool.ag-ui.scripts]
 test = "python -m unittest discover tests"
 

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -4,12 +4,16 @@ requires-python = ">=3.10, <3.15"
 
 [[package]]
 name = "ag-ui-a2ui-toolkit"
-version = "0.0.1a3"
-source = { editable = "../../../sdks/python/a2ui_toolkit" }
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/1e/82ce4d32e7710be30cb942c7a3ea13386b1c8e50fff4c642eef399d7f21c/ag_ui_a2ui_toolkit-0.0.2.tar.gz", hash = "sha256:5908fa7a9cf474fa26d8821ac15b135bdca2c1cfddce0b7c580c6382d1f0bfd9", size = 10379, upload-time = "2026-06-05T15:56:43.259Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/bb/f8c6fb7b0fae34f802fcf9af8fe66e193137245dfc888fd8d9c119146cfd/ag_ui_a2ui_toolkit-0.0.2-py3-none-any.whl", hash = "sha256:028e497dfa2c9ca716143248dee14712d5c1055615a1bd91efa95f85e0a467ef", size = 12479, upload-time = "2026-06-05T15:56:42.404Z" },
+]
 
 [[package]]
 name = "ag-ui-langgraph"
-version = "0.0.37"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-a2ui-toolkit" },
@@ -35,7 +39,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-a2ui-toolkit", editable = "../../../sdks/python/a2ui_toolkit" },
+    { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.2" },
     { name = "ag-ui-protocol", specifier = ">=0.1.15" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.12" },
     { name = "langchain", specifier = ">=1.2.0" },

--- a/integrations/langgraph/typescript/examples/package.json
+++ b/integrations/langgraph/typescript/examples/package.json
@@ -9,9 +9,8 @@
     "dev": "pnpx @langchain/langgraph-cli@1.2.3 dev",
     "start": "node dist/index.js"
   },
-  "//oss-162-temp": "TEMPORARY (OSS-162): '@ag-ui/langgraph' points to link:.. (the local adapter at ../, i.e. integrations/langgraph/typescript) ONLY so the dojo runs the LOCAL adapter, which carries the A2UI recovery loop. This package is a DELIBERATELY ISOLATED nested pnpm workspace (own pnpm-lock.yaml + pnpm-workspace.yaml) that pins @langchain/langgraph@1.3.0 — required by langgraph-cli@1.2.3's API server (imports STREAM_EVENTS_V3_MODES). Do NOT add it to the root pnpm-workspace.yaml: that dedupes langgraph to 1.2.2 and breaks `pnpm dev`. REVERT to a published version (e.g. 0.0.36+) once @ag-ui/langgraph ships the recovery loop; langgraph-cli deploys read published versions, so link:.. must NOT ship. See memory: project_oss-162-examples-workspace-temp.",
   "dependencies": {
-    "@ag-ui/langgraph": "link:..",
+    "@ag-ui/langgraph": "0.0.39",
     "@copilotkit/sdk-js": "1.57.1",
     "@langchain/core": "^1.1.44",
     "@langchain/anthropic": "^0.3.0",

--- a/integrations/langgraph/typescript/examples/pnpm-lock.yaml
+++ b/integrations/langgraph/typescript/examples/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: link:..
-        version: link:..
+        specifier: 0.0.39
+        version: 0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
       '@copilotkit/sdk-js':
         specifier: 1.57.1
         version: 1.57.1(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(typescript@5.8.3)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
@@ -51,6 +51,9 @@ importers:
 
 packages:
 
+  '@ag-ui/a2ui-toolkit@0.0.2':
+    resolution: {integrity: sha512-HFphlNxBxGSQfvxlI2LCQValSMDUTh3MAsaFMgYlF8sQXgCrXNiLJ70+Dz3uyOv4y/rfqdFafvlo1GKQtEVIVA==}
+
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
@@ -62,6 +65,12 @@ packages:
 
   '@ag-ui/langgraph@0.0.31':
     resolution: {integrity: sha512-mK24pfQZiV5SlnDLhTka+873gw7QQOAWXqqDSnwkuyoQQQFX7KC8xZR+4Da2dWqyVhbhNPx+amE16X7twS1wcg==}
+    peerDependencies:
+      '@ag-ui/client': '>=0.0.42'
+      '@ag-ui/core': '>=0.0.42'
+
+  '@ag-ui/langgraph@0.0.39':
+    resolution: {integrity: sha512-+pFw49I9liEt8omTFFiie2YdtRFodjnWQTgN0Vxgo2XdC68xtyUy6I68D0QlZJE2Yy29oEx377vvkrNkL2AplA==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.42'
       '@ag-ui/core': '>=0.0.42'
@@ -442,6 +451,8 @@ packages:
 
 snapshots:
 
+  '@ag-ui/a2ui-toolkit@0.0.2': {}
+
   '@ag-ui/client@0.0.53':
     dependencies:
       '@ag-ui/core': 0.0.53
@@ -466,6 +477,28 @@ snapshots:
 
   '@ag-ui/langgraph@0.0.31(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))':
     dependencies:
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@langchain/core': 1.1.46(openai@6.15.0(zod@3.25.76))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.15.0(zod@3.25.76))
+      langchain: 1.2.8(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  '@ag-ui/langgraph@0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))':
+    dependencies:
+      '@ag-ui/a2ui-toolkit': 0.0.2
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
       '@langchain/core': 1.1.46(openai@6.15.0(zod@3.25.76))

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
       "langium": "3.2.0",
       "@copilotkit/runtime>@langchain/core": "0.3.80",
       "@langchain/openai>@langchain/core": "0.3.80",
-      "@ag-ui/a2ui-middleware": "link:./middlewares/a2ui-middleware",
       "zod": "3.25.76",
       "@strands-agents/sdk>zod": "^4.4.3",
       "@ag-ui/aws-strands>zod": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "pnpm": {
     "overrides": {
       "langium": "3.2.0",
+      "@copilotkit/runtime>@ag-ui/a2ui-middleware": "0.0.8",
       "@copilotkit/runtime>@langchain/core": "0.3.80",
       "@langchain/openai>@langchain/core": "0.3.80",
       "zod": "3.25.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,6 @@ overrides:
   langium: 3.2.0
   '@copilotkit/runtime>@langchain/core': 0.3.80
   '@langchain/openai>@langchain/core': 0.3.80
-  '@ag-ui/a2ui-middleware': link:./middlewares/a2ui-middleware
   zod: 3.25.76
   '@strands-agents/sdk>zod': ^4.4.3
   '@ag-ui/aws-strands>zod': ^4.4.3
@@ -97,7 +96,7 @@ importers:
         specifier: workspace:*
         version: link:../../middlewares/a2a-middleware
       '@ag-ui/a2ui-middleware':
-        specifier: link:../../middlewares/a2ui-middleware
+        specifier: workspace:*
         version: link:../../middlewares/a2ui-middleware
       '@ag-ui/adk':
         specifier: workspace:*
@@ -1582,6 +1581,12 @@ packages:
 
   '@a2ui/web_core@0.9.0':
     resolution: {integrity: sha512-TsMWuEeuVDsScGIGPy/fWIZu+EOBRfhx6KwjKh3VwY1AwysRenQM8zDr8VrSk14Wck/aBgVxk2zWVrMCK2/s6A==}
+
+  '@ag-ui/a2ui-middleware@0.0.6':
+    resolution: {integrity: sha512-LAv6Prh399WgGIbjnkd9Qw0/9SuyjVh6Hatkbs5IjO7zVeipY6fMyVunBN52j4AnJANRnk4qbSqpG/HOcGMaGw==}
+    peerDependencies:
+      '@ag-ui/client': '>=0.0.40'
+      rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.1-alpha.3':
     resolution: {integrity: sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw==}
@@ -12557,6 +12562,12 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
+  '@ag-ui/a2ui-middleware@0.0.6(@ag-ui/client@0.0.53)(rxjs@7.8.1)':
+    dependencies:
+      '@ag-ui/client': 0.0.53
+      clarinet: 0.12.6
+      rxjs: 7.8.1
+
   '@ag-ui/a2ui-toolkit@0.0.1-alpha.3': {}
 
   '@ag-ui/client@0.0.46':
@@ -14942,7 +14953,7 @@ snapshots:
 
   '@copilotkit/runtime@1.59.5(2ea9b4f56e43567ad28ff71961bd4e0e)':
     dependencies:
-      '@ag-ui/a2ui-middleware': link:middlewares/a2ui-middleware
+      '@ag-ui/a2ui-middleware': 0.0.6(@ag-ui/client@0.0.53)(rxjs@7.8.1)
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
       '@ag-ui/encoder': 0.0.53

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   langium: 3.2.0
+  '@copilotkit/runtime>@ag-ui/a2ui-middleware': 0.0.8
   '@copilotkit/runtime>@langchain/core': 0.3.80
   '@langchain/openai>@langchain/core': 0.3.80
   zod: 3.25.76
@@ -1582,14 +1583,17 @@ packages:
   '@a2ui/web_core@0.9.0':
     resolution: {integrity: sha512-TsMWuEeuVDsScGIGPy/fWIZu+EOBRfhx6KwjKh3VwY1AwysRenQM8zDr8VrSk14Wck/aBgVxk2zWVrMCK2/s6A==}
 
-  '@ag-ui/a2ui-middleware@0.0.6':
-    resolution: {integrity: sha512-LAv6Prh399WgGIbjnkd9Qw0/9SuyjVh6Hatkbs5IjO7zVeipY6fMyVunBN52j4AnJANRnk4qbSqpG/HOcGMaGw==}
+  '@ag-ui/a2ui-middleware@0.0.8':
+    resolution: {integrity: sha512-YXabOMyNekshHWLc63fD166ndy/zOXp+UWbx1alYoGRhO2y2uZJzOlPLvBAkFY4PF3Lng78ByG4mNpxJlSLDvw==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.1-alpha.3':
     resolution: {integrity: sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw==}
+
+  '@ag-ui/a2ui-toolkit@0.0.2':
+    resolution: {integrity: sha512-HFphlNxBxGSQfvxlI2LCQValSMDUTh3MAsaFMgYlF8sQXgCrXNiLJ70+Dz3uyOv4y/rfqdFafvlo1GKQtEVIVA==}
 
   '@ag-ui/client@0.0.46':
     resolution: {integrity: sha512-9Bl6GN6N3NWa3Ewqgl8E3nJzo88prIB2LS50bTNgw35h5BxC1UY21c0SImqQWZ+VV5kbhs6AUrriypKEBB7F5A==}
@@ -12562,13 +12566,16 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
-  '@ag-ui/a2ui-middleware@0.0.6(@ag-ui/client@0.0.53)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.8(@ag-ui/client@0.0.53)(rxjs@7.8.1)':
     dependencies:
+      '@ag-ui/a2ui-toolkit': 0.0.2
       '@ag-ui/client': 0.0.53
       clarinet: 0.12.6
       rxjs: 7.8.1
 
   '@ag-ui/a2ui-toolkit@0.0.1-alpha.3': {}
+
+  '@ag-ui/a2ui-toolkit@0.0.2': {}
 
   '@ag-ui/client@0.0.46':
     dependencies:
@@ -14953,7 +14960,7 @@ snapshots:
 
   '@copilotkit/runtime@1.59.5(2ea9b4f56e43567ad28ff71961bd4e0e)':
     dependencies:
-      '@ag-ui/a2ui-middleware': 0.0.6(@ag-ui/client@0.0.53)(rxjs@7.8.1)
+      '@ag-ui/a2ui-middleware': 0.0.8(@ag-ui/client@0.0.53)(rxjs@7.8.1)
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
       '@ag-ui/encoder': 0.0.53


### PR DESCRIPTION
The A2UI recovery loop is now published with recovery on both registries, so the local-linking scaffolding from OSS-162 can be removed and everything pinned to the real published versions.

**Published (verified):** npm `@ag-ui/a2ui-toolkit@0.0.2` (recovery), `@ag-ui/a2ui-middleware@0.0.8` → toolkit `0.0.2`, `@ag-ui/langgraph@0.0.39` → toolkit `0.0.2`; PyPI `ag-ui-a2ui-toolkit 0.0.2` + `ag-ui-langgraph 0.0.40`.

## Removed
- **examples**: `@ag-ui/langgraph` `link:..` → `0.0.39` (+ dropped the `//oss-162-temp` note). The examples stay a deliberately isolated nested workspace — they still pin `@langchain/langgraph@1.3.0` for `langgraph-cli`, which is an independent reason from the link.
- **langgraph-py**: dropped the `[tool.uv.sources]` editable mapping to the local toolkit. The dependency pin was already `>=0.0.2`, so `uv.lock` now resolves `ag-ui-a2ui-toolkit` straight from PyPI.
- **root**: removed the `"@ag-ui/a2ui-middleware": "link:./middlewares/a2ui-middleware"` pnpm override.

## Added
- `.npmrc`: `minimum-release-age-exclude[]` for `@ag-ui/langgraph`, `@ag-ui/a2ui-middleware`, `@ag-ui/a2ui-toolkit` — mirroring `CopilotKit/.npmrc`, so freshly-published `@ag-ui` versions install locally without tripping the 24h supply-chain guard (CI's frozen installs were never blocked; this is the local-dev ergonomics fix).

## Lockfiles
Updated root `pnpm-lock.yaml`, examples nested `pnpm-lock.yaml`, and langgraph-py `uv.lock`. Verified locally: root + examples installs resolve cleanly with no `@langchain/core` churn, `langgraph@1.3.0` pin intact in the examples, and `uv.lock` now points the toolkit at the PyPI registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)