### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "node": ">=18"
   },
   "version": "0.0.1",
+  "bugs": {
+    "url": "https://github.com/ag-ui-protocol/ag-ui/issues"
+  },
   "pnpm": {
     "overrides": {
       "langium": "3.2.0",


### PR DESCRIPTION
Adds missing `bugs` metadata.

Fixes npm tooling resolution.