### PR TITLE
fix(langroid): disable credentialed wildcard CORS (#1940)

### DIFF
--- a/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
+++ b/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
@@ -57,11 +57,18 @@ def create_langroid_app(agent: LangroidAgent, path: str = "/") -> FastAPI:
     """Create a FastAPI app with a single Langroid agent endpoint."""
     app = FastAPI(title=f"Langroid - {agent.name}")
     
-    # Add CORS middleware
+    # Add CORS middleware.
+    #
+    # allow_credentials is intentionally False. With Starlette's CORSMiddleware,
+    # allow_origins=["*"] together with allow_credentials=True does NOT emit a
+    # literal "*" — it reflects the request's Origin back per-request, which is a
+    # credentialed any-origin posture (a security hole). Keeping credentials off
+    # makes "*" a true non-credentialed wildcard. Companion to #1939 / #1931;
+    # closes #1940.
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
-        allow_credentials=True,
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/integrations/langroid/python/tests/test_endpoint.py
+++ b/integrations/langroid/python/tests/test_endpoint.py
@@ -47,6 +47,40 @@ class TestCreateLangroidApp(unittest.TestCase):
         response = client.get("/chat/health")
         self.assertEqual(response.status_code, 200)
 
+    def test_cors_preflight_returns_literal_wildcard_not_reflected_origin(self):
+        # Regression for #1940: a wildcard origin must not be reflected.
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test", description="")
+        client = TestClient(create_langroid_app(agent))
+
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        allow_origin = response.headers.get("access-control-allow-origin")
+        self.assertEqual(allow_origin, "*")
+        self.assertNotEqual(allow_origin, "https://evil.example.com")
+
+    def test_cors_credentials_not_allowed_with_wildcard_origin(self):
+        # Regression for #1940: no credentialed any-origin posture.
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test", description="")
+        client = TestClient(create_langroid_app(agent))
+
+        response = client.options(
+            "/",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        self.assertNotEqual(
+            response.headers.get("access-control-allow-credentials"), "true"
+        )
+
 
 class TestAddLangroidFastapiEndpoint(unittest.TestCase):
     """Test add_langroid_fastapi_endpoint function."""


### PR DESCRIPTION
Fixes #1940

## Root cause
The langroid Python adapter configured Starlette `CORSMiddleware` with `allow_origins=["*"]` **and** `allow_credentials=True`. With Starlette that reflects the request `Origin` back per-request instead of emitting a literal `*` — a credentialed any-origin posture.

## Fix
Set `allow_credentials=False` while keeping `allow_origins=["*"]`, making `*` a true non-credentialed wildcard. Companion to #1939 (aws-strands Python) and follow-up to #1931 (aws-strands TypeScript).

## Tests added
`integrations/langroid/python/tests/test_endpoint.py`:
- preflight from an arbitrary Origin returns `Access-Control-Allow-Origin: *`, not the reflected origin
- `Access-Control-Allow-Credentials` is not `true`

Both fail on the old config and pass with the fix.

## Checklist
- [x] Failing test written and confirmed failing before fix
- [x] Fix applied, tests pass
- [x] Full package test suite passes (45 passed)
- [x] Minimal change, scoped to the issue