### PR TITLE
ci(adk-middleware): add allowed-to-fail google-adk 2.x test leg (#1947)

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -195,11 +195,13 @@ jobs:
   # Exercises the suite against google-adk 2.x. pyproject advertises
   # google-adk>=1.16.0,<3.0.0 ("compatible with 1.x and 2.x"), but the lockfile
   # resolves 1.x (see #1946), so CI never sees 2.x. The suite is currently red
-  # under 2.x (#1947), so this leg is allowed to fail (continue-on-error) — it
-  # surfaces the breakage to burn down without blocking merges.
+  # under 2.x (#1947). This leg is INFORMATIONAL: the test step is
+  # continue-on-error, so the job stays green and never blocks a merge, while a
+  # failing 2.x run is surfaced as a warning annotation and a job summary. Once
+  # the 2.x failures are burned down, drop the step's continue-on-error to make
+  # this a required, blocking check.
   adk-middleware-python-adk-2x:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - name: Checkout code
@@ -235,8 +237,22 @@ jobs:
           uv run --no-sync python -c "import importlib.metadata as m; print('google-adk', m.version('google-adk'))"
 
       - name: Run tests (google-adk 2.x)
+        id: adk2x-tests
+        continue-on-error: true
         working-directory: integrations/adk-middleware/python
         run: uv run --no-sync python -m pytest tests/ -v
+
+      - name: Report google-adk 2.x result
+        if: always()
+        run: |
+          if [ "${{ steps.adk2x-tests.outcome }}" = "success" ]; then
+            echo "### ✅ google-adk 2.x: suite passed" >> "$GITHUB_STEP_SUMMARY"
+            echo "The suite now passes under \`google-adk>=2,<3\`. Consider dropping the step's \`continue-on-error\` to make this a required check (#1947)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning title=google-adk 2.x suite is red (#1947)::Informational leg — does not block merges. See the job summary."
+            echo "### ⚠️ google-adk 2.x: suite is currently red (#1947)" >> "$GITHUB_STEP_SUMMARY"
+            echo "This leg runs the suite against \`google-adk>=2,<3\` and is allowed to fail until the 2.x failures are burned down. It does not block merges." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   aws-strands-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -192,6 +192,52 @@ jobs:
         working-directory: integrations/adk-middleware/python
         run: uv run python -m pytest tests/ -v
 
+  # Exercises the suite against google-adk 2.x. pyproject advertises
+  # google-adk>=1.16.0,<3.0.0 ("compatible with 1.x and 2.x"), but the lockfile
+  # resolves 1.x (see #1946), so CI never sees 2.x. The suite is currently red
+  # under 2.x (#1947), so this leg is allowed to fail (continue-on-error) — it
+  # surfaces the breakage to burn down without blocking merges.
+  adk-middleware-python-adk-2x:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Detect fork PR
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
+            echo "prefix=fork-" >> "$GITHUB_OUTPUT"
+          else
+            echo "prefix=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          version: ">=0.8.0"
+
+      - name: Install dependencies
+        working-directory: integrations/adk-middleware/python
+        run: uv sync
+
+      - name: Force google-adk 2.x
+        working-directory: integrations/adk-middleware/python
+        run: |
+          uv pip install "google-adk>=2,<3"
+          uv run --no-sync python -c "import importlib.metadata as m; print('google-adk', m.version('google-adk'))"
+
+      - name: Run tests (google-adk 2.x)
+        working-directory: integrations/adk-middleware/python
+        run: uv run --no-sync python -m pytest tests/ -v
+
   aws-strands-python:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Addresses #1947. `pyproject.toml` advertises `google-adk>=1.16.0,<3.0.0` ("Compatible with both google-adk 1.x and 2.x"), but the lockfile resolves 1.x (#1946), so CI has **never** exercised 2.x — and the suite is currently **red under google-adk 2.2.0** (35 failures). The advertised 2.x compatibility is therefore unverified and partially broken.

## Change

Adds an `adk-middleware-python-adk-2x` job to `unit-python-sdk.yml` that:
1. Installs the locked (1.x) environment via `uv sync`.
2. Force-installs `google-adk>=2,<3` over it (the issue's documented repro).
3. Runs the full suite under 2.x.

**This leg is informational and never blocks a merge.** The test step is `continue-on-error`, so the job stays **green**; a failing 2.x run is surfaced as a **warning annotation + a job summary** rather than a red check on every PR. A reporting step also prints a "now passes — consider making this required" note when the suite is green. Once the 35 failures are burned down, dropping the step's `continue-on-error` turns this into a required, blocking check.

This implements suggested action #1 from the issue ("add a CI matrix leg running the suite against latest `google-adk>=2,<3`, allowed-to-fail at first, then burn down").

No cache step is used for this leg, so it always resolves fresh and never collides with the 1.x adk job's venv cache.

## Validation

The first CI run confirmed the leg does exactly what it should: under google-adk 2.x it reported **35 failed, 816 passed, 14 skipped** — matching the failure breakdown in #1947 — while the 1.x `adk-middleware-python` job stayed green.

> Note (updated): the initial version used job-level `continue-on-error`, which left the job showing a red ❌ in the PR check list even though it didn't block. Moved `continue-on-error` to the test step + added the reporting step so the check is green and the breakage shows as a warning/summary instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)