### PR TITLE
chore(oss-248): remove temp scaffolding now that A2UI packages are published

### DIFF
--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -19,15 +19,6 @@ dependencies = [
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.115.12"]
 
-# Dev-only TEMP bridge (OSS-248): resolve the sibling A2UI toolkit from local
-# source so the new A2UIToolParams / A2UIGuidelines / resolve_a2ui_tool_params
-# symbols are picked up before `ag-ui-a2ui-toolkit` 0.0.3 is published. uv
-# strips [tool.uv.sources] from the built wheel, so the published package still
-# depends on `ag-ui-a2ui-toolkit>=0.0.3` from PyPI. REMOVE once 0.0.3 ships
-# (mirrors the OSS-162 scaffolding that was removed in c096afed after publish).
-[tool.uv.sources]
-ag-ui-a2ui-toolkit = { path = "../../../sdks/python/a2ui_toolkit", editable = true }
-
 [tool.ag-ui.scripts]
 test = "python -m unittest discover tests"
 

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -5,11 +5,15 @@ requires-python = ">=3.10, <3.15"
 [[package]]
 name = "ag-ui-a2ui-toolkit"
 version = "0.0.3"
-source = { editable = "../../../sdks/python/a2ui_toolkit" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b1/ea7ad7f0b3d1b20388d072ffbe4416577b4d4ab5471d45dfc04791a91602/ag_ui_a2ui_toolkit-0.0.3.tar.gz", hash = "sha256:468f25473ac00d098878da54c0069b7fa27dc63b4c1ff61315d4349a324c2fb7", size = 14785, upload-time = "2026-06-09T06:18:18.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/75/fc87bdf81bb1bf6d0fac09179e8bb17807d1bc5b3c0e8640f32e843b0857/ag_ui_a2ui_toolkit-0.0.3-py3-none-any.whl", hash = "sha256:e0354bd361c09f342fbe671cf870cbd19fdcb1b27e7a5bb2d8a392a4f00c2ba9", size = 16739, upload-time = "2026-06-09T06:18:17.316Z" },
+]
 
 [[package]]
 name = "ag-ui-langgraph"
-version = "0.0.40"
+version = "0.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-a2ui-toolkit" },
@@ -35,7 +39,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-a2ui-toolkit", editable = "../../../sdks/python/a2ui_toolkit" },
+    { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.3" },
     { name = "ag-ui-protocol", specifier = ">=0.1.15" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.12" },
     { name = "langchain", specifier = ">=1.2.0" },

--- a/integrations/langgraph/typescript/examples/package.json
+++ b/integrations/langgraph/typescript/examples/package.json
@@ -9,9 +9,8 @@
     "dev": "pnpx @langchain/langgraph-cli@1.2.3 dev",
     "start": "node dist/index.js"
   },
-  "//oss-248-temp": "TEMPORARY (OSS-248): '@ag-ui/langgraph' points to link:.. (the local adapter at ../, i.e. integrations/langgraph/typescript) so the dojo runs the LOCAL adapter + local @ag-ui/a2ui-toolkit, which carry this PR's UNPUBLISHED changes — the object-arg getA2UITools({ model, guidelines, recovery }) signature, the A2UIAttemptRecord export, and the re-enabled generation/design guidelines. Published @ag-ui/langgraph@0.0.39 still has the old getA2UITools(model, options) signature, so consuming it makes the agents call an incompatible API and NO surface renders (every A2UI e2e 404s). This package is a DELIBERATELY ISOLATED nested pnpm workspace (own pnpm-lock.yaml + pnpm-workspace.yaml) that pins @langchain/langgraph@1.3.0 — required by langgraph-cli@1.2.3's API server (imports STREAM_EVENTS_V3_MODES). Do NOT add it to the root pnpm-workspace.yaml: that dedupes langgraph to 1.2.2 and breaks `pnpm dev`. REVERT to a published version once OSS-248's adapter + toolkit are published; langgraph-cli deploys read published versions, so link:.. must NOT ship. See memory: project_oss-162-examples-workspace-temp.",
   "dependencies": {
-    "@ag-ui/langgraph": "link:..",
+    "@ag-ui/langgraph": "0.0.41",
     "@copilotkit/sdk-js": "1.57.1",
     "@langchain/core": "^1.1.44",
     "@langchain/anthropic": "^0.3.0",

--- a/integrations/langgraph/typescript/examples/pnpm-lock.yaml
+++ b/integrations/langgraph/typescript/examples/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ag-ui/langgraph':
-        specifier: link:..
-        version: link:..
+        specifier: 0.0.41
+        version: 0.0.41(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
       '@copilotkit/sdk-js':
         specifier: 1.57.1
         version: 1.57.1(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76))(langchain@1.2.8(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(typescript@5.8.3)(zod-to-json-schema@3.24.6(zod@3.25.76))(zod@3.25.76)
@@ -51,6 +51,9 @@ importers:
 
 packages:
 
+  '@ag-ui/a2ui-toolkit@0.0.3':
+    resolution: {integrity: sha512-bKjtuYQufGZ+vc2oTz1v5S6ab2gH/whQIIgbGfP+LMisdAkDV7bqeg4e+lZO3xNmdmkCa6nvkovtudMkqxmxEA==}
+
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
@@ -62,6 +65,12 @@ packages:
 
   '@ag-ui/langgraph@0.0.31':
     resolution: {integrity: sha512-mK24pfQZiV5SlnDLhTka+873gw7QQOAWXqqDSnwkuyoQQQFX7KC8xZR+4Da2dWqyVhbhNPx+amE16X7twS1wcg==}
+    peerDependencies:
+      '@ag-ui/client': '>=0.0.42'
+      '@ag-ui/core': '>=0.0.42'
+
+  '@ag-ui/langgraph@0.0.41':
+    resolution: {integrity: sha512-xo7ja/kuctmdPiH83QOUIpDs/AY3GzxW1fM37x9otK9fqwnKgi2JIcjfcdvAdGYdsCkXBn2WWQ2PVH+rdsLOzg==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.42'
       '@ag-ui/core': '>=0.0.42'
@@ -442,6 +451,8 @@ packages:
 
 snapshots:
 
+  '@ag-ui/a2ui-toolkit@0.0.3': {}
+
   '@ag-ui/client@0.0.53':
     dependencies:
       '@ag-ui/core': 0.0.53
@@ -466,6 +477,28 @@ snapshots:
 
   '@ag-ui/langgraph@0.0.31(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))':
     dependencies:
+      '@ag-ui/client': 0.0.53
+      '@ag-ui/core': 0.0.53
+      '@langchain/core': 1.1.46(openai@6.15.0(zod@3.25.76))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.15.0(zod@3.25.76))
+      langchain: 1.2.8(@langchain/core@1.1.46(openai@6.15.0(zod@3.25.76)))(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))
+      partial-json: 0.1.7
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  '@ag-ui/langgraph@0.0.41(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(openai@6.15.0(zod@3.25.76))(zod-to-json-schema@3.24.6(zod@3.25.76))':
+    dependencies:
+      '@ag-ui/a2ui-toolkit': 0.0.3
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
       '@langchain/core': 1.1.46(openai@6.15.0(zod@3.25.76))


### PR DESCRIPTION
## What

Closes the OSS-248 scaffolding loop. The A2UI packages now ship the new APIs on the registries, so the local-linking temps that #1894 restored can come out again.

| Package | published |
|---|---|
| `@ag-ui/a2ui-toolkit` | npm **0.0.3** |
| `@ag-ui/langgraph` | npm **0.0.41** |
| `ag-ui-a2ui-toolkit` | PyPI **0.0.3** |
| `ag-ui-langgraph` | PyPI **0.0.41** |

Verified the published `@ag-ui/langgraph@0.0.41` genuinely carries the new API — `getA2UITools(A2UIToolParams)` (object-arg) + `A2UIAttemptRecord` export, and pins `@ag-ui/a2ui-toolkit@0.0.3` (not stale 0.0.2).

## Changes

- **examples**: `@ag-ui/langgraph` `"link:.." → "0.0.41"`, drop the `//oss-248-temp` note. Nested `pnpm-lock.yaml` regenerated → resolves published 0.0.41 + toolkit 0.0.3, no `link:`.
- **langgraph-py**: drop the `[tool.uv.sources]` editable bridge. `uv.lock` regenerated → `ag-ui-a2ui-toolkit` resolves from PyPI at 0.0.3 (pin already `>=0.0.3`).

## Kept on purpose

`@copilotkit/runtime>@ag-ui/a2ui-middleware: 0.0.8` (root `package.json`) — OSS-248 didn't touch the middleware; that pin stays until `@copilotkit/runtime` ships a build depending on `a2ui-middleware ≥ 0.0.8`.

## Notes

- `apps/dojo/src/files.json` needs no regen (generator produces no diff — no baked demo content changed).
- Mirrors the OSS-162 cleanup (c096afed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)