### PR TITLE
feat(client): preserve stable render identity across message id re-keys

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -276,6 +276,49 @@ describe("AgentSubscriber", () => {
       );
     });
 
+    it("strips client-only renderId from outgoing messages even when injected via onRunInitialized", async () => {
+      let capturedInput: RunAgentInput | undefined;
+
+      class CapturingAgent extends AbstractAgent {
+        run(input: RunAgentInput): Observable<BaseEvent> {
+          capturedInput = input;
+          return of({
+            type: EventType.RUN_STARTED,
+            threadId: "test",
+            runId: "test",
+          } as RunStartedEvent);
+        }
+      }
+
+      const capturingAgent = new CapturingAgent({
+        threadId: "test-thread",
+        initialMessages: [{ id: "msg-1", role: "user", content: "Hello" }],
+      });
+
+      // A subscriber injects messages carrying a client-only renderId — the
+      // same shape the agent holds after a snapshot re-key. These bypass
+      // prepareRunAgentInput's strip via the onRunInitialized override.
+      const injectingSubscriber: AgentSubscriber = {
+        onRunInitialized: vi.fn().mockReturnValue({
+          messages: [
+            { id: "msg-1", role: "user", content: "Hello" },
+            { id: "canon-id", role: "assistant", content: "hi", renderId: "stream-id" },
+          ],
+        }),
+      };
+
+      await capturingAgent.runAgent({}, injectingSubscriber);
+
+      expect(capturedInput).toBeDefined();
+      const sent = capturedInput!.messages.find((m) => m.id === "canon-id")!;
+      expect(sent).toBeDefined();
+      expect((sent as { renderId?: string }).renderId).toBeUndefined();
+
+      // The agent retains renderId locally so rendering identity stays stable.
+      const local = capturingAgent.messages.find((m) => m.id === "canon-id")!;
+      expect((local as { renderId?: string }).renderId).toBe("stream-id");
+    });
+
     it("should allow subscribers to mutate state", async () => {
       const mutatingSubscriber: AgentSubscriber = {
         onRunInitialized: vi.fn().mockReturnValue({

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -379,14 +379,9 @@ export abstract class AbstractAgent {
 
   protected prepareRunAgentInput(parameters?: RunAgentParameters): RunAgentInput {
     const clonedMessages = structuredClone_(this.messages) as Message[];
-    const messagesWithoutActivity = clonedMessages
-      .filter((message) => message.role !== "activity")
-      .map((message) => {
-        // `renderId` is a client-only stable render identity — strip it before
-        // sending so it never crosses the wire to the agent.
-        delete (message as { renderId?: string }).renderId;
-        return message;
-      });
+    const messagesWithoutActivity = this.stripRenderId(
+      clonedMessages.filter((message) => message.role !== "activity"),
+    );
 
     return {
       threadId: this.threadId,
@@ -398,6 +393,21 @@ export abstract class AbstractAgent {
       messages: messagesWithoutActivity,
       ...(parameters?.resume !== undefined ? { resume: structuredClone_(parameters.resume) } : {}),
     };
+  }
+
+  // `renderId` is a client-only stable render identity — strip it from outgoing
+  // messages so it never crosses the wire to the agent. Returns the original
+  // element when there's nothing to strip (no deep clone — keeps the
+  // structuredClone hot path light); otherwise a shallow copy without renderId.
+  private stripRenderId(messages: Message[]): Message[] {
+    return messages.map((message) => {
+      if ((message as { renderId?: string }).renderId === undefined) {
+        return message;
+      }
+      const copy = { ...message };
+      delete (copy as { renderId?: string }).renderId;
+      return copy as Message;
+    });
   }
 
   protected async onInitialize(input: RunAgentInput, subscribers: AgentSubscriber[]) {
@@ -431,7 +441,10 @@ export abstract class AbstractAgent {
     ) {
       if (onRunInitializedMutation.messages) {
         this.messages = onRunInitializedMutation.messages;
-        input.messages = onRunInitializedMutation.messages;
+        // Strip renderId again: this override replaces the messages built (and
+        // stripped) by prepareRunAgentInput, so without this the client-only
+        // renderId would cross the wire.
+        input.messages = this.stripRenderId(onRunInitializedMutation.messages);
         subscribers.forEach((subscriber) => {
           subscriber.onMessagesChanged?.({
             messages: this.messages,

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -379,7 +379,14 @@ export abstract class AbstractAgent {
 
   protected prepareRunAgentInput(parameters?: RunAgentParameters): RunAgentInput {
     const clonedMessages = structuredClone_(this.messages) as Message[];
-    const messagesWithoutActivity = clonedMessages.filter((message) => message.role !== "activity");
+    const messagesWithoutActivity = clonedMessages
+      .filter((message) => message.role !== "activity")
+      .map((message) => {
+        // `renderId` is a client-only stable render identity — strip it before
+        // sending so it never crosses the wire to the agent.
+        delete (message as { renderId?: string }).renderId;
+        return message;
+      });
 
     return {
       threadId: this.threadId,

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -437,4 +437,60 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       "m1", "asst-1", "act-1", "asst-2", "tool-canon",
     ]);
   });
+
+  it("preserves a stable renderId when a tool-call message is re-keyed in snapshot", async () => {
+    // Streaming creates an assistant message holding a tool call under a
+    // transient id ("stream-id"); the snapshot carries the SAME tool call
+    // under a new canonical id ("canon-id"). The renamed message must keep a
+    // stable renderId (the original id) so UIs keying on `renderId ?? id`
+    // reconcile the row in place instead of remounting it.
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "process a $200 expense" },
+        {
+          id: "stream-id",
+          role: "assistant",
+          toolCalls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "requestApproval", arguments: "{}" },
+            },
+          ],
+        },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "process a $200 expense" },
+        {
+          id: "canon-id",
+          role: "assistant",
+          toolCalls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "requestApproval", arguments: "{}" },
+            },
+          ],
+        },
+      ] as Message[],
+    );
+
+    const renamed = msgs.find((m) => m.id === "canon-id")!;
+    expect(renamed).toBeDefined();
+    expect(renamed.renderId).toBe("stream-id");
+  });
+
+  it("does not set renderId for a genuinely new message (falls back to id)", async () => {
+    const msgs = await applySnapshot(
+      [{ id: "m1", role: "user", content: "hi" }] as Message[],
+      [
+        { id: "m1", role: "user", content: "hi" },
+        { id: "a1", role: "assistant", content: "hello" },
+      ] as Message[],
+    );
+
+    const created = msgs.find((m) => m.id === "a1")!;
+    expect(created).toBeDefined();
+    expect(created.renderId).toBeUndefined();
+  });
 });

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -493,4 +493,33 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
     expect(created).toBeDefined();
     expect(created.renderId).toBeUndefined();
   });
