### PR TITLE
feat(a2a): pass RunAgentInput.state through A2A and emit STATE_SNAPSHOT/STATE_DELTA

### DIFF
--- a/integrations/a2a/typescript/src/__tests__/agent.test.ts
+++ b/integrations/a2a/typescript/src/__tests__/agent.test.ts
@@ -17,6 +17,8 @@ type SendMessageResponseError = {
 };
 
 class FakeA2AClient {
+  public lastSendParams: MessageSendParams | undefined;
+
   constructor(
     readonly behaviour: {
       stream?: () => AsyncGenerator<any, void, unknown>;
@@ -26,6 +28,7 @@ class FakeA2AClient {
   ) {}
 
   sendMessageStream(params: MessageSendParams) {
+    this.lastSendParams = params;
     if (!this.behaviour.stream) {
       throw new Error("Streaming not configured");
     }
@@ -33,6 +36,7 @@ class FakeA2AClient {
   }
 
   async sendMessage(params: MessageSendParams) {
+    this.lastSendParams = params;
     if (!this.behaviour.send) {
       throw new Error("sendMessage not configured");
     }
@@ -139,5 +143,71 @@ describe("A2AAgent", () => {
     });
 
     await expect(agent.runAgent()).rejects.toThrow("Agent failure");
+  });
+
+  it("passes RunAgentInput.state as metadata['x-agui-state'] in MessageSendParams", async () => {
+    const fakeClient = new FakeA2AClient({
+      stream: async function* () {
+        yield {
+          kind: "message",
+          messageId: "resp-state",
+          role: "agent",
+          parts: [{ kind: "text", text: "ok" }],
+        };
+      },
+    });
+
+    const agent = new A2AAgent({ a2aClient: fakeClient as any });
+
+    const state = { host: { route: "/insights" }, selectedInsight: { id: "abc" } };
+
+    await new Promise<void>((resolve, reject) => {
+      agent
+        .run({
+          runId: "run-1",
+          threadId: "thread-1",
+          messages: [createMessage({ id: "u1", role: "user", content: "hi" })],
+          state,
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        })
+        .subscribe({ complete: resolve, error: reject });
+    });
+
+    expect(fakeClient.lastSendParams?.metadata).toEqual(
+      expect.objectContaining({ "x-agui-state": state }),
+    );
+  });
+
+  it("omits metadata when state is empty", async () => {
+    const fakeClient = new FakeA2AClient({
+      stream: async function* () {
+        yield {
+          kind: "message",
+          messageId: "resp-no-state",
+          role: "agent",
+          parts: [{ kind: "text", text: "ok" }],
+        };
+      },
+    });
+
+    const agent = new A2AAgent({ a2aClient: fakeClient as any });
+
+    await new Promise<void>((resolve, reject) => {
+      agent
+        .run({
+          runId: "run-2",
+          threadId: "thread-2",
+          messages: [createMessage({ id: "u2", role: "user", content: "hi" })],
+          state: {},
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        })
+        .subscribe({ complete: resolve, error: reject });
+    });
+
+    expect(fakeClient.lastSendParams?.metadata).toBeUndefined();
   });
 });

--- a/integrations/a2a/typescript/src/__tests__/utils.test.ts
+++ b/integrations/a2a/typescript/src/__tests__/utils.test.ts
@@ -181,6 +181,74 @@ describe("convertA2AEventToAGUIEvents", () => {
 
     expect(events).toHaveLength(0);
   });
+
+  it("emits STATE_SNAPSHOT when a data part with type agui-state-snapshot is received", () => {
+    const snapshot = { selectedInsight: { id: "abc", title: "Abandono no bloco CPF" } };
+    const a2aEvent = {
+      kind: "message" as const,
+      messageId: "state-msg-1",
+      role: "agent" as const,
+      parts: [
+        {
+          kind: "data" as const,
+          data: { type: "agui-state-snapshot", snapshot },
+        },
+      ],
+    };
+
+    const events = convertA2AEventToAGUIEvents(a2aEvent, { messageIdMap: new Map() });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        type: EventType.STATE_SNAPSHOT,
+        snapshot,
+      }),
+    );
+  });
+
+  it("emits STATE_DELTA when a data part with type agui-state-delta is received", () => {
+    const patch = [{ op: "replace", path: "/selectedInsight/status", value: "analyzing" }];
+    const a2aEvent = {
+      kind: "message" as const,
+      messageId: "state-msg-2",
+      role: "agent" as const,
+      parts: [
+        {
+          kind: "data" as const,
+          data: { type: "agui-state-delta", patch },
+        },
+      ],
+    };
+
+    const events = convertA2AEventToAGUIEvents(a2aEvent, { messageIdMap: new Map() });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        type: EventType.STATE_DELTA,
+        delta: patch,
+      }),
+    );
+  });
+
+  it("skips a state-delta data part with a non-array patch", () => {
+    const a2aEvent = {
+      kind: "message" as const,
+      messageId: "state-msg-3",
+      role: "agent" as const,
+      parts: [
+        {
+          kind: "data" as const,
+          data: { type: "agui-state-delta", patch: "invalid" },
+        },
+      ],
+    };
+
+    const events = convertA2AEventToAGUIEvents(a2aEvent, { messageIdMap: new Map() });
+
+    expect(events).toHaveLength(0);
+  });
 });
 
 describe("sendMessageToA2AAgentTool", () => {

--- a/integrations/a2a/typescript/src/agent.ts
+++ b/integrations/a2a/typescript/src/agent.ts
@@ -154,6 +154,11 @@ export class A2AAgent extends AbstractAgent {
     return {
       message,
       configuration,
+      ...(input.state &&
+        typeof input.state === "object" &&
+        Object.keys(input.state as Record<string, unknown>).length > 0 && {
+          metadata: { "x-agui-state": input.state },
+        }),
     } as MessageSendParams;
   }
 

--- a/integrations/a2a/typescript/src/utils.ts
+++ b/integrations/a2a/typescript/src/utils.ts
@@ -4,6 +4,8 @@ import type {
   Message,
   TextMessageChunkEvent,
   RawEvent,
+  StateDeltaEvent,
+  StateSnapshotEvent,
   ToolCallArgsEvent,
   ToolCallEndEvent,
   ToolCallStartEvent,
@@ -37,6 +39,14 @@ const SURFACE_OPERATION_KEYS = [
   "surfaceUpdate",
   "dataModelUpdate",
 ] as const;
+
+/**
+ * Data part `type` values used to carry AG-UI state events back to the client.
+ * The server emits a data part with one of these types inside
+ * `status-update.status.message.parts`.
+ */
+export const AGUI_STATE_SNAPSHOT_TYPE = "agui-state-snapshot";
+export const AGUI_STATE_DELTA_TYPE = "agui-state-delta";
 
 type SurfaceOperationKey = (typeof SURFACE_OPERATION_KEYS)[number];
 
@@ -405,6 +415,35 @@ function convertMessageToEvents(
           ],
         } as BaseEvent);
 
+        continue;
+      }
+
+      // State snapshot/delta sent back by the agent via a data part.
+      if (
+        payload &&
+        typeof payload === "object" &&
+        (payload as Record<string, unknown>).type === AGUI_STATE_SNAPSHOT_TYPE
+      ) {
+        const statePayload = payload as { type: string; snapshot: unknown };
+        events.push({
+          type: EventType.STATE_SNAPSHOT,
+          snapshot: statePayload.snapshot,
+        } as StateSnapshotEvent);
+        continue;
+      }
+
+      if (
+        payload &&
+        typeof payload === "object" &&
+        (payload as Record<string, unknown>).type === AGUI_STATE_DELTA_TYPE
+      ) {
+        const statePayload = payload as { type: string; patch: unknown[] };
+        if (Array.isArray(statePayload.patch)) {
+          events.push({
+            type: EventType.STATE_DELTA,
+            delta: statePayload.patch,
+          } as StateDeltaEvent);
+        }
         continue;
       }
 


