### PR TITLE
chore(release): create-ag-ui-app@0.0.58

### DIFF
--- a/sdks/typescript/packages/cli/package.json
+++ b/sdks/typescript/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-ag-ui-app",
   "author": "Markus Ecker <markus.ecker@gmail.com>",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "repository": {
     "type": "git",
     "url": "https://github.com/ag-ui-protocol/ag-ui.git"


### PR DESCRIPTION
## What

Bumps `create-ag-ui-app` (the AG-UI CLI) `0.0.57 → 0.0.58`.

## Why

The `0.0.57` release predates several unreleased CLI fixes already on `main`:
- `f5bcafd0` — track `copilotkit@latest` instead of pinning `@3`
- `829752eb` — pin copilotkit + fix `crewai-flows` flag mapping
- refactor/formatting follow-ups

## Notes

- **Already published to npm out-of-band**: `create-ag-ui-app@0.0.58` was published manually (local `npm publish`) and is live on the `latest` dist-tag. This PR only syncs the repo's `package.json` to match the registry.
- **CLI only**: only `create-ag-ui-app` is bumped; `@ag-ui/core`/`client`/`encoder`/`proto` stay at `0.0.57`, temporarily desyncing the shared `sdk-ts` version. The next coordinated `sdk-ts` bump will realign them (the stable publish loop treats an already-published version as a benign skip).
- **No double-publish on merge**: when this lands on `main`, `publish-release.yml`'s per-package detection sees local `0.0.58 == npm 0.0.58` → up-to-date → no-op.