### PR TITLE
chore(dart): add .pubignore to exclude tests/build artifacts from published package

### DIFF
--- a/sdks/community/dart/.pubignore
+++ b/sdks/community/dart/.pubignore
@@ -1,0 +1,10 @@
+# Files to exclude from the package published to pub.dev (gitignore syntax).
+# pub.dev only needs lib/, example/, and the docs to serve and score the
+# package; the test suite and build artifacts add weight without value.
+#
+# 0.1.0 unintentionally shipped test/ (plus large committed artifacts in
+# example/). Keep 0.3.0+ lean and, in particular, never ship compiled kernel
+# (.dill) or disabled (.skip) files.
+test/
+*.dill
+*.skip


### PR DESCRIPTION
## What

Adds `sdks/community/dart/.pubignore` excluding `test/`, `*.dill`, and `*.skip` from the package published to pub.dev.

## Why

A local `dart pub publish --dry-run` of the current `0.3.0` tree showed the package ships the entire `test/` directory — including:
- `test/client/config_test.dill` — a **committed 10 MB compiled-kernel artifact**
- `test/sse/sse_client_test.dart.skip` — a disabled test

pub.dev only needs `lib/`, `example/`, and docs. With this `.pubignore`, the dry-run archive drops from **~3 MB to ~111 KB** with no change to the library API or examples.

## Verification (local, Dart 3.12.2)

| | Before | After |
|---|---|---|
| `dart pub publish --dry-run` archive | ~3 MB (incl. 10 MB `.dill`) | **111 KB** |
| Published top-level | `lib/ example/ test/ + docs` | `lib/ example/ + docs` |
| `dart test --exclude-tags requires-server` | 722 pass | 722 pass (unaffected) |

Context: `0.1.0` also unintentionally shipped `test/` (plus a 6.5 MB binary and 4.75 MB text file in `example/`, since removed). This keeps `0.3.0+` lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)