### PR TITLE
Add client package npm license metadata

### DIFF
--- a/sdks/typescript/packages/client/package.json
+++ b/sdks/typescript/packages/client/package.json
@@ -2,6 +2,7 @@
   "name": "@ag-ui/client",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.56",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## Summary

Add explicit npm `license` metadata to `sdks/typescript/packages/client/package.json` for `@ag-ui/client`.

The repository is MIT-licensed, and the currently published package exposes repository, bugs, and homepage metadata, but npm metadata does not expose a `license` field. This change makes the package manifest report the same MIT license as the repository.

## Validation

- `node -e "const p=require('./sdks/typescript/packages/client/package.json'); if(p.license!=='MIT') throw new Error('license mismatch'); console.log(JSON.stringify({name:p.name,license:p.license,repository:p.repository}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `sdks/typescript/packages/client`

## Scope

Manifest metadata only. No runtime code, dependency, generated output, or lockfile changes.

Note: this is separate from #1851, which adds bundled LICENSE files. This PR only adds the npm `license` metadata field for `@ag-ui/client`.