### PR TITLE
docs: add AG-UI A2UI integration skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 
 # General Guidelines for working with Nx
 
+- For requests to add A2UI rendering to AG-UI applications or to scaffold an
+  AG-UI + A2UI quickstart, use
+  `skills/ag-ui-a2ui-integration/SKILL.md`.
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
 - You have access to the Nx MCP server and its tools, use them to help the user
 - When answering questions about the repository, use the `nx_workspace` tool first to gain an understanding of the workspace architecture where applicable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+For requests to add A2UI rendering to AG-UI applications or to scaffold an
+AG-UI + A2UI quickstart, use `skills/ag-ui-a2ui-integration/SKILL.md`.
+
 ## Common Development Commands
 
 ### TypeScript SDK (Main Development)

--- a/skills/ag-ui-a2ui-integration/SKILL.md
+++ b/skills/ag-ui-a2ui-integration/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ag-ui-a2ui-integration
+description: "Use when adding A2UI rendering to any AG-UI-supported framework or custom AG-UI application, scaffolding an AG-UI app that should render A2UI, adapting an AG-UI integration to emit A2UI surfaces, or wiring CopilotKit's A2UI runtime and renderer around an AG-UI agent."
+version: 1.0.0
+---
+
+# AG-UI + A2UI Integration Skill
+
+## Overview
+
+Use this skill to add A2UI rendering to an AG-UI application. Treat AG-UI as
+the transport and agent integration layer, and A2UI as the UI payload format
+that the agent emits and the client renders.
+
+This is a developer-facing skill artifact. It is meant to be loaded by coding
+agents and used against a real app or repo, not published as a docs page.
+
+## When to Use
+
+- Adding A2UI rendering to an existing AG-UI app.
+- Creating an AG-UI quickstart that should display A2UI surfaces.
+- Connecting any AG-UI-supported framework or custom AG-UI agent to an
+  A2UI-capable frontend.
+- Adding or extending an A2UI component catalog.
+- Debugging why an A2UI surface does not render or why a user action does not
+  flow back to the agent.
+
+## When NOT to Use
+
+- For AG-UI protocol event semantics only, use the AG-UI protocol skill or
+  protocol docs.
+- For A2UI renderer internals outside an AG-UI app, use the A2UI renderer
+  docs or renderer-specific skills.
+- For generic CopilotKit frontend work without A2UI, use CopilotKit-specific
+  setup and React skills.
+
+## Workflow
+
+1. Inspect the app shape: framework, package manager, AG-UI endpoint, frontend
+   shell, and any existing A2UI renderer or catalog.
+2. If starting from a blank app, inspect the current AG-UI CLI and integration
+   docs. Use a CLI flag when the target framework is scaffoldable; otherwise
+   start from the framework's AG-UI package or example.
+3. Select the framework adapter from
+   `references/framework-adapters.md`, or use that reference to find the
+   closest AG-UI integration pattern. Preserve the app's existing agent
+   architecture.
+4. Wire the A2UI runtime and renderer using
+   `references/a2ui-runtime-and-renderer.md`.
+5. Add or extend the component catalog only when the built-in A2UI catalog is
+   not enough for the requested UI.
+6. Verify the streaming path with `references/verification.md`: agent stream,
+   rendered A2UI surface, and a user interaction flowing back through AG-UI.
+
+## AG-UI Framework Support
+
+This skill is not limited to the framework examples below. For any target
+framework, first check the AG-UI repository's `integrations/` directory, the
+AG-UI docs, and the current CLI source. If AG-UI supports the framework, use
+that integration's documented package, endpoint helper, or scaffold path. If
+there is no framework adapter, implement the custom AG-UI agent path and keep
+the A2UI runtime/client wiring the same.
+
+## Common AG-UI CLI Flags
+
+Use the CLI flags that exist in `sdks/typescript/packages/cli/src/index.ts`.
+The table is a quick reference for known scaffold paths, not the full AG-UI
+support matrix. Do not invent flags.
+
+| Framework            | CLI flag         |
+| -------------------- | ---------------- |
+| ADK                  | `--adk`          |
+| LangGraph Python     | `--langgraph-py` |
+| LangGraph JavaScript | `--langgraph-js` |
+| CrewAI Flows         | `--crewai-flows` |
+| Mastra               | `--mastra`       |
+| Pydantic AI          | `--pydantic-ai`  |
+| LlamaIndex           | `--llamaindex`   |
+| Agno                 | `--agno`         |
+| AG2                  | `--ag2`          |
+
+Strands has AG-UI integration packages and examples, but no Strands CLI flag
+is present in the current AG-UI CLI source. Use the Strands integration docs
+instead of guessing a scaffold command.
+
+## Key Rules
+
+- Keep the integration AG-UI-first for every supported framework. CopilotKit is
+  the common runtime and renderer path for A2UI in web apps, but do not
+  describe AG-UI as merely a CopilotKit implementation detail.
+- Enable A2UI on both sides: runtime support on the server and renderer
+  support on the client.
+- If dynamic component schemas are needed, inject the A2UI tool on the runtime
+  and pass a real runtime schema value. Type-only definitions are not enough.
+- Emit `createSurface` once per `surfaceId`; use update operations for later
+  changes.
+- Preserve AG-UI run boundaries and error events. Do not swallow server or
+  stream errors.
+- Verify with a real browser or client run when possible. A static typecheck is
+  not enough for streaming UI work.
+
+## References
+
+- `references/framework-adapters.md` - framework-specific AG-UI adapter
+  patterns.
+- `references/a2ui-runtime-and-renderer.md` - server/client A2UI wiring and
+  catalog patterns.
+- `references/verification.md` - checks to confirm the integration works.
+- `sources.md` - source files and docs used by this skill.

--- a/skills/ag-ui-a2ui-integration/SKILL.md
+++ b/skills/ag-ui-a2ui-integration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ag-ui-a2ui-integration
-description: "Use when adding A2UI rendering to any AG-UI-supported framework or custom AG-UI application, scaffolding an AG-UI app that should render A2UI, adapting an AG-UI integration to emit A2UI surfaces, or wiring CopilotKit's A2UI runtime and renderer around an AG-UI agent."
-version: 1.0.0
+description: "Use when adding A2UI rendering to any AG-UI-supported framework or custom AG-UI application, scaffolding an AG-UI app that should render A2UI, adapting an AG-UI integration to emit A2UI surfaces, or wiring the AG-UI A2UI middleware/toolkit with a compatible renderer."
+version: 1.1.0
 ---
 
 # AG-UI + A2UI Integration Skill
