### PR TITLE
test(client): cover HttpAgent default fetch binding (#1891)

### DIFF
--- a/sdks/typescript/packages/client/src/__tests__/http-agent-fetch.test.ts
+++ b/sdks/typescript/packages/client/src/__tests__/http-agent-fetch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { HttpAgent } from "../agent/http";
+
+/**
+ * Regression test for #1891: HttpAgent threw "Illegal invocation" in browsers
+ * when no custom `fetch` was supplied.
+ *
+ * A browser's native `fetch` is a checked-receiver method: it throws
+ * "Illegal invocation" unless called with the global object as `this`. The old
+ * code stored the bare global (`this.fetch = config.fetch ?? fetch`) and later
+ * invoked it as `this.fetch(...)`, setting the receiver to the agent instance.
+ *
+ * We replicate the browser behaviour by installing a checked-receiver stub on
+ * `globalThis.fetch`, then invoke the agent's default fetch the same way the
+ * agent does internally.
+ */
+describe("HttpAgent default fetch binding (#1891)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("does not throw 'Illegal invocation' when the default fetch is invoked as a method", async () => {
+    const response = new Response("ok");
+    // Checked-receiver stub: behaves like the browser's native fetch, which
+    // rejects any receiver that is not the global object.
+    const browserLikeFetch = function (this: unknown, ..._args: unknown[]) {
+      if (this !== undefined && this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+      }
+      return Promise.resolve(response);
+    };
+    globalThis.fetch = browserLikeFetch as unknown as typeof fetch;
+
+    const agent = new HttpAgent({ url: "https://example.com/api" });
+
+    // Invoke exactly as the agent does internally: `this.fetch(...)`, i.e. with
+    // the agent instance as the receiver. The binding must keep `fetch` happy.
+    await expect(agent.fetch("https://example.com/api", {})).resolves.toBe(response);
+  });
+
+  it("delegates to the global fetch with the given url and init", async () => {
+    const response = new Response("ok");
+    const spy = vi.fn().mockResolvedValue(response);
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    const agent = new HttpAgent({ url: "https://example.com/api" });
+    const init = { method: "POST" };
+    await agent.fetch("https://example.com/api", init);
+
+    expect(spy).toHaveBeenCalledWith("https://example.com/api", init);
+  });
+
+  it("still honours a custom fetch when supplied", async () => {
+    const response = new Response("custom");
+    const custom = vi.fn().mockResolvedValue(response);
+
+    const agent = new HttpAgent({ url: "https://example.com/api", fetch: custom });
+    await expect(agent.fetch("https://example.com/api", {})).resolves.toBe(response);
+    expect(custom).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Relates to #1891

## Context
#1891 (HttpAgent throws "Illegal invocation" in browsers with no custom fetch) was **already fixed on `main`** by commit `0dc4c554` ("fix(client): bind default fetch in HttpAgent..."), which wraps the global fetch in an arrow function so the receiver is no longer the agent instance. That fix shipped **without a regression test**.

## What this adds
A focused regression test (`src/__tests__/http-agent-fetch.test.ts`) that replicates the browser behaviour with a checked-receiver `globalThis.fetch` stub (native browser fetch throws "Illegal invocation" unless `this` is the global object) and asserts:
- the default fetch, invoked as `this.fetch(...)`, does **not** throw "Illegal invocation"
- it delegates to the global fetch with the given url + init
- a custom `fetch` is still honoured

The first test fails against the pre-fix source (`this.fetch = config.fetch ?? fetch`) and passes with the shipped fix — locking in the fix.

## Tests
- New file: 3 tests pass.
- Full client suite: 497 pass. The one unrelated failure (`esm-interop.test.ts`, regression #1577) loads the **built** ESM bundle and requires `pnpm build` first — orthogonal to this source-only change.

## Note
This PR does not change runtime code. If #1891 should be closed, the fix is already on main; this just adds the missing coverage.