### PR TITLE
feat(java): add REASONING_MESSAGE_START/CONTENT/END event types

### DIFF
--- a/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageContentEvent.java
+++ b/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageContentEvent.java
@@ -1,0 +1,79 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+
+/**
+ * An event that delivers incremental content for a reasoning message.
+ * <p>
+ * This event carries a delta (partial fragment) of the reasoning text
+ * being streamed for the message identified by {@code messageId}.
+ * Consumers concatenate successive deltas into the assembled reasoning
+ * content, mirroring the streaming pattern used by
+ * {@link TextMessageContentEvent} for primary text output.
+ * </p>
+ * <p>
+ * The event automatically sets its type to
+ * {@link EventType#REASONING_MESSAGE_CONTENT}.
+ * </p>
+ *
+ * @see BaseEvent
+ * @see EventType#REASONING_MESSAGE_CONTENT
+ * @see ReasoningMessageStartEvent
+ * @see ReasoningMessageEndEvent
+ */
+public class ReasoningMessageContentEvent extends BaseEvent {
+
+    private String messageId;
+    private String delta;
+
+    /**
+     * Creates a new ReasoningMessageContentEvent with type set to
+     * {@link EventType#REASONING_MESSAGE_CONTENT}.
+     * <p>
+     * The timestamp is automatically set to the current time and both
+     * fields are initialized as null.
+     * </p>
+     */
+    public ReasoningMessageContentEvent() {
+        super(EventType.REASONING_MESSAGE_CONTENT);
+    }
+
+    /**
+     * Sets the unique identifier of the reasoning message this content
+     * belongs to.
+     *
+     * @param messageId the message identifier. Can be null.
+     */
+    public void setMessageId(final String messageId) {
+        this.messageId = messageId;
+    }
+
+    /**
+     * Returns the unique identifier of the reasoning message this
+     * content belongs to.
+     *
+     * @return the message identifier, can be null
+     */
+    public String getMessageId() {
+        return this.messageId;
+    }
+
+    /**
+     * Sets the incremental reasoning content fragment for this message.
+     *
+     * @param delta the reasoning text delta. Can be null.
+     */
+    public void setDelta(final String delta) {
+        this.delta = delta;
+    }
+
+    /**
+     * Returns the incremental reasoning content fragment for this
+     * message.
+     *
+     * @return the reasoning text delta, can be null
+     */
+    public String getDelta() {
+        return this.delta;
+    }
+}

--- a/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageEndEvent.java
+++ b/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageEndEvent.java
@@ -1,0 +1,58 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+
+/**
+ * An event that signals the completion of a reasoning message stream.
+ * <p>
+ * This event is fired when no more
+ * {@link ReasoningMessageContentEvent} deltas will be emitted for the
+ * identified reasoning message. Client renderers should treat the
+ * assembled content as final once this event is observed.
+ * </p>
+ * <p>
+ * The event automatically sets its type to
+ * {@link EventType#REASONING_MESSAGE_END}.
+ * </p>
+ *
+ * @see BaseEvent
+ * @see EventType#REASONING_MESSAGE_END
+ * @see ReasoningMessageStartEvent
+ * @see ReasoningMessageContentEvent
+ */
+public class ReasoningMessageEndEvent extends BaseEvent {
+
+    private String messageId;
+
+    /**
+     * Creates a new ReasoningMessageEndEvent with type set to
+     * {@link EventType#REASONING_MESSAGE_END}.
+     * <p>
+     * The timestamp is automatically set to the current time and the
+     * message ID is initialized as null.
+     * </p>
+     */
+    public ReasoningMessageEndEvent() {
+        super(EventType.REASONING_MESSAGE_END);
+    }
+
+    /**
+     * Sets the unique identifier of the reasoning message that has
+     * finished streaming.
+     *
+     * @param messageId the message identifier. Can be null.
+     */
+    public void setMessageId(final String messageId) {
+        this.messageId = messageId;
+    }
+
+    /**
+     * Returns the unique identifier of the reasoning message that has
+     * finished streaming.
+     *
+     * @return the message identifier, can be null
+     */
+    public String getMessageId() {
+        return this.messageId;
+    }
+}

