### PR TITLE
fix(aws-strands): disable credentialed wildcard CORS (#1939)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -218,12 +218,19 @@ def create_strands_app(
 
     app = FastAPI(title=f"AWS Strands - {agent.name}")
 
-    # Add CORS middleware
+    # Add CORS middleware.
+    #
+    # allow_credentials is intentionally False. With Starlette's CORSMiddleware,
+    # allow_origins=["*"] together with allow_credentials=True does NOT emit a
+    # literal "*" — it reflects the request's Origin back per-request, which is a
+    # credentialed any-origin posture (a security hole). Keeping credentials off
+    # makes "*" a true non-credentialed wildcard, matching the TypeScript adapter
+    # (see #1931) and closing #1939.
     from fastapi.middleware.cors import CORSMiddleware
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
-        allow_credentials=True,
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/integrations/aws-strands/python/tests/test_cors.py
+++ b/integrations/aws-strands/python/tests/test_cors.py
@@ -1,0 +1,56 @@
+"""Regression tests for CORS configuration on the AWS Strands FastAPI app.
+
+Covers #1939: the adapter must not combine a wildcard origin with credentials.
+With Starlette, allow_origins=["*"] + allow_credentials=True reflects the
+request Origin back per-request (credentialed any-origin). The app must instead
+emit a literal "*" and must not allow credentials, matching the TypeScript
+adapter (#1931).
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from ag_ui_strands.utils import create_strands_app
+
+
+class _FakeAgent:
+    name = "fake"
+
+
+def _build_client() -> TestClient:
+    # Isolate the CORS layer: stub out the endpoint/ping wiring so the app can
+    # be built without a real StrandsAgent or model.
+    with patch("ag_ui_strands.endpoint.add_strands_fastapi_endpoint"), patch(
+        "ag_ui_strands.endpoint.add_ping"
+    ):
+        app = create_strands_app(_FakeAgent())
+    return TestClient(app)
+
+
+def test_preflight_returns_literal_wildcard_not_reflected_origin():
+    client = _build_client()
+    res = client.options(
+        "/",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    allow_origin = res.headers.get("access-control-allow-origin")
+    # Literal wildcard, NOT the reflected request Origin.
+    assert allow_origin == "*"
+    assert allow_origin != "https://evil.example.com"
+
+
+def test_credentials_not_allowed_with_wildcard_origin():
+    client = _build_client()
+    res = client.options(
+        "/",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    # A credentialed wildcard is exactly the posture #1939 forbids.
+    assert res.headers.get("access-control-allow-credentials") != "true"


### PR DESCRIPTION
Fixes #1939

## Root cause
The AWS Strands Python adapter configured Starlette `CORSMiddleware` with `allow_origins=["*"]` **and** `allow_credentials=True`. With Starlette, that combination does not emit a literal `*` — it reflects the request `Origin` back per-request, producing a credentialed any-origin posture (any site can make credentialed cross-origin calls).

## Fix
Set `allow_credentials=False` while keeping `allow_origins=["*"]`. This makes `*` a true non-credentialed wildcard and stops per-request origin reflection. Mirrors the TypeScript adapter fix in #1931 (which forced a literal `*`).

## Tests added
`integrations/aws-strands/python/tests/test_cors.py`:
- preflight from an arbitrary Origin returns `Access-Control-Allow-Origin: *`, not the reflected origin
- `Access-Control-Allow-Credentials` is not `true`

Both tests fail on the old config and pass with the fix.

## Checklist
- [x] Failing test written and confirmed failing before fix
- [x] Fix applied, tests pass
- [x] Full package test suite passes (137 passed, 2 skipped)
- [ ] Build/format — repo formatter (ruff) not run locally; change is formatting-clean
- [x] Minimal change, scoped to the issue