### PR TITLE
fix(strands): forward HITL tool result on resume instead of discarding it

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -756,7 +756,24 @@ class StrandsAgent:
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
                         if tool_name and tool_name in frontend_tool_names:
-                            user_message = f"{tool_name} executed successfully with no return value."
+                            # Forward the ACTUAL frontend tool result so the model
+                            # can act on the human's decision (e.g. an approval
+                            # resolving to {"approved": false}). Previously this
+                            # discarded ``msg.content`` and hardcoded a success
+                            # string, silently breaking HITL — the model was told
+                            # the tool "executed successfully with no return value"
+                            # regardless of what the human actually returned.
+                            # Only fall back to that synthetic acknowledgement when
+                            # the result is genuinely empty.
+                            result_text = (
+                                msg.content
+                                if isinstance(msg.content, str)
+                                else flatten_content_to_text(msg.content)
+                            )
+                            if result_text and result_text.strip():
+                                user_message = f"{tool_name} returned: {result_text}"
+                            else:
+                                user_message = f"{tool_name} executed successfully with no return value."
                         else:
                             # Could not resolve the executed tool's name from
                             # input messages or session history. Leave the


### PR DESCRIPTION
## Summary

On a continuation run after a frontend/HITL tool, the Strands adapter's legacy / session-manager path (`stream_async(user_message)`) overwrote the real tool result with the literal `"{tool_name} executed successfully with no return value."` before the model saw it. An approval tool resolving to `{"approved": false}` was reported to the model as a **no-value success**, so the model could proceed as if approved — HITL silently broken. Reported in the field (Strands + CopilotKit v2 runtime).

**Fix:** forward the actual result (`"{tool_name} returned: <result>"`); fall back to the synthetic acknowledgement only when the result is genuinely empty.

## Testing
- All **150** existing strands tests pass (2 skipped).
- Verified live against a reproduction sandbox: denying an approval now yields "Cancelled" (model receives `requestApproval returned: {"confirmed":false}`) instead of proceeding as approved.

## Scope note
A second reported item — `RunAgentInput.context` never reaching the model — is handled separately in #2004.