### PR TITLE
fix(dojo/e2e): make agentic_chat sendMessage multi-turn safe (flaky langgraph-typescript)

### DIFF
--- a/apps/dojo/e2e/featurePages/AgenticChatPage.ts
+++ b/apps/dojo/e2e/featurePages/AgenticChatPage.ts
@@ -1,6 +1,6 @@
 import { Page, Locator, expect } from "@playwright/test";
 import { CopilotSelectors } from "../utils/copilot-selectors";
-import { sendChatMessage, awaitLLMResponseDone } from "../utils/copilot-actions";
+import { sendAndAwaitResponse } from "../utils/copilot-actions";
 import { DEFAULT_WELCOME_MESSAGE } from "../lib/constants";
 
 export class AgenticChatPage {
@@ -32,8 +32,16 @@ export class AgenticChatPage {
   }
 
   async sendMessage(message: string) {
-    await sendChatMessage(this.page, message);
-    await awaitLLMResponseDone(this.page);
+    // Use the multi-turn-safe send. The previous `awaitLLMResponseDone`
+    // returned as soon as it saw `data-copilot-running="false"`, but on a
+    // multi-turn conversation that attribute still holds the PREVIOUS turn's
+    // finished state — so the wait could return before the new run started.
+    // The next send would then fire while the prior run was still active, the
+    // agent dropped it, and the user message never rendered (flaky timeout).
+    // `sendAndAwaitResponse` snapshots the assistant-message count and waits
+    // for a NEW response before treating the run as done, so each turn fully
+    // completes before the next send.
+    await sendAndAwaitResponse(this.page, message);
   }
 
   async getGradientButtonByName(name: string | RegExp) {


### PR DESCRIPTION
## Problem

`dojo / langgraph-typescript` e2e flakes (~25–30% across unrelated branches) on:

> `[LangGraph] Agentic Chat changes background on message and reset`
> `apps/dojo/e2e/tests/langgraphTypescriptTests/agenticChatPage.spec.ts:25`

Turn 1 ("blue") passes; the second `sendMessage("…pink")` intermittently never renders, and the 30s `assertUserMessageVisible("pink")` times out. State dump at failure shows the pink message was never added:

```
[AI State Dump] 1 user message(s), 2 assistant message(s)
[AI State Dump] User[0]: Hi change the background color to blue
copilot-running: false
```

aimock is active and matched every request (no `NO match`/`404`), so this is not a fixture gap or a live-LLM timeout. See #1911 for the full investigation (it also reproduces on `feat/stable-message-render-id` and a `dependabot` bump — branch-independent).

## Root cause

`AgenticChatPage.sendMessage` used `awaitLLMResponseDone`, which returns as soon as it sees `data-copilot-running="false"`. In a multi-turn conversation that attribute still holds the **previous** turn's finished state, so the wait can return before the new run has started. The next `sendMessage` then fires while the prior run is still active — and per the protocol a run must reach `RUN_FINISHED` before a new `RUN_STARTED` (see `CLAUDE.md`), so the agent drops the message and the user bubble never renders.

## Fix

Route `sendMessage` through the existing `sendAndAwaitResponse` helper, which snapshots the assistant-message count and waits for a **new** response before treating the run as done (its own comment documents this exact race). Each turn now fully completes before the next send. Scoped to `AgenticChatPage`; other page objects keep their own `sendMessage`.

## Verification

Type-trivial change (removed imports gone, signature matches). Not run through the full local e2e stack — the proof is CI stability across runs. Will watch this PR's `langgraph-typescript` job plus subsequent runs.

Refs #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