@@ -9,8 +9,9 @@ version: 1.0.0
 ## Overview
 
 Use this skill to add A2UI rendering to an AG-UI application. Treat AG-UI as
-the transport and agent integration layer, and A2UI as the UI payload format
-that the agent emits and the client renders.
+the transport and agent integration layer, `@ag-ui/a2ui-middleware` as the
+server-side bridge that detects and paints A2UI operations, and A2UI as the UI
+payload format that the client renderer displays.
 
 This is a developer-facing skill artifact. It is meant to be loaded by coding
 agents and used against a real app or repo, not published as a docs page.
@@ -36,30 +37,38 @@ agents and used against a real app or repo, not published as a docs page.
 
 ## Workflow
 
-1. Inspect the app shape: framework, package manager, AG-UI endpoint, frontend
-   shell, and any existing A2UI renderer or catalog.
-2. If starting from a blank app, inspect the current AG-UI CLI and integration
-   docs. Use a CLI flag when the target framework is scaffoldable; otherwise
-   start from the framework's AG-UI package or example.
-3. Select the framework adapter from
+1. Inspect the app shape: framework adapter, AG-UI agent endpoint, runtime
+   host, frontend shell, and any existing A2UI renderer/catalog.
+2. Decide the A2UI mode before editing code:
+   - Fixed schema: backend tools return an `a2ui_operations` envelope with
+     `createSurface`, `updateComponents`, and `updateDataModel`.
+   - Dynamic schema: a framework A2UI tool (`generate_a2ui`) delegates to a
+     sub-agent that streams `render_a2ui` args through `A2UIMiddleware`.
+3. Select framework-specific wiring from
    `references/framework-adapters.md`, or use that reference to find the
    closest AG-UI integration pattern. Preserve the app's existing agent
    architecture.
-4. Wire the A2UI runtime and renderer using
-   `references/a2ui-runtime-and-renderer.md`.
-5. Add or extend the component catalog only when the built-in A2UI catalog is
-   not enough for the requested UI.
-6. Verify the streaming path with `references/verification.md`: agent stream,
-   rendered A2UI surface, and a user interaction flowing back through AG-UI.
+4. Wire server middleware/runtime and client renderer using
+   `references/a2ui-runtime-and-renderer.md`. Avoid double-applying
+   `A2UIMiddleware`; use either runtime-level A2UI config or per-agent
+   `agent.use(new A2UIMiddleware(...))` for a given agent.
+5. Register a catalog on the client. For dynamic schema, ensure the middleware
+   or adapter uses the same `defaultCatalogId` as the renderer-registered
+   catalog.
+6. Verify the streaming path with `references/verification.md`: AG-UI stream,
+   `a2ui-surface` activity snapshots or `a2ui_operations`, rendered A2UI
+   surface, and a user interaction flowing back through AG-UI.
 
 ## AG-UI Framework Support
 
 This skill is not limited to the framework examples below. For any target
 framework, first check the AG-UI repository's `integrations/` directory, the
-AG-UI docs, and the current CLI source. If AG-UI supports the framework, use
-that integration's documented package, endpoint helper, or scaffold path. If
-there is no framework adapter, implement the custom AG-UI agent path and keep
-the A2UI runtime/client wiring the same.
+AG-UI docs, the framework adapter's A2UI files, and the current CLI source. If
+AG-UI supports the framework, use that integration's documented package,
+endpoint helper, A2UI tool factory, or scaffold path. If there is no framework
+A2UI adapter, implement the custom AG-UI agent path, return `a2ui_operations`
+from backend tools for fixed layouts, and keep the middleware/client wiring the
+same.
 
 ## Common AG-UI CLI Flags
 
@@ -86,14 +95,19 @@ instead of guessing a scaffold command.
 ## Key Rules
 
 - Keep the integration AG-UI-first for every supported framework. CopilotKit is
-  the common runtime and renderer path for A2UI in web apps, but do not
-  describe AG-UI as merely a CopilotKit implementation detail.
-- Enable A2UI on both sides: runtime support on the server and renderer
-  support on the client.
-- If dynamic component schemas are needed, inject the A2UI tool on the runtime
-  and pass a real runtime schema value. Type-only definitions are not enough.
+  a common runtime/renderer path for web apps, but AG-UI owns the middleware,
+  framework adapters, and wire events.
+- Enable A2UI on both sides: `A2UIMiddleware` or runtime A2UI config on the
+  server, and an A2UI-capable renderer/catalog on the client.
+- For dynamic schema, prefer the framework adapter's A2UI tool factory or
+  auto-injection path. The model should call `generate_a2ui`; the sub-agent
+  should stream `render_a2ui` args so the middleware can progressively paint.
+- For fixed schema, return an `a2ui_operations` envelope from backend tools
+  rather than asking the model to invent component trees.
 - Emit `createSurface` once per `surfaceId`; use update operations for later
   changes.
+- Do not let the model invent catalog ids. The host/middleware/adapter should
+  stamp a `defaultCatalogId` that matches the client-registered catalog.
 - Preserve AG-UI run boundaries and error events. Do not swallow server or
   stream errors.
 - Verify with a real browser or client run when possible. A static typecheck is

--- a/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
+++ b/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
@@ -1,121 +1,174 @@
 # A2UI Runtime and Renderer Wiring
 
-A2UI needs a server-side runtime path that tells the agent how to emit UI and
-a client-side renderer path that turns emitted A2UI operations into a visible
-surface.
+A2UI needs three pieces to line up: a server-side AG-UI bridge, an A2UI
+operation source, and a client renderer with the matching catalog.
 
-## Runtime Side
+## Server Bridge
 
-Enable A2UI on the runtime. For dynamic schema flows, inject the A2UI tool so
-the agent can create and update surfaces.
+AG-UI now provides `@ag-ui/a2ui-middleware`. It injects schema context, can
+inject the `render_a2ui` tool, detects `a2ui_operations` tool results, emits
+`ACTIVITY_SNAPSHOT` events with `activityType: "a2ui-surface"`, and forwards
+user actions back to the agent as synthetic `log_a2ui_event` tool messages.
 
