### PR TITLE
feat(adk-middleware): add HeartbeatPlugin for SSE keep-alive during long tools (#1001)

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **FEATURE**: `HeartbeatPlugin` for SSE connection keep-alive during long-running tools (#1001)
+  - An ADK `BasePlugin` that emits periodic `ACTIVITY_SNAPSHOT` events while a tool runs, keeping the SSE stream warm so timeout-sensitive infrastructure (Lambda/API Gateway, Cloud Run, proxies, CDNs) doesn't drop the connection mid-execution. Each tool call emits `starting`, a `processing` heartbeat every `interval_seconds` (default 5s), and a terminal `complete`/`error`, with progress carried in the event `content`. The middleware binds the in-flight run's event queue to a `ContextVar` around `runner.run_async`, so the plugin (and the exported `emit_progress` helper for tool-driven progress) can push events onto the current request's stream; the binding is per-request isolated. Plugins are only honored on the `ADKAgent.from_app(...)` path. New exports: `HeartbeatPlugin`, `emit_progress`, `set_event_queue`, `get_event_queue`, `reset_event_queue`. See "Keeping SSE Connections Alive During Long-Running Tools" in `USAGE.md`.
+
 ### Changed
 
 - **PERFORMANCE**: Cache session reads per execution to cut redundant `get_session` round-trips (#1880, #1890, thanks @he-yufeng)

--- a/integrations/adk-middleware/python/USAGE.md
+++ b/integrations/adk-middleware/python/USAGE.md
@@ -466,6 +466,51 @@ The middleware translates between AG-UI and ADK event formats:
 | TEXT_MESSAGE_* | Event with content.parts[].text | Text messages |
 | RUN_STARTED/FINISHED | Runner lifecycle | Execution flow |
 
+## Keeping SSE Connections Alive During Long-Running Tools
+
+When a tool runs for tens of seconds (scraping a site, processing a document,
+calling a slow API), no data flows on the SSE stream. Timeout-sensitive
+infrastructure — AWS Lambda/API Gateway (~29s), Cloud Run (~60s), load
+balancers, and CDNs — can interpret that silence as a dead connection and drop
+it, cutting the response off mid-execution.
+
+`HeartbeatPlugin` is an ADK `BasePlugin` that emits periodic `ACTIVITY_SNAPSHOT`
+events while a tool is running, keeping the stream warm:
+
+```python
+from ag_ui_adk import ADKAgent, HeartbeatPlugin
+from google.adk.apps import App
+from google.adk.agents import LlmAgent
+
+agent = LlmAgent(name="assistant", model="gemini-3.5-flash", tools=[slow_tool])
+
+# Plugins are only honored on the App path, so use ADKAgent.from_app(...).
+app = App(name="my_app", root_agent=agent, plugins=[HeartbeatPlugin(interval_seconds=5.0)])
+adk_agent = ADKAgent.from_app(app, user_id="user123")
+```
+
+Each running tool emits a `starting` event, a `processing` event every
+`interval_seconds`, and a terminal `complete`/`error` event. Progress is carried
+in the event's `content`:
+
+```json
+{
+  "type": "ACTIVITY_SNAPSHOT",
+  "activity_type": "TOOL_EXECUTION",
+  "replace": true,
+  "content": {"status": "processing", "tool_name": "web_scraper", "heartbeat": 5, "elapsed_seconds": 25.0}
+}
+```
+
+Notes:
+
+- Heartbeats are per-tool-call and isolated per request — a shared plugin
+  instance is safe under concurrent runs.
+- The plugin is a no-op outside the middleware (when no AG-UI stream is bound).
+- For richer, tool-driven progress, call `emit_progress(...)` from inside a tool;
+  it pushes an `ACTIVITY_SNAPSHOT` onto the current run's stream (and is a safe
+  no-op if called outside a run).
+
 ## Message History Features
 
 ### MESSAGES_SNAPSHOT Emission

--- a/integrations/adk-middleware/python/examples/server/api/heartbeat_keepalive.py
+++ b/integrations/adk-middleware/python/examples/server/api/heartbeat_keepalive.py
@@ -1,0 +1,65 @@
+"""HeartbeatPlugin keep-alive feature.
+
+Demonstrates keeping the SSE stream alive during a long-running tool with
+``HeartbeatPlugin``. While ``slow_research`` sleeps, the plugin emits
+``ACTIVITY_SNAPSHOT`` events every ``interval_seconds`` so timeout-sensitive
+infrastructure (Lambda/API Gateway, Cloud Run, proxies, CDNs) doesn't drop the
+connection before the tool returns.
+
+Key points:
+1. Plugins are only honored on the App path — build the agent with
+   ``ADKAgent.from_app(...)``, not the plain ``ADKAgent(adk_agent=...)`` form.
+2. Each tool call emits ``starting`` → ``processing`` (every interval) →
+   ``complete``/``error``, with progress carried in the event ``content``.
+3. ``emit_progress(...)`` can be called from inside a tool for richer,
+   tool-driven progress updates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI
+from ag_ui_adk import ADKAgent, AGUIToolset, HeartbeatPlugin, add_adk_fastapi_endpoint
+from google.adk.agents import LlmAgent
+from google.adk.apps import App
+
+
+async def slow_research(topic: str) -> str:
+    """Simulate a slow, long-running tool (e.g. scraping or document processing)."""
+    await asyncio.sleep(15)
+    return f"Finished researching '{topic}'."
+
+
+sample_agent = LlmAgent(
+    name="assistant",
+    model="gemini-3.5-flash",
+    instruction=(
+        "You are a research assistant. When the user asks you to research a topic, "
+        "call the slow_research tool and then summarize its result."
+    ),
+    tools=[
+        slow_research,
+        AGUIToolset(),  # Tools provided by the AG-UI client
+    ],
+)
+
+# Plugins are wired through the App, so use from_app() (not ADKAgent(adk_agent=...)).
+app_def = App(
+    name="demo_app",
+    root_agent=sample_agent,
+    plugins=[HeartbeatPlugin(interval_seconds=5.0)],
+)
+
+heartbeat_agent = ADKAgent.from_app(
+    app_def,
+    user_id="demo_user",
+    session_timeout_seconds=3600,
+    use_in_memory_services=True,
+)
+
+# Create FastAPI app
+app = FastAPI(title="ADK Middleware Heartbeat Keep-Alive")
+
+# Add the ADK endpoint
+add_adk_fastapi_endpoint(app, heartbeat_agent, path="/")

--- a/integrations/adk-middleware/python/src/ag_ui_adk/__init__.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/__init__.py
@@ -17,6 +17,13 @@ from .session_manager import SessionManager, CONTEXT_STATE_KEY, INVOCATION_ID_ST
 from .endpoint import add_adk_fastapi_endpoint, create_adk_app
 from .config import PredictStateMapping, normalize_predict_state
 from .agui_toolset import AGUIToolset
+from .heartbeat import (
+    HeartbeatPlugin,
+    set_event_queue,
+    get_event_queue,
+    reset_event_queue,
+    emit_progress,
+)
 __all__ = [
     'ADKAgent',
     'add_adk_fastapi_endpoint',
@@ -29,6 +36,11 @@ __all__ = [
     'normalize_predict_state',
     'adk_events_to_messages',
     'AGUIToolset',
+    'HeartbeatPlugin',
+    'set_event_queue',
+    'get_event_queue',
+    'reset_event_queue',
+    'emit_progress',
 ]
 
 __version__ = "0.1.0"

--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -74,6 +74,7 @@ from .client_proxy_toolset import ClientProxyToolset
 from .config import PredictStateMapping
 from .request_state_service import RequestStateSessionService
 from .utils.converters import convert_message_content_to_parts
+from .heartbeat import set_event_queue, reset_event_queue
 
 import logging
 logger = logging.getLogger(__name__)
@@ -2534,6 +2535,10 @@ class ADKAgent:
         pending_lro_id_remap: Dict[str, str] = {}
         logger.debug(f"[BG_EXEC] _run_adk_in_background called for thread={input.thread_id}")
         logger.debug(f"[BG_EXEC]   tool_results={len(tool_results) if tool_results else 0}, message_batch={len(message_batch) if message_batch else 0}")
+        # Bind this run's event queue so plugins (e.g. HeartbeatPlugin) running
+        # inside runner.run_async can push extra AG-UI events onto the stream.
+        # This task owns its own context copy, so the binding is per-request.
+        heartbeat_queue_token = set_event_queue(event_queue)
         try:
             # Agent is already prepared with tools and SystemMessage instructions (if any)
             # from _start_background_execution, so no additional agent copying needed here
@@ -3300,6 +3305,9 @@ class ADKAgent:
             )
             await event_queue.put(None)
         finally:
+            # Unbind the heartbeat event queue bound at the top of this run.
+            reset_event_queue(heartbeat_queue_token)
+
             # Background task cleanup completed
             # Ensure the ADK runner releases any resources (e.g. toolsets)
             if runner is not None:

--- a/integrations/adk-middleware/python/src/ag_ui_adk/heartbeat.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/heartbeat.py
@@ -1,0 +1,224 @@
+# src/ag_ui_adk/heartbeat.py
+
+"""HeartbeatPlugin: keep SSE connections alive during long-running ADK tools.
+
+When an ADK tool runs for tens of seconds (scraping a site, processing a
+document, calling a slow external API), no data flows on the SSE stream. Many
+infrastructure components treat "no data" as "connection dead" and terminate it
+(AWS Lambda/API Gateway ~29s, Cloud Run ~60s, load balancers/CDNs idle
+timeouts), cutting agent responses off mid-execution.
+
+``HeartbeatPlugin`` is an ADK ``BasePlugin`` that emits periodic
+``ACTIVITY_SNAPSHOT`` events while a tool is running, keeping the stream warm.
+
+Wiring: the middleware binds the in-flight run's AG-UI event queue to a
+``ContextVar`` (:func:`set_event_queue`) around ``runner.run_async``. The plugin
+— attached to your ADK ``App`` via ``plugins=[HeartbeatPlugin()]`` — reads that
+queue from its tool callbacks and pushes ``ACTIVITY_SNAPSHOT`` events onto it.
+Each background run is its own ``asyncio.Task`` with its own context copy, so the
+binding is naturally per-request isolated.
+
+Plugins are only honored for agents constructed via ``ADKAgent.from_app(...)``
+(the component-based constructor has no plugin support), so the heartbeat only
+fires for ``from_app`` agents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from contextvars import ContextVar, Token
+from typing import Any, Dict, Optional
+
+from ag_ui.core import ActivitySnapshotEvent, EventType
+from google.adk.plugins.base_plugin import BasePlugin
+
+logger = logging.getLogger(__name__)
+
+# The in-flight run's AG-UI event queue. Bound by the middleware around
+# runner.run_async so a plugin — which ADK constructs once and shares across all
+# requests — can find the queue belonging to the *current* request.
+_EVENT_QUEUE: ContextVar[Optional["asyncio.Queue"]] = ContextVar(
+    "ag_ui_adk_event_queue", default=None
+)
+
+
+def set_event_queue(queue: Optional["asyncio.Queue"]) -> Token:
+    """Bind ``queue`` as the current run's event queue.
+
+    Returns a ``Token`` that :func:`reset_event_queue` can use to restore the
+    previous value.
+    """
+    return _EVENT_QUEUE.set(queue)
+
+
+def get_event_queue() -> Optional["asyncio.Queue"]:
+    """Return the event queue bound for the current run, or ``None`` if unbound."""
+    return _EVENT_QUEUE.get()
+
+
+def reset_event_queue(token: Token) -> None:
+    """Undo a previous :func:`set_event_queue` using its ``Token``."""
+    try:
+        _EVENT_QUEUE.reset(token)
+    except (ValueError, LookupError):
+        # Token created in a different context (e.g. the set happened in a parent
+        # task); fall back to clearing so we never leak a stale queue.
+        _EVENT_QUEUE.set(None)
+
+
+def _build_activity_event(
+    activity_type: str,
+    status: str,
+    tool_name: str,
+    *,
+    elapsed_seconds: float,
+    heartbeat: Optional[int] = None,
+    replace: bool = True,
+) -> ActivitySnapshotEvent:
+    """Construct an ACTIVITY_SNAPSHOT carrying tool-progress info in ``content``.
+
+    ``content`` is the protocol's free-form ``Any`` field; the status/tool_name/
+    elapsed_seconds/heartbeat live there rather than as top-level event fields
+    (the event schema only defines message_id, activity_type, content, replace).
+    """
+    content: Dict[str, Any] = {
+        "status": status,
+        "tool_name": tool_name,
+        "elapsed_seconds": round(elapsed_seconds, 1),
+    }
+    if heartbeat is not None:
+        content["heartbeat"] = heartbeat
+    return ActivitySnapshotEvent(
+        type=EventType.ACTIVITY_SNAPSHOT,
+        message_id=f"heartbeat_{uuid.uuid4().hex}",
+        activity_type=activity_type,
+        content=content,
+        replace=replace,
+    )
+
+
+async def emit_progress(
+    activity_type: str,
+    status: str,
+    tool_name: str,
+    *,
+    elapsed_seconds: float = 0.0,
+    heartbeat: Optional[int] = None,
+    replace: bool = True,
+    queue: Optional["asyncio.Queue"] = None,
+) -> bool:
+    """Emit a single ACTIVITY_SNAPSHOT onto the run's event queue.
+
+    Resolves the target queue from the ``queue`` argument or, if omitted, the
+    current :func:`get_event_queue` binding. Returns ``True`` if an event was
+    enqueued, or ``False`` when no queue is bound — making it a safe no-op when
+    called outside an in-flight run.
+    """
+    queue = queue if queue is not None else get_event_queue()
+    if queue is None:
+        return False
+    await queue.put(
+        _build_activity_event(
+            activity_type,
+            status,
+            tool_name,
+            elapsed_seconds=elapsed_seconds,
+            heartbeat=heartbeat,
+            replace=replace,
+        )
+    )
+    return True
+
+
+class HeartbeatPlugin(BasePlugin):
+    """Emit periodic ACTIVITY_SNAPSHOT heartbeats while ADK tools execute.
+
+    Args:
+        name: Plugin identifier (ADK requires plugin names to be unique).
+        interval_seconds: Seconds between ``processing`` heartbeats while a tool
+            runs. Must be > 0.
+        activity_type: ``activity_type`` stamped on emitted events.
+
+    Usage::
+
+        from ag_ui_adk import ADKAgent, HeartbeatPlugin
+        from google.adk.apps import App
+
+        app = App(name="my_app", root_agent=agent, plugins=[HeartbeatPlugin()])
+        adk_agent = ADKAgent.from_app(app, user_id="user123")
+    """
+
+    def __init__(
+        self,
+        name: str = "heartbeat",
+        interval_seconds: float = 5.0,
+        activity_type: str = "TOOL_EXECUTION",
+    ):
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        super().__init__(name=name)
+        self.interval_seconds = interval_seconds
+        self.activity_type = activity_type
+        # Per in-flight tool call. The plugin instance is shared across
+        # concurrent requests, so state must be keyed off the tool call — never
+        # stored as a single shared attribute.
+        self._tasks: Dict[Any, asyncio.Task] = {}
+
+    @staticmethod
+    def _key(tool_context: Any) -> Any:
+        return getattr(tool_context, "function_call_id", None) or id(tool_context)
+
+    async def before_tool_callback(self, *, tool, tool_args, tool_context):
+        queue = get_event_queue()
+        if queue is None:
+            # No AG-UI stream bound (e.g. plugin used outside the middleware).
+            return None
+
+        tool_name = getattr(tool, "name", "tool")
+        await emit_progress(
+            self.activity_type, "starting", tool_name, elapsed_seconds=0.0, queue=queue
+        )
+
+        start = time.monotonic()
+
+        async def _beat() -> None:
+            count = 0
+            # Bind the queue captured at callback time rather than re-reading the
+            # ContextVar here: the var may be reset by the time this task runs.
+            while True:
+                await asyncio.sleep(self.interval_seconds)
+                count += 1
+                await emit_progress(
+                    self.activity_type,
+                    "processing",
+                    tool_name,
+                    elapsed_seconds=time.monotonic() - start,
+                    heartbeat=count,
+                    queue=queue,
+                )
+
+        self._tasks[self._key(tool_context)] = asyncio.create_task(_beat())
+        return None
+
+    async def after_tool_callback(self, *, tool, tool_args, tool_context, result):
+        await self._finish(tool, tool_context, "complete")
+        return None
+
+    async def on_tool_error_callback(self, *, tool, tool_args, tool_context, error):
+        await self._finish(tool, tool_context, "error")
+        return None
+
+    async def _finish(self, tool, tool_context, status: str) -> None:
+        """Cancel the heartbeat task for this tool call and emit a terminal event."""
+        task = self._tasks.pop(self._key(tool_context), None)
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        tool_name = getattr(tool, "name", "tool")
+        await emit_progress(self.activity_type, status, tool_name)

--- a/integrations/adk-middleware/python/tests/test_heartbeat_plugin.py
+++ b/integrations/adk-middleware/python/tests/test_heartbeat_plugin.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+"""Tests for HeartbeatPlugin and its per-request event-queue plumbing."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from ag_ui.core import ActivitySnapshotEvent, EventType
+from ag_ui_adk.heartbeat import (
+    HeartbeatPlugin,
+    set_event_queue,
+    get_event_queue,
+    reset_event_queue,
+    emit_progress,
+)
+
+
+def _make_tool(name="web_scraper"):
+    return SimpleNamespace(name=name)
+
+
+def _make_ctx(function_call_id="call_1"):
+    return SimpleNamespace(function_call_id=function_call_id)
+
+
+def _drain(queue):
+    events = []
+    while True:
+        try:
+            events.append(queue.get_nowait())
+        except asyncio.QueueEmpty:
+            return events
+
+
+def test_interval_validation():
+    """A non-positive interval is rejected at construction."""
+    with pytest.raises(ValueError):
+        HeartbeatPlugin(interval_seconds=0)
+    with pytest.raises(ValueError):
+        HeartbeatPlugin(interval_seconds=-1.0)
+    # A valid interval constructs fine.
+    assert HeartbeatPlugin(interval_seconds=0.5).interval_seconds == 0.5
+
+
+def test_contextvar_set_and_reset():
+    q = asyncio.Queue()
+    assert get_event_queue() is None
+    token = set_event_queue(q)
+    assert get_event_queue() is q
+    reset_event_queue(token)
+    assert get_event_queue() is None
+
+
+async def test_emit_progress_is_noop_without_queue():
+    """emit_progress is a safe no-op (returns False) when no queue is bound."""
+    assert get_event_queue() is None
+    assert await emit_progress("TOOL_EXECUTION", "starting", "tool") is False
+
+
+async def test_emitted_event_is_a_valid_activity_snapshot():
+    """The emitted event is a schema-valid ACTIVITY_SNAPSHOT carrying progress
+    info in `content`."""
+    q = asyncio.Queue()
+    token = set_event_queue(q)
+    try:
+        assert await emit_progress(
+            "TOOL_EXECUTION", "processing", "web_scraper",
+            elapsed_seconds=25.04, heartbeat=5,
+        ) is True
+    finally:
+        reset_event_queue(token)
+
+    (event,) = _drain(q)
+    assert isinstance(event, ActivitySnapshotEvent)
+    assert event.type == EventType.ACTIVITY_SNAPSHOT
+    assert event.activity_type == "TOOL_EXECUTION"
+    assert event.replace is True
+    assert event.content["status"] == "processing"
+    assert event.content["tool_name"] == "web_scraper"
+    assert event.content["heartbeat"] == 5
+    assert event.content["elapsed_seconds"] == 25.0  # rounded to 1dp
+    # Re-validate against the model to guard the content shape.
+    ActivitySnapshotEvent.model_validate(event.model_dump())
+
+
+async def test_before_tool_emits_starting_event():
+    plugin = HeartbeatPlugin(interval_seconds=10.0)  # long: no processing beat
+    q = asyncio.Queue()
+    token = set_event_queue(q)
+    try:
+        await plugin.before_tool_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx()
+        )
+        # Stop the beat task immediately so it doesn't linger.
+        await plugin.after_tool_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx(), result={}
+        )
+    finally:
+        reset_event_queue(token)
+
+    statuses = [e.content["status"] for e in _drain(q)]
+    assert statuses[0] == "starting"
+    assert "complete" in statuses
+
+
+async def test_before_tool_is_noop_without_queue():
+    """With no stream bound, the plugin does nothing and starts no beat task."""
+    plugin = HeartbeatPlugin(interval_seconds=0.01)
+    result = await plugin.before_tool_callback(
+        tool=_make_tool(), tool_args={}, tool_context=_make_ctx()
+    )
+    assert result is None
+    assert plugin._tasks == {}
+
+
+async def test_heartbeats_emit_at_interval_then_stop_on_completion():
+    plugin = HeartbeatPlugin(interval_seconds=0.05)
+    q = asyncio.Queue()
+    token = set_event_queue(q)
+    try:
+        await plugin.before_tool_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx()
+        )
+        await asyncio.sleep(0.17)  # ~3 intervals
+        await plugin.after_tool_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx(), result={}
+        )
+        # The beat task must be gone once the tool finished.
+        assert plugin._tasks == {}
+
+        events = _drain(q)
+        processing = [e for e in events if e.content["status"] == "processing"]
+        assert len(processing) >= 2
+        # Heartbeat counter increments and elapsed time is non-decreasing.
+        assert [e.content["heartbeat"] for e in processing] == sorted(
+            e.content["heartbeat"] for e in processing
+        )
+        elapsed = [e.content["elapsed_seconds"] for e in processing]
+        assert elapsed == sorted(elapsed)
+        assert events[-1].content["status"] == "complete"
+
+        # No further heartbeats after completion.
+        await asyncio.sleep(0.12)
+        assert not any(e.content["status"] == "processing" for e in _drain(q))
+    finally:
+        reset_event_queue(token)
+
+
+async def test_error_path_emits_error_status_and_stops():
+    plugin = HeartbeatPlugin(interval_seconds=0.05)
+    q = asyncio.Queue()
+    token = set_event_queue(q)
+    try:
+        await plugin.before_tool_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx()
+        )
+        await asyncio.sleep(0.07)
+        await plugin.on_tool_error_callback(
+            tool=_make_tool(), tool_args={}, tool_context=_make_ctx(),
+            error=RuntimeError("boom"),
+        )
+        assert plugin._tasks == {}
+        statuses = [e.content["status"] for e in _drain(q)]
+        assert statuses[-1] == "error"
+    finally:
+        reset_event_queue(token)
+
+
+async def test_concurrent_requests_are_isolated():
+    """A shared plugin instance keeps two concurrent runs' heartbeats on their
+    own queues (per-task ContextVar + per-call-id task tracking)."""
+    plugin = HeartbeatPlugin(interval_seconds=0.05)
+
+    async def run(tool_name, call_id):
+        q = asyncio.Queue()
+        token = set_event_queue(q)
+        try:
+            await plugin.before_tool_callback(
+                tool=_make_tool(tool_name), tool_args={}, tool_context=_make_ctx(call_id)
+            )
+            await asyncio.sleep(0.13)
+            await plugin.after_tool_callback(
+                tool=_make_tool(tool_name), tool_args={}, tool_context=_make_ctx(call_id),
+                result={},
+            )
+            return _drain(q)
+        finally:
+            reset_event_queue(token)
+
+    a_events, b_events = await asyncio.gather(
+        run("scraper_a", "call_a"),
+        run("scraper_b", "call_b"),
+    )
+
+    assert a_events and b_events
+    assert {e.content["tool_name"] for e in a_events} == {"scraper_a"}
+    assert {e.content["tool_name"] for e in b_events} == {"scraper_b"}
+    assert plugin._tasks == {}


### PR DESCRIPTION
## Summary

Closes #1001. When an ADK tool runs for tens of seconds (scraping, document processing, slow external APIs), no data flows on the SSE stream, and timeout-sensitive infrastructure (AWS Lambda/API Gateway ~29s, Cloud Run ~60s, load balancers/CDNs idle timeouts) interprets the silence as a dead connection and terminates it — cutting agent responses off mid-execution.

`HeartbeatPlugin` is an ADK `BasePlugin` that emits periodic `ACTIVITY_SNAPSHOT` events while a tool runs, keeping the stream warm.

## How it works

- **Per-request seam:** the middleware binds the in-flight run's event queue to a `ContextVar` around `runner.run_async` (`set_event_queue` at the top of `_run_adk_in_background`, `reset_event_queue` in its `finally`). Each background run is its own `asyncio.Task` with its own context copy, so the binding is naturally per-request isolated — no new transport needed; it bridges to the existing per-run event queue.
- **The plugin** reads that queue from its tool callbacks (`before_tool_callback` / `after_tool_callback` / `on_tool_error_callback`) and pushes events: `starting` → a `processing` heartbeat every `interval_seconds` (default 5s) → terminal `complete`/`error`. Progress lives in the event `content` (`status`, `tool_name`, `heartbeat`, `elapsed_seconds`).
- **Concurrency:** heartbeat tasks are keyed per tool-call id, so a single shared plugin instance is safe across concurrent runs.
- **`emit_progress(...)`** is exported for tools that want to push richer progress; it's a safe no-op outside a run.

Plugins are only honored on the `ADKAgent.from_app(...)` path (the component-based constructor has no plugin support), so the heartbeat fires for `from_app` agents.

```python
from ag_ui_adk import ADKAgent, HeartbeatPlugin
from google.adk.apps import App

app = App(name="my_app", root_agent=agent, plugins=[HeartbeatPlugin(interval_seconds=5.0)])
adk_agent = ADKAgent.from_app(app, user_id="user123")
```

## Changes

- New `src/ag_ui_adk/heartbeat.py` (`HeartbeatPlugin`, `emit_progress`, `set_event_queue`, `get_event_queue`, `reset_event_queue`).
- `adk_agent.py`: bind/reset the event queue around the run loop (import + 2 lines).
- `__init__.py`: new exports.
- Tests, `USAGE.md` section, `CHANGELOG.md` entry, and a runnable `examples/server/api/heartbeat_keepalive.py`.

## Tests

9 new tests in `tests/test_heartbeat_plugin.py`: interval validation, `starting`/heartbeat/stop lifecycle, error path, no-queue no-op, concurrency isolation, and ACTIVITY_SNAPSHOT schema-validity. **Full suite: 868 passed, 6 skipped, 0 failed** (was 859 before; +9 heartbeat tests, no regressions).

## Notes

The issue's proposed event shape put `status`/`elapsed_seconds` at the top level, but `ActivitySnapshotEvent` only defines `message_id`/`activity_type`/`content`/`replace` — so progress fields are carried inside `content` (validated by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)