### PR TITLE
fix(langgraph/ts): preserve multimodal metadata + media type through round-trip

### DIFF
--- a/integrations/langgraph/typescript/src/utils.test.ts
+++ b/integrations/langgraph/typescript/src/utils.test.ts
@@ -12,8 +12,14 @@ import {
   AudioInputContent,
   VideoInputContent,
   DocumentInputContent,
+  InputContent,
 } from "@ag-ui/client";
-import { aguiMessagesToLangChain, langchainMessagesToAgui, resolveReasoningContent } from "./utils";
+import {
+  aguiMessagesToLangChain,
+  langchainMessagesToAgui,
+  resolveReasoningContent,
+  AGUI_TYPE_KEY,
+} from "./utils";
 
 describe("Multimodal Message Conversion", () => {
   describe("aguiMessagesToLangChain", () => {
@@ -378,6 +384,162 @@ describe("Multimodal Message Conversion", () => {
       expect(content).toHaveLength(1);
       expect(content[0].type).toBe("text");
     });
+  });
+
+  describe("Metadata + media type round-trip", () => {
+    it("forward preserves metadata and tags type", () => {
+      const aguiMessage: UserMessage = {
+        id: "fwd-image",
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: { type: "url", value: "https://example.com/photo.jpg" },
+            metadata: { alt: "a cat", id: 42 },
+          } as ImageInputContent,
+        ],
+      };
+
+      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+
+      const block = (lcMessages[0].content as Array<any>)[0];
+      expect(block.type).toBe("image_url");
+      expect(block.metadata).toEqual({ alt: "a cat", id: 42, [AGUI_TYPE_KEY]: "image" });
+    });
+
+    it("forward embeds __agui_type in metadata for non-image media", () => {
+      const aguiMessage: UserMessage = {
+        id: "fwd-audio",
+        role: "user",
+        content: [
+          {
+            type: "audio",
+            source: { type: "url", value: "https://example.com/a.mp3" },
+            metadata: { duration: 12 },
+          } as AudioInputContent,
+        ],
+      };
+
+      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+
+      const block = (lcMessages[0].content as Array<any>)[0];
+      expect(block.type).toBe("image_url");
+      expect(block.metadata).toEqual({ duration: 12, [AGUI_TYPE_KEY]: "audio" });
+    });
+
+    it("reverse restores type + metadata from a tagged block", () => {
+      const lcMessage: LangGraphMessage = {
+        id: "rev-tagged",
+        type: "human",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/v.mp4" },
+            metadata: { fps: 30, [AGUI_TYPE_KEY]: "video" },
+          },
+        ] as any,
+      };
+
+      const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+      const part = (aguiMessages[0].content as Array<any>)[0];
+      expect(part.type).toBe("video");
+      expect(part.source).toEqual({ type: "url", value: "https://example.com/v.mp4" });
+      expect(part.metadata).toEqual({ fps: 30 });
+    });
+
+    it("reverse falls back to image for untagged blocks", () => {
+      const lcMessage: LangGraphMessage = {
+        id: "rev-untagged",
+        type: "human",
+        content: [
+          { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+        ] as any,
+      };
+
+      const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+      const part = (aguiMessages[0].content as Array<any>)[0];
+      expect(part.type).toBe("image");
+      expect(part.metadata).toBeUndefined();
+    });
+
+    it("reverse falls back to image for an invalid media type tag", () => {
+      const lcMessage: LangGraphMessage = {
+        id: "rev-invalid-tag",
+        type: "human",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/x.jpg" },
+            metadata: { [AGUI_TYPE_KEY]: "binary", preserved: true },
+          },
+        ] as any,
+      };
+
+      const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+      const part = (aguiMessages[0].content as Array<any>)[0];
+      expect(part.type).toBe("image");
+      expect(part.metadata).toEqual({ preserved: true });
+    });
+
+    const roundTripFixtures = [
+      {
+        type: "image",
+        source: { type: "url", value: "https://example.com/image.jpg" },
+      },
+      {
+        type: "image",
+        source: { type: "data", value: "aW1hZ2U=", mimeType: "image/jpeg" },
+      },
+      {
+        type: "audio",
+        source: { type: "url", value: "https://example.com/audio.mp3" },
+      },
+      {
+        type: "audio",
+        source: { type: "data", value: "YXVkaW8=", mimeType: "audio/mpeg" },
+      },
+      {
+        type: "video",
+        source: { type: "url", value: "https://example.com/video.mp4" },
+      },
+      {
+        type: "video",
+        source: { type: "data", value: "dmlkZW8=", mimeType: "video/mp4" },
+      },
+      {
+        type: "document",
+        source: { type: "url", value: "https://example.com/document.pdf" },
+      },
+      {
+        type: "document",
+        source: { type: "data", value: "ZG9jdW1lbnQ=", mimeType: "application/pdf" },
+      },
+    ] satisfies InputContent[];
+
+    it.each(roundTripFixtures)(
+      "round-trips $type through LangChain preserving each source shape and metadata",
+      (mediaContent) => {
+        const metadata = { kind: mediaContent.type, sourceType: mediaContent.source.type, n: 7 };
+        const original: UserMessage = {
+          id: `rt-${mediaContent.type}-${mediaContent.source.type}`,
+          role: "user",
+          content: [{ ...mediaContent, metadata }],
+        };
+
+        const lcMessages = aguiMessagesToLangChain([original]);
+        const roundTripped = langchainMessagesToAgui([
+          { id: original.id, type: "human", content: lcMessages[0].content } as LangGraphMessage,
+        ]);
+
+        const part = (roundTripped[0].content as Array<any>)[0];
+        expect(part.type).toBe(mediaContent.type);
+        expect(part.source).toEqual(mediaContent.source);
+        expect(part.metadata).toEqual(metadata);
+      }
+    );
   });
 });
 