--- a/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageStartEvent.java
+++ b/sdks/community/java/packages/core/src/main/java/com/agui/core/event/ReasoningMessageStartEvent.java
@@ -1,0 +1,84 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+
+/**
+ * An event that signals the beginning of a reasoning message stream.
+ * <p>
+ * Reasoning messages convey assistant chain-of-thought / reasoning traces
+ * that are surfaced to the UI separately from the primary text message
+ * stream. They are emitted by integrations that expose reasoning content
+ * (e.g. OpenAI o1-style reasoning, Anthropic extended thinking) and are
+ * consumed by client renderers that display the reasoning inline with
+ * the assistant turn.
+ * </p>
+ * <p>
+ * The event automatically sets its type to
+ * {@link EventType#REASONING_MESSAGE_START} and establishes the context
+ * for the reasoning content events that follow. The {@code role} field
+ * mirrors the AG-UI protocol wire schema where reasoning messages carry
+ * the literal role {@code "reasoning"}.
+ * </p>
+ *
+ * @see BaseEvent
+ * @see EventType#REASONING_MESSAGE_START
+ * @see ReasoningMessageContentEvent
+ * @see ReasoningMessageEndEvent
+ */
+public class ReasoningMessageStartEvent extends BaseEvent {
+
+    private String messageId;
+    private String role;
+
+    /**
+     * Creates a new ReasoningMessageStartEvent with type set to
+     * {@link EventType#REASONING_MESSAGE_START}.
+     * <p>
+     * The timestamp is automatically set to the current time and both
+     * fields are initialized as null. Per the AG-UI protocol the
+     * {@code role} should be set to {@code "reasoning"}.
+     * </p>
+     */
+    public ReasoningMessageStartEvent() {
+        super(EventType.REASONING_MESSAGE_START);
+    }
+
+    /**
+     * Sets the unique identifier for the reasoning message that is
+     * starting to stream.
+     *
+     * @param messageId the message identifier. Can be null.
+     */
+    public void setMessageId(final String messageId) {
+        this.messageId = messageId;
+    }
+
+    /**
+     * Returns the unique identifier for the reasoning message that is
+     * starting to stream.
+     *
+     * @return the message identifier, can be null
+     */
+    public String getMessageId() {
+        return this.messageId;
+    }
+
+    /**
+     * Sets the role of the reasoning message. Per the AG-UI protocol
+     * this is the literal {@code "reasoning"}.
+     *
+     * @param role the role string. Can be null.
+     */
+    public void setRole(final String role) {
+        this.role = role;
+    }
+
+    /**
+     * Returns the role of the reasoning message.
+     *
+     * @return the role string, can be null
+     */
+    public String getRole() {
+        return this.role;
+    }
+}

