### PR TITLE
fix(client): guard against null/undefined agent.messages at all call sites

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-messages-non-array.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-messages-non-array.test.ts
@@ -1,0 +1,45 @@
+import { AbstractAgent } from "../agent";
+import { BaseEvent, RunAgentInput } from "@ag-ui/core";
+import { Observable, of } from "rxjs";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("uuid", () => ({
+  v4: vi.fn().mockReturnValue("mock-uuid"),
+}));
+
+vi.mock("@/verify", () => ({
+  verifyEvents: vi.fn(() => (source$: Observable<any>) => source$),
+}));
+
+vi.mock("@/chunks", () => ({
+  transformChunks: vi.fn(() => (source$: Observable<any>) => source$),
+}));
+
+class TestAgent extends AbstractAgent {
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return of();
+  }
+}
+
+describe("runAgent when messages is not an array", () => {
+  it("treats null messages as empty array — does not throw", async () => {
+    const agent = new TestAgent({ threadId: "t1" });
+    (agent as any).messages = null;
+
+    await expect(agent.runAgent()).resolves.toBeDefined();
+  });
+
+  it("treats undefined messages as empty array — does not throw", async () => {
+    const agent = new TestAgent({ threadId: "t1" });
+    (agent as any).messages = undefined;
+
+    await expect(agent.runAgent()).resolves.toBeDefined();
+  });
+
+  it("works normally when messages is a valid array", async () => {
+    const agent = new TestAgent({ threadId: "t1" });
+    agent.messages = [{ id: "msg-1", role: "user", content: "hi" }];
+
+    await expect(agent.runAgent()).resolves.toBeDefined();
+  });
+});

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -168,7 +168,7 @@ export abstract class AbstractAgent {
       });
 
       let result: any = undefined;
-      const currentMessageIds = new Set(this.messages.map((message) => message.id));
+      const currentMessageIds = new Set((this.messages ?? []).map((message) => message.id));
 
       const subscribers: AgentSubscriber[] = [
         {
@@ -243,7 +243,7 @@ export abstract class AbstractAgent {
       );
 
       await lastValueFrom(pipeline(of(null)));
-      const newMessages = structuredClone_(this.messages).filter(
+      const newMessages = structuredClone_(this.messages ?? []).filter(
         (message: Message) => !currentMessageIds.has(message.id),
       );
       return { result, newMessages };
@@ -264,7 +264,7 @@ export abstract class AbstractAgent {
       this.agentId = this.agentId ?? uuidv4();
       const input = this.prepareRunAgentInput(parameters);
       let result: any = undefined;
-      const currentMessageIds = new Set(this.messages.map((message) => message.id));
+      const currentMessageIds = new Set((this.messages ?? []).map((message) => message.id));
 
       const subscribers: AgentSubscriber[] = [
         {
@@ -315,7 +315,7 @@ export abstract class AbstractAgent {
       // defaultValue prevents EmptyError when catchError returns EMPTY
       // (e.g. ConnectNotImplementedError path)
       await lastValueFrom(pipeline(of(null)), { defaultValue: undefined });
-      const newMessages = structuredClone_(this.messages).filter(
+      const newMessages = structuredClone_(this.messages ?? []).filter(
         (message: Message) => !currentMessageIds.has(message.id),
       );
       return { result, newMessages };
@@ -378,7 +378,7 @@ export abstract class AbstractAgent {
   }
 
   protected prepareRunAgentInput(parameters?: RunAgentParameters): RunAgentInput {
-    const clonedMessages = structuredClone_(this.messages) as Message[];
+    const clonedMessages = structuredClone_(this.messages ?? []) as Message[];
     const messagesWithoutActivity = clonedMessages.filter((message) => message.role !== "activity");
 
     return {
@@ -413,7 +413,7 @@ export abstract class AbstractAgent {
 
     const onRunInitializedMutation = await runSubscribersWithMutation(
       subscribers,
-      this.messages,
+      this.messages ?? [],
       this.state,
       (subscriber, messages, state) =>
         subscriber.onRunInitialized?.({ messages, state, agent: this, input }),
@@ -453,7 +453,7 @@ export abstract class AbstractAgent {
     return from(
       runSubscribersWithMutation(
         subscribers,
-        this.messages,
+        this.messages ?? [],
         this.state,
         (subscriber, messages, state) =>
           subscriber.onRunFailed?.({ error, messages, state, agent: this, input }),
@@ -513,7 +513,7 @@ export abstract class AbstractAgent {
   protected async onFinalize(input: RunAgentInput, subscribers: AgentSubscriber[]) {
     const onRunFinalizedMutation = await runSubscribersWithMutation(
       subscribers,
-      this.messages,
+      this.messages ?? [],
       this.state,
       (subscriber, messages, state) =>
         subscriber.onRunFinalized?.({ messages, state, agent: this, input }),

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -99,7 +99,7 @@ export const defaultApplyEvents = (
   debugLogger?: DebugLoggerInput,
 ): Observable<AgentStateMutation> => {
   const log = resolveDebugLogger(debugLogger);
-  let messages = structuredClone_(agent.messages);
+  let messages = structuredClone_(agent.messages ?? []);
   let state = structuredClone_(input.state);
   let currentMutation: AgentStateMutation = {};
 


### PR DESCRIPTION
Fixes #1961

## Summary

- `AbstractAgent.messages` is public — runtime code can assign `null`/`undefined` to it
- Seven call sites in `agent.ts` and `default.ts` called `.map()` / `.filter()` on it directly with no guard
- Any of these sites would crash with `TypeError` when `messages` is not an array
- The `onRunErrorEvent` path was the live production trigger: `defaultApplyEvents` passed `undefined` as `initialMessages` to `runSubscribersWithMutation`, which forwarded it to subscribers

## Changes

Added `?? []` fallback at all 7 unsafe sites:

| File | Method | Fix |
|------|--------|-----|
| `agent.ts` | `runAgent` | `(this.messages ?? []).map(...)` |
| `agent.ts` | `connectAgent` | `(this.messages ?? []).map(...)` |
| `agent.ts` | `prepareRunAgentInput` | `structuredClone_(this.messages ?? [])` |
| `agent.ts` | `runAgent` / `connectAgent` post-run | `structuredClone_(this.messages ?? []).filter(...)` |
| `agent.ts` | `onInitialize` | `runSubscribersWithMutation(subscribers, this.messages ?? [], ...)` |
| `agent.ts` | `onError` | `runSubscribersWithMutation(subscribers, this.messages ?? [], ...)` |
| `default.ts` | `defaultApplyEvents` | `structuredClone_(agent.messages ?? [])` |

## Test plan

- [ ] New test file `agent-messages-non-array.test.ts` covers `null`, `undefined`, and valid-array cases for `runAgent()`
- [ ] All 497 existing tests still pass (1 pre-existing `esm-interop` failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)