### PR TITLE
feat(a2ui): toolkit schema-context/catalog resolver + middleware catalog fallback

### DIFF
--- a/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
+++ b/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
@@ -13,6 +13,7 @@ import { Observable, firstValueFrom, toArray } from "rxjs";
 import {
   A2UIMiddleware,
   A2UIActivityType,
+  A2UI_SCHEMA_CONTEXT_DESCRIPTION,
   RENDER_A2UI_TOOL_NAME,
   LOG_A2UI_EVENT_TOOL_NAME,
   extractSurfaceIds,
@@ -512,6 +513,98 @@ describe("A2UIMiddleware", () => {
             expect(op.createSurface.catalogId).not.toBe("");
             expect(typeof op.createSurface.catalogId).toBe("string");
             expect((op.createSurface.catalogId as string).length).toBeGreaterThan(0);
+          }
+        }
+      }
+    });
+
+    it("falls back to the frontend-registered catalog id when no defaultCatalogId is configured", async () => {
+      // Zero-config path: the host sets NO defaultCatalogId. The renderer ships
+      // the catalog it registered as the A2UI schema context entry
+      // ({ catalogId, components }). The middleware must stamp createSurface with
+      // THAT id — not "basic" — so the surface resolves against the catalog the
+      // frontend actually has.
+      const middleware = new A2UIMiddleware({});
+      const toolCallId = "tc-fe-catalog";
+
+      const fullArgs = JSON.stringify({
+        surfaceId: "s-fe",
+        components: [
+          { id: "root", component: "Row", children: { componentId: "card", path: "/items" } },
+          { id: "card", component: "HotelCard", name: { path: "name" } },
+        ],
+        data: { items: [{ name: "A" }] },
+      });
+
+      const mockAgent = new MockAgent([
+        { type: EventType.RUN_STARTED, runId: "test", threadId: "test" },
+        { type: EventType.TOOL_CALL_START, toolCallId, toolCallName: "render_a2ui" },
+        { type: EventType.TOOL_CALL_ARGS, toolCallId, delta: fullArgs } as BaseEvent,
+        { type: EventType.TOOL_CALL_END, toolCallId },
+        { type: EventType.RUN_FINISHED, runId: "test", threadId: "test" },
+      ]);
+
+      const input = createRunAgentInput({
+        context: [
+          {
+            description: A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+            value: JSON.stringify({ catalogId: "declarative-gen-ui-catalog", components: {} }),
+          },
+        ],
+      });
+
+      const events = await collectEvents(middleware.run(input, mockAgent));
+      const snapshots = events.filter(isPaint);
+      expect(snapshots.length).toBeGreaterThan(0);
+      for (const snap of snapshots) {
+        const ops = (snap as any).content.a2ui_operations as any[];
+        for (const op of ops) {
+          if (op.createSurface) {
+            expect(op.createSurface.catalogId).toBe("declarative-gen-ui-catalog");
+          }
+        }
+      }
+    });
+
+    it("configured defaultCatalogId wins over the frontend-registered catalog id", async () => {
+      // Explicit host override must take precedence over the frontend-shipped id.
+      const middleware = new A2UIMiddleware({ defaultCatalogId: "server://override" });
+      const toolCallId = "tc-config-wins";
+
+      const fullArgs = JSON.stringify({
+        surfaceId: "s-override",
+        components: [
+          { id: "root", component: "Row", children: { componentId: "card", path: "/items" } },
+          { id: "card", component: "HotelCard", name: { path: "name" } },
+        ],
+        data: { items: [{ name: "A" }] },
+      });
+
+      const mockAgent = new MockAgent([
+        { type: EventType.RUN_STARTED, runId: "test", threadId: "test" },
+        { type: EventType.TOOL_CALL_START, toolCallId, toolCallName: "render_a2ui" },
+        { type: EventType.TOOL_CALL_ARGS, toolCallId, delta: fullArgs } as BaseEvent,
+        { type: EventType.TOOL_CALL_END, toolCallId },
+        { type: EventType.RUN_FINISHED, runId: "test", threadId: "test" },
+      ]);
+
+      const input = createRunAgentInput({
+        context: [
+          {
+            description: A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+            value: JSON.stringify({ catalogId: "declarative-gen-ui-catalog", components: {} }),
+          },
+        ],
+      });
+
+      const events = await collectEvents(middleware.run(input, mockAgent));
+      const snapshots = events.filter(isPaint);
+      expect(snapshots.length).toBeGreaterThan(0);
+      for (const snap of snapshots) {
+        const ops = (snap as any).content.a2ui_operations as any[];
+        for (const op of ops) {
+          if (op.createSurface) {
+            expect(op.createSurface.catalogId).toBe("server://override");
           }
         }
       }

--- a/middlewares/a2ui-middleware/src/index.ts
+++ b/middlewares/a2ui-middleware/src/index.ts
@@ -62,6 +62,37 @@ export const A2UIActivityType = "a2ui-surface";
 export const A2UI_SCHEMA_CONTEXT_DESCRIPTION = "A2UI Component Schema — available components for generating UI surfaces. Use these component names and properties when creating A2UI operations.";
 
 /**
+ * Read the catalog id the frontend registered, from the A2UI schema context
+ * entry it ships on every run.
+ *
+ * The renderer sends `{ description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value:
+ * JSON.stringify({ catalogId, components }) }` as agent context (so the model
+ * knows the available components). The `catalogId` in that payload is, by
+ * construction, the id of the catalog the renderer actually registered — so a
+ * `createSurface` stamped with it provably resolves on the client.
+ *
+ * Used as the catalog fallback when the host did NOT configure an explicit
+ * `defaultCatalogId`, so a zero-config app whose only catalog declaration is the
+ * frontend `<CopilotKit a2ui={{ catalog }}>` never hits "Catalog not found".
+ *
+ * Returns undefined when the entry is absent or unparseable (the caller then
+ * falls back to the streamed/basic catalog as before).
+ */
+function extractFrontendCatalogId(input: RunAgentInput): string | undefined {
+  const entry = (input.context || []).find(
+    (c) => c.description === A2UI_SCHEMA_CONTEXT_DESCRIPTION,
+  );
+  if (!entry || typeof entry.value !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(entry.value);
+    const id = (parsed as { catalogId?: unknown } | null)?.catalogId;
+    return typeof id === "string" && id.length > 0 ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Extract EventWithState type from Middleware.runNextWithState return type
  */
 type ExtractObservableType<T> = T extends Observable<infer U> ? U : never;
@@ -157,6 +188,13 @@ export class A2UIMiddleware extends Middleware {
    * Main middleware run method
    */
   run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    // Capture the frontend-registered catalog id BEFORE injectSchemaContext may
+    // replace the frontend schema entry with a server-side one — we want the id
+    // of the catalog the renderer actually registered, used as the zero-config
+    // catalog fallback when no `defaultCatalogId` is configured (see
+    // extractFrontendCatalogId and the catalogId resolution in processStream).
+    const frontendCatalogId = extractFrontendCatalogId(input);
+
     // Process user action from forwardedProps (append synthetic messages)
     const enhancedInput = this.processUserAction(input);
 
@@ -169,7 +207,7 @@ export class A2UIMiddleware extends Middleware {
       : withSchema;
 
     // Process the event stream using runNextWithState for automatic message tracking
-    return this.processStream(this.runNextWithState(finalInput, next));
+    return this.processStream(this.runNextWithState(finalInput, next), frontendCatalogId);
   }
 
   /**
@@ -333,7 +371,7 @@ export class A2UIMiddleware extends Middleware {
    * Process the event stream, holding back RUN_FINISHED to process pending A2UI tool calls.
    * Uses runNextWithState for automatic message tracking.
    */
-  private processStream(source: Observable<EventWithState>): Observable<BaseEvent> {
+  private processStream(source: Observable<EventWithState>, frontendCatalogId?: string): Observable<BaseEvent> {
     // Tool names recognized as A2UI rendering tools. When the middleware also
     // INJECTS the rendering tool (config.injectA2UITool truthy), the injected
     // name MUST be part of the intercept set — otherwise TOOL_CALL_START for
@@ -514,12 +552,17 @@ export class A2UIMiddleware extends Middleware {
                 // Nothing actionable until we know which surface we're building.
                 if (surfaceId) {
                   // Catalog ownership: the host/factory decides the catalog, not
-                  // the subagent. Prefer the configured defaultCatalogId; only
-                  // fall back to a streamed catalogId (legacy) or the basic
-                  // catalog when no catalog was configured. This keeps the
-                  // streamed createSurface from referencing a catalog the
-                  // frontend never registered (e.g. "basic" when the app uses a
-                  // custom catalog) — which throws "Catalog not found".
+                  // the subagent. Resolution order:
+                  //   1. configured defaultCatalogId — explicit host override.
+                  //   2. frontendCatalogId — the id of the catalog the renderer
+                  //      actually registered (shipped on the run as the A2UI
+                  //      schema context entry). Zero-config: an app whose only
+                  //      catalog declaration is `<CopilotKit a2ui={{ catalog }}>`
+                  //      gets the right id with no server-side setting.
+                  //   3. a streamed catalogId (legacy) or the basic catalog.
+                  // This keeps the streamed createSurface from referencing a
+                  // catalog the frontend never registered (e.g. "basic" when the
+                  // app uses a custom catalog) — which throws "Catalog not found".
                   //
                   // Treat an empty-string defaultCatalogId as unset: a `??`
                   // alone would propagate "" into the emitted createSurface and
@@ -532,6 +575,7 @@ export class A2UIMiddleware extends Middleware {
                   const streamedCatalogId = extractStringField(streaming.args, "catalogId");
                   const catalogId =
                     configCatalogId ??
+                    frontendCatalogId ??
                     (streamedCatalogId && streamedCatalogId !== "basic"
                       ? streamedCatalogId
                       : "https://a2ui.org/specification/v0_9/basic_catalog.json");

--- a/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/__init__.py
+++ b/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/__init__.py
@@ -11,12 +11,16 @@ invoke). Nothing in this package depends on any agent framework.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Optional, TypedDict
 
 
 __all__ = [
     "A2UI_OPERATIONS_KEY",
     "BASIC_CATALOG_ID",
+    "A2UI_SCHEMA_CONTEXT_DESCRIPTION",
+    "split_a2ui_schema_context",
+    "resolve_a2ui_catalog",
     "RENDER_A2UI_TOOL_DEF",
     "DEFAULT_SURFACE_ID",
     "GENERATE_A2UI_TOOL_NAME",
@@ -74,6 +78,19 @@ A2UI_OPERATIONS_KEY = "a2ui_operations"
 
 BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json"
 """Default catalog id used when the subagent does not specify one."""
+
+A2UI_SCHEMA_CONTEXT_DESCRIPTION = (
+    "A2UI Component Schema — available components for generating UI surfaces. "
+    "Use these component names and properties when creating A2UI operations."
+)
+"""Context-entry description the ``@ag-ui/a2ui-middleware`` stamps onto the A2UI
+component schema it injects into ``RunAgentInput.context``. Single home for the
+constant so every framework adapter splits on the same string. MUST stay
+byte-identical to ``A2UI_SCHEMA_CONTEXT_DESCRIPTION`` in
+``@ag-ui/a2ui-middleware`` (the TypeScript twin cannot import this Python copy).
+``split_a2ui_schema_context`` matches it by exact equality — any drift silently
+routes the schema into the generic context block instead of
+``## Available Components``."""
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +203,93 @@ def build_context_prompt(state: dict) -> str:
         parts.append(f"## Available Components\n{a2ui_schema}\n")
 
     return "\n".join(parts)
+
+
+def split_a2ui_schema_context(context: Optional[list]) -> tuple:
+    """Split AG-UI context entries into the A2UI component-schema entry and the
+    rest. The schema entry is the one whose ``description`` exactly equals
+    ``A2UI_SCHEMA_CONTEXT_DESCRIPTION`` (stamped by ``@ag-ui/a2ui-middleware``).
+
+    Returns ``(schema_value, regular_context)``: framework adapters route
+    ``schema_value`` to ``state["ag-ui"]["a2ui_schema"]`` (rendered as
+    ``## Available Components`` by ``build_context_prompt``) and
+    ``regular_context`` to ``state["ag-ui"]["context"]``. ``schema_value`` is
+    ``None`` when no schema entry is present. Entries are returned unchanged
+    (dicts or objects exposing ``.description``/``.value``) — the same dual
+    shape ``build_context_prompt`` already tolerates.
+    """
+    schema_value = None
+    regular_context: list = []
+    for entry in context or []:
+        if isinstance(entry, dict):
+            description = entry.get("description")
+            value = entry.get("value")
+        else:
+            description = getattr(entry, "description", None)
+            value = getattr(entry, "value", None)
+        if description == A2UI_SCHEMA_CONTEXT_DESCRIPTION:
+            schema_value = value
+        else:
+            regular_context.append(entry)
+    return schema_value, regular_context
+
+
+def resolve_a2ui_catalog(state: dict) -> "Optional[tuple]":
+    """Find the frontend-registered A2UI catalog in run ``state``, returning
+    ``(component_schema, catalog_id)`` — or ``None`` when no catalog is present
+    (so the adapter falls back to its configured default / the basic catalog).
+
+    Framework-agnostic, so every adapter resolves the catalog the same way
+    instead of each reimplementing it. Two delivery paths are supported because
+    the catalog lands in different places depending on how the agent is served:
+
+    Both live under ``state["ag-ui"]`` — the canonical key every adapter
+    populates:
+
+    - **Schema entry** → ``state["ag-ui"]["a2ui_schema"]``, a JSON string
+      ``{"catalogId": ..., "components": [...]}`` (routed there from
+      ``RunAgentInput.context`` by ``split_a2ui_schema_context``). The toolkit
+      reads ``a2ui_schema`` from state for the prompt itself, so only the
+      ``catalog_id`` is surfaced here (``component_schema`` is ``None``).
+    - **Catalog context entry** → an ``state["ag-ui"]["context"]`` entry whose
+      description mentions ``"A2UI catalog"`` (catalog id + component schemas as
+      text); the value lists catalogs as ``"- <catalogId>"`` lines, the first
+      being the custom catalog the client registered.
+
+    ``component_schema`` becomes the sub-agent ``composition_guide``;
+    ``catalog_id`` becomes ``default_catalog_id`` so generated surfaces bind to
+    the frontend's catalog (BYOC custom catalogs render their own components,
+    not the basic one).
+    """
+    ag_ui = state.get("ag-ui") or {}
+    a2ui_schema = ag_ui.get("a2ui_schema")
+    if a2ui_schema:
+        catalog_id = None
+        try:
+            parsed = (
+                json.loads(a2ui_schema)
+                if isinstance(a2ui_schema, str)
+                else a2ui_schema
+            )
+            if isinstance(parsed, dict):
+                catalog_id = parsed.get("catalogId")
+        except (TypeError, ValueError):
+            pass
+        return None, catalog_id
+
+    context = ag_ui.get("context") or []
+    for entry in context:
+        if not isinstance(entry, dict):
+            continue
+        description = entry.get("description") or ""
+        value = entry.get("value") or ""
+        if "A2UI catalog" not in description or not value:
+            continue
+        match = re.search(r"(?m)^\s*-\s+(\S+)", value)
+        catalog_id = match.group(1) if match else None
+        return value, catalog_id
+
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/a2ui_toolkit/pyproject.toml
+++ b/sdks/python/a2ui_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag-ui-a2ui-toolkit"
-version = "0.0.3"
+version = "0.0.4-alpha.1"
 description = "Framework-agnostic helpers for building A2UI subagent tools — op builders, prompt assembly, history walkers, and request/envelope orchestration shared across framework adapters."
 authors = [
     { name = "Ran Shem Tov", email = "ran@copilotkit.ai" }

--- a/sdks/python/a2ui_toolkit/tests/test_toolkit.py
+++ b/sdks/python/a2ui_toolkit/tests/test_toolkit.py
@@ -11,6 +11,7 @@ import unittest
 
 from ag_ui_a2ui_toolkit import (
     A2UI_OPERATIONS_KEY,
+    A2UI_SCHEMA_CONTEXT_DESCRIPTION,
     BASIC_CATALOG_ID,
     DEFAULT_DESIGN_GUIDELINES,
     DEFAULT_GENERATION_GUIDELINES,
@@ -25,7 +26,9 @@ from ag_ui_a2ui_toolkit import (
     create_surface,
     find_prior_surface,
     prepare_a2ui_request,
+    resolve_a2ui_catalog,
     resolve_a2ui_tool_params,
+    split_a2ui_schema_context,
     update_components,
     update_data_model,
     wrap_as_operations_envelope,
@@ -141,6 +144,126 @@ class TestBuildContextPrompt(unittest.TestCase):
     def test_empty_entries_dropped(self):
         prompt = build_context_prompt({"ag-ui": {"context": [{}]}})
         self.assertEqual(prompt, "")
+
+
+class TestSplitA2UISchemaContext(unittest.TestCase):
+    def test_splits_schema_from_regular(self):
+        ctx = [
+            {"description": "Style guide", "value": "use cards"},
+            {"description": A2UI_SCHEMA_CONTEXT_DESCRIPTION, "value": "<catalog>"},
+        ]
+        schema_value, regular = split_a2ui_schema_context(ctx)
+        self.assertEqual(schema_value, "<catalog>")
+        self.assertEqual(len(regular), 1)
+        self.assertEqual(regular[0]["description"], "Style guide")
+
+    def test_none_when_no_schema_entry(self):
+        schema_value, regular = split_a2ui_schema_context(
+            [{"description": "Style guide", "value": "use cards"}]
+        )
+        self.assertIsNone(schema_value)
+        self.assertEqual(len(regular), 1)
+
+    def test_handles_none_and_objects(self):
+        self.assertEqual(split_a2ui_schema_context(None), (None, []))
+
+        class _Entry:
+            def __init__(self, description, value):
+                self.description = description
+                self.value = value
+
+        schema_value, regular = split_a2ui_schema_context(
+            [_Entry(A2UI_SCHEMA_CONTEXT_DESCRIPTION, "obj-catalog")]
+        )
+        self.assertEqual(schema_value, "obj-catalog")
+        self.assertEqual(regular, [])
+
+    def test_roundtrips_into_build_context_prompt(self):
+        ctx = [
+            {"description": "App context", "value": "on dashboard"},
+            {"description": A2UI_SCHEMA_CONTEXT_DESCRIPTION, "value": "<catalog>"},
+        ]
+        schema_value, regular = split_a2ui_schema_context(ctx)
+        prompt = build_context_prompt(
+            {"ag-ui": {"context": regular, "a2ui_schema": schema_value}}
+        )
+        self.assertIn("## Available Components", prompt)
+        self.assertIn("<catalog>", prompt)
+        self.assertIn("## App context", prompt)
+        self.assertNotIn(A2UI_SCHEMA_CONTEXT_DESCRIPTION, prompt)
+
+
+class TestResolveA2UICatalog(unittest.TestCase):
+    def test_native_ag_ui_schema_path(self):
+        state = {
+            "ag-ui": {
+                "a2ui_schema": json.dumps(
+                    {"catalogId": "my-catalog", "components": []}
+                )
+            }
+        }
+        schema, catalog_id = resolve_a2ui_catalog(state)
+        # Native path: toolkit reads a2ui_schema from state for the prompt, so
+        # only the id is surfaced (schema None).
+        self.assertIsNone(schema)
+        self.assertEqual(catalog_id, "my-catalog")
+
+    def test_native_schema_already_parsed_dict(self):
+        state = {"ag-ui": {"a2ui_schema": {"catalogId": "parsed-cat"}}}
+        _, catalog_id = resolve_a2ui_catalog(state)
+        self.assertEqual(catalog_id, "parsed-cat")
+
+    def test_native_malformed_json_yields_no_id(self):
+        state = {"ag-ui": {"a2ui_schema": "{not json"}}
+        schema, catalog_id = resolve_a2ui_catalog(state)
+        self.assertIsNone(schema)
+        self.assertIsNone(catalog_id)
+
+    def test_ag_ui_context_path(self):
+        # Canonical key — what a plain AG-UI adapter (e.g. Strands) has; no
+        # "copilotkit" alias present.
+        state = {
+            "ag-ui": {
+                "context": [
+                    {"description": "Registered A2UI catalog", "value": "- ag-ui-cat"}
+                ]
+            }
+        }
+        schema, catalog_id = resolve_a2ui_catalog(state)
+        self.assertEqual(catalog_id, "ag-ui-cat")
+        self.assertIn("ag-ui-cat", schema)
+
+    def test_context_path_picks_first_listed_catalog(self):
+        state = {
+            "ag-ui": {
+                "context": [
+                    {"description": "unrelated", "value": "x"},
+                    {
+                        "description": "Registered A2UI catalog",
+                        "value": "- custom-cat\n- basic",
+                    },
+                ]
+            }
+        }
+        schema, catalog_id = resolve_a2ui_catalog(state)
+        self.assertEqual(catalog_id, "custom-cat")
+        self.assertIn("custom-cat", schema)
+
+    def test_schema_entry_takes_precedence_over_context(self):
+        state = {
+            "ag-ui": {
+                "a2ui_schema": json.dumps({"catalogId": "native-cat"}),
+                "context": [
+                    {"description": "A2UI catalog", "value": "- ctx-cat"}
+                ],
+            },
+        }
+        _, catalog_id = resolve_a2ui_catalog(state)
+        self.assertEqual(catalog_id, "native-cat")
+
+    def test_no_catalog_returns_none(self):
+        self.assertIsNone(resolve_a2ui_catalog({}))
+        self.assertIsNone(resolve_a2ui_catalog({"ag-ui": {"context": []}}))
 
 
 class _ToolMessage:

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/toolkit.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/toolkit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   A2UI_OPERATIONS_KEY,
+  A2UI_SCHEMA_CONTEXT_DESCRIPTION,
   BASIC_CATALOG_ID,
   DEFAULT_DESIGN_GUIDELINES,
   DEFAULT_GENERATION_GUIDELINES,
@@ -16,6 +17,8 @@ import {
   createSurface,
   findPriorSurface,
   prepareA2UIRequest,
+  resolveA2UICatalog,
+  splitA2UISchemaContext,
   updateComponents,
   updateDataModel,
   wrapAsOperationsEnvelope,
@@ -118,6 +121,96 @@ describe("buildContextPrompt", () => {
       "ag-ui": { context: [{}] },
     });
     expect(prompt).toBe("");
+  });
+});
+
+describe("splitA2UISchemaContext", () => {
+  it("splits the schema entry from regular context", () => {
+    const [schema, regular] = splitA2UISchemaContext([
+      { description: "Style guide", value: "use cards" },
+      { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "<catalog>" },
+    ]);
+    expect(schema).toBe("<catalog>");
+    expect(regular).toHaveLength(1);
+    expect(regular[0].description).toBe("Style guide");
+  });
+
+  it("returns undefined schema when no schema entry is present", () => {
+    const [schema, regular] = splitA2UISchemaContext([
+      { description: "Style guide", value: "use cards" },
+    ]);
+    expect(schema).toBeUndefined();
+    expect(regular).toHaveLength(1);
+  });
+
+  it("handles null/undefined context", () => {
+    expect(splitA2UISchemaContext(undefined)).toEqual([undefined, []]);
+    expect(splitA2UISchemaContext(null)).toEqual([undefined, []]);
+  });
+
+  it("round-trips into buildContextPrompt", () => {
+    const [schema, regular] = splitA2UISchemaContext([
+      { description: "App context", value: "on dashboard" },
+      { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "<catalog>" },
+    ]);
+    const prompt = buildContextPrompt({
+      "ag-ui": { context: regular, a2ui_schema: schema },
+    });
+    expect(prompt).toContain("## Available Components");
+    expect(prompt).toContain("<catalog>");
+    expect(prompt).toContain("## App context");
+    expect(prompt).not.toContain(A2UI_SCHEMA_CONTEXT_DESCRIPTION);
+  });
+});
+
+describe("resolveA2UICatalog", () => {
+  it("reads catalogId from the native ag-ui a2ui_schema (schema undefined)", () => {
+    const resolved = resolveA2UICatalog({
+      "ag-ui": {
+        a2ui_schema: JSON.stringify({ catalogId: "my-catalog", components: [] }),
+      },
+    });
+    expect(resolved).toEqual([undefined, "my-catalog"]);
+  });
+
+  it("accepts an already-parsed a2ui_schema object", () => {
+    const resolved = resolveA2UICatalog({
+      "ag-ui": { a2ui_schema: { catalogId: "parsed-cat" } },
+    });
+    expect(resolved?.[1]).toBe("parsed-cat");
+  });
+
+  it("degrades to no id on unparseable schema", () => {
+    const resolved = resolveA2UICatalog({ "ag-ui": { a2ui_schema: "{not json" } });
+    expect(resolved).toEqual([undefined, undefined]);
+  });
+
+  it("reads the catalog from an 'A2UI catalog' context entry (first listed)", () => {
+    const resolved = resolveA2UICatalog({
+      "ag-ui": {
+        context: [
+          { description: "unrelated", value: "x" },
+          { description: "Registered A2UI catalog", value: "- custom-cat\n- basic" },
+        ],
+      },
+    });
+    expect(resolved?.[1]).toBe("custom-cat");
+    expect(resolved?.[0]).toContain("custom-cat");
+  });
+
+  it("prefers the schema entry over the context entry", () => {
+    const resolved = resolveA2UICatalog({
+      "ag-ui": {
+        a2ui_schema: JSON.stringify({ catalogId: "native-cat" }),
+        context: [{ description: "A2UI catalog", value: "- ctx-cat" }],
+      },
+    });
+    expect(resolved?.[1]).toBe("native-cat");
+  });
+
+  it("returns undefined when no catalog is present", () => {
+    expect(resolveA2UICatalog({})).toBeUndefined();
+    expect(resolveA2UICatalog({ "ag-ui": { context: [] } })).toBeUndefined();
   });
 });
 

--- a/sdks/typescript/packages/a2ui-toolkit/src/index.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/index.ts
@@ -127,6 +127,87 @@ export function buildContextPrompt(state: Record<string, unknown>): string {
   return parts.join("\n");
 }
 
+/**
+ * Context-entry description the ``@ag-ui/a2ui-middleware`` stamps onto the A2UI
+ * component schema it injects into ``RunAgentInput.context``. Single home for
+ * the constant so every framework adapter splits on the same string. MUST stay
+ * byte-identical to ``A2UI_SCHEMA_CONTEXT_DESCRIPTION`` in
+ * ``@ag-ui/a2ui-middleware`` (this is a wire contract, not prose).
+ */
+export const A2UI_SCHEMA_CONTEXT_DESCRIPTION =
+  "A2UI Component Schema — available components for generating UI surfaces. " +
+  "Use these component names and properties when creating A2UI operations.";
+
+/**
+ * Split AG-UI context entries into the A2UI component-schema entry and the
+ * rest. The schema entry is the one whose ``description`` exactly equals
+ * ``A2UI_SCHEMA_CONTEXT_DESCRIPTION``. Returns ``[schemaValue, regularContext]``:
+ * adapters route ``schemaValue`` to ``state["ag-ui"]["a2ui_schema"]`` (rendered
+ * as ``## Available Components`` by ``buildContextPrompt``) and ``regularContext``
+ * to ``state["ag-ui"]["context"]``. Entries are returned unchanged.
+ */
+export function splitA2UISchemaContext(
+  context: Array<Record<string, unknown>> | undefined | null,
+): [string | undefined, Array<Record<string, unknown>>] {
+  let schemaValue: string | undefined;
+  const regular: Array<Record<string, unknown>> = [];
+  for (const entry of context ?? []) {
+    const description = entry?.description as string | undefined;
+    if (description === A2UI_SCHEMA_CONTEXT_DESCRIPTION) {
+      schemaValue = entry?.value as string | undefined;
+    } else {
+      regular.push(entry);
+    }
+  }
+  return [schemaValue, regular];
+}
+
+/**
+ * Find the frontend-registered A2UI catalog in run ``state``, returning
+ * ``[componentSchema, catalogId]`` or ``undefined`` when no catalog is present.
+ * Framework-agnostic, so every adapter resolves the catalog the same way.
+ * Both delivery shapes live under the canonical ``state["ag-ui"]`` key:
+ * - Schema entry: ``state["ag-ui"]["a2ui_schema"]``, a JSON string
+ *   ``{"catalogId": ..., "components": [...]}`` (toolkit reads the schema from
+ *   state for the prompt itself, so only the id is surfaced here).
+ * - Catalog context entry: an ``state["ag-ui"]["context"]`` entry whose
+ *   description mentions ``"A2UI catalog"``; the value lists catalogs as
+ *   ``"- <catalogId>"`` lines, the first being the custom catalog.
+ */
+export function resolveA2UICatalog(
+  state: Record<string, unknown>,
+): [string | undefined, string | undefined] | undefined {
+  const agUi = (state["ag-ui"] as Record<string, unknown> | undefined) ?? {};
+  const a2uiSchema = agUi.a2ui_schema;
+  if (a2uiSchema) {
+    let catalogId: string | undefined;
+    try {
+      const parsed =
+        typeof a2uiSchema === "string" ? JSON.parse(a2uiSchema) : a2uiSchema;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        catalogId = (parsed as Record<string, unknown>).catalogId as
+          | string
+          | undefined;
+      }
+    } catch {
+      // Unparseable schema -> no id (degrade to the configured default).
+    }
+    return [undefined, catalogId];
+  }
+
+  const contextEntries =
+    (agUi.context as Array<Record<string, unknown>> | undefined) ?? [];
+  for (const entry of contextEntries) {
+    const description = (entry?.description as string | undefined) ?? "";
+    const value = (entry?.value as string | undefined) ?? "";
+    if (!description.includes("A2UI catalog") || !value) continue;
+    const match = value.match(/^\s*-\s+(\S+)/m);
+    return [value, match ? match[1] : undefined];
+  }
+
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Prior surface lookup (used for intent="update")
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Splits the framework-agnostic A2UI changes out of #1980 (strands/langgraph parity) so they can be tested, merged, and **released first**. #1980 will then consume the published packages instead of carrying these alongside adapter changes.

Three cherry-picked commits, no adapter code:

- **`ag-ui-a2ui-toolkit` (Python)** — add `split_a2ui_schema_context` + `resolve_a2ui_catalog` (read only `state["ag-ui"]`), bump to `0.0.4-alpha.1`.
- **`@ag-ui/a2ui-toolkit` (TS)** — TS twins `splitA2UISchemaContext` / `resolveA2UICatalog` + `A2UI_SCHEMA_CONTEXT_DESCRIPTION`.
- **`@ag-ui/a2ui-middleware` (TS)** — when no `defaultCatalogId` is configured, fall back to the frontend-registered catalog id (parsed from the `A2UI_SCHEMA_CONTEXT_DESCRIPTION` context entry the middleware already owns) before basic. Zero-config apps stop hitting "Catalog not found".

## Why separate

The adapters (langgraph/strands) in #1980 import `split_a2ui_schema_context`, which only exists once this toolkit ships. Shipping the toolkit first removes the latent dependency gap (a clean `pip install` of the adapters otherwise resolves an older toolkit without the symbol).

## Tests
- Python toolkit: 100 passed
- TS toolkit: 100 passed
- a2ui-middleware: 96 passed (2 new — frontend-id fallback + config-wins-over-frontend-id)

## Follow-up
After this merges + releases, raise the toolkit floor to `>=0.0.4` in the langgraph/strands adapter pyprojects on #1980.