### PR TITLE
fix(aws-strands): single forced render_a2ui turn so dynamic A2UI run completes

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
@@ -32,8 +32,6 @@ import threading
 import uuid
 from typing import Any, Callable, Optional
 
-from strands import Agent
-from strands.tools.tools import PythonAgentTool
 from strands.types._events import ToolResultEvent, ToolStreamEvent
 from strands.types.tools import AgentTool, ToolSpec, ToolUse
 
@@ -244,117 +242,131 @@ async def _stream_render_subagent(
     push: Callable[[dict], None],
     catalog_id: Optional[str] = None,
 ) -> Optional[dict]:
-    """Run the structured-output sub-agent once: bind a ``render_a2ui`` tool,
-    stream the model, push per-event render progress (start / args deltas /
-    end) via ``push``, and return the captured ``render_a2ui`` args — or
-    ``None`` if the model produced no call.
+    """Run a SINGLE forced ``render_a2ui`` model call and return the captured
+    args — or ``None`` if the model produced no call.
 
-    ``catalog_id`` (the host-resolved ``default_catalog_id``) is stamped into the
-    streamed args. The model never emits ``catalogId`` — the render schema omits
-    it and the host owns the catalog — so without this the progressive paint in
-    ``@ag-ui/a2ui-middleware`` (which reads ``catalogId`` off the streamed args)
-    falls back to the basic catalog and the renderer throws "Catalog not found".
-    The id matches what ``build_a2ui_envelope`` stamps on the final surface, so
-    the progressive and committed surfaces agree."""
+    Mirrors the LangGraph adapter's single forced structured-output turn
+    (``bind_tools([RENDER_A2UI_TOOL_DEF], tool_choice="render_a2ui")`` + one
+    ``astream``): we call the model DIRECTLY (not a Strands ``Agent``), so there
+    is no agentic loop. The model emits exactly one ``render_a2ui`` tool call and
+    we stop. A full ``Agent`` loop would EXECUTE the bound render tool and then
+    fire a SECOND model call to continue the turn — and with the "render the
+    surface" system prompt that continuation re-invokes render (or never settles
+    on a terminal text turn). The sub-agent stream would then never end, so the
+    outer ``generate_a2ui`` tool never returns its result and the run never emits
+    RUN_FINISHED (the surface paints, but the call hangs). The forced single turn
+    is the fix.
+
+    Streams ``render_a2ui``'s arg fragments to the AG-UI wire (start / args
+    deltas / end) via ``push`` so the a2ui middleware paints progressively.
+    ``catalog_id`` (the host-resolved ``default_catalog_id``) is spliced into the
+    first chunk: the model never emits ``catalogId`` (the render schema omits it
+    and the host owns the catalog), so without it the progressive paint in
+    ``@ag-ui/a2ui-middleware`` falls back to the basic catalog and the renderer
+    throws "Catalog not found". The splice affects only the EMITTED delta, never
+    the captured args — the committed envelope stamps the id via
+    ``build_a2ui_envelope`` so the progressive and committed surfaces agree."""
+    render_spec: ToolSpec = {
+        "name": RENDER_A2UI_TOOL_NAME,
+        "description": RENDER_A2UI_TOOL_DEF["function"]["description"],
+        "inputSchema": {"json": RENDER_A2UI_TOOL_DEF["function"]["parameters"]},
+    }
+
     captured: dict | None = None
-
-    def _capture(tool_use: ToolUse, **_kwargs: Any):
-        nonlocal captured
-        raw = tool_use.get("input")
-        captured = raw if isinstance(raw, dict) else {}
-        return {
-            "toolUseId": tool_use["toolUseId"],
-            "status": "success",
-            "content": [{"text": "ok"}],
-        }
-
-    render_tool = PythonAgentTool(
-        tool_name=RENDER_A2UI_TOOL_NAME,
-        tool_spec={
-            "name": RENDER_A2UI_TOOL_NAME,
-            "description": RENDER_A2UI_TOOL_DEF["function"]["description"],
-            "inputSchema": {"json": RENDER_A2UI_TOOL_DEF["function"]["parameters"]},
-        },
-        tool_func=_capture,
-    )
-
-    subagent = Agent(
-        model=model,
-        system_prompt=prompt,
-        messages=list(messages),
-        tools=[render_tool],
-    )
-
+    accumulated = ""
     live_call_id: Optional[str] = None
-    emitted_len = 0
     # Whether the host ``catalog_id`` has been spliced into the streamed args
-    # for the current call yet (reset per call below).
+    # for the current call yet (reset per render-block start below).
     catalog_prefixed = False
-    # Per-invocation fallback id: providers that never stamp toolUseId must
-    # not reuse one literal id across recovery attempts (two full lifecycles
-    # under one toolCallId would mis-merge in id-keyed consumers).
+    # Fallback id for providers that don't stamp a toolUseId on the start frame.
     fallback_call_id = f"a2ui-render-{uuid.uuid4().hex[:8]}"
+
+    def _finish_call() -> None:
+        # The model streams render_a2ui's args as a JSON string (partial
+        # fragments reconstruct into the full object). Parse the accumulated raw
+        # string — NOT the catalog-spliced stream — so the committed args are the
+        # model's own (catalogId is stamped by build_a2ui_envelope).
+        nonlocal captured
+        try:
+            captured = json.loads(accumulated) if accumulated.strip() else {}
+        except (json.JSONDecodeError, TypeError):
+            captured = {}
+
     try:
-        async for event in subagent.stream_async(None):
+        async for event in model.stream(
+            messages,
+            tool_specs=[render_spec],
+            system_prompt=prompt,
+            tool_choice={"tool": {"name": RENDER_A2UI_TOOL_NAME}},
+        ):
             if not isinstance(event, dict):
                 continue
-            current = event.get("current_tool_use")
-            if not isinstance(current, dict) or current.get("name") != RENDER_A2UI_TOOL_NAME:
+
+            block_start = event.get("contentBlockStart")
+            if isinstance(block_start, dict):
+                tool_use = (block_start.get("start") or {}).get("toolUse")
+                if (
+                    isinstance(tool_use, dict)
+                    and tool_use.get("name") == RENDER_A2UI_TOOL_NAME
+                ):
+                    # New render block. Close any still-open one first so the
+                    # synthetic stream never leaves an unclosed inner
+                    # TOOL_CALL_START (mirrors the TS adapter's per-start reset).
+                    if live_call_id is not None:
+                        push({"kind": "end", "tool_call_id": live_call_id})
+                    live_call_id = tool_use.get("toolUseId") or fallback_call_id
+                    accumulated = ""
+                    catalog_prefixed = False
+                    push(
+                        {
+                            "kind": "start",
+                            "tool_call_id": live_call_id,
+                            "tool_call_name": RENDER_A2UI_TOOL_NAME,
+                        }
+                    )
                 continue
