### PR TITLE
fix(adk-middleware): strip additionalProperties from client tool schemas (Gemini Developer API 400)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FIX**: Strip `additionalProperties` from client tool schemas before building Gemini function declarations
+  - CopilotKit / AG-UI frontend tools serialize their parameters with `zodToJsonSchema(..., {$refStrategy: "none"})`, which stamps `additionalProperties: false` on every object (root and nested). `_clean_schema_for_genai` allowlisted it because it is a field on `google.genai.types.Schema`, so it was forwarded verbatim. The Gemini **Developer API** rejects it in `function_declarations` with `400 INVALID_ARGUMENT` ("Unknown name \"additional_properties\" ... Cannot find field"), which surfaced as a `RUN_ERROR` and **no tool call reaching the UI** — e.g. the Human-in-the-Loop dojo demo rendered nothing for the ADK backend, while OpenAI-based backends (which tolerate the field) worked.
+  - `_clean_schema_for_genai` now strips `additionalProperties` / `additional_properties` at every depth via an explicit `_GENAI_REJECTED_SCHEMA_KEYS` denylist, closing both the dynamic `types.Schema.model_fields` allowlist and the static fallback. Gemini ignores `additionalProperties` for argument generation so no model behavior changes; **Vertex** already accepted the field, making this a no-op there and a fix on the Developer API.
+  - The middleware never read the value anywhere — it was only ever forwarded. The three #1495 tests that asserted pass-through (they validated `model_validate()` only, never a live request) were updated, and a regression test reproduces the exact dojo HITL tool schema and asserts `additional_properties` appears at no depth.
+
 - **FIX**: `adk_events_to_messages` now preserves `file_data` parts on user
   events (#1771). Previously only the text part was extracted, so image,
   audio, video, and document attachments were silently dropped from

--- a/integrations/adk-middleware/python/src/ag_ui_adk/client_proxy_tool.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/client_proxy_tool.py
@@ -41,9 +41,21 @@ except (ImportError, AttributeError):
         "type", "format", "description", "nullable", "enum", "example",
         "items", "properties", "required", "default", "title", "pattern",
         "minimum", "maximum", "minItems", "maxItems", "minLength", "maxLength",
-        "minProperties", "maxProperties", "additionalProperties", "anyOf",
+        "minProperties", "maxProperties", "anyOf",
         "ref", "defs", "propertyOrdering",
     })
+
+
+# Keys that ``google.genai.types.Schema`` accepts as model fields (so the
+# allowlist above keeps them) but the Gemini ``generateContent`` function-calling
+# API rejects with a 400 ("Unknown name ... Cannot find field"). They must be
+# stripped explicitly. ``zod-to-json-schema`` (used by CopilotKit / AG-UI
+# frontend tools) emits ``additionalProperties: false`` on every object, so any
+# client-supplied tool trips this — manifesting as a RUN_ERROR and no tool call
+# reaching the UI. See ag-ui-protocol/ag-ui HITL dojo "nothing renders" report.
+_GENAI_REJECTED_SCHEMA_KEYS = frozenset({
+    "additionalProperties", "additional_properties",
+})
 
 
 def _clean_schema_for_genai(schema: Any) -> Any:
@@ -62,6 +74,10 @@ def _clean_schema_for_genai(schema: Any) -> Any:
         for k, v in schema.items():
             # Always strip $-prefixed keys
             if k.startswith("$"):
+                continue
+            # Strip keys the Gemini API rejects even though genai.Schema accepts
+            # them as model fields (e.g. additionalProperties from zod schemas).
+            if k in _GENAI_REJECTED_SCHEMA_KEYS:
                 continue
             # Map examples -> example (preserve first element as opaque data)
             if k == "examples" and isinstance(v, list) and v:

--- a/integrations/adk-middleware/python/tests/test_client_proxy_tool.py
+++ b/integrations/adk-middleware/python/tests/test_client_proxy_tool.py
@@ -454,7 +454,9 @@ class TestCleanSchemaForGenai:
         result = _clean_schema_for_genai(schema)
         assert result["title"] == "MyTool"
         assert result["default"] == {"key": "value"}
