### PR TITLE
fix(aws-strands): drain stranded tool calls before RUN_FINISHED on halt

### DIFF
--- a/integrations/aws-strands/typescript/package.json
+++ b/integrations/aws-strands/typescript/package.json
@@ -66,6 +66,7 @@
     "cors": "^2.8.5",
     "express": "^5.0.0",
     "publint": "^0.3.12",
+    "rxjs": "7.8.1",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
     "vitest": "^4.0.18",

--- a/integrations/aws-strands/typescript/src/__tests__/parallel-tool-calls.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/parallel-tool-calls.test.ts
@@ -7,12 +7,18 @@
  * Scenario B – New tool calls must not be suppressed by a pending tool result
  *              on continuation turns.
  * Scenario C – Backend tool results must not leak after halt flag is set.
+ * Scenario D – A stopStreamingAfterResult halt must drain sibling parallel
+ *              tool calls (emit TOOL_CALL_END) before RUN_FINISHED, so the
+ *              AG-UI client verifier does not reject with INCOMPLETE_STREAM.
  */
 
 import { describe, it, expect } from "vitest";
 import { ToolUseBlock, TextBlock, ToolResultBlock } from "@strands-agents/sdk";
 import type { AgentStreamEvent } from "@strands-agents/sdk";
 import { EventType } from "@ag-ui/core";
