### PR TITLE
docs: clarify client-provided run tools

### DIFF
--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -8,9 +8,13 @@ description:
 
 Tools are a fundamental concept in the AG-UI protocol that enable AI agents to
 interact with external systems and incorporate human judgment into their
-workflows. By defining tools in the frontend and passing them to agents,
-developers can create sophisticated human-in-the-loop experiences that combine
-AI capabilities with human expertise.
+workflows.
+
+AG-UI distinguishes between tools that are defined by the agent backend and
+tools that are provided by the client at runtime. Backend-defined tools stay in
+the backend agent or framework configuration. Client-defined tools are passed in
+`RunAgentInput.tools` so the agent can call back into application-specific
+frontend behavior, such as UI actions, approvals, or user-mediated workflows.
 
 ## What Are Tools?
 
@@ -93,6 +97,12 @@ This approach has several advantages:
    tool implementation
 4. **Security**: Sensitive operations are controlled by the application, not the
    agent
+
+`RunAgentInput.tools` is only for these client-provided tools. It is not
+intended to contain every tool available to the backend agent. If your
+integration has backend tools, define them in the backend framework or advertise
+them through agent capabilities instead of sending their schemas from the
+client.
 
 ## Tool Call Lifecycle
 

--- a/docs/sdk/js/core/types.mdx
+++ b/docs/sdk/js/core/types.mdx
@@ -16,6 +16,10 @@ documents these types and their properties.
 Input parameters for running an agent. In the HTTP API, this is the body of the
 `POST` request.
 
+`tools` contains tools provided by the client for this run. Backend-defined
+tools should remain in the backend agent or framework configuration, and may be
+advertised separately through agent capabilities.
+
 ```typescript
 type RunAgentInput = {
   threadId: string
@@ -36,7 +40,7 @@ type RunAgentInput = {
 | `parentRunId`    | `string (optional)` | ID of the run that spawned this run            |
 | `state`          | `any`               | Current state of the agent                     |
 | `messages`       | `Message[]`         | Array of messages in the conversation          |
-| `tools`          | `Tool[]`            | Array of tools available to the agent          |
+| `tools`          | `Tool[]`            | Client-provided tools available for this run   |
 | `context`        | `Context[]`         | Array of context objects provided to the agent |
 | `forwardedProps` | `any`               | Additional properties forwarded to the agent   |
 
@@ -404,19 +408,19 @@ interface AgentCapabilities {
 }
 ```
 
-| Property         | Type                              | Description                                  |
-| ---------------- | --------------------------------- | -------------------------------------------- |
-| `identity`       | `IdentityCapabilities`            | Agent identity and metadata                  |
-| `transport`      | `TransportCapabilities`           | Supported transport mechanisms               |
-| `tools`          | `ToolsCapabilities`               | Agent-provided tools and tool calling config |
-| `output`         | `OutputCapabilities`              | Output format support                        |
-| `state`          | `StateCapabilities`               | State and memory management                  |
-| `multiAgent`     | `MultiAgentCapabilities`          | Multi-agent coordination                     |
-| `reasoning`      | `ReasoningCapabilities`           | Reasoning and thinking support               |
-| `multimodal`     | `MultimodalCapabilities`          | Multimodal input/output support              |
-| `execution`      | `ExecutionCapabilities`           | Execution control and limits                 |
-| `humanInTheLoop` | `HumanInTheLoopCapabilities`      | Human-in-the-loop support                    |
-| `custom`         | `Record<string, unknown>`         | Integration-specific capabilities            |
+| Property         | Type                         | Description                                  |
+| ---------------- | ---------------------------- | -------------------------------------------- |
+| `identity`       | `IdentityCapabilities`       | Agent identity and metadata                  |
+| `transport`      | `TransportCapabilities`      | Supported transport mechanisms               |
+| `tools`          | `ToolsCapabilities`          | Agent-provided tools and tool calling config |
+| `output`         | `OutputCapabilities`         | Output format support                        |
+| `state`          | `StateCapabilities`          | State and memory management                  |
+| `multiAgent`     | `MultiAgentCapabilities`     | Multi-agent coordination                     |
+| `reasoning`      | `ReasoningCapabilities`      | Reasoning and thinking support               |
+| `multimodal`     | `MultimodalCapabilities`     | Multimodal input/output support              |
+| `execution`      | `ExecutionCapabilities`      | Execution control and limits                 |
+| `humanInTheLoop` | `HumanInTheLoopCapabilities` | Human-in-the-loop support                    |
+| `custom`         | `Record<string, unknown>`    | Integration-specific capabilities            |
 
 See [Capabilities](/concepts/capabilities) for the full category type
 definitions and usage patterns.

--- a/docs/sdk/python/core/types.mdx
+++ b/docs/sdk/python/core/types.mdx
@@ -18,6 +18,10 @@ documents these types and their properties.
 Input parameters for running an agent. In the HTTP API, this is the body of the
 `POST` request.
 
