### PR TITLE
feat(core)!: remove deprecated THINKING events and BinaryInputContent (1.0.0 major)

### DIFF
--- a/docs/concepts/reasoning.mdx
+++ b/docs/concepts/reasoning.mdx
@@ -406,15 +406,17 @@ const response = await agent.run({
 ## Migration from Thinking Events
 
 <Warning>
-  The `THINKING_*` events are deprecated and will be removed in version 1.0.0.
-  New implementations should use `REASONING_*` events.
+  The `THINKING_*` events were **removed in version 1.0.0**. Use `REASONING_*`
+  events instead. Legacy agents (`maxVersion <= 0.0.45`) that still emit
+  `THINKING_*` on the wire keep working — the client transparently rewrites them
+  to their `REASONING_*` equivalents before validation.
 </Warning>
 
-### Deprecated Events
+### Removed Events
 
-The following events are deprecated:
+The following events were removed; each maps 1:1 to a `REASONING_*` event:
 
-| Deprecated Event                | Replacement                 |
+| Removed Event                   | Replacement                 |
 | ------------------------------- | --------------------------- |
 | `THINKING_START`                | `REASONING_START`           |
 | `THINKING_END`                  | `REASONING_END`             |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,7 +85,8 @@
                   "sdk/js/core/types",
                   "sdk/js/core/multimodal-inputs",
                   "sdk/js/core/events",
-                  "sdk/js/core/migration-0-1-0"
+                  "sdk/js/core/migration-0-1-0",
+                  "sdk/js/core/migration-1-0-0"
                 ]
               },
               {

--- a/docs/sdk/js/core/events.mdx
+++ b/docs/sdk/js/core/events.mdx
@@ -5,7 +5,7 @@ description:
 ---
 
 <Callout type="info">
-**Upgrading from 0.0.x?** See the [0.1.0 migration guide](/sdk/js/core/migration-0-1-0) — schemas moved to a new subpath and zod is now an optional peer dependency.
+**Upgrading from 0.0.x?** See the [1.0.0 migration guide](/sdk/js/core/migration-1-0-0) — schemas moved to a new subpath and zod is now an optional peer dependency.
 </Callout>
 
 # Events
@@ -571,18 +571,18 @@ type CustomEvent = BaseEvent & {
 | `name`   | `string` | Name of the custom event        |
 | `value`  | `any`    | Value associated with the event |
 
-## Deprecated Events
+## Removed Events
 
 <Warning>
-  The `THINKING_*` events are deprecated and will be removed in version 1.0.0.
-  New implementations should use `REASONING_*` events instead.
+  The `THINKING_*` events were **removed in 1.0.0**. Use the `REASONING_*` events
+  instead. Legacy agents (`maxVersion <= 0.0.45`) that still emit `THINKING_*` on
+  the wire continue to work — the client transparently rewrites them to their
+  `REASONING_*` equivalents before validation.
 </Warning>
 
-### Thinking Events (Deprecated)
+The following event types were removed; each maps 1:1 to a `REASONING_*` event:
 
-The following event types are deprecated:
-
-| Deprecated Event                | Replacement                 |
+| Removed Event                   | Replacement                 |
 | ------------------------------- | --------------------------- |
 | `THINKING_START`                | `REASONING_START`           |
 | `THINKING_END`                  | `REASONING_END`             |

--- a/docs/sdk/js/core/migration-1-0-0.mdx
+++ b/docs/sdk/js/core/migration-1-0-0.mdx
@@ -1,0 +1,78 @@
+---
+title: "Migrating to @ag-ui/core 1.0.0"
+description: "Update your code for 1.0.0: the deprecated THINKING events and binary multimodal input are removed."
+---
+
+# Migrating to @ag-ui/core 1.0.0
+
+`@ag-ui/core` 1.0.0 removes two long-deprecated surfaces: the `THINKING_*` events
+(replaced by `REASONING_*`) and the `BinaryInputContent` multimodal input
+(replaced by the dedicated `image` / `audio` / `video` / `document` content types).
+
+<Callout type="info">
+Coming from 0.0.x? 1.0.0 also includes the 0.1.0 change that moved zod schemas to
+the `@ag-ui/core/schemas` subpath and made zod an optional peer dependency. See the
+[0.1.0 migration guide](/sdk/js/core/migration-0-1-0) for that step.
+</Callout>
+
+## Removed: THINKING events
+
+The `EventType.THINKING_*` enum members, the `Thinking*Event` types, the
+`Thinking*EventSchema` schemas, and the `createThinking*` factories no longer
+exist. Switch to the `REASONING_*` events — each maps 1:1:
+
+| Removed                         | Replacement                 |
+| ------------------------------- | --------------------------- |
+| `THINKING_START`                | `REASONING_START`           |
+| `THINKING_END`                  | `REASONING_END`             |
+| `THINKING_TEXT_MESSAGE_START`   | `REASONING_MESSAGE_START`   |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
+
+```ts
+// Before
+import { createThinkingStartEvent } from "@ag-ui/core";
+const event = createThinkingStartEvent({ title: "Working" });
+
+// After
+import { createReasoningStartEvent } from "@ag-ui/core";
+const event = createReasoningStartEvent({ messageId: "r-1" });
+```
+
+<Callout type="info">
+**Consuming a legacy agent?** If you connect to an agent that still emits
+`THINKING_*` events on the wire (`maxVersion <= 0.0.45`), you don't need to do
+anything — `@ag-ui/client` transparently rewrites those events to their
+`REASONING_*` equivalents before they reach your code.
+</Callout>
+
+## Removed: binary multimodal input
+
+The deprecated `BinaryInputContent` (`type: "binary"`) message content is removed.
+The `BinaryInputContent` type, `BinaryInputContentSchema`, and its place in the
+`InputContent` union no longer exist. Use the dedicated content types with a
+`source` discriminator instead:
+
+```ts
+// Before
+const content = [
+  { type: "binary", mimeType: "image/png", data: "base64..." },
+  { type: "binary", mimeType: "image/jpeg", url: "https://example.com/p.jpg" },
+];
+
+// After
+const content = [
+  { type: "image", source: { type: "data", value: "base64...", mimeType: "image/png" } },
+  { type: "image", source: { type: "url", value: "https://example.com/p.jpg", mimeType: "image/jpeg" } },
+];
+```
+
+Map the mime type to the content type: `image/*` → `image`, `audio/*` → `audio`,
+`video/*` → `video`, everything else → `document`.
+
+<Callout type="info">
+**Still sending binary?** `@ag-ui/client` upgrades legacy binary parts to the new
+types on outgoing input automatically. Parts with `data` or `url` are converted;
+`id`-only binary parts (no `data`/`url`) have no equivalent in the new source model
+and are dropped with a warning — re-send those with a `data` or `url` source.
+</Callout>

--- a/docs/sdk/js/core/overview.mdx
+++ b/docs/sdk/js/core/overview.mdx
@@ -4,7 +4,7 @@ description: "Core concepts in the Agent User Interaction Protocol SDK"
 ---
 
 <Callout type="info">
-**Upgrading from 0.0.x?** See the [0.1.0 migration guide](/sdk/js/core/migration-0-1-0) — schemas moved to a new subpath and zod is now an optional peer dependency.
+**Upgrading from 0.0.x?** See the [1.0.0 migration guide](/sdk/js/core/migration-1-0-0) — schemas moved to a new subpath and zod is now an optional peer dependency.
 </Callout>
 
 # @ag-ui/core

--- a/integrations/a2a/typescript/src/utils.ts
+++ b/integrations/a2a/typescript/src/utils.ts
@@ -15,7 +15,6 @@ import type {
   A2APart,
   A2ATextPart,
   A2ADataPart,
-  A2AFilePart,
   A2AStreamEvent,
   ConvertAGUIMessagesOptions,
   ConvertedA2AMessages,
@@ -40,10 +39,6 @@ const SURFACE_OPERATION_KEYS = [
 
 type SurfaceOperationKey = (typeof SURFACE_OPERATION_KEYS)[number];
 
-const isBinaryContent = (
-  content: InputContent,
-): content is Extract<InputContent, { type: "binary" }> => content.type === "binary";
-
 const isTextContent = (content: InputContent): content is Extract<InputContent, { type: "text" }> =>
   content.type === "text";
 
@@ -51,32 +46,6 @@ const createTextPart = (text: string): A2ATextPart => ({
   kind: "text",
   text,
 });
-
-const createFilePart = (content: Extract<InputContent, { type: "binary" }>): A2AFilePart | null => {
-  if (content.url) {
-    return {
-      kind: "file",
-      file: {
-        uri: content.url,
-        mimeType: content.mimeType,
-        name: content.filename,
-      },
-    };
-  }
-
-  if (content.data) {
-    return {
-      kind: "file",
-      file: {
-        bytes: content.data,
-        mimeType: content.mimeType,
-        name: content.filename,
-      },
-    };
-  }
-
-  return null;
-};
 
 const extractSurfaceOperation = (
   payload: unknown,
@@ -123,11 +92,6 @@ const messageContentToParts = (message: Message): A2APart[] => {
         const value = chunk.text.trim();
         if (value.length > 0) {
           parts.push(createTextPart(value));
-        }
-      } else if (isBinaryContent(chunk)) {
-        const filePart = createFilePart(chunk);
-        if (filePart) {
-          parts.push(filePart);
         }
       } else {
         parts.push({ kind: "data", data: chunk } as A2ADataPart);

--- a/integrations/aws-strands/typescript/src/utils.ts
+++ b/integrations/aws-strands/typescript/src/utils.ts
@@ -191,39 +191,6 @@ export async function convertAguiContentToStrands(
       continue;
     }
 
-    if (item.type === "binary") {
-      // Deprecated legacy binary content — try to map to an image block.
-      const bin = item as {
-        type: "binary";
-        mimeType: string;
-        url?: string;
-        data?: string;
-      };
-      let bytes: Uint8Array | null = null;
-      if (bin.data) {
-        bytes = decodeBase64(bin.data, log);
-      } else if (bin.url) {
-        bytes = await fetchUrlBytes(bin.url, log);
-      }
-      if (!bytes) {
-        log.warn(
-          `${LOG_PREFIX} Skipping binary content: could not resolve bytes`,
-        );
-        continue;
-      }
-      const fmt = mimeToFormat(bin.mimeType, IMAGE_FORMATS, log);
-      if (!fmt) {
-        log.warn(
-          `${LOG_PREFIX} Skipping binary content: unsupported MIME type '${bin.mimeType}'`,
-        );
-        continue;
-      }
-      blocks.push(
-        new ImageBlock({ format: fmt as ImageFormat, source: { bytes } }),
-      );
-      continue;
-    }
-
     log.warn(
       `${LOG_PREFIX} Skipping unknown content type: ${(item as { type?: string }).type}`,
     );

--- a/integrations/langgraph/typescript/examples/src/agents/multimodal_messages/agent.ts
+++ b/integrations/langgraph/typescript/examples/src/agents/multimodal_messages/agent.ts
@@ -9,7 +9,7 @@
  * Example usage:
  *
  * ```typescript
- * import { UserMessage, TextInputContent, BinaryInputContent } from "@ag-ui/core";
+ * import { UserMessage, ImageInputContent } from "@ag-ui/core";
  *
  * // Create a multimodal user message
  * const message: UserMessage = {
@@ -18,9 +18,8 @@
  *   content: [
  *     { type: "text", text: "What's in this image?" },
  *     {
- *       type: "binary",
- *       mimeType: "image/jpeg",
- *       url: "https://example.com/photo.jpg"
+ *       type: "image",
+ *       source: { type: "url", value: "https://example.com/photo.jpg", mimeType: "image/jpeg" },
  *     },
  *   ],
  * };
@@ -32,10 +31,8 @@
  *   content: [
  *     { type: "text", text: "Describe this picture" },
  *     {
- *       type: "binary",
- *       mimeType: "image/png",
- *       data: "iVBORw0KGgoAAAANSUhEUgAAAAUA...", // base64 encoded
- *       filename: "screenshot.png"
+ *       type: "image",
+ *       source: { type: "data", value: "iVBORw0KGgoAAAANSUhEUgAAAAUA...", mimeType: "image/png" },
  *     },
  *   ],
  * };

--- a/integrations/langgraph/typescript/src/utils.test.ts
+++ b/integrations/langgraph/typescript/src/utils.test.ts
@@ -7,7 +7,6 @@ import {
   Message,
   UserMessage,
   TextInputContent,
-  BinaryInputContent,
   ImageInputContent,
   AudioInputContent,
   VideoInputContent,
@@ -171,51 +170,6 @@ describe("Multimodal Message Conversion", () => {
       expect(content[1].image_url.url).toBe("https://example.com/doc.pdf");
     });
 
-    it("should handle BinaryInputContent for backwards compatibility", () => {
-      const aguiMessage: UserMessage = {
-        id: "test-binary-compat",
-        role: "user",
-        content: [
-          { type: "text", text: "What's in this image?" },
-          {
-            type: "binary",
-            mimeType: "image/jpeg",
-            url: "https://example.com/photo.jpg",
-          } as BinaryInputContent,
-        ],
-      };
-
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      const content = lcMessages[0].content as Array<any>;
-      expect(content).toHaveLength(2);
-
-      expect(content[1].type).toBe("image_url");
-      expect(content[1].image_url.url).toBe("https://example.com/photo.jpg");
-    });
-
-    it("should handle BinaryInputContent with base64 data for backwards compat", () => {
-      const aguiMessage: UserMessage = {
-        id: "test-binary-data",
-        role: "user",
-        content: [
-          {
-            type: "binary",
-            mimeType: "image/png",
-            data: "iVBORw0KGgoAAAANSUhEUgAAAAUA",
-          } as BinaryInputContent,
-        ],
-      };
-
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      const content = lcMessages[0].content as Array<any>;
-      expect(content).toHaveLength(1);
-      expect(content[0].type).toBe("image_url");
-      expect(content[0].image_url.url).toBe(
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
-      );
-    });
   });
 
   describe("langchainMessagesToAgui", () => {
@@ -315,28 +269,6 @@ describe("Multimodal Message Conversion", () => {
       expect((lcMessages[0].content as Array<any>)).toHaveLength(0);
     });
 
-    it("should handle BinaryInputContent with only id for backwards compat", () => {
-      const aguiMessage: UserMessage = {
-        id: "test-8",
-        role: "user",
-        content: [
-          {
-            type: "binary",
-            mimeType: "image/jpeg",
-            id: "img-123",
-          } as BinaryInputContent,
-        ],
-      };
-
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      expect(lcMessages).toHaveLength(1);
-      const content = lcMessages[0].content as Array<any>;
-      expect(content).toHaveLength(1);
-      expect(content[0].type).toBe("image_url");
-      expect(content[0].image_url.url).toBe("img-123");
-    });
-
     it("should skip media content with unknown source type", () => {
       const aguiMessage: UserMessage = {
         id: "test-unknown-source",
@@ -356,27 +288,5 @@ describe("Multimodal Message Conversion", () => {
       expect(content[0].type).toBe("text");
     });
 
-    it("should skip binary content without any source", () => {
-      const aguiMessage: UserMessage = {
-        id: "test-9",
-        role: "user",
-        content: [
-          { type: "text", text: "Hello" },
-          {
-            type: "binary",
-            mimeType: "image/jpeg",
-            // No url, data, or id
-          } as BinaryInputContent,
-        ],
-      };
-
-      const lcMessages = aguiMessagesToLangChain([aguiMessage]);
-
-      expect(lcMessages).toHaveLength(1);
-      const content = lcMessages[0].content as Array<any>;
-      // Binary content should be skipped, only text remains
-      expect(content).toHaveLength(1);
-      expect(content[0].type).toBe("text");
-    });
   });
 });

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -112,10 +112,10 @@ function convertLangchainMultimodalToAgui(
 /**
  * Convert AG-UI multimodal content to LangChain's format.
  *
- * Handles the new typed content classes (ImageInputContent, AudioInputContent,
- * VideoInputContent, DocumentInputContent) as well as legacy BinaryInputContent
- * for backwards compatibility. All media types are routed through LangChain's
- * `image_url` format since that is the only media block type LangChain supports.
+ * Handles the typed content classes (ImageInputContent, AudioInputContent,
+ * VideoInputContent, DocumentInputContent). All media types are routed through
+ * LangChain's `image_url` format since that is the only media block type
+ * LangChain supports.
  */
 function convertAguiMultimodalToLangchain(
   content: InputContent[]
@@ -140,28 +140,6 @@ function convertAguiMultimodalToLangchain(
       } else {
         console.warn(`[convertAguiMultimodalToLangchain] Dropping ${item.type} content: source could not be converted to URL`);
       }
-    } else if (item.type === "binary") {
-      // Legacy BinaryInputContent — backwards compatibility
-      let url: string;
-
-      // Prioritize url, then data, then id
-      if (item.url) {
-        url = item.url;
-      } else if (item.data) {
-        // Construct data URL from base64 data
-        url = `data:${item.mimeType};base64,${item.data}`;
-      } else if (item.id) {
-        // Use id as a reference
-        url = item.id;
-      } else {
-        console.warn("[convertAguiMultimodalToLangchain] Dropping BinaryInputContent: no url, data, or id provided");
-        continue;
-      }
-
-      langchainContent.push({
-        type: "image_url",
-        image_url: { url },
-      });
     }
   }
 

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -78,21 +78,6 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
           mimeType: part.source.mimeType ?? "application/octet-stream",
         });
         break;
-      case "binary": {
-        // Deprecated BinaryInputContent
-        const binaryPart = part as Extract<InputContent, { type: "binary" }>;
-        if (binaryPart.url) {
-          parts.push({ type: "image", image: binaryPart.url });
-        } else if (binaryPart.data && binaryPart.mimeType) {
-          parts.push({
-            type: "image",
-            image: `data:${binaryPart.mimeType};base64,${binaryPart.data}`,
-          });
-        } else {
-          console.warn("[toMastraContent] Dropping BinaryInputContent: no url or data provided");
-        }
-        break;
-      }
       default:
         console.warn(`[toMastraContent] Unknown content type "${part.type}"; skipping`);
         break;

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -114,14 +114,19 @@ export abstract class AbstractAgent {
       this.middlewares.unshift(new BackwardCompatibility_0_0_39());
     }
 
-    // Auto-insert BackwardCompatibility_0_0_45 for backward compatibility
-    // with legacy THINKING events (deprecated, will be removed in 1.0.0)
+    // Auto-insert BackwardCompatibility_0_0_45 to translate legacy THINKING
+    // events to REASONING for old agents. The THINKING_* types were removed in
+    // 1.0.0; the HTTP transport applies the same mapping unconditionally
+    // (see transform/http.ts), so this guard mainly covers non-HTTP agents.
     if (compareVersions(this.maxVersion, "0.0.45") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_45());
     }
 
-    // Auto-insert BackwardCompatibility_0_0_47 for backward compatibility
-    // with legacy BinaryInputContent (maps to dedicated image/audio/video/document types)
+    // Auto-insert BackwardCompatibility_0_0_47 to map legacy binary content to
+    // the dedicated image/audio/video/document types. The binary type was removed
+    // in 1.0.0; the HTTP transport applies the same upgrade unconditionally on
+    // outgoing input (see HttpAgent.requestInit), so this guard mainly covers
+    // non-HTTP agents.
     if (compareVersions(this.maxVersion, "0.0.47") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_47());
     }

--- a/sdks/typescript/packages/client/src/agent/http.ts
+++ b/sdks/typescript/packages/client/src/agent/http.ts
@@ -4,6 +4,7 @@ import { HttpAgentConfig, HttpAgentFetchFn, RunAgentParameters } from "./types";
 import { RunAgentInput, BaseEvent } from "@ag-ui/core";
 import { structuredClone_ } from "@/utils";
 import { transformHttpEventStream } from "@/transform/http";
+import { upgradeLegacyBinaryInput } from "@/middleware/backward-compatibility-0-0-47";
 import { Observable } from "rxjs";
 import { AgentSubscriber } from "./subscriber";
 
@@ -31,7 +32,10 @@ export class HttpAgent extends AbstractAgent {
         "Content-Type": "application/json",
         Accept: "text/event-stream",
       },
-      body: JSON.stringify(input),
+      // Upgrade legacy binary content parts to the dedicated image/audio/video/
+      // document types before sending. The binary type was removed in 1.0.0, so
+      // this keeps apps that still construct binary content interoperable.
+      body: JSON.stringify(upgradeLegacyBinaryInput(input)),
       signal: this.abortController.signal,
     };
   }

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -947,26 +947,6 @@ export const defaultApplyEvents = (
           throw new Error("TOOL_CALL_CHUNK must be tranformed before being applied");
         }
 
-        case EventType.THINKING_START: {
-          return emitUpdates();
-        }
-
-        case EventType.THINKING_END: {
-          return emitUpdates();
-        }
-
-        case EventType.THINKING_TEXT_MESSAGE_START: {
-          return emitUpdates();
-        }
-
-        case EventType.THINKING_TEXT_MESSAGE_CONTENT: {
-          return emitUpdates();
-        }
-
-        case EventType.THINKING_TEXT_MESSAGE_END: {
-          return emitUpdates();
-        }
-
         case EventType.REASONING_START: {
           const mutation = await runSubscribersWithMutation(
             subscribers,

--- a/sdks/typescript/packages/client/src/chunks/transform.ts
+++ b/sdks/typescript/packages/client/src/chunks/transform.ts
@@ -127,11 +127,6 @@ export const transformChunks =
           case EventType.RUN_ERROR:
           case EventType.STEP_STARTED:
           case EventType.STEP_FINISHED:
-          case EventType.THINKING_START:
-          case EventType.THINKING_END:
-          case EventType.THINKING_TEXT_MESSAGE_START:
-          case EventType.THINKING_TEXT_MESSAGE_CONTENT:
-          case EventType.THINKING_TEXT_MESSAGE_END:
           case EventType.REASONING_START:
           case EventType.REASONING_MESSAGE_START:
           case EventType.REASONING_MESSAGE_CONTENT:

--- a/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
@@ -75,7 +75,7 @@ describe("BackwardCompatibility_0_0_45", () => {
     expect(result[0]).toEqual({
       type: EventType.REASONING_MESSAGE_START,
       messageId: "mock-uuid",
-      role: "assistant",
+      role: "reasoning",
     });
   });
 

--- a/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-47.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-47.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { AbstractAgent } from "@/agent";
 import { BaseEvent, EventType, RunAgentInput } from "@ag-ui/core";
 import { Observable, from, lastValueFrom, toArray } from "rxjs";
-import { BackwardCompatibility_0_0_47 } from "../backward-compatibility-0-0-47";
+import {
+  BackwardCompatibility_0_0_47,
+  upgradeLegacyBinaryInput,
+} from "../backward-compatibility-0-0-47";
 
 class MockAgent extends AbstractAgent {
   private events: BaseEvent[];
@@ -230,7 +233,7 @@ describe("BackwardCompatibility_0_0_47", () => {
     ]);
   });
 
-  it("leaves binary with only id as-is", async () => {
+  it("drops binary with only id (no data/url has no new-format equivalent)", async () => {
     const agent = new MockAgent([]);
 
     const input = createInput([
@@ -252,13 +255,7 @@ describe("BackwardCompatibility_0_0_47", () => {
     });
 
     const msg = agent.receivedInput!.messages[0] as { content: unknown[] };
-    expect(msg.content).toEqual([
-      {
-        type: "binary",
-        mimeType: "image/png",
-        id: "file-123",
-      },
-    ]);
+    expect(msg.content).toEqual([]);
   });
 
   it("handles mixed content parts", async () => {
@@ -353,5 +350,29 @@ describe("BackwardCompatibility_0_0_47", () => {
       type: "image",
       source: { type: "data", value: "base64data", mimeType: "image/png" },
     });
+  });
+
+  // HttpAgent.requestInit and this middleware can both run, so the upgrade must
+  // be idempotent — already-upgraded parts pass through unchanged.
+  it("upgradeLegacyBinaryInput is idempotent when applied twice", () => {
+    const input = createInput([
+      {
+        id: "msg-1",
+        role: "user",
+        content: [
+          { type: "text", text: "look:" },
+          { type: "binary", mimeType: "image/png", data: "base64data" },
+        ],
+      },
+    ] as unknown as RunAgentInput["messages"]);
+
+    const once = upgradeLegacyBinaryInput(input);
+    const twice = upgradeLegacyBinaryInput(once);
+
+    expect(twice.messages[0]).toEqual(once.messages[0]);
+    expect((twice.messages[0] as { content: unknown[] }).content).toEqual([
+      { type: "text", text: "look:" },
+      { type: "image", source: { type: "data", value: "base64data", mimeType: "image/png" } },
+    ]);
   });
 });

--- a/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
+++ b/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-45.ts
@@ -4,6 +4,7 @@ import type { RunAgentInput, BaseEvent } from "@ag-ui/core";
 import { EventType } from "@ag-ui/core";
 import type { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { transformChunks } from "@/chunks";
 import { randomUUID } from "@/utils";
 
 // Event type strings for THINKING events (deprecated)
@@ -13,12 +14,26 @@ const THINKING_TEXT_MESSAGE_START = "THINKING_TEXT_MESSAGE_START";
 const THINKING_TEXT_MESSAGE_CONTENT = "THINKING_TEXT_MESSAGE_CONTENT";
 const THINKING_TEXT_MESSAGE_END = "THINKING_TEXT_MESSAGE_END";
 
+function warnAboutTransformation(from: string, to: string) {
+  if (
+    typeof process !== "undefined" &&
+    typeof process.env !== "undefined" &&
+    process.env.SUPPRESS_TRANSFORMATION_WARNINGS
+  )
+    return;
+  console.warn(
+    `AG-UI is converting ${from} to ${to}. To remove this warning, upgrade your AG-UI integration package (e.g. @ag-ui/langgraph). To surpress it, set SUPPRESS_TRANSFORMATION_WARNINGS=true in your .env file.`,
+  );
+}
+
 /**
- * Middleware that maps deprecated THINKING events to the new REASONING events.
+ * Creates a stateful mapper that rewrites deprecated legacy THINKING events into
+ * their REASONING replacements. The THINKING_* event types were removed from the
+ * protocol in 1.0.0; this keeps backward compatibility for legacy agents that
+ * still emit them on the wire.
  *
- * This ensures backward compatibility for agents that still emit legacy THINKING
- * events (THINKING_START, THINKING_END, THINKING_TEXT_MESSAGE_START, etc.)
- * by transforming them into the corresponding REASONING events.
+ * The mapper is stateful (it remembers the generated reasoning/message ids across
+ * a START → … → END sequence), so create a fresh one per run/stream.
  *
  * Event mapping:
  * - THINKING_START → REASONING_START
@@ -27,76 +42,50 @@ const THINKING_TEXT_MESSAGE_END = "THINKING_TEXT_MESSAGE_END";
  * - THINKING_TEXT_MESSAGE_END → REASONING_MESSAGE_END
  * - THINKING_END → REASONING_END
  *
+ * Non-THINKING events pass through unchanged.
  */
-export class BackwardCompatibility_0_0_45 extends Middleware {
-  private currentReasoningId: string | null = null;
-  private currentMessageId: string | null = null;
+export function createLegacyThinkingMapper(): (event: BaseEvent) => BaseEvent {
+  let currentReasoningId: string | null = null;
+  let currentMessageId: string | null = null;
 
-  private warnAboutTransformation(from: string, to: string) {
-    if (
-      typeof process !== "undefined" &&
-      typeof process.env !== "undefined" &&
-      process.env.SUPPRESS_TRANSFORMATION_WARNINGS
-    )
-      return;
-    console.warn(
-      `AG-UI is converting ${from} to ${to}. To remove this warning, upgrade your AG-UI integration package (e.g. @ag-ui/langgraph). To surpress it, set SUPPRESS_TRANSFORMATION_WARNINGS=true in your .env file.`,
-    );
-  }
-  override run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    // Reset state for each run
-    this.currentReasoningId = null;
-    this.currentMessageId = null;
-
-    return this.runNext(input, next).pipe(map((event) => this.transformEvent(event)));
-  }
-
-  private transformEvent(event: BaseEvent): BaseEvent {
-    const eventType = event.type as string;
-
-    switch (eventType) {
+  return (event: BaseEvent): BaseEvent => {
+    switch (event.type as string) {
       case THINKING_START: {
-        this.currentReasoningId = randomUUID();
+        currentReasoningId = randomUUID();
         const { title, ...rest } = event as BaseEvent & { title?: string };
-        this.warnAboutTransformation(THINKING_START, EventType.REASONING_START);
+        warnAboutTransformation(THINKING_START, EventType.REASONING_START);
         return {
           ...rest,
           type: EventType.REASONING_START,
-          messageId: this.currentReasoningId,
+          messageId: currentReasoningId,
         };
       }
 
       case THINKING_TEXT_MESSAGE_START: {
-        this.currentMessageId = randomUUID();
-        this.warnAboutTransformation(
-          THINKING_TEXT_MESSAGE_START,
-          EventType.REASONING_MESSAGE_START,
-        );
+        currentMessageId = randomUUID();
+        warnAboutTransformation(THINKING_TEXT_MESSAGE_START, EventType.REASONING_MESSAGE_START);
         return {
           ...event,
           type: EventType.REASONING_MESSAGE_START,
-          messageId: this.currentMessageId,
-          role: "assistant" as const,
+          messageId: currentMessageId,
+          role: "reasoning" as const,
         };
       }
 
       case THINKING_TEXT_MESSAGE_CONTENT: {
         const { delta, ...rest } = event as BaseEvent & { delta: string };
-        this.warnAboutTransformation(
-          THINKING_TEXT_MESSAGE_CONTENT,
-          EventType.REASONING_MESSAGE_CONTENT,
-        );
+        warnAboutTransformation(THINKING_TEXT_MESSAGE_CONTENT, EventType.REASONING_MESSAGE_CONTENT);
         return {
           ...rest,
           type: EventType.REASONING_MESSAGE_CONTENT,
-          messageId: this.currentMessageId ?? randomUUID(),
+          messageId: currentMessageId ?? randomUUID(),
           delta,
         };
       }
 
       case THINKING_TEXT_MESSAGE_END: {
-        const messageId = this.currentMessageId ?? randomUUID();
-        this.warnAboutTransformation(THINKING_TEXT_MESSAGE_END, EventType.REASONING_MESSAGE_END);
+        const messageId = currentMessageId ?? randomUUID();
+        warnAboutTransformation(THINKING_TEXT_MESSAGE_END, EventType.REASONING_MESSAGE_END);
         return {
           ...event,
           type: EventType.REASONING_MESSAGE_END,
@@ -105,8 +94,8 @@ export class BackwardCompatibility_0_0_45 extends Middleware {
       }
 
       case THINKING_END: {
-        const reasoningId = this.currentReasoningId ?? randomUUID();
-        this.warnAboutTransformation(THINKING_END, EventType.REASONING_END);
+        const reasoningId = currentReasoningId ?? randomUUID();
+        warnAboutTransformation(THINKING_END, EventType.REASONING_END);
         return {
           ...event,
           type: EventType.REASONING_END,
@@ -117,5 +106,24 @@ export class BackwardCompatibility_0_0_45 extends Middleware {
       default:
         return event;
     }
+  };
+}
+
+/**
+ * Middleware that maps deprecated THINKING events to the new REASONING events.
+ *
+ * This ensures backward compatibility for agents that still emit legacy THINKING
+ * events by transforming them into the corresponding REASONING events. The HTTP
+ * transport applies the same mapping pre-validation (see {@link createLegacyThinkingMapper});
+ * this middleware covers non-HTTP agents that emit THINKING events directly.
+ */
+export class BackwardCompatibility_0_0_45 extends Middleware {
+  override run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    // Fresh mapper state for each run.
+    const mapEvent = createLegacyThinkingMapper();
+    // Translate legacy THINKING events to REASONING *before* chunk transformation.
+    // transformChunks no longer recognizes the removed THINKING_* types and would
+    // otherwise drop them at its exhaustiveness fallthrough.
+    return next.run(input).pipe(map(mapEvent), transformChunks(false));
   }
 }

--- a/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-47.ts
+++ b/sdks/typescript/packages/client/src/middleware/backward-compatibility-0-0-47.ts
@@ -38,7 +38,24 @@ function isLegacyBinaryContent(part: unknown): part is LegacyBinaryContent {
   );
 }
 
-function convertBinaryToNewFormat(binary: LegacyBinaryContent): NewContentPart | LegacyBinaryContent {
+function warnDroppedBinary() {
+  if (
+    typeof process !== "undefined" &&
+    typeof process.env !== "undefined" &&
+    process.env.SUPPRESS_TRANSFORMATION_WARNINGS
+  )
+    return;
+  console.warn(
+    "AG-UI dropped a legacy binary content part that only has an `id` (no `data` or `url`). " +
+      "The binary content type was removed in 1.0.0 and `id`-only parts have no equivalent in the " +
+      "image/audio/video/document model. Re-send it with `source: { type: \"data\" | \"url\", ... }`. " +
+      "To suppress this warning, set SUPPRESS_TRANSFORMATION_WARNINGS=true.",
+  );
+}
+
+// Returns null to signal that the part should be dropped (id-only binary, which
+// has no representation in the new data|url source model).
+function convertBinaryToNewFormat(binary: LegacyBinaryContent): NewContentPart | null {
   const contentType = mimeTypeToContentType(binary.mimeType);
 
   if (binary.data) {
@@ -57,9 +74,8 @@ function convertBinaryToNewFormat(binary: LegacyBinaryContent): NewContentPart |
     };
   }
 
-  // If only `id` is present, we can't map to the new source format.
-  // Return as-is — the schema still accepts BinaryInputContent.
-  return binary;
+  warnDroppedBinary();
+  return null;
 }
 
 function upgradeMessageContent(message: InputMessage): InputMessage {
@@ -69,38 +85,48 @@ function upgradeMessageContent(message: InputMessage): InputMessage {
     return message;
   }
 
-  const upgraded = rawContent.map((part: unknown) => {
+  const upgraded = rawContent.reduce<unknown[]>((parts, part: unknown) => {
     if (isLegacyBinaryContent(part)) {
-      return convertBinaryToNewFormat(part);
+      const converted = convertBinaryToNewFormat(part);
+      if (converted !== null) parts.push(converted);
+    } else {
+      parts.push(part);
     }
-    return part;
-  });
+    return parts;
+  }, []);
 
   return { ...message, content: upgraded } as InputMessage;
 }
 
 /**
- * Middleware that converts legacy BinaryInputContent entries (type: "binary")
- * to the new dedicated content types (image, audio, video, document) with
- * source discriminator.
+ * Upgrades any legacy binary content parts (`type: "binary"`) in a RunAgentInput's
+ * messages to the dedicated content types (image/audio/video/document) with a
+ * `source` discriminator. Shared by the HTTP transport (applied unconditionally on
+ * outgoing input, since the binary type was removed in 1.0.0) and the
+ * {@link BackwardCompatibility_0_0_47} middleware.
  *
  * Old format (v0.0.47 and below):
  *   { type: "binary", mimeType: "image/png", data: "base64..." }
- *
- * New format (v0.0.48+):
+ * New format:
  *   { type: "image", source: { type: "data", value: "base64...", mimeType: "image/png" } }
  *
- * Plain string content and TextInputContent pass through unchanged.
- * BinaryInputContent entries that only have `id` (no data/url) are left as-is
- * since they can't be mapped to the new source format.
+ * Plain string content and non-binary parts pass through unchanged. `id`-only
+ * binary parts (no data/url) are dropped with a warning.
+ */
+export function upgradeLegacyBinaryInput(input: RunAgentInput): RunAgentInput {
+  return {
+    ...input,
+    messages: input.messages.map(upgradeMessageContent),
+  };
+}
+
+/**
+ * Middleware that converts legacy BinaryInputContent entries to the new dedicated
+ * content types. The HTTP transport applies the same upgrade unconditionally on
+ * outgoing input (see HttpAgent.requestInit); this middleware covers non-HTTP agents.
  */
 export class BackwardCompatibility_0_0_47 extends Middleware {
   override run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
-    const upgradedInput: RunAgentInput = {
-      ...input,
-      messages: input.messages.map(upgradeMessageContent),
-    };
-
-    return this.runNext(upgradedInput, next);
+    return this.runNext(upgradeLegacyBinaryInput(input), next);
   }
 }

--- a/sdks/typescript/packages/client/src/transform/http.ts
+++ b/sdks/typescript/packages/client/src/transform/http.ts
@@ -7,6 +7,7 @@ import { parseSSEStream } from "./sse";
 import { parseProtoStream } from "./proto";
 import * as proto from "@ag-ui/proto";
 import { type DebugLoggerInput, resolveDebugLogger } from "@/debug-logger";
+import { createLegacyThinkingMapper } from "@/middleware/backward-compatibility-0-0-45";
 
 /**
  * Transforms HTTP events into BaseEvents using the appropriate format parser based on content type.
@@ -23,6 +24,11 @@ export const transformHttpEventStream = (
 
   // Flag to track whether we've set up the parser
   let parserInitialized = false;
+
+  // Rewrites deprecated legacy THINKING events to REASONING before schema
+  // validation, so legacy (<= 0.0.45) agents still interoperate now that the
+  // THINKING_* event types are removed from the protocol (1.0.0).
+  const mapLegacyThinking = createLegacyThinkingMapper();
 
   // Subscribe to source and buffer events while we determine the content type
   source$.subscribe({
@@ -53,7 +59,8 @@ export const transformHttpEventStream = (
           parseSSEStream(bufferSubject, log).subscribe({
             next: (json) => {
               try {
-                const parsedEvent = EventSchemas.parse(json);
+                const normalized = mapLegacyThinking(json as BaseEvent);
+                const parsedEvent = EventSchemas.parse(normalized);
                 log?.event("HTTP", "Event validated:", parsedEvent, {
                   type: parsedEvent.type,
                   valid: true,

--- a/sdks/typescript/packages/client/src/verify/verify.ts
+++ b/sdks/typescript/packages/client/src/verify/verify.ts
@@ -16,8 +16,6 @@ export const verifyEvents =
     let firstEventReceived = false;
     // Track active steps
     let activeSteps = new Map<string, boolean>(); // Map of step name -> active status
-    let activeThinkingStep = false;
-    let activeThinkingStepMessage = false;
     let runStarted = false; // Track if a run has started
 
     // Function to reset state for a new run
@@ -25,8 +23,6 @@ export const verifyEvents =
       activeMessages.clear();
       activeToolCalls.clear();
       activeSteps.clear();
-      activeThinkingStep = false;
-      activeThinkingStepMessage = false;
       runFinished = false;
       runError = false;
       runStarted = true;
@@ -273,90 +269,6 @@ export const verifyEvents =
           }
 
           case EventType.CUSTOM: {
-            return of(event);
-          }
-
-          // Text message flow
-          case EventType.THINKING_TEXT_MESSAGE_START: {
-            if (!activeThinkingStep) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_TEXT_MESSAGE_START' event: A thinking step is not in progress. Create one with 'THINKING_START' first.`,
-                  ),
-              );
-            }
-            // Can't start a message if one is already in progress
-            if (activeThinkingStepMessage) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_TEXT_MESSAGE_START' event: A thinking message is already in progress. Complete it with 'THINKING_TEXT_MESSAGE_END' first.`,
-                  ),
-              );
-            }
-
-            activeThinkingStepMessage = true;
-            return of(event);
-          }
-
-          case EventType.THINKING_TEXT_MESSAGE_CONTENT: {
-            // Must be in a message and IDs must match
-            if (!activeThinkingStepMessage) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_TEXT_MESSAGE_CONTENT' event: No active thinking message found. Start a message with 'THINKING_TEXT_MESSAGE_START' first.`,
-                  ),
-              );
-            }
-
-            return of(event);
-          }
-
-          case EventType.THINKING_TEXT_MESSAGE_END: {
-            // Must be in a message and IDs must match
-            if (!activeThinkingStepMessage) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_TEXT_MESSAGE_END' event: No active thinking message found. A 'THINKING_TEXT_MESSAGE_START' event must be sent first.`,
-                  ),
-              );
-            }
-
-            // Reset message state
-            activeThinkingStepMessage = false;
-            return of(event);
-          }
-
-          case EventType.THINKING_START: {
-            if (activeThinkingStep) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_START' event: A thinking step is already in progress. End it with 'THINKING_END' first.`,
-                  ),
-              );
-            }
-
-            activeThinkingStep = true;
-            return of(event);
-          }
-
-          case EventType.THINKING_END: {
-            // Must be in a message and IDs must match
-            if (!activeThinkingStep) {
-              return throwError(
-                () =>
-                  new AGUIError(
-                    `Cannot send 'THINKING_END' event: No active thinking step found. A 'THINKING_START' event must be sent first.`,
-                  ),
-              );
-            }
-
-            // Reset message state
-            activeThinkingStep = false;
             return of(event);
           }
 

--- a/sdks/typescript/packages/core/CHANGELOG.md
+++ b/sdks/typescript/packages/core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ag-ui/core CHANGELOG
 
+## 1.0.0
+
+### BREAKING CHANGES
+
+- The deprecated `THINKING_*` events are removed. The `EventType.THINKING_*` enum members, the `Thinking*Event` types, the `Thinking*EventSchema` schemas, and the `createThinking*` factories no longer exist. Use the `REASONING_*` events instead — each maps 1:1 (`THINKING_START` → `REASONING_START`, `THINKING_TEXT_MESSAGE_START` → `REASONING_MESSAGE_START`, `THINKING_TEXT_MESSAGE_CONTENT` → `REASONING_MESSAGE_CONTENT`, `THINKING_TEXT_MESSAGE_END` → `REASONING_MESSAGE_END`, `THINKING_END` → `REASONING_END`). `@ag-ui/client` still transparently rewrites legacy `THINKING_*` wire events from `maxVersion <= 0.0.45` agents to their `REASONING_*` equivalents, so existing agents keep working.
+- The deprecated `BinaryInputContent` multimodal input (`type: "binary"`) is removed — the `BinaryInputContent` type, `BinaryInputContentSchema`, and its membership in `InputContentSchema` no longer exist. Use the dedicated `ImageInputContent` / `AudioInputContent` / `VideoInputContent` / `DocumentInputContent` types with a `source: { type: "data" | "url", ... }` discriminator. `@ag-ui/client` upgrades legacy binary parts to the new types on outgoing input (data/url parts are converted; `id`-only parts are dropped with a warning), so apps still sending binary keep working.
+
+### Migration
+
+See the [1.0.0 migration guide](https://docs.ag-ui.com/sdk/js/core/migration-1-0-0).
+
 ## 0.1.0
 
 ### BREAKING CHANGES

--- a/sdks/typescript/packages/core/src/__tests__/event-factories.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/event-factories.test.ts
@@ -17,11 +17,6 @@ import {
   createTextMessageContentEvent,
   createTextMessageEndEvent,
   createTextMessageStartEvent,
-  createThinkingEndEvent,
-  createThinkingStartEvent,
-  createThinkingTextMessageContentEvent,
-  createThinkingTextMessageEndEvent,
-  createThinkingTextMessageStartEvent,
   createToolCallArgsEvent,
   createToolCallChunkEvent,
   createToolCallEndEvent,
@@ -109,17 +104,6 @@ describe("event factories", () => {
     expect(event.messageId).toBeUndefined();
   });
 
-  it("creates THINKING_TEXT_MESSAGE_START/CONTENT/END", () => {
-    const start = createThinkingTextMessageStartEvent({});
-    const content = createThinkingTextMessageContentEvent({ delta: "thinking…" });
-    const end = createThinkingTextMessageEndEvent({});
-
-    expect(start.type).toBe(EventType.THINKING_TEXT_MESSAGE_START);
-    expect(content.type).toBe(EventType.THINKING_TEXT_MESSAGE_CONTENT);
-    expect(content.delta).toBe("thinking…");
-    expect(end.type).toBe(EventType.THINKING_TEXT_MESSAGE_END);
-  });
-
   it("creates TOOL_CALL_START/ARGS/END/CHUNK/RESULT", () => {
     const start = createToolCallStartEvent({
       toolCallId: "tc-1",
@@ -147,15 +131,6 @@ describe("event factories", () => {
     expect(end.type).toBe(EventType.TOOL_CALL_END);
     expect(result.role).toBe("tool");
     expect(result.content).toBe('{"ok":true}');
-  });
-
-  it("creates THINKING_START/END", () => {
-    const start = createThinkingStartEvent({ title: "working" });
-    const end = createThinkingEndEvent({});
-
-    expect(start.type).toBe(EventType.THINKING_START);
-    expect(start.title).toBe("working");
-    expect(end.type).toBe(EventType.THINKING_END);
   });
 
   it("creates STATE_SNAPSHOT and STATE_DELTA", () => {

--- a/sdks/typescript/packages/core/src/__tests__/multimodal-messages.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/multimodal-messages.test.ts
@@ -7,7 +7,6 @@ import {
   ImageInputPartSchema,
   InputContentDataSourceSchema,
   InputContentUrlSourceSchema,
-  BinaryInputContentSchema,
 } from "../schemas";
 
 const MODALITIES = ["image", "audio", "video", "document"] as const;
@@ -96,30 +95,14 @@ describe("Multimodal messages", () => {
     expect(result.mimeType).toBe("application/pdf");
   });
 
-  it("rejects binary content without payload source", () => {
+  it("rejects legacy binary content (removed in 1.0.0)", () => {
     const result = UserMessageSchema.safeParse({
       id: "user_invalid",
       role: "user" as const,
-      content: [{ type: "binary" as const, mimeType: "image/png" }],
+      content: [{ type: "binary" as const, mimeType: "image/png", data: "base64" }],
     });
 
     expect(result.success).toBe(false);
-  });
-
-  it("parses binary input with embedded data", () => {
-    const binary = BinaryInputContentSchema.parse({
-      type: "binary" as const,
-      mimeType: "image/png",
-      data: "base64",
-    });
-
-    expect(binary.data).toBe("base64");
-  });
-
-  it("requires binary payload source", () => {
-    expect(() =>
-      BinaryInputContentSchema.parse({ type: "binary" as const, mimeType: "image/png" }),
-    ).toThrow(/id, url, or data/);
   });
 
   describe.each(MODALITIES)("%s modality combinations", (modality) => {

--- a/sdks/typescript/packages/core/src/__tests__/schema-type-equality.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/schema-type-equality.test.ts
@@ -46,7 +46,6 @@ import type {
   RunAgentInputSchema,
   RoleSchema,
   InputContentSchema,
-  BinaryInputContentSchema,
   // Event schemas
   BaseEventSchema,
   TextMessageStartEventSchema,
@@ -80,11 +79,6 @@ import type {
   ReasoningMessageChunkEventSchema,
   ReasoningEndEventSchema,
   ReasoningEncryptedValueEventSchema,
-  ThinkingStartEventSchema,
-  ThinkingEndEventSchema,
-  ThinkingTextMessageStartEventSchema,
-  ThinkingTextMessageContentEventSchema,
-  ThinkingTextMessageEndEventSchema,
   // Capability schemas
   SubAgentInfoSchema,
   IdentityCapabilitiesSchema,
@@ -123,7 +117,6 @@ import type {
   RunAgentInput,
   Role,
   InputContent,
-  BinaryInputContent,
 } from "../types";
 
 import type {
@@ -159,11 +152,6 @@ import type {
   ReasoningMessageChunkEvent,
   ReasoningEndEvent,
   ReasoningEncryptedValueEvent,
-  ThinkingStartEvent,
-  ThinkingEndEvent,
-  ThinkingTextMessageStartEvent,
-  ThinkingTextMessageContentEvent,
-  ThinkingTextMessageEndEvent,
 } from "../events";
 
 import type {
@@ -229,11 +217,6 @@ type _IReasoningMessageEndEvent = z.infer<typeof ReasoningMessageEndEventSchema>
 type _IReasoningMessageChunkEvent = z.infer<typeof ReasoningMessageChunkEventSchema>;
 type _IReasoningEndEvent = z.infer<typeof ReasoningEndEventSchema>;
 type _IReasoningEncryptedValueEvent = z.infer<typeof ReasoningEncryptedValueEventSchema>;
-type _IThinkingStartEvent = z.infer<typeof ThinkingStartEventSchema>;
-type _IThinkingEndEvent = z.infer<typeof ThinkingEndEventSchema>;
-type _IThinkingTextMessageStartEvent = z.infer<typeof ThinkingTextMessageStartEventSchema>;
-type _IThinkingTextMessageContentEvent = z.infer<typeof ThinkingTextMessageContentEventSchema>;
-type _IThinkingTextMessageEndEvent = z.infer<typeof ThinkingTextMessageEndEventSchema>;
 
 // ==========================================================================
 // Types tests
@@ -290,9 +273,6 @@ describe("schema inferred types match hand-written types (types.ts)", () => {
   });
   it("InputContent", () => {
     expectTypeOf<z.infer<typeof InputContentSchema>>().toEqualTypeOf<InputContent>();
-  });
-  it("BinaryInputContent", () => {
-    expectTypeOf<z.infer<typeof BinaryInputContentSchema>>().toEqualTypeOf<BinaryInputContent>();
   });
 });
 
@@ -423,21 +403,6 @@ describe("schema inferred types match hand-written types (events.ts)", () => {
   });
   it("ReasoningEncryptedValueEvent", () => {
     expectTypeOf<_IReasoningEncryptedValueEvent>().toExtend<ReasoningEncryptedValueEvent>();
-  });
-  it("ThinkingStartEvent", () => {
-    expectTypeOf<_IThinkingStartEvent>().toExtend<ThinkingStartEvent>();
-  });
-  it("ThinkingEndEvent", () => {
-    expectTypeOf<_IThinkingEndEvent>().toExtend<ThinkingEndEvent>();
-  });
-  it("ThinkingTextMessageStartEvent", () => {
-    expectTypeOf<_IThinkingTextMessageStartEvent>().toExtend<ThinkingTextMessageStartEvent>();
-  });
-  it("ThinkingTextMessageContentEvent", () => {
-    expectTypeOf<_IThinkingTextMessageContentEvent>().toExtend<ThinkingTextMessageContentEvent>();
-  });
-  it("ThinkingTextMessageEndEvent", () => {
-    expectTypeOf<_IThinkingTextMessageEndEvent>().toExtend<ThinkingTextMessageEndEvent>();
   });
 });
 

--- a/sdks/typescript/packages/core/src/event-factories.ts
+++ b/sdks/typescript/packages/core/src/event-factories.ts
@@ -33,16 +33,6 @@ import type {
   TextMessageEndEventProps,
   TextMessageStartEvent,
   TextMessageStartEventProps,
-  ThinkingEndEvent,
-  ThinkingEndEventProps,
-  ThinkingStartEvent,
-  ThinkingStartEventProps,
-  ThinkingTextMessageContentEvent,
-  ThinkingTextMessageContentEventProps,
-  ThinkingTextMessageEndEvent,
-  ThinkingTextMessageEndEventProps,
-  ThinkingTextMessageStartEvent,
-  ThinkingTextMessageStartEventProps,
   ToolCallArgsEvent,
   ToolCallArgsEventProps,
   ToolCallChunkEvent,
@@ -98,33 +88,6 @@ export const createTextMessageChunkEvent = (
 ): TextMessageChunkEvent =>
   ({ type: EventType.TEXT_MESSAGE_CHUNK, ...props }) as TextMessageChunkEvent;
 
-/** @deprecated Use `createReasoningMessageStartEvent` instead. Will be removed in 1.0.0. */
-export const createThinkingTextMessageStartEvent = (
-  props: ThinkingTextMessageStartEventProps,
-): ThinkingTextMessageStartEvent =>
-  ({
-    type: EventType.THINKING_TEXT_MESSAGE_START,
-    ...props,
-  }) as ThinkingTextMessageStartEvent;
-
-/** @deprecated Use `createReasoningMessageContentEvent` instead. Will be removed in 1.0.0. */
-export const createThinkingTextMessageContentEvent = (
-  props: ThinkingTextMessageContentEventProps,
-): ThinkingTextMessageContentEvent =>
-  ({
-    type: EventType.THINKING_TEXT_MESSAGE_CONTENT,
-    ...props,
-  }) as ThinkingTextMessageContentEvent;
-
-/** @deprecated Use `createReasoningMessageEndEvent` instead. Will be removed in 1.0.0. */
-export const createThinkingTextMessageEndEvent = (
-  props: ThinkingTextMessageEndEventProps,
-): ThinkingTextMessageEndEvent =>
-  ({
-    type: EventType.THINKING_TEXT_MESSAGE_END,
-    ...props,
-  }) as ThinkingTextMessageEndEvent;
-
 /** Creates a TOOL_CALL_START event. */
 export const createToolCallStartEvent = (
   props: ToolCallStartEventProps,
@@ -154,18 +117,6 @@ export const createToolCallResultEvent = (
   props: ToolCallResultEventProps,
 ): ToolCallResultEvent =>
   ({ type: EventType.TOOL_CALL_RESULT, ...props }) as ToolCallResultEvent;
-
-/** @deprecated Use `createReasoningStartEvent` instead. Will be removed in 1.0.0. */
-export const createThinkingStartEvent = (
-  props: ThinkingStartEventProps,
-): ThinkingStartEvent =>
-  ({ type: EventType.THINKING_START, ...props }) as ThinkingStartEvent;
-
-/** @deprecated Use `createReasoningEndEvent` instead. Will be removed in 1.0.0. */
-export const createThinkingEndEvent = (
-  props: ThinkingEndEventProps,
-): ThinkingEndEvent =>
-  ({ type: EventType.THINKING_END, ...props }) as ThinkingEndEvent;
 
 /** Creates a STATE_SNAPSHOT event. */
 export const createStateSnapshotEvent = (

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -13,16 +13,6 @@ export enum EventType {
   TOOL_CALL_END = "TOOL_CALL_END",
   TOOL_CALL_CHUNK = "TOOL_CALL_CHUNK",
   TOOL_CALL_RESULT = "TOOL_CALL_RESULT",
-  /** @deprecated Use REASONING_START instead. Will be removed in 1.0.0. */
-  THINKING_START = "THINKING_START",
-  /** @deprecated Use REASONING_END instead. Will be removed in 1.0.0. */
-  THINKING_END = "THINKING_END",
-  /** @deprecated Use REASONING_MESSAGE_START instead. Will be removed in 1.0.0. */
-  THINKING_TEXT_MESSAGE_START = "THINKING_TEXT_MESSAGE_START",
-  /** @deprecated Use REASONING_MESSAGE_CONTENT instead. Will be removed in 1.0.0. */
-  THINKING_TEXT_MESSAGE_CONTENT = "THINKING_TEXT_MESSAGE_CONTENT",
-  /** @deprecated Use REASONING_MESSAGE_END instead. Will be removed in 1.0.0. */
-  THINKING_TEXT_MESSAGE_END = "THINKING_TEXT_MESSAGE_END",
   STATE_SNAPSHOT = "STATE_SNAPSHOT",
   STATE_DELTA = "STATE_DELTA",
   MESSAGES_SNAPSHOT = "MESSAGES_SNAPSHOT",
@@ -98,27 +88,6 @@ export interface TextMessageChunkEvent extends BaseEvent {
 }
 
 // ---------------------------------------------------------------------------
-// Deprecated Thinking events (aliased to Reasoning counterparts in 1.0.0)
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use ReasoningTextMessageStartEvent instead. Will be removed in 1.0.0. */
-export interface ThinkingTextMessageStartEvent extends BaseEvent {
-  type: EventType.THINKING_TEXT_MESSAGE_START;
-}
-
-/** @deprecated Use ReasoningMessageContentEvent instead. Will be removed in 1.0.0. */
-export interface ThinkingTextMessageContentEvent extends BaseEvent {
-  type: EventType.THINKING_TEXT_MESSAGE_CONTENT;
-  // ThinkingTextMessageContentEventSchema omits messageId from TextMessageContentEventSchema
-  delta: string;
-}
-
-/** @deprecated Use ReasoningMessageEndEvent instead. Will be removed in 1.0.0. */
-export interface ThinkingTextMessageEndEvent extends BaseEvent {
-  type: EventType.THINKING_TEXT_MESSAGE_END;
-}
-
-// ---------------------------------------------------------------------------
 // Tool-call events
 // ---------------------------------------------------------------------------
 
@@ -154,21 +123,6 @@ export interface ToolCallChunkEvent extends BaseEvent {
   toolCallName?: string;
   parentMessageId?: string;
   delta?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Deprecated Thinking start/end
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use ReasoningStartEvent instead. Will be removed in 1.0.0. */
-export interface ThinkingStartEvent extends BaseEvent {
-  type: EventType.THINKING_START;
-  title?: string;
-}
-
-/** @deprecated Use ReasoningEndEvent instead. Will be removed in 1.0.0. */
-export interface ThinkingEndEvent extends BaseEvent {
-  type: EventType.THINKING_END;
 }
 
 // ---------------------------------------------------------------------------
@@ -327,11 +281,6 @@ export type AGUIEvent =
   | TextMessageContentEvent
   | TextMessageEndEvent
   | TextMessageChunkEvent
-  | ThinkingStartEvent
-  | ThinkingEndEvent
-  | ThinkingTextMessageStartEvent
-  | ThinkingTextMessageContentEvent
-  | ThinkingTextMessageEndEvent
   | ToolCallStartEvent
   | ToolCallArgsEvent
   | ToolCallEndEvent
@@ -366,16 +315,11 @@ export type AGUIEventByType = {
   [EventType.TEXT_MESSAGE_CONTENT]: TextMessageContentEvent;
   [EventType.TEXT_MESSAGE_END]: TextMessageEndEvent;
   [EventType.TEXT_MESSAGE_CHUNK]: TextMessageChunkEvent;
-  [EventType.THINKING_TEXT_MESSAGE_START]: ThinkingTextMessageStartEvent;
-  [EventType.THINKING_TEXT_MESSAGE_CONTENT]: ThinkingTextMessageContentEvent;
-  [EventType.THINKING_TEXT_MESSAGE_END]: ThinkingTextMessageEndEvent;
   [EventType.TOOL_CALL_START]: ToolCallStartEvent;
   [EventType.TOOL_CALL_ARGS]: ToolCallArgsEvent;
   [EventType.TOOL_CALL_END]: ToolCallEndEvent;
   [EventType.TOOL_CALL_CHUNK]: ToolCallChunkEvent;
   [EventType.TOOL_CALL_RESULT]: ToolCallResultEvent;
-  [EventType.THINKING_START]: ThinkingStartEvent;
-  [EventType.THINKING_END]: ThinkingEndEvent;
   [EventType.STATE_SNAPSHOT]: StateSnapshotEvent;
   [EventType.STATE_DELTA]: StateDeltaEvent;
   [EventType.MESSAGES_SNAPSHOT]: MessagesSnapshotEvent;
@@ -415,18 +359,11 @@ export type TextMessageContentEventProps = Omit<TextMessageContentEvent, "type">
 export type TextMessageEndEventProps = Omit<TextMessageEndEvent, "type">;
 export type TextMessageChunkEventProps = Omit<TextMessageChunkEvent, "type">;
 
-export type ThinkingTextMessageStartEventProps = Omit<ThinkingTextMessageStartEvent, "type">;
-export type ThinkingTextMessageContentEventProps = Omit<ThinkingTextMessageContentEvent, "type">;
-export type ThinkingTextMessageEndEventProps = Omit<ThinkingTextMessageEndEvent, "type">;
-
 export type ToolCallStartEventProps = Omit<ToolCallStartEvent, "type">;
 export type ToolCallArgsEventProps = Omit<ToolCallArgsEvent, "type">;
 export type ToolCallEndEventProps = Omit<ToolCallEndEvent, "type">;
 export type ToolCallChunkEventProps = Omit<ToolCallChunkEvent, "type">;
 export type ToolCallResultEventProps = Omit<ToolCallResultEvent, "type">;
-
-export type ThinkingStartEventProps = Omit<ThinkingStartEvent, "type">;
-export type ThinkingEndEventProps = Omit<ThinkingEndEvent, "type">;
 
 export type StateSnapshotEventProps = Omit<StateSnapshotEvent, "type">;
 export type StateDeltaEventProps = Omit<StateDeltaEvent, "type">;

--- a/sdks/typescript/packages/core/src/schemas.ts
+++ b/sdks/typescript/packages/core/src/schemas.ts
@@ -26,11 +26,6 @@ export const EventTypeSchema = z.enum([
   "TOOL_CALL_END",
   "TOOL_CALL_CHUNK",
   "TOOL_CALL_RESULT",
-  "THINKING_START",
-  "THINKING_END",
-  "THINKING_TEXT_MESSAGE_START",
-  "THINKING_TEXT_MESSAGE_CONTENT",
-  "THINKING_TEXT_MESSAGE_END",
   "STATE_SNAPSHOT",
   "STATE_DELTA",
   "MESSAGES_SNAPSHOT",
@@ -119,48 +114,13 @@ export const AudioInputPartSchema = AudioInputContentSchema;
 export const VideoInputPartSchema = VideoInputContentSchema;
 export const DocumentInputPartSchema = DocumentInputContentSchema;
 
-export const BinaryInputContentSchema = z
-  .object({
-    type: z.literal("binary"),
-    mimeType: z.string(),
-    id: z.string().optional(),
-    url: z.string().optional(),
-    data: z.string().optional(),
-    filename: z.string().optional(),
-  })
-  .refine((value) => Boolean(value.id || value.url || value.data), {
-    message: "BinaryInputContent requires at least one of id, url, or data.",
-  });
-
-export const InputContentSchema = z
-  .discriminatedUnion("type", [
-    TextInputContentSchema,
-    ImageInputContentSchema,
-    AudioInputContentSchema,
-    VideoInputContentSchema,
-    DocumentInputContentSchema,
-    z.object({
-      type: z.literal("binary"),
-      mimeType: z.string(),
-      id: z.string().optional(),
-      url: z.string().optional(),
-      data: z.string().optional(),
-      filename: z.string().optional(),
-    }),
-  ])
-  .refine(
-    (value) => {
-      if (value.type === "binary") {
-        return Boolean(
-          (value as { id?: string; url?: string; data?: string }).id ||
-            (value as { id?: string; url?: string; data?: string }).url ||
-            (value as { id?: string; url?: string; data?: string }).data,
-        );
-      }
-      return true;
-    },
-    { message: "BinaryInputContent requires at least one of id, url, or data." },
-  );
+export const InputContentSchema = z.discriminatedUnion("type", [
+  TextInputContentSchema,
+  ImageInputContentSchema,
+  AudioInputContentSchema,
+  VideoInputContentSchema,
+  DocumentInputContentSchema,
+]);
 
 export const InputContentPartSchema = InputContentSchema;
 
@@ -321,28 +281,6 @@ export const TextMessageChunkEventSchema = BaseEventSchema.extend({
   name: z.string().optional(),
 });
 
-/**
- * @deprecated Use ReasoningTextMessageStartEventSchema instead. Will be removed in 1.0.0.
- */
-export const ThinkingTextMessageStartEventSchema = BaseEventSchema.extend({
-  type: z.literal(EventType.THINKING_TEXT_MESSAGE_START),
-});
-
-/**
- * @deprecated Use ReasoningMessageContentEventSchema instead. Will be removed in 1.0.0.
- */
-export const ThinkingTextMessageContentEventSchema = BaseEventSchema.extend({
-  type: z.literal(EventType.THINKING_TEXT_MESSAGE_CONTENT),
-  delta: z.string(),
-});
-
-/**
- * @deprecated Use ReasoningMessageEndEventSchema instead. Will be removed in 1.0.0.
- */
-export const ThinkingTextMessageEndEventSchema = BaseEventSchema.extend({
-  type: z.literal(EventType.THINKING_TEXT_MESSAGE_END),
-});
-
 export const ToolCallStartEventSchema = BaseEventSchema.extend({
   type: z.literal(EventType.TOOL_CALL_START),
   toolCallId: z.string(),
@@ -375,21 +313,6 @@ export const ToolCallChunkEventSchema = BaseEventSchema.extend({
   toolCallName: z.string().optional(),
   parentMessageId: z.string().optional(),
   delta: z.string().optional(),
-});
-
-/**
- * @deprecated Use ReasoningStartEventSchema instead. Will be removed in 1.0.0.
- */
-export const ThinkingStartEventSchema = BaseEventSchema.extend({
-  type: z.literal(EventType.THINKING_START),
-  title: z.string().optional(),
-});
-
-/**
- * @deprecated Use ReasoningEndEventSchema instead. Will be removed in 1.0.0.
- */
-export const ThinkingEndEventSchema = BaseEventSchema.extend({
-  type: z.literal(EventType.THINKING_END),
 });
 
 export const StateSnapshotEventSchema = BaseEventSchema.extend({
@@ -540,11 +463,6 @@ export const EventSchemas = z.discriminatedUnion("type", [
   TextMessageContentEventSchema,
   TextMessageEndEventSchema,
   TextMessageChunkEventSchema,
-  ThinkingStartEventSchema,
-  ThinkingEndEventSchema,
-  ThinkingTextMessageStartEventSchema,
-  ThinkingTextMessageContentEventSchema,
-  ThinkingTextMessageEndEventSchema,
   ToolCallStartEventSchema,
   ToolCallArgsEventSchema,
   ToolCallEndEventSchema,

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -61,22 +61,12 @@ export type AudioInputPart = AudioInputContent;
 export type VideoInputPart = VideoInputContent;
 export type DocumentInputPart = DocumentInputContent;
 
-export interface BinaryInputContent {
-  type: "binary";
-  mimeType: string;
-  id?: string;
-  url?: string;
-  data?: string;
-  filename?: string;
-}
-
 export type InputContent =
   | TextInputContent
   | ImageInputContent
   | AudioInputContent
   | VideoInputContent
-  | DocumentInputContent
-  | BinaryInputContent;
+  | DocumentInputContent;
 
 export type InputContentPart = InputContent;
 

--- a/sdks/typescript/packages/proto/src/proto.ts
+++ b/sdks/typescript/packages/proto/src/proto.ts
@@ -75,30 +75,6 @@ const toProtoContentPart = (part: any): any => {
           metadata: part.metadata,
         },
       };
-    case "binary": {
-      const source = part.data
-        ? { data: { value: part.data, mimeType: part.mimeType } }
-        : part.url
-          ? { url: { value: part.url, mimeType: part.mimeType } }
-          : part.id
-            ? { url: { value: part.id, mimeType: part.mimeType } }
-            : undefined;
-
-      if (!source) {
-        return undefined;
-      }
-
-      return {
-        document: {
-          source,
-          metadata: {
-            legacyBinary: true,
-            filename: part.filename,
-            id: part.id,
-          },
-        },
-      };
-    }
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

**Stacked on top of #1637** (the 0.1.0 zod-extraction minor). Merge #1637 first, then this as the **1.0.0 major** once ready.

This removes the two long-deprecated surfaces:

- **`THINKING_*` events** → use `REASONING_*` (1:1 mapping). Removes the `EventType.THINKING_*` enum members, `Thinking*Event` types, `Thinking*EventSchema` schemas, and `createThinking*` factories.
- **`BinaryInputContent` (`type: "binary"`)** → use the dedicated `image`/`audio`/`video`/`document` content types with a `source: { type: "data" | "url", ... }` discriminator.

## Legacy interop preserved

- `@ag-ui/client` rewrites legacy `THINKING_*` wire events to `REASONING_*` **before** schema validation (transport-level), so legacy (`maxVersion <= 0.0.45`) agents keep working.
- `HttpAgent` upgrades legacy binary input parts to the new content types on outgoing requests (data/url converted; `id`-only dropped with a warning).
- The `BackwardCompatibility_0_0_45` / `_0_0_47` middlewares are kept (rewired to a shared mapper) for non-HTTP agents.

Dead binary branches removed from `langgraph`, `mastra`, `aws-strands`, `a2a`, and `proto` message conversion.

## Versioning

No manual version bump — the release flow cuts the **major** (`scope sdk-ts, bump major`). New `migration-1-0-0` guide (THINKING + binary); the 0.1.0 zod migration guide and `0.1.0-schemas-to-subpath` codemod ship in the base PR and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)