-            raw_call_id = current.get("toolUseId")
-            call_id = raw_call_id or live_call_id or fallback_call_id
-            if live_call_id == fallback_call_id and raw_call_id:
-                # The provider delivered the real toolUseId only after id-less
-                # frames: same logical call — keep the latched fallback id so the
-                # synthetic stream stays continuous (no spurious end/start and no
-                # duplicate prefix re-push under the new id). Residual: a DISTINCT
-                # second call after an entirely id-less first would merge into it
-                # — accepted; real providers stamp ids, and the envelope rides the
-                # captured args, not these deltas.
-                call_id = live_call_id
-            if call_id != live_call_id:
-                # New render call (normally the only one). Close any previous call
-                # first so streamed args DELTAS never mis-attribute across call ids
-                # (mirrors the TS adapter's per-toolUseStart reset). NOTE: the
-                # dict-input fallback below still emits the single shared
-                # `captured` under the LAST call id — exact per-call capture isn't
-                # worth the bookkeeping for a path models shouldn't take.
-                if live_call_id is not None:
-                    push({"kind": "end", "tool_call_id": live_call_id})
-                live_call_id = call_id
-                emitted_len = 0
-                catalog_prefixed = False
-                push(
-                    {
-                        "kind": "start",
-                        "tool_call_id": call_id,
-                        "tool_call_name": RENDER_A2UI_TOOL_NAME,
-                    }
+
+            block_delta = event.get("contentBlockDelta")
+            if isinstance(block_delta, dict) and live_call_id is not None:
+                tool_use_delta = (block_delta.get("delta") or {}).get("toolUse")
+                frag = (
+                    tool_use_delta.get("input")
+                    if isinstance(tool_use_delta, dict)
+                    else None
                 )
-            raw = current.get("input")
-            if isinstance(raw, str) and len(raw) > emitted_len:
-                delta = raw[emitted_len:]
-                # Stamp the host catalog id into the FIRST chunk by splicing it
-                # right after the opening brace, so the accumulated args become
-                # ``{"catalogId": "<id>", ...}`` — valid JSON the middleware's
-                # progressive paint reads the id from. The model never emits it.
-                if catalog_id and not catalog_prefixed:
-                    brace = delta.find("{")
-                    if brace != -1:
-                        delta = (
-                            delta[: brace + 1]
-                            + f'"catalogId": {json.dumps(catalog_id)}, '
-                            + delta[brace + 1 :]
-                        )
-                        catalog_prefixed = True
-                push(
-                    {
-                        "kind": "args",
-                        "tool_call_id": live_call_id,
-                        "delta": delta,
-                    }
-                )
-                emitted_len = len(raw)
+                if isinstance(frag, str) and frag:
+                    accumulated += frag
+                    # Splice the host catalog id into the FIRST chunk (right after
+                    # the opening brace) so the streamed args read as
+                    # ``{"catalogId": "<id>", ...}`` — valid JSON the middleware
+                    # progressive paint reads the id from.
+                    if catalog_id and not catalog_prefixed:
+                        brace = frag.find("{")
+                        if brace != -1:
+                            frag = (
+                                frag[: brace + 1]
+                                + f'"catalogId": {json.dumps(catalog_id)}, '
+                                + frag[brace + 1 :]
+                            )
+                            catalog_prefixed = True
+                    push(
+                        {
+                            "kind": "args",
+                            "tool_call_id": live_call_id,
+                            "delta": frag,
+                        }
+                    )
+                continue
+
+            # `contentBlockStop` carries an (often empty) dict, so test for the
+            # KEY, not truthiness.
+            if "contentBlockStop" in event and live_call_id is not None:
+                push({"kind": "end", "tool_call_id": live_call_id})
+                _finish_call()
+                live_call_id = None
+                # Single forced turn: the render call is complete. Stop the
+                # stream so no continuation model call ever fires.
+                break
     except BaseException:
         # The provider stream died mid-call (model 429, network drop, ...):
         # close the live synthetic call before unwinding — an unclosed inner
@@ -368,46 +380,14 @@ async def _stream_render_subagent(
                 # original exception (e.g. a CancelledError) mid-unwind.
                 pass
         raise
-    if live_call_id is None and captured is not None:
-        # The provider invoked the bound render tool without emitting any
-        # current_tool_use stream frames: synthesize the full triplet so the
-        # middleware still sees components before the result (no bulk paint).
-        live_call_id = fallback_call_id
-        push(
-            {
-                "kind": "start",
-                "tool_call_id": live_call_id,
-                "tool_call_name": RENDER_A2UI_TOOL_NAME,
-            }
-        )
-        push(
-            {
-                "kind": "args",
-                "tool_call_id": live_call_id,
-                "delta": json.dumps(
-                    {**captured, "catalogId": catalog_id} if catalog_id else captured
-                ),
-            }
-        )
+
+    # Stream ended without a per-block ``contentBlockStop`` for the live call
+    # (some providers close the message without one): close + capture so the
+    # middleware still sees the end and the recovery loop gets the args.
+    if live_call_id is not None:
         push({"kind": "end", "tool_call_id": live_call_id})
-    elif live_call_id is not None:
-        # Some providers deliver the input as a parsed dict (no raw growth); if
-        # nothing streamed, emit the captured args as one delta so the
-        # middleware still sees the components before the result. (Providers
-        # are assumed not to MIX shapes within one call — a str-then-dict
-        # switch would leave the streamed deltas truncated; paint still
-        # completes from the captured args in the result envelope.)
-        if emitted_len == 0 and captured is not None:
-            push(
-                {
-                    "kind": "args",
-                    "tool_call_id": live_call_id,
-                    "delta": json.dumps(
-                        {**captured, "catalogId": catalog_id} if catalog_id else captured
-                    ),
-                }
-            )
-        push({"kind": "end", "tool_call_id": live_call_id})
+        _finish_call()
+
     return captured
 
 

--- a/integrations/aws-strands/python/tests/test_a2ui_tool.py
+++ b/integrations/aws-strands/python/tests/test_a2ui_tool.py
@@ -646,6 +646,33 @@ async def test_stream_drains_all_pushed_events_through_executor(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_generate_tool_single_forced_render_call_and_returns_envelope():
+    """Regression for the dynamic-A2UI hang: driving the tool's real stream()
+    against a fake model, the sub-agent must fire EXACTLY ONE forced render_a2ui
+    model call (no agentic continuation that would never settle), and the tool
+    must yield the committed envelope so the outer Strands loop can emit
+    RUN_FINISHED instead of hanging on a still-Running generate_a2ui."""
+    calls: list = []
+
+    class FakeModel:
+        async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+            calls.append(kwargs.get("tool_choice"))
+            yield _block_start()
+            yield _block_delta(
+                '{"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}'
+            )
+            yield _BLOCK_STOP
+
+    tool = get_a2ui_tools({"model": FakeModel()})
+    events = await _drive_stream(tool)
+
+    # Single forced turn — the model is called once, forced to render_a2ui.
+    assert calls == [{"tool": {"name": RENDER_A2UI_TOOL_NAME}}]
+    # The committed envelope reaches the outer loop (the run can finish).
+    assert A2UI_OPS_KEY in str(events[-1])
+
+
+@pytest.mark.asyncio
 async def test_stream_update_intent_without_prior_returns_error_envelope(monkeypatch):
     """intent='update' with an unknown surface short-circuits to an error
     envelope (no recovery loop, no sub-agent call)."""
@@ -703,41 +730,56 @@ async def test_stream_programmer_error_propagates(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _stream_render_subagent — the REAL streaming translation (faked Agent)
+# _stream_render_subagent — the REAL streaming translation (faked model.stream)
 # ---------------------------------------------------------------------------
 
 
+def _block_start(tool_use_id="r1", name=RENDER_A2UI_TOOL_NAME):
+    return {"contentBlockStart": {"start": {"toolUse": {"name": name, "toolUseId": tool_use_id}}}}
+
+
+def _block_delta(fragment):
+    return {"contentBlockDelta": {"delta": {"toolUse": {"input": fragment}}}}
+
+
+_BLOCK_STOP = {"contentBlockStop": {}}
+
+
+def _fake_stream_model(events):
+    """A minimal Strands ``Model`` stand-in whose ``stream`` replays raw
+    ``StreamEvent`` dicts. ``_stream_render_subagent`` now drives the model
+    DIRECTLY (single forced render_a2ui turn), so the fakes mirror the model
+    streaming protocol rather than the old ``Agent`` loop."""
+
+    class FakeModel:
+        async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+            # The forced single turn must request exactly the render tool.
+            assert kwargs.get("tool_choice") == {"tool": {"name": RENDER_A2UI_TOOL_NAME}}
+            for ev in events:
+                yield ev
+
+    return FakeModel()
+
+
 @pytest.mark.asyncio
-async def test_render_subagent_streams_raw_arg_growth_as_deltas(monkeypatch):
-    """Direct coverage of ``_stream_render_subagent`` (OpenAI-chat provider
-    shape): the growing ``current_tool_use.input`` string must become start +
-    incremental args deltas + end, all under the live toolUseId."""
+async def test_render_subagent_streams_arg_fragments_as_deltas():
+    """Direct coverage of ``_stream_render_subagent``: a forced render_a2ui model
+    call's streamed toolUse input fragments become start + incremental args
+    deltas + end (all under the live toolUseId), and the accumulated JSON is
+    captured for the recovery loop."""
     import ag_ui_strands.a2ui_tool as mod
 
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            self._tools = kwargs.get("tools") or []
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"surf',
-                }
-            }
-            yield {"unrelated_event": True}
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"surfaceId": "s1"}',
-                }
-            }
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
+    events = [
+        _block_start(),
+        _block_delta('{"surf'),
+        {"unrelated_event": True},
+        _block_delta('aceId": "s1"}'),
+        _BLOCK_STOP,
+    ]
     pushed = []