-```ts
-import { CopilotRuntime } from "@copilotkit/runtime";
-
-const runtime = new CopilotRuntime({
-  agents: {
-    default: myAgUiAgent,
-  },
-  a2ui: { injectA2UITool: true },
-});
-```
-
-For static UI generation or apps that already expose the necessary A2UI tool
-contract, `a2ui: true` or `a2ui: {}` can be enough. Scope to specific agents
-when needed:
+Apply it directly to one agent:
 
 ```ts
-const runtime = new CopilotRuntime({
-  agents: {
-    booking: bookingAgent,
-    support: supportAgent,
-  },
-  a2ui: {
+import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
+
+agent.use(
+  new A2UIMiddleware({
     injectA2UITool: true,
-    agents: ["booking"],
+    defaultCatalogId: "https://example.com/catalogs/product-catalog.json",
+  }),
+);
+```
+
+Or let CopilotRuntime v2 apply it to selected agents:
+
+```ts
+import { CopilotRuntime, InMemoryAgentRunner } from "@copilotkit/runtime/v2";
+
+const runtime = new CopilotRuntime({
+  agents,
+  runner: new InMemoryAgentRunner(),
+  a2ui: {
+    agents: ["a2ui_dynamic_schema"],
+    injectA2UITool: true,
+    defaultCatalogId: "https://example.com/catalogs/product-catalog.json",
   },
 });
 ```
+
+Do not apply the middleware twice to the same agent. If an integration needs
+per-agent middleware because only some agents should get `injectA2UITool`,
+exclude those agents from runtime-level A2UI config.
+
+## Fixed Schema Mode
+
+Use fixed schema mode when the app already knows the component tree. Backend
+tools return an `a2ui_operations` envelope, and only the data changes per tool
+call.
+
+```ts
+import {
+  A2UI_OPERATIONS_KEY,
+  createSurface,
+  updateComponents,
+  updateDataModel,
+} from "@ag-ui/a2ui-toolkit";
+
+const CATALOG_ID = "https://example.com/catalogs/travel.json";
+const SURFACE_ID = "flight-search-results";
+
+function searchFlights(flights: Array<Record<string, unknown>>) {
+  return {
+    [A2UI_OPERATIONS_KEY]: [
+      createSurface(SURFACE_ID, CATALOG_ID),
+      updateComponents(SURFACE_ID, FLIGHT_SCHEMA),
+      updateDataModel(SURFACE_ID, { flights }),
+    ],
+  };
+}
+```
+
+For Python adapters, use the equivalent helpers from `ag_ui_a2ui_toolkit`:
+`A2UI_OPERATIONS_KEY`, `create_surface`, `update_components`, and
+`update_data_model`. Return a dict/object envelope when the framework preserves
+structured tool results. Only stringify when that specific adapter expects a
+string result that the middleware can scan.
+
+## Dynamic Schema Mode
+
+Use dynamic schema mode when the model must compose a surface from the available
+catalog. Current AG-UI adapters share this shape:
+
+- The host asks for injection with runtime `a2ui.injectA2UITool` or per-agent
+  `new A2UIMiddleware({ injectA2UITool: true })`.
+- The framework adapter injects a planner-facing `generate_a2ui` tool when it
+  sees the `injectA2UITool` flag.
+- `generate_a2ui` runs a sub-agent that is forced to call `render_a2ui`.
+- The sub-agent streams `render_a2ui` arguments (`surfaceId`, `components`,
+  `data`) so `A2UIMiddleware` can show building/retry states and progressively
+  paint.
+- The adapter/toolkit validates and retries before committing the final
+  `a2ui_operations` envelope.
+
+For adapters that expose an explicit tool factory, use that rather than
+hand-rolling prompts:
+
+```ts
+import { getA2UITools } from "@ag-ui/langgraph";
+
+const a2uiTool = getA2UITools({
+  model: subagentModel,
+  defaultCatalogId: "https://example.com/catalogs/product-catalog.json",
+  guidelines: {
+    compositionGuide: "Use ProductCard for product comparisons.",
+  },
+});
+```
+
+Frameworks with auto-injection, such as ADK and Strands, can infer the model
+and create `generate_a2ui` when the runtime/middleware forwards
+`injectA2UITool`. Prefer explicit tool wiring only when the adapter cannot infer
+the model, the developer has already wired a custom `generate_a2ui`, or the app
+is not hosted behind CopilotRuntime.
 
 ## Client Side
 
-Enable A2UI on the app shell that owns the AG-UI conversation.
+Register the renderer and catalog on the app shell that owns the AG-UI
+conversation.
 
 ```tsx
-import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { CopilotChat } from "@copilotkit/react-core/v2";
 import "@copilotkit/react-core/v2/styles.css";
+import { productCatalog } from "./a2ui-catalog";
 
 export function AppShell() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui>
-      <App />
-    </CopilotKitProvider>
+    <CopilotKit
+      runtimeUrl="/api/copilotkit/my-integration"
+      agent="a2ui_dynamic_schema"
+      a2ui={{ catalog: productCatalog }}
+    >
+      <CopilotChat agentId="a2ui_dynamic_schema" />
+    </CopilotKit>
   );
 }
 ```
 
-Pass a theme or catalog through the `a2ui` prop when the app needs custom
-rendering:
-
-```tsx
-<CopilotKitProvider
-  runtimeUrl="/api/copilotkit"
-  a2ui={{ catalog: myCatalog, theme: myTheme }}
->
-  <App />
-</CopilotKitProvider>
-```
+The catalog registered here must match the `catalogId` stamped into
+`createSurface`. For dynamic schema, set middleware/adapter `defaultCatalogId`
+to that same id so streamed `createSurface` operations resolve before the final
+tool result arrives.
 
 ## Component Catalog Pattern
 
 Use a catalog when the agent needs app-specific components beyond the built-in
-A2UI catalog. Define runtime schemas and matching renderers.
+A2UI catalog. On the client, current AG-UI/CopilotKit examples register a
+runtime `Catalog` instance that carries the catalog id, renderer
+implementations, and component schemas.
 
-```tsx
-import {
-  createCatalog,
-  type CatalogRenderers,
-} from "@copilotkit/a2ui-renderer";
-import { z } from "zod";
+```ts
+import { Catalog } from "@copilotkit/a2ui-renderer";
+import type { ReactComponentImplementation } from "@copilotkit/a2ui-renderer";
+import { ProductCard, Row } from "./a2ui-renderers";
 
