### PR TITLE
fix(client): bind default fetch in HttpAgent to prevent browser "Illegal invocation"

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/http-fetch-binding.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/http-fetch-binding.test.ts
@@ -1,0 +1,69 @@
+import { HttpAgent } from "../http";
+import { runHttpRequest } from "@/run/http-request";
+import { RunAgentInput } from "@ag-ui/core";
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from "vitest";
+
+// Capture the fetch thunk passed to runHttpRequest without performing a real request.
+vi.mock("@/run/http-request", () => ({
+  runHttpRequest: vi.fn(() => ({ subscribe: () => ({ unsubscribe: () => {} }) })),
+}));
+vi.mock("@/transform/http", () => ({
+  transformHttpEventStream: vi.fn((source$) => source$),
+}));
+
+const minimalInput = (): RunAgentInput =>
+  ({
+    threadId: "t1",
+    runId: "r1",
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    state: {},
+    messages: [],
+  }) as unknown as RunAgentInput;
+
+describe("HttpAgent fetch receiver binding", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // Regression test for the browser "Illegal invocation" bug: when HttpAgent stores
+  // the global fetch unbound (`this.fetch = config.fetch ?? fetch`) and later calls
+  // it as a method (`this.fetch(...)`), the receiver becomes the agent instead of
+  // window. A browser's native fetch is a checked-receiver method and throws. Node's
+  // fetch tolerates it, so this only surfaces in the browser — exactly the dojo e2e
+  // failure. We simulate the browser's checked receiver here.
+  it("calls the default global fetch with a valid receiver (no Illegal invocation)", async () => {
+    const seen: Array<{ url: string }> = [];
+    const checkedReceiverFetch = function (
+      this: unknown,
+      url: string,
+      _init?: RequestInit,
+    ) {
+      if (this !== globalThis && this !== undefined) {
+        throw new TypeError(
+          "Failed to execute 'fetch' on 'Window': Illegal invocation",
+        );
+      }
+      seen.push({ url });
+      return Promise.resolve(new Response("ok"));
+    };
+    globalThis.fetch = checkedReceiverFetch as unknown as typeof globalThis.fetch;
+
+    const agent = new HttpAgent({ url: "https://api.example.com/agent" });
+
+    agent.run(minimalInput());
+
+    const thunk = (runHttpRequest as Mock).mock.calls[0][0] as () => Promise<Response>;
+    await expect(thunk()).resolves.toBeInstanceOf(Response);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("https://api.example.com/agent");
+  });
+});

--- a/sdks/typescript/packages/client/src/agent/http.ts
+++ b/sdks/typescript/packages/client/src/agent/http.ts
@@ -53,7 +53,12 @@ export class HttpAgent extends AbstractAgent {
     super(config);
     this.url = config.url;
     this.headers = structuredClone_(config.headers ?? {});
-    this.fetch = config.fetch ?? fetch;
+    // Bind the default fetch to the global object. Storing the bare `fetch`
+    // and later invoking it as `this.fetch(...)` sets the receiver to the agent
+    // instance; a browser's native fetch is a checked-receiver method and throws
+    // "Illegal invocation" when not called with `window` as `this`. (Node's fetch
+    // tolerates any receiver, so this only surfaces in the browser.)
+    this.fetch = config.fetch ?? ((url, requestInit) => fetch(url, requestInit));
   }
 
   run(input: RunAgentInput): Observable<BaseEvent> {


### PR DESCRIPTION
## Problem

`HttpAgent` stored the global `fetch` **unbound** and invoked it as a method:

```ts
// sdks/typescript/packages/client/src/agent/http.ts
this.fetch = config.fetch ?? fetch;                       // unbound native fetch
...
runHttpRequest(() => this.fetch(this.url, this.requestInit(input)));   // this === agent
```

A browser's native `fetch` is a **checked-receiver** method: calling it with `this !== window` throws `TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation`. Node's `fetch` tolerates any receiver, so the bug is **invisible server-side and only fires in the browser**.

## Impact

Any browser client that runs an agent through `HttpAgent`'s request path breaks. In particular `@copilotkit/core`'s `ProxiedCopilotRuntimeAgent` extends `HttpAgent` and — as of **CopilotKit 1.60.0** — routes connect/run through `this.fetch(...)`. The result: the **AG-UI Dojo v2 agentic-chat e2e hangs across all proxied integrations** (the run never starts; the runtime-info handshake, which uses a bare `fetch(...)`, still succeeds). v1 (GraphQL client) and in-process agents are unaffected.

## Root-cause proof

Driving the real `@copilotkit/core` 1.60.0 client against a live dojo endpoint (aimock, no keys) in Node:
- with Node's native `fetch` → run completes, assistant replies `"Hello world!"`.
- with a **browser-accurate checked-receiver `fetch`** → `connectAgent`/`runAgent` throw `Illegal invocation`, 0 assistant messages — exactly the e2e symptom.

The only variable is the receiver check.

## Fix

```ts
this.fetch = config.fetch ?? ((url, requestInit) => fetch(url, requestInit));
```

Binding the default fetch keeps the receiver correct at every call site (including subclasses like `ProxiedCopilotRuntimeAgent`). Added a regression test that simulates the browser's checked receiver and asserts the run path no longer throws.

## Verification

- New `http-fetch-binding.test.ts`: **RED** before the fix (`Illegal invocation` at `http.ts:60`), **GREEN** after.
- Existing `http.test.ts` (6 tests) still pass; full client suite green except a pre-existing, unrelated `esm-interop` env failure (fails on `main` without this change too).
- `pnpm build` for `@ag-ui/client` succeeds.

> Note: this is the source-of-truth fix. To unblock the dojo's CopilotKit 1.60.0 bump, `@ag-ui/client` needs a release that `@copilotkit/core` then consumes (the dojo's `@copilotkit/core@1.60.0` currently links the published `@ag-ui/client@0.0.56`, which still has the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)