### PR TITLE
ci(release): one-click canary publish orchestrator

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -109,13 +109,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Collapse the source ref to a single path segment under canary/ so it
-          # matches the `canary/*` deployment-branch policy and is a valid ref.
-          # Also collapse dot runs and strip leading/trailing separators so the
-          # result can never form an invalid ref (e.g. `..`, trailing `.`).
+          # Byte-deterministic (LC_ALL=C) transform collapsing the source ref to a
+          # single path segment under canary/ so it matches the `canary/*`
+          # deployment-branch policy. tr -s collapses same-char runs (so no `..`),
+          # and the sed fully strips any leading/trailing `.`/`-` runs.
+          export LC_ALL=C
           SLUG=$(printf '%s' "$REF_NAME" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-' | tr -s '.-')
-          SLUG="${SLUG#[-.]}"
-          SLUG="${SLUG%[-.]}"
+          SLUG=$(printf '%s' "$SLUG" | sed -E 's/^[.-]+//; s/[.-]+$//')
           if [ -z "$SLUG" ]; then
             echo "::error::Could not derive a canary slug from ref '$REF_NAME'"
             exit 1
@@ -166,7 +166,9 @@ jobs:
           # here with a clear message rather than deep inside the delegated run.
           # Mirrors publish-release.yml's own check; blank is allowed (it falls
           # back to a unix timestamp downstream).
-          if [ -n "$SUFFIX" ] && ! printf '%s' "$SUFFIX" | grep -Eq '^[a-zA-Z0-9._-]+$'; then
+          # Bash regex matches the WHOLE string (unlike grep, which matches per
+          # line and would accept a multi-line value whose first line is valid).
+          if [ -n "$SUFFIX" ] && ! [[ "$SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
             echo "::error::Invalid suffix '$SUFFIX'. Allowed: [a-zA-Z0-9._-]+ (blank = unix timestamp)."
             exit 1
           fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -90,11 +90,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Guard against main
-        if: github.ref == 'refs/heads/main'
+      - name: Guard ref
+        # Canary publishes are for non-main BRANCHES only. Block main (use the
+        # stable release flow) and block non-branch refs such as tags (a tag
+        # dispatch would otherwise canary-publish from the tagged commit).
+        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/heads/')
         run: |
-          echo "::error::Canary publishes are for non-main branches. To release from main, use the 'release / publish' workflow with mode=stable."
+          echo "::error::Canary publishes are for non-main branches only (got '${{ github.ref }}'). To release from main, use the 'release / publish' workflow with mode=stable."
           exit 1
+
+      - name: Validate suffix
+        if: inputs.suffix != ''
+        env:
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
+          set -euo pipefail
+          # Validate BEFORE any side effect (token mint, ref creation) so a bad
+          # suffix can't leave an orphaned canary ref behind. Bash regex matches
+          # the WHOLE string (grep matches per line and would accept a multi-line
+          # value whose first line is valid).
+          if ! [[ "$SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Invalid suffix '$SUFFIX'. Allowed: [a-zA-Z0-9._-]+ (blank = unix timestamp)."
+            exit 1
+          fi
 
       - name: Mint devops-bot token
         id: app-token
@@ -120,12 +138,14 @@ jobs:
             echo "::error::Could not derive a canary slug from ref '$REF_NAME'"
             exit 1
           fi
-          # Append the orchestration run id so every dispatch owns a UNIQUE canary
-          # ref. This is what prevents two dispatches whose source branches slugify
-          # to the same value from racing one shared ref, and it makes the run
+          # Append run id AND attempt so every dispatch — including a re-run of
+          # this same orchestration — owns a UNIQUE canary ref. This prevents two
+          # dispatches whose source branches slugify to the same value (or a
+          # re-run reusing the run id) from racing one shared ref, and keeps run
           # discovery below unambiguous (exactly one publish run per ref).
-          echo "branch=canary/${SLUG}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-          echo "Canary branch: canary/${SLUG}-${GITHUB_RUN_ID}"
+          REF_SUFFIX="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "branch=canary/${SLUG}-${REF_SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "Canary branch: canary/${SLUG}-${REF_SUFFIX}"
 
       - name: Create or update canary ref
         env:
@@ -162,17 +182,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          # Validate the suffix at the orchestrator boundary so a bad value fails
-          # here with a clear message rather than deep inside the delegated run.
-          # Mirrors publish-release.yml's own check; blank is allowed (it falls
-          # back to a unix timestamp downstream).
-          # Bash regex matches the WHOLE string (unlike grep, which matches per
-          # line and would accept a multi-line value whose first line is valid).
-          if [ -n "$SUFFIX" ] && ! [[ "$SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-            echo "::error::Invalid suffix '$SUFFIX'. Allowed: [a-zA-Z0-9._-]+ (blank = unix timestamp)."
-            exit 1
-          fi
-
+          # (suffix already validated in the "Validate suffix" step above, before
+          # the canary ref was created)
           gh workflow run publish-release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$BRANCH" \
@@ -181,10 +192,12 @@ jobs:
             -f suffix="$SUFFIX" \
             -f dry_run="$DRY_RUN"
 
-          # The canary ref is unique to this run, so there is exactly ONE
+          # The canary ref is unique to this run+attempt, so there is exactly ONE
           # publish-release dispatch on it — no timestamp watermark needed (which
           # also sidesteps runner/server clock-skew). Poll until it indexes
-          # (30 x 6s = 3 min tolerance for Actions indexing lag).
+          # (30 x 6s = 3 min tolerance for Actions indexing lag). --limit is
+          # defensive headroom; the branch/workflow/event filters are applied
+          # server-side so the matching run is never crowded out.
           RUN_ID=""
           for _ in $(seq 1 30); do
             sleep 6
@@ -193,6 +206,7 @@ jobs:
               --workflow=publish-release.yml \
               --branch "$BRANCH" \
               --event workflow_dispatch \
+              --limit 100 \
               --json databaseId \
               --jq 'sort_by(.databaseId) | last | .databaseId // empty') || RUN_ID=""
             if [ -n "$RUN_ID" ]; then

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -74,8 +74,9 @@ on:
         type: boolean
 
 concurrency:
-  # One canary orchestration per source branch at a time so two dispatches don't
-  # race the same canary/<slug> ref.
+  # Serialize repeated dispatches on the same source branch. Cross-branch ref
+  # races are independently prevented by making the canary ref unique per run
+  # (slug + github.run_id, see the slug step below).
   group: canary-publish-${{ github.ref }}
   cancel-in-progress: false
 
@@ -110,15 +111,21 @@ jobs:
           set -euo pipefail
           # Collapse the source ref to a single path segment under canary/ so it
           # matches the `canary/*` deployment-branch policy and is a valid ref.
-          SLUG=$(printf '%s' "$REF_NAME" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-' | tr -s '-')
-          SLUG="${SLUG#-}"
-          SLUG="${SLUG%-}"
+          # Also collapse dot runs and strip leading/trailing separators so the
+          # result can never form an invalid ref (e.g. `..`, trailing `.`).
+          SLUG=$(printf '%s' "$REF_NAME" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-' | tr -s '.-')
+          SLUG="${SLUG#[-.]}"
+          SLUG="${SLUG%[-.]}"
           if [ -z "$SLUG" ]; then
             echo "::error::Could not derive a canary slug from ref '$REF_NAME'"
             exit 1
           fi
-          echo "branch=canary/${SLUG}" >> "$GITHUB_OUTPUT"
-          echo "Canary branch: canary/${SLUG}"
+          # Append the orchestration run id so every dispatch owns a UNIQUE canary
+          # ref. This is what prevents two dispatches whose source branches slugify
+          # to the same value from racing one shared ref, and it makes the run
+          # discovery below unambiguous (exactly one publish run per ref).
+          echo "branch=canary/${SLUG}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "Canary branch: canary/${SLUG}-${GITHUB_RUN_ID}"
 
       - name: Create or update canary ref
         env:
@@ -127,18 +134,26 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Point canary/<slug> at the dispatched ref's HEAD. Create, or force it
-          # forward if a stale ref survived an aborted prior run.
+          # Point canary/<slug> at the dispatched ref's HEAD. The ref is unique
+          # per run, so it should not pre-exist; only force-update on the specific
+          # "already exists" case (e.g. a re-run reusing the run id). Any OTHER
+          # failure (auth, rate limit, 5xx) must surface, not be silently retried.
+          ERR=$(mktemp)
           if gh api --silent -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/heads/${BRANCH}" -f sha="$SHA"; then
+              -f ref="refs/heads/${BRANCH}" -f sha="$SHA" 2>"$ERR"; then
             echo "Created ${BRANCH} at ${SHA}"
-          else
-            echo "Ref exists; force-updating ${BRANCH} to ${SHA}"
+          elif grep -qi "already exists" "$ERR"; then
+            echo "Ref ${BRANCH} already exists; force-updating to ${SHA}"
             gh api --silent -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
               -f sha="$SHA" -F force=true
+          else
+            echo "::error::Failed to create canary ref ${BRANCH}:"
+            cat "$ERR" >&2
+            exit 1
           fi
 
       - name: Dispatch publish-release.yml on the canary ref and wait
+        id: dispatch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.slug.outputs.branch }}
@@ -147,8 +162,15 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          # Watermark to disambiguate our run from any earlier run on this ref.
-          BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # Validate the suffix at the orchestrator boundary so a bad value fails
+          # here with a clear message rather than deep inside the delegated run.
+          # Mirrors publish-release.yml's own check; blank is allowed (it falls
+          # back to a unix timestamp downstream).
+          if [ -n "$SUFFIX" ] && ! printf '%s' "$SUFFIX" | grep -Eq '^[a-zA-Z0-9._-]+$'; then
+            echo "::error::Invalid suffix '$SUFFIX'. Allowed: [a-zA-Z0-9._-]+ (blank = unix timestamp)."
+            exit 1
+          fi
+
           gh workflow run publish-release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$BRANCH" \
@@ -157,26 +179,33 @@ jobs:
             -f suffix="$SUFFIX" \
             -f dry_run="$DRY_RUN"
 
-          # gh workflow run does not return the run id; poll for the new run on
-          # our ref created at/after the watermark (registry indexing can lag).
+          # The canary ref is unique to this run, so there is exactly ONE
+          # publish-release dispatch on it — no timestamp watermark needed (which
+          # also sidesteps runner/server clock-skew). Poll until it indexes
+          # (30 x 6s = 3 min tolerance for Actions indexing lag).
           RUN_ID=""
-          for _ in $(seq 1 20); do
+          for _ in $(seq 1 30); do
             sleep 6
             RUN_ID=$(gh run list \
               --repo "$GITHUB_REPOSITORY" \
               --workflow=publish-release.yml \
               --branch "$BRANCH" \
               --event workflow_dispatch \
-              --json databaseId,createdAt \
-              --jq "map(select(.createdAt >= \"$BEFORE\")) | sort_by(.createdAt) | last | .databaseId // empty") || RUN_ID=""
+              --json databaseId \
+              --jq 'sort_by(.databaseId) | last | .databaseId // empty') || RUN_ID=""
             if [ -n "$RUN_ID" ]; then
               break
             fi
           done
           if [ -z "$RUN_ID" ]; then
-            echo "::error::Could not locate the dispatched publish-release run on ${BRANCH}"
+            echo "::error::Dispatched publish-release run never appeared on ${BRANCH}. Leaving the ref in place for debugging; delete it manually once resolved."
             exit 1
           fi
+
+          # Mark located BEFORE the watch so cleanup runs even if the publish
+          # fails — but is skipped entirely if we never tracked a run (so we
+          # never delete a ref a still-pending run may need).
+          echo "located=true" >> "$GITHUB_OUTPUT"
 
           RUN_URL=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json url --jq .url)
           echo "Delegated publish run: ${RUN_URL}"
@@ -192,14 +221,24 @@ jobs:
           gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
 
       - name: Delete canary ref
-        # Always clean up once the ref exists, even if the publish failed — but
-        # skip when slug never computed (e.g. the main guard tripped).
-        if: always() && steps.slug.outputs.branch != ''
+        # Clean up only when we actually tracked a dispatched run (located=true),
+        # even if that run then failed. If the run was never located, the ref is
+        # deliberately left in place — deleting it could yank the ref out from
+        # under a publish run that is still about to start.
+        if: always() && steps.dispatch.outputs.located == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.slug.outputs.branch }}
         run: |
-          set -euo pipefail
-          gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
-            && echo "Deleted ${BRANCH}" \
-            || echo "Branch ${BRANCH} already gone"
+          # Best-effort cleanup: never fail the job on a delete hiccup, but do
+          # surface a real error instead of masking every failure as "gone".
+          set -uo pipefail
+          ERR=$(mktemp)
+          if gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" 2>"$ERR"; then
+            echo "Deleted ${BRANCH}"
+          elif grep -qiE "not found|does not exist" "$ERR"; then
+            echo "Branch ${BRANCH} already gone"
+          else
+            echo "::warning::Failed to delete canary ref ${BRANCH} (manual cleanup may be needed):"
+            cat "$ERR" >&2
+          fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,205 @@
+name: canary / publish
+
+# Discoverable, one-click canary publisher. Surfaces in the Actions tab so any
+# maintainer can publish a prerelease of the branch they're working on without
+# learning the manual `canary/*` branch + dispatch dance.
+#
+# IMPORTANT: this workflow does NOT publish to npm itself. It ORCHESTRATES
+# publish-release.yml, which holds the SINGLE npm OIDC trusted-publisher binding
+# (see that file's header). Adding a second npm-publishing entry point would
+# break OIDC for every @ag-ui/* package.
+#
+# Why a separate orchestrator instead of a flag inside publish-release.yml:
+#   The `npm` GitHub Environment's deployment-branch policy is evaluated against
+#   the ref a run is TRIGGERED on — NOT against branches created mid-run. So
+#   publish-release.yml can only publish a canary when its run's ref already
+#   matches the policy (`canary/*`). Creating a branch inside a run triggered on
+#   `feature/*` does not change that run's ref, so it would still be rejected.
+#   This workflow therefore runs on any non-main branch, mirrors it to a
+#   short-lived `canary/<slug>` ref, dispatches publish-release.yml ON that ref
+#   (clearing the env gate), waits for it, then deletes the ref.
+#
+# Token: the branch create/delete and the cross-workflow dispatch use the
+# devops-bot GitHub App token, NOT the default GITHUB_TOKEN. Events authenticated
+# with GITHUB_TOKEN do not start new workflow runs (recursion prevention), so the
+# delegated publish-release run would silently never fire.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Package scope to publish a canary for. Regenerated from scripts/release/release.config.json — do NOT hand-edit (the release-scope-dropdown-sync CI guard enforces parity)."
+        required: true
+        type: choice
+        options:
+          - integration-a2a
+          - integration-adk-py
+          - integration-adk-ts
+          - integration-ag2
+          - integration-agent-spec
+          - integration-agno
+          - integration-aws-strands-py
+          - integration-aws-strands-ts
+          - integration-claude-agent-sdk-py
+          - integration-claude-agent-sdk-ts
+          - integration-cloudflare-agents
+          - integration-crewai-py
+          - integration-crewai-ts
+          - integration-langchain
+          - integration-langgraph-py
+          - integration-langgraph-ts
+          - integration-langroid
+          - integration-llama-index
+          - integration-mastra
+          - integration-pydantic-ai
+          - integration-spring-ai
+          - integration-watsonx-py
+          - integration-watsonx-ts
+          - middleware-a2a
+          - middleware-a2ui
+          - middleware-mcp
+          - middleware-mcp-apps
+          - sdk-py
+          - sdk-py-a2ui-toolkit
+          - sdk-ts
+          - sdk-ts-a2ui-toolkit
+      suffix:
+        description: "Prerelease suffix (e.g. 'fix-user-issue'); blank = unix timestamp. Allowed: [a-zA-Z0-9._-]+. Reuse a suffix only if the base version moved, else the publish collides."
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run: build + detect but do NOT publish to npm. Useful for previewing what would ship."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # One canary orchestration per source branch at a time so two dispatches don't
+  # race the same canary/<slug> ref.
+  group: canary-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  # The job's own GITHUB_TOKEN does nothing privileged — every write goes through
+  # the App token minted below.
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Guard against main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "::error::Canary publishes are for non-main branches. To release from main, use the 'release / publish' workflow with mode=stable."
+          exit 1
+
+      - name: Mint devops-bot token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: "3877599"
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+
+      - name: Compute canary branch name
+        id: slug
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Collapse the source ref to a single path segment under canary/ so it
+          # matches the `canary/*` deployment-branch policy and is a valid ref.
+          SLUG=$(printf '%s' "$REF_NAME" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-' | tr -s '-')
+          SLUG="${SLUG#-}"
+          SLUG="${SLUG%-}"
+          if [ -z "$SLUG" ]; then
+            echo "::error::Could not derive a canary slug from ref '$REF_NAME'"
+            exit 1
+          fi
+          echo "branch=canary/${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "Canary branch: canary/${SLUG}"
+
+      - name: Create or update canary ref
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Point canary/<slug> at the dispatched ref's HEAD. Create, or force it
+          # forward if a stale ref survived an aborted prior run.
+          if gh api --silent -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="$SHA"; then
+            echo "Created ${BRANCH} at ${SHA}"
+          else
+            echo "Ref exists; force-updating ${BRANCH} to ${SHA}"
+            gh api --silent -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
+              -f sha="$SHA" -F force=true
+          fi
+
+      - name: Dispatch publish-release.yml on the canary ref and wait
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          SCOPE: ${{ inputs.scope }}
+          SUFFIX: ${{ inputs.suffix }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # Watermark to disambiguate our run from any earlier run on this ref.
+          BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run publish-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$BRANCH" \
+            -f mode=prerelease \
+            -f scope="$SCOPE" \
+            -f suffix="$SUFFIX" \
+            -f dry_run="$DRY_RUN"
+
+          # gh workflow run does not return the run id; poll for the new run on
+          # our ref created at/after the watermark (registry indexing can lag).
+          RUN_ID=""
+          for _ in $(seq 1 20); do
+            sleep 6
+            RUN_ID=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow=publish-release.yml \
+              --branch "$BRANCH" \
+              --event workflow_dispatch \
+              --json databaseId,createdAt \
+              --jq "map(select(.createdAt >= \"$BEFORE\")) | sort_by(.createdAt) | last | .databaseId // empty") || RUN_ID=""
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Could not locate the dispatched publish-release run on ${BRANCH}"
+            exit 1
+          fi
+
+          RUN_URL=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json url --jq .url)
+          echo "Delegated publish run: ${RUN_URL}"
+          {
+            echo "## Canary publish"
+            echo ""
+            echo "- **Scope:** \`${SCOPE}\`"
+            echo "- **Source branch:** \`${GITHUB_REF_NAME}\`"
+            echo "- **Delegated run:** ${RUN_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # --exit-status propagates the publish run's failure to this job.
+          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
+
+      - name: Delete canary ref
+        # Always clean up once the ref exists, even if the publish failed — but
+        # skip when slug never computed (e.g. the main guard tripped).
+        if: always() && steps.slug.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+        run: |
+          set -euo pipefail
+          gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
+            && echo "Deleted ${BRANCH}" \
+            || echo "Branch ${BRANCH} already gone"

--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -1,8 +1,8 @@
 name: Lint Release Workflows
 
-# Runs actionlint + shellcheck against the release / create-pr and
-# release / publish pipelines and the scripts they call. Keeps these
-# critical, retry-sensitive files from silently regressing on shell or
+# Runs actionlint + shellcheck against the release / create-pr, release /
+# publish, and canary / publish pipelines and the scripts they call. Keeps
+# these critical, retry-sensitive files from silently regressing on shell or
 # action-syntax bugs.
 #
 # Scope is intentionally narrow: only the release workflows and

--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - ".github/workflows/prepare-release.yml"
       - ".github/workflows/publish-release.yml"
+      - ".github/workflows/canary.yml"
       - ".github/workflows/lint-release-workflows.yml"
       - "scripts/release/**"
       - "nx.json"
@@ -22,6 +23,7 @@ on:
     paths:
       - ".github/workflows/prepare-release.yml"
       - ".github/workflows/publish-release.yml"
+      - ".github/workflows/canary.yml"
       - ".github/workflows/lint-release-workflows.yml"
       - "scripts/release/**"
       - "nx.json"
@@ -45,6 +47,7 @@ jobs:
           actionlint_flags: >-
             .github/workflows/prepare-release.yml
             .github/workflows/publish-release.yml
+            .github/workflows/canary.yml
             .github/workflows/lint-release-workflows.yml
 
   shellcheck:

--- a/scripts/release/verify-release-scope-dropdowns.sh
+++ b/scripts/release/verify-release-scope-dropdowns.sh
@@ -12,9 +12,10 @@
 # (newly-enrolled packages weren't canary-selectable; stale scopes lingered).
 # This guard fails CI whenever a dropdown diverges from the config.
 #
-# Two files are checked:
+# Three files are checked:
 #   .github/workflows/publish-release.yml  — canary/prerelease `scope` input
 #   .github/workflows/prepare-release.yml  — create-pr `scope` input
+#   .github/workflows/canary.yml           — one-click canary orchestrator `scope` input
 #
 # Sentinel exception: neither workflow uses a non-scope sentinel option (no
 # `all` / `canary` pseudo-scope — an empty/omitted scope is handled outside
@@ -35,11 +36,12 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CONFIG="$REPO_ROOT/scripts/release/release.config.json"
 PUBLISH_WF="$REPO_ROOT/.github/workflows/publish-release.yml"
 PREPARE_WF="$REPO_ROOT/.github/workflows/prepare-release.yml"
+CANARY_WF="$REPO_ROOT/.github/workflows/canary.yml"
 
 # Documented non-scope sentinel options to ignore (none today). Space-separated.
 SENTINELS=""
 
-for f in "$CONFIG" "$PUBLISH_WF" "$PREPARE_WF"; do
+for f in "$CONFIG" "$PUBLISH_WF" "$PREPARE_WF" "$CANARY_WF"; do
   if [ ! -f "$f" ]; then
     echo "ERROR: $f not found" >&2
     exit 1
@@ -234,11 +236,12 @@ check_notify_case() {
 rc=0
 check_workflow "publish-release.yml" "$PUBLISH_WF" || rc=1
 check_workflow "prepare-release.yml" "$PREPARE_WF" || rc=1
+check_workflow "canary.yml" "$CANARY_WF" || rc=1
 check_notify_case "$PUBLISH_WF" || rc=1
 
 if [ "$rc" -ne 0 ]; then
   exit 1
 fi
 
-echo "OK: both release scope dropdowns match release.config.json; notify-job ecosystem case matches too"
+echo "OK: all release scope dropdowns match release.config.json; notify-job ecosystem case matches too"
 exit 0


### PR DESCRIPTION
## Summary

Adds a discoverable **`canary / publish`** `workflow_dispatch` action so any maintainer can publish a prerelease of the branch they're working on straight from the Actions tab — no need to learn the manual `canary/*` branch + dispatch dance.

It is a **thin orchestrator** — it does *not* publish to npm itself:
1. Guards against `main` (stable releases go through `release / publish`).
2. Mints the **devops-bot App token** (same `app-id 3877599` / `DEVOPS_BOT_PRIVATE_KEY` as `prepare-release.yml`).
3. Mirrors the selected ref to a short-lived `canary/<slug>` branch (via the GitHub API — no checkout).
4. Dispatches **`publish-release.yml --ref canary/<slug> -f mode=prerelease …`**, locates the run, and **waits** for it (`gh run watch --exit-status`).
5. Deletes the `canary/<slug>` branch in an `if: always()` step.

### Why a separate orchestrator (and not a flag in `publish-release.yml`)
- The `npm` GitHub Environment's **deployment-branch policy is evaluated against the ref a run is *triggered on*** — not branches created mid-run. So `publish-release.yml` can only publish a canary when its run's ref already matches `canary/*`. This workflow exists to get the run *onto* such a ref.
- `publish-release.yml` holds the **single npm OIDC trusted-publisher binding** (pinned to that exact file path + `environment: npm`). A second publishing entry point would silently break OIDC for every `@ag-ui/*` package. The orchestrator never touches npm, so it stays clear of that.
- The cross-workflow dispatch uses the **App token, not `GITHUB_TOKEN`** — events authenticated with `GITHUB_TOKEN` do not start new workflow runs, so the delegated publish would never fire.

Also wires `canary.yml` into the **scope-dropdown drift-guard** (`verify-release-scope-dropdowns.sh`) and the **`lint-release-workflows.yml`** actionlint coverage so its scope list can't drift from `release.config.json`.

## Testing done
Simulated the full orchestration locally against the live repo (using personal `gh` auth in place of the App token), in dry-run:
- ✅ create `canary/<slug>` via API → ✅ dispatch `publish-release.yml` (dry_run) on the canary ref → ✅ locate run → ✅ `gh run watch --exit-status` (exit 0) → ✅ delete branch. No npm publish, no leftover branches.
- ✅ `verify-release-scope-dropdowns.sh` passes for all three workflows.
- ✅ YAML parses; shell blocks pass `bash -n`; slug logic yields valid single-segment `canary/*` names.

## ⚠️ Still to verify before first real use
These could not be exercised by the local simulation (they only run inside the workflow itself) and should be confirmed on the **first post-merge dry-run**:

- [ ] **devops-bot App has `Actions: write` permission.** Required for the in-workflow `gh workflow run` to fire. If it only has `Contents: write` (what `prepare-release.yml` needs today), the dispatch step will **403**. The merged workflow is inert until dispatched, so the safe first test is: run it once with `dry_run=true` and confirm the dispatch step succeeds.
- [ ] **App-token mint step** resolves on the runner (depends on `DEVOPS_BOT_PRIVATE_KEY`, already used by `prepare-release.yml`).
- [ ] First real (`dry_run=false`) run actually clears the `npm` environment gate end-to-end via the App token (the `canary/*` policy itself is already proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)