-const definitions = {
-  ProductCard: {
-    description: "A product card with title, price, and availability.",
-    props: z.object({
-      title: z.string(),
-      price: z.number(),
-      inStock: z.boolean(),
-    }),
-  },
-};
-
-const renderers = {
-  ProductCard: ({ props }) => (
-    <article>
-      <h3>{props.title}</h3>
-      <p>${props.price}</p>
-      <button disabled={!props.inStock}>Add to cart</button>
-    </article>
-  ),
-} satisfies CatalogRenderers<typeof definitions>;
-
-export const myCatalog = createCatalog(definitions, renderers, {
-  includeBasicCatalog: true,
-});
+export const productCatalog = new Catalog<ReactComponentImplementation>(
+  "https://example.com/catalogs/product-catalog.json",
+  [Row, ProductCard],
+  [],
+);
 ```
 
-Keep the schema value available at runtime. TypeScript types alone disappear
-at runtime and cannot teach the agent what it may render.
+Each renderer implementation should expose a runtime schema, usually from Zod
+schemas that include the same component names and prop names the agent is
+allowed to generate. TypeScript types alone are not enough; the middleware and
+adapter need runtime schema data to instruct and validate generated components.
 
-## Agent Instructions
-
-Tell the agent when to emit A2UI and what interaction should flow back:
-
-```text
-When the user asks to compare products, create one A2UI surface named
-"product-comparison". Use ProductCard components for each item. When the user
-clicks Add to cart, continue the AG-UI run with the selected product id.
-```
-
-Prefer concrete UI goals and component names over broad instructions like
-"render a nice interface".
+Server-side inline catalogs are still useful when the host owns validation
+directly. When passing an inline catalog to `A2UIMiddleware.schema` or an
+adapter's `a2ui.catalog`, use the v0.9 inline catalog shape:
+`{ catalogId, components }`. The `catalogId` must match the client
+`Catalog` id.

--- a/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
+++ b/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
@@ -1,0 +1,121 @@
+# A2UI Runtime and Renderer Wiring
+
+A2UI needs a server-side runtime path that tells the agent how to emit UI and
+a client-side renderer path that turns emitted A2UI operations into a visible
+surface.
+
+## Runtime Side
+
+Enable A2UI on the runtime. For dynamic schema flows, inject the A2UI tool so
+the agent can create and update surfaces.
+
+```ts
+import { CopilotRuntime } from "@copilotkit/runtime";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: myAgUiAgent,
+  },
+  a2ui: { injectA2UITool: true },
+});
+```
+
+For static UI generation or apps that already expose the necessary A2UI tool
+contract, `a2ui: true` or `a2ui: {}` can be enough. Scope to specific agents
+when needed:
+
+```ts
+const runtime = new CopilotRuntime({
+  agents: {
+    booking: bookingAgent,
+    support: supportAgent,
+  },
+  a2ui: {
+    injectA2UITool: true,
+    agents: ["booking"],
+  },
+});
+```
+
+## Client Side
+
+Enable A2UI on the app shell that owns the AG-UI conversation.
+
+```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export function AppShell() {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui>
+      <App />
+    </CopilotKitProvider>
+  );
+}
+```
+
+Pass a theme or catalog through the `a2ui` prop when the app needs custom
+rendering:
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  a2ui={{ catalog: myCatalog, theme: myTheme }}
+>
+  <App />
+</CopilotKitProvider>
+```
+
+## Component Catalog Pattern
+
+Use a catalog when the agent needs app-specific components beyond the built-in
+A2UI catalog. Define runtime schemas and matching renderers.
+
+```tsx
+import {
+  createCatalog,
+  type CatalogRenderers,
+} from "@copilotkit/a2ui-renderer";
+import { z } from "zod";
+
+const definitions = {
+  ProductCard: {
+    description: "A product card with title, price, and availability.",
+    props: z.object({
+      title: z.string(),
+      price: z.number(),
+      inStock: z.boolean(),
+    }),
+  },
+};
+
+const renderers = {
+  ProductCard: ({ props }) => (
+    <article>
+      <h3>{props.title}</h3>
+      <p>${props.price}</p>
+      <button disabled={!props.inStock}>Add to cart</button>
+    </article>
+  ),
+} satisfies CatalogRenderers<typeof definitions>;
+
+export const myCatalog = createCatalog(definitions, renderers, {
+  includeBasicCatalog: true,
+});
+```
+
+Keep the schema value available at runtime. TypeScript types alone disappear
+at runtime and cannot teach the agent what it may render.
+
+## Agent Instructions
+
+Tell the agent when to emit A2UI and what interaction should flow back:
+
+```text
+When the user asks to compare products, create one A2UI surface named
+"product-comparison". Use ProductCard components for each item. When the user
+clicks Add to cart, continue the AG-UI run with the selected product id.
+```
+
+Prefer concrete UI goals and component names over broad instructions like
+"render a nice interface".

--- a/skills/ag-ui-a2ui-integration/references/framework-adapters.md
+++ b/skills/ag-ui-a2ui-integration/references/framework-adapters.md
@@ -1,48 +1,84 @@
 # Framework Adapters
 
 Start from the app's existing agent framework. Use the relevant AG-UI adapter
-instead of hand-rolling event translation when an adapter exists.
+and its A2UI helpers instead of hand-rolling event translation when an adapter
+exists.
 
 The examples below are common adapter patterns, not the complete AG-UI support
-matrix. For any other AG-UI-supported framework, search the AG-UI repo's
-`integrations/` directory, the AG-UI docs, and the current CLI source before
-choosing an implementation path. Use the framework's own AG-UI package,
-endpoint helper, or example when one exists.
+matrix. For any other AG-UI-supported framework, search `integrations/`, the
+AG-UI docs, the current CLI source, and any framework-specific skills before
+choosing an implementation path.
+
+## Choose Fixed or Dynamic A2UI
+
+- **Fixed schema**: the app owns the component tree. Backend tools return an
+  `a2ui_operations` envelope from `@ag-ui/a2ui-toolkit` /
+  `ag_ui_a2ui_toolkit`. Use this for search results, dashboards, known cards,
+  and workflows with stable layouts.
+- **Dynamic schema**: the model composes a component tree from a catalog. Use
+  the framework adapter's A2UI tool factory or auto-injection path so the main
+  agent calls `generate_a2ui` and a sub-agent streams `render_a2ui`.
 
 ## ADK
 