### PR DESCRIPTION
> Fixes #1938

## Summary

`RunAgentInput.state` is silently dropped by `A2AAgent.createSendParams()`. This PR forwards it via `MessageSendParams.metadata["x-agui-state"]` (the A2A spec's own extension point) and adds a return path so the agent can emit `STATE_SNAPSHOT` / `STATE_DELTA` events back to the host.

## Changes

### `agent.ts` — outbound state

Forward `state` to `MessageSendParams.metadata["x-agui-state"]` when non-empty:

```typescript
return {
  message,
  configuration,
  ...(input.state &&
    typeof input.state === "object" &&
    Object.keys(input.state as Record<string, unknown>).length > 0 && {
      metadata: { "x-agui-state": input.state },
    }),
} as MessageSendParams;
```

Empty `state` objects (`{}`) do **not** produce a `metadata` key — backward-compatible with servers that ignore unknown metadata.

### `utils.ts` — inbound state events

Export two type constants and recognise them in `convertMessageToEvents()`:

```typescript
export const AGUI_STATE_SNAPSHOT_TYPE = "agui-state-snapshot";
export const AGUI_STATE_DELTA_TYPE    = "agui-state-delta";
```

Server emits a data part inside `status-update.status.message.parts`:

```json
{ "kind": "data", "data": { "type": "agui-state-snapshot", "snapshot": { ... } } }
{ "kind": "data", "data": { "type": "agui-state-delta",    "patch":    [ ... ] } }
```

Adapter converts them to `STATE_SNAPSHOT` / `STATE_DELTA` events, which CopilotKit / `useCoAgent` apply automatically. No extra code needed on the consumer side.

### Tests

| File | New cases |
|---|---|
| `__tests__/agent.test.ts` | state passed as `metadata["x-agui-state"]`; empty state omits metadata |
| `__tests__/utils.test.ts` | `STATE_SNAPSHOT` emitted; `STATE_DELTA` emitted; malformed (non-array) patch silently skipped |

## Behavior table

| `input.state` | `MessageSendParams.metadata` |
|---|---|
| `undefined` | field omitted |
| `{}` | field omitted |
| `{ route: "/dashboard" }` | `{ "x-agui-state": { route: "/dashboard" } }` |

| Server data part `type` | AG-UI event |
|---|---|
| `"agui-state-snapshot"` | `STATE_SNAPSHOT` |
| `"agui-state-delta"` + array patch | `STATE_DELTA` |
| `"agui-state-delta"` + non-array | silently skipped |