+`tools` contains tools provided by the client for this run. Backend-defined
+tools should remain in the backend agent or framework configuration, and may be
+advertised separately through agent capabilities.
+
 ```python
 class RunAgentInput(ConfiguredBaseModel):
     thread_id: str
@@ -37,7 +41,7 @@ class RunAgentInput(ConfiguredBaseModel):
 | `parent_run_id`   | `Optional[str]` | (Optional) ID of the run that spawned this run |
 | `state`           | `Any`           | Current state of the agent                     |
 | `messages`        | `List[Message]` | List of messages in the conversation           |
-| `tools`           | `List[Tool]`    | List of tools available to the agent           |
+| `tools`           | `List[Tool]`    | Client-provided tools available for this run   |
 | `context`         | `List[Context]` | List of context objects provided to the agent  |
 | `forwarded_props` | `Any`           | Additional properties forwarded to the agent   |
 

--- a/docs/sdk/ruby/core/types.mdx
+++ b/docs/sdk/ruby/core/types.mdx
@@ -1,13 +1,15 @@
 ---
 title: "Types"
-description: "Documentation for the core types used in the Agent User Interaction Protocol (Ruby SDK)"
+description:
+  "Documentation for the core types used in the Agent User Interaction Protocol
+  (Ruby SDK)"
 ---
 
 # Core Types
 
 The Agent User Interaction Protocol Ruby SDK is built on a set of core types
-that represent the fundamental structures used throughout the system. This
-page documents these types and their properties.
+that represent the fundamental structures used throughout the system. This page
+documents these types and their properties.
 
 ## AudioInputContent
 
@@ -94,8 +96,7 @@ content = AgUiProtocol::Core::Types::ImageInputContent.new(
 
 `AgUiProtocol::Core::Types::InputContentDataSource`
 
-Represents a data source for multimodal input content using base64-encoded
-data.
+Represents a data source for multimodal input content using base64-encoded data.
 
 ```ruby
 
@@ -226,8 +227,12 @@ AgUiProtocol::Core::Types::Role # => ["developer", "system", "assistant",
 
 `AgUiProtocol::Core::Types::RunAgentInput`
 
-Input parameters for running an agent. In the HTTP API, this is the body of
-the `POST` request.
+Input parameters for running an agent. In the HTTP API, this is the body of the
+`POST` request.
+
+`tools` contains tools provided by the client for this run. Backend-defined
+tools should remain in the backend agent or framework configuration, and may be
+advertised separately through agent capabilities.
 
 ```ruby
 
@@ -251,7 +256,7 @@ input = AgUiProtocol::Core::Types::RunAgentInput.new(
 | `run_id`          | `String`                              | ID of the current run                                      |
 | `state`           | `Object`                              | Current state of the agent                                 |
 | `messages`        | `Array<BaseMessage, ActivityMessage>` | List of messages in the conversation                       |
-| `tools`           | `Array<Tool>`                         | List of tools available to the agent                       |
+| `tools`           | `Array<Tool>`                         | Client-provided tools available for this run               |
 | `context`         | `Array<Context>`                      | List of context objects provided to the agent              |
 | `forwarded_props` | `Object`                              | Additional properties forwarded to the agent               |
 | `parent_run_id`   | `String` (optional)                   | Lineage pointer for branching/time travel. Default: `nil`. |
@@ -425,7 +430,7 @@ content = AgUiProtocol::Core::Types::BinaryInputContent.new(
 ```
 
 > <strong>Validation:</strong> At least one of `id`, `url`, or `data` must be
-provided.
+> provided.
 
 | Property    | Type                | Description                                                    |
 | ----------- | ------------------- | -------------------------------------------------------------- |
@@ -541,15 +546,16 @@ msg = AgUiProtocol::Core::Types::UserMessage.new(
 
 ```
 
-| Property          | Type                                                                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`              | `String`                                                                                                                                   | Unique identifier for the message                                                                                                                                                                                                                                                                                                                                                     |
-| `content`         | `String, Array<TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent, Hash>` | Accepted shapes: a String for plain text, or an Array whose elements are either *InputContent Models (TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent) OR Hashes with a `type:` key (`text`, `binary`, `image`, `audio`, `video`, `document`); Hash entries are normalized internally to the corresponding Model. |
-| `name`            | `String` (optional)                                                                                                                        | Optional name of the sender. Default: `nil`.                                                                                                                                                                                                                                                                                                                                          |
-| `encrypted_value` | `String` (optional)                                                                                                                        | Encrypted content for zero-data-retention mode. Default: `nil`.                                                                                                                                                                                                                                                                                                                       |
+| Property          | Type                                                                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | `String`                                                                                                                                   | Unique identifier for the message                                                                                                                                                                                                                                                                                                                                                      |
+| `content`         | `String, Array<TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent, Hash>` | Accepted shapes: a String for plain text, or an Array whose elements are either \*InputContent Models (TextInputContent, BinaryInputContent, ImageInputContent, AudioInputContent, VideoInputContent, DocumentInputContent) OR Hashes with a `type:` key (`text`, `binary`, `image`, `audio`, `video`, `document`); Hash entries are normalized internally to the corresponding Model. |
+| `name`            | `String` (optional)                                                                                                                        | Optional name of the sender. Default: `nil`.                                                                                                                                                                                                                                                                                                                                           |
+| `encrypted_value` | `String` (optional)                                                                                                                        | Encrypted content for zero-data-retention mode. Default: `nil`.                                                                                                                                                                                                                                                                                                                        |
 
 ## State
 
 `State` is represented as `Any`.
 
-The state type is flexible and can hold any data structure needed by the agent implementation.
+The state type is flexible and can hold any data structure needed by the agent
+implementation.


### PR DESCRIPTION
## Problem

`RunAgentInput.tools` was documented as the tools available to the agent, which made it sound like clients should send every backend-defined tool schema with each run.

## Why

AG-UI separates backend/agent tools from client-provided tools. Backend-defined tools should stay in the backend agent or framework configuration, and may be advertised through agent capabilities. `RunAgentInput.tools` is for tools provided by the client at runtime, such as frontend actions, approvals, or user-mediated workflows.

## Fix

- Clarify the tools concept page distinction between backend-defined tools and client-provided tools.
- Update the JavaScript, Python, and Ruby `RunAgentInput` references to describe `tools` as client-provided.
- Point backend-defined tools to backend configuration or agent capabilities instead of `RunAgentInput.tools`.

Fix #142