-AG-UI provides Python ADK middleware. For a FastAPI endpoint, use
-`ADKAgent` and `add_adk_fastapi_endpoint`.
+AG-UI provides Python ADK middleware through `ag_ui_adk`.
+
+For ordinary AG-UI serving, wrap the ADK agent and add the FastAPI endpoint:
 
 ```python
 from fastapi import FastAPI
-from ag_ui_adk import ADKAgent, AGUIToolset, add_adk_fastapi_endpoint
-from google.adk.agents import Agent
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+from google.adk.agents import LlmAgent
 
-my_agent = Agent(
+adk_agent = LlmAgent(
+    model="gemini-2.5-pro",
     name="assistant",
     instruction="You are a helpful assistant.",
-    tools=[
-        AGUIToolset(),
-    ],
 )
 
 agent = ADKAgent(
-    adk_agent=my_agent,
+    adk_agent=adk_agent,
     app_name="my_app",
     user_id="user123",
+    use_in_memory_services=True,
 )
 
 app = FastAPI()
 add_adk_fastapi_endpoint(app, agent, path="/chat")
 ```
 
-Use the ADK resumability path for human-in-the-loop flows that must pause and
-resume around frontend tools.
+For dynamic A2UI, keep the ADK agent's tool list free of manual A2UI tools and
+configure the wrapper's `a2ui` options. The runtime or per-agent
+`A2UIMiddleware` forwards `injectA2UITool`; the ADK adapter then injects
+`generate_a2ui`, infers the sub-agent model, streams nested `render_a2ui`
+events, and returns the final envelope.
+
+```python
+agent = ADKAgent(
+    adk_agent=adk_agent,
+    app_name="demo_app",
+    user_id="demo_user",
+    use_in_memory_services=True,
+    a2ui={
+        "default_catalog_id": "https://example.com/catalogs/product-catalog.json",
+        "guidelines": {
+            "composition_guide": "Use ProductCard for product comparisons.",
+        },
+    },
+)
+```
+
+For fixed A2UI, define normal ADK backend tools that return a dict envelope
+with `A2UI_OPERATIONS_KEY`, `create_surface`, `update_components`, and
+`update_data_model`. Return a dict, not a JSON string, so ADK preserves the
+envelope shape for the middleware.
 
 ## LangGraph
 
-AG-UI provides `ag-ui-langgraph` for Python LangGraph apps.
+AG-UI provides Python and TypeScript LangGraph integrations. Keep the graph's
+state model intact and add A2UI as tools/context around the graph.
+
+Python FastAPI endpoint:
 
 ```python
 from fastapi import FastAPI
@@ -53,69 +89,32 @@ app = FastAPI()
 add_langgraph_fastapi_endpoint(app, graph, "/agent")
 ```
 
-Keep the LangGraph state model intact. Add A2UI instructions and tools around
-the graph rather than replacing graph nodes with AG-UI-specific code.
-
-## Mastra
-
-AG-UI provides `@ag-ui/mastra` for TypeScript Mastra agents.
+TypeScript dynamic A2UI tool:
 
 ```ts
-import { MastraAgent } from "@ag-ui/mastra";
-import { mastra } from "./mastra";
+import { getA2UITools } from "@ag-ui/langgraph";
 
-const agent = new MastraAgent({
-  agent: mastra.getAgent("weather-agent"),
-  resourceId: "user-123",
+const a2ui = getA2UITools({
+  model: subagentModel,
+  defaultCatalogId: "https://example.com/catalogs/product-catalog.json",
+  guidelines: {
+    compositionGuide: "Use ProductCard for product comparisons.",
+  },
 });
 
-const result = await agent.runAgent({
-  messages: [{ role: "user", content: "What's the weather like?" }],
+const modelWithTools = chatModel.bindTools([...state.tools, a2ui], {
+  parallel_tool_calls: false,
 });
 ```
 
-Wire this into the app's existing AG-UI server route or scaffolded runtime.
-
-## CrewAI
-
-AG-UI provides `ag-ui-crewai` for Python CrewAI flows.
-
-```python
-from crewai.flow.flow import Flow, start
-from litellm import acompletion
-from ag_ui_crewai import (
-    add_crewai_flow_fastapi_endpoint,
-    copilotkit_stream,
-    CopilotKitState,
-)
-from fastapi import FastAPI
-
-class MyFlow(Flow[CopilotKitState]):
-    @start()
-    async def chat(self):
-        response = await copilotkit_stream(
-            await acompletion(
-                model="openai/gpt-4o",
-                messages=[
-                    {"role": "system", "content": "You are a helpful assistant."},
-                    *self.state.messages,
-                ],
-                tools=self.state.copilotkit.actions,
-                stream=True,
-            )
-        )
-        self.state.messages.append(response.choices[0].message)
-
-app = FastAPI()
-add_crewai_flow_fastapi_endpoint(app, MyFlow(), "/flow")
-```
-
-The CrewAI adapter currently exposes some legacy CopilotKit names. Keep the
-source package names exactly as documented by AG-UI.
+LangGraph streams nested model tool-call deltas natively, so the adapter can
+surface `render_a2ui` progress without custom events. Preserve that streaming
+path; using a non-streaming invoke path removes progressive paint.
 
 ## Strands
 
-AG-UI provides `@ag-ui/aws-strands` for TypeScript Strands agents.
+AG-UI provides TypeScript and Python Strands integrations. For TypeScript,
+`@ag-ui/aws-strands` exposes both explicit and auto-injected A2UI paths.
 
 ```ts
 import { Agent } from "@strands-agents/sdk";
@@ -123,35 +122,66 @@ import { StrandsAgent } from "@ag-ui/aws-strands";
 import { createStrandsApp } from "@ag-ui/aws-strands/server";
 
 const strandsAgent = new Agent({
-  model: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+  model,
+  systemPrompt,
 });
 
-const aguiAgent = new StrandsAgent({ agent: strandsAgent });
+const aguiAgent = new StrandsAgent({
+  agent: strandsAgent,
+  a2ui: {
+    injectA2UITool: true,
+    defaultCatalogId: "https://example.com/catalogs/product-catalog.json",
+    guidelines: {
+      compositionGuide: "Use ProductCard for product comparisons.",
+    },
+  },
+});
+
 const app = await createStrandsApp(aguiAgent, { path: "/invocations" });
 app.listen(8080);
 ```
 
