### PR TITLE
fix(aws-strands): send non-empty tool result to model for empty content

### DIFF
--- a/integrations/aws-strands/typescript/src/__tests__/tool-result-void.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/tool-result-void.test.ts
@@ -10,6 +10,7 @@ import type { AgentStreamEvent } from "@strands-agents/sdk";
 import { EventType } from "@ag-ui/core";
 
 import { collect, scriptedStrandsAgent } from "./helpers";
+import { _buildToolResultContent } from "../agent";
 
 describe("Tool callback returning null/empty", () => {
   it("still emits TOOL_CALL_RESULT with empty content", async () => {
@@ -47,5 +48,24 @@ describe("Tool callback returning null/empty", () => {
     // Empty content (not JSON `null`, not a stringified null) — the UI can
     // still render a result card.
     expect(result?.content).toBe("");
+  });
+
+  it("builds a non-empty model-bound tool result for empty content", () => {
+    // Render-only frontend tools (CopilotKit `useComponent`) produce an empty
+    // client tool result. The UI event stays empty (above), but the
+    // model-bound tool message must NOT be empty — OpenAI rejects tool
+    // messages with empty content (HTTP 400, STRANDS_ERROR).
+    for (const empty of ["", "   ", null, undefined, []]) {
+      const block = _buildToolResultContent(empty) as { text?: string };
+      expect(block.text).toBeTruthy();
+      expect((block.text ?? "").trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("leaves non-empty text and JSON tool results unchanged", () => {
+    expect(_buildToolResultContent("hello")).toEqual({ text: "hello" });
+    expect(_buildToolResultContent('{"accepted":true}')).toEqual({
+      json: { accepted: true },
+    });
   });
 });

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -170,12 +170,19 @@ function _coerceText(content: unknown): string {
  * JSON object/array, emit it as `{ json: parsed }` so the LLM sees a real
  * structured result. Fall back to `{ text: ... }` for everything else.
  */
-function _buildToolResultContent(
+export function _buildToolResultContent(
   content: unknown,
 ): { text: string } | { json: unknown } {
   const text = _coerceText(content);
   const trimmed = text.trim();
-  if (trimmed.length === 0) return { text };
+  // Render-only frontend tools (e.g. CopilotKit `useComponent`) legitimately
+  // produce an empty client tool result. Forwarding an empty `text` block to
+  // the Strands model reaches OpenAI, which rejects tool messages with empty
+  // content (HTTP 400). Synthesize a non-empty acknowledgement instead — this
+  // matches the Python adapter's behavior. The UI-bound TOOL_CALL_RESULT event
+  // is emitted on a separate path and stays faithfully empty.
+  if (trimmed.length === 0)
+    return { text: "Tool executed successfully with no return value." };
   const first = trimmed[0];
   if (first !== "{" && first !== "[") return { text };
   try {


### PR DESCRIPTION
## Problem

On the strands-typescript integration with real OpenAI (gpt-4o), any demo using a **render-only frontend tool** (gen-ui tool-based charts, beautiful-chat theme toggle + charts) rendered the UI but then the run died with:

> `Tool result for toolUseId "..." has empty content. OpenAI requires tool messages to have non-empty content.` (`runtimeErrorCode: STRANDS_ERROR`)

The empty result poisoned the thread — subsequent turns got no reply. The Python sibling adapter does **not** have this bug.

## Root cause

`_buildToolResultContent` in `integrations/aws-strands/typescript/src/agent.ts` returned `{ text: "" }` when the incoming AG-UI tool message content was empty. That empty-text `toolResult` block is forwarded to the Strands model → OpenAI → HTTP 400. Render-only frontend tools (CopilotKit `useComponent`) legitimately produce an empty client tool result, so this path was hit routinely.

## Fix

`_buildToolResultContent` now synthesizes a non-empty acknowledgement (`"Tool executed successfully with no return value."`) for empty content — matching the Python adapter (`agent.py` ~L768-776). Non-empty text and JSON tool results are unchanged.

The UI-bound `TOOL_CALL_RESULT` event is emitted on a separate path and **stays faithfully empty** — only the model-bound message gets the placeholder.

## Tests

- Kept the existing assertion that the UI `TOOL_CALL_RESULT` content is `""`.
- Added: `_buildToolResultContent` returns non-empty text for empty inputs (`""`, whitespace, `null`, `undefined`, `[]`).
- Added: non-empty text and JSON results pass through unchanged.
- Full adapter vitest suite green (237 tests); `tsc --noEmit` clean.