--- a/sdks/community/java/packages/core/src/main/java/com/agui/core/type/EventType.java
+++ b/sdks/community/java/packages/core/src/main/java/com/agui/core/type/EventType.java
@@ -48,6 +48,15 @@ public enum EventType {
     /** Signals the end of thinking text message content */
     THINKING_TEXT_MESSAGE_END("THINKING_TEXT_MESSAGE_END"), // Fixed typo
 
+    /** Signals the start of a reasoning message stream (assistant chain-of-thought) */
+    REASONING_MESSAGE_START("REASONING_MESSAGE_START"),
+
+    /** Represents incremental reasoning message content */
+    REASONING_MESSAGE_CONTENT("REASONING_MESSAGE_CONTENT"),
+
+    /** Signals the end of a reasoning message stream */
+    REASONING_MESSAGE_END("REASONING_MESSAGE_END"),
+
     /** Signals the start of a tool call */
     TOOL_CALL_START("TOOL_CALL_START"),
 

--- a/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageContentEventTest.java
+++ b/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageContentEventTest.java
@@ -1,0 +1,46 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReasoningMessageContentEvent")
+class ReasoningMessageContentEventTest {
+
+    @Test
+    void shouldSetCorrectEventType() {
+        var event = new ReasoningMessageContentEvent();
+
+        assertThat(event.getType()).isEqualTo(EventType.REASONING_MESSAGE_CONTENT);
+    }
+
+    @Test
+    void shouldSetCurrentTimestamp() {
+        var event = new ReasoningMessageContentEvent();
+
+        assertThat(event.getTimestamp()).isCloseTo(Instant.now().toEpochMilli(), Offset.offset(1000L));
+    }
+
+    @Test
+    void shouldSetMessageId() {
+        var event = new ReasoningMessageContentEvent();
+        var id = UUID.randomUUID().toString();
+        event.setMessageId(id);
+
+        assertThat(event.getMessageId()).isEqualTo(id);
+    }
+
+    @Test
+    void shouldSetDelta() {
+        var event = new ReasoningMessageContentEvent();
+        event.setDelta("partial reasoning");
+
+        assertThat(event.getDelta()).isEqualTo("partial reasoning");
+    }
+}

--- a/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageEndEventTest.java
+++ b/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageEndEventTest.java
@@ -1,0 +1,38 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReasoningMessageEndEvent")
+class ReasoningMessageEndEventTest {
+
+    @Test
+    void shouldSetCorrectEventType() {
+        var event = new ReasoningMessageEndEvent();
+
+        assertThat(event.getType()).isEqualTo(EventType.REASONING_MESSAGE_END);
+    }
+
+    @Test
+    void shouldSetCurrentTimestamp() {
+        var event = new ReasoningMessageEndEvent();
+
+        assertThat(event.getTimestamp()).isCloseTo(Instant.now().toEpochMilli(), Offset.offset(1000L));
+    }
+
+    @Test
+    void shouldSetMessageId() {
+        var event = new ReasoningMessageEndEvent();
+        var id = UUID.randomUUID().toString();
+        event.setMessageId(id);
+
+        assertThat(event.getMessageId()).isEqualTo(id);
+    }
+}

--- a/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageStartEventTest.java
+++ b/sdks/community/java/packages/core/src/test/java/com/agui/core/event/ReasoningMessageStartEventTest.java
@@ -1,0 +1,46 @@
+package com.agui.core.event;
+
+import com.agui.core.type.EventType;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReasoningMessageStartEvent")
+class ReasoningMessageStartEventTest {
+
+    @Test
+    void shouldSetCorrectEventType() {
+        var event = new ReasoningMessageStartEvent();
+
+        assertThat(event.getType()).isEqualTo(EventType.REASONING_MESSAGE_START);
+    }
+
+    @Test
+    void shouldSetCurrentTimestamp() {
+        var event = new ReasoningMessageStartEvent();
+
+        assertThat(event.getTimestamp()).isCloseTo(Instant.now().toEpochMilli(), Offset.offset(1000L));
+    }
+
+    @Test
+    void shouldSetMessageId() {
+        var event = new ReasoningMessageStartEvent();
+        var id = UUID.randomUUID().toString();
+        event.setMessageId(id);
+
+        assertThat(event.getMessageId()).isEqualTo(id);
+    }
+
+    @Test
+    void shouldSetRole() {
+        var event = new ReasoningMessageStartEvent();
+        event.setRole("reasoning");
+
+        assertThat(event.getRole()).isEqualTo("reasoning");
+    }
+}

--- a/sdks/community/java/utils/json/src/main/java/com/agui/json/mixins/EventMixin.java
+++ b/sdks/community/java/utils/json/src/main/java/com/agui/json/mixins/EventMixin.java
@@ -26,6 +26,7 @@ import com.agui.core.event.*;
  * <li>Message events: TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_CHUNK, TEXT_MESSAGE_END</li>
  * <li>Tool execution: TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_CHUNK, TOOL_CALL_END, TOOL_CALL_RESULT</li>
  * <li>Thinking process: THINKING_START, THINKING_END, THINKING_TEXT_MESSAGE_START, THINKING_TEXT_MESSAGE_CONTENT, THINKING_TEXT_MESSAGE_END</li>
+ * <li>Reasoning messages: REASONING_MESSAGE_START, REASONING_MESSAGE_CONTENT, REASONING_MESSAGE_END</li>
  * <li>State management: STATE_SNAPSHOT, STATE_DELTA, MESSAGES_SNAPSHOT</li>
  * <li>Generic: CUSTOM, RAW</li>
  * </ul>
@@ -58,6 +59,9 @@ import com.agui.core.event.*;
     @JsonSubTypes.Type(value = CustomEvent.class, name = "CUSTOM"),
     @JsonSubTypes.Type(value = MessagesSnapshotEvent.class, name = "MESSAGES_SNAPSHOT"),
     @JsonSubTypes.Type(value = RawEvent.class, name = "RAW"),
+    @JsonSubTypes.Type(value = ReasoningMessageContentEvent.class, name = "REASONING_MESSAGE_CONTENT"),
+    @JsonSubTypes.Type(value = ReasoningMessageEndEvent.class, name = "REASONING_MESSAGE_END"),
+    @JsonSubTypes.Type(value = ReasoningMessageStartEvent.class, name = "REASONING_MESSAGE_START"),
     @JsonSubTypes.Type(value = RunErrorEvent.class, name = "RUN_ERROR"),
     @JsonSubTypes.Type(value = RunFinishedEvent.class, name = "RUN_FINISHED"),
     @JsonSubTypes.Type(value = RunStartedEvent.class, name = "RUN_STARTED"),

--- a/sdks/community/java/utils/json/src/test/java/com/agui/json/ReasoningMessageEventSerdeTest.java
+++ b/sdks/community/java/utils/json/src/test/java/com/agui/json/ReasoningMessageEventSerdeTest.java
@@ -1,0 +1,133 @@
+package com.agui.json;
+
+import com.agui.core.event.BaseEvent;
+import com.agui.core.event.ReasoningMessageContentEvent;
+import com.agui.core.event.ReasoningMessageEndEvent;
+import com.agui.core.event.ReasoningMessageStartEvent;
+import com.agui.core.type.EventType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies Jackson polymorphic round-trip of the REASONING_MESSAGE_*
+ * event family wired in {@link com.agui.json.mixins.EventMixin}. Each
+ * payload mirrors the AG-UI TypeScript wire schema
+ * (@ag-ui/core ReasoningMessage*EventSchema) so cross-SDK clients
+ * decode emitted events identically.
+ */
+@DisplayName("REASONING_MESSAGE_* Jackson serde")
+class ReasoningMessageEventSerdeTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+        ObjectMapperFactory.addMixins(mapper);
+    }
+
+    @Test
+    void shouldDeserializeReasoningMessageStartFromWirePayload() throws Exception {
+        var json = """
+                {
+                  "type": "REASONING_MESSAGE_START",
+                  "messageId": "msg-r1",
+                  "role": "reasoning"
+                }
+                """;
+
+        BaseEvent decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageStartEvent.class);
+        var start = (ReasoningMessageStartEvent) decoded;
+        assertThat(start.getType()).isEqualTo(EventType.REASONING_MESSAGE_START);
+        assertThat(start.getMessageId()).isEqualTo("msg-r1");
+        assertThat(start.getRole()).isEqualTo("reasoning");
+    }
+
+    @Test
+    void shouldDeserializeReasoningMessageContentFromWirePayload() throws Exception {
+        var json = """
+                {
+                  "type": "REASONING_MESSAGE_CONTENT",
+                  "messageId": "msg-r1",
+                  "delta": "Considering"
+                }
+                """;
+
+        BaseEvent decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageContentEvent.class);
+        var content = (ReasoningMessageContentEvent) decoded;
+        assertThat(content.getType()).isEqualTo(EventType.REASONING_MESSAGE_CONTENT);
+        assertThat(content.getMessageId()).isEqualTo("msg-r1");
+        assertThat(content.getDelta()).isEqualTo("Considering");
+    }
+
+    @Test
+    void shouldDeserializeReasoningMessageEndFromWirePayload() throws Exception {
+        var json = """
+                {
+                  "type": "REASONING_MESSAGE_END",
+                  "messageId": "msg-r1"
+                }
+                """;
+
+        BaseEvent decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageEndEvent.class);
+        var end = (ReasoningMessageEndEvent) decoded;
+        assertThat(end.getType()).isEqualTo(EventType.REASONING_MESSAGE_END);
+        assertThat(end.getMessageId()).isEqualTo("msg-r1");
+    }
+
+    @Test
+    void shouldRoundTripReasoningMessageStart() throws Exception {
+        var original = new ReasoningMessageStartEvent();
+        original.setMessageId("msg-r1");
+        original.setRole("reasoning");
+
+        var json = mapper.writeValueAsString(original);
+        var decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageStartEvent.class);
+        var roundTripped = (ReasoningMessageStartEvent) decoded;
+        assertThat(roundTripped.getMessageId()).isEqualTo(original.getMessageId());
+        assertThat(roundTripped.getRole()).isEqualTo(original.getRole());
+        assertThat(json).contains("\"type\":\"REASONING_MESSAGE_START\"");
+    }
+
+    @Test
+    void shouldRoundTripReasoningMessageContent() throws Exception {
+        var original = new ReasoningMessageContentEvent();
+        original.setMessageId("msg-r1");
+        original.setDelta("partial");
+
+        var json = mapper.writeValueAsString(original);
+        var decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageContentEvent.class);
+        var roundTripped = (ReasoningMessageContentEvent) decoded;
+        assertThat(roundTripped.getMessageId()).isEqualTo(original.getMessageId());
+        assertThat(roundTripped.getDelta()).isEqualTo(original.getDelta());
+        assertThat(json).contains("\"type\":\"REASONING_MESSAGE_CONTENT\"");
+    }
+
+    @Test
+    void shouldRoundTripReasoningMessageEnd() throws Exception {
+        var original = new ReasoningMessageEndEvent();
+        original.setMessageId("msg-r1");
+
+        var json = mapper.writeValueAsString(original);
+        var decoded = mapper.readValue(json, BaseEvent.class);
+
+        assertThat(decoded).isInstanceOf(ReasoningMessageEndEvent.class);
+        var roundTripped = (ReasoningMessageEndEvent) decoded;
+        assertThat(roundTripped.getMessageId()).isEqualTo(original.getMessageId());
+        assertThat(json).contains("\"type\":\"REASONING_MESSAGE_END\"");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the typed `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END` event family to the AG-UI Java SDK so JVM integrations can emit and consume reasoning streams via the typed event API instead of raw JSON.

- Mirrors the TypeScript wire schema (`@ag-ui/core` `ReasoningMessage*EventSchema`) field-for-field: `messageId` on all three, `delta` on CONTENT, literal role `"reasoning"` on START.
- Purely additive: no existing enum value, mixin entry, or event class is modified — safe for all existing consumers.

## Motivation

The CopilotKit Spring AI showcase integration currently has to bypass the typed `AgUiService` event emitter and write raw JSON for reasoning streams because the Java SDK had no typed analogue of the TS `REASONING_MESSAGE_*` family. Once this lands and is released, the showcase can drop that workaround and emit reasoning events through the normal AG-UI Java path.

## Changes

| Layer | File | Change |
|-------|------|--------|
| core | `event/ReasoningMessageStartEvent.java` | new class — `messageId`, `role` |
| core | `event/ReasoningMessageContentEvent.java` | new class — `messageId`, `delta` |
| core | `event/ReasoningMessageEndEvent.java` | new class — `messageId` |
| core | `type/EventType.java` | three new enum constants |
| json | `mixins/EventMixin.java` | three new `@JsonSubTypes.Type` registrations + docstring update |
| tests | core event tests | 11 new unit tests covering type, timestamp, accessors |
| tests | `utils/json/ReasoningMessageEventSerdeTest.java` | 6 new Jackson round-trip tests covering wire-format decode and emit-decode round-trips |

## Test plan

- [x] `mvn -pl packages/core,utils/json -am test` — **145 core tests pass, 13 json tests pass, BUILD SUCCESS**
- [x] New tests assert wire payloads matching the TS `@ag-ui/core` `ReasoningMessage*EventSchema` (literal role `"reasoning"`, `delta` on CONTENT, `messageId` discriminator) deserialize into the correct concrete Java subclass via the polymorphic `BaseEvent` Jackson type info.
- [x] Round-trip tests serialize each new event and re-decode through `BaseEvent` to verify the `type` discriminator survives Jackson serialization.

## Notes

- No version bump in this PR — current parent version is `0.0.1` and no `CHANGELOG.md` exists yet in the Java SDK tree. Happy to add a follow-up version bump in this PR if maintainers prefer.
- No commitlint config detected in this repo; commit follows the existing conventional-commit style observed in `git log`.