### PR TITLE
chore: update CODEOWNERS to remove Kotlin and ADK middleware

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,16 +3,11 @@
 sdks/community/java @pascalwilbrink
 docs/sdk/java @pascalwilbrink
 
-sdks/community/kotlin @contextablemark
-docs/sdk/kotlin @contextablemark
-
 sdks/community/go @mattsp1290
 docs/sdk/go @mattsp1290
 
 sdks/community/dart @mattsp1290
 docs/sdk/dart @mattsp1290
-
-integrations/adk-middleware @contextablemark
 
 integrations/agent-spec @sonleoracle
 


### PR DESCRIPTION
Removed Kotlin and ADK middleware ownership from CODEOWNERS. @contextablemark is now a part of the official @ag-ui-protocol/copilotkit team and therefore no longer needs special code ownership.