-        assert result["additionalProperties"] is False
+        # additionalProperties is stripped: the Gemini Developer API rejects it
+        # in function declarations with a 400 even though genai.Schema accepts it.
+        assert "additionalProperties" not in result
         assert result["minProperties"] == 1
         assert result["maxProperties"] == 10
         assert result["properties"]["amount"]["minimum"] == 0
@@ -733,8 +735,16 @@ class TestEndToEndSchemaValidation:
         assert query_prop.example == "machine learning"
         assert query_prop.default == "hello world"
 
-    def test_e2e_schema_with_additional_properties(self):
-        """Schema with additionalProperties passes model_validate (Google docs example)."""
+    def test_e2e_schema_with_additional_properties_stripped(self):
+        """additionalProperties is stripped from the function declaration.
+
+        The Gemini Developer API rejects ``additionalProperties`` in function
+        declarations with a 400 ("Unknown name additional_properties ... Cannot
+        find field"), even though ``genai.types.Schema`` accepts it as a model
+        field. zod-to-json-schema (CopilotKit / AG-UI frontend tools) emits it on
+        every object, so leaving it in breaks every client-supplied tool on the
+        Developer API. It must be stripped.
+        """
         tool = AGUITool(
             name="recipe_tool",
             description="Recipe schema per Google docs",
@@ -757,7 +767,66 @@ class TestEndToEndSchemaValidation:
 
         assert declaration is not None
         assert declaration.parameters is not None
-        assert declaration.parameters.additional_properties is False
+        # Stripped, not preserved — otherwise the Developer API 400s on this tool.
+        assert declaration.parameters.additional_properties is None
+
+    def test_e2e_dojo_hitl_tool_has_no_additional_properties_at_any_depth(self):
+        """Regression for the AG-UI HITL dojo "nothing renders" report.
+
+        CopilotKit's ``useHumanInTheLoop`` registers a frontend tool whose zod
+        schema is serialized via ``zodToJsonSchema(..., {$refStrategy: "none"})``,
+        which stamps ``additionalProperties: false`` on every object (root *and*
+        array items) plus a ``$schema`` key. Forwarded verbatim, the Gemini
+        Developer API returns 400 ("Unknown name additional_properties ... Cannot
+        find field"), the run emits RUN_ERROR, and no tool call reaches the UI.
+
+        The cleaned declaration must therefore contain ``additional_properties``
+        nowhere — at any nesting depth — while keeping the real schema intact.
+        """
+        tool = AGUITool(
+            name="generate_task_steps",
+            description="Generates a list of steps for the user to perform",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "steps": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "description": {"type": "string"},
+                                "status": {
+                                    "type": "string",
+                                    "enum": ["enabled", "disabled", "executing"],
+                                },
+                            },
+                            "required": ["description", "status"],
+                            "additionalProperties": False,  # nested — must also be stripped
+                        },
+                    }
+                },
+                "required": ["steps"],
+                "additionalProperties": False,  # root
+                "$schema": "http://json-schema.org/draft-07/schema#",
+            },
+        )
+        proxy = ClientProxyTool(ag_ui_tool=tool, event_queue=AsyncMock())
+        declaration = proxy._get_declaration()
+
+        assert declaration is not None
+        assert declaration.parameters is not None
+
+        # Serialize exactly as it goes on the wire to Gemini; the rejected key
+        # must appear at no depth (and neither must the $schema meta key).
+        dumped = declaration.parameters.model_dump_json(by_alias=True, exclude_none=True)
+        assert "additionalProperties" not in dumped
+        assert "additional_properties" not in dumped
+        assert "$schema" not in dumped
+
+        # The real schema survived: steps -> array of objects with the enum intact.
+        steps = declaration.parameters.properties["steps"]
+        assert steps.items is not None
+        assert steps.items.properties["status"].enum == ["enabled", "disabled", "executing"]
 
     def test_e2e_schema_with_const_mapped_to_enum(self):
         """Schema with const is mapped to enum and passes model_validate."""
