### PR TITLE
feat(a2ui): bulk data by reference (#2005)

### DIFF
--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # validate→retry loop shared with the LangGraph adapter and the a2ui-middleware
     # paint gate. 0.0.3 carries the A2UIToolParams/guidelines API (OSS-248); published
     # on PyPI, so no local source bridge is needed.
-    "ag-ui-a2ui-toolkit>=0.0.3",
+    "ag-ui-a2ui-toolkit>=0.0.5",
     # Google's A2UI Agent SDK (OSS-158): we reuse the two parts that are independent
     # of its strict validator and safe to use with the client-supplied catalog as-is —
     # catalog/prompt rendering (A2uiSchemaManager + catalog.render_as_llm_instructions,

--- a/integrations/adk-middleware/python/src/ag_ui_adk/a2ui_tool.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/a2ui_tool.py
@@ -42,6 +42,7 @@ from ag_ui_a2ui_toolkit import (
     build_a2ui_envelope,
     prepare_a2ui_request,
     resolve_a2ui_tool_params,
+    resolve_external_data,
     run_a2ui_generation_with_recovery,
     wrap_error_envelope,
 )
@@ -150,6 +151,14 @@ class A2UISubAgentTool(BaseTool):
                         type=types.Type.STRING,
                         description="Natural-language changes to apply on update.",
                     ),
+                    "data_ref": types.Schema(
+                        type=types.Type.STRING,
+                        description=(
+                            "Optional tool-call-id of a prior tool result whose content is "
+                            "the dataset to render by reference. Pass this id, NOT the rows, "
+                            "when a tool already fetched the data so you render structure only."
+                        ),
+                    ),
                 },
             ),
         )
@@ -159,6 +168,7 @@ class A2UISubAgentTool(BaseTool):
         intent = args.get("intent", "create")
         target_surface_id = args.get("target_surface_id")
         changes = args.get("changes")
+        data_ref = args.get("data_ref")
 
         events = self._session_events(tool_context)
         # AG-UI messages drive prepare_a2ui_request's prior-surface lookup
@@ -166,6 +176,17 @@ class A2UISubAgentTool(BaseTool):
         messages = self._normalize_a2ui_tool_results(adk_events_to_messages(events))
         conversation = self._conversation_contents(events)
         state, schema_value = self._state_view(tool_context)
+
+        # Resolve the host's by-reference data (OSS-2005): Channel A is the
+        # forwardedProps blob parked into ag-ui state; Channel B is the dataset
+        # held in the `data_ref` tool result. Absent → the subagent's own data
+        # arg is used (unchanged behavior).
+        ag_ui_state = state.get("ag-ui") if isinstance(state.get("ag-ui"), dict) else {}
+        external_data = resolve_external_data(
+            a2ui_data=ag_ui_state.get("a2ui_data"),
+            data_ref=data_ref,
+            messages=messages,
+        )
 
         # Single catalog, client-sourced (no drift): prefer a host-supplied catalog
         # param, else the middleware-injected schema. Render it via Google's
@@ -188,6 +209,7 @@ class A2UISubAgentTool(BaseTool):
             messages=messages,
             state=state,
             guidelines=self._guidelines,
+            external_data=external_data,
         )
         if prep.get("error"):
             return self._as_tool_return(wrap_error_envelope(prep["error"]))
@@ -223,12 +245,14 @@ class A2UISubAgentTool(BaseTool):
                 prior=prep.get("prior"),
                 default_surface_id=self._default_surface_id,
                 default_catalog_id=self._default_catalog_id,