-There is no Strands flag in the current AG-UI CLI source. Use the integration
-package and examples directly.
+The adapter's auto-injection reads the runtime `injectA2UITool` flag or its
+own `a2ui.injectA2UITool` config, registers `generate_a2ui`, drops the raw
+`render_a2ui` tool, and streams nested render progress onto the AG-UI wire.
+If the agent is a multi-agent orchestrator with no inferable model, wire
+`getA2UITools()` explicitly.
+
+For fixed Strands A2UI, return a plain object envelope from backend tools; the
+adapter serializes it into the tool result the middleware scans for
+`a2ui_operations`.
+
+## .NET
+
+AG-UI now includes a .NET SDK and framework-specific public skills under
+`sdks/dotnet/plugins/ag-ui-dotnet/skills/`. For .NET apps, use the relevant
+`agui-dotnet-*` skill first for client/server setup, tools, shared state,
+interrupts, protobuf, or troubleshooting. Then apply this A2UI skill only for
+the cross-framework A2UI decisions: fixed envelope vs dynamic generation,
+catalog ids, and renderer wiring.
 
 ## Other AG-UI-Supported Frameworks
 
 For frameworks not shown above, follow this order:
 
-1. Search `integrations/` for the framework name.
+1. Search `integrations/` for the framework name and A2UI-specific files.
 2. Check `sdks/typescript/packages/cli/src/index.ts` for a scaffold flag.
-3. Check the AG-UI docs for the framework's package name and endpoint helper.
-4. Reuse the closest documented integration pattern, preserving the target
-   framework's normal agent lifecycle, state model, and tool conventions.
-5. Apply the shared A2UI runtime, renderer, catalog, and verification steps
-   from the other references in this skill.
+3. Check the AG-UI docs and framework README for package names and endpoint
+   helpers.
+4. If a framework A2UI tool factory exists, use it.
+5. If no A2UI tool factory exists, return fixed `a2ui_operations` envelopes
+   from backend tools or implement the custom AG-UI agent path.
+6. Apply shared middleware, renderer, catalog, and verification steps from the
+   other references in this skill.
 
 ## Custom AG-UI Agents
 
-For a custom backend, keep the protocol stream valid:
+For a custom backend, keep the AG-UI stream valid:
 
 - Start each run with `RUN_STARTED`.
 - Emit text, tool, state, and A2UI-related events in order.
 - End with `RUN_FINISHED` or `RUN_ERROR`.
 - Preserve `threadId`, `runId`, message ids, and tool call ids consistently.
+- Prefer `A2UIMiddleware` to translate A2UI tool results/actions into AG-UI
+  events.
 - Use the encoder packages where available instead of ad hoc SSE formatting.

--- a/skills/ag-ui-a2ui-integration/references/framework-adapters.md
+++ b/skills/ag-ui-a2ui-integration/references/framework-adapters.md
@@ -1,0 +1,157 @@
+# Framework Adapters
+
+Start from the app's existing agent framework. Use the relevant AG-UI adapter
+instead of hand-rolling event translation when an adapter exists.
+
+The examples below are common adapter patterns, not the complete AG-UI support
+matrix. For any other AG-UI-supported framework, search the AG-UI repo's
+`integrations/` directory, the AG-UI docs, and the current CLI source before
+choosing an implementation path. Use the framework's own AG-UI package,
+endpoint helper, or example when one exists.
+
+## ADK
+
+AG-UI provides Python ADK middleware. For a FastAPI endpoint, use
+`ADKAgent` and `add_adk_fastapi_endpoint`.
+
+```python
+from fastapi import FastAPI
+from ag_ui_adk import ADKAgent, AGUIToolset, add_adk_fastapi_endpoint
+from google.adk.agents import Agent
+
+my_agent = Agent(
+    name="assistant",
+    instruction="You are a helpful assistant.",
+    tools=[
+        AGUIToolset(),
+    ],
+)
+
+agent = ADKAgent(
+    adk_agent=my_agent,
+    app_name="my_app",
+    user_id="user123",
+)
+
+app = FastAPI()
+add_adk_fastapi_endpoint(app, agent, path="/chat")
+```
+
+Use the ADK resumability path for human-in-the-loop flows that must pause and
+resume around frontend tools.
+
+## LangGraph
+
+AG-UI provides `ag-ui-langgraph` for Python LangGraph apps.
+
+```python
+from fastapi import FastAPI
+from ag_ui_langgraph import add_langgraph_fastapi_endpoint
+from my_langgraph_workflow import graph
+
+app = FastAPI()
+add_langgraph_fastapi_endpoint(app, graph, "/agent")
+```
+
+Keep the LangGraph state model intact. Add A2UI instructions and tools around
+the graph rather than replacing graph nodes with AG-UI-specific code.
+
+## Mastra
+
+AG-UI provides `@ag-ui/mastra` for TypeScript Mastra agents.
+
+```ts
+import { MastraAgent } from "@ag-ui/mastra";
+import { mastra } from "./mastra";
+
+const agent = new MastraAgent({
+  agent: mastra.getAgent("weather-agent"),
+  resourceId: "user-123",
+});
+
+const result = await agent.runAgent({
+  messages: [{ role: "user", content: "What's the weather like?" }],
+});
+```
+
+Wire this into the app's existing AG-UI server route or scaffolded runtime.
+
+## CrewAI
+
+AG-UI provides `ag-ui-crewai` for Python CrewAI flows.
+
+```python
+from crewai.flow.flow import Flow, start
+from litellm import acompletion
+from ag_ui_crewai import (
+    add_crewai_flow_fastapi_endpoint,
+    copilotkit_stream,
+    CopilotKitState,
+)
+from fastapi import FastAPI
+
+class MyFlow(Flow[CopilotKitState]):
+    @start()
+    async def chat(self):
+        response = await copilotkit_stream(
+            await acompletion(
+                model="openai/gpt-4o",
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    *self.state.messages,
+                ],
+                tools=self.state.copilotkit.actions,
+                stream=True,
+            )
+        )
+        self.state.messages.append(response.choices[0].message)
+
+app = FastAPI()
+add_crewai_flow_fastapi_endpoint(app, MyFlow(), "/flow")
+```
+
+The CrewAI adapter currently exposes some legacy CopilotKit names. Keep the
+source package names exactly as documented by AG-UI.
+
+## Strands
+
+AG-UI provides `@ag-ui/aws-strands` for TypeScript Strands agents.
+
+```ts
+import { Agent } from "@strands-agents/sdk";
+import { StrandsAgent } from "@ag-ui/aws-strands";
+import { createStrandsApp } from "@ag-ui/aws-strands/server";
+
+const strandsAgent = new Agent({
+  model: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+});
+
+const aguiAgent = new StrandsAgent({ agent: strandsAgent });
+const app = await createStrandsApp(aguiAgent, { path: "/invocations" });
+app.listen(8080);
+```
+
+There is no Strands flag in the current AG-UI CLI source. Use the integration
+package and examples directly.
+
+## Other AG-UI-Supported Frameworks
+
+For frameworks not shown above, follow this order:
+
+1. Search `integrations/` for the framework name.
+2. Check `sdks/typescript/packages/cli/src/index.ts` for a scaffold flag.
+3. Check the AG-UI docs for the framework's package name and endpoint helper.
+4. Reuse the closest documented integration pattern, preserving the target
+   framework's normal agent lifecycle, state model, and tool conventions.
+5. Apply the shared A2UI runtime, renderer, catalog, and verification steps
+   from the other references in this skill.
+
+## Custom AG-UI Agents
+
+For a custom backend, keep the protocol stream valid:
+
+- Start each run with `RUN_STARTED`.
+- Emit text, tool, state, and A2UI-related events in order.
+- End with `RUN_FINISHED` or `RUN_ERROR`.
+- Preserve `threadId`, `runId`, message ids, and tool call ids consistently.
+- Use the encoder packages where available instead of ad hoc SSE formatting.

