### PR TITLE
fix(aws-strands): bundle parallel tool results into one user message for Bedrock (#1847)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -204,9 +204,21 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
     than a fresh prompt that re-fires the same tool every turn.
     """
     out: List[Dict[str, Any]] = []
+    # Buffer consecutive tool results so parallel tool calls land in a single
+    # following user message. Amazon Bedrock Converse rejects history where the
+    # toolResults for one assistant turn's multiple toolUse blocks are split
+    # across several user messages — they must all sit in one user message. See #1847.
+    pending_tool_results: List[Dict[str, Any]] = []
+
+    def flush_tool_results() -> None:
+        if pending_tool_results:
+            out.append({"role": "user", "content": list(pending_tool_results)})
+            pending_tool_results.clear()
+
     for msg in input_messages or []:
         role = getattr(msg, "role", None)
         if role == "user":
+            flush_tool_results()
             content = msg.content
             if isinstance(content, list):
                 has_media = any(
@@ -223,6 +235,7 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
             else:
                 out.append({"role": "user", "content": [{"text": _coerce_text(content)}]})
         elif role == "assistant":
+            flush_tool_results()
             blocks: List[Dict[str, Any]] = []
             text = _coerce_text(msg.content)
             if text:
@@ -253,20 +266,16 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
                 blocks = [{"text": ""}]
             out.append({"role": "assistant", "content": blocks})
         elif role == "tool":
-            out.append(
+            pending_tool_results.append(
                 {
-                    "role": "user",
-                    "content": [
-                        {
-                            "toolResult": {
-                                "toolUseId": getattr(msg, "tool_call_id", "") or "",
-                                "content": [{"text": _coerce_text(msg.content)}],
-                                "status": "success",
-                            }
-                        }
-                    ],
+                    "toolResult": {
+                        "toolUseId": getattr(msg, "tool_call_id", "") or "",
+                        "content": [{"text": _coerce_text(msg.content)}],
+                        "status": "success",
+                    }
                 }
             )
+    flush_tool_results()
     return out
 
 

--- a/integrations/aws-strands/python/tests/test_build_strands_history.py
+++ b/integrations/aws-strands/python/tests/test_build_strands_history.py
@@ -1,0 +1,88 @@
+"""Regression tests for #1847.
+
+`_build_strands_history` converts AG-UI messages to Strands/Bedrock native
+messages. For parallel tool calls (one assistant turn with multiple toolUse
+blocks), Amazon Bedrock Converse requires all matching toolResult blocks to
+appear in a SINGLE following user message. The old code emitted one user
+message per AG-UI tool message, which Bedrock rejects.
+"""
+
+from types import SimpleNamespace
+
+from ag_ui_strands.agent import _build_strands_history
+
+
+def _tc(tc_id, name, args="{}"):
+    return SimpleNamespace(id=tc_id, function={"name": name, "arguments": args})
+
+
+def _tool_result_messages(out):
+    return [
+        m
+        for m in out
+        if m["role"] == "user"
+        and m["content"]
+        and all("toolResult" in b for b in m["content"])
+    ]
+
+
+def test_parallel_tool_results_bundled_into_one_user_message():
+    msgs = [
+        SimpleNamespace(role="user", content="hi"),
+        SimpleNamespace(
+            role="assistant", content="", tool_calls=[_tc("a", "f1"), _tc("b", "f2")]
+        ),
+        SimpleNamespace(role="tool", tool_call_id="a", content="r1"),
+        SimpleNamespace(role="tool", tool_call_id="b", content="r2"),
+    ]
+    out = _build_strands_history(msgs)
+
+    tool_msgs = _tool_result_messages(out)
+    # Bedrock requires ONE user message carrying both toolResults.
+    assert len(tool_msgs) == 1, f"expected 1 bundled tool-result message, got {len(tool_msgs)}"
+    assert len(tool_msgs[0]["content"]) == 2
+    ids = [b["toolResult"]["toolUseId"] for b in tool_msgs[0]["content"]]
+    assert ids == ["a", "b"]
+
+
+def test_single_tool_result_still_one_message():
+    msgs = [
+        SimpleNamespace(role="assistant", content="", tool_calls=[_tc("a", "f1")]),
+        SimpleNamespace(role="tool", tool_call_id="a", content="r1"),
+    ]
+    out = _build_strands_history(msgs)
+    tool_msgs = _tool_result_messages(out)
+    assert len(tool_msgs) == 1
+    assert len(tool_msgs[0]["content"]) == 1
+    assert tool_msgs[0]["content"][0]["toolResult"]["toolUseId"] == "a"
+
+
+def test_separate_turns_not_merged():
+    # Tool results from two distinct assistant turns must NOT collapse together;
+    # a user message between them is a turn boundary.
+    msgs = [
+        SimpleNamespace(role="assistant", content="", tool_calls=[_tc("a", "f1")]),
+        SimpleNamespace(role="tool", tool_call_id="a", content="r1"),
+        SimpleNamespace(role="user", content="next"),
+        SimpleNamespace(role="assistant", content="", tool_calls=[_tc("b", "f2")]),
+        SimpleNamespace(role="tool", tool_call_id="b", content="r2"),
+    ]
+    out = _build_strands_history(msgs)
+    tool_msgs = _tool_result_messages(out)
+    assert len(tool_msgs) == 2
+    assert [len(m["content"]) for m in tool_msgs] == [1, 1]
+
+
+def test_ordering_preserved():
+    msgs = [
+        SimpleNamespace(role="user", content="hi"),
+        SimpleNamespace(
+            role="assistant", content="", tool_calls=[_tc("a", "f1"), _tc("b", "f2")]
+        ),
+        SimpleNamespace(role="tool", tool_call_id="a", content="r1"),
+        SimpleNamespace(role="tool", tool_call_id="b", content="r2"),
+    ]
+    out = _build_strands_history(msgs)
+    roles = [m["role"] for m in out]
+    # user, assistant(toolUse), user(bundled toolResults)
+    assert roles == ["user", "assistant", "user"]


### PR DESCRIPTION
Fixes #1847

## Root cause
With `replay_history_into_strands` enabled, `_build_strands_history()` emitted one `user` message per AG-UI `tool` message, each with a single `toolResult` block. When the preceding assistant turn has multiple `toolUse` blocks (parallel tool calls), Amazon Bedrock Converse rejects the history — all matching `toolResult` blocks for a turn must appear in **one** following `user` message.

## Fix
Buffer consecutive `tool` results and flush them as a single `user` message (flushing on the next user/assistant message and at end of history). Sequential single-result turns are unchanged; only parallel results are now bundled.

## Tests added
`tests/test_build_strands_history.py`:
- parallel tool results → one user message with both `toolResult` blocks (ids preserved)
- single tool result → still one message, one block
- two distinct turns separated by a user message → not merged
- block ordering preserved (user, assistant/toolUse, user/toolResults)

The parallel + ordering tests fail on the old code and pass with the fix.

## Checklist
- [x] Failing tests written and confirmed failing before fix
- [x] Fix applied, tests pass
- [x] Full package suite passes (154 passed, 2 skipped)
- [x] Minimal change, scoped to the issue