### PR TITLE
docs: align A2UI skill with catalog-forwarding auto-inject DX (follow-on to #1993)

### DIFF
--- a/skills/ag-ui-a2ui-integration/SKILL.md
+++ b/skills/ag-ui-a2ui-integration/SKILL.md
@@ -52,9 +52,11 @@ agents and used against a real app or repo, not published as a docs page.
    `references/a2ui-runtime-and-renderer.md`. Avoid double-applying
    `A2UIMiddleware`; use either runtime-level A2UI config or per-agent
    `agent.use(new A2UIMiddleware(...))` for a given agent.
-5. Register a catalog on the client. For dynamic schema, ensure the middleware
-   or adapter uses the same `defaultCatalogId` as the renderer-registered
-   catalog.
+5. Register a catalog on the client. With CopilotKit >= 1.61.2, forwarding it to
+   the provider (`a2ui={{ catalog }}`) auto-enables A2UI and auto-derives
+   `defaultCatalogId` from the catalog's id. Only when you are not forwarding a
+   catalog, ensure the middleware or adapter sets a `defaultCatalogId` matching
+   the renderer-registered catalog.
 6. Verify the streaming path with `references/verification.md`: AG-UI stream,
    `a2ui-surface` activity snapshots or `a2ui_operations`, rendered A2UI
    surface, and a user interaction flowing back through AG-UI.
@@ -106,8 +108,10 @@ instead of guessing a scaffold command.
   rather than asking the model to invent component trees.
 - Emit `createSurface` once per `surfaceId`; use update operations for later
   changes.
-- Do not let the model invent catalog ids. The host/middleware/adapter should
-  stamp a `defaultCatalogId` that matches the client-registered catalog.
+- Do not let the model invent catalog ids. When the client forwards a catalog to
+  the provider (CopilotKit >= 1.61.2), its `catalogId` is derived automatically;
+  otherwise the host/middleware/adapter should stamp a `defaultCatalogId` that
+  matches the client-registered catalog.
 - Preserve AG-UI run boundaries and error events. Do not swallow server or
   stream errors.
 - Verify with a real browser or client run when possible. A static typecheck is

--- a/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
+++ b/skills/ag-ui-a2ui-integration/references/a2ui-runtime-and-renderer.md
@@ -23,7 +23,15 @@ agent.use(
 );
 ```
 
-Or let CopilotRuntime v2 apply it to selected agents:
+When hosting behind CopilotRuntime v2, prefer the client-driven path: forward a
+catalog to the provider (`<CopilotKit a2ui={{ catalog }}>`, see "Client Side").
+With CopilotKit >= 1.61.2 this auto-enables A2UI, defaults tool injection on,
+and auto-derives `defaultCatalogId` from the forwarded catalog's `catalogId`, so
+no runtime `a2ui` block is required.
+
+Use an explicit runtime `a2ui` block only to override that default — for
+example, to scope injection to specific agents or pin a catalog id when the
+client does not forward one:
 
 ```ts
 import { CopilotRuntime, InMemoryAgentRunner } from "@copilotkit/runtime/v2";
@@ -31,6 +39,7 @@ import { CopilotRuntime, InMemoryAgentRunner } from "@copilotkit/runtime/v2";
 const runtime = new CopilotRuntime({
   agents,
   runner: new InMemoryAgentRunner(),
+  // Optional override; omit when the provider forwards a catalog.
   a2ui: {
     agents: ["a2ui_dynamic_schema"],
     injectA2UITool: true,
@@ -82,8 +91,9 @@ string result that the middleware can scan.
 Use dynamic schema mode when the model must compose a surface from the available
 catalog. Current AG-UI adapters share this shape:
 
-- The host asks for injection with runtime `a2ui.injectA2UITool` or per-agent
-  `new A2UIMiddleware({ injectA2UITool: true })`.
+- Injection is enabled by forwarding a catalog from the client provider
+  (`a2ui={{ catalog }}`, CopilotKit >= 1.61.2), or explicitly via runtime
+  `a2ui.injectA2UITool` or per-agent `new A2UIMiddleware({ injectA2UITool: true })`.
 - The framework adapter injects a planner-facing `generate_a2ui` tool when it
   sees the `injectA2UITool` flag.
 - `generate_a2ui` runs a sub-agent that is forced to call `render_a2ui`.
@@ -139,9 +149,11 @@ export function AppShell() {
 ```
 
 The catalog registered here must match the `catalogId` stamped into
-`createSurface`. For dynamic schema, set middleware/adapter `defaultCatalogId`
-to that same id so streamed `createSurface` operations resolve before the final
-tool result arrives.
+`createSurface`. With CopilotKit >= 1.61.2 the forwarded catalog supplies its
+own `catalogId`, which the middleware uses to auto-derive `defaultCatalogId`, so
+streamed `createSurface` operations resolve without any manual pin. Set
+middleware/adapter `defaultCatalogId` explicitly only when you are not
+forwarding a catalog from the provider.
 
 ## Component Catalog Pattern
 

--- a/skills/ag-ui-a2ui-integration/references/verification.md
+++ b/skills/ag-ui-a2ui-integration/references/verification.md
@@ -28,16 +28,16 @@ Use this checklist before calling an AG-UI + A2UI integration complete.
 
 ## Common Failure Modes
 
-| Symptom                               | Likely cause                                                         | Fix                                                                              |
-| ------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| No A2UI surface appears               | A2UI is enabled only on the client or only on the runtime            | Enable renderer/catalog plus `A2UIMiddleware` or runtime A2UI config             |
-| Agent describes UI in prose           | Agent lacks `generate_a2ui` or fixed-schema backend tools            | Use the framework A2UI tool factory/auto-injection or return `a2ui_operations`   |
-| Custom component never renders        | Catalog id or component keys differ between server and client        | Register the catalog and align `defaultCatalogId`, `catalogId`, and names        |
-| Dynamic surface appears only at end   | Nested `render_a2ui` args are not streaming to the AG-UI wire        | Use the adapter's streaming A2UI tool path, not a non-streaming sub-agent invoke |
-| Action clicks do nothing              | The action bridge is not reaching `forwardedProps.a2uiAction`        | Verify the client action is forwarded and middleware emits `log_a2ui_event`      |
-| Skeletons duplicate or flicker        | Middleware is applied twice or catalog/tool names are misconfigured  | Use either runtime-level or per-agent middleware for each agent, not both        |
-| `Catalog not found` in the renderer   | Model or server stamped a catalog id the client did not register     | Set `defaultCatalogId` to the renderer catalog id; do not let the model pick it  |
-| Invalid component tree keeps retrying | Components fail toolkit validation against the inline/client catalog | Fix required props, child refs, root layout, and component names                 |
+| Symptom                               | Likely cause                                                         | Fix                                                                                                                                                                     |
+| ------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No A2UI surface appears               | A2UI is enabled only on the client or only on the runtime            | Enable renderer/catalog plus `A2UIMiddleware` or runtime A2UI config                                                                                                    |
+| Agent describes UI in prose           | Agent lacks `generate_a2ui` or fixed-schema backend tools            | Use the framework A2UI tool factory/auto-injection or return `a2ui_operations`                                                                                          |
+| Custom component never renders        | Catalog id or component keys differ between server and client        | Register the catalog and align `defaultCatalogId`, `catalogId`, and names                                                                                               |
+| Dynamic surface appears only at end   | Nested `render_a2ui` args are not streaming to the AG-UI wire        | Use the adapter's streaming A2UI tool path, not a non-streaming sub-agent invoke                                                                                        |
+| Action clicks do nothing              | The action bridge is not reaching `forwardedProps.a2uiAction`        | Verify the client action is forwarded and middleware emits `log_a2ui_event`                                                                                             |
+| Skeletons duplicate or flicker        | Middleware is applied twice or catalog/tool names are misconfigured  | Use either runtime-level or per-agent middleware for each agent, not both                                                                                               |
+| `Catalog not found` in the renderer   | Model or server stamped a catalog id the client did not register     | Forward the catalog to the provider (`a2ui={{ catalog }}`, CopilotKit >= 1.61.2) so its id is auto-derived; otherwise set `defaultCatalogId` to the renderer catalog id |
+| Invalid component tree keeps retrying | Components fail toolkit validation against the inline/client catalog | Fix required props, child refs, root layout, and component names                                                                                                        |
 
 A runtime smoke test should show the AG-UI stream in logs or devtools, an
 `a2ui-surface` activity or `a2ui_operations` result, a rendered A2UI surface in


### PR DESCRIPTION
## Summary

Follow-on to #1993. That skill was authored against CopilotKit **1.61.1** and predates the catalog-forwarding auto-inject DX shipped in **1.61.2** ([CopilotKit#5611](https://github.com/CopilotKit/CopilotKit/pull/5611)), which the CopilotKit showcase adopted across all `declarative-gen-ui` routes in [CopilotKit#5697](https://github.com/CopilotKit/CopilotKit/pull/5697).

Since 1.61.2, forwarding a catalog to the provider — `<CopilotKit a2ui={{ catalog }}>` — **auto-enables A2UI, defaults `injectA2UITool` on, and auto-derives `defaultCatalogId`** from the catalog's own `catalogId`. #5697 removed the now-redundant runtime `a2ui: { injectA2UITool, defaultCatalogId }` block from six showcase routes, and the `"Catalog not found"` fallback that the manual pin existed to fix no longer applies.

The skill still taught that runtime block as the primary path and mandated manual `defaultCatalogId` pinning in several places — including a self-contradiction where the client example used the new `a2ui={{ catalog }}` pattern but the surrounding prose still required the old manual pin. An agent following it verbatim would re-add exactly the config the showcase just deleted.

## Changes

- **`references/a2ui-runtime-and-renderer.md`** — lead the CopilotRuntime v2 section with the client-forwarding path; reframe the runtime `a2ui` block as an explicit *override* (with an inline comment); add catalog-forwarding to the "Dynamic Schema Mode" injection trigger; fix the "Client Side" prose so it no longer mandates a manual `defaultCatalogId` alongside the forwarded catalog.
- **`SKILL.md`** — Workflow step 5 and the catalog-id Key Rule now present auto-derivation as the default, manual stamping as the fallback.
- **`references/verification.md`** — `"Catalog not found"` failure-mode fix now leads with "forward the catalog," manual `defaultCatalogId` as the otherwise-case.

The explicit runtime `a2ui`/`defaultCatalogId` path is **kept** as a documented override — it is still valid and is the live pattern in this repo's own dojo route (`apps/dojo/.../[[...slug]]/route.ts`), so the `sources.md` citation remains accurate.

## Verification

- `npx prettier@^3.5.0 --check` on all three changed files — clean.
- No code or wire-protocol changes; docs/skill only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)