--- a/integrations/langgraph/typescript/src/utils.test.ts
+++ b/integrations/langgraph/typescript/src/utils.test.ts
@@ -387,9 +387,12 @@ describe("Multimodal Message Conversion", () => {
   });
 
   describe("Provider-safe multimodal sidecar", () => {
-    // Helper: read the validated sidecar off a converted human message.
-    const sidecarOf = (message: LangGraphMessage): unknown =>
-      (message as any).response_metadata?.[AGUI_MULTIMODAL_SIDECAR_KEY];
+    // Helper: read the sidecar off a converted human message's response_metadata.
+    const sidecarOf = (message: LangGraphMessage): unknown => {
+      const responseMetadata = (message as { response_metadata?: Record<string, unknown> })
+        .response_metadata;
+      return responseMetadata?.[AGUI_MULTIMODAL_SIDECAR_KEY];
+    };
 
     describe("forward: provider-safe blocks + response_metadata sidecar", () => {
       it("emits legacy blocks with no metadata key and records the sidecar on response_metadata", () => {
@@ -444,6 +447,35 @@ describe("Multimodal Message Conversion", () => {
         // No metadata key when the source block had none.
         expect(sidecarOf(lcMessages[0])).toEqual([{ type: "audio" }]);
       });
+
+      it.each([
+        { type: "image", value: "https://example.com/i.jpg" },
+        { type: "audio", value: "https://example.com/a.mp3" },
+        { type: "video", value: "https://example.com/v.mp4" },
+        { type: "document", value: "https://example.com/d.pdf" },
+      ])(
+        "emits a provider-safe block and a typed sidecar entry for $type",
+        ({ type, value }) => {
+          const aguiMessage: UserMessage = {
+            id: `fwd-${type}`,
+            role: "user",
+            content: [
+              {
+                type,
+                source: { type: "url", value },
+                metadata: { k: type },
+              } as InputContent,
+            ],
+          };
+
+          const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+
+          const blocks = lcMessages[0].content as Array<any>;
+          expect(blocks[0]).toEqual({ type: "image_url", image_url: { url: value } });
+          expect(blocks[0]).not.toHaveProperty("metadata");
+          expect(sidecarOf(lcMessages[0])).toEqual([{ type, metadata: { k: type } }]);
+        }
+      );
 
       it("does not attach a sidecar to text-only content", () => {
         const aguiMessage: UserMessage = {
@@ -530,6 +562,43 @@ describe("Multimodal Message Conversion", () => {
         const aguiMessages = langchainMessagesToAgui([lcMessage]);
 
         const part = (aguiMessages[0].content as Array<any>)[1];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("ignores a longer-than-content sidecar and falls back to legacy behavior", () => {
+        const lcMessage = {
+          id: "rev-too-long",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          // Length 2 but content has 1 block -> misaligned -> rejected.
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: [{ type: "video" }, { type: "audio" }],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("ignores a non-object response_metadata and falls back to legacy behavior", () => {
+        const lcMessage = {
+          id: "rev-bad-response-metadata",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          response_metadata: "oops",
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
         expect(part.type).toBe("image");
         expect(part.metadata).toBeUndefined();
       });
@@ -675,8 +744,14 @@ describe("Multimodal Message Conversion", () => {
           };
 
           const lcMessages = aguiMessagesToLangChain([original]);
+          // The model-bound block is a plain legacy image_url with no metadata.
+          expect((lcMessages[0].content as Array<any>)[0]).not.toHaveProperty("metadata");
+
           // Simulate the LangGraph checkpoint JSON round-trip.
           const persisted = JSON.parse(JSON.stringify(lcMessages[0])) as LangGraphMessage;
+          // The sidecar survives serialization on response_metadata.
+          expect(sidecarOf(persisted)).toEqual([{ type: mediaContent.type, metadata }]);
+
           const roundTripped = langchainMessagesToAgui([persisted]);
 
           const part = (roundTripped[0].content as Array<any>)[0];
@@ -685,6 +760,49 @@ describe("Multimodal Message Conversion", () => {
           expect(part.metadata).toEqual(metadata);
         }
       );
+
+      it("preserves text/media index alignment across a checkpoint round-trip", () => {
+        const original: UserMessage = {
+          id: "rt-alignment",
+          role: "user",
+          content: [
+            { type: "text", text: "first" },
+            {
+              type: "audio",
+              source: { type: "url", value: "https://example.com/a.mp3" },
+              metadata: { lang: "en" },
+            } as AudioInputContent,
+            { type: "text", text: "second" },
+            {
+              type: "document",
+              source: { type: "url", value: "https://example.com/d.pdf" },
+            } as DocumentInputContent,
+          ],
+        };
+
+        const lcMessages = aguiMessagesToLangChain([original]);
+        for (const block of lcMessages[0].content as Array<any>) {
+          expect(block).not.toHaveProperty("metadata");
+        }
+
+        const persisted = JSON.parse(JSON.stringify(lcMessages[0])) as LangGraphMessage;
+        expect(sidecarOf(persisted)).toEqual([
+          null,
+          { type: "audio", metadata: { lang: "en" } },
+          null,
+          { type: "document" },
+        ]);
+
+        const roundTripped = langchainMessagesToAgui([persisted]);
+        const content = roundTripped[0].content as Array<any>;
+        expect(content).toHaveLength(4);
+        expect(content[0]).toEqual({ type: "text", text: "first" });
+        expect(content[1].type).toBe("audio");
+        expect(content[1].metadata).toEqual({ lang: "en" });
+        expect(content[2]).toEqual({ type: "text", text: "second" });
+        expect(content[3].type).toBe("document");
+        expect(content[3].metadata).toBeUndefined();
+      });
 
       it.each([
         { label: "primitive string", metadata: "just a string" },

--- a/integrations/langgraph/typescript/src/utils.test.ts
+++ b/integrations/langgraph/typescript/src/utils.test.ts
@@ -18,7 +18,7 @@ import {
   aguiMessagesToLangChain,
   langchainMessagesToAgui,
   resolveReasoningContent,
-  AGUI_TYPE_KEY,
+  AGUI_MULTIMODAL_SIDECAR_KEY,
 } from "./utils";
 
 describe("Multimodal Message Conversion", () => {
@@ -386,160 +386,344 @@ describe("Multimodal Message Conversion", () => {
     });
   });
 
-  describe("Metadata + media type round-trip", () => {
-    it("forward preserves metadata and tags type", () => {
-      const aguiMessage: UserMessage = {
-        id: "fwd-image",
-        role: "user",
-        content: [
-          {
-            type: "image",
-            source: { type: "url", value: "https://example.com/photo.jpg" },
-            metadata: { alt: "a cat", id: 42 },
-          } as ImageInputContent,
-        ],
-      };
+  describe("Provider-safe multimodal sidecar", () => {
+    // Helper: read the validated sidecar off a converted human message.
+    const sidecarOf = (message: LangGraphMessage): unknown =>
+      (message as any).response_metadata?.[AGUI_MULTIMODAL_SIDECAR_KEY];
 
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      const block = (lcMessages[0].content as Array<any>)[0];
-      expect(block.type).toBe("image_url");
-      expect(block.metadata).toEqual({ alt: "a cat", id: 42, [AGUI_TYPE_KEY]: "image" });
-    });
-
-    it("forward embeds __agui_type in metadata for non-image media", () => {
-      const aguiMessage: UserMessage = {
-        id: "fwd-audio",
-        role: "user",
-        content: [
-          {
-            type: "audio",
-            source: { type: "url", value: "https://example.com/a.mp3" },
-            metadata: { duration: 12 },
-          } as AudioInputContent,
-        ],
-      };
-
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      const block = (lcMessages[0].content as Array<any>)[0];
-      expect(block.type).toBe("image_url");
-      expect(block.metadata).toEqual({ duration: 12, [AGUI_TYPE_KEY]: "audio" });
-    });
-
-    it("reverse restores type + metadata from a tagged block", () => {
-      const lcMessage: LangGraphMessage = {
-        id: "rev-tagged",
-        type: "human",
-        content: [
-          {
-            type: "image_url",
-            image_url: { url: "https://example.com/v.mp4" },
-            metadata: { fps: 30, [AGUI_TYPE_KEY]: "video" },
-          },
-        ] as any,
-      };
-
-      const aguiMessages = langchainMessagesToAgui([lcMessage]);
-
-      const part = (aguiMessages[0].content as Array<any>)[0];
-      expect(part.type).toBe("video");
-      expect(part.source).toEqual({ type: "url", value: "https://example.com/v.mp4" });
-      expect(part.metadata).toEqual({ fps: 30 });
-    });
-
-    it("reverse falls back to image for untagged blocks", () => {
-      const lcMessage: LangGraphMessage = {
-        id: "rev-untagged",
-        type: "human",
-        content: [
-          { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
-        ] as any,
-      };
-
-      const aguiMessages = langchainMessagesToAgui([lcMessage]);
-
-      const part = (aguiMessages[0].content as Array<any>)[0];
-      expect(part.type).toBe("image");
-      expect(part.metadata).toBeUndefined();
-    });
-
-    it("reverse falls back to image for an invalid media type tag", () => {
-      const lcMessage: LangGraphMessage = {
-        id: "rev-invalid-tag",
-        type: "human",
-        content: [
-          {
-            type: "image_url",
-            image_url: { url: "https://example.com/x.jpg" },
-            metadata: { [AGUI_TYPE_KEY]: "binary", preserved: true },
-          },
-        ] as any,
-      };
-
-      const aguiMessages = langchainMessagesToAgui([lcMessage]);
-
-      const part = (aguiMessages[0].content as Array<any>)[0];
-      expect(part.type).toBe("image");
-      expect(part.metadata).toEqual({ preserved: true });
-    });
-
-    const roundTripFixtures = [
-      {
-        type: "image",
-        source: { type: "url", value: "https://example.com/image.jpg" },
-      },
-      {
-        type: "image",
-        source: { type: "data", value: "aW1hZ2U=", mimeType: "image/jpeg" },
-      },
-      {
-        type: "audio",
-        source: { type: "url", value: "https://example.com/audio.mp3" },
-      },
-      {
-        type: "audio",
-        source: { type: "data", value: "YXVkaW8=", mimeType: "audio/mpeg" },
-      },
-      {
-        type: "video",
-        source: { type: "url", value: "https://example.com/video.mp4" },
-      },
-      {
-        type: "video",
-        source: { type: "data", value: "dmlkZW8=", mimeType: "video/mp4" },
-      },
-      {
-        type: "document",
-        source: { type: "url", value: "https://example.com/document.pdf" },
-      },
-      {
-        type: "document",
-        source: { type: "data", value: "ZG9jdW1lbnQ=", mimeType: "application/pdf" },
-      },
-    ] satisfies InputContent[];
-
-    it.each(roundTripFixtures)(
-      "round-trips $type through LangChain preserving each source shape and metadata",
-      (mediaContent) => {
-        const metadata = { kind: mediaContent.type, sourceType: mediaContent.source.type, n: 7 };
-        const original: UserMessage = {
-          id: `rt-${mediaContent.type}-${mediaContent.source.type}`,
+    describe("forward: provider-safe blocks + response_metadata sidecar", () => {
+      it("emits legacy blocks with no metadata key and records the sidecar on response_metadata", () => {
+        const aguiMessage: UserMessage = {
+          id: "fwd-image",
           role: "user",
-          content: [{ ...mediaContent, metadata }],
+          content: [
+            { type: "text", text: "look" },
+            {
+              type: "image",
+              source: { type: "url", value: "https://example.com/photo.jpg" },
+              metadata: { alt: "a cat", id: 42 },
+            } as ImageInputContent,
+          ],
         };
 
-        const lcMessages = aguiMessagesToLangChain([original]);
-        const roundTripped = langchainMessagesToAgui([
-          { id: original.id, type: "human", content: lcMessages[0].content } as LangGraphMessage,
-        ]);
+        const lcMessages = aguiMessagesToLangChain([aguiMessage]);
 
-        const part = (roundTripped[0].content as Array<any>)[0];
-        expect(part.type).toBe(mediaContent.type);
-        expect(part.source).toEqual(mediaContent.source);
-        expect(part.metadata).toEqual(metadata);
-      }
-    );
+        const blocks = lcMessages[0].content as Array<any>;
+        // The model-bound image block is a plain legacy image_url with no
+        // AG-UI metadata leaking onto it.
+        expect(blocks[1]).toEqual({
+          type: "image_url",
+          image_url: { url: "https://example.com/photo.jpg" },
+        });
+        expect(blocks[1]).not.toHaveProperty("metadata");
+        expect(blocks[0]).not.toHaveProperty("metadata");
+
+        // Type + metadata live out-of-band in the aligned sidecar.
+        expect(sidecarOf(lcMessages[0])).toEqual([
+          null,
+          { type: "image", metadata: { alt: "a cat", id: 42 } },
+        ]);
+      });
+
+      it("records the media type even when no metadata is present", () => {
+        const aguiMessage: UserMessage = {
+          id: "fwd-audio",
+          role: "user",
+          content: [
+            {
+              type: "audio",
+              source: { type: "url", value: "https://example.com/a.mp3" },
+            } as AudioInputContent,
+          ],
+        };
+
+        const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+
+        const blocks = lcMessages[0].content as Array<any>;
+        expect(blocks[0]).not.toHaveProperty("metadata");
+        // No metadata key when the source block had none.
+        expect(sidecarOf(lcMessages[0])).toEqual([{ type: "audio" }]);
+      });
+
+      it("does not attach a sidecar to text-only content", () => {
+        const aguiMessage: UserMessage = {
+          id: "fwd-text-only",
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        };
+
+        const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+        expect(sidecarOf(lcMessages[0])).toBeUndefined();
+      });
+
+      it("does not attach a sidecar to legacy-binary-only content", () => {
+        const aguiMessage: UserMessage = {
+          id: "fwd-binary-only",
+          role: "user",
+          content: [
+            {
+              type: "binary",
+              mimeType: "image/jpeg",
+              url: "https://example.com/photo.jpg",
+            } as BinaryInputContent,
+          ],
+        };
+
+        const lcMessages = aguiMessagesToLangChain([aguiMessage]);
+        const blocks = lcMessages[0].content as Array<any>;
+        expect(blocks[0]).not.toHaveProperty("metadata");
+        expect(sidecarOf(lcMessages[0])).toBeUndefined();
+      });
+    });
+
+    describe("reverse: sidecar restores type + metadata, falls back safely", () => {
+      it("restores type + metadata from the sidecar", () => {
+        const lcMessage = {
+          id: "rev-tagged",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/v.mp4" } },
+          ],
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: [{ type: "video", metadata: { fps: 30 } }],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
+        expect(part.type).toBe("video");
+        expect(part.source).toEqual({ type: "url", value: "https://example.com/v.mp4" });
+        expect(part.metadata).toEqual({ fps: 30 });
+      });
+
+      it("falls back to image with no metadata when the sidecar is missing", () => {
+        const lcMessage = {
+          id: "rev-untagged",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("ignores a wrong-length sidecar and falls back to legacy behavior", () => {
+        const lcMessage = {
+          id: "rev-wrong-length",
+          type: "human",
+          content: [
+            { type: "text", text: "hi" },
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          // Length 1 but content has 2 blocks -> misaligned -> rejected.
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: [{ type: "video" }],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[1];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("ignores a non-array sidecar and falls back to legacy behavior", () => {
+        const lcMessage = {
+          id: "rev-non-array",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: { type: "video" },
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("ignores a sidecar with an invalid entry type and falls back for all blocks", () => {
+        const lcMessage = {
+          id: "rev-invalid-type",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/a.mp3" } },
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          response_metadata: {
+            // First entry has a non-media type -> whole sidecar rejected.
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: [{ type: "binary" }, { type: "image" }],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const content = aguiMessages[0].content as Array<any>;
+        expect(content[0].type).toBe("image");
+        expect(content[0].metadata).toBeUndefined();
+        expect(content[1].type).toBe("image");
+        expect(content[1].metadata).toBeUndefined();
+      });
+
+      it("ignores a malformed sidecar entry (string instead of null/record)", () => {
+        const lcMessage = {
+          id: "rev-malformed-entry",
+          type: "human",
+          content: [
+            { type: "image_url", image_url: { url: "https://example.com/x.jpg" } },
+          ],
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: ["video"],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const part = (aguiMessages[0].content as Array<any>)[0];
+        expect(part.type).toBe("image");
+        expect(part.metadata).toBeUndefined();
+      });
+
+      it("keeps text/media index alignment when reading the sidecar", () => {
+        const lcMessage = {
+          id: "rev-alignment",
+          type: "human",
+          content: [
+            { type: "text", text: "first" },
+            { type: "image_url", image_url: { url: "https://example.com/a.mp3" } },
+            { type: "text", text: "second" },
+            { type: "image_url", image_url: { url: "https://example.com/d.pdf" } },
+          ],
+          response_metadata: {
+            [AGUI_MULTIMODAL_SIDECAR_KEY]: [
+              null,
+              { type: "audio", metadata: { lang: "en" } },
+              null,
+              { type: "document" },
+            ],
+          },
+        } as unknown as LangGraphMessage;
+
+        const aguiMessages = langchainMessagesToAgui([lcMessage]);
+
+        const content = aguiMessages[0].content as Array<any>;
+        expect(content).toHaveLength(4);
+        expect(content[0]).toEqual({ type: "text", text: "first" });
+        expect(content[1].type).toBe("audio");
+        expect(content[1].metadata).toEqual({ lang: "en" });
+        expect(content[2]).toEqual({ type: "text", text: "second" });
+        expect(content[3].type).toBe("document");
+        expect(content[3].metadata).toBeUndefined();
+      });
+    });
+
+    describe("round-trip survives a JSON checkpoint", () => {
+      const roundTripFixtures = [
+        {
+          type: "image",
+          source: { type: "url", value: "https://example.com/image.jpg" },
+        },
+        {
+          type: "image",
+          source: { type: "data", value: "aW1hZ2U=", mimeType: "image/jpeg" },
+        },
+        {
+          type: "audio",
+          source: { type: "url", value: "https://example.com/audio.mp3" },
+        },
+        {
+          type: "audio",
+          source: { type: "data", value: "YXVkaW8=", mimeType: "audio/mpeg" },
+        },
+        {
+          type: "video",
+          source: { type: "url", value: "https://example.com/video.mp4" },
+        },
+        {
+          type: "video",
+          source: { type: "data", value: "dmlkZW8=", mimeType: "video/mp4" },
+        },
+        {
+          type: "document",
+          source: { type: "url", value: "https://example.com/document.pdf" },
+        },
+        {
+          type: "document",
+          source: { type: "data", value: "ZG9jdW1lbnQ=", mimeType: "application/pdf" },
+        },
+      ] satisfies InputContent[];
+
+      it.each(roundTripFixtures)(
+        "round-trips $type ($source.type) through a stringify/parse checkpoint preserving metadata",
+        (mediaContent) => {
+          const metadata = { kind: mediaContent.type, sourceType: mediaContent.source.type, n: 7 };
+          const original: UserMessage = {
+            id: `rt-${mediaContent.type}-${mediaContent.source.type}`,
+            role: "user",
+            content: [{ ...mediaContent, metadata }],
+          };
+
+          const lcMessages = aguiMessagesToLangChain([original]);
+          // Simulate the LangGraph checkpoint JSON round-trip.
+          const persisted = JSON.parse(JSON.stringify(lcMessages[0])) as LangGraphMessage;
+          const roundTripped = langchainMessagesToAgui([persisted]);
+
+          const part = (roundTripped[0].content as Array<any>)[0];
+          expect(part.type).toBe(mediaContent.type);
+          expect(part.source).toEqual(mediaContent.source);
+          expect(part.metadata).toEqual(metadata);
+        }
+      );
+
+      it.each([
+        { label: "primitive string", metadata: "just a string" },
+        { label: "primitive number", metadata: 0 },
+        { label: "primitive boolean", metadata: false },
+        { label: "primitive null", metadata: null },
+        { label: "array", metadata: [1, "two", { three: 3 }] },
+        {
+          label: "object with a user-owned __agui_type key",
+          metadata: { __agui_type: "user-owned", note: "not touched" },
+        },
+      ])(
+        "preserves arbitrary metadata ($label) across a checkpoint round-trip",
+        ({ metadata }) => {
+          const original: UserMessage = {
+            id: "rt-arbitrary-metadata",
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: { type: "url", value: "https://example.com/photo.jpg" },
+                metadata,
+              } as ImageInputContent,
+            ],
+          };
+
+          const lcMessages = aguiMessagesToLangChain([original]);
+          // The model-bound block never carries the metadata.
+          expect((lcMessages[0].content as Array<any>)[0]).not.toHaveProperty("metadata");
+
+          const persisted = JSON.parse(JSON.stringify(lcMessages[0])) as LangGraphMessage;
+          const roundTripped = langchainMessagesToAgui([persisted]);
+
+          const part = (roundTripped[0].content as Array<any>)[0];
+          expect(part.type).toBe("image");
+          expect(part.metadata).toEqual(metadata);
+        }
+      );
+    });
   });
 });
 

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -47,28 +47,45 @@ type MediaInputContent =
   | VideoInputContent
   | DocumentInputContent;
 const DEFAULT_MEDIA_CONTENT_TYPE: MediaContentType = "image";
-export const AGUI_TYPE_KEY = "__agui_type" as const;
 
 /**
- * Metadata carried through a LangChain content block. Survives the LangGraph
- * checkpoint JSON round-trip as an inert extra key. `__agui_type` stashes the
- * original AG-UI media type so the reverse converter can restore it; defaults
- * to `"image"` when absent (legacy blocks written before this fix).
+ * Key under a HumanMessage's `response_metadata` that holds the multimodal
+ * sidecar. `response_metadata` is the internal checkpoint channel: LangGraph
+ * persists it through the checkpoint JSON round-trip, while provider request
+ * serializers do not forward it to the model (unlike `additional_kwargs`).
  */
-type LangchainBlockMetadata = Record<string, unknown>;
+export const AGUI_MULTIMODAL_SIDECAR_KEY = "__agui_multimodal" as const;
 
 /**
- * The shape carried through LangChain content blocks. `metadata` is an inert
- * extra key for LangChain/model providers that survives the LangGraph
- * checkpoint JSON round-trip. The original AG-UI media type is stashed inside
- * metadata as `__agui_type` so the reverse converter can restore it without
- * adding a separate top-level field to the block.
+ * A provider-valid LangChain content block. Only the legacy `text` and
+ * `image_url` shapes are emitted, with no extra keys, so strict
+ * OpenAI-compatible providers accept the block unchanged. AG-UI media type and
+ * metadata are carried out-of-band in the response_metadata sidecar instead.
  */
-type LangchainMultimodalBlock = {
+type LangchainMultimodalBlock =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+/**
+ * A loosely-typed view of an incoming LangChain content block, used when
+ * reading messages back. LangChain's `image_url` may be a bare string or an
+ * object, so both are accepted.
+ */
+type LangchainContentBlock = {
   type: string;
   text?: string;
   image_url?: { url: string } | string;
-  metadata?: LangchainBlockMetadata;
+};
+
+/**
+ * One entry of the aligned multimodal sidecar, indexed 1:1 with the message's
+ * content blocks. `null` marks a block that carries no AG-UI media type (text
+ * or legacy binary). Otherwise it records the original media type and, when the
+ * source block had one, its arbitrary `InputContent.metadata`.
+ */
+type MultimodalSidecarEntry = null | {
+  type: MediaContentType;
+  metadata?: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -136,63 +153,82 @@ function mediaSourceToUrl(source: InputContentDataSource | InputContentUrlSource
   return null;
 }
 
+// Turn an `image_url` string back into an AG-UI content source. `data:` URLs are
+// parsed into a data source; everything else is treated as a plain URL.
+function imageUrlToSource(imageUrl: string): InputContentDataSource | InputContentUrlSource {
+  if (imageUrl.startsWith("data:")) {
+    // Format: data:mime_type;base64,data
+    const [header, data] = imageUrl.split(",", 2);
+    const mimeType = header.includes(":") ? header.split(":")[1].split(";")[0] : "image/png";
+    return { type: "data", value: data || "", mimeType };
+  }
+  return { type: "url", value: imageUrl };
+}
+
+/**
+ * Validate and normalize the raw multimodal sidecar read from a HumanMessage's
+ * `response_metadata`. Returns a sidecar aligned 1:1 with the message content
+ * blocks, or `null` when the value is missing or malformed in any way — a wrong
+ * length, a non-array, or an entry that is neither `null` nor a record carrying
+ * a known media `type`. Returning `null` makes the caller fall back to the
+ * legacy behavior instead of misattaching metadata to the wrong block.
+ */
+function parseMultimodalSidecar(raw: unknown, expectedLength: number): MultimodalSidecarEntry[] | null {
+  if (!Array.isArray(raw) || raw.length !== expectedLength) return null;
+
+  const parsed: MultimodalSidecarEntry[] = [];
+  for (const entry of raw) {
+    if (entry === null) {
+      parsed.push(null);
+      continue;
+    }
+    if (!isRecord(entry) || !isMediaContentType(entry.type)) return null;
+    const normalized: { type: MediaContentType; metadata?: unknown } = { type: entry.type };
+    // Preserve arbitrary metadata verbatim (primitives, arrays, objects). Only
+    // copy the key when it was actually present so absent metadata round-trips
+    // to `undefined` rather than an explicit `metadata: undefined`.
+    if ("metadata" in entry) normalized.metadata = entry.metadata;
+    parsed.push(normalized);
+  }
+  return parsed;
+}
+
 /**
  * Convert LangChain's multimodal content to AG-UI format.
  *
- * LangChain only supports `text` and `image_url` content blocks. `image_url`
- * blocks are converted back to the original AG-UI media type when the forward
- * converter tagged them with `__agui_type` (and any carried `metadata` is
- * restored); untagged blocks fall back to `DEFAULT_MEDIA_CONTENT_TYPE`.
+ * LangChain only supports `text` and `image_url` content blocks. Each
+ * `image_url` block is restored to its original AG-UI media type and metadata
+ * using the aligned `sidecar` (indexed by block position). Blocks with no valid
+ * sidecar entry fall back to `DEFAULT_MEDIA_CONTENT_TYPE` with no metadata,
+ * preserving the legacy behavior for untagged/legacy checkpoints.
  */
 function convertLangchainMultimodalToAgui(
-  content: Array<LangchainMultimodalBlock>
+  content: Array<LangchainContentBlock>,
+  sidecar: MultimodalSidecarEntry[] | null,
 ): InputContent[] {
   const aguiContent: InputContent[] = [];
 
-  for (const item of content) {
+  content.forEach((item, index) => {
     if (item.type === "text" && item.text) {
       aguiContent.push({
         type: "text",
         text: item.text,
       });
     } else if (item.type === "image_url") {
-      const imageUrl = typeof item.image_url === "string"
-        ? item.image_url
-        : item.image_url?.url;
+      const imageUrl = typeof item.image_url === "string" ? item.image_url : item.image_url?.url;
 
-      if (!imageUrl) continue;
+      if (!imageUrl) return;
 
-      // Restore the original media type from __agui_type in metadata, then
-      // strip it so the returned InputContent.metadata matches the original.
-      // Blocks without __agui_type fall back to image (preserves legacy behavior).
-      const rawMeta = isRecord(item.metadata) ? item.metadata : undefined;
-      const taggedType = rawMeta?.[AGUI_TYPE_KEY];
-      const restoredType = isMediaContentType(taggedType)
-        ? taggedType
-        : DEFAULT_MEDIA_CONTENT_TYPE;
-      let cleanMeta: LangchainBlockMetadata | undefined;
-      if (rawMeta !== undefined) {
-        const { [AGUI_TYPE_KEY]: _stripped, ...rest } = rawMeta;
-        cleanMeta = Object.keys(rest).length > 0 ? rest : undefined;
-      }
+      // The sidecar is already validated, so an entry is either null or a record
+      // with a known media type. Index alignment guarantees we only read the
+      // entry for this exact block.
+      const entry = sidecar?.[index] ?? null;
+      const restoredType = entry ? entry.type : DEFAULT_MEDIA_CONTENT_TYPE;
+      const metadata = entry && "metadata" in entry ? entry.metadata : undefined;
 
-      let source: InputContentDataSource | InputContentUrlSource;
-      // Parse data URLs to extract base64 data
-      if (imageUrl.startsWith("data:")) {
-        // Format: data:mime_type;base64,data
-        const [header, data] = imageUrl.split(",", 2);
-        const mimeType = header.includes(":")
-          ? header.split(":")[1].split(";")[0]
-          : "image/png";
-        source = { type: "data", value: data || "", mimeType };
-      } else {
-        // Regular URL
-        source = { type: "url", value: imageUrl };
-      }
-
-      aguiContent.push(createMediaInputContent(restoredType, source, cleanMeta));
+      aguiContent.push(createMediaInputContent(restoredType, imageUrlToSource(imageUrl), metadata));
     }
-  }
+  });
 
   return aguiContent;
 }
@@ -204,11 +240,17 @@ function convertLangchainMultimodalToAgui(
  * VideoInputContent, DocumentInputContent) as well as legacy BinaryInputContent
  * for backwards compatibility. All media types are routed through LangChain's
  * `image_url` format since that is the only media block type LangChain supports.
+ *
+ * Returns provider-valid content blocks (no extra keys) plus an aligned sidecar
+ * that records each media block's original AG-UI type and metadata so the
+ * reverse converter can restore them from `response_metadata`.
  */
-function convertAguiMultimodalToLangchain(
-  content: InputContent[]
-): LangchainMultimodalBlock[] {
+function convertAguiMultimodalToLangchain(content: InputContent[]): {
+  content: LangchainMultimodalBlock[];
+  sidecar: MultimodalSidecarEntry[];
+} {
   const langchainContent: LangchainMultimodalBlock[] = [];
+  const sidecar: MultimodalSidecarEntry[] = [];
 
   for (const item of content) {
     if (item.type === "text") {
@@ -216,25 +258,26 @@ function convertAguiMultimodalToLangchain(
         type: "text",
         text: item.text,
       });
+      sidecar.push(null);
     } else if (isMediaInputContent(item)) {
       // ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent
       const url = mediaSourceToUrl(item.source);
       if (url) {
-        // Stash the original media type inside metadata as __agui_type so the
-        // reverse converter can restore it without a separate top-level field.
+        // The block stays a plain legacy image_url so strict providers accept
+        // it; the media type and metadata go into the sidecar instead.
         langchainContent.push({
           type: "image_url",
           image_url: { url },
-          metadata: {
-            ...(isRecord(item.metadata) ? item.metadata : {}),
-            [AGUI_TYPE_KEY]: item.type,
-          },
         });
+        const entry: { type: MediaContentType; metadata?: unknown } = { type: item.type };
+        if (item.metadata !== undefined) entry.metadata = item.metadata;
+        sidecar.push(entry);
       } else {
         console.warn(`[convertAguiMultimodalToLangchain] Dropping ${item.type} content: source could not be converted to URL`);
       }
     } else if (item.type === "binary") {
-      // Legacy BinaryInputContent — backwards compatibility
+      // Legacy BinaryInputContent — backwards compatibility. Unchanged: no
+      // sidecar entry, so it reads back as the legacy image fallback.
       let url: string;
 
       // Prioritize url, then data, then id
@@ -255,10 +298,11 @@ function convertAguiMultimodalToLangchain(
         type: "image_url",
         image_url: { url },
       });
+      sidecar.push(null);
     }
   }
 
-  return langchainContent;
+  return { content: langchainContent, sidecar };
 }
 
 // A reasoning content block as it appears on a LangChain assistant message
@@ -345,7 +389,12 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
         // Handle multimodal content
         let userContent: string | InputContent[];
         if (Array.isArray(message.content)) {
-          userContent = convertLangchainMultimodalToAgui(message.content as any);
+          const blocks = message.content as LangchainContentBlock[];
+          const rawSidecar = isRecord(message.response_metadata)
+            ? message.response_metadata[AGUI_MULTIMODAL_SIDECAR_KEY]
+            : undefined;
+          const sidecar = parseMultimodalSidecar(rawSidecar, blocks.length);
+          userContent = convertLangchainMultimodalToAgui(blocks, sidecar);
         } else {
           userContent = stringifyIfNeeded(resolveMessageContent(message.content));
         }
@@ -466,10 +515,17 @@ export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[]
         pendingReasoning = [];
         // Handle multimodal content
         let content: UserMessage['content'];
+        let responseMetadata: Record<string, unknown> | undefined;
         if (typeof message.content === "string") {
           content = message.content;
         } else if (Array.isArray(message.content)) {
-          content = convertAguiMultimodalToLangchain(message.content) as any;
+          const converted = convertAguiMultimodalToLangchain(message.content);
+          content = converted.content as any;
+          // Only attach the sidecar when it actually carries media info, so
+          // text-only / legacy-binary-only messages stay free of extra metadata.
+          if (converted.sidecar.some((entry) => entry !== null)) {
+            responseMetadata = { [AGUI_MULTIMODAL_SIDECAR_KEY]: converted.sidecar };
+          }
         } else {
           content = String(message.content);
         }
@@ -479,6 +535,7 @@ export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[]
           role: message.role,
           content,
           type: "human",
+          ...(responseMetadata ? { response_metadata: responseMetadata } : {}),
         } as LangGraphMessage);
         break;
       }

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -12,7 +12,6 @@ import {
   InputContentDataSource,
   InputContentUrlSource,
   InputContent,
-  UserMessage,
 } from "@ag-ui/client";
 
 export const DEFAULT_SCHEMA_KEYS = ["messages", "tools"];
@@ -217,7 +216,9 @@ function convertLangchainMultimodalToAgui(
     } else if (item.type === "image_url") {
       const imageUrl = typeof item.image_url === "string" ? item.image_url : item.image_url?.url;
 
-      if (!imageUrl) return;
+      // Guard against malformed checkpoint data (e.g. a non-string url); a bad
+      // block is skipped rather than crashing imageUrlToSource on `.startsWith`.
+      if (typeof imageUrl !== "string" || !imageUrl) return;
 
       // The sidecar is already validated, so an entry is either null or a record
       // with a known media type. Index alignment guarantees we only read the
@@ -276,8 +277,9 @@ function convertAguiMultimodalToLangchain(content: InputContent[]): {
         console.warn(`[convertAguiMultimodalToLangchain] Dropping ${item.type} content: source could not be converted to URL`);
       }
     } else if (item.type === "binary") {
-      // Legacy BinaryInputContent — backwards compatibility. Unchanged: no
-      // sidecar entry, so it reads back as the legacy image fallback.
+      // Legacy BinaryInputContent — backwards compatibility. Unchanged: records
+      // a null sidecar entry (to keep 1:1 index alignment), so it reads back as
+      // the legacy image fallback.
       let url: string;
 
       // Prioritize url, then data, then id
@@ -514,13 +516,13 @@ export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[]
       case "user": {
         pendingReasoning = [];
         // Handle multimodal content
-        let content: UserMessage['content'];
+        let content: string | LangchainMultimodalBlock[];
         let responseMetadata: Record<string, unknown> | undefined;
         if (typeof message.content === "string") {
           content = message.content;
         } else if (Array.isArray(message.content)) {
           const converted = convertAguiMultimodalToLangchain(message.content);
-          content = converted.content as any;
+          content = converted.content;
           // Only attach the sidecar when it actually carries media info, so
           // text-only / legacy-binary-only messages stay free of extra metadata.
           if (converted.sidecar.some((entry) => entry !== null)) {

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -39,7 +39,93 @@ export function getStreamPayloadInput({
   return input;
 }
 
-const MEDIA_CONTENT_TYPES = new Set(["image", "audio", "video", "document"]);
+const MEDIA_CONTENT_TYPES = ["image", "audio", "video", "document"] as const;
+type MediaContentType = (typeof MEDIA_CONTENT_TYPES)[number];
+type MediaInputContent =
+  | ImageInputContent
+  | AudioInputContent
+  | VideoInputContent
+  | DocumentInputContent;
+const DEFAULT_MEDIA_CONTENT_TYPE: MediaContentType = "image";
+export const AGUI_TYPE_KEY = "__agui_type" as const;
+
+/**
+ * Metadata carried through a LangChain content block. Survives the LangGraph
+ * checkpoint JSON round-trip as an inert extra key. `__agui_type` stashes the
+ * original AG-UI media type so the reverse converter can restore it; defaults
+ * to `"image"` when absent (legacy blocks written before this fix).
+ */
+type LangchainBlockMetadata = Record<string, unknown>;
+
+/**
+ * The shape carried through LangChain content blocks. `metadata` is an inert
+ * extra key for LangChain/model providers that survives the LangGraph
+ * checkpoint JSON round-trip. The original AG-UI media type is stashed inside
+ * metadata as `__agui_type` so the reverse converter can restore it without
+ * adding a separate top-level field to the block.
+ */
+type LangchainMultimodalBlock = {
+  type: string;
+  text?: string;
+  image_url?: { url: string } | string;
+  metadata?: LangchainBlockMetadata;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMediaContentType(value: unknown): value is MediaContentType {
+  switch (value) {
+    case "image":
+    case "audio":
+    case "video":
+    case "document":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isMediaInputContent(content: InputContent): content is MediaInputContent {
+  switch (content.type) {
+    case "image":
+    case "audio":
+    case "video":
+    case "document":
+      return true;
+    case "text":
+    case "binary":
+      return false;
+    default: {
+      const exhaustiveCheck: never = content;
+      return exhaustiveCheck;
+    }
+  }
+}
+
+function createMediaInputContent(
+  type: MediaContentType,
+  source: InputContentDataSource | InputContentUrlSource,
+  metadata?: unknown,
+): MediaInputContent {
+  const optionalMetadata = metadata === undefined ? {} : { metadata };
+
+  switch (type) {
+    case "image":
+      return { type, source, ...optionalMetadata };
+    case "audio":
+      return { type, source, ...optionalMetadata };
+    case "video":
+      return { type, source, ...optionalMetadata };
+    case "document":
+      return { type, source, ...optionalMetadata };
+    default: {
+      const exhaustiveCheck: never = type;
+      return exhaustiveCheck;
+    }
+  }
+}
 
 function mediaSourceToUrl(source: InputContentDataSource | InputContentUrlSource): string | null {
   if (source.type === "data") {
@@ -53,12 +139,13 @@ function mediaSourceToUrl(source: InputContentDataSource | InputContentUrlSource
 /**
  * Convert LangChain's multimodal content to AG-UI format.
  *
- * LangChain only supports `text` and `image_url` content blocks.
- * `image_url` blocks are converted to `ImageInputContent` with the
- * appropriate source type (data or URL).
+ * LangChain only supports `text` and `image_url` content blocks. `image_url`
+ * blocks are converted back to the original AG-UI media type when the forward
+ * converter tagged them with `__agui_type` (and any carried `metadata` is
+ * restored); untagged blocks fall back to `DEFAULT_MEDIA_CONTENT_TYPE`.
  */
 function convertLangchainMultimodalToAgui(
-  content: Array<{ type: string; text?: string; image_url?: any }>
+  content: Array<LangchainMultimodalBlock>
 ): InputContent[] {
   const aguiContent: InputContent[] = [];
 
@@ -69,14 +156,27 @@ function convertLangchainMultimodalToAgui(
         text: item.text,
       });
     } else if (item.type === "image_url") {
-      // LangChain only uses `image_url` blocks for all media, so we always
-      // produce ImageInputContent here. The true media type is not recoverable.
       const imageUrl = typeof item.image_url === "string"
         ? item.image_url
         : item.image_url?.url;
 
       if (!imageUrl) continue;
 
+      // Restore the original media type from __agui_type in metadata, then
+      // strip it so the returned InputContent.metadata matches the original.
+      // Blocks without __agui_type fall back to image (preserves legacy behavior).
+      const rawMeta = isRecord(item.metadata) ? item.metadata : undefined;
+      const taggedType = rawMeta?.[AGUI_TYPE_KEY];
+      const restoredType = isMediaContentType(taggedType)
+        ? taggedType
+        : DEFAULT_MEDIA_CONTENT_TYPE;
+      let cleanMeta: LangchainBlockMetadata | undefined;
+      if (rawMeta !== undefined) {
+        const { [AGUI_TYPE_KEY]: _stripped, ...rest } = rawMeta;
+        cleanMeta = Object.keys(rest).length > 0 ? rest : undefined;
+      }
+
+      let source: InputContentDataSource | InputContentUrlSource;
       // Parse data URLs to extract base64 data
       if (imageUrl.startsWith("data:")) {
         // Format: data:mime_type;base64,data
@@ -84,25 +184,13 @@ function convertLangchainMultimodalToAgui(
         const mimeType = header.includes(":")
           ? header.split(":")[1].split(";")[0]
           : "image/png";
-
-        aguiContent.push({
-          type: "image",
-          source: {
-            type: "data",
-            value: data || "",
-            mimeType,
-          },
-        });
+        source = { type: "data", value: data || "", mimeType };
       } else {
         // Regular URL
-        aguiContent.push({
-          type: "image",
-          source: {
-            type: "url",
-            value: imageUrl,
-          },
-        });
+        source = { type: "url", value: imageUrl };
       }
+
+      aguiContent.push(createMediaInputContent(restoredType, source, cleanMeta));
     }
   }
 
@@ -119,8 +207,8 @@ function convertLangchainMultimodalToAgui(
  */
 function convertAguiMultimodalToLangchain(
   content: InputContent[]
-): Array<{ type: string; text?: string; image_url?: { url: string } }> {
-  const langchainContent: Array<{ type: string; text?: string; image_url?: { url: string } }> = [];
+): LangchainMultimodalBlock[] {
+  const langchainContent: LangchainMultimodalBlock[] = [];
 
   for (const item of content) {
     if (item.type === "text") {
@@ -128,14 +216,19 @@ function convertAguiMultimodalToLangchain(
         type: "text",
         text: item.text,
       });
-    } else if (MEDIA_CONTENT_TYPES.has(item.type)) {
+    } else if (isMediaInputContent(item)) {
       // ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent
-      const mediaItem = item as ImageInputContent | AudioInputContent | VideoInputContent | DocumentInputContent;
-      const url = mediaSourceToUrl(mediaItem.source);
+      const url = mediaSourceToUrl(item.source);
       if (url) {
+        // Stash the original media type inside metadata as __agui_type so the
+        // reverse converter can restore it without a separate top-level field.
         langchainContent.push({
           type: "image_url",
           image_url: { url },
+          metadata: {
+            ...(isRecord(item.metadata) ? item.metadata : {}),
+            [AGUI_TYPE_KEY]: item.type,
+          },
         });
       } else {
         console.warn(`[convertAguiMultimodalToLangchain] Dropping ${item.type} content: source could not be converted to URL`);


### PR DESCRIPTION
## Summary

* Preserve `InputContent.metadata` and the original AG-UI media type when converting to LangChain multimodal blocks
* Restore both in the reverse direction, so an attachment survives an AG-UI → LangGraph → AG-UI round-trip
* Construct the restored discriminated-union member explicitly for each media type instead of casting to `InputContent`
* Add regression coverage for the forward and reverse paths, including URL/data sources for all four media types

Fixes #2011. Extends the TypeScript conversion to close the reverse-direction gap.

## What changed

**`integrations/langgraph/typescript/src/utils.ts`**

* `MediaContentType` is derived from the media-type tuple, providing one source of truth for valid type values
* `convertAguiMultimodalToLangchain` always emits `metadata`, because every media block carries `[AGUI_TYPE_KEY]: item.type`; caller metadata is preserved alongside it
* `convertLangchainMultimodalToAgui` validates and reads `[AGUI_TYPE_KEY]`, strips the internal key, restores caller metadata, and falls back to `image` for legacy or invalid tags
* A type-safe, exhaustive factory constructs the matching `ImageInputContent`, `AudioInputContent`, `VideoInputContent`, or `DocumentInputContent` without `as InputContent`

**`integrations/langgraph/typescript/src/utils.test.ts`**

Regression coverage verifies:

* forward metadata preservation and media-type tagging
* reverse type/metadata restoration
* legacy untagged and invalid-tag fallback to `image`
* round-tripping URL and data sources for image, audio, video, and document content

## Test plan

```bash
# Node 22; workspace SDK dependencies built first
pnpm --filter @ag-ui/langgraph typecheck
pnpm --filter @ag-ui/langgraph test
```

Both pass on the rebased branch.