+import type { BaseEvent } from "@ag-ui/core";
+import { verifyEvents } from "@ag-ui/client";
+import { from, lastValueFrom, toArray } from "rxjs";
 
 import type { StrandsAgentConfig } from "../config";
 import {
@@ -257,5 +263,93 @@ describe("No backend result leak after halt", () => {
     expect(resultIds).toContain("st1");
     expect(resultIds).not.toContain("st2");
     expect(resultEvents).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario D – stopStreamingAfterResult halt drains stranded sibling calls
+// ---------------------------------------------------------------------------
+
+describe("stopStreamingAfterResult halt drains stranded parallel tool calls", () => {
+  // Repro of the showcase "Chain tools" crash: gpt-4o fans out several
+  // parallel tool calls in one turn; the streaming model opens TOOL_CALL_START
+  // for each, but the stopStreamingAfterResult tool (get_weather) returns and
+  // halts the stream before the siblings reach their contentBlockStop. Without
+  // a drain those siblings stay active at RUN_FINISHED and the client verifier
+  // rejects with INCOMPLETE_STREAM.
+  const config: StrandsAgentConfig = {
+    toolBehaviors: {
+      get_weather: { stopStreamingAfterResult: true },
+    },
+  };
+
+  // Interleaved streaming blocks: flights + dice open and emit START via their
+  // first toolUseInputDelta but never receive a blockStop; only get_weather
+  // closes (blockStop) and then returns its result, halting the stream.
+  function haltingStream(): AgentStreamEvent[] {
+    const weatherResult = new ToolResultBlock({
+      toolUseId: "st-weather",
+      status: "success",
+      content: [new TextBlock(JSON.stringify({ temp: 72 }))],
+    });
+    return [
+      stream.toolUseStart("st-flights", "get_flights"),
+      stream.toolUseDelta("{}"),
+      stream.toolUseStart("st-dice", "roll_dice"),
+      stream.toolUseDelta("{}"),
+      stream.toolUseStart("st-weather", "get_weather"),
+      stream.toolUseDelta("{}"),
+      stream.blockStop(),
+      {
+        type: "afterToolCallEvent",
+        toolUse: { toolUseId: "st-weather", name: "get_weather", input: {} },
+        result: weatherResult,
+      } as unknown as AgentStreamEvent,
+    ];
+  }
+
+  it("emits a TOOL_CALL_END for every started call, all before RUN_FINISHED", async () => {
+    const agent = scriptedStrandsAgent(haltingStream(), { config });
+    const events = await collect(agent);
+
+    const startIds = (
+      events.filter((e) => e.type === EventType.TOOL_CALL_START) as unknown as {
+        toolCallId: string;
+      }[]
+    ).map((e) => e.toolCallId);
+    const endIds = (
+      events.filter((e) => e.type === EventType.TOOL_CALL_END) as unknown as {
+        toolCallId: string;
+      }[]
+    ).map((e) => e.toolCallId);
+
+    // All three siblings started; all three must end.
+    expect(new Set(startIds)).toEqual(
+      new Set(["st-flights", "st-dice", "st-weather"]),
+    );
+    expect(new Set(endIds)).toEqual(new Set(startIds));
+
+    // Every TOOL_CALL_END precedes RUN_FINISHED (no still-active calls).
+    const runFinishedIdx = events.findIndex(
+      (e) => e.type === EventType.RUN_FINISHED,
+    );
+    expect(runFinishedIdx).toBeGreaterThanOrEqual(0);
+    const lastEndIdx = events.reduce(
+      (acc, e, i) => (e.type === EventType.TOOL_CALL_END ? i : acc),
+      -1,
+    );
+    expect(lastEndIdx).toBeLessThan(runFinishedIdx);
+  });
+
+  it("the AG-UI client verifier accepts the stream", async () => {
+    const agent = scriptedStrandsAgent(haltingStream(), { config });
+    const events = await collect(agent);
+
+    // verifyEvents throws (INCOMPLETE_STREAM) on RUN_FINISHED with active tool
+    // calls. lastValueFrom rejects if the operator errors.
+    const verified = await lastValueFrom(
+      from(events as BaseEvent[]).pipe(verifyEvents(), toArray()),
+    );
+    expect(verified.length).toBe(events.length);
   });
 });

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -220,6 +220,30 @@ function _resolveToolUseId(
 }
 
 /**
+ * Emit a TOOL_CALL_END for every tracked tool call that started but never
+ * ended, so the stream is left with no active tool calls.
+ *
+ * Parallel tool fan-out (e.g. gpt-4o chaining weather + flights + dice in one
+ * turn) can leave sibling calls mid-flight: when a `stopStreamingAfterResult`
+ * tool returns first it halts the stream before the other calls reach their
+ * `contentBlockStop`/TOOL_CALL_END. Without draining them, the terminal
+ * RUN_FINISHED trips the AG-UI client verifier's "tool calls still active"
+ * guard (runtimeErrorCode INCOMPLETE_STREAM). Idempotent: flips `endEmitted`
+ * so a second drain (or a normal-path call after the events already went out)
+ * is a no-op.
+ */
+function* _drainPendingToolCalls(
+  seen: Map<string, SeenToolCall>,
+): Generator<BaseEvent> {
+  for (const [toolCallId, entry] of seen) {
+    if (entry.startEmitted && !entry.endEmitted) {
+      entry.endEmitted = true;
+      yield { type: EventType.TOOL_CALL_END, toolCallId } as BaseEvent;
+    }
+  }
+}
+
+/**
  * Convert ``RunAgentInput.messages`` to AG-UI message objects.
  *
  * Used to seed the running ``MessagesSnapshotEvent`` payload so each snapshot
@@ -1886,6 +1910,13 @@ export class StrandsAgent {
           };
         }
       }
+
+      // Close out any tool calls still in flight before RUN_FINISHED. On the
+      // halt path (stopStreamingAfterResult) the break above exits the loop
+      // with sibling parallel calls that emitted TOOL_CALL_START but never
+      // reached their TOOL_CALL_END; the normal path drains nothing (all ends
+      // already emitted). Either way the verifier must see zero active calls.
+      yield* _drainPendingToolCalls(toolCallsSeen);
 
       // Final state snapshot with `currentState` verbatim. Unlike the initial
       // snapshot this is not filtered — the initial filter exists only to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)


### PR DESCRIPTION
## Problem

On the strands-typescript integration with real gpt-4o, the tool-rendering catch-all demos (`tool-rendering-default-catchall`, `tool-rendering-custom-catchall`) — the "Chain tools" prompt that chains weather + flights + dice in one turn — throw:

```
Cannot send 'RUN_FINISHED' while tool calls are still active: <call_ids>
```

with `runtimeErrorCode: INCOMPLETE_STREAM`. Single-tool prompts never trip it; the failure tracks gpt-4o's parallel tool fan-out. The error is raised by the AG-UI client verify layer (`sdks/typescript/packages/client/src/verify/verify.ts`).

## Root cause

In `integrations/aws-strands/typescript/src/agent.ts`, when a tool configured with `stopStreamingAfterResult: true` (e.g. showcase `get_weather`) returns, the `afterToolCallEvent` handler sets `haltEventStream` and breaks the stream loop. The terminal section then emits `RUN_FINISHED` **without** first emitting `TOOL_CALL_END` for the other parallel tool calls that already emitted `TOOL_CALL_START` but never reached their `contentBlockStop`. The verifier sees still-active tool calls at `RUN_FINISHED` and rejects.

## Fix

Add `_drainPendingToolCalls(seen)`, which emits a `TOOL_CALL_END` for every tracked call where `startEmitted && !endEmitted`, flipping `endEmitted` so it is idempotent. It is invoked immediately before the terminal `STATE_SNAPSHOT` / `RUN_FINISHED`. Because the halt-break, native-interrupt, and normal-completion paths all flow through that same terminal section, a single drain point covers them all: the halt path closes the stranded siblings, while the normal path is a no-op (every `TOOL_CALL_END` already went out).

## Tests

Adds Scenario D to `parallel-tool-calls.test.ts`: a turn with three parallel **streaming** tool calls where the `stopStreamingAfterResult` tool returns first and halts before the siblings reach `contentBlockStop`. It asserts:

1. every started call gets a `TOOL_CALL_END`, all ordered before `RUN_FINISHED`; and
2. the real AG-UI client verifier (`verifyEvents` from `@ag-ui/client`) accepts the resulting stream.

Both assertions fail on `main` (confirmed by disabling the drain) and pass with the fix. Full adapter suite green (237 tests). `rxjs` was added as a devDependency so the test can feed events through `verifyEvents` (an rxjs operator); the lockfile change is the minimal +3-line importer entry and passes `--frozen-lockfile`.