### PR TITLE
fix(aws-strands): preserve plugins on per-thread agents

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -19,6 +19,8 @@ from strands.session import SessionManager
 # AG-UI injects messages at runtime via RunAgentInput.
 # "hooks" is excluded: Agent stores hooks as a HookRegistry after init, not
 # the original list the constructor expects — forwarding it causes a TypeError.
+# "plugins" is excluded for the same reason: newer Strands versions consume
+# plugin providers into an internal registry and do not retain the original list.
 # "session_manager" is excluded: it is supplied per-thread via
 # StrandsAgentConfig.session_manager_provider (see run()). Forwarding a
 # template-level session_manager would make every thread share one session_id.
@@ -29,6 +31,7 @@ _AGUI_EXPLICIT_PARAMS = {
     "tools",
     "messages",
     "hooks",
+    "plugins",
     "session_manager",
 }
 
@@ -65,6 +68,26 @@ def _has_strands_session_manager(agent: Any) -> bool:
         getattr(agent, "session_manager", None) is not None
         or getattr(agent, "_session_manager", None) is not None
     )
+
+
+def _strands_agent_accepts_kwarg(name: str) -> bool:
+    try:
+        parameters = inspect.signature(StrandsAgentCore.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+    return name in parameters or any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    )
+
+
+def _register_plugins_on_agent(agent: Any, plugins: List[Any]) -> bool:
+    registry = getattr(agent, "_plugin_registry", None)
+    add_and_init = getattr(registry, "add_and_init", None)
+    if not callable(add_and_init):
+        return False
+    for plugin in plugins:
+        add_and_init(plugin)
+    return True
 
 
 logger = logging.getLogger(__name__)
@@ -278,6 +301,7 @@ class StrandsAgent:
         description: str = "",
         config: "StrandsAgentConfig | None" = None,
         hooks: "list | None" = None,
+        plugins: "list | None" = None,
     ):
         # Store template agent configuration for creating fresh instances
         self._model = agent.model
@@ -301,6 +325,11 @@ class StrandsAgent:
         # the caller and forward them to every per-thread instance so any
         # observability / loop-cap / policy-enforcement hook actually fires.
         self._hooks = list(hooks) if hooks else []
+        # Plugin providers have the same lifecycle problem as hook providers:
+        # Strands consumes them during Agent construction, so the template Agent
+        # cannot be inspected later to recover the original provider objects.
+        # Callers that need plugins on each per-thread Agent must pass them here.
+        self._plugins = list(plugins) if plugins else []
 
         self.name = name
         self.description = description
@@ -411,13 +440,25 @@ class StrandsAgent:
                     core_kwargs = dict(self._agent_kwargs)
                     if self._hooks:
                         core_kwargs["hooks"] = list(self._hooks)