--- a/skills/ag-ui-a2ui-integration/references/verification.md
+++ b/skills/ag-ui-a2ui-integration/references/verification.md
@@ -1,0 +1,36 @@
+# Verification
+
+Use this checklist before calling an AG-UI + A2UI integration complete.
+
+## Static Checks
+
+- Install dependencies with the app's existing package manager.
+- Run the app's typecheck, lint, and unit tests when available.
+- Run the AG-UI package or integration tests touched by the change.
+- Confirm no invented package names, CLI flags, or import paths were added.
+
+## Runtime Checks
+
+- Start the AG-UI backend or runtime route.
+- Start the frontend app.
+- Trigger a user prompt that should produce A2UI.
+- Confirm the stream begins with a valid AG-UI run and ends with
+  `RUN_FINISHED` or `RUN_ERROR`.
+- Confirm an A2UI surface renders, not just a text explanation.
+- Confirm a user interaction in the rendered surface flows back to the agent.
+- Check the browser console and backend logs for schema, hydration, stream, or
+  action bridge errors.
+
+## Common Failure Modes
+
+| Symptom                        | Likely cause                                                 | Fix                                                                        |
+| ------------------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| No A2UI surface appears        | A2UI is enabled only on the client or only on the runtime    | Enable both sides                                                          |
+| Agent describes UI in prose    | Agent lacks A2UI tool/schema instructions                    | Inject the A2UI tool and add concrete agent instructions                   |
+| Custom component never renders | Catalog is missing or schema key does not match renderer key | Register the catalog and align definition and renderer names               |
+| Action clicks do nothing       | The action bridge is not connected to AG-UI run input        | Verify the client action handler continues the run with the action payload |
+| Surface flickers or duplicates | Agent emits `createSurface` repeatedly for the same surface  | Emit `createSurface` once and update afterward                             |
+
+A runtime smoke test should show the agent stream in logs or devtools, a
+rendered A2UI surface in the page, and one user interaction returning through
+AG-UI.

--- a/skills/ag-ui-a2ui-integration/references/verification.md
+++ b/skills/ag-ui-a2ui-integration/references/verification.md
@@ -16,6 +16,11 @@ Use this checklist before calling an AG-UI + A2UI integration complete.
 - Trigger a user prompt that should produce A2UI.
 - Confirm the stream begins with a valid AG-UI run and ends with
   `RUN_FINISHED` or `RUN_ERROR`.
+- For dynamic schema, confirm `generate_a2ui` leads to streamed
+  `render_a2ui` tool-call args and `ACTIVITY_SNAPSHOT` events with
+  `activityType: "a2ui-surface"`.
+- For fixed schema, confirm the backend tool result contains an
+  `a2ui_operations` envelope.
 - Confirm an A2UI surface renders, not just a text explanation.
 - Confirm a user interaction in the rendered surface flows back to the agent.
 - Check the browser console and backend logs for schema, hydration, stream, or
@@ -23,14 +28,17 @@ Use this checklist before calling an AG-UI + A2UI integration complete.
 
 ## Common Failure Modes
 
-| Symptom                        | Likely cause                                                 | Fix                                                                        |
-| ------------------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| No A2UI surface appears        | A2UI is enabled only on the client or only on the runtime    | Enable both sides                                                          |
-| Agent describes UI in prose    | Agent lacks A2UI tool/schema instructions                    | Inject the A2UI tool and add concrete agent instructions                   |
-| Custom component never renders | Catalog is missing or schema key does not match renderer key | Register the catalog and align definition and renderer names               |
-| Action clicks do nothing       | The action bridge is not connected to AG-UI run input        | Verify the client action handler continues the run with the action payload |
-| Surface flickers or duplicates | Agent emits `createSurface` repeatedly for the same surface  | Emit `createSurface` once and update afterward                             |
+| Symptom                               | Likely cause                                                         | Fix                                                                              |
+| ------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| No A2UI surface appears               | A2UI is enabled only on the client or only on the runtime            | Enable renderer/catalog plus `A2UIMiddleware` or runtime A2UI config             |
+| Agent describes UI in prose           | Agent lacks `generate_a2ui` or fixed-schema backend tools            | Use the framework A2UI tool factory/auto-injection or return `a2ui_operations`   |
+| Custom component never renders        | Catalog id or component keys differ between server and client        | Register the catalog and align `defaultCatalogId`, `catalogId`, and names        |
+| Dynamic surface appears only at end   | Nested `render_a2ui` args are not streaming to the AG-UI wire        | Use the adapter's streaming A2UI tool path, not a non-streaming sub-agent invoke |
+| Action clicks do nothing              | The action bridge is not reaching `forwardedProps.a2uiAction`        | Verify the client action is forwarded and middleware emits `log_a2ui_event`      |
+| Skeletons duplicate or flicker        | Middleware is applied twice or catalog/tool names are misconfigured  | Use either runtime-level or per-agent middleware for each agent, not both        |
+| `Catalog not found` in the renderer   | Model or server stamped a catalog id the client did not register     | Set `defaultCatalogId` to the renderer catalog id; do not let the model pick it  |
+| Invalid component tree keeps retrying | Components fail toolkit validation against the inline/client catalog | Fix required props, child refs, root layout, and component names                 |
 
