### PR TITLE
fix(dojo): unbreak TS demo servers on Render (drop read-only-FS global pnpm install)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -149,7 +149,7 @@ projects:
       - key: OPENAI_API_KEY
         sync: false
       region: virginia
-      buildCommand: cd ../../../.. && npm install -g pnpm && pnpm install && npx nx run @ag-ui/aws-strands:build
+      buildCommand: cd ../../../.. && pnpm install && npx nx run @ag-ui/aws-strands:build
       startCommand: npx tsx server/server.ts
       autoDeployTrigger: commit
       rootDir: integrations/aws-strands/typescript/examples
@@ -404,7 +404,7 @@ projects:
       - key: ANTHROPIC_API_KEY
         sync: false
       region: virginia
-      buildCommand: cd ../../.. && npm install -g pnpm && pnpm install && npx nx run @ag-ui/claude-agent-sdk:build
+      buildCommand: cd ../../.. && pnpm install && npx nx run @ag-ui/claude-agent-sdk:build
       startCommand: npx tsx examples/server.ts
       autoDeployTrigger: commit
       rootDir: integrations/claude-agent-sdk/typescript


### PR DESCRIPTION
## What

Drop \`npm install -g pnpm &&\` from the build commands of two Render services in \`render.yaml\`:
- \`ag-ui-dojo-strands-typescript\`
- \`ag-ui-dojo-claude-agent-sdk-typescript\`

## Why

Both demo servers are returning **HTTP 502 on every endpoint** — e.g. https://dojo.ag-ui.com/aws-strands-typescript/feature/backend_tool_rendering (reported by a user from AWS), but also `agentic_chat` and every other feature on those integrations.

Root cause is the Render **build failing**, so nothing deploys:

```
==> Using Node.js version 24.14.1
==> Running build command 'cd ../../../.. && npm install -g pnpm && pnpm install && ...'
npm error code EROFS
npm error syscall rename
npm error path /usr/lib/node_modules/pnpm
npm error rofs EROFS: read-only file system
==> Build failed 😞
```

Render's Node 24 image has a **read-only `/usr/lib/node_modules`**, so the global `npm install -g pnpm` cannot write and the build dies before the server is ever built. No process → Render serves its 502 page on all routes.

## The fix

Rely on Render's built-in pnpm, provisioned from the repo's `packageManager: pnpm@10.33.4` pin — no global install needed. This is exactly how the working `ag-ui-dojo-app` service already builds (`cd ../.. && pnpm install && npx nx run demo-viewer:build`, no global pnpm).

These two TS services need the monorepo (`@ag-ui/*` are `workspace:*` deps), so they must `pnpm install` at the repo root — but the global-install step was never the right way to get pnpm there.

## Reviewer notes

- No code change, no npm release — the integration source (e.g. `server.ts`) was always correct; this is purely a deploy-config regression that surfaced when Render's default Node bumped to 24.
- After merge, `autoDeployTrigger: commit` rebuilds both services; the 502s should clear with no manual restart.
- Mastra and the Python services are unaffected (they don't use pnpm/global install).

## Test plan

- [ ] Merge → confirm Render builds for `ag-ui-dojo-strands-typescript` and `ag-ui-dojo-claude-agent-sdk-typescript` go green
- [ ] Verify https://dojo.ag-ui.com/aws-strands-typescript/feature/backend_tool_rendering renders weather cards
- [ ] Spot-check `agentic_chat` on both integrations