### PR TITLE
feat(a2ui-toolkit): validate catalog-derived child ref-fields (#1948)

### DIFF
--- a/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/validate.py
+++ b/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/validate.py
@@ -61,23 +61,94 @@ def _collect_child_refs(children: Any) -> list[str]:
     return refs
 
 
-def _child_adjacency(components: list) -> dict[str, list[str]]:
-    """id -> ordered child-id references, gathered from singular ``child`` + plural ``children``.
+def _collect_component_ref_edges(comp: dict, schema: Optional[dict]) -> list[tuple[str, str]]:
+    """Collect ``(path_suffix, ref_id)`` pairs for every child reference a component makes (#1948).
 
-    Scope note: only these two fields feed the dangling-ref check and the cycle
-    graph. Other catalog ref-fields (Modal ``trigger``/``content``, Tabs
-    ``tabs[].child``) are NOT yet traversed — deriving ref-fields from the
-    catalog (in lockstep across the TS/Python/.NET toolkits) is tracked in
-    https://github.com/ag-ui-protocol/ag-ui/issues/1948.
+    The implicit ``child`` (single) and ``children`` (list) fields are ALWAYS ref
+    fields, even with no catalog — this preserves the #1944 / catalog-free
+    behaviour. Other fields are refs ONLY when the component's catalog schema
+    marks the property ``"format": "componentRef"`` (single) or
+    ``"componentRefList"`` (list). For an array-typed property whose ``items`` is
+    an object schema, marked sub-properties are honoured per element (this finds
+    Tabs ``tabItems[].child`` — derived, never hard-coded). An unmarked property
+    is data, never a ref: a bare data string and a bare ref string are otherwise
+    indistinguishable, so shape-based detection is unsafe.
+
+    Path grammar (byte-aligned with the TS/.NET siblings):
+      single-ref field             -> ``<field>``
+      list-ref field (array)       -> ``<field>[k]``
+      list-ref field (single tmpl) -> ``<field>``
+      nested array-of-object ref   -> ``<arrayField>[k].<refField>`` (and ``[j]`` if that sub-field is a list)
     """
+    edges: list[tuple[str, str]] = []
+
+    def push_single(field: str, value: Any) -> None:
+        for ref in _collect_child_refs(value):
+            edges.append((field, ref))
+
+    def push_list(field: str, value: Any) -> None:
+        if isinstance(value, list):
+            for k, item in enumerate(value):
+                for ref in _collect_child_refs(item):
+                    edges.append((f"{field}[{k}]", ref))
+        else:
+            for ref in _collect_child_refs(value):
+                edges.append((field, ref))
+
+    # Implicit refs — always, regardless of catalog.
+    push_single("child", comp.get("child"))
+    push_list("children", comp.get("children"))
+
+    # Explicit catalog-marked refs.
+    props = schema.get("properties") if _is_object(schema) else None
+    if _is_object(props):
+        for field, prop_schema in props.items():
+            if field in ("child", "children") or not _is_object(prop_schema):
+                continue
+            fmt = prop_schema.get("format")
+            if fmt == "componentRef":
+                push_single(field, comp.get(field))
+            elif fmt == "componentRefList":
+                push_list(field, comp.get(field))
+            elif prop_schema.get("type") == "array" and _is_object(prop_schema.get("items")):
+                item_props = prop_schema["items"].get("properties")
+                arr_val = comp.get(field)
+                if _is_object(item_props) and isinstance(arr_val, list):
+                    for k, item in enumerate(arr_val):
+                        if not _is_object(item):
+                            continue
+                        for sub, sub_schema in item_props.items():
+                            if not _is_object(sub_schema):
+                                continue
+                            sub_fmt = sub_schema.get("format")
+                            if sub_fmt == "componentRef":
+                                for ref in _collect_child_refs(item.get(sub)):
+                                    edges.append((f"{field}[{k}].{sub}", ref))
+                            elif sub_fmt == "componentRefList":
+                                sub_val = item.get(sub)
+                                if isinstance(sub_val, list):
+                                    for j, sv in enumerate(sub_val):
+                                        for ref in _collect_child_refs(sv):
+                                            edges.append((f"{field}[{k}].{sub}[{j}]", ref))
+                                else:
+                                    for ref in _collect_child_refs(sub_val):
+                                        edges.append((f"{field}[{k}].{sub}", ref))
+    return edges
+
+
+def _child_adjacency(components: list, catalog: Optional[dict] = None) -> dict[str, list[str]]:
+    """id -> ordered child-id references, derived per component via ``_collect_component_ref_edges``."""
+    catalog_components = (catalog or {}).get("components", {}) if catalog else {}
     adj: dict[str, list[str]] = {}
     for comp in components:
         if _is_object(comp) and isinstance(comp.get("id"), str):
-            adj[comp["id"]] = _collect_child_refs(comp.get("child")) + _collect_child_refs(comp.get("children"))
+            ctype = comp.get("component")
+            schema = catalog_components.get(ctype) if isinstance(ctype, str) else None
+            adj[comp["id"]] = [ref for _, ref in _collect_component_ref_edges(comp, schema)]
     return adj
 
 
-def _find_child_cycles(components: list) -> list[list[str]]:
+def _find_child_cycles(components: list, catalog: Optional[dict] = None) -> list[list[str]]:
     """Find unique child-reference cycles (self-references and longer loops) via DFS.
 
     Each cycle is canonicalised — rotated so the lexicographically smallest id
@@ -89,7 +160,7 @@ def _find_child_cycles(components: list) -> list[list[str]]:
     runs on untrusted model output, so a pathologically deep child chain must not
     raise ``RecursionError`` (and the .NET sibling must not overflow its stack).
     """
-    adj = _child_adjacency(components)
+    adj = _child_adjacency(components, catalog)
     color: dict[str, int] = {}  # absent/0 = unvisited, 1 = on stack, 2 = done
     cycles: dict[str, list[str]] = {}
 
@@ -199,20 +270,21 @@ def validate_a2ui_components(
                         errors.append({"code": "missing_required_prop", "path": f"components[{i}].{req}", "message": f"Component '{ctype}' (index {i}) is missing required prop '{req}'"})
 
         if _is_object(comp):
-            # Validate both the singular ``child`` (one-child containers such as
-            # Card/Button, which the default prompt emits) and the plural
-            # ``children`` so a dangling reference in either feeds the recovery loop.
-            for field in ("child", "children"):
-                for ref in _collect_child_refs(comp.get(field)):
-                    if ref not in ids:
-                        errors.append({"code": "unresolved_child", "path": f"components[{i}].{field}", "message": f"Child reference '{ref}' does not match any component id"})
+            # Implicit ``child``/``children`` are always checked; catalog-marked
+            # ref-fields (Modal ``trigger``/``content``, Tabs ``tabItems[].child``,
+            # ...) are checked too when a catalog is supplied. A dangling reference
+            # in any of them feeds the recovery loop. See ``_collect_component_ref_edges``.
+            schema = catalog_components.get(ctype) if isinstance(ctype, str) else None
+            for ref_path, ref in _collect_component_ref_edges(comp, schema):
+                if ref not in ids:
+                    errors.append({"code": "unresolved_child", "path": f"components[{i}].{ref_path}", "message": f"Child reference '{ref}' does not match any component id"})
             for p in (_collect_absolute_binding_paths(comp, []) if validate_bindings else []):
                 if not _absolute_path_resolves(p, data or {}):
                     errors.append({"code": "unresolved_binding", "path": f"components[{i}]", "message": f"Binding path '{p}' does not resolve in the data model"})
 
-    # The child/children tree must be a DAG — a component that (transitively)
+    # The child reference tree must be a DAG — a component that (transitively)
     # references itself never terminates at render time. Report each cycle once.
-    for cycle in _find_child_cycles(components):
+    for cycle in _find_child_cycles(components, catalog):
         chain = " -> ".join(cycle + [cycle[0]])
         errors.append({"code": "child_cycle", "path": f"components[id={cycle[0]}]", "message": f"Child reference cycle detected: {chain}"})
 

--- a/sdks/python/a2ui_toolkit/tests/test_validate.py
+++ b/sdks/python/a2ui_toolkit/tests/test_validate.py
@@ -178,6 +178,80 @@ class TestChildCycles(unittest.TestCase):
         self.assertEqual(len([e for e in r["errors"] if e["code"] == "child_cycle"]), 1)
 
 
+# #1948 — ref-fields beyond child/children, derived from catalog `format` markers.
+# A property is a child reference only when marked `componentRef` (single) or
+# `componentRefList` (list); unmarked props stay data, so a data string is never
+# mistaken for a dangling id. `tabItems[].child` is found via the array item schema.
+REF_CATALOG = {
+    "components": {
+        "Modal": {
+            "type": "object",
+            "properties": {
+                "trigger": {"type": "string", "format": "componentRef"},
+                "content": {"type": "string", "format": "componentRef"},
+                "title": {"type": "string"},  # unmarked data prop
+            },
+        },
+        "Tabs": {
+            "type": "object",
+            "properties": {
+                "tabItems": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"label": {"type": "string"}, "child": {"type": "string", "format": "componentRef"}}},
+                },
+            },
+        },
+        "Stack": {"type": "object", "properties": {"items": {"type": "array", "format": "componentRefList"}}},
+        "Text": {"type": "object"},
+    }
+}
+
+
+class TestCatalogDerivedRefFields(unittest.TestCase):
+    def test_modal_trigger_content_dangling(self):
+        comps = [{"id": "root", "component": "Modal", "trigger": "ghost-btn", "content": "ghost-body", "title": "Hi"}]
+        r = validate_a2ui_components(components=comps, catalog=REF_CATALOG)
+        self.assertTrue(any(e["code"] == "unresolved_child" and e["path"] == "components[0].trigger" and "ghost-btn" in e["message"] for e in r["errors"]))
+        self.assertTrue(any(e["code"] == "unresolved_child" and e["path"] == "components[0].content" and "ghost-body" in e["message"] for e in r["errors"]))
+
+    def test_unmarked_data_string_not_a_ref(self):
+        comps = [
+            {"id": "root", "component": "Modal", "trigger": "btn", "content": "body", "title": "not-an-id"},
+            {"id": "btn", "component": "Text"},
+            {"id": "body", "component": "Text"},
+        ]
+        r = validate_a2ui_components(components=comps, catalog=REF_CATALOG)
+        self.assertNotIn("unresolved_child", codes(r))
+
+    def test_nested_tabitems_child_dangling_per_index_path(self):
+        comps = [
+            {"id": "root", "component": "Tabs", "tabItems": [{"label": "A", "child": "panel-a"}, {"label": "B", "child": "ghost-panel"}]},
+            {"id": "panel-a", "component": "Text"},
+        ]
+        r = validate_a2ui_components(components=comps, catalog=REF_CATALOG)
+        self.assertTrue(any(e["code"] == "unresolved_child" and e["path"] == "components[0].tabItems[1].child" and "ghost-panel" in e["message"] for e in r["errors"]))
+        self.assertFalse(any(e["path"] == "components[0].tabItems[0].child" for e in r["errors"]))
+
+    def test_cycle_through_marked_field(self):
+        comps = [
+            {"id": "root", "component": "Modal", "content": "b"},
+            {"id": "b", "component": "Card", "child": "root"},
+        ]
+        r = validate_a2ui_components(components=comps, catalog=REF_CATALOG)
+        self.assertEqual(len([e for e in r["errors"] if e["code"] == "child_cycle"]), 1)
+        self.assertTrue(any(e["code"] == "child_cycle" and ("b -> root -> b" in e["message"] or "root -> b -> root" in e["message"]) for e in r["errors"]))
+
+    def test_list_ref_array_per_index_path(self):
+        comps = [{"id": "root", "component": "Stack", "items": ["x", "ghost-1"]}, {"id": "x", "component": "Text"}]
+        r = validate_a2ui_components(components=comps, catalog=REF_CATALOG)
+        self.assertTrue(any(e["code"] == "unresolved_child" and e["path"] == "components[0].items[1]" and "ghost-1" in e["message"] for e in r["errors"]))
+
+    def test_marked_fields_ignored_without_catalog(self):
+        comps = [{"id": "root", "component": "Modal", "trigger": "ghost-btn", "content": "ghost-body"}]
+        r = validate_a2ui_components(components=comps)
+        self.assertNotIn("unresolved_child", codes(r))
+
+
 class TestBindings(unittest.TestCase):
     def test_absolute_binding_unresolved(self):
         r = validate_a2ui_components(components=valid_components(), data={}, catalog=CATALOG)

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
@@ -214,6 +214,98 @@ describe("validateA2UIComponents — child cycles", () => {
   );
 });
 
+// #1948 — ref-fields beyond child/children, derived from catalog `format` markers.
+// A property is a child reference only when its schema marks it `componentRef`
+// (single) or `componentRefList` (list); unmarked props stay data, so a data
+// string is never mistaken for a dangling id. `tabItems[].child` is found by
+// honouring markers on an array property's item sub-schema.
+const REF_CATALOG = {
+  components: {
+    Modal: {
+      type: "object",
+      properties: {
+        trigger: { type: "string", format: "componentRef" },
+        content: { type: "string", format: "componentRef" },
+        title: { type: "string" }, // unmarked data prop
+      },
+    },
+    Tabs: {
+      type: "object",
+      properties: {
+        tabItems: {
+          type: "array",
+          items: { type: "object", properties: { label: { type: "string" }, child: { type: "string", format: "componentRef" } } },
+        },
+      },
+    },
+    Stack: {
+      type: "object",
+      properties: { items: { type: "array", format: "componentRefList" } },
+    },
+    Text: { type: "object" },
+  },
+};
+
+describe("validateA2UIComponents — catalog-derived ref-fields (#1948)", () => {
+  it("flags a dangling Modal `trigger`/`content` ref via the catalog marker", () => {
+    const comps = [{ id: "root", component: "Modal", trigger: "ghost-btn", content: "ghost-body", title: "Hi" }];
+    const r = validateA2UIComponents({ components: comps, catalog: REF_CATALOG });
+    expect(r.errors.some((e) => e.code === "unresolved_child" && e.path === "components[0].trigger" && /ghost-btn/.test(e.message))).toBe(true);
+    expect(r.errors.some((e) => e.code === "unresolved_child" && e.path === "components[0].content" && /ghost-body/.test(e.message))).toBe(true);
+  });
+
+  it("does not treat an unmarked data string as a child reference", () => {
+    // `title` is a plain string prop; its value must never be flagged as a dangling id.
+    const comps = [
+      { id: "root", component: "Modal", trigger: "btn", content: "body", title: "not-an-id" },
+      { id: "btn", component: "Text" },
+      { id: "body", component: "Text" },
+    ];
+    const r = validateA2UIComponents({ components: comps, catalog: REF_CATALOG });
+    expect(r.errors.some((e) => e.code === "unresolved_child")).toBe(false);
+  });
+
+  it("flags a dangling nested `tabItems[k].child` with a per-index path", () => {
+    const comps = [
+      {
+        id: "root",
+        component: "Tabs",
+        tabItems: [
+          { label: "A", child: "panel-a" },
+          { label: "B", child: "ghost-panel" },
+        ],
+      },
+      { id: "panel-a", component: "Text" },
+    ];
+    const r = validateA2UIComponents({ components: comps, catalog: REF_CATALOG });
+    expect(r.errors.some((e) => e.code === "unresolved_child" && e.path === "components[0].tabItems[1].child" && /ghost-panel/.test(e.message))).toBe(true);
+    expect(r.errors.some((e) => e.path === "components[0].tabItems[0].child")).toBe(false);
+  });
+
+  it("detects a cycle routed through a catalog-marked field", () => {
+    // root(Modal).content -> b(Card).child -> root : undetectable without the marker.
+    const comps = [
+      { id: "root", component: "Modal", content: "b" },
+      { id: "b", component: "Card", child: "root" },
+    ];
+    const r = validateA2UIComponents({ components: comps, catalog: REF_CATALOG });
+    expect(r.errors.filter((e) => e.code === "child_cycle").length).toBe(1);
+    expect(r.errors.some((e) => e.code === "child_cycle" && /b -> root -> b|root -> b -> root/.test(e.message))).toBe(true);
+  });
+
+  it("emits per-index paths for list-ref array refs", () => {
+    const comps = [{ id: "root", component: "Stack", items: ["x", "ghost-1"] }, { id: "x", component: "Text" }];
+    const r = validateA2UIComponents({ components: comps, catalog: REF_CATALOG });
+    expect(r.errors.some((e) => e.code === "unresolved_child" && e.path === "components[0].items[1]" && /ghost-1/.test(e.message))).toBe(true);
+  });
+
+  it("ignores marked ref-fields when no catalog is supplied (structural child/children only)", () => {
+    const comps = [{ id: "root", component: "Modal", trigger: "ghost-btn", content: "ghost-body" }];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.errors.some((e) => e.code === "unresolved_child")).toBe(false);
+  });
+});
+
 describe("validateA2UIComponents — data bindings", () => {
   it("flags an absolute binding path absent from the data model", () => {
     const r = validateA2UIComponents({ components: validComponents(), data: {}, catalog: CATALOG });

--- a/sdks/typescript/packages/a2ui-toolkit/src/validate.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/validate.ts
@@ -157,21 +157,21 @@ export function validateA2UIComponents(input: ValidateA2UIInput): ValidateA2UIRe
       }
     }
 
-    // Child references must resolve to existing component ids. Both the singular
-    // `child` (one-child containers such as Card/Button, which the default prompt
-    // emits) and the plural `children` are validated so a dangling reference in
-    // either is caught and fed back to the recovery loop.
+    // Child references must resolve to existing component ids. The implicit
+    // `child`/`children` fields are always checked; catalog-marked ref-fields
+    // (Modal `trigger`/`content`, Tabs `tabItems[].child`, …) are checked too
+    // when a catalog is supplied. A dangling reference in any of them is fed
+    // back to the recovery loop. See `collectComponentRefEdges`.
     if (isObject(comp)) {
-      (["child", "children"] as const).forEach((field) => {
-        collectChildRefs(comp[field]).forEach((ref) => {
-          if (!ids.has(ref)) {
-            errors.push({
-              code: "unresolved_child",
-              path: `components[${i}].${field}`,
-              message: `Child reference '${ref}' does not match any component id`,
-            });
-          }
-        });
+      const schema = catalog && typeof type === "string" ? catalog.components[type] : undefined;
+      collectComponentRefEdges(comp, schema).forEach(({ path: refPath, ref }) => {
+        if (!ids.has(ref)) {
+          errors.push({
+            code: "unresolved_child",
+            path: `components[${i}].${refPath}`,
+            message: `Child reference '${ref}' does not match any component id`,
+          });
+        }
       });
 
       // Absolute binding paths must resolve against the data model (unless
@@ -188,9 +188,9 @@ export function validateA2UIComponents(input: ValidateA2UIInput): ValidateA2UIRe
     }
   });
 
-  // The child/children tree must be a DAG — a component that (transitively)
+  // The child reference tree must be a DAG — a component that (transitively)
   // references itself never terminates at render time. Report each cycle once.
-  findChildCycles(components).forEach((cycle) => {
+  findChildCycles(components, catalog).forEach((cycle) => {
     errors.push({
       code: "child_cycle",
       path: `components[id=${cycle[0]}]`,
@@ -221,20 +221,102 @@ function collectChildRefs(children: unknown): string[] {
   return refs;
 }
 
+/** A single child reference and the field-path suffix it was found at (e.g. `children[0]`, `tabItems[1].child`). */
+interface RefEdge {
+  path: string;
+  ref: string;
+}
+
 /**
- * id → ordered child-id references, gathered from singular `child` + plural `children`.
+ * Collect every child reference a component makes, paired with its field-path
+ * suffix, by deriving ref-fields from the catalog (#1948).
  *
- * Scope note: only these two fields feed the dangling-ref check and the cycle
- * graph. Other catalog ref-fields (Modal `trigger`/`content`, Tabs
- * `tabs[].child`) are NOT yet traversed — deriving ref-fields from the catalog
- * (in lockstep across the TS/Python/.NET toolkits) is tracked in
- * https://github.com/ag-ui-protocol/ag-ui/issues/1948.
+ * The implicit `child` (single) and `children` (list) fields are ALWAYS ref
+ * fields, even with no catalog — this preserves the #1944 / catalog-free
+ * behaviour. Other fields are refs ONLY when the component's catalog schema
+ * marks the property `"format": "componentRef"` (single) or
+ * `"componentRefList"` (list). For an array-typed property whose `items` is an
+ * object schema, marked sub-properties are honoured per element (this is how
+ * Tabs `tabItems[].child` is found — derived, never hard-coded). A property with
+ * no marker is treated as data, never a ref — a bare data string and a bare ref
+ * string are otherwise indistinguishable, so shape-based detection is unsafe.
+ *
+ * Path grammar (byte-aligned with the Python/.NET siblings):
+ *   single-ref field             → `<field>`
+ *   list-ref field (array)       → `<field>[k]`
+ *   list-ref field (single tmpl) → `<field>`
+ *   nested array-of-object ref   → `<arrayField>[k].<refField>` (and `[j]` if that sub-field is itself a list)
  */
-function childAdjacency(components: Array<Record<string, unknown>>): Map<string, string[]> {
+function collectComponentRefEdges(
+  comp: Record<string, unknown>,
+  schema: { properties?: Record<string, unknown>; [k: string]: unknown } | undefined,
+): RefEdge[] {
+  const edges: RefEdge[] = [];
+
+  const pushSingle = (field: string, value: unknown) => {
+    collectChildRefs(value).forEach((ref) => edges.push({ path: field, ref }));
+  };
+  const pushList = (field: string, value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach((item, k) => collectChildRefs(item).forEach((ref) => edges.push({ path: `${field}[${k}]`, ref })));
+    } else {
+      collectChildRefs(value).forEach((ref) => edges.push({ path: field, ref }));
+    }
+  };
+
+  // Implicit refs — always, regardless of catalog.
+  pushSingle("child", comp.child);
+  pushList("children", comp.children);
+
+  // Explicit catalog-marked refs.
+  const props = schema?.properties;
+  if (isObject(props)) {
+    for (const [field, propSchema] of Object.entries(props)) {
+      if (field === "child" || field === "children" || !isObject(propSchema)) continue;
+      const fmt = propSchema.format;
+      if (fmt === "componentRef") {
+        pushSingle(field, comp[field]);
+      } else if (fmt === "componentRefList") {
+        pushList(field, comp[field]);
+      } else if (propSchema.type === "array" && isObject(propSchema.items)) {
+        const itemProps = (propSchema.items as Record<string, unknown>).properties;
+        const arrVal = comp[field];
+        if (isObject(itemProps) && Array.isArray(arrVal)) {
+          arrVal.forEach((item, k) => {
+            if (!isObject(item)) return;
+            for (const [sub, subSchema] of Object.entries(itemProps)) {
+              if (!isObject(subSchema)) continue;
+              if (subSchema.format === "componentRef") {
+                collectChildRefs(item[sub]).forEach((ref) => edges.push({ path: `${field}[${k}].${sub}`, ref }));
+              } else if (subSchema.format === "componentRefList") {
+                const subVal = item[sub];
+                if (Array.isArray(subVal)) {
+                  subVal.forEach((sv, j) => collectChildRefs(sv).forEach((ref) => edges.push({ path: `${field}[${k}].${sub}[${j}]`, ref })));
+                } else {
+                  collectChildRefs(subVal).forEach((ref) => edges.push({ path: `${field}[${k}].${sub}`, ref }));
+                }
+              }
+            }
+          });
+        }
+      }
+    }
+  }
+
+  return edges;
+}
+
+/** id → ordered child-id references, derived per component via `collectComponentRefEdges`. */
+function childAdjacency(components: Array<Record<string, unknown>>, catalog?: A2UIValidationCatalog): Map<string, string[]> {
   const adj = new Map<string, string[]>();
   for (const comp of components) {
     if (isObject(comp) && typeof comp.id === "string") {
-      adj.set(comp.id, [...collectChildRefs(comp.child), ...collectChildRefs(comp.children)]);
+      const type = typeof comp.component === "string" ? comp.component : undefined;
+      const schema = catalog && type ? catalog.components[type] : undefined;
+      adj.set(
+        comp.id,
+        collectComponentRefEdges(comp, schema).map((e) => e.ref),
+      );
     }
   }
   return adj;
@@ -247,8 +329,8 @@ function childAdjacency(components: Array<Record<string, unknown>>): Map<string,
  * different entry points collapses to one finding, and the reported chain stays
  * byte-identical across the sibling toolkits.
  */
-function findChildCycles(components: Array<Record<string, unknown>>): string[][] {
-  const adj = childAdjacency(components);
+function findChildCycles(components: Array<Record<string, unknown>>, catalog?: A2UIValidationCatalog): string[][] {
+  const adj = childAdjacency(components, catalog);
   const color = new Map<string, number>(); // absent/0 = unvisited, 1 = on stack, 2 = done
   const cycles = new Map<string, string[]>();
 


### PR DESCRIPTION
Closes #1948.

## What

#1944 closed the singular-`child` + cycle gaps, scoped to the `child`/`children` fields. This extends both the dangling-ref check and the cycle graph to **every** child reference a component makes, derived from the catalog rather than a hardcoded field list — covering Modal `trigger`/`content`, Tabs `tabItems[].child`, etc. Kept byte-aligned with the .NET sibling (microsoft/agent-framework#6494).

## How

A property is a child reference only when its catalog schema marks it:
- `"format": "componentRef"` — single ref
- `"format": "componentRefList"` — list ref (array of ids, or a `{ componentId, path }` template)

For an array property whose `items` is an object schema, marked sub-properties are honoured per element (this is how `tabItems[].child` is found — derived, never hardcoded).

**Why a marker and not shape inference:** the validator catalog carries no machine-readable ref marker today, and a ref value (`"card"`) is indistinguishable from a data value (`"$289"`) — both are bare strings. Shape-based detection would flag every non-id data string as a dangling child. So detection is marker-driven; an unmarked property is data, never a reference.

`child`/`children` remain implicit references **always**, so #1944 and the catalog-free structural path are unchanged.

A new `collectComponentRefEdges` / `_collect_component_ref_edges` returns `(path, ref)` pairs consumed by **both** the dangling check and the cycle adjacency, so a cycle routed through a marked field (e.g. Modal `content`) is now detected.

### Path grammar (byte-aligned across TS / Python / .NET)
| ref shape | path |
|---|---|
| single-ref field | `components[i].<field>` |
| list-ref (array), k-th | `components[i].<field>[k]` |
| list-ref (single template) | `components[i].<field>` |
| nested array-of-object | `components[i].<arrayField>[k].<refField>` (and `[j]` if that sub-field is itself a list) |

Error code reuses `unresolved_child` (field-specific paths); cycle stays `child_cycle`.

## Gating & scope

Extended fields are derived **only when a marked catalog is supplied**; with no catalog, only `child`/`children` are checked — exactly as before. The dojo demos pass no catalog, so **there is no dojo behaviour change**; this fires for hosts that supply a marked catalog. Enriching catalog producers to emit `format` markers is downstream follow-up, out of scope here.

## Tests

vitest + unittest, byte-aligned: Modal trigger/content dangling, unmarked data string **not** flagged, nested `tabItems[k].child` per-index, cycle through a marked field, list-ref array per-index, marked fields ignored without a catalog. All #1944 child/children + deep-chain tests stay green. **TS 90/90, Python 89/89, `tsc --noEmit` clean.**

## Cross-language parity

.NET ships in microsoft/agent-framework#6494 (`xunit 117/117`). Emitted paths diffed byte-for-byte across all three toolkits before commit.