### PR TITLE
Add a2ui toolkit package npm license metadata

### DIFF
--- a/sdks/typescript/packages/a2ui-toolkit/package.json
+++ b/sdks/typescript/packages/a2ui-toolkit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ag-ui/a2ui-toolkit",
   "version": "0.0.3",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## Summary
- add the missing `license` field to the published `@ag-ui/a2ui-toolkit` package metadata

## Verification
- `node -e "const p=require('./sdks/typescript/packages/a2ui-toolkit/package.json'); if(p.license!=='MIT') throw new Error('license mismatch'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license,repository:p.repository}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from `sdks/typescript/packages/a2ui-toolkit`