### PR TITLE
fix(create-ag-ui-app): fix --crewai-flows, build argv via tested helper

### DIFF
--- a/sdks/typescript/packages/cli/src/build-args.test.ts
+++ b/sdks/typescript/packages/cli/src/build-args.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "vitest";
 import { buildCopilotKitCreateArgs } from "./build-args";
 
-test("pins copilotkit@3 and forwards name + --no-banner", () => {
+test("uses copilotkit@latest and forwards name + --no-banner", () => {
   const args = buildCopilotKitCreateArgs({ langgraphPy: true }, "my-app");
   expect(args).toEqual([
-    "copilotkit@3",
+    "copilotkit@latest",
     "create",
     "--no-banner",
     "-n",
@@ -23,7 +23,7 @@ test("maps --crewai-flows (crewaiFlows) to -f flows", () => {
 test("emits no -f when no framework flag is set", () => {
   const args = buildCopilotKitCreateArgs({}, "demo");
   expect(args).not.toContain("-f");
-  expect(args).toEqual(["copilotkit@3", "create", "--no-banner", "-n", "demo"]);
+  expect(args).toEqual(["copilotkit@latest", "create", "--no-banner", "-n", "demo"]);
 });
 
 test("maps each framework flag to its canonical -f value", () => {

--- a/sdks/typescript/packages/cli/src/build-args.test.ts
+++ b/sdks/typescript/packages/cli/src/build-args.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+import { buildCopilotKitCreateArgs } from "./build-args";
+
+test("pins copilotkit@3 and forwards name + --no-banner", () => {
+  const args = buildCopilotKitCreateArgs({ langgraphPy: true }, "my-app");
+  expect(args).toEqual([
+    "copilotkit@3",
+    "create",
+    "--no-banner",
+    "-n",
+    "my-app",
+    "-f",
+    "langgraph-py",
+  ]);
+});
+
+test("maps --crewai-flows (crewaiFlows) to -f flows", () => {
+  const args = buildCopilotKitCreateArgs({ crewaiFlows: true }, "demo");
+  expect(args).toContain("-f");
+  expect(args).toContain("flows");
+});
+
+test("emits no -f when no framework flag is set", () => {
+  const args = buildCopilotKitCreateArgs({}, "demo");
+  expect(args).not.toContain("-f");
+  expect(args).toEqual(["copilotkit@3", "create", "--no-banner", "-n", "demo"]);
+});
+
+test("maps each framework flag to its canonical -f value", () => {
+  const cases: Array<[Record<string, boolean>, string]> = [
+    [{ langgraphJs: true }, "langgraph-js"],
+    [{ mastra: true }, "mastra"],
+    [{ ag2: true }, "ag2"],
+    [{ llamaindex: true }, "llamaindex"],
+    [{ agno: true }, "agno"],
+    [{ pydanticAi: true }, "pydantic-ai"],
+    [{ adk: true }, "adk"],
+  ];
+  for (const [opts, expected] of cases) {
+    const args = buildCopilotKitCreateArgs(opts, "x");
+    expect(args.slice(-2)).toEqual(["-f", expected]);
+  }
+});

--- a/sdks/typescript/packages/cli/src/build-args.ts
+++ b/sdks/typescript/packages/cli/src/build-args.ts
@@ -1,9 +1,9 @@
 /**
- * Version spec for the underlying CopilotKit CLI. Pinned to the v3 line (not
- * `@latest`) so a future major with different arguments cannot silently break
- * `create-ag-ui-app`; `@3` still picks up bug-fix releases within v3.
+ * Version spec for the underlying CopilotKit CLI. Tracks `@latest` so
+ * `create-ag-ui-app` always scaffolds with the current CopilotKit CLI rather
+ * than freezing on a pinned major.
  */
-export const COPILOTKIT_CLI_SPEC = "copilotkit@3";
+export const COPILOTKIT_CLI_SPEC = "copilotkit@latest";
 
 /** Framework flags as parsed by commander, in selection-priority order. */
 export interface FrameworkOptions {
@@ -20,7 +20,7 @@ export interface FrameworkOptions {
 
 /**
  * Builds the argv passed to `npx` to invoke the CopilotKit CLI's `create`
- * command. Pure and exported so the mapping (and the version pin) is unit
+ * command. Pure and exported so the mapping (and the version spec) is unit
  * tested without spawning a process.
  *
  * @param options - Parsed commander framework flags.

--- a/sdks/typescript/packages/cli/src/build-args.ts
+++ b/sdks/typescript/packages/cli/src/build-args.ts
@@ -1,0 +1,64 @@
+/**
+ * Version spec for the underlying CopilotKit CLI. Pinned to the v3 line (not
+ * `@latest`) so a future major with different arguments cannot silently break
+ * `create-ag-ui-app`; `@3` still picks up bug-fix releases within v3.
+ */
+export const COPILOTKIT_CLI_SPEC = "copilotkit@3";
+
+/** Framework flags as parsed by commander, in selection-priority order. */
+export interface FrameworkOptions {
+  langgraphPy?: boolean;
+  langgraphJs?: boolean;
+  crewaiFlows?: boolean;
+  mastra?: boolean;
+  ag2?: boolean;
+  llamaindex?: boolean;
+  agno?: boolean;
+  pydanticAi?: boolean;
+  adk?: boolean;
+}
+
+/**
+ * Builds the argv passed to `npx` to invoke the CopilotKit CLI's `create`
+ * command. Pure and exported so the mapping (and the version pin) is unit
+ * tested without spawning a process.
+ *
+ * @param options - Parsed commander framework flags.
+ * @param projectName - Validated project name.
+ * @returns The argv array for `spawn("npx", ...)`.
+ */
+export function buildCopilotKitCreateArgs(
+  options: FrameworkOptions,
+  projectName: string,
+): string[] {
+  const frameworkArgs: string[] = [];
+
+  if (options.langgraphPy) {
+    frameworkArgs.push("-f", "langgraph-py");
+  } else if (options.langgraphJs) {
+    frameworkArgs.push("-f", "langgraph-js");
+  } else if (options.crewaiFlows) {
+    frameworkArgs.push("-f", "flows");
+  } else if (options.mastra) {
+    frameworkArgs.push("-f", "mastra");
+  } else if (options.ag2) {
+    frameworkArgs.push("-f", "ag2");
+  } else if (options.llamaindex) {
+    frameworkArgs.push("-f", "llamaindex");
+  } else if (options.agno) {
+    frameworkArgs.push("-f", "agno");
+  } else if (options.pydanticAi) {
+    frameworkArgs.push("-f", "pydantic-ai");
+  } else if (options.adk) {
+    frameworkArgs.push("-f", "adk");
+  }
+
+  return [
+    COPILOTKIT_CLI_SPEC,
+    "create",
+    "--no-banner",
+    "-n",
+    projectName,
+    ...frameworkArgs,
+  ];
+}

--- a/sdks/typescript/packages/cli/src/build-args.ts
+++ b/sdks/typescript/packages/cli/src/build-args.ts
@@ -53,12 +53,5 @@ export function buildCopilotKitCreateArgs(
     frameworkArgs.push("-f", "adk");
   }
 
-  return [
-    COPILOTKIT_CLI_SPEC,
-    "create",
-    "--no-banner",
-    "-n",
-    projectName,
-    ...frameworkArgs,
-  ];
+  return [COPILOTKIT_CLI_SPEC, "create", "--no-banner", "-n", projectName, ...frameworkArgs];
 }

--- a/sdks/typescript/packages/cli/src/index.ts
+++ b/sdks/typescript/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ ${RESET}
 
 const description = `
 Quickly scaffold AG-UI enabled applications for your favorite agent frameworks.
-`
+`;
 
 async function createProject() {
   displayBanner();
@@ -47,8 +47,8 @@ async function createProject() {
     "llamaindex",
     "pydanticAi",
     "agno",
-    "adk"
-  ].some(flag => options[flag]);
+    "adk",
+  ].some((flag) => options[flag]);
 
   if (isFrameworkDefined) {
     await handleCopilotKitNextJs();
@@ -175,10 +175,7 @@ async function handleCliClient() {
 }
 
 // Metadata
-program
-  .name("create-ag-ui-app")
-  .description(description)
-  .version("0.0.36");
+program.name("create-ag-ui-app").description(description).version("0.0.36");
 
 // Add framework flags
 program
@@ -190,7 +187,7 @@ program
   .option("--llamaindex", "Use the LlamaIndex framework")
   .option("--agno", "Use the Agno framework")
   .option("--ag2", "Use the AG2 framework")
-  .option("--adk", "Use the ADK framework")
+  .option("--adk", "Use the ADK framework");
 
 program.action(async () => {
   await createProject();

--- a/sdks/typescript/packages/cli/src/index.ts
+++ b/sdks/typescript/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import inquirer from "inquirer";
 import { spawn } from "child_process";
+import { buildCopilotKitCreateArgs } from "./build-args";
 import fs from "fs";
 import path from "path";
 import { downloadTemplate } from "giget";
@@ -85,7 +86,6 @@ async function createProject() {
 
 async function handleCopilotKitNextJs() {
   const options = program.opts();
-  const frameworkArgs: string[] = [];
 
   const projectName = await inquirer.prompt([
     {
@@ -105,40 +105,10 @@ async function handleCopilotKitNextJs() {
     },
   ]);
 
-  // Translate options to CopilotKit framework flags
-  if (options.langgraphPy) {
-    frameworkArgs.push("-f", "langgraph-py");
-  } else if (options.langgraphJs) {
-    frameworkArgs.push("-f", "langgraph-js");
-  } else if (options.crewiAiFlows) {
-    frameworkArgs.push("-f", "flows");
-  } else if (options.mastra) {
-    frameworkArgs.push("-f", "mastra");
-  } else if (options.ag2) {
-    frameworkArgs.push("-f", "ag2");
-  } else if (options.llamaindex) {
-    frameworkArgs.push("-f", "llamaindex");
-  } else if (options.agno) {
-    frameworkArgs.push("-f", "agno");
-  } else if (options.pydanticAi) {
-    frameworkArgs.push("-f", "pydantic-ai");
-  } else if (options.adk) {
-    frameworkArgs.push("-f", "adk");
-  }
-
-  const copilotkit = spawn("npx",
-    [
-      "copilotkit@latest",
-      "create",
-      "--no-banner",
-      "-n", projectName.name,
-      ...frameworkArgs,
-    ],
-    {
-      stdio: "inherit",
-      shell: true,
-    },
-  );
+  const copilotkit = spawn("npx", buildCopilotKitCreateArgs(options, projectName.name), {
+    stdio: "inherit",
+    shell: true,
+  });
 
   copilotkit.on("close", (code) => {
     if (code !== 0) {


### PR DESCRIPTION
## What
Make `create-ag-ui-app`'s delegation to the `copilotkit` CLI robust, and fix a pre-existing framework-flag bug.

`create-ag-ui-app` spawns `npx copilotkit@latest create --no-banner ...`. The latest `copilotkit` CLI (now published from CopilotKit/Intelligence) rejected `--no-banner` under strict arg parsing, breaking the Next.js scaffold. This PR is the consumer half of the fix.

## Changes
- Extract the spawned `copilotkit create` argv into a pure, unit-tested `buildCopilotKitCreateArgs()` (`src/build-args.ts`) — previously built inline in `index.ts`.
- **Fix a pre-existing typo**: `options.crewiAiFlows` → `options.crewaiFlows`. `--crewai-flows` now actually emits `-f flows` (previously it routed to the handler via `isFrameworkDefined` but then dropped the framework because the typo'd key was always `undefined`).
- Keep invoking `copilotkit@latest` (unchanged) so the scaffold always uses the current CopilotKit CLI.
- 4 unit tests: the `copilotkit@latest` + `--no-banner` argv, the crewai→flows mapping, the no-framework case, and all per-framework mappings.

## Depends on
**CopilotKit/Intelligence#363** (the `copilotkit` CLI accepting `--no-banner`). Since `create-ag-ui-app` invokes `copilotkit@latest`, #363 must be **published as the newest `copilotkit` before/with** this PR — otherwise the live `copilotkit@latest` still rejects `--no-banner`.

## Verification
- prettier `--check` ✓, `tsc --noEmit` ✓, vitest 4/4 ✓, tsdown build ✓ (`crewiAiFlows` typo gone).
- Reviewed via a 7-agent code-review loop to convergence.

## Follow-ups (pre-existing — flagged by review for a separate "spawn hardening" PR)
The review surfaced real but **pre-existing** issues (verified byte-identical in `main`, so out of scope here):
- Child exit code not propagated: `copilotkit.on("close")` logs failure but `create-ag-ui-app` still exits `0` — failed scaffolds look like success to CI/scripts.
- No `error` handler on the spawned child (`npx` ENOENT → unhandled throw).
- `spawn(..., { shell: true })` with the interpolated project name (currently regex-mitigated; `shell: true` is unnecessary for `npx`).
- Spawn not awaited.
- Project-name validation drift: this CLI's `^[a-zA-Z0-9-_]+$` accepts names (uppercase, `_`, >30 chars) the downstream `copilotkit` `validateName` rejects → hard failure for valid-looking input.
- Stale `program.version("0.0.36")` vs `package.json` `0.0.55`.

🤖 Generated with Claude Code
