### PR TITLE
fix: add claude agent sdk license metadata

### DIFF
--- a/integrations/claude-agent-sdk/typescript/package.json
+++ b/integrations/claude-agent-sdk/typescript/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"
   },
   "description": "AG-UI integration for Anthropic Claude Agent SDK",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add the MIT license field to the published `@ag-ui/claude-agent-sdk` package manifest
- keep runtime code, dependencies, exports, and version fields unchanged

## Why
The repository is MIT licensed, but `@ag-ui/claude-agent-sdk@0.0.3` does not expose a `license` field in npm metadata. Adding it makes the package metadata match the repository license.

## Validation
- parsed `integrations/claude-agent-sdk/typescript/package.json` and confirmed `license` is `MIT`
- `npm view @ag-ui/claude-agent-sdk@0.0.3 license --json` currently returns empty output
- `git diff --check`
