### PR TITLE
fix(dojo): only enable runtime a2ui config for integrations with a2ui agents

### DIFF
--- a/apps/dojo/src/app/api/copilotkit/[integrationId]/[[...slug]]/route.ts
+++ b/apps/dojo/src/app/api/copilotkit/[integrationId]/[[...slug]]/route.ts
@@ -33,17 +33,30 @@ async function getHandler(integrationId: string) {
 
   const agents = await getAgents();
 
+  // Passing any `a2ui` config makes the runtime advertise `a2uiEnabled: true`
+  // for the whole endpoint (the per-agent scoping below is not forwarded in
+  // the runtime info response), and the client's CopilotKitProvider then
+  // injects the A2UI catalog/schema/guidelines context (~30KB) into every
+  // agent run it serves. Only enable it for integrations that actually have
+  // a2ui agents (currently just langgraph).
+  const a2uiAgentIds = ["a2ui_fixed_schema", "a2ui_dynamic_schema", "a2ui_advanced", "a2ui_recovery"];
+  const hasA2uiAgents = a2uiAgentIds.some((id) => id in agents);
+
   const runtime = new CopilotRuntime({
     agents: agents as Record<string, AbstractAgent>,
     runner: new InMemoryAgentRunner(),
-    a2ui: {
-      agents: ["a2ui_fixed_schema", "a2ui_dynamic_schema", "a2ui_advanced", "a2ui_recovery"],
-      // Catalog used when creating a surface from a STREAMED render_a2ui call.
-      // Only the dynamic (subagent) agents stream; fixed_schema uses direct
-      // tools that carry their own catalog in the result envelope, so a single
-      // catalog id here is correct for every streaming agent.
-      defaultCatalogId: "https://a2ui.org/demos/dojo/dynamic_catalog.json",
-    },
+    ...(hasA2uiAgents
+      ? {
+          a2ui: {
+            agents: a2uiAgentIds,
+            // Catalog used when creating a surface from a STREAMED render_a2ui call.
+            // Only the dynamic (subagent) agents stream; fixed_schema uses direct
+            // tools that carry their own catalog in the result envelope, so a single
+            // catalog id here is correct for every streaming agent.
+            defaultCatalogId: "https://a2ui.org/demos/dojo/dynamic_catalog.json",
+          },
+        }
+      : {}),
   });
 
   const app = createCopilotEndpointSingleRoute({


### PR DESCRIPTION
## Problem

Every agent request from the dojo — for **every** integration and feature — carries four A2UI context entries (catalog capabilities, the full component JSON Schema, generation guidelines, design guidelines; ~30KB total). They show up in `RunAgentInput.context` even for agents with no relation to A2UI, e.g. the ADK middleware Human-in-the-Loop agent.

## Cause

The shared v1 runtime route (`/api/copilotkit/[integrationId]`) constructs **every** integration's `CopilotRuntime` with the `a2ui` config block. The chain:

1. `@copilotkit/runtime` 1.59.5 advertises `a2uiEnabled: !!runtime.a2ui` in its runtime-info response — an **endpoint-wide boolean**; the per-agent scoping in `a2ui.agents` is not forwarded.
2. `@copilotkit/core` stores it globally (`_a2uiEnabled = runtimeInfoResponse.a2uiEnabled`).
3. `CopilotKitProvider` (the v1 `<CopilotKit>` wrapping every dojo feature page) auto-mounts `A2UICatalogContext` whenever the flag is true.
4. `A2UICatalogContext` `addContext()`s the four entries into the **global** context store, which is attached to **every** agent run.

So although the dojo's config correctly scopes A2UI to four agents, the runtime/client flatten that scoping into "on for everything".

## Fix

Gate the `a2ui` block on the integration actually exposing a2ui agents (currently only `langgraph`). All other integrations' runtime info now reports `a2uiEnabled: false`, and their requests stay free of A2UI context. The a2ui feature pages are unaffected — their integration still gets the exact same config.

The scoping flattening itself is an upstream CopilotKit issue (runtime info should forward `a2ui.agents`; the client should attach catalog context only to runs against a2ui-enabled agents) and is being filed against CopilotKit separately.

## Validation

- `tsc -p apps/dojo/tsconfig.json --noEmit`: no errors in the changed file (pre-existing unrelated errors in workspace package sources only).
- Behavior: with this change, non-langgraph integrations construct their runtime without `a2ui`, so `get-runtime-info` returns `a2uiEnabled: false` → `CopilotKitProvider` no longer mounts `A2UICatalogContext` → no A2UI context entries on e.g. ADK HITL requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
