### PR TITLE
fix(client): dedupe reasoning when MESSAGES_SNAPSHOT supplies it

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1522,7 +1522,13 @@ class LangGraphAgent:
             self.active_run["reasoning_process"] = None
 
         if not self.active_run.get("reasoning_process"):
-            message_id = str(uuid.uuid4())
+            # Prefer the provider's canonical reasoning id (e.g. OpenAI
+            # ``rs_…``) when the stream carries one: the snapshot converter
+            # (_reasoning_block_to_agui_message) re-emits this same reasoning
+            # under that id, and only a matching id lets the client reconcile
+            # the streamed copy with the snapshot copy instead of rendering
+            # both.
+            message_id = reasoning_data.get("id") or str(uuid.uuid4())
             yield self._dispatch_event(
                 ReasoningStartEvent(
                     type=EventType.REASONING_START,
@@ -1548,7 +1554,9 @@ class LangGraphAgent:
         if reasoning_data.get("signature"):
             self.active_run["reasoning_process"]["signature"] = reasoning_data["signature"]
 
-        if self.active_run["reasoning_process"].get("type"):
+        # Skip empty deltas: the id-bearing `reasoning_summary_part.added`
+        # chunk carries no text — it exists only to open the message above.
+        if self.active_run["reasoning_process"].get("type") and reasoning_data["text"]:
             yield self._dispatch_event(
                 ReasoningMessageContentEvent(
                     type=EventType.REASONING_MESSAGE_CONTENT,

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1499,6 +1499,17 @@ class LangGraphAgent:
             )
             return
 
+        # A text-less chunk is still meaningful when it carries the provider's
+        # canonical reasoning id (the `response.output_item.added` /
+        # `…summary_part.added` chunks): stash the id so the first text delta
+        # opens the reasoning message under it, WITHOUT opening a message here
+        # — a summary-less (store=true) reasoning item must keep rendering
+        # nothing.
+        if not reasoning_data["text"]:
+            if reasoning_data.get("id"):
+                self.active_run["pending_reasoning_id"] = reasoning_data["id"]
+            return
+
         reasoning_step_index = reasoning_data.get("index", 0)
 
         if (self.active_run.get("reasoning_process") and
@@ -1523,12 +1534,16 @@ class LangGraphAgent:
 
         if not self.active_run.get("reasoning_process"):
             # Prefer the provider's canonical reasoning id (e.g. OpenAI
-            # ``rs_…``) when the stream carries one: the snapshot converter
+            # ``rs_…``) when the stream carried one: the snapshot converter
             # (_reasoning_block_to_agui_message) re-emits this same reasoning
             # under that id, and only a matching id lets the client reconcile
             # the streamed copy with the snapshot copy instead of rendering
             # both.
-            message_id = reasoning_data.get("id") or str(uuid.uuid4())
+            message_id = (
+                reasoning_data.get("id")
+                or self.active_run.pop("pending_reasoning_id", None)
+                or str(uuid.uuid4())
+            )
             yield self._dispatch_event(
                 ReasoningStartEvent(
                     type=EventType.REASONING_START,
@@ -1554,9 +1569,7 @@ class LangGraphAgent:
         if reasoning_data.get("signature"):
             self.active_run["reasoning_process"]["signature"] = reasoning_data["signature"]
 
-        # Skip empty deltas: the id-bearing `reasoning_summary_part.added`
-        # chunk carries no text — it exists only to open the message above.
-        if self.active_run["reasoning_process"].get("type") and reasoning_data["text"]:
+        if self.active_run["reasoning_process"].get("type"):
             yield self._dispatch_event(
                 ReasoningMessageContentEvent(
                     type=EventType.REASONING_MESSAGE_CONTENT,

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -115,4 +115,9 @@ LangGraphReasoning = TypedDict("LangGraphReasoning", {
     "text": str,
     "index": int,
     "signature": NotRequired[Optional[str]],
+    # The provider's canonical id for the reasoning item (e.g. OpenAI
+    # ``rs_…``), when the stream carries one. Used as the AG-UI reasoning
+    # message id so the streamed message reconciles with the snapshot copy
+    # emitted by ``_reasoning_block_to_agui_message`` under the same id.
+    "id": NotRequired[Optional[str]],
 })

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -469,16 +469,30 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
                 return result
 
         # OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
+        #
+        # The `response.reasoning_summary_part.added` chunk carries the
+        # reasoning item's canonical id (OpenAI ``rs_…``) with an empty text,
+        # while the `…summary_text.delta` chunks carry text but no id. Surface
+        # the empty-text chunk too (instead of dropping it) so the reasoning
+        # message can open under the canonical id — the id the snapshot
+        # converter (_reasoning_block_to_agui_message) emits for the same
+        # block. Only the first summary part (index 0) takes the id: later
+        # parts belong to the same item, and reusing its id would mint two
+        # messages with one id. An item chunk with an empty summary LIST
+        # (store=true reasoning: id only, never any text) stays dropped.
         if block_type == "reasoning" and block.get("summary"):
             summaries = block["summary"]
-            if summaries and isinstance(summaries, list) and summaries[0]:
+            if summaries and isinstance(summaries, list) and isinstance(summaries[0], dict):
                 data = summaries[0]
-                if data.get("text"):
-                    return LangGraphReasoning(
+                if data.get("text") or block.get("id"):
+                    result = LangGraphReasoning(
                         type="text",
-                        text=data["text"],
+                        text=data.get("text") or "",
                         index=data.get("index", 0)
                     )
+                    if block.get("id") and data.get("index", 0) == 0:
+                        result["id"] = str(block["id"])
+                    return result
 
         # Bedrock Converse API format: { type: "reasoning_content", reasoning_content: { type: "text", text: "..." } }
         if block_type == "reasoning_content" and isinstance(block.get("reasoning_content"), dict):

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -470,19 +470,29 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
 
         # OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
         #
-        # The `response.reasoning_summary_part.added` chunk carries the
-        # reasoning item's canonical id (OpenAI ``rs_…``) with an empty text,
-        # while the `…summary_text.delta` chunks carry text but no id. Surface
-        # the empty-text chunk too (instead of dropping it) so the reasoning
-        # message can open under the canonical id — the id the snapshot
-        # converter (_reasoning_block_to_agui_message) emits for the same
-        # block. Only the first summary part (index 0) takes the id: later
-        # parts belong to the same item, and reusing its id would mint two
-        # messages with one id. An item chunk with an empty summary LIST
-        # (store=true reasoning: id only, never any text) stays dropped.
-        if block_type == "reasoning" and block.get("summary"):
+        # The reasoning item's canonical id (OpenAI ``rs_…``) only travels on
+        # text-less chunks: the `response.output_item.added` chunk
+        # ({ id, summary: [] }) and — depending on the langchain-openai
+        # version — the `…summary_part.added` chunk ({ id, summary:
+        # [{ text: "" }] }). The `…summary_text.delta` chunks carry text but
+        # no id. Surface the id carriers (instead of dropping them for having
+        # no text) so the streamed reasoning message can adopt the canonical
+        # id — the id the snapshot converter
+        # (_reasoning_block_to_agui_message) emits for the same block;
+        # handle_reasoning_event stashes the id without opening a message, so
+        # summary-less (store=true) items still render nothing. Only the
+        # first summary part takes the id: later parts belong to the same
+        # item, and reusing its id would mint two messages with one id.
+        if block_type == "reasoning" and isinstance(block.get("summary"), list):
             summaries = block["summary"]
-            if summaries and isinstance(summaries, list) and isinstance(summaries[0], dict):
+            if not summaries and block.get("id"):
+                return LangGraphReasoning(
+                    type="text",
+                    text="",
+                    index=block.get("index", 0),
+                    id=str(block["id"]),
+                )
+            if summaries and isinstance(summaries[0], dict):
                 data = summaries[0]
                 if data.get("text") or block.get("id"):
                     result = LangGraphReasoning(

--- a/integrations/langgraph/python/tests/test_reasoning_canonical_id.py
+++ b/integrations/langgraph/python/tests/test_reasoning_canonical_id.py
@@ -1,0 +1,159 @@
+"""The streamed reasoning message must adopt the provider's canonical
+reasoning id when the stream carries one.
+
+Since 2111267 the snapshot converter (``_reasoning_block_to_agui_message``)
+emits checkpointed reasoning under the provider's canonical block id (OpenAI
+``rs_…``). If the streaming path mints a fresh ``uuid4`` instead, the client
+can never reconcile the streamed copy with the snapshot copy and renders the
+same reasoning twice (the langgraph-python dojo e2e strict-mode failure).
+
+With ``use_responses_api=True``, langchain-openai surfaces the canonical id on
+the ``response.reasoning_summary_part.added`` chunk (empty text, ``id`` set);
+the subsequent ``response.reasoning_summary_text.delta`` chunks carry text but
+no id. These tests pin that:
+
+  * ``resolve_reasoning_content`` surfaces the part-added chunk (instead of
+    dropping it for having empty text) and extracts the block id,
+  * ``handle_reasoning_event`` opens the reasoning message under that id and
+    does not emit an empty content delta for the id-bearing chunk,
+  * everything else (store=true empty-summary items, id-less providers,
+    non-first summary parts) behaves exactly as before.
+"""
+
+import unittest
+
+from ag_ui.core import EventType
+
+from ag_ui_langgraph.utils import resolve_reasoning_content
+from tests._helpers import make_agent, _record_dispatch
+
+
+class FakeChunk:
+    def __init__(self, content=None, additional_kwargs=None):
+        self.content = content or []
+        self.additional_kwargs = additional_kwargs or {}
+
+
+class TestResolveReasoningContentCanonicalId(unittest.TestCase):
+    def test_summary_part_added_chunk_carries_id(self):
+        """`response.reasoning_summary_part.added` shape: empty text, id set.
+
+        Must be surfaced (not dropped) so the id can seed REASONING_START.
+        """
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "id": "rs-canonical",
+            "summary": [{"index": 0, "type": "summary_text", "text": ""}],
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["text"], "")
+        self.assertEqual(result["id"], "rs-canonical")
+        self.assertEqual(result["index"], 0)
+
+    def test_summary_text_delta_chunk_has_no_id(self):
+        """`response.reasoning_summary_text.delta` shape: text, no id —
+        unchanged behavior, and no id key invented."""
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "summary": [{"index": 0, "type": "summary_text", "text": "Because X"}],
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["text"], "Because X")
+        self.assertIsNone(result.get("id"))
+
+    def test_id_attached_when_text_and_id_both_present(self):
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "id": "rs-canonical",
+            "summary": [{"index": 0, "type": "summary_text", "text": "Hi"}],
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        self.assertEqual(result["text"], "Hi")
+        self.assertEqual(result["id"], "rs-canonical")
+
+    def test_store_true_empty_summary_item_still_dropped(self):
+        """`response.output_item.added` for a store=true reasoning item has an
+        id but an empty summary list — must stay dropped (no ghost reasoning
+        bubble for summary-less reasoning)."""
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "id": "rs-canonical",
+            "summary": [],
+            "index": 0,
+        }])
+        self.assertIsNone(resolve_reasoning_content(chunk))
+
+    def test_non_first_summary_part_does_not_reuse_id(self):
+        """A second summary part (summary index 1) belongs to the same
+        reasoning item; reusing the canonical id there would mint two AG-UI
+        messages with the same id. It must fall back to the uuid path."""
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "id": "rs-canonical",
+            "summary": [{"index": 1, "type": "summary_text", "text": ""}],
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["index"], 1)
+        self.assertIsNone(result.get("id"))
+
+
+class TestHandleReasoningEventCanonicalId(unittest.TestCase):
+    def setUp(self):
+        self.agent = _record_dispatch(make_agent())
+        self.agent.active_run = {}
+
+    def _events(self, reasoning_data):
+        return list(self.agent.handle_reasoning_event(reasoning_data))
+
+    def test_reasoning_start_uses_canonical_id(self):
+        self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
+        start_events = [
+            e for e in self.agent.dispatched if e.type == EventType.REASONING_START
+        ]
+        self.assertEqual(len(start_events), 1)
+        self.assertEqual(start_events[0].message_id, "rs-canonical")
+
+    def test_empty_text_chunk_emits_no_content_delta(self):
+        self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
+        content_events = [
+            e
+            for e in self.agent.dispatched
+            if e.type == EventType.REASONING_MESSAGE_CONTENT
+        ]
+        self.assertEqual(content_events, [])
+
+    def test_subsequent_deltas_join_the_canonical_message(self):
+        self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
+        self._events({"type": "text", "text": "Because X", "index": 0})
+        start_events = [
+            e for e in self.agent.dispatched if e.type == EventType.REASONING_START
+        ]
+        content_events = [
+            e
+            for e in self.agent.dispatched
+            if e.type == EventType.REASONING_MESSAGE_CONTENT
+        ]
+        self.assertEqual(len(start_events), 1)
+        self.assertEqual(len(content_events), 1)
+        self.assertEqual(content_events[0].message_id, "rs-canonical")
+        self.assertEqual(content_events[0].delta, "Because X")
+
+    def test_uuid_fallback_when_stream_has_no_id(self):
+        self._events({"type": "text", "text": "thinking…", "index": 0})
+        start_events = [
+            e for e in self.agent.dispatched if e.type == EventType.REASONING_START
+        ]
+        self.assertEqual(len(start_events), 1)
+        self.assertTrue(start_events[0].message_id)
+        self.assertNotEqual(start_events[0].message_id, "rs-canonical")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_reasoning_canonical_id.py
+++ b/integrations/langgraph/python/tests/test_reasoning_canonical_id.py
@@ -7,17 +7,21 @@ emits checkpointed reasoning under the provider's canonical block id (OpenAI
 can never reconcile the streamed copy with the snapshot copy and renders the
 same reasoning twice (the langgraph-python dojo e2e strict-mode failure).
 
-With ``use_responses_api=True``, langchain-openai surfaces the canonical id on
-the ``response.reasoning_summary_part.added`` chunk (empty text, ``id`` set);
-the subsequent ``response.reasoning_summary_text.delta`` chunks carry text but
-no id. These tests pin that:
+With ``use_responses_api=True``, the canonical id only travels on text-less
+chunks — the ``response.output_item.added`` chunk (``{id, summary: []}``,
+observed on the LangGraph Platform wire) and, depending on the
+langchain-openai version, the ``…summary_part.added`` chunk (``{id, summary:
+[{text: ""}]}``). The ``…summary_text.delta`` chunks carry text but no id.
+These tests pin that:
 
-  * ``resolve_reasoning_content`` surfaces the part-added chunk (instead of
-    dropping it for having empty text) and extracts the block id,
-  * ``handle_reasoning_event`` opens the reasoning message under that id and
-    does not emit an empty content delta for the id-bearing chunk,
-  * everything else (store=true empty-summary items, id-less providers,
-    non-first summary parts) behaves exactly as before.
+  * ``resolve_reasoning_content`` surfaces the id-carrier chunks (instead of
+    dropping them for having no text) and extracts the block id,
+  * ``handle_reasoning_event`` stashes the id from a text-less chunk WITHOUT
+    emitting anything (summary-less store=true items must keep rendering
+    nothing) and opens the reasoning message under the stashed id when the
+    first text delta arrives,
+  * id-less providers keep the uuid fallback, and non-first summary parts
+    never reuse the item id.
 """
 
 import unittest
@@ -76,14 +80,32 @@ class TestResolveReasoningContentCanonicalId(unittest.TestCase):
         self.assertEqual(result["text"], "Hi")
         self.assertEqual(result["id"], "rs-canonical")
 
-    def test_store_true_empty_summary_item_still_dropped(self):
-        """`response.output_item.added` for a store=true reasoning item has an
-        id but an empty summary list — must stay dropped (no ghost reasoning
-        bubble for summary-less reasoning)."""
+    def test_item_added_empty_summary_carries_id(self):
+        """`response.output_item.added` shape ({id, summary: []}) — the only
+        id carrier on the LangGraph Platform wire. Surfaced as a text-less
+        carrier; handle_reasoning_event stashes it without emitting."""
         chunk = FakeChunk(content=[{
             "type": "reasoning",
             "id": "rs-canonical",
             "summary": [],
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["text"], "")
+        self.assertEqual(result["id"], "rs-canonical")
+
+    def test_empty_summary_without_id_still_dropped(self):
+        chunk = FakeChunk(content=[{"type": "reasoning", "summary": [], "index": 0}])
+        self.assertIsNone(resolve_reasoning_content(chunk))
+
+    def test_part_added_with_null_id_dropped(self):
+        """Observed platform wire shape: part.added with `id: null` and empty
+        text — nothing to surface."""
+        chunk = FakeChunk(content=[{
+            "type": "reasoning",
+            "id": None,
+            "summary": [{"index": 0, "type": "summary_text", "text": ""}],
             "index": 0,
         }])
         self.assertIsNone(resolve_reasoning_content(chunk))
@@ -112,22 +134,25 @@ class TestHandleReasoningEventCanonicalId(unittest.TestCase):
     def _events(self, reasoning_data):
         return list(self.agent.handle_reasoning_event(reasoning_data))
 
-    def test_reasoning_start_uses_canonical_id(self):
+    def test_id_carrier_chunk_emits_nothing(self):
+        """The text-less id carrier must not open a message — a store=true
+        item (id only, no summary ever) must keep rendering nothing."""
         self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
+        self.assertEqual(self.agent.dispatched, [])
+        self.assertEqual(
+            self.agent.active_run.get("pending_reasoning_id"), "rs-canonical"
+        )
+
+    def test_first_delta_opens_under_stashed_canonical_id(self):
+        self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
+        self._events({"type": "text", "text": "Because X", "index": 0})
         start_events = [
             e for e in self.agent.dispatched if e.type == EventType.REASONING_START
         ]
         self.assertEqual(len(start_events), 1)
         self.assertEqual(start_events[0].message_id, "rs-canonical")
-
-    def test_empty_text_chunk_emits_no_content_delta(self):
-        self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})
-        content_events = [
-            e
-            for e in self.agent.dispatched
-            if e.type == EventType.REASONING_MESSAGE_CONTENT
-        ]
-        self.assertEqual(content_events, [])
+        # consumed: a later id-less reasoning item must not inherit it
+        self.assertIsNone(self.agent.active_run.get("pending_reasoning_id"))
 
     def test_subsequent_deltas_join_the_canonical_message(self):
         self._events({"type": "text", "text": "", "index": 0, "id": "rs-canonical"})

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1575,7 +1575,11 @@ export class LangGraphAgent extends AbstractAgent {
   }
 
   handleReasoningEvent(reasoningData: LangGraphReasoning) {
-    if (!reasoningData || !reasoningData.type || !reasoningData.text) {
+    // An empty-text chunk is still meaningful when it carries the provider's
+    // canonical reasoning id (`response.reasoning_summary_part.added`): it
+    // opens the reasoning message under that id. Text-less AND id-less
+    // chunks remain dropped.
+    if (!reasoningData || !reasoningData.type || (!reasoningData.text && !reasoningData.id)) {
       return;
     }
 
@@ -1599,8 +1603,12 @@ export class LangGraphAgent extends AbstractAgent {
     }
 
     if (!this.reasoningProcess) {
-      // No thinking step yet. Start a new one
-      const messageId = randomUUID();
+      // No thinking step yet. Start a new one. Prefer the provider's
+      // canonical reasoning id (e.g. OpenAI `rs_…`) when the stream carries
+      // one: the snapshot converter re-emits this same reasoning under that
+      // id, and only a matching id lets the client reconcile the streamed
+      // copy with the snapshot copy instead of rendering both.
+      const messageId = reasoningData.id ?? randomUUID();
       this.dispatchEvent({
         type: EventType.REASONING_START,
         messageId,
@@ -1625,7 +1633,9 @@ export class LangGraphAgent extends AbstractAgent {
       this.reasoningProcess.signature = reasoningData.signature;
     }
 
-    if (this.reasoningProcess.type) {
+    // Skip empty deltas: the id-bearing `reasoning_summary_part.added`
+    // chunk carries no text — it exists only to open the message above.
+    if (this.reasoningProcess.type && reasoningData.text) {
       this.dispatchEvent({
         type: EventType.REASONING_MESSAGE_CONTENT,
         messageId: this.reasoningProcess.messageId,

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -158,6 +158,10 @@ export class LangGraphAgent extends AbstractAgent {
   messagesInProcess: MessagesInProgressRecord;
   emittedToolCallStartIds: Set<string> = new Set();
   reasoningProcess: null | ReasoningInProgress;
+  // Canonical reasoning id (e.g. OpenAI `rs_…`) stashed from a text-less id
+  // carrier chunk, consumed when the first text delta opens the reasoning
+  // message. See handleReasoningEvent.
+  private pendingReasoningId?: string;
   activeRun?: RunMetadata;
   // Subgraph node names discovered dynamically from langgraph_checkpoint_ns
   private subgraphs: Set<string> = new Set();
@@ -295,6 +299,7 @@ export class LangGraphAgent extends AbstractAgent {
       hasFunctionStreaming: false,
       modelMadeToolCall: false,
     };
+    this.pendingReasoningId = undefined;
     // Reset per-run flags
     this.cancelRequested = false;
     this.cancelSent = false;
@@ -1575,11 +1580,19 @@ export class LangGraphAgent extends AbstractAgent {
   }
 
   handleReasoningEvent(reasoningData: LangGraphReasoning) {
-    // An empty-text chunk is still meaningful when it carries the provider's
-    // canonical reasoning id (`response.reasoning_summary_part.added`): it
-    // opens the reasoning message under that id. Text-less AND id-less
-    // chunks remain dropped.
-    if (!reasoningData || !reasoningData.type || (!reasoningData.text && !reasoningData.id)) {
+    if (!reasoningData || !reasoningData.type) {
+      return;
+    }
+
+    // A text-less chunk is still meaningful when it carries the provider's
+    // canonical reasoning id (the `response.output_item.added` /
+    // `…summary_part.added` chunks): stash the id so the first text delta
+    // opens the reasoning message under it, WITHOUT opening a message here —
+    // a summary-less (store=true) reasoning item must keep rendering nothing.
+    if (!reasoningData.text) {
+      if (reasoningData.id) {
+        this.pendingReasoningId = reasoningData.id;
+      }
       return;
     }
 
@@ -1604,11 +1617,12 @@ export class LangGraphAgent extends AbstractAgent {
 
     if (!this.reasoningProcess) {
       // No thinking step yet. Start a new one. Prefer the provider's
-      // canonical reasoning id (e.g. OpenAI `rs_…`) when the stream carries
+      // canonical reasoning id (e.g. OpenAI `rs_…`) when the stream carried
       // one: the snapshot converter re-emits this same reasoning under that
       // id, and only a matching id lets the client reconcile the streamed
       // copy with the snapshot copy instead of rendering both.
-      const messageId = reasoningData.id ?? randomUUID();
+      const messageId = reasoningData.id ?? this.pendingReasoningId ?? randomUUID();
+      this.pendingReasoningId = undefined;
       this.dispatchEvent({
         type: EventType.REASONING_START,
         messageId,
@@ -1633,9 +1647,7 @@ export class LangGraphAgent extends AbstractAgent {
       this.reasoningProcess.signature = reasoningData.signature;
     }
 
-    // Skip empty deltas: the id-bearing `reasoning_summary_part.added`
-    // chunk carries no text — it exists only to open the message above.
-    if (this.reasoningProcess.type && reasoningData.text) {
+    if (this.reasoningProcess.type) {
       this.dispatchEvent({
         type: EventType.REASONING_MESSAGE_CONTENT,
         messageId: this.reasoningProcess.messageId,

--- a/integrations/langgraph/typescript/src/reasoning-content.test.ts
+++ b/integrations/langgraph/typescript/src/reasoning-content.test.ts
@@ -272,10 +272,35 @@ describe("resolveReasoningContent canonical id", () => {
     expect(result!.id).toBe("rs-canonical");
   });
 
-  it("still drops store=true items (id set, empty summary list)", () => {
+  it("surfaces the output_item.added shape (id, empty summary) as a text-less id carrier", () => {
+    // The only id carrier observed on the LangGraph Platform wire.
     const eventData = {
       chunk: {
         content: [{ type: "reasoning", id: "rs-canonical", summary: [], index: 0 }],
+      },
+    };
+    const result = resolveReasoningContent(eventData);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("");
+    expect(result!.id).toBe("rs-canonical");
+  });
+
+  it("drops empty-summary items without an id", () => {
+    const eventData = {
+      chunk: { content: [{ type: "reasoning", summary: [], index: 0 }] },
+    };
+    expect(resolveReasoningContent(eventData)).toBeNull();
+  });
+
+  it("drops the part.added shape when its id is null (platform wire shape)", () => {
+    const eventData = {
+      chunk: {
+        content: [{
+          type: "reasoning",
+          id: null,
+          summary: [{ index: 0, type: "summary_text", text: "" }],
+          index: 0,
+        }],
       },
     };
     expect(resolveReasoningContent(eventData)).toBeNull();
@@ -313,7 +338,13 @@ describe("handleReasoningEvent canonical id", () => {
     return { agent, dispatched };
   }
 
-  it("opens REASONING_START under the canonical id and skips the empty delta", () => {
+  it("stashes the id from a text-less carrier without emitting anything", () => {
+    const { agent, dispatched } = buildAgent();
+    agent.handleReasoningEvent({ type: "text", text: "", index: 0, id: "rs-canonical" });
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it("opens REASONING_START under the stashed canonical id on the first text delta", () => {
     const { agent, dispatched } = buildAgent();
     agent.handleReasoningEvent({ type: "text", text: "", index: 0, id: "rs-canonical" });
     agent.handleReasoningEvent({ type: "text", text: "Because X", index: 0 });

--- a/integrations/langgraph/typescript/src/reasoning-content.test.ts
+++ b/integrations/langgraph/typescript/src/reasoning-content.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { resolveReasoningContent, resolveEncryptedReasoningContent } from "./utils";
+import { LangGraphAgent } from "./agent";
+import { EventType } from "@ag-ui/client";
 
 describe("resolveReasoningContent", () => {
   it("should handle Anthropic old format (thinking)", () => {
@@ -211,5 +213,135 @@ describe("resolveEncryptedReasoningContent", () => {
         chunk: { content: [{ type: "redacted_thinking" }] },
       }),
     ).toBeNull();
+  });
+});
+
+// ─── Canonical reasoning id (snapshot reconciliation) ────────────────────────
+//
+// Since reasoning round-trips through MESSAGES_SNAPSHOT under the provider's
+// canonical block id (e.g. OpenAI `rs_…`), the streamed reasoning message must
+// open under that same id or the client renders the reasoning twice (the
+// langgraph-python dojo e2e strict-mode failure). The canonical id arrives on
+// the `response.reasoning_summary_part.added` chunk (empty text, id set).
+describe("resolveReasoningContent canonical id", () => {
+  it("surfaces the empty-text summary_part.added chunk and extracts the id", () => {
+    const eventData = {
+      chunk: {
+        content: [{
+          type: "reasoning",
+          id: "rs-canonical",
+          summary: [{ index: 0, type: "summary_text", text: "" }],
+          index: 0,
+        }],
+      },
+    };
+    const result = resolveReasoningContent(eventData);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("");
+    expect(result!.id).toBe("rs-canonical");
+    expect(result!.index).toBe(0);
+  });
+
+  it("does not invent an id on text delta chunks", () => {
+    const eventData = {
+      chunk: {
+        content: [{
+          type: "reasoning",
+          summary: [{ index: 0, type: "summary_text", text: "Because X" }],
+          index: 0,
+        }],
+      },
+    };
+    const result = resolveReasoningContent(eventData);
+    expect(result!.text).toBe("Because X");
+    expect(result!.id).toBeUndefined();
+  });
+
+  it("attaches the id when text and id are both present", () => {
+    const eventData = {
+      chunk: {
+        content: [{
+          type: "reasoning",
+          id: "rs-canonical",
+          summary: [{ index: 0, type: "summary_text", text: "Hi" }],
+        }],
+      },
+    };
+    const result = resolveReasoningContent(eventData);
+    expect(result!.text).toBe("Hi");
+    expect(result!.id).toBe("rs-canonical");
+  });
+
+  it("still drops store=true items (id set, empty summary list)", () => {
+    const eventData = {
+      chunk: {
+        content: [{ type: "reasoning", id: "rs-canonical", summary: [], index: 0 }],
+      },
+    };
+    expect(resolveReasoningContent(eventData)).toBeNull();
+  });
+
+  it("does not reuse the item id for non-first summary parts", () => {
+    const eventData = {
+      chunk: {
+        content: [{
+          type: "reasoning",
+          id: "rs-canonical",
+          summary: [{ index: 1, type: "summary_text", text: "" }],
+          index: 0,
+        }],
+      },
+    };
+    const result = resolveReasoningContent(eventData);
+    expect(result).not.toBeNull();
+    expect(result!.index).toBe(1);
+    expect(result!.id).toBeUndefined();
+  });
+});
+
+describe("handleReasoningEvent canonical id", () => {
+  function buildAgent() {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+    const dispatched: any[] = [];
+    (agent as any).dispatchEvent = (event: any) => {
+      dispatched.push(event);
+      return true;
+    };
+    return { agent, dispatched };
+  }
+
+  it("opens REASONING_START under the canonical id and skips the empty delta", () => {
+    const { agent, dispatched } = buildAgent();
+    agent.handleReasoningEvent({ type: "text", text: "", index: 0, id: "rs-canonical" });
+    agent.handleReasoningEvent({ type: "text", text: "Because X", index: 0 });
+
+    const starts = dispatched.filter((e) => e.type === EventType.REASONING_START);
+    const contents = dispatched.filter(
+      (e) => e.type === EventType.REASONING_MESSAGE_CONTENT,
+    );
+    expect(starts).toHaveLength(1);
+    expect(starts[0].messageId).toBe("rs-canonical");
+    expect(contents).toHaveLength(1);
+    expect(contents[0].messageId).toBe("rs-canonical");
+    expect(contents[0].delta).toBe("Because X");
+  });
+
+  it("falls back to a random id when the stream carries none", () => {
+    const { agent, dispatched } = buildAgent();
+    agent.handleReasoningEvent({ type: "text", text: "thinking…", index: 0 });
+
+    const starts = dispatched.filter((e) => e.type === EventType.REASONING_START);
+    expect(starts).toHaveLength(1);
+    expect(starts[0].messageId).toBeTruthy();
+    expect(starts[0].messageId).not.toBe("rs-canonical");
+  });
+
+  it("still drops chunks with neither text nor id", () => {
+    const { agent, dispatched } = buildAgent();
+    agent.handleReasoningEvent({ type: "text", text: "", index: 0 });
+    expect(dispatched).toHaveLength(0);
   });
 });

--- a/integrations/langgraph/typescript/src/types.ts
+++ b/integrations/langgraph/typescript/src/types.ts
@@ -137,4 +137,9 @@ export interface LangGraphReasoning {
   text: string;
   index: number;
   signature?: string;
+  // The provider's canonical id for the reasoning item (e.g. OpenAI
+  // `rs_…`), when the stream carries one. Used as the AG-UI reasoning
+  // message id so the streamed message reconciles with the snapshot copy
+  // emitted under the same id.
+  id?: string;
 }

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -453,18 +453,24 @@ export function resolveReasoningContent(eventData: any): LangGraphReasoning | nu
 
     // OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
     //
-    // The `response.reasoning_summary_part.added` chunk carries the reasoning
-    // item's canonical id (OpenAI `rs_…`) with an empty text, while the
-    // `…summary_text.delta` chunks carry text but no id. Surface the
-    // empty-text chunk too (instead of dropping it) so the reasoning message
-    // can open under the canonical id — the id the snapshot converter emits
-    // for the same block. Only the first summary part (index 0) takes the id:
-    // later parts belong to the same item, and reusing its id would mint two
-    // messages with one id. An item chunk with an empty summary LIST
-    // (store=true reasoning: id only, never any text) stays dropped.
-    if (block.type === 'reasoning' && Array.isArray(block.summary) && typeof block.summary[0] === 'object' && block.summary[0] !== null) {
+    // The reasoning item's canonical id (OpenAI `rs_…`) only travels on
+    // text-less chunks: the `response.output_item.added` chunk ({ id,
+    // summary: [] }) and — depending on the langchain-openai version — the
+    // `…summary_part.added` chunk ({ id, summary: [{ text: "" }] }). The
+    // `…summary_text.delta` chunks carry text but no id. Surface the id
+    // carriers (instead of dropping them for having no text) so the streamed
+    // reasoning message can adopt the canonical id — the id the snapshot
+    // converter emits for the same block; handleReasoningEvent stashes the id
+    // without opening a message, so summary-less (store=true) items still
+    // render nothing. Only the first summary part takes the id: later parts
+    // belong to the same item, and reusing its id would mint two messages
+    // with one id.
+    if (block.type === 'reasoning' && Array.isArray(block.summary)) {
+      if (block.summary.length === 0 && block.id) {
+        return { type: 'text', text: '', index: block.index ?? 0, id: String(block.id) };
+      }
       const part = block.summary[0];
-      if (part.text || block.id) {
+      if (part && typeof part === 'object' && (part.text || block.id)) {
         const result: LangGraphReasoning = {
           type: 'text',
           text: part.text ?? '',

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -452,11 +452,28 @@ export function resolveReasoningContent(eventData: any): LangGraphReasoning | nu
     }
 
     // OpenAI Responses API v1 format: { type: "reasoning", summary: [{ text: "..." }] }
-    if (block.type === 'reasoning' && block.summary?.[0]?.text) {
-      return {
-        type: 'text',
-        text: block.summary[0].text,
-        index: block.summary[0].index ?? 0,
+    //
+    // The `response.reasoning_summary_part.added` chunk carries the reasoning
+    // item's canonical id (OpenAI `rs_…`) with an empty text, while the
+    // `…summary_text.delta` chunks carry text but no id. Surface the
+    // empty-text chunk too (instead of dropping it) so the reasoning message
+    // can open under the canonical id — the id the snapshot converter emits
+    // for the same block. Only the first summary part (index 0) takes the id:
+    // later parts belong to the same item, and reusing its id would mint two
+    // messages with one id. An item chunk with an empty summary LIST
+    // (store=true reasoning: id only, never any text) stays dropped.
+    if (block.type === 'reasoning' && Array.isArray(block.summary) && typeof block.summary[0] === 'object' && block.summary[0] !== null) {
+      const part = block.summary[0];
+      if (part.text || block.id) {
+        const result: LangGraphReasoning = {
+          type: 'text',
+          text: part.text ?? '',
+          index: part.index ?? 0,
+        };
+        if (block.id && (part.index ?? 0) === 0) {
+          result.id = String(block.id);
+        }
+        return result;
       }
     }
 

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -438,3 +438,111 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
     ]);
   });
 });
+
+describe("MESSAGES_SNAPSHOT with snapshot-supplied reasoning", () => {
+  // When the backend includes reasoning in the snapshot (e.g. LangGraph
+  // re-deriving it from checkpointed content blocks), the snapshot is the
+  // source of truth for reasoning: the streamed copy — which carries a
+  // different, locally-generated id — must be replaced, not kept alongside.
+
+  it("replaces streamed reasoning with the snapshot's canonical copy when ids differ", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "What is the best car to buy?" },
+        { id: "uuid-a", role: "reasoning", content: "The user wants a car recommendation." },
+        { id: "lc-1", role: "assistant", content: "Based on my analysis…" },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "What is the best car to buy?" },
+        { id: "rs-1", role: "reasoning", content: "The user wants a car recommendation." },
+        { id: "resp-1", role: "assistant", content: "Based on my analysis…" },
+      ],
+    );
+
+    expect(msgs.filter((m) => m.role === "reasoning").length).toBe(1);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "rs-1", "resp-1"]);
+  });
+
+  it("replaces streamed reasoning when the snapshot arrives before the assistant streamed", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "What is the best car to buy?" },
+        { id: "uuid-a", role: "reasoning", content: "The user wants a car recommendation." },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "What is the best car to buy?" },
+        { id: "rs-1", role: "reasoning", content: "The user wants a car recommendation." },
+        { id: "resp-1", role: "assistant", content: "Based on my analysis…" },
+      ],
+    );
+
+    expect(msgs.filter((m) => m.role === "reasoning").length).toBe(1);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "rs-1", "resp-1"]);
+  });
+
+  it("converges multi-turn reasoning to one message per turn", async () => {
+    // Models turn 2 of the real flow: turn 1 already converged to canonical
+    // ids via its own end-of-run snapshot; turn 2's streamed reasoning and
+    // assistant still carry locally-generated ids.
+    const msgs = await applySnapshot(
+      [
+        { id: "u1", role: "user", content: "q1" },
+        { id: "rs-1", role: "reasoning", content: "thinking about q1" },
+        { id: "resp-1", role: "assistant", content: "a1" },
+        { id: "u2", role: "user", content: "q2" },
+        { id: "uuid-b", role: "reasoning", content: "thinking about q2" },
+        { id: "lc-2", role: "assistant", content: "a2" },
+      ] as Message[],
+      [
+        { id: "u1", role: "user", content: "q1" },
+        { id: "rs-1", role: "reasoning", content: "thinking about q1" },
+        { id: "resp-1", role: "assistant", content: "a1" },
+        { id: "u2", role: "user", content: "q2" },
+        { id: "rs-2", role: "reasoning", content: "thinking about q2" },
+        { id: "resp-2", role: "assistant", content: "a2" },
+      ],
+    );
+
+    expect(msgs.filter((m) => m.role === "reasoning").length).toBe(2);
+    expect(msgs.map((m) => m.id)).toEqual(["u1", "rs-1", "resp-1", "u2", "rs-2", "resp-2"]);
+  });
+
+  it("still preserves activity messages when the snapshot carries reasoning", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["a"] } },
+        { id: "uuid-a", role: "reasoning", content: "thinking" },
+        { id: "lc-1", role: "assistant", content: "hi" },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "rs-1", role: "reasoning", content: "thinking" },
+        { id: "resp-1", role: "assistant", content: "hi" },
+      ],
+    );
+
+    expect(msgs.filter((m) => m.role === "activity").length).toBe(1);
+    expect(msgs.filter((m) => m.role === "reasoning").length).toBe(1);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-1", "rs-1", "resp-1"]);
+  });
+
+  it("updates an id-stable reasoning message with the snapshot version", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "r1", role: "reasoning", content: "thinking" },
+        { id: "a1", role: "assistant", content: "hi" },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "r1", role: "reasoning", content: "thinking", encryptedValue: "enc-1" } as Message,
+        { id: "a1", role: "assistant", content: "hi" },
+      ],
+    );
+
+    expect(msgs.filter((m) => m.role === "reasoning").length).toBe(1);
+    const reasoning = msgs.find((m) => m.id === "r1")! as { encryptedValue?: string };
+    expect(reasoning.encryptedValue).toBe("enc-1");
+  });
+});

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -591,17 +591,34 @@ export const defaultApplyEvents = (
             const { messages: newMessages } = event as MessagesSnapshotEvent;
 
             // Edit-based merge: update existing messages with snapshot data while
-            // preserving activity and reasoning messages (which the backend
-            // doesn't include in the snapshot).
+            // preserving client-only messages the backend leaves out of the
+            // snapshot.
             const snapshotMap = new Map(newMessages.map((m) => [m.id, m]));
 
-            // Step 1 + 2: Keep activity/reasoning messages as-is, keep messages
-            // present in the snapshot (replaced with snapshot version), drop
-            // everything else.
-            const isClientOnlyRole = (role: string) => role === "activity" || role === "reasoning";
+            // `activity` messages are always client-only — backends never include
+            // them in MESSAGES_SNAPSHOT — so they are always preserved.
+            //
+            // `reasoning` messages are only sometimes client-only. Most backends
+            // never include reasoning in the snapshot (it exists purely as
+            // streamed REASONING_* events), so dropping local reasoning here
+            // would lose it. But a backend that round-trips reasoning (e.g.
+            // LangGraph re-deriving it from checkpointed content blocks)
+            // re-delivers the streamed reasoning under its own canonical id —
+            // message ids are generally NOT stable between streamed events and
+            // the snapshot. Preserving the streamed copy next to the snapshot
+            // copy would render the same reasoning twice. So when the snapshot
+            // itself carries reasoning, treat it as the source of truth for
+            // reasoning messages too and apply the normal replace semantics.
+            const snapshotHasReasoning = newMessages.some((m) => m.role === "reasoning");
+            const isPreservedClientOnly = (m: Message) =>
+              m.role === "activity" || (m.role === "reasoning" && !snapshotHasReasoning);
+
+            // Step 1 + 2: Keep preserved client-only messages as-is, keep
+            // messages present in the snapshot (replaced with snapshot version),
+            // drop everything else.
             messages = messages
-              .filter((m) => isClientOnlyRole(m.role) || snapshotMap.has(m.id))
-              .map((m) => (isClientOnlyRole(m.role) ? m : snapshotMap.get(m.id)!));
+              .filter((m) => isPreservedClientOnly(m) || snapshotMap.has(m.id))
+              .map((m) => (isPreservedClientOnly(m) ? m : snapshotMap.get(m.id)!));
 
             // Step 3: Append messages from the snapshot that we don't have yet.
             const existingIds = new Set(messages.map((m) => m.id));


### PR DESCRIPTION
## Problem

The langgraph-python dojo e2e has failed deterministically on main since 2111267. One turn renders two identical "Thought for..." reasoning collapsibles:

```
Error: strict mode violation: getByText(/Thought for/i) resolved to 2 elements
```

Failing runs: [ag-ui e2e on 2111267](https://github.com/ag-ui-protocol/ag-ui/actions/runs/27299771076), [CopilotKit dojo e2e](https://github.com/CopilotKit/CopilotKit/actions/runs/27299986729).

## Root cause

The same reasoning exists under two different ids, so the client cannot tell the copies apart:

1. While streaming, the integration mints a `randomUUID()` for `REASONING_START`.
2. Since 2111267, the snapshot re-delivers that reasoning under its canonical provider id (`rs_...`).
3. The client preserves streamed reasoning (it assumes backends never snapshot it, per #1370) and appends snapshot messages with unknown ids. Result: both copies render.

## Fix

Two complementary changes:

**1. Integration (Python + TypeScript): stream reasoning under the canonical id.**

The canonical id is already on the wire, but only on text-less chunks. Captured from `langgraph dev`:

```
{"id": "rs-...", "summary": [], "type": "reasoning"}     <- output_item.added: id, no text
{"id": null, "summary": [{"text": ""}]}                  <- summary_part.added: no id
{"summary": [{"text": "The user wants..."}]}             <- deltas: text, no id
```

Previously these id carriers were dropped for having no text. Now the integration stashes the id from a text-less chunk (without opening a message, so summary-less store=true items still render nothing) and opens the reasoning message under it on the first text delta. Providers that stream no id keep the uuid fallback.

With matching ids the already-released client (0.0.53) dedupes on its own, which is what turns this e2e green without waiting for a client release.

**2. Client: snapshot wins when it carries reasoning.**

If a snapshot includes reasoning messages, treat it as the source of truth and drop streamed copies. Snapshots without reasoning preserve local reasoning exactly as before. This covers backends that round-trip reasoning under ids the stream cannot know.

## Verification

- Wire probe against `langgraph dev` + aimock: streamed `REASONING_START` and the snapshot reasoning message now share the same `rs-...` id.
- Client: 494/494. LangGraph Python: 197/197. LangGraph TypeScript: 196 passed.
- This PR's `dojo / langgraph-python` job (red on main, red on the first attempt here) is green.

## Follow-up (not in this PR)

- Anthropic `thinking` blocks do not round-trip into snapshots, so mixed-model threads drop that turn's reasoning bubble at snapshot time.
- Message ids are generally not stable between stream and snapshot (the assistant is re-identified too: `lc_run-...` vs `resp-...`). Worth deciding a protocol-level rule rather than handling it per-role.