-    captured = await mod._stream_render_subagent(STUB_MODEL, "prompt", [], pushed.append)
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append
+    )
 
     kinds = [p["kind"] for p in pushed]
     assert kinds == ["start", "args", "args", "end"]
@@ -746,121 +788,84 @@ async def test_render_subagent_streams_raw_arg_growth_as_deltas(monkeypatch):
         == '{"surfaceId": "s1"}'
     )
     assert all(p["tool_call_id"] == "r1" for p in pushed)
-    # The fake never invoked the render tool: no captured args -> the recovery
-    # loop records a no-call attempt.
+    assert captured == {"surfaceId": "s1"}
+
+
+@pytest.mark.asyncio
+async def test_render_subagent_single_chunk_input_is_captured():
+    """A provider that delivers the whole render_a2ui args in ONE toolUse delta
+    still emits start + one args delta + end, and parses the captured object."""
+    import ag_ui_strands.a2ui_tool as mod
+
+    full = '{"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}'
+    events = [_block_start(), _block_delta(full), _BLOCK_STOP]
+    pushed = []
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append
+    )
+
+    assert [p["kind"] for p in pushed] == ["start", "args", "end"]
+    assert captured == {
+        "surfaceId": "s1",
+        "components": [{"id": "root", "component": "Row"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_render_subagent_no_render_call_returns_none():
+    """A turn that emits no render_a2ui block (e.g. text only) captures nothing
+    and pushes nothing — the recovery loop records a no-call attempt."""
+    import ag_ui_strands.a2ui_tool as mod
+
+    events = [
+        {"contentBlockStart": {"start": {"text": {}}}},
+        {"contentBlockDelta": {"delta": {"text": "hi"}}},
+        _BLOCK_STOP,
+    ]
+    pushed = []
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append
+    )
+    assert pushed == []
     assert captured is None
 
 
 @pytest.mark.asyncio
-async def test_render_subagent_dict_input_falls_back_to_single_delta(monkeypatch):
-    """Direct coverage of the parsed-dict provider shape (Anthropic/Gemini
-    deliver ``input`` as a dict with no raw string growth): the captured args
-    must be emitted as ONE args delta before ``end`` so the middleware still
-    sees the components before the result."""
-    import ag_ui_strands.a2ui_tool as mod
-
-    args = {"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}
-
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            self._tools = kwargs.get("tools") or []
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": dict(args),
-                }
-            }
-            # The model "invokes" the bound render tool, which captures args.
-            async for _ in self._tools[0].stream(
-                {"name": RENDER_A2UI_TOOL_NAME, "toolUseId": "r1", "input": dict(args)},
-                {},
-            ):
-                pass
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
-    pushed = []
-    captured = await mod._stream_render_subagent(STUB_MODEL, "prompt", [], pushed.append)
-
-    kinds = [p["kind"] for p in pushed]
-    assert kinds == ["start", "args", "end"]
-    assert json.loads(pushed[1]["delta"]) == args
-    assert captured == args
-
-
-@pytest.mark.asyncio
-async def test_render_subagent_stamps_catalog_id_into_streamed_args(monkeypatch):
+async def test_render_subagent_stamps_catalog_id_into_streamed_args():
     """The host catalog id is spliced into the FIRST streamed chunk (after the
     opening brace) so the middleware's progressive paint binds to the real
-    catalog instead of falling back to basic. The model never emits catalogId."""
+    catalog instead of falling back to basic. The model never emits catalogId,
+    and the splice must NOT contaminate the captured args."""
     import ag_ui_strands.a2ui_tool as mod
 
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            pass
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"surf',
-                }
-            }
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"surfaceId": "s1"}',
-                }
-            }
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
+    events = [_block_start(), _block_delta('{"surf'), _block_delta('aceId": "s1"}'), _BLOCK_STOP]
     pushed = []
-    await mod._stream_render_subagent(
-        STUB_MODEL, "prompt", [], pushed.append, catalog_id="my-cat"
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append, catalog_id="my-cat"
     )
     args_str = "".join(p["delta"] for p in pushed if p["kind"] == "args")
-    # Accumulated args are valid JSON carrying the stamped id.
+    # Streamed args are valid JSON carrying the stamped id.
     assert json.loads(args_str) == {"catalogId": "my-cat", "surfaceId": "s1"}
+    # The committed args stay the model's own (envelope builder stamps the id).
+    assert captured == {"surfaceId": "s1"}
 
 
 @pytest.mark.asyncio
-async def test_render_subagent_stamps_catalog_id_in_dict_fallback(monkeypatch):
-    """The parsed-dict provider shape also gets the catalog id merged into the
-    single emitted delta (host id wins over anything the model put there)."""
+async def test_render_subagent_stamps_catalog_id_in_single_chunk():
+    """The single-chunk shape also gets the catalog id spliced into the one
+    emitted delta, while the captured object stays catalogId-free."""
     import ag_ui_strands.a2ui_tool as mod
 
-    args = {"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}
-
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            self._tools = kwargs.get("tools") or []
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": dict(args),
-                }
-            }
-            async for _ in self._tools[0].stream(
-                {"name": RENDER_A2UI_TOOL_NAME, "toolUseId": "r1", "input": dict(args)},
-                {},
-            ):
-                pass
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
+    full = '{"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}'
+    events = [_block_start(), _block_delta(full), _BLOCK_STOP]
     pushed = []
-    await mod._stream_render_subagent(
-        STUB_MODEL, "prompt", [], pushed.append, catalog_id="my-cat"
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append, catalog_id="my-cat"
     )
-    delta = json.loads(pushed[1]["delta"])
+    delta = json.loads("".join(p["delta"] for p in pushed if p["kind"] == "args"))
     assert delta["catalogId"] == "my-cat"
     assert delta["surfaceId"] == "s1"
+    assert "catalogId" not in captured
 
 
 @pytest.mark.asyncio
@@ -1085,98 +1090,62 @@ def test_get_a2ui_tools_requires_model():
 
 
 @pytest.mark.asyncio
-async def test_render_subagent_zero_frames_synthesizes_triplet(monkeypatch):
-    """A provider that invokes the bound render tool without emitting any
-    current_tool_use frames must still produce start/args/end so the
-    middleware paints before the result (no bulk paint)."""
+async def test_render_subagent_no_block_stop_still_closes_and_captures():
+    """A provider that ends the message without a per-block contentBlockStop
+    must still close the live synthetic call and capture the accumulated args,
+    so the middleware sees the end and the recovery loop gets the surface."""
     import ag_ui_strands.a2ui_tool as mod
 
-    args = {"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}]}
-
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            self._tools = kwargs.get("tools") or []
-
-        async def stream_async(self, _msg):
-            # No current_tool_use frames at all — only the tool invocation.
-            async for _ in self._tools[0].stream(
-                {"name": RENDER_A2UI_TOOL_NAME, "toolUseId": "r1", "input": dict(args)},
-                {},
-            ):
-                pass
-            if False:  # pragma: no cover — make this an async generator
-                yield None
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
+    events = [_block_start(), _block_delta('{"surfaceId": "s1"}')]  # no stop
     pushed = []
-    captured = await mod._stream_render_subagent(STUB_MODEL, "prompt", [], pushed.append)
-
-    kinds = [p["kind"] for p in pushed]
-    assert kinds == ["start", "args", "end"]
-    assert json.loads(pushed[1]["delta"]) == args
-    assert captured == args
+    captured = await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append
+    )
+    assert [p["kind"] for p in pushed] == ["start", "args", "end"]
+    assert pushed[-1]["tool_call_id"] == "r1"
+    assert captured == {"surfaceId": "s1"}
 
 
 @pytest.mark.asyncio
-async def test_render_subagent_midstream_error_closes_live_call(monkeypatch):
-    """A provider stream dying mid-call (429, network drop) must close the
-    live synthetic call — an unclosed inner TOOL_CALL_START is a wire-protocol
-    violation and the next recovery attempt would open a fresh call on top."""
+async def test_render_subagent_midstream_error_closes_live_call():
+    """A model stream dying mid-call (429, network drop) must close the live
+    synthetic call before re-raising — an unclosed inner TOOL_CALL_START is a
+    wire-protocol violation and the next recovery attempt would open a fresh
+    call on top."""
     import ag_ui_strands.a2ui_tool as mod
 
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            pass
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"surf',
-                }
-            }
+    class FakeModel:
+        async def stream(self, messages, **kwargs):
+            yield _block_start()
+            yield _block_delta('{"surf')
             raise RuntimeError("model 429")
 
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
     pushed = []
     with pytest.raises(RuntimeError):
-        await mod._stream_render_subagent(STUB_MODEL, "prompt", [], pushed.append)
+        await mod._stream_render_subagent(FakeModel(), "prompt", [], pushed.append)
 
-    kinds = [p["kind"] for p in pushed]
-    assert kinds == ["start", "args", "end"]
+    assert [p["kind"] for p in pushed] == ["start", "args", "end"]
     assert pushed[-1]["tool_call_id"] == "r1"
 
 
 @pytest.mark.asyncio
-async def test_render_subagent_second_call_id_closes_first(monkeypatch):
-    """A second render call with a distinct real toolUseId must close the
-    first call and reset the delta accumulator (no cross-call mis-attribution)."""
+async def test_render_subagent_second_block_closes_first():
+    """A second render block with a distinct toolUseId must close the first and
+    reset the delta accumulator (no cross-call mis-attribution). The forced
+    single tool emits one block in practice; this guards the close-on-restart
+    invariant regardless of provider quirks."""
     import ag_ui_strands.a2ui_tool as mod
 
-    class FakeAgent:
-        def __init__(self, **kwargs):
-            pass
-
-        async def stream_async(self, _msg):
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r1",
-                    "input": '{"a": 1}',
-                }
-            }
-            yield {
-                "current_tool_use": {
-                    "name": RENDER_A2UI_TOOL_NAME,
-                    "toolUseId": "r2",
-                    "input": '{"b',
-                }
-            }
-
-    monkeypatch.setattr(mod, "Agent", FakeAgent)
+    events = [
+        _block_start("r1"),
+        _block_delta('{"a": 1}'),
+        _block_start("r2"),
+        _block_delta('{"b'),
+    ]
     pushed = []
-    await mod._stream_render_subagent(STUB_MODEL, "prompt", [], pushed.append)
+    await mod._stream_render_subagent(
+        _fake_stream_model(events), "prompt", [], pushed.append
+    )
 
     assert [(p["kind"], p["tool_call_id"]) for p in pushed] == [
         ("start", "r1"),

--- a/integrations/aws-strands/python/tests/test_a2ui_tool.py
+++ b/integrations/aws-strands/python/tests/test_a2ui_tool.py
@@ -1245,3 +1245,130 @@ async def test_stream_update_intent_finds_same_run_surface(monkeypatch):
     text = str(events[-1])
     assert "updateComponents" in text
     assert "createSurface" not in text
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the REAL Strands agent loop completes the dynamic-A2UI flow
+# (run-level regression for the hang — generate_a2ui returns + RUN_FINISHED).
+# ---------------------------------------------------------------------------
+
+from strands import Agent as StrandsAgentCore
+from strands.models.model import Model as StrandsModel
+
+
+def _tool_use_chunks(name, tool_use_id, args_json):
+    return [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {"toolUse": {"name": name, "toolUseId": tool_use_id}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": args_json}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+
+
+def _text_chunks(text):
+    return [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"text": text}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+
+
+class _DynamicA2UIFakeModel(StrandsModel):
+    """Scripts the full dynamic-A2UI conversation across the OUTER Strands agent
+    loop AND the inner forced render turn, so an end-to-end run exercises the
+    real event loop (not a stubbed stream_async). The forced render turn (the
+    sub-agent) is identified by its tool_choice; the outer turn calls
+    generate_a2ui first, then narrates once its result is in history."""
+
+    def __init__(self):
+        self.render_calls = 0
+        self.outer_calls = 0
+
+    def get_config(self):
+        return {}
+
+    def update_config(self, **kwargs):
+        pass
+
+    async def structured_output(self, output_model, prompt=None, system_prompt=None, **kwargs):
+        raise NotImplementedError
+        yield  # pragma: no cover — make this an async generator
+
+    async def stream(
+        self, messages, tool_specs=None, system_prompt=None, *, tool_choice=None, **kwargs
+    ):
+        # Inner forced render turn (the generate_a2ui sub-agent).
+        if tool_choice == {"tool": {"name": RENDER_A2UI_TOOL_NAME}}:
+            self.render_calls += 1
+            for ch in _tool_use_chunks(
+                RENDER_A2UI_TOOL_NAME,
+                "render-1",
+                '{"surfaceId": "s1", "components": [{"id": "root", "component": "Row"}], "data": {}}',
+            ):
+                yield ch
+            return
+
+        # Outer agent turn. Narrate once generate_a2ui already ran (its toolUse
+        # is in history); else call generate_a2ui. The outer_calls guard keeps
+        # the loop terminating even if detection drifts.
+        self.outer_calls += 1
+        already_generated = any(
+            isinstance(m, dict)
+            and m.get("role") == "assistant"
+            and any(
+                isinstance(b, dict)
+                and (b.get("toolUse") or {}).get("name") == GENERATE_A2UI_TOOL_NAME
+                for b in (m.get("content") or [])
+            )
+            for m in messages
+        )
+        if already_generated or self.outer_calls >= 2:
+            for ch in _text_chunks("Here is your sales dashboard."):
+                yield ch
+        else:
+            for ch in _tool_use_chunks(GENERATE_A2UI_TOOL_NAME, "gen-1", '{"intent": "create"}'):
+                yield ch
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_dynamic_a2ui_run_emits_run_finished():
+    """End-to-end through the REAL Strands agent loop: an auto-injected
+    generate_a2ui call paints an A2UI surface (render_a2ui streams), its
+    envelope returns to the outer loop as a TOOL_CALL_RESULT, the agent
+    narrates, and the run emits RUN_FINISHED — instead of hanging on a
+    still-Running generate_a2ui. Run-level regression for the dynamic-A2UI hang."""
+    model = _DynamicA2UIFakeModel()
+    core = StrandsAgentCore(model=model, system_prompt="You render UIs.", tools=[])
+    agent = StrandsAgent(core, name="strands-e2e", config=StrandsAgentConfig())
+
+    inp = _msg_input(
+        forwarded_props={"injectA2UITool": True},
+        tools=[RENDER_TOOL_INPUT],
+        messages=[UserMessage(id="u1", role="user", content="Show my sales dashboard")],
+    )
+    events = await _collect(agent, inp)
+    types = [e.type for e in events]
+
+    # generate_a2ui was auto-injected, called, and its result returned to the loop.
+    assert any(
+        e.type == EventType.TOOL_CALL_START
+        and getattr(e, "tool_call_name", None) == GENERATE_A2UI_TOOL_NAME
+        for e in events
+    )
+    assert EventType.TOOL_CALL_RESULT in types
+    # The A2UI surface painted (inner render_a2ui streamed as synthetic events).
+    assert any(
+        e.type == EventType.TOOL_CALL_START
+        and getattr(e, "tool_call_name", None) == RENDER_A2UI_TOOL_NAME
+        for e in events
+    )
+    # The agent narrated and the run COMPLETED (no hang, no error).
+    assert EventType.TEXT_MESSAGE_CONTENT in types
+    assert EventType.RUN_FINISHED in types
+    assert EventType.RUN_ERROR not in types
+    # Exactly one forced render turn — no agentic continuation in the sub-agent.
+    assert model.render_calls == 1
+    # Outer loop: one generate call + one narration.
+    assert model.outer_calls == 2

--- a/integrations/aws-strands/typescript/src/__tests__/a2ui-e2e.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/a2ui-e2e.test.ts
@@ -1,0 +1,168 @@
+/**
+ * End-to-end regression for the dynamic-A2UI hang: drive a REAL Strands `Agent`
+ * loop (not a scripted stub) with a fake `Model` that scripts the full
+ * conversation — outer turn calls the auto-injected `generate_a2ui`, the
+ * sub-agent's single forced `render_a2ui` turn paints the surface, the envelope
+ * returns to the outer loop, and the agent narrates. The run MUST emit
+ * RUN_FINISHED instead of hanging on a still-Running generate_a2ui.
+ */
+import { describe, it, expect } from "vitest";
+
+import { Agent, Model } from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { StrandsAgent } from "../agent";
+import { collect, minimalRunInput } from "./helpers";
+
+const GENERATE_A2UI_TOOL_NAME = "generate_a2ui";
+const RENDER_A2UI_TOOL_NAME = "render_a2ui";
+
+const RENDER_TOOL_INPUT = {
+  name: RENDER_A2UI_TOOL_NAME,
+  description: "render",
+  parameters: { type: "object", properties: {} },
+};
+
+function toolUseEvents(name: string, toolUseId: string, input: string) {
+  return [
+    { type: "modelMessageStartEvent", role: "assistant" },
+    {
+      type: "modelContentBlockStartEvent",
+      start: { type: "toolUseStart", name, toolUseId },
+    },
+    {
+      type: "modelContentBlockDeltaEvent",
+      delta: { type: "toolUseInputDelta", input },
+    },
+    { type: "modelContentBlockStopEvent" },
+    { type: "modelMessageStopEvent", stopReason: "toolUse" },
+  ];
+}
+
+function textEvents(text: string) {
+  return [
+    { type: "modelMessageStartEvent", role: "assistant" },
+    {
+      type: "modelContentBlockDeltaEvent",
+      delta: { type: "textDelta", text },
+    },
+    { type: "modelContentBlockStopEvent" },
+    { type: "modelMessageStopEvent", stopReason: "endTurn" },
+  ];
+}
+
+/**
+ * Scripts the full dynamic-A2UI conversation across the OUTER Strands agent loop
+ * AND the inner forced render turn. The forced render turn (sub-agent) is
+ * identified by its toolChoice; the outer turn calls generate_a2ui first, then
+ * narrates once its result is in history.
+ */
+class DynamicA2UIFakeModel extends Model {
+  renderCalls = 0;
+  outerCalls = 0;
+
+  getConfig() {
+    return { modelId: "fake" };
+  }
+
+  updateConfig() {}
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async *stream(messages: any, options?: any) {
+    const tc = options?.toolChoice;
+    if (tc?.tool?.name === RENDER_A2UI_TOOL_NAME) {
+      this.renderCalls++;
+      for (const ev of toolUseEvents(
+        RENDER_A2UI_TOOL_NAME,
+        "render-1",
+        '{"surfaceId":"s1","components":[{"id":"root","component":"Row"}],"data":{}}',
+      )) {
+        yield ev as never;
+      }
+      return;
+    }
+
+    this.outerCalls++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const alreadyGenerated = (messages as any[]).some(
+      (m) =>
+        m?.role === "assistant" &&
+        Array.isArray(m.content) &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        m.content.some(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (b: any) =>
+            (b?.name ?? b?.toolUse?.name) === GENERATE_A2UI_TOOL_NAME,
+        ),
+    );
+    // outerCalls guard guarantees termination even if detection drifts.
+    if (alreadyGenerated || this.outerCalls >= 2) {
+      for (const ev of textEvents("Here is your sales dashboard.")) {
+        yield ev as never;
+      }
+    } else {
+      for (const ev of toolUseEvents(
+        GENERATE_A2UI_TOOL_NAME,
+        "gen-1",
+        '{"intent":"create"}',
+      )) {
+        yield ev as never;
+      }
+    }
+  }
+}
+
+describe("end-to-end dynamic A2UI run (real Strands loop, hang regression)", () => {
+  it("auto-injects generate_a2ui, paints the surface, returns the result, and emits RUN_FINISHED", async () => {
+    const model = new DynamicA2UIFakeModel();
+    const core = new Agent({
+      model: model as never,
+      systemPrompt: "You render UIs.",
+      tools: [],
+    });
+    const agent = new StrandsAgent({ agent: core, name: "strands-e2e" });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        forwardedProps: { injectA2UITool: true },
+        tools: [RENDER_TOOL_INPUT] as never,
+        messages: [
+          { id: "u1", role: "user", content: "Show my sales dashboard" },
+        ] as never,
+      }),
+    );
+    const types = events.map((e) => e.type);
+
+    // generate_a2ui was auto-injected, called, and its result returned to the loop.
+    expect(
+      events.some(
+        (e) =>
+          e.type === EventType.TOOL_CALL_START &&
+          (e as { toolCallName?: string }).toolCallName ===
+            GENERATE_A2UI_TOOL_NAME,
+      ),
+    ).toBe(true);
+    expect(types).toContain(EventType.TOOL_CALL_RESULT);
+
+    // The A2UI surface painted (inner render_a2ui streamed as synthetic events).
+    expect(
+      events.some(
+        (e) =>
+          e.type === EventType.TOOL_CALL_START &&
+          (e as { toolCallName?: string }).toolCallName ===
+            RENDER_A2UI_TOOL_NAME,
+      ),
+    ).toBe(true);
+
+    // The agent narrated and the run COMPLETED (no hang, no error).
+    expect(types).toContain(EventType.TEXT_MESSAGE_CONTENT);
+    expect(types).toContain(EventType.RUN_FINISHED);
+    expect(types).not.toContain(EventType.RUN_ERROR);
+
+    // Exactly one forced render turn — no agentic continuation in the sub-agent.
+    expect(model.renderCalls).toBe(1);
+    // Outer loop: one generate call + one narration.
+    expect(model.outerCalls).toBe(2);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/a2ui-tool.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/a2ui-tool.test.ts
@@ -410,6 +410,79 @@ describe("A2UI sub-agent streaming → synthetic inner TOOL_CALL events", () => 
   });
 });
 
+describe("generate_a2ui sub-agent — single forced render turn (hang regression)", () => {
+  const A2UI_STREAM_KEY = "__a2uiRenderStream";
+
+  it("drives ONE forced render_a2ui model call (no agentic continuation) and returns the envelope", async () => {
+    // A full Agent loop would execute the render tool and then fire a SECOND
+    // model call that never settles — the outer generate_a2ui would hang and
+    // the run would never emit RUN_FINISHED. The fix streams the MODEL directly
+    // for a single forced turn; this locks that contract in.
+    const toolChoices: unknown[] = [];
+    const fakeModel = {
+      modelId: "fake",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async *stream(_messages: unknown, opts?: any) {
+        toolChoices.push(opts?.toolChoice);
+        yield {
+          type: "modelContentBlockStartEvent",
+          start: { type: "toolUseStart", toolUseId: "r1", name: "render_a2ui" },
+        };
+        yield {
+          type: "modelContentBlockDeltaEvent",
+          delta: {
+            type: "toolUseInputDelta",
+            input:
+              '{"surfaceId":"s1","components":[{"id":"root","component":"Row"}]}',
+          },
+        };
+        yield { type: "modelContentBlockStopEvent" };
+      },
+    };
+
+    const tool = getA2UITools({ model: fakeModel as never });
+    const ctx = {
+      toolUse: { toolUseId: "tu-1", input: {} },
+      agent: { messages: [] },
+    };
+    const events: unknown[] = [];
+    // The tool RETURNS the ToolResultBlock (not yielded), so iterate manually
+    // to capture the generator return value.
+    const gen = (
+      tool as { stream: (c: unknown) => AsyncGenerator<unknown, unknown> }
+    ).stream(ctx);
+    let result: unknown;
+    for (;;) {
+      const step = await gen.next();
+      if (step.done) {
+        result = step.value;
+        break;
+      }
+      events.push(step.value);
+    }
+
+    // Single forced turn — the model is called exactly once, forced to render.
+    expect(toolChoices).toEqual([{ tool: { name: "render_a2ui" } }]);
+
+    // Synthetic inner render events were streamed (progressive paint).
+    const payloads = events
+      .map(
+        (e) =>
+          (e as { data?: Record<string, { kind?: string }> }).data?.[
+            A2UI_STREAM_KEY
+          ],
+      )
+      .filter(Boolean) as Array<{ kind?: string }>;
+    expect(payloads.some((p) => p.kind === "start")).toBe(true);
+    expect(payloads.some((p) => p.kind === "end")).toBe(true);
+
+    // The committed envelope reaches the outer loop (so the run can finish).
+    const ret = result as { content?: Array<{ text?: string }> };
+    const text = ret?.content?.[0]?.text ?? JSON.stringify(ret);
+    expect(text).toContain("a2ui_operations");
+  });
+});
+
 describe("classifyA2UISubagentError (cancel / adapter-bug vs recoverable)", () => {
   it("rethrows on an aborted signal regardless of error", () => {
     expect(classifyA2UISubagentError(new Error("any"), true)).toBe("rethrow");

--- a/integrations/aws-strands/typescript/src/a2ui-tool.ts
+++ b/integrations/aws-strands/typescript/src/a2ui-tool.ts
@@ -26,10 +26,10 @@
  */
 
 import {
-  Agent,
   TextBlock,
   ToolResultBlock,
   ToolStreamEvent,
+  type Message as StrandsMessage,
   type Model,
   type Tool,
   type ToolContext,
@@ -368,9 +368,20 @@ export function classifyA2UISubagentError(
 }
 
 /**
- * Run the structured-output sub-agent once: bind a `render_a2ui` tool, invoke
- * the model with the (already error-augmented) prompt, and return the captured
- * `render_a2ui` args — or `null` if the model produced no call.
+ * Run a SINGLE forced `render_a2ui` model call and return the captured args —
+ * or `null` if the model produced no call.
+ *
+ * Mirrors the LangGraph adapter's single forced structured-output turn
+ * (`bind_tools([RENDER_A2UI_TOOL_DEF], tool_choice="render_a2ui")` + one
+ * `astream`): we call the model DIRECTLY (not a Strands `Agent`), so there is no
+ * agentic loop. The model emits exactly one `render_a2ui` tool call and we stop.
+ * A full `Agent` loop would EXECUTE the bound render tool and then fire a SECOND
+ * model call to continue the turn — and with the "render the surface" system
+ * prompt that continuation re-invokes render (or never settles on a terminal
+ * text turn). The sub-agent stream would then never end, so the outer
+ * `generate_a2ui` tool never returns its result and the run never emits
+ * RUN_FINISHED (the surface paints, but the call hangs). The forced single turn
+ * is the fix.
  */
 async function invokeRenderSubagent(
   model: Model,
@@ -385,65 +396,67 @@ async function invokeRenderSubagent(
      * model never emits `catalogId` (render schema omits it; host owns the
      * catalog), so without this the middleware's progressive paint falls back
      * to the basic catalog and the renderer throws "Catalog not found". The id
-     * matches what `buildA2UIEnvelope` stamps on the final surface.
+     * matches what `buildA2UIEnvelope` stamps on the final surface. Spliced into
+     * the EMITTED stream only — the captured args stay the model's own.
      */
     catalogId?: string;
   } = {},
 ): Promise<Record<string, unknown> | null> {
-  let captured: Record<string, unknown> | null = null;
-  const renderTool: Tool = {
-    name: RENDER_A2UI_TOOL_NAME,
-    description: RENDER_A2UI_TOOL_DEF.function.description,
-    toolSpec: {
-      name: RENDER_A2UI_TOOL_NAME,
-      description: RENDER_A2UI_TOOL_DEF.function.description,
-      inputSchema: RENDER_A2UI_TOOL_DEF.function
-        .parameters as Tool["toolSpec"]["inputSchema"],
-    },
-    // eslint-disable-next-line require-yield
-    async *stream(ctx: ToolContext): ToolStreamGenerator {
-      captured = (ctx.toolUse.input ?? {}) as Record<string, unknown>;
-      return new ToolResultBlock({
-        toolUseId: ctx.toolUse.toolUseId,
-        status: "success",
-        content: [new TextBlock("ok")],
-      });
-    },
-  };
-
-  const subagent = new Agent({
-    model,
-    tools: [renderTool],
-    systemPrompt: prompt,
-  });
   const emit = options.onStreamEvent;
   const catalogId = options.catalogId;
+  const renderSpec: Tool["toolSpec"] = {
+    name: RENDER_A2UI_TOOL_NAME,
+    description: RENDER_A2UI_TOOL_DEF.function.description,
+    inputSchema: RENDER_A2UI_TOOL_DEF.function
+      .parameters as Tool["toolSpec"]["inputSchema"],
+  };
+
+  let captured: Record<string, unknown> | null = null;
+  let accumulated = "";
   // Tracks the in-flight render_a2ui block between toolUseStart and blockStop.
   let liveRenderCallId: string | null = null;
-  let sawRenderStart = false;
   // Whether the host catalog id has been spliced into the streamed args for
   // the current call yet (reset per render start).
   let catalogPrefixed = false;
+
+  const finishCall = () => {
+    // The model streams render_a2ui's args as a JSON string (partial fragments
+    // reconstruct into the full object). Parse the accumulated RAW string — not
+    // the catalog-spliced stream — so the committed args are the model's own
+    // (catalogId is stamped by buildA2UIEnvelope).
+    try {
+      captured = accumulated.trim()
+        ? (JSON.parse(accumulated) as Record<string, unknown>)
+        : {};
+    } catch {
+      captured = {};
+    }
+  };
+
+  const aborted = () => !!options.cancelSignal?.aborted;
+  const abortError = () => {
+    const e = new Error("consumer disconnected; abandoning A2UI render");
+    e.name = "AbortError";
+    return e;
+  };
+
   try {
-    // Stream (not invoke) so the render_a2ui arg deltas can be surfaced to the
-    // AG-UI wire as they generate — the middleware's building/progressive-paint
-    // lifecycle depends on seeing them live.
-    const gen = subagent.stream(
-      messages as never,
-      options.cancelSignal ? { cancelSignal: options.cancelSignal } : undefined,
-    );
+    if (aborted()) throw abortError();
+    // Stream the MODEL directly (no Agent loop, no tool execution) so the
+    // render_a2ui arg deltas surface live for the middleware's progressive
+    // paint while guaranteeing a single forced turn.
+    const gen = model.stream(messages as unknown as StrandsMessage[], {
+      systemPrompt: prompt,
+      toolSpecs: [renderSpec],
+      toolChoice: { tool: { name: RENDER_A2UI_TOOL_NAME } },
+    });
     for await (const ev of gen) {
-      if (!emit) continue;
-      // Agent.stream() wraps raw model events in `modelStreamUpdateEvent`
-      // decorators (same unwrap the adapter's main loop performs).
-      const unwrapped =
-        ev &&
-        typeof ev === "object" &&
-        (ev as { type?: string }).type === "modelStreamUpdateEvent" &&
-        "event" in (ev as object)
-          ? (ev as { event: unknown }).event
-          : ev;
-      const e = unwrapped as {
+      // `model.stream` yields raw model events directly (no
+      // `modelStreamUpdateEvent` wrapper, unlike `Agent.stream`).
+      // Cooperative cancellation: `model.stream` has no cancelSignal option, so
+      // bail between events when the outer run is abandoned.
+      if (aborted()) throw abortError();
+      const e = ev as {
         type?: string;
         start?: { type?: string; toolUseId?: string; name?: string };
         delta?: { type?: string; input?: string };
@@ -456,16 +469,16 @@ async function invokeRenderSubagent(
         // blockStop must not leave an unclosed inner TOOL_CALL_START on the
         // wire, and a foreign tool's arg deltas must never attribute to it).
         if (liveRenderCallId) {
-          emit({ kind: "end", toolCallId: liveRenderCallId });
+          emit?.({ kind: "end", toolCallId: liveRenderCallId });
           liveRenderCallId = null;
         }
         if (e.start.name !== RENDER_A2UI_TOOL_NAME) continue;
         // `||` (not `??`): an empty-string toolUseId must take the fallback —
         // a falsy live id would disable every close/delta guard below.
         liveRenderCallId = e.start.toolUseId || `a2ui-render-${++a2uiRenderSeq}`;
-        sawRenderStart = true;
+        accumulated = "";
         catalogPrefixed = false;
-        emit({
+        emit?.({
           kind: "start",
           toolCallId: liveRenderCallId,
           toolCallName: RENDER_A2UI_TOOL_NAME,
@@ -477,6 +490,7 @@ async function invokeRenderSubagent(
         typeof e.delta.input === "string"
       ) {
         let delta = e.delta.input;
+        accumulated += delta;
         // Stamp the host catalog id into the FIRST chunk by splicing it right
         // after the opening brace, so the accumulated args become
         // `{"catalogId": "<id>", ...}` — valid JSON the middleware's progressive
@@ -491,22 +505,26 @@ async function invokeRenderSubagent(
             catalogPrefixed = true;
           }
         }
-        emit({ kind: "args", toolCallId: liveRenderCallId, delta });
+        emit?.({ kind: "args", toolCallId: liveRenderCallId, delta });
       } else if (liveRenderCallId && e?.type === "modelContentBlockStopEvent") {
-        emit({ kind: "end", toolCallId: liveRenderCallId });
+        emit?.({ kind: "end", toolCallId: liveRenderCallId });
+        finishCall();
         liveRenderCallId = null;
+        // Single forced turn: the render call is complete. Stop the stream so
+        // no continuation model call ever fires.
+        break;
       }
     }
   } catch (err) {
-    if (emit && liveRenderCallId) {
+    if (liveRenderCallId) {
       // The provider stream died mid-call: close the live synthetic call
       // before unwinding — an unclosed inner TOOL_CALL_START is a
       // wire-protocol violation, and the next recovery attempt would open a
       // fresh call on top of it.
-      emit({ kind: "end", toolCallId: liveRenderCallId });
+      emit?.({ kind: "end", toolCallId: liveRenderCallId });
       liveRenderCallId = null;
     }
-    if (classifyA2UISubagentError(err, !!options.cancelSignal?.aborted) === "rethrow") {
+    if (classifyA2UISubagentError(err, aborted()) === "rethrow") {
       throw err;
     }
     // A genuine model/network error must not crash the whole turn — the recovery
@@ -520,35 +538,11 @@ async function invokeRenderSubagent(
     );
     return null;
   }
-  if (emit) {
-    if (liveRenderCallId) {
-      // Stream ended without a blockStop for the live call — close it.
-      emit({ kind: "end", toolCallId: liveRenderCallId });
-      liveRenderCallId = null;
-    } else if (!sawRenderStart && captured !== null) {
-      // The provider invoked the bound render tool without emitting any
-      // content-block events: synthesize the full triplet so the middleware
-      // still sees components before the result (no bulk paint). NOTE: the
-      // Python adapter additionally handles a mid-call parsed-dict input
-      // shape; the TS SDK delivers tool input exclusively via
-      // toolUseInputDelta frames, so that fallback has no analog here.
-      const syntheticId = `a2ui-render-${++a2uiRenderSeq}`;
-      emit({
-        kind: "start",
-        toolCallId: syntheticId,
-        toolCallName: RENDER_A2UI_TOOL_NAME,
-      });
-      emit({
-        kind: "args",
-        toolCallId: syntheticId,
-        delta: JSON.stringify(
-          catalogId && captured
-            ? { ...(captured as Record<string, unknown>), catalogId }
-            : captured,
-        ),
-      });
-      emit({ kind: "end", toolCallId: syntheticId });
-    }
+  if (liveRenderCallId) {
+    // Stream ended without a blockStop for the live call — close + capture.
+    emit?.({ kind: "end", toolCallId: liveRenderCallId });
+    finishCall();
+    liveRenderCallId = null;
   }
   return captured;
 }


### PR DESCRIPTION
## Problem

On the dynamic A2UI (`declarative-gen-ui`) flow backed by AWS Strands, clicking a pill paints the A2UI surface correctly — but the assistant response never finishes: `generate_a2ui` stays **Running** indefinitely and **no `RUN_FINISHED` is emitted**. Confirmed on real-LLM staging (Python, >1 min hang) and in the CopilotKit showcase D6 probe `gen-ui-declarative` on **both** `strands` and `strands-typescript` (`waitForTurnComplete … reason=sse-missing, runsFinished=0`). Not an aimock artifact — reproduces on a real LLM.

## Root cause

The runtime auto-injects a no-arg `generate_a2ui` tool; the Strands adapter intercepts the call and drives a sub-agent to emit the flat A2UI components via `render_a2ui`. That sub-agent ran a **full Strands `Agent` loop** (`Agent.stream_async` in Python, `Agent.stream` in TS). After the bound `render_a2ui` tool returned, the loop fired a **second** model call to continue the turn — and with the "render the surface" system prompt that continuation re-invoked render (or never settled on a terminal text turn). The sub-agent stream therefore never ended, so the outer `generate_a2ui` tool never returned its result and the run never emitted `RUN_FINISHED`. The surface paints (the first render call streams), but the call hangs.

The extra model call also desyncs the aimock fixture sequence (which matches the passing langgraph-python: outer-generate → single render → outer-narrate), explaining the D6 `runsFinished=0`.

## Fix

Mirror the LangGraph gold standard, which does a **single forced structured-output turn** (`bind_tools([render_a2ui], tool_choice="render_a2ui")` + one `astream`). Both adapters now stream the **model directly** for exactly one forced turn — no agentic loop, no tool execution, no continuation:

- **Python** (`a2ui_tool.py`): `model.stream(messages, tool_specs=[render], system_prompt=prompt, tool_choice={"tool": {"name": "render_a2ui"}})`, parsing raw `contentBlockStart/Delta/Stop` events.
- **TypeScript** (`a2ui-tool.ts`): the equivalent `Model.stream(messages, { systemPrompt, toolSpecs, toolChoice })`, parsing `modelContentBlock*` events (dropping the prior `Agent`/`modelStreamUpdateEvent` path).

The render args are captured from the streamed tool-use input; the committed envelope returns to the outer Strands loop so it narrates and emits `RUN_FINISHED`. Progressive-paint streaming (synthetic inner `TOOL_CALL_START/ARGS/END` + host `catalogId` splice into the first chunk) is preserved unchanged. The model-call shape now matches langgraph 1:1 (outer-generate → single render → outer-narrate).

## Tests

- Both adapters: new regression test driving the real `generate_a2ui` tool stream against a fake model — asserts **exactly one** forced `render_a2ui` model call (`tool_choice` forced) and that the committed `a2ui_operations` envelope is returned so the run can finish.
- Reworked the `_stream_render_subagent` / `invokeRenderSubagent` unit tests onto the model-stream protocol (fragment deltas, single-chunk input, catalogId splice not contaminating captured args, no-render-call → none, mid-stream error closes the live call, second-block-closes-first).
- Python: `48` a2ui tests + full suite `151 passed`. TypeScript: full suite `240 passed`; `tsc --noEmit` clean; build clean.

## Release follow-up

Cut a patch release (separate `release / create-pr` workflow) so the showcase can bump deps:
- `integration-aws-strands-py` — `ag_ui_strands` `0.2.1 → 0.2.2`
- `integration-aws-strands-ts` — `@ag-ui/aws-strands` `0.2.2 → 0.2.3`