### PR TITLE
feat(adk-middleware): agent-facing named CustomEvent via reserved state key (#1915)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **FEATURE**: Agent-facing named `CustomEvent` emission (#1915)
-  - An ADK agent can now emit a named AG-UI `CustomEvent` by writing the reserved key `ag_ui:custom_event` into `EventActions.state_delta` (a `{"name", "value"}` mapping or a list of them). The translator turns each into a `CUSTOM` event and strips the reserved key from the resulting `STATE_DELTA` so it doesn't leak. Previously the only generic path keyed off `Event.custom_data`, which ADK's `Event` model rejects, leaving agents with no supported way to emit a named custom event. See "Emitting Named Custom Events" in `USAGE.md`.
+  - An ADK agent can now emit a named AG-UI `CustomEvent` by writing the reserved key `ag_ui:custom_event` into `EventActions.state_delta` (a `{"name", "value"}` mapping or a list of them). The translator turns each into a `CUSTOM` event and strips the reserved key from the resulting `STATE_DELTA` so it doesn't leak. The reserved key is also scrubbed from any `STATE_SNAPSHOT` (ADK can persist the key, since the delta path works on a copy) so it never leaks into AG-UI state by either path. Previously the only generic path keyed off `Event.custom_data`, which ADK's `Event` model rejects, leaving agents with no supported way to emit a named custom event. See "Emitting Named Custom Events" in `USAGE.md`.
 
 ### Changed
 

--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **FEATURE**: Agent-facing named `CustomEvent` emission (#1915)
+  - An ADK agent can now emit a named AG-UI `CustomEvent` by writing the reserved key `ag_ui:custom_event` into `EventActions.state_delta` (a `{"name", "value"}` mapping or a list of them). The translator turns each into a `CUSTOM` event and strips the reserved key from the resulting `STATE_DELTA` so it doesn't leak. Previously the only generic path keyed off `Event.custom_data`, which ADK's `Event` model rejects, leaving agents with no supported way to emit a named custom event. See "Emitting Named Custom Events" in `USAGE.md`.
+
 ### Changed
 
 - **PERFORMANCE**: Cache session reads per execution to cut redundant `get_session` round-trips (#1880, #1890, thanks @he-yufeng)

--- a/integrations/adk-middleware/python/USAGE.md
+++ b/integrations/adk-middleware/python/USAGE.md
@@ -457,6 +457,33 @@ adk_agent = ADKAgent(
 
 See `examples/server/api/predictive_state_updates.py` for a complete working example.
 
+### Emitting Named Custom Events
+
+An ADK agent can emit a named AG-UI [`CustomEvent`](https://docs.ag-ui.com/concepts/events#custom) — e.g. `conversation_complete`, `resume_validated`, `payment_required` — by writing the reserved key `ag_ui:custom_event` into `EventActions.state_delta`. The middleware intercepts that key, emits one `CUSTOM` event per spec, and strips it from the state delta (so it never leaks out as a `STATE_DELTA` patch). The colon namespace mirrors ADK's own `temp:`/`app:`/`user:` state-key convention.
+
+```python
+from google.adk.agents import BaseAgent
+from google.adk.events import Event, EventActions
+
+class NotifyingAgent(BaseAgent):
+    async def _run_async_impl(self, ctx):
+        # Emit a single named custom event...
+        yield Event(
+            author=self.name,
+            invocation_id=ctx.invocation_id,
+            actions=EventActions(state_delta={
+                "ag_ui:custom_event": {"name": "conversation_complete", "value": {"turns": 3}},
+            }),
+        )
+```
+
+Notes:
+
+- The value is either a single `{"name": str, "value": Any}` mapping or a **list** of them (emitted in order).
+- Other keys in the same `state_delta` are still translated to a `STATE_DELTA` as usual.
+- Malformed entries (missing/empty `name`) are skipped with a warning rather than aborting the run.
+- Because `ag_ui:custom_event` is an ordinary state key, ADK persists it into session state. Agents wanting ephemeral behavior should clear it on the next turn.
+
 ## Event Translation
 
 The middleware translates between AG-UI and ADK event formats:

--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -472,6 +472,21 @@ class EventTranslator:
                 if hasattr(adk_event.actions, 'state_snapshot'):
                     state_snapshot = adk_event.actions.state_snapshot
                     if state_snapshot is not None:
+                        # The delta path above works on a copy and never mutates
+                        # ADK's persisted state, so ADK can still persist the
+                        # reserved key. A later snapshot would then carry it.
+                        # Strip it on a copy so the reserved key — an agent→AG-UI
+                        # signalling channel, not application state — never leaks
+                        # into AG-UI state.
+                        if (
+                            isinstance(state_snapshot, dict)
+                            and AG_UI_CUSTOM_EVENT_STATE_KEY in state_snapshot
+                        ):
+                            state_snapshot = {
+                                key: value
+                                for key, value in state_snapshot.items()
+                                if key != AG_UI_CUSTOM_EVENT_STATE_KEY
+                            }
                         yield self._create_state_snapshot_event(state_snapshot)
                 
             

--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -31,6 +31,13 @@ from .serialization import serialize_tool_args
 import logging
 logger = logging.getLogger(__name__)
 
+# Reserved key an ADK agent can set in ``EventActions.state_delta`` to emit a
+# named AG-UI CustomEvent instead of a STATE_DELTA. The colon namespace mirrors
+# ADK's own ``temp:``/``app:``/``user:`` state-key convention and avoids
+# colliding with real application state. The value is either a single
+# ``{"name": str, "value": Any}`` mapping or a list of them.
+AG_UI_CUSTOM_EVENT_STATE_KEY = "ag_ui:custom_event"
+
 # Backwards-compatible thought support detection
 # The part.thought attribute may not exist in older versions of google-genai
 _THOUGHT_SUPPORT_CHECKED = False
@@ -449,9 +456,18 @@ class EventTranslator:
             # Handle state changes
             if hasattr(adk_event, 'actions') and adk_event.actions:
                 if hasattr(adk_event.actions, 'state_delta') and adk_event.actions.state_delta:
-                    yield self._create_state_delta_event(
-                        adk_event.actions.state_delta, thread_id, run_id
-                    )
+                    # An agent emits a named CustomEvent by writing the reserved
+                    # AG_UI_CUSTOM_EVENT_STATE_KEY into state_delta. Pull those
+                    # out (on a copy — don't mutate ADK's persisted state) and
+                    # translate them; the remaining keys become a STATE_DELTA.
+                    state_delta = dict(adk_event.actions.state_delta)
+                    custom_specs = state_delta.pop(AG_UI_CUSTOM_EVENT_STATE_KEY, None)
+                    for custom_event in self._build_custom_events(custom_specs):
+                        yield custom_event
+                    if state_delta:
+                        yield self._create_state_delta_event(
+                            state_delta, thread_id, run_id
+                        )
 
                 if hasattr(adk_event.actions, 'state_snapshot'):
                     state_snapshot = adk_event.actions.state_snapshot
@@ -1203,6 +1219,52 @@ class EventTranslator:
                 content=_serialize_tool_response(func_response.response)
             )
   
+    def _build_custom_events(self, specs: Any) -> List[CustomEvent]:
+        """Translate the reserved AG_UI_CUSTOM_EVENT_STATE_KEY payload into
+        named AG-UI CustomEvents.
+
+        ``specs`` is either a single ``{"name": str, "value": Any}`` mapping or
+        a list of them. Malformed entries (not a mapping, or missing/empty/
+        non-str ``name``) are skipped with a warning so one bad payload can't
+        abort translation of the rest of the event.
+
+        Args:
+            specs: The value popped from ``state_delta[AG_UI_CUSTOM_EVENT_STATE_KEY]``.
+
+        Returns:
+            The CustomEvents to emit, in order (empty if ``specs`` is None).
+        """
+        if specs is None:
+            return []
+        if isinstance(specs, Mapping):
+            specs = [specs]
+        elif not isinstance(specs, (list, tuple)):
+            logger.warning(
+                "Ignoring %s: expected a mapping or list of mappings, got %s",
+                AG_UI_CUSTOM_EVENT_STATE_KEY, type(specs).__name__
+            )
+            return []
+
+        events: List[CustomEvent] = []
+        for spec in specs:
+            if not isinstance(spec, Mapping):
+                logger.warning(
+                    "Ignoring malformed %s entry: expected a mapping, got %s",
+                    AG_UI_CUSTOM_EVENT_STATE_KEY, type(spec).__name__
+                )
+                continue
+            name = spec.get("name")
+            if not isinstance(name, str) or not name:
+                logger.warning(
+                    "Ignoring %s entry with missing/invalid 'name': %r",
+                    AG_UI_CUSTOM_EVENT_STATE_KEY, spec
+                )
+                continue
+            events.append(
+                CustomEvent(type=EventType.CUSTOM, name=name, value=spec.get("value"))
+            )
+        return events
+
     def _create_state_delta_event(
         self,
         state_delta: Dict[str, Any],

--- a/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
+++ b/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
@@ -16,7 +16,7 @@ from ag_ui.core import (
     StateDeltaEvent, StateSnapshotEvent, CustomEvent
 )
 from google.adk.events import Event as ADKEvent
-from ag_ui_adk.event_translator import EventTranslator
+from ag_ui_adk.event_translator import EventTranslator, AG_UI_CUSTOM_EVENT_STATE_KEY
 
 
 class TestEventTranslatorComprehensive:
@@ -201,6 +201,112 @@ class TestEventTranslatorComprehensive:
         assert len(patches) == 2
         assert any(patch["path"] == "/key1" and patch["value"] == "value1" for patch in patches)
         assert any(patch["path"] == "/key2" and patch["value"] == "value2" for patch in patches)
+
+    @pytest.mark.asyncio
+    async def test_reserved_state_key_emits_named_custom_event(self, translator, mock_adk_event):
+        """A reserved state_delta key is translated to a named CustomEvent,
+        and no STATE_DELTA is emitted when it's the only key."""
+        mock_actions = MagicMock()
+        mock_actions.state_delta = {
+            AG_UI_CUSTOM_EVENT_STATE_KEY: {"name": "conversation_complete", "value": {"ok": True}},
+        }
+        mock_actions.state_snapshot = None
+        mock_adk_event.actions = mock_actions
+
+        events = [e async for e in translator.translate(mock_adk_event, "thread_1", "run_1")]
+
+        custom = [e for e in events if isinstance(e, CustomEvent)]
+        assert len(custom) == 1
+        assert custom[0].type == EventType.CUSTOM
+        assert custom[0].name == "conversation_complete"
+        assert custom[0].value == {"ok": True}
+        # The reserved key must not also leak out as a STATE_DELTA.
+        assert not any(isinstance(e, StateDeltaEvent) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_reserved_state_key_coexists_with_regular_state(self, translator, mock_adk_event):
+        """A CustomEvent is emitted for the reserved key while the remaining
+        keys still produce a STATE_DELTA — and the reserved key is stripped
+        from the delta so it doesn't leak."""
+        mock_actions = MagicMock()
+        mock_actions.state_delta = {
+            AG_UI_CUSTOM_EVENT_STATE_KEY: {"name": "payment_required", "value": 42},
+            "real_key": "real_value",
+        }
+        mock_actions.state_snapshot = None
+        mock_adk_event.actions = mock_actions
+
+        events = [e async for e in translator.translate(mock_adk_event, "thread_1", "run_1")]
+
+        custom_idx = next(i for i, e in enumerate(events) if isinstance(e, CustomEvent))
+        delta_idx = next(i for i, e in enumerate(events) if isinstance(e, StateDeltaEvent))
+        # CustomEvent precedes the StateDeltaEvent (mirrors the PredictState precedent).
+        assert custom_idx < delta_idx
+        assert events[custom_idx].name == "payment_required"
+        assert events[custom_idx].value == 42
+
+        paths = [patch["path"] for patch in events[delta_idx].delta]
+        assert "/real_key" in paths
+        assert f"/{AG_UI_CUSTOM_EVENT_STATE_KEY}" not in paths
+
+    @pytest.mark.asyncio
+    async def test_reserved_state_key_accepts_list_of_events(self, translator, mock_adk_event):
+        """A list payload emits one CustomEvent per spec, in order."""
+        mock_actions = MagicMock()
+        mock_actions.state_delta = {
+            AG_UI_CUSTOM_EVENT_STATE_KEY: [
+                {"name": "first", "value": 1},
+                {"name": "second", "value": 2},
+            ],
+        }
+        mock_actions.state_snapshot = None
+        mock_adk_event.actions = mock_actions
+
+        events = [e async for e in translator.translate(mock_adk_event, "thread_1", "run_1")]
+
+        custom = [e for e in events if isinstance(e, CustomEvent)]
+        assert [(e.name, e.value) for e in custom] == [("first", 1), ("second", 2)]
+
+    @pytest.mark.asyncio
+    async def test_reserved_state_key_skips_malformed_payload(self, translator, mock_adk_event):
+        """A malformed reserved payload (missing 'name') is skipped without
+        raising, and does not emit a CustomEvent."""
+        mock_actions = MagicMock()
+        mock_actions.state_delta = {
+            AG_UI_CUSTOM_EVENT_STATE_KEY: {"value": "no name here"},
+        }
+        mock_actions.state_snapshot = None
+        mock_adk_event.actions = mock_actions
+
+        events = [e async for e in translator.translate(mock_adk_event, "thread_1", "run_1")]
+
+        assert not any(isinstance(e, CustomEvent) for e in events)
+        # No StateDelta either — the reserved key was the only key.
+        assert not any(isinstance(e, StateDeltaEvent) for e in events)
+
+    def test_build_custom_events_normalizes_and_validates(self, translator):
+        """Direct unit test of the helper: single mapping, list, and the
+        skip-malformed / wrong-type guards."""
+        # Single mapping → one event.
+        single = translator._build_custom_events({"name": "n", "value": "v"})
+        assert len(single) == 1 and single[0].name == "n" and single[0].value == "v"
+
+        # None → empty.
+        assert translator._build_custom_events(None) == []
+
+        # Wrong top-level type → empty (skipped with a warning).
+        assert translator._build_custom_events("not a mapping or list") == []
+
+        # List with a mix of valid and invalid entries → only valid kept.
+        mixed = translator._build_custom_events([
+            {"name": "good", "value": 1},
+            {"value": "missing name"},
+            {"name": "", "value": "empty name"},
+            "not a mapping",
+            {"name": "also_good"},
+        ])
+        assert [e.name for e in mixed] == ["good", "also_good"]
+        assert mixed[1].value is None  # missing 'value' defaults to None
 
     @pytest.mark.asyncio
     async def test_translate_state_snapshot_event_passthrough(self, translator, mock_adk_event):

--- a/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
+++ b/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
@@ -341,6 +341,37 @@ class TestEventTranslatorComprehensive:
         assert snapshot_event.snapshot["custom_state"]["view"]["active_tab"] == "details"
         assert "extra_field" in snapshot_event.snapshot
 
+    @pytest.mark.asyncio
+    async def test_reserved_state_key_stripped_from_snapshot(self, translator, mock_adk_event):
+        """ADK can persist the reserved key (the delta path works on a copy),
+        so a later state_snapshot may still carry it. It must be scrubbed on a
+        copy before the snapshot is forwarded — the reserved key must never
+        leak into AG-UI state."""
+        state_snapshot = {
+            "user_name": "Alice",
+            "timezone": "UTC",
+            AG_UI_CUSTOM_EVENT_STATE_KEY: {"name": "conversation_complete", "value": {"ok": True}},
+        }
+
+        mock_adk_event.actions = SimpleNamespace(
+            state_delta=None,
+            state_snapshot=state_snapshot,
+        )
+
+        events = [e async for e in translator.translate(mock_adk_event, "thread_1", "run_1")]
+
+        snapshot_events = [event for event in events if isinstance(event, StateSnapshotEvent)]
+        assert snapshot_events, "Expected a StateSnapshotEvent to be emitted"
+
+        snapshot = snapshot_events[0].snapshot
+        assert AG_UI_CUSTOM_EVENT_STATE_KEY not in snapshot
+        assert snapshot == {"user_name": "Alice", "timezone": "UTC"}
+        # Scrubbing happens on a copy — the source dict is left untouched.
+        assert AG_UI_CUSTOM_EVENT_STATE_KEY in state_snapshot
+        # The reserved key in a snapshot is leftover persisted state, not a fresh
+        # emission, so it must not be re-translated into a CustomEvent.
+        assert not any(isinstance(e, CustomEvent) for e in events)
+
     def test_create_state_snapshot_event_passthrough(self, translator):
         """Direct helper should forward the snapshot unchanged."""
 


### PR DESCRIPTION
## Summary

Closes #1915. The ADK middleware (`ag_ui_adk`) had no supported way for an agent to emit a **named** AG-UI [`CustomEvent`](https://docs.ag-ui.com/concepts/events#custom). Every `CustomEvent` was constructed internally (PredictState, `adk_metadata`), and the one generic-looking path was unreachable:

```python
if hasattr(adk_event, 'custom_data') and adk_event.custom_data:
    yield CustomEvent(type=EventType.CUSTOM, name="adk_metadata", value=adk_event.custom_data)
```

`google.adk.events.Event` has no `custom_data` field and rejects extras, so `hasattr(...)` is always `False` for real ADK events — and even if it weren't, the name was hardcoded.

## Change

An agent emits a named custom event by writing the reserved key `ag_ui:custom_event` into `EventActions.state_delta`:

```python
yield Event(
    author=self.name,
    invocation_id=ctx.invocation_id,
    actions=EventActions(state_delta={
        "ag_ui:custom_event": {"name": "conversation_complete", "value": {"turns": 3}},
    }),
)
```

The translator:
- pops the reserved key off a **copy** of the delta (never mutating ADK's persisted state),
- emits one `CUSTOM` event per spec — accepting a single `{"name", "value"}` mapping **or a list** — **before** any `STATE_DELTA` (mirroring the existing PredictState ordering),
- translates the remaining keys to a `STATE_DELTA` as usual, so the reserved key never leaks as a state patch,
- skips malformed entries (missing/empty/non-str `name`) with a warning instead of aborting translation.

The colon namespace mirrors ADK's own `temp:`/`app:`/`user:` state-key convention.

## Tests

Added to `tests/test_event_translator_comprehensive.py`:
- reserved-key-only → one `CustomEvent`, no `STATE_DELTA`
- reserved key + regular key → `CustomEvent` precedes `STATE_DELTA`; reserved key stripped from patches
- list payload → ordered `CustomEvent`s
- malformed payload → skipped, no raise
- direct `_build_custom_events` unit test (normalization + guards)

`240 passed` across the event-translation / state test set; the 5 new tests pass.

## Docs

- `USAGE.md`: new "Emitting Named Custom Events" section (incl. the state-persistence note).
- `CHANGELOG.md`: `### Added` entry.

## Out of scope

The unreachable `custom_data` branch is left in place (it's still covered by existing mock-based tests); removing it would be an unrelated cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)