### PR TITLE
docs: add disallowedToolCalls example for FilterToolCallsMiddleware

### DIFF
--- a/docs/sdk/js/client/middleware.mdx
+++ b/docs/sdk/js/client/middleware.mdx
@@ -246,7 +246,17 @@ const allowFilter = new FilterToolCallsMiddleware({
 agent.use(allowFilter)
 ```
 
-You can also use `disallowedToolCalls` instead of `allowedToolCalls`.
+#### Block Specific Tools
+
+```typescript
+const blockFilter = new FilterToolCallsMiddleware({
+  disallowedToolCalls: ["deleteFile", "sendEmail"]
+})
+
+agent.use(blockFilter)
+```
+
+You must specify exactly one of `allowedToolCalls` or `disallowedToolCalls`. The constructor throws if both or neither are provided.
 
 ## Middleware Patterns
 


### PR DESCRIPTION
## What

Expands the **FilterToolCallsMiddleware** section in `sdk/js/client/middleware.mdx`.

The docs already showed the `allowedToolCalls` path but only mentioned `disallowedToolCalls` in a one-liner. This adds:

- A real **Block Specific Tools** code example using `disallowedToolCalls`
- The constructor rule: exactly one of `allowedToolCalls` / `disallowedToolCalls` must be set (throws on both or neither)

## Why

`disallowedToolCalls` is fully supported by `FilterToolCallsMiddleware` (`@ag-ui/client`) but had no example, so users had to read the source to learn the shape.

## Verified against source

`sdks/typescript/packages/client/src/middleware/filter-tool-calls.ts`:
- `FilterToolCallsConfig` is an XOR union of `allowedToolCalls` / `disallowedToolCalls`
- Constructor throws `"Cannot specify both..."` and `"Must specify either..."`
- Exported from `@ag-ui/client` (`src/index.ts`)

Docs-only change.