### PR TITLE
fix(langgraph): handle non-str dict keys in dump_json_safe (#1740)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1781,4 +1781,10 @@ def dump_json_safe(value):
     # (not re-encoded with json.dumps). Callers passing pre-serialized JSON
     # strings get them back as-is; callers passing a raw non-JSON string get
     # that raw string back — no quoting is applied.
-    return json.dumps(value, default=json_safe_stringify) if not isinstance(value, str) else value
+    if isinstance(value, str):
+        return value
+    # json.dumps only invokes ``default`` for non-serializable *values*, never for
+    # dict *keys*. A non-str key (e.g. a UUID from a LangGraph interrupt value or
+    # tool input) therefore raises TypeError before json_safe_stringify can run.
+    # make_json_safe recurses into keys as well as values, so normalize first.
+    return json.dumps(make_json_safe(value), default=json_safe_stringify)

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import uuid
 from enum import Enum
 
 from pydantic import TypeAdapter
@@ -698,6 +699,14 @@ def make_json_safe(value: Any, _seen: set[int] | None = None) -> Any:
     # --- 2. Enum → use underlying value -----------------------------------
     if isinstance(value, Enum):
         return make_json_safe(value.value, _seen)
+
+    # --- 2b. UUID → canonical string --------------------------------------
+    # Handled explicitly (before the repr() last resort) so UUIDs serialize as
+    # "00000000-..." rather than "UUID('00000000-...')". Critical for dict keys:
+    # json.dumps rejects non-str keys outright, and a canonical string key is far
+    # more useful to clients than a Python repr.
+    if isinstance(value, uuid.UUID):
+        return str(value)
 
     # --- 3. Dicts ----------------------------------------------------------
     if isinstance(value, dict):

--- a/integrations/langgraph/python/tests/test_make_json_safe.py
+++ b/integrations/langgraph/python/tests/test_make_json_safe.py
@@ -2,10 +2,12 @@
 import json
 import threading
 import unittest
+import uuid
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from ag_ui_langgraph.agent import dump_json_safe
 from ag_ui_langgraph.utils import make_json_safe, json_safe_stringify
 
 
@@ -218,3 +220,38 @@ class TestMakeJsonSafe(unittest.TestCase):
         assert parsed["tool_call"]["args"] == {"url": "https://example.com"}
         assert "runtime" not in parsed["tool_call"]
         assert "config" not in parsed["tool_call"]
+
+    def test_uuid_value_uses_canonical_string(self):
+        """A UUID *value* serializes to its canonical string, not repr()."""
+        u = uuid.UUID(int=1)
+        assert make_json_safe(u) == str(u)
+        assert make_json_safe(u) == "00000000-0000-0000-0000-000000000001"
+
+    def test_uuid_dict_key_is_made_safe(self):
+        """A UUID dict *key* is normalized to a string so json.dumps accepts it."""
+        u = uuid.UUID(int=42)
+        safe = make_json_safe({u: "value"})
+        assert safe == {str(u): "value"}
+
+
+class TestDumpJsonSafe(unittest.TestCase):
+    """dump_json_safe must survive non-str dict keys (regression for UUID keys)."""
+
+    def test_uuid_dict_keys_do_not_raise(self):
+        # json.dumps never runs ``default`` for dict keys, so without
+        # pre-normalization a UUID key raises TypeError mid-encode.
+        value = {uuid.UUID(int=1): {"nested": uuid.UUID(int=2)}}
+        parsed = json.loads(dump_json_safe(value))
+        assert parsed == {
+            "00000000-0000-0000-0000-000000000001": {
+                "nested": "00000000-0000-0000-0000-000000000002"
+            }
+        }
+
+    def test_plain_string_passed_through_verbatim(self):
+        # Documented sharp edge: a str argument is returned as-is, not re-encoded.
+        assert dump_json_safe("already a string") == "already a string"
+
+    def test_regular_payload_still_serializes(self):
+        parsed = json.loads(dump_json_safe({"a": 1, "b": [1, 2, 3]}))
+        assert parsed == {"a": 1, "b": [1, 2, 3]}


### PR DESCRIPTION
## Summary

Fixes #1740. `dump_json_safe()` crashed with `TypeError: keys must be str, int, float, bool or None, not UUID` whenever a serialized value contained a dict with non-string keys (commonly UUID-keyed dicts from LangGraph interrupt values, tool inputs, or UUID-keyed state).

## Root cause

```python
return json.dumps(value, default=json_safe_stringify) if not isinstance(value, str) else value
```

Python's `json.dumps` only invokes the `default=` callback for non-serializable **values** — never for dict **keys**. Dict keys must already be `str/int/float/bool/None`. So a `UUID` key raised `TypeError` mid-encode, before `json_safe_stringify` ever ran, aborting the event stream.

`make_json_safe()` already recurses into dict keys, but `dump_json_safe` wasn't using it as a pre-processing step.

## Fix

- `dump_json_safe` now normalizes through `make_json_safe` before `json.dumps`. The documented str pass-through sharp edge is preserved.
- `make_json_safe` gains an explicit `uuid.UUID` branch so UUIDs serialize to their canonical string (`"00000000-..."`) instead of falling through to the `repr()` last resort (`"UUID('00000000-...')"`). This applies to both keys and values, producing clean, client-friendly output.

## Tests

Added to `tests/test_make_json_safe.py`:
- UUID value → canonical string
- UUID dict key → string key (no crash)
- `dump_json_safe` round-trips nested UUID keys/values without raising
- str pass-through and ordinary payloads still serialize

`21 passed` in `tests/test_make_json_safe.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)