+
+  it("does not mutate the inbound snapshot event payload when assigning renderId", async () => {
+    const renamedSnapshotMessage = {
+      id: "canon-id",
+      role: "assistant",
+      toolCalls: [
+        { id: "call_1", type: "function", function: { name: "requestApproval", arguments: "{}" } },
+      ],
+    } as Message;
+
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "process a $200 expense" },
+        {
+          id: "stream-id",
+          role: "assistant",
+          toolCalls: [
+            { id: "call_1", type: "function", function: { name: "requestApproval", arguments: "{}" } },
+          ],
+        },
+      ] as Message[],
+      [{ id: "m1", role: "user", content: "process a $200 expense" }, renamedSnapshotMessage],
+    );
+
+    // The merged message carries the stable renderId...
+    expect(msgs.find((m) => m.id === "canon-id")!.renderId).toBe("stream-id");
+    // ...but the original event-payload object is left untouched.
+    expect(renamedSnapshotMessage.renderId).toBeUndefined();
+  });
 });

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -616,7 +616,12 @@ export const defaultApplyEvents = (
                 renderIdByToolAnchor.set(`tool:${existingToolCallId}`, rid);
               }
             }
-            for (const sm of newMessages) {
+            // Carry renderId onto re-keyed snapshot messages. Shallow-copy the
+            // re-keyed ones rather than mutating in place: `newMessages` is the
+            // inbound event payload, and mutating it would leak the client-only
+            // renderId into any consumer holding the event. A shallow copy (not
+            // a structuredClone) keeps this off the documented OOM hot path.
+            const snapshotMessages = newMessages.map((sm) => {
               let rid = renderIdByMessageId.get(sm.id);
               if (rid === undefined && sm.role === "assistant") {
                 const firstToolCallId = (sm as AssistantMessage).toolCalls?.[0]?.id;
@@ -634,14 +639,15 @@ export const defaultApplyEvents = (
               // id — keeps the field sparse and meaningful ("this row was
               // re-keyed; here's its original render identity").
               if (rid !== undefined && rid !== sm.id) {
-                sm.renderId = rid;
+                return { ...sm, renderId: rid } as Message;
               }
-            }
+              return sm;
+            });
 
             // Edit-based merge: update existing messages with snapshot data while
             // preserving activity and reasoning messages (which the backend
             // doesn't include in the snapshot).
-            const snapshotMap = new Map(newMessages.map((m) => [m.id, m]));
+            const snapshotMap = new Map(snapshotMessages.map((m) => [m.id, m]));
 
             // Step 1 + 2: Keep activity/reasoning messages as-is, keep messages
             // present in the snapshot (replaced with snapshot version), drop
@@ -653,7 +659,7 @@ export const defaultApplyEvents = (
 
             // Step 3: Append messages from the snapshot that we don't have yet.
             const existingIds = new Set(messages.map((m) => m.id));
-            for (const snapshotMsg of newMessages) {
+            for (const snapshotMsg of snapshotMessages) {
               if (!existingIds.has(snapshotMsg.id)) {
                 messages.push(snapshotMsg);
               }

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -590,6 +590,54 @@ export const defaultApplyEvents = (
           if (mutation.stopPropagation !== true) {
             const { messages: newMessages } = event as MessagesSnapshotEvent;
 
+            // Preserve a stable render identity across canonical-id changes.
+            // A snapshot can carry the same logical message under a NEW id
+            // (e.g. a transient streaming/run id replaced by a provider's
+            // final response id). Correlate snapshot messages to existing ones
+            // by tool-call identity (which survives the rename) and carry over
+            // the existing message's renderId, so UIs keying on `renderId ?? id`
+            // reconcile the row in place instead of remounting it (the cause of
+            // the HITL chat flash). Messages matched by id keep their identity;
+            // genuinely new messages leave renderId unset and fall back to
+            // their own id at render time. renderId chains across repeated
+            // renames because we read `existing.renderId ?? existing.id`.
+            const renderIdByMessageId = new Map<string, string>();
+            const renderIdByToolAnchor = new Map<string, string>();
+            for (const m of messages) {
+              const rid = m.renderId ?? m.id;
+              renderIdByMessageId.set(m.id, rid);
+              if (m.role === "assistant") {
+                for (const tc of (m as AssistantMessage).toolCalls ?? []) {
+                  renderIdByToolAnchor.set(`call:${tc.id}`, rid);
+                }
+              }
+              const existingToolCallId = (m as { toolCallId?: string }).toolCallId;
+              if (m.role === "tool" && existingToolCallId) {
+                renderIdByToolAnchor.set(`tool:${existingToolCallId}`, rid);
+              }
+            }
+            for (const sm of newMessages) {
+              let rid = renderIdByMessageId.get(sm.id);
+              if (rid === undefined && sm.role === "assistant") {
+                const firstToolCallId = (sm as AssistantMessage).toolCalls?.[0]?.id;
+                if (firstToolCallId) {
+                  rid = renderIdByToolAnchor.get(`call:${firstToolCallId}`);
+                }
+              }
+              if (rid === undefined && sm.role === "tool") {
+                const toolCallId = (sm as { toolCallId?: string }).toolCallId;
+                if (toolCallId) {
+                  rid = renderIdByToolAnchor.get(`tool:${toolCallId}`);
+                }
+              }
+              // Only set renderId when it actually differs from the canonical
+              // id — keeps the field sparse and meaningful ("this row was
+              // re-keyed; here's its original render identity").
+              if (rid !== undefined && rid !== sm.id) {
+                sm.renderId = rid;
+              }
+            }
+
             // Edit-based merge: update existing messages with snapshot data while
             // preserving activity and reasoning messages (which the backend
             // doesn't include in the snapshot).

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -18,6 +18,17 @@ export const BaseMessageSchema = z.object({
   content: z.string().optional(),
   name: z.string().optional(),
   encryptedValue: z.string().optional(),
+  /**
+   * Client-assigned stable render identity. NOT a wire field that backends
+   * are expected to produce or consume: servers should ignore it and clients
+   * strip it before sending. The AG-UI client sets it during snapshot merges
+   * so a message whose canonical `id` changes mid-stream (e.g. a transient
+   * streaming/run id replaced by a provider's final response id) keeps one
+   * identity for rendering. UIs should key list rows by `renderId ?? id` to
+   * avoid remounting a row (and the flicker that causes) when only the
+   * canonical id changes. Declared in the schema so it survives Zod parsing.
+   */
+  renderId: z.string().optional(),
 });
 
 export const TextInputContentSchema = z.object({

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -153,6 +153,10 @@ export const ToolMessageSchema = z.object({
   toolCallId: z.string(),
   error: z.string().optional(),
   encryptedValue: z.string().optional(),
+  // See `renderId` on BaseMessageSchema. These message variants don't extend
+  // BaseMessageSchema, so the client-only stable render identity is declared
+  // here too, keeping `renderId` uniform across the Message union.
+  renderId: z.string().optional(),
 });
 
 export const ActivityMessageSchema = z.object({
@@ -160,6 +164,7 @@ export const ActivityMessageSchema = z.object({
   role: z.literal("activity"),
   activityType: z.string(),
   content: z.record(z.any()),
+  renderId: z.string().optional(),
 });
 
 export const ReasoningMessageSchema = z.object({
@@ -167,6 +172,7 @@ export const ReasoningMessageSchema = z.object({
   role: z.literal("reasoning"),
   content: z.string(),
   encryptedValue: z.string().optional(),
+  renderId: z.string().optional(),
 });
 
 export const MessageSchema = z.discriminatedUnion("role", [


### PR DESCRIPTION
## Summary

A backend `MESSAGES_SNAPSHOT` can carry the same logical message under a **new canonical `id`** mid-stream (e.g. a transient streaming/run id like `lc_run--…` replaced by a provider's final response id like `resp_…`). Because UIs key list rows by message `id`, that re-key unmounts and recreates the row — a visible flash/flicker. It's most noticeable with a human-in-the-loop tool card during a tool's `executing → complete` transition, where the chat appears to briefly reset.

This adds a client-only, immutable **render identity** so UIs can key rows by a value that survives the canonical-id change:

- Add optional `renderId` to the message schema — documented client-only (servers ignore it; stripped before send). Declared in the schema so Zod parsing preserves it.
- In the `MESSAGES_SNAPSHOT` merge, correlate snapshot messages to existing ones by **tool-call identity** (which survives the rename) and carry over the existing message's `renderId` (`renderId ?? id`). Existing drop/append positioning is unchanged. `renderId` chains correctly across repeated renames.
- Strip `renderId` before sending upstream in `prepareRunAgentInput`.

Consumers key rows by `renderId ?? id` to reconcile the row in place instead of remounting it.

## Tests

- New: `renderId` is preserved when a tool-call message is re-keyed in a snapshot; not set for genuinely-new messages.
- Existing snapshot/activity merge tests unchanged and passing (incl. the "message ID changes in snapshot" positioning test).

## Notes / follow-up

- A message **without a tool-call anchor** (e.g. a plain assistant text message) still re-keys on the snapshot — a sub-frame blip. A complete fix would give such messages a stable id upstream; tracked separately.
- Consumed by CopilotKit react-core (keys `CopilotChatMessageView` rows by `renderId ?? id`); that change depends on this shipping.