-                    self._agents_by_thread[thread_id] = StrandsAgentCore(
+                    plugins_forwarded = False
+                    if self._plugins and _strands_agent_accepts_kwarg("plugins"):
+                        core_kwargs["plugins"] = list(self._plugins)
+                        plugins_forwarded = True
+                    strands_agent = StrandsAgentCore(
                         model=self._model,
                         system_prompt=self._system_prompt,
                         tools=self._tools,
                         session_manager=session_manager,
                         **core_kwargs,
                     )
+                    if self._plugins and not plugins_forwarded:
+                        if not _register_plugins_on_agent(strands_agent, self._plugins):
+                            logger.warning(
+                                "plugins were supplied to StrandsAgent but the installed "
+                                "Strands Agent does not expose plugin registration; "
+                                "per-thread agents will be created without plugins."
+                            )
+                    self._agents_by_thread[thread_id] = strands_agent
         strands_agent = self._agents_by_thread[thread_id]
 
         # Forward ``RunAgentInput.context`` to the per-thread Strands agent's

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -19,8 +19,8 @@ from strands.session import SessionManager
 # AG-UI injects messages at runtime via RunAgentInput.
 # "hooks" is excluded: Agent stores hooks as a HookRegistry after init, not
 # the original list the constructor expects — forwarding it causes a TypeError.
-# "plugins" is excluded for the same reason: newer Strands versions consume
-# plugin providers into an internal registry and do not retain the original list.
+# "plugins" is excluded: they are recovered from Strands' plugin registry and
+# forwarded explicitly so plugin-provided tools can be filtered from self._tools.
 # "session_manager" is excluded: it is supplied per-thread via
 # StrandsAgentConfig.session_manager_provider (see run()). Forwarding a
 # template-level session_manager would make every thread share one session_id.
@@ -88,6 +88,39 @@ def _register_plugins_on_agent(agent: Any, plugins: List[Any]) -> bool:
     for plugin in plugins:
         add_and_init(plugin)
     return True
+
+
+def _extract_agent_plugins(agent: Any) -> List[Any]:
+    registry = getattr(agent, "_plugin_registry", None)
+    plugins_by_name = getattr(registry, "_plugins", None)
+    if not isinstance(plugins_by_name, dict):
+        return []
+    return [
+        plugin
+        for name, plugin in plugins_by_name.items()
+        if not (isinstance(name, str) and name.startswith("strands:"))
+    ]
+
+
+def _plugin_tool_names(plugins: List[Any]) -> set:
+    names = set()
+    for plugin in plugins:
+        for tool in getattr(plugin, "tools", []) or []:
+            name = getattr(tool, "tool_name", None)
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def _filter_plugin_tools(tools: List[Any], plugins: List[Any]) -> List[Any]:
+    plugin_tool_names = _plugin_tool_names(plugins)
+    if not plugin_tool_names:
+        return tools
+    return [
+        tool
+        for tool in tools
+        if getattr(tool, "tool_name", None) not in plugin_tool_names
+    ]
 
 
 logger = logging.getLogger(__name__)
@@ -306,11 +339,20 @@ class StrandsAgent:
         # Store template agent configuration for creating fresh instances
         self._model = agent.model
         self._system_prompt = agent.system_prompt
-        self._tools = (
+        # Plugin providers have the same lifecycle problem as hook providers:
+        # Strands consumes them during Agent construction. Newer Strands keeps
+        # the initialized providers in an internal plugin registry, so recover
+        # them from the template unless the caller passed an explicit list.
+        self._plugins = list(plugins) if plugins else _extract_agent_plugins(agent)
+        template_tools = (
             list(agent.tool_registry.registry.values())
             if hasattr(agent, "tool_registry")
             else []
         )
+        # The template tool registry already contains plugin-provided tools.
+        # When plugins are forwarded to per-thread agents those tools will be
+        # registered again by Strands; filter them here to avoid duplicate names.
+        self._tools = _filter_plugin_tools(template_tools, self._plugins)
         self._agent_kwargs = _extract_agent_kwargs(agent)
 
         # Hook providers forwarded to each per-thread StrandsAgentCore.
@@ -325,11 +367,6 @@ class StrandsAgent:
         # the caller and forward them to every per-thread instance so any
         # observability / loop-cap / policy-enforcement hook actually fires.
         self._hooks = list(hooks) if hooks else []
-        # Plugin providers have the same lifecycle problem as hook providers:
-        # Strands consumes them during Agent construction, so the template Agent
-        # cannot be inspected later to recover the original provider objects.
-        # Callers that need plugins on each per-thread Agent must pass them here.
-        self._plugins = list(plugins) if plugins else []
 
         self.name = name
         self.description = description

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -65,7 +65,7 @@ _UNTESTABLE_VIA_SENTINEL = {
     "tools",              # handled via tool_registry
     "system_prompt",      # handled explicitly
     "session_manager",    # excluded; see StrandsAgentConfig.session_manager_provider
-    "plugins",            # stored as _plugin_registry, not forwarded
+    "plugins",            # explicitly handled via StrandsAgent(plugins=...)
     "structured_output_model",  # template Agent rejects a MagicMock sentinel here
     "trace_attributes",         # Strands merges into a dict, losing sentinel identity
 }

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -66,6 +66,7 @@ _UNTESTABLE_VIA_SENTINEL = {
     "system_prompt",      # handled explicitly
     "session_manager",    # excluded; see StrandsAgentConfig.session_manager_provider
     "plugins",            # explicitly handled via StrandsAgent(plugins=...)
+    "interventions",      # stored as _intervention_registry, not original handlers
     "structured_output_model",  # template Agent rejects a MagicMock sentinel here
     "trace_attributes",         # Strands merges into a dict, losing sentinel identity
 }

--- a/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
+++ b/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
@@ -1,0 +1,121 @@
+"""Tests that plugin providers are preserved on per-thread Strands agents."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from strands import Agent
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+
+
+def _mock_model():
+    m = MagicMock()
+    m.stateful = False
+    return m
+
+
+def _run_input(thread_id: str = "t1"):
+    from ag_ui.core import RunAgentInput, UserMessage
+
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+class _CapturingCore:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.tool_registry = ToolRegistry()
+
+    async def stream_async(self, _msg: str, **_kwargs):
+        if False:
+            yield
+
+
+class _PluginRegistry:
+    def __init__(self):
+        self.plugins = []
+
+    def add_and_init(self, plugin):
+        self.plugins.append(plugin)
+
+
+class _RegistryOnlyCore(_CapturingCore):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._plugin_registry = _PluginRegistry()
+
+
+async def _trigger_thread_creation(ag: StrandsAgent, thread_id: str):
+    async for _ in ag.run(_run_input(thread_id)):
+        if thread_id in ag._agents_by_thread:
+            break
+    return ag._agents_by_thread[thread_id]
+
+
+@pytest.mark.asyncio
+async def test_plugins_kwarg_forwarded_when_provider_supplied():
+    plugin = object()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert instance.init_kwargs.get("plugins") == [plugin]
+
+
+@pytest.mark.asyncio
+async def test_each_thread_receives_independent_plugins_list():
+    plugin = object()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance_a = await _trigger_thread_creation(ag, "thread-a")
+        instance_b = await _trigger_thread_creation(ag, "thread-b")
+
+    assert instance_a.init_kwargs.get("plugins") == [plugin]
+    assert instance_b.init_kwargs.get("plugins") == [plugin]
+    assert instance_a.init_kwargs["plugins"] is not instance_b.init_kwargs["plugins"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "plugins_value", [None, []], ids=["default-none", "empty-list"]
+)
+async def test_plugins_kwarg_omitted_for_falsy_input(plugins_value):
+    template = Agent(model=_mock_model())
+    kwargs = {} if plugins_value is None else {"plugins": plugins_value}
+    ag = StrandsAgent(template, name="test", **kwargs)
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" not in instance.init_kwargs
+
+
+@pytest.mark.asyncio
+async def test_plugins_registered_via_registry_when_kwarg_unavailable(monkeypatch):
+    plugin = object()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+    monkeypatch.setattr(
+        "ag_ui_strands.agent._strands_agent_accepts_kwarg",
+        lambda name: False,
+    )
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _RegistryOnlyCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" not in instance.init_kwargs
+    assert instance._plugin_registry.plugins == [plugin]

--- a/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
+++ b/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from strands import Agent
+from strands import Agent, tool
+from strands.hooks.events import BeforeInvocationEvent
+from strands.plugins import Plugin, hook
 from strands.tools.registry import ToolRegistry
 
 from ag_ui_strands.agent import StrandsAgent
@@ -55,11 +57,50 @@ class _RegistryOnlyCore(_CapturingCore):
         self._plugin_registry = _PluginRegistry()
 
 
+class _ToolAndHookPlugin(Plugin):
+    name = "agui_test_plugin"
+
+    def __init__(self):
+        self.hook_calls = 0
+        super().__init__()
+
+    @tool
+    def plugin_tool(self) -> str:
+        """A tool provided by the plugin."""
+        return "ok"
+
+    @hook
+    def before_invocation(self, event: BeforeInvocationEvent) -> None:
+        self.hook_calls += 1
+
+
 async def _trigger_thread_creation(ag: StrandsAgent, thread_id: str):
     async for _ in ag.run(_run_input(thread_id)):
         if thread_id in ag._agents_by_thread:
             break
     return ag._agents_by_thread[thread_id]
+
+
+@pytest.mark.asyncio
+async def test_template_plugins_recovered_without_explicit_kwarg():
+    plugin = _ToolAndHookPlugin()
+    template = Agent(model=_mock_model(), plugins=[plugin])
+    assert "plugin_tool" in template.tool_registry.registry
+
+    ag = StrandsAgent(template, name="test")
+    assert "plugin_tool" not in [
+        getattr(tool, "tool_name", None) for tool in ag._tools
+    ], (
+        "plugin tool should be filtered from explicit tools to avoid duplicate registration"
+    )
+
+    per_thread = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugin_tool" in per_thread.tool_registry.registry
+    assert per_thread._plugin_registry._plugins[plugin.name] is plugin
+
+    per_thread.hooks.invoke_callbacks(BeforeInvocationEvent(agent=per_thread))
+    assert plugin.hook_calls == 1
 
 
 @pytest.mark.asyncio

--- a/integrations/aws-strands/python/uv.lock
+++ b/integrations/aws-strands/python/uv.lock
@@ -649,6 +649,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -762,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.18.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -774,12 +802,13 @@ dependencies = [
     { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/58/08665fc8d5330fc32727793c39ad019f6cc3f75272ede3629dd67b4fe6a5/strands_agents-1.18.0.tar.gz", hash = "sha256:85bd251d50de5d441cc2578068b4656ca86bdbaa1764e292d56b0edf0cf54c52", size = 521216, upload-time = "2025-11-21T21:30:26.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/4d/a1c8c0b870808877b9b82b9885294cddc7ec38fea5de5a941a80e11406b4/strands_agents-1.44.0.tar.gz", hash = "sha256:e876161bce6cc2a459356434746275be4e112cc1038a089adf3ee96e8a69b9d9", size = 1070256, upload-time = "2026-06-16T21:14:44.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/37/79c63bf7ac194754748fc42b5c9fb8f964dc742d92c19052e6cc74fede39/strands_agents-1.18.0-py3-none-any.whl", hash = "sha256:c9cf9662b24344413d204a7ee60d3e3ab88791568e9f572020901eb3df9b6b5e", size = 255594, upload-time = "2025-11-21T21:30:24.662Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/a01d4ab2ce9cb25c44ff84c692a38568d5b2f256b5b3b111fab30373978f/strands_agents-1.44.0-py3-none-any.whl", hash = "sha256:dfa59c7fb891f6079bc467ede12aeaefd2a2f455941267d60b9ddcdf716f8629", size = 568378, upload-time = "2026-06-16T21:14:42.294Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #1933

## Summary
- add an explicit `plugins` option to the Python `StrandsAgent` wrapper
- forward plugin providers to each per-thread Strands agent when the installed Strands version accepts `plugins`
- fall back to `_plugin_registry.add_and_init(...)` when available, and warn instead of silently dropping plugins otherwise
- add regression coverage for kwarg forwarding, per-thread list isolation, falsy plugin inputs, and registry fallback

## Validation
- `uv run pytest tests/test_template_plugins_preservation.py tests/test_template_agent_propagation.py tests/test_template_hooks_preservation.py -q`
- `uv run pytest -q`
- `uv run python -m compileall -q src tests/test_template_plugins_preservation.py tests/test_template_agent_propagation.py`
- `git diff --check`
- `uv run ruff format --check tests/test_template_plugins_preservation.py && uv run ruff check tests/test_template_plugins_preservation.py`