+                external_data=external_data,
             )
 
         result = await asyncio.to_thread(
             run_a2ui_generation_with_recovery,
             base_prompt=prep["prompt"],
             catalog=validation_catalog,
+            external_data=external_data,
             config=self._recovery,
             invoke_subagent=_invoke_subagent,
             build_envelope=_build_envelope,

--- a/integrations/aws-strands/python/pyproject.toml
+++ b/integrations/aws-strands/python/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12, <3.14"
 dependencies = [
-    "ag-ui-a2ui-toolkit>=0.0.4",
+    "ag-ui-a2ui-toolkit>=0.0.5",
     "ag-ui-protocol>=0.1.18",
     "fastapi>=0.115.12",
     "strands-agents>=1.15.0",

--- a/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
@@ -48,6 +48,7 @@ from ag_ui_a2ui_toolkit import (
     prepare_a2ui_request,
     resolve_a2ui_catalog,
     resolve_a2ui_tool_params,
+    resolve_external_data,
     run_a2ui_generation_with_recovery,
     wrap_error_envelope,
 )
@@ -425,6 +426,10 @@ class _GenerateA2UITool(AgentTool):
                             "type": "string",
                             "description": GENERATE_A2UI_ARG_DESCRIPTIONS["changes"],
                         },
+                        "data_ref": {
+                            "type": "string",
+                            "description": GENERATE_A2UI_ARG_DESCRIPTIONS["data_ref"],
+                        },
                     },
                 }
             },
@@ -450,6 +455,7 @@ class _GenerateA2UITool(AgentTool):
         intent = args.get("intent")
         target_surface_id = args.get("target_surface_id")
         changes = args.get("changes")
+        data_ref = args.get("data_ref")
 
         # Strands history for the sub-agent, minus the in-flight generate_a2ui
         # call. Prefer the LIVE calling agent (execution-time history); fall
@@ -471,11 +477,26 @@ class _GenerateA2UITool(AgentTool):
             strands_tool_results_to_agui(strands_messages)
         )
 
