### PR TITLE
test(a2ui-toolkit): de-flake deep child-chain cycle tests

### DIFF
--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
@@ -179,25 +179,39 @@ describe("validateA2UIComponents — child cycles", () => {
     expect(r.errors.some((e) => e.code === "child_cycle")).toBe(false);
   });
 
-  it("handles a pathologically deep child chain without overflowing the stack", () => {
-    // The cycle check runs on untrusted model output; a deep linear chain that
-    // would blow a recursive DFS's call stack must validate iteratively. 50k deep
-    // is well past V8's recursion limit but a no-op for the explicit-stack walk.
-    const N = 50000;
-    const comps: Array<Record<string, unknown>> = [{ id: "root", component: "Row", children: ["n0"] }];
-    for (let i = 0; i < N; i++) comps.push({ id: `n${i}`, component: "Row", children: i + 1 < N ? [`n${i + 1}`] : [] });
-    const r = validateA2UIComponents({ components: comps });
-    expect(r.errors.some((e) => e.code === "child_cycle")).toBe(false);
-  });
+  it(
+    "handles a pathologically deep child chain without overflowing the stack",
+    () => {
+      // The cycle check runs on untrusted model output; a deep linear chain that
+      // would blow a recursive DFS's call stack must validate iteratively. 20k deep
+      // is >2x V8's recursion overflow depth (~8.8k for a trivial frame, lower for
+      // a real DFS frame), so it still proves the walk is iterative — but allocates
+      // far less than 50k, keeping GC pressure (and thus the chance of a CI-runner
+      // stall) low. The explicit-stack walk itself is linear (~25ms for this N).
+      const N = 20000;
+      const comps: Array<Record<string, unknown>> = [{ id: "root", component: "Row", children: ["n0"] }];
+      for (let i = 0; i < N; i++) comps.push({ id: `n${i}`, component: "Row", children: i + 1 < N ? [`n${i + 1}`] : [] });
+      const r = validateA2UIComponents({ components: comps });
+      expect(r.errors.some((e) => e.code === "child_cycle")).toBe(false);
+    },
+    // The work is ~25ms; the default 5s timeout flaked under parallel-fork GC
+    // contention on shared CI runners. A generous explicit budget decouples the
+    // (provably fast) assertion from runner scheduling jitter.
+    30000,
+  );
 
-  it("detects a cycle that closes at the end of a deep chain", () => {
-    // Same deep chain, but the tail points back at root — one cycle, no overflow.
-    const N = 50000;
-    const comps: Array<Record<string, unknown>> = [{ id: "root", component: "Row", children: ["n0"] }];
-    for (let i = 0; i < N; i++) comps.push({ id: `n${i}`, component: "Row", children: [i + 1 < N ? `n${i + 1}` : "root"] });
-    const r = validateA2UIComponents({ components: comps });
-    expect(r.errors.filter((e) => e.code === "child_cycle").length).toBe(1);
-  });
+  it(
+    "detects a cycle that closes at the end of a deep chain",
+    () => {
+      // Same deep chain, but the tail points back at root — one cycle, no overflow.
+      const N = 20000;
+      const comps: Array<Record<string, unknown>> = [{ id: "root", component: "Row", children: ["n0"] }];
+      for (let i = 0; i < N; i++) comps.push({ id: `n${i}`, component: "Row", children: [i + 1 < N ? `n${i + 1}` : "root"] });
+      const r = validateA2UIComponents({ components: comps });
+      expect(r.errors.filter((e) => e.code === "child_cycle").length).toBe(1);
+    },
+    30000,
+  );
 });
 
 describe("validateA2UIComponents — data bindings", () => {


### PR DESCRIPTION
## Problem

The two deep-chain cycle tests in `sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts` intermittently trip vitest's 5000ms default timeout on CI (measured ~5358ms), reddening the `unit` workflow's `typescript` job repo-wide. Unrelated to any open PR — pure `main`-branch CI hygiene.

Introduced by `ddb4184d` (@contextablemark, #1944 child-cycle work).

## Diagnosis

**The validator is not quadratic.** Profiled `validateA2UIComponents` on the exact 50k chain: **~59ms** (build 6ms + validate 53ms). `findChildCycles` is already a linear, `Set`/`Map`-backed iterative DFS — no `.includes()` scan, no per-node re-lookup, no recursion to overflow. Nothing to optimize.

**The flake is GC/scheduling jitter, not CPU.** Each test allocates ~150k objects (50k components + 50k DFS frames + path/adjacency arrays). Two such tests under vitest's parallel-fork pool on a 2-vCPU runner stall on GC, inflating wall-clock far past the ~59ms of actual CPU work. Bigger N = more allocations = more stall susceptibility.

## Fix (test-only — validator left untouched, it is optimal)

Changing the validator would be a fake fix. Instead, in **both** deep-chain tests:

1. **N 50000 → 20000.** Measured V8 recursive-overflow depth is **~8807** (trivial frame; a real DFS frame overflows lower). 20k is still >2x past that, so it still proves the walk is iterative-not-recursive, while cutting allocations 2.5x to shrink the GC-stall window. Runtime ~25ms.
2. **Explicit 30000ms timeout** (vitest 4 positional arg) to decouple the provably-fast assertion from CI runner scheduling jitter.

## Verification

`cd sdks/typescript/packages/a2ui-toolkit && pnpm test` → **84/84 pass**, `validate.test.ts` ~103ms total (both deep tests included), comfortably under timeout.

No product behavior change. cc @contextablemark — touches your #1944 cycle-check tests.