@@ -949,7 +1018,9 @@ class TestEndToEndSchemaValidation:
         params = declaration.parameters
         # Valid fields preserved
         assert params.title == "DatabaseQuery"
-        assert params.additional_properties is False
+        # additionalProperties stripped (Developer API rejects it; see
+        # test_e2e_schema_with_additional_properties_stripped).
+        assert params.additional_properties is None
         assert params.min_properties == 1
         assert params.max_properties == 10
         # sql: examples[0] mapped to example, minLength/maxLength preserved
@@ -969,8 +1040,9 @@ class TestEndToEndSchemaValidation:
         assert format_prop.title == "Output Format"
         assert format_prop.enum == ["json", "csv", "table"]
         assert format_prop.default == "json"
-        # options: nested additionalProperties preserved
+        # options: nested additionalProperties also stripped (Developer API
+        # rejects it at any depth, not just the root).
         options_prop = params.properties["options"]
-        assert options_prop.additional_properties is True
+        assert options_prop.additional_properties is None
         # Invalid fields stripped at root level
         # (readOnly, writeOnly, deprecated, contentMediaType, dependentRequired)


### PR DESCRIPTION
## Problem

In the Dojo, the **Human-in-the-Loop** demo rendered **nothing** for the ADK backend (no checklist), while other backends (e.g. LangGraph Python on OpenAI) worked. Driving the demo server with the real `@ag-ui/adk` client reproduced a `RUN_ERROR` on turn 1:

```
400 INVALID_ARGUMENT: Invalid JSON payload received.
Unknown name "additional_properties" at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

## Root cause

CopilotKit / AG-UI **frontend tools** serialize their parameters with `zodToJsonSchema(..., {$refStrategy: "none"})`, which stamps `additionalProperties: false` on every object (root **and** nested array items). `_clean_schema_for_genai` allowlisted the key because it *is* a field on `google.genai.types.Schema`, so it was forwarded verbatim into the Gemini function declaration.

The **Gemini Developer API rejects `additionalProperties`** in `function_declarations` with a 400 → the middleware emits `RUN_ERROR` → no tool call reaches the UI. OpenAI-based backends tolerate the field, which is why they rendered fine.

Confirmed on both backends:

| Backend | `additionalProperties` in a function declaration |
|---|---|
| Gemini **Developer API** (`GOOGLE_API_KEY`) | **400 rejected** |
| Gemini **Vertex** | accepted (no-op) |

The existing #1495 tests only validated `types.Schema.model_validate()` — which *accepts* the field — and never made a live request, so the gap slipped through.

## Fix

`_clean_schema_for_genai` now strips `additionalProperties` / `additional_properties` at **every depth** via an explicit `_GENAI_REJECTED_SCHEMA_KEYS` denylist, closing both the dynamic `types.Schema.model_fields` allowlist and the static fallback. Gemini ignores `additionalProperties` for argument generation (no model-behavior change), and Vertex already accepted it, so this is purely a fix on the Developer API.

Verified the middleware **never reads** the value anywhere (it was only ever forwarded), so stripping it is safe — the sole consumer is the function-declaration builder.

## Tests

- Updated the three #1495 tests that asserted pass-through (now assert it is stripped, with comments explaining the Developer API rejection).
- Added `test_e2e_dojo_hitl_tool_has_no_additional_properties_at_any_depth` reproducing the exact dojo HITL tool schema and asserting `additional_properties` appears at no depth.
- `tests/test_client_proxy_tool.py`: **38 passed**; broader tool/schema/toolset subset: **123 passed**.
- End-to-end: the real `@ag-ui/adk` client against the demo server now returns a clean tool call (no `RUN_ERROR`) and a rendered 10-step checklist.

## Note

This is the primary cause of the "nothing renders" report. A separate PR (#1917) trims the demo's system prompt to reduce intermittent empty turns once the schema is accepted — the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)