### PR TITLE
fix(aws-strands): add license metadata and bundle LICENSE in package (#1927)

### DIFF
--- a/integrations/aws-strands/python/LICENSE
+++ b/integrations/aws-strands/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/aws-strands/python/pyproject.toml
+++ b/integrations/aws-strands/python/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "ag_ui_strands"
 version = "0.1.9"
+description = "Implementation of the AG-UI protocol for AWS Strands."
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "AG-UI Contributors" }
 ]


### PR DESCRIPTION
Fixes #1927

## Root cause
`integrations/aws-strands/python/pyproject.toml` declared no `license` field and the package directory had no `LICENSE` file, so the published `ag_ui_strands` sdist/wheel (v0.1.9 on PyPI) carried zero license information — no SPDX expression, no classifier, no license text.

## Fix
Mirror the langroid adapter (the clean reference in this monorepo):
- add `license = "MIT"` and `license-files = ["LICENSE"]` to `[project]`
- add a `description`
- add a `LICENSE` file (MIT, same text as the repo root) to the package directory

## Verification
Built the wheel locally (`uv build`) and inspected the artifact:
```
Name: ag_ui_strands
Summary: Implementation of the AG-UI protocol for AWS Strands.
License-Expression: MIT
License-File: LICENSE
```
LICENSE file present at `ag_ui_strands-0.1.9.dist-info/licenses/LICENSE`.

## Tests
No runtime code changed. Full package suite: 135 passed, 2 skipped.

## Checklist
- [x] Packaging metadata + LICENSE verified in built wheel
- [x] Full package test suite passes
- [x] Minimal change, scoped to the issue
- [ ] Version bump intentionally omitted — leaving the next release/version decision to maintainers