-A runtime smoke test should show the agent stream in logs or devtools, a
-rendered A2UI surface in the page, and one user interaction returning through
-AG-UI.
+A runtime smoke test should show the AG-UI stream in logs or devtools, an
+`a2ui-surface` activity or `a2ui_operations` result, a rendered A2UI surface in
+the page, and one user interaction returning through AG-UI.

--- a/skills/ag-ui-a2ui-integration/sources.md
+++ b/skills/ag-ui-a2ui-integration/sources.md
@@ -1,0 +1,29 @@
+# Sources
+
+This skill is based on the AG-UI repo sources and the public A2UI/CopilotKit
+runtime docs.
+
+## AG-UI Repository Sources
+
+- `integrations/` - AG-UI-supported framework integrations and examples.
+- `sdks/typescript/packages/cli/src/index.ts` - supported `create-ag-ui-app`
+  framework flags.
+- `integrations/adk-middleware/python/README.md` - ADK middleware setup and
+  FastAPI endpoint pattern.
+- `integrations/langgraph/python/README.md` - LangGraph FastAPI endpoint
+  pattern.
+- `integrations/mastra/typescript/README.md` - Mastra adapter setup.
+- `integrations/crew-ai/python/README.md` - CrewAI flow endpoint pattern.
+- `integrations/aws-strands/typescript/README.md` - Strands adapter and server
+  setup.
+
+## External Sources
+
+- CopilotKit public skills layout:
+  <https://github.com/CopilotKit/CopilotKit/tree/main/skills>
+- CopilotKit A2UI docs:
+  <https://docs.copilotkit.ai/generative-ui/a2ui>
+- A2UI docs:
+  <https://a2ui.org/>
+- AG-UI docs:
+  <https://docs.ag-ui.com/>

--- a/skills/ag-ui-a2ui-integration/sources.md
+++ b/skills/ag-ui-a2ui-integration/sources.md
@@ -5,17 +5,41 @@ runtime docs.
 
 ## AG-UI Repository Sources
 
+- `middlewares/a2ui-middleware/src/index.ts` - `A2UIMiddleware`, schema
+  context, `a2ui-surface` activity snapshots, action forwarding, and runtime
+  tool interception.
+- `middlewares/a2ui-middleware/src/tools.ts` - `render_a2ui` and
+  `log_a2ui_event` tool contracts.
+- `middlewares/a2ui-middleware/src/types.ts` - middleware config, inline
+  catalog schema, `injectA2UITool`, recognized A2UI tool names, and
+  `defaultCatalogId`.
+- `apps/dojo/src/app/api/copilotkit/[integrationId]/[[...slug]]/route.ts` -
+  current CopilotRuntime v2 A2UI config shape.
+- `apps/dojo/src/agents.ts` - per-agent `A2UIMiddleware` wiring for ADK and
+  Strands dynamic A2UI agents.
 - `integrations/` - AG-UI-supported framework integrations and examples.
 - `sdks/typescript/packages/cli/src/index.ts` - supported `create-ag-ui-app`
   framework flags.
-- `integrations/adk-middleware/python/README.md` - ADK middleware setup and
-  FastAPI endpoint pattern.
+- `integrations/adk-middleware/python/src/ag_ui_adk/a2ui_tool.py` - ADK
+  dynamic A2UI `generate_a2ui` adapter.
+- `integrations/adk-middleware/python/examples/server/api/a2ui_dynamic_schema.py`
+  - ADK dynamic schema example.
+- `integrations/adk-middleware/python/examples/server/api/a2ui_fixed_schema.py`
+  - ADK fixed schema `a2ui_operations` example.
+- `integrations/langgraph/typescript/src/a2ui-tool.ts` - LangGraph TypeScript
+  dynamic A2UI tool factory.
+- `integrations/langgraph/python/ag_ui_langgraph/a2ui_tool.py` - LangGraph
+  Python dynamic A2UI tool factory.
 - `integrations/langgraph/python/README.md` - LangGraph FastAPI endpoint
   pattern.
-- `integrations/mastra/typescript/README.md` - Mastra adapter setup.
-- `integrations/crew-ai/python/README.md` - CrewAI flow endpoint pattern.
-- `integrations/aws-strands/typescript/README.md` - Strands adapter and server
-  setup.
+- `integrations/aws-strands/typescript/src/a2ui-tool.ts` - Strands explicit and
+  auto-injected A2UI tools.
+- `integrations/aws-strands/typescript/src/config.ts` - Strands `a2ui` adapter
+  config.
+- `integrations/aws-strands/typescript/examples/server/api/a2ui-fixed-schema.ts`
+  - Strands fixed schema `a2ui_operations` example.
+- `sdks/dotnet/plugins/ag-ui-dotnet/skills/` - new framework-specific .NET
+  skills that should be used before cross-framework A2UI guidance in .NET apps.
 
 ## External Sources
 


### PR DESCRIPTION
## Summary
- add a portable `skills/ag-ui-a2ui-integration` artifact modeled after CopilotKit public skills
- include framework adapter, A2UI runtime/renderer, verification, and source references
- point AGENTS.md and CLAUDE.md at the new skill for A2UI + AG-UI work

## Verification
- `npx --yes prettier@^3.5.0 --check /tmp/ag-ui-repo/skills/ag-ui-a2ui-integration/SKILL.md /tmp/ag-ui-repo/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md /tmp/ag-ui-repo/skills/ag-ui-a2ui-integration/references/framework-adapters.md /tmp/ag-ui-repo/skills/ag-ui-a2ui-integration/references/verification.md /tmp/ag-ui-repo/skills/ag-ui-a2ui-integration/sources.md`
- `node -e "JSON.parse(require('fs').readFileSync('/tmp/ag-ui-repo/docs/docs.json','utf8')); console.log('docs.json ok')"`
- `git -C /tmp/ag-ui-repo diff --check -- AGENTS.md CLAUDE.md skills/ag-ui-a2ui-integration`
- searched for stale docs-page and launch wording references