### PR TITLE
fix(dart): sync agUiVersion constant to 0.3.0

### DIFF
--- a/sdks/community/dart/lib/ag_ui.dart
+++ b/sdks/community/dart/lib/ag_ui.dart
@@ -72,7 +72,7 @@ export 'src/encoder/client_codec.dart';
 // export 'src/transport.dart';
 
 /// SDK version
-const String agUiVersion = '0.2.0';
+const String agUiVersion = '0.3.0';
 
 /// Initialize the AG-UI SDK
 void initAgUI() {

--- a/sdks/community/dart/test/ag_ui_test.dart
+++ b/sdks/community/dart/test/ag_ui_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group('AG-UI SDK', () {
     test('has correct version', () {
-      expect(agUiVersion, '0.2.0');
+      expect(agUiVersion, '0.3.0');
     });
 
     test('can initialize', () {


### PR DESCRIPTION
## What

The `agUiVersion` constant in `lib/ag_ui.dart` was left at `0.2.0` while `pubspec.yaml` advanced to `0.3.0`. This updates the constant — and the matching assertion in `test/ag_ui_test.dart` — to `0.3.0` so the SDK self-reports its correct version.

## Why separate

Split out of #2015 (which adds the pub.dev publish workflow) so the Dart code change can be reviewed/approved by the Dart codeowner (@mattsp1290) independently of the CI workflow.

## Test

`test/ag_ui_test.dart` ("has correct version") is updated alongside the constant, so `dart test` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)