### PR TITLE
fix(ci): upload nested Python SDK dist dirs in release publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -410,7 +410,9 @@ jobs:
           name: py-build-artifacts
           path: |
             sdks/python/dist/
+            sdks/python/*/dist/
             integrations/*/python/dist/
+          if-no-files-found: error
           retention-days: 1
 
       # ===== Prerelease mode: validate suffix, bump in place, build/test, upload =====
@@ -548,7 +550,9 @@ jobs:
           name: py-canary-artifacts
           path: |
             sdks/python/dist/
+            sdks/python/*/dist/
             integrations/*/python/dist/
+          if-no-files-found: error
           retention-days: 1
 
       - name: Upload bump result (prerelease)


### PR DESCRIPTION
## Root cause

The `release / publish` workflow run [27168242193](https://github.com/ag-ui-protocol/ag-ui/actions/runs/27168242193) failed because the new Python package `ag-ui-a2ui-toolkit` (introduced in #1894) lives in a **nested** subdir `sdks/python/a2ui_toolkit/`. The build loop `cd`s into each detected package and runs `uv build`, so its wheel/sdist land at `sdks/python/a2ui_toolkit/dist/`.

But the Python artifact-upload globs only covered:
- `sdks/python/dist/`
- `integrations/*/python/dist/`

Neither matches the nested path. So **zero files matched**, the upload silently produced no artifact (`if-no-files-found` defaults to `warn`), and the downstream `download-artifact` hard-failed with `Artifact not found for name: py-build-artifacts`.

## Fix

In both Python upload steps (stable `py-build-artifacts` and prerelease `py-canary-artifacts`):
- Add `sdks/python/*/dist/` to the `path:` glob list so nested SDK packages are captured (keeps the existing `sdks/python/dist/` and `integrations/*/python/dist/` patterns).
- Flip `if-no-files-found` from the default `warn` to `error` so a future empty upload fails loudly at the upload step instead of silently passing and breaking the downstream download.

`sdks/python/*/dist/` requires an intervening directory, so it does not double-match `sdks/python/dist/`; even if it did, `download-artifact` merges duplicates harmlessly.

## Validation

- `actionlint` passes on the workflow file.
- Verified against the repo layout: `sdks/python/pyproject.toml` (root pkg → `sdks/python/dist/`) and `sdks/python/a2ui_toolkit/pyproject.toml` (nested → `sdks/python/a2ui_toolkit/dist/`, now matched by the new glob).

Origin: run 27168242193, PR #1894.