### PR TITLE
Add encoder package npm license metadata

### DIFF
--- a/sdks/typescript/packages/encoder/package.json
+++ b/sdks/typescript/packages/encoder/package.json
@@ -2,6 +2,7 @@
   "name": "@ag-ui/encoder",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
   "version": "0.0.56",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## Summary
- add the missing `license` field to the published `@ag-ui/encoder` package metadata

## Verification
- `node -e "const p=require('./sdks/typescript/packages/encoder/package.json'); if(p.license!=='MIT') throw new Error('license mismatch'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license,repository:p.repository}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `sdks/typescript/packages/encoder`