### PR TITLE
Add core package npm license metadata

### DIFF
--- a/sdks/typescript/packages/core/package.json
+++ b/sdks/typescript/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@ag-ui/core",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.56",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## Summary

Add explicit npm `license` metadata to `sdks/typescript/packages/core/package.json` for `@ag-ui/core`.

The repository is MIT-licensed, and the currently published package exposes repository, bugs, and homepage metadata, but npm metadata does not expose a `license` field. This change makes the package manifest report the same MIT license as the repository.

## Validation

- `node -e "const p=require('./sdks/typescript/packages/core/package.json'); if(p.license!=='MIT') throw new Error('license mismatch'); console.log(JSON.stringify({name:p.name,license:p.license,repository:p.repository}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `sdks/typescript/packages/core`

## Scope

Manifest metadata only. No runtime code, dependency, generated output, or lockfile changes.

Note: this is separate from #1851, which adds bundled LICENSE files. This PR only adds the npm `license` metadata field for `@ag-ui/core`.