+        # Resolve the host's by-reference data (OSS-2005): Channel A is the
+        # forwardedProps blob parked into ag-ui state; Channel B is the dataset
+        # held in the `data_ref` tool result. Absent → the subagent's own data
+        # arg is used (unchanged behavior).
+        glue_state = glue.get("state") if isinstance(glue.get("state"), dict) else {}
+        ag_ui_state = (
+            glue_state.get("ag-ui") if isinstance(glue_state.get("ag-ui"), dict) else {}
+        )
+        external_data = resolve_external_data(
+            a2ui_data=ag_ui_state.get("a2ui_data"),
+            data_ref=data_ref,
+            messages=agui_messages,
+        )
+
         prep = prepare_a2ui_request(
             intent=intent,
             target_surface_id=target_surface_id,
             changes=changes,
             messages=agui_messages,
+            external_data=external_data,
             # `RunAgentInput.state` is Any on the wire; a truthy non-dict must
             # degrade to empty state (generation proceeds without it) rather
             # than crash the tool before the recovery loop engages.
@@ -548,6 +569,7 @@ class _GenerateA2UITool(AgentTool):
                     prior=prep.get("prior"),
                     default_surface_id=cfg["default_surface_id"],
                     default_catalog_id=cfg["default_catalog_id"],
+                    external_data=external_data,
                 )
 
             future = loop.run_in_executor(
@@ -555,6 +577,7 @@ class _GenerateA2UITool(AgentTool):
                 lambda: run_a2ui_generation_with_recovery(
                     base_prompt=prep["prompt"],
                     catalog=cfg["catalog"],
+                    external_data=external_data,
                     config=cfg["recovery"],
                     on_attempt=cfg["on_a2ui_attempt"],
                     invoke_subagent=_invoke_subagent,

--- a/integrations/aws-strands/typescript/src/a2ui-tool.ts
+++ b/integrations/aws-strands/typescript/src/a2ui-tool.ts
@@ -45,6 +45,7 @@ import {
   prepareA2UIRequest,
   resolveA2UICatalog,
   resolveA2UIToolParams,
+  resolveExternalData,
   runA2UIGenerationWithRecovery,
   splitA2UISchemaContext,
   wrapErrorEnvelope,
@@ -78,6 +79,12 @@ interface GenerateA2UIArgs {
   intent?: "create" | "update";
   target_surface_id?: string;
   changes?: string;
+  /**
+   * Optional tool-call-id of a prior tool result whose content is the dataset to
+   * render by reference (OSS-2005). Pass this id, NOT the rows, when a backend
+   * tool already fetched the data so the subagent renders structure only.
+   */
+  data_ref?: string;
 }
 
 /**
@@ -179,6 +186,10 @@ export function getA2UITools<TModel = Model>(
             type: "string",
             description: GENERATE_A2UI_ARG_DESCRIPTIONS.changes,
           },
+          data_ref: {
+            type: "string",
+            description: GENERATE_A2UI_ARG_DESCRIPTIONS.data_ref,
+          },
         },
       },
     },
@@ -205,6 +216,25 @@ export function getA2UITools<TModel = Model>(
         ...strandsToolResultsToAgui(strandsMessages),
       ];
 
+      const safeState =
+        glue.state && typeof glue.state === "object" && !Array.isArray(glue.state)
+          ? glue.state
+          : {};
+
+      // Resolve the host's by-reference data (OSS-2005): Channel A is the
+      // forwardedProps blob parked into ag-ui state; Channel B is the dataset
+      // held in the `data_ref` tool result. Absent → the subagent's own data
+      // arg is used (unchanged behavior).
+      const agUi = ((safeState as Record<string, unknown>)["ag-ui"] ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const externalData = resolveExternalData({
+        a2uiData: agUi.a2ui_data as Record<string, unknown> | undefined,
+        dataRef: input.data_ref,
+        messages: aguiMessages,
+      });
+
       const prep = prepareA2UIRequest({
         intent: input.intent,
         targetSurfaceId: input.target_surface_id,
@@ -212,11 +242,9 @@ export function getA2UITools<TModel = Model>(
         messages: aguiMessages,
         // `RunAgentInput.state` is `any` on the wire; a truthy non-object
         // must degrade to empty state (mirrors the Python adapter's guard).
-        state:
-          glue.state && typeof glue.state === "object" && !Array.isArray(glue.state)
-            ? glue.state
-            : {},
+        state: safeState,
         guidelines,
+        externalData,
       });
 
       // The sub-agent's render_a2ui call must STREAM to the AG-UI wire — the
@@ -251,6 +279,7 @@ export function getA2UITools<TModel = Model>(
         : runA2UIGenerationWithRecovery({
             basePrompt: prep.prompt,
             catalog,
+            externalData,
             config: recovery,
             onAttempt: onA2UIAttempt,
             invokeSubagent: (prompt) => {
@@ -280,6 +309,7 @@ export function getA2UITools<TModel = Model>(
                 prior: prep.prior,
                 defaultSurfaceId,
                 defaultCatalogId,
+                externalData,
               }),
           }).then((r) => r.envelope);
 

--- a/integrations/langgraph/python/ag_ui_langgraph/a2ui_tool.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/a2ui_tool.py
@@ -49,6 +49,7 @@ from ag_ui_a2ui_toolkit import (
     build_a2ui_envelope,
     prepare_a2ui_request,
     resolve_a2ui_tool_params,
+    resolve_external_data,
     wrap_error_envelope,
     run_a2ui_generation_with_recovery,
 )
@@ -143,6 +144,7 @@ def get_a2ui_tools(params: A2UIToolParams):
         intent: str = "create",
         target_surface_id: Optional[str] = None,
         changes: Optional[str] = None,
+        data_ref: Optional[str] = None,
     ) -> str:
         """Generate or edit an A2UI surface.
 
@@ -153,11 +155,27 @@ def get_a2ui_tools(params: A2UIToolParams):
                 id of the prior render to modify.
             changes: Optional natural-language description of the changes to
                 apply when ``intent="update"``.
+            data_ref: Optional tool-call-id of a prior tool result whose content
+                is the dataset to render by reference (OSS-2005). Pass this id —
+                NOT the rows — when a backend tool already fetched the data, so
+                the subagent renders structure only and never re-serializes the
+                dataset as output tokens.
         """
         # Defensive: a custom state schema may not preseed ``messages``, and
         # ``state["messages"]`` would then raise KeyError mid-tool — mirror the
         # TS adapter's `state.messages ?? []` graceful-degrade.
         messages = runtime.state.get("messages", [])[:-1]
+
+        # Resolve the host's by-reference data (OSS-2005): Channel A is the
+        # forwardedProps blob parked into ag-ui state; Channel B is the dataset
+        # held in the `data_ref` tool result. Absent → the subagent's own data
+        # arg is used (unchanged behavior).
+        ag_ui_state = runtime.state.get("ag-ui", {}) or {}
+        external_data = resolve_external_data(
+            a2ui_data=ag_ui_state.get("a2ui_data"),
+            data_ref=data_ref,
+            messages=messages,
+        )
 
         # Shared: decide create/update, find prior surface, build the prompt.
         prep = prepare_a2ui_request(
@@ -167,6 +185,7 @@ def get_a2ui_tools(params: A2UIToolParams):
             messages=messages,
             state=runtime.state,
             guidelines=guidelines,
+            external_data=external_data,
         )
         if prep.get("error"):
             return wrap_error_envelope(prep["error"])
@@ -187,6 +206,7 @@ def get_a2ui_tools(params: A2UIToolParams):
                 prior=prep["prior"],
                 default_surface_id=default_surface_id,
                 default_catalog_id=default_catalog_id,
+                external_data=external_data,
             )
 
         # Shared: validate->retry loop (mirrors the TS adapter). On each retry the
@@ -204,6 +224,7 @@ def get_a2ui_tools(params: A2UIToolParams):
             run_a2ui_generation_with_recovery,
             base_prompt=prep["prompt"],
             catalog=catalog,
+            external_data=external_data,
             config=recovery,
             invoke_subagent=lambda prompt, attempt: asyncio.run(
                 _invoke_subagent(prompt, attempt)

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -986,6 +986,15 @@ class LangGraphAgent:
         elif "injectA2UITool" in forwarded:
             ag_ui_state["inject_a2ui_tool"] = forwarded["injectA2UITool"]
 
+        # Surface the by-reference data model (OSS-2005) into ag-ui state so the
+        # generate_a2ui tool can merge it without the subagent re-emitting the
+        # rows. The contract key is lowercase snake (`a2ui_data`) precisely so it
+        # survives camel_to_snake unchanged; accept the camelCase form too.
+        if "a2ui_data" in forwarded:
+            ag_ui_state["a2ui_data"] = forwarded["a2ui_data"]
+        elif "a2uiData" in forwarded:
+            ag_ui_state["a2ui_data"] = forwarded["a2uiData"]
+
         return {
             **state,
             "messages": new_messages,

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "ag-ui-protocol>=0.1.15",
-    "ag-ui-a2ui-toolkit>=0.0.4",
+    "ag-ui-a2ui-toolkit>=0.0.5",
     "langchain>=1.2.0",
     "langchain-core>=0.3.0",
     "langgraph>=0.6.0,<2",

--- a/integrations/langgraph/typescript/src/a2ui-tool.ts
+++ b/integrations/langgraph/typescript/src/a2ui-tool.ts
@@ -45,6 +45,7 @@ import {
   buildA2UIEnvelope,
   prepareA2UIRequest,
   resolveA2UIToolParams,
+  resolveExternalData,
   wrapErrorEnvelope,
   runA2UIGenerationWithRecovery,
   type A2UIToolParams,
@@ -82,6 +83,13 @@ interface GenerateA2UIArgs {
   target_surface_id?: string;
   /** Optional natural-language description of the changes to apply on update. */
   changes?: string;
+  /**
+   * Optional tool-call-id of a prior tool result whose content is the dataset to
+   * render by reference (OSS-2005). Pass this id — NOT the rows — when a backend
+   * tool already fetched the data, so the subagent renders structure only and
+   * never re-serializes the dataset as output tokens.
+   */
+  data_ref?: string;
 }
 
 /**
@@ -165,6 +173,17 @@ export function getA2UITools<TModel = A2UISubagentModel>(
       // Strip current (unbalanced) tool call from history.
       const messages = allMessages.slice(0, -1);
 
+      // Resolve the host's by-reference data (OSS-2005): Channel A is the
+      // forwardedProps blob parked into ag-ui state; Channel B is the dataset
+      // held in the `data_ref` tool result. Absent → the subagent's own data
+      // arg is used (unchanged behavior).
+      const agUi = (state["ag-ui"] ?? {}) as Record<string, unknown>;
+      const externalData = resolveExternalData({
+        a2uiData: agUi.a2ui_data as Record<string, unknown> | undefined,
+        dataRef: input.data_ref,
+        messages,
+      });
+
       // Shared: decide create/update, find prior surface, build the prompt.
       const prep = prepareA2UIRequest({
         intent: input.intent,
@@ -173,6 +192,7 @@ export function getA2UITools<TModel = A2UISubagentModel>(
         messages,
         state,
         guidelines,
+        externalData,
       });
       if (prep.error) return wrapErrorEnvelope(prep.error);
 
@@ -192,6 +212,7 @@ export function getA2UITools<TModel = A2UISubagentModel>(
       const { envelope } = await runA2UIGenerationWithRecovery({
         basePrompt: prep.prompt,
         catalog,
+        externalData,
         config: recovery,
         onAttempt: onA2UIAttempt,
         invokeSubagent: (prompt) =>
@@ -204,6 +225,7 @@ export function getA2UITools<TModel = A2UISubagentModel>(
             prior: prep.prior,
             defaultSurfaceId,
             defaultCatalogId,
+            externalData,
           }),
       });
       return envelope;
@@ -226,6 +248,10 @@ export function getA2UITools<TModel = A2UISubagentModel>(
           changes: {
             type: "string",
             description: GENERATE_A2UI_ARG_DESCRIPTIONS.changes,
+          },
+          data_ref: {
+            type: "string",
+            description: GENERATE_A2UI_ARG_DESCRIPTIONS.data_ref,
           },
         },
       } as any,


### PR DESCRIPTION
## What

Implements the by-reference data mechanism from #2005: an agent can render an
already-fetched dataset without the render subagent re-serializing every row
into its tool arguments. A 1,000-row table that previously cost ~27K output
tokens now ships as a path-bound component tree plus a host-supplied data model.

Closes #2005 (engine + docs; see "Out of scope" below).

## How it works

A new optional `externalData` flows through the framework-agnostic toolkit:

1. **Merge** — `buildA2UIEnvelope` / `assembleOps` shallow-merge `externalData`
   over the subagent's `data` at the surface root (`externalData` wins per
   top-level key). The `updateDataModel` op is emitted even when the subagent
   omits `data` entirely.
2. **Validate** — `runA2UIGenerationWithRecovery` validates bindings against the
   merged data, so a by-reference render does not false-positive
   `unresolved_binding` and retry to exhaustion.
3. **Prompt** — `prepareA2UIRequest` adds a compact data-shape outline (keys
   plus one truncated sample per array, never the rows) and directs the subagent
   to bind to those paths and omit `data`. This is what actually saves tokens.
4. **Source** — `resolveExternalData` picks from two channels (A wins):
   - **A** `forwardedProps.a2ui_data` — a caller-supplied blob (lowercase-snake
     key so it survives the LangGraph camel-to-snake conversion).
   - **B** `data_ref` — a planner tool argument naming the tool-call-id of a
     prior tool result whose content is the dataset. The id is cheap to pass;
     the rows never re-enter the LLM.

Middleware: a data-only `updateDataModel` in the final envelope now survives the
streamed-surface dedup, so a by-reference surface that streamed components but no
data still paints its dataset.

Adapters (langgraph py+ts, aws-strands py+ts, adk py) source `externalData` from
both channels and thread it through prepare, recovery, and envelope build. The
LangGraph connector parks `forwardedProps.a2ui_data` into `ag-ui` state.

## Safety

Additive and opt-in. With no `externalData`, every code path is byte-identical
to before. No e2e tests were touched, by design, so the existing e2e suite is
the behavior-invariance proof.

## Tests

New unit tests (TDD, red then green) in both SDKs and the middleware:

- a2ui-toolkit: 118 TS, 118 Py
- a2ui-middleware: 99
- adapters: langgraph-py 6, aws-strands-py 50, adk-py 23, langgraph-ts 2,
  aws-strands-ts 241
- Broad invariance: langgraph-python full 386, aws-strands-python full 155

(adk full suite has pre-existing env failures unrelated to this change: missing
`greenlet` for database-session tests and live-LLM credential tests. The failing
files contain no A2UI references.)

## Out of scope (follow-ups)

- Fixed-schema demo restructure to showcase by-reference (demo-only; the engine
  already supports it).
- e2e coverage for the by-reference path (left untouched intentionally).
