### PR TITLE
feat(aws-strands): add config.reuse_agent to run the wrapped Agent directly (preserves plugins)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -281,6 +281,9 @@ class StrandsAgent:
         config: "StrandsAgentConfig | None" = None,
         hooks: "list | None" = None,
     ):
+        # The wrapped Agent. Used directly when config.reuse_agent is True;
+        # otherwise it is the template the per-thread clones are built from.
+        self._template_agent = agent
         # Store template agent configuration for creating fresh instances
         self._model = agent.model
         self._system_prompt = agent.system_prompt
@@ -311,10 +314,14 @@ class StrandsAgent:
         # Detect the common footgun: session_manager set on the template Agent
         # (stored as `_session_manager` by Strands) with no per-thread provider.
         # Forwarding it would make every AG-UI thread share one session_id.
+        # Skipped when reuse_agent is set: in that mode the template Agent IS
+        # the agent that runs, so its own session_manager is honoured natively
+        # (not ignored), and the per-thread provider does not apply.
         template_session_manager = getattr(agent, "_session_manager", None)
         if (
             template_session_manager is not None
             and self.config.session_manager_provider is None
+            and not self.config.reuse_agent
         ):
             logger.warning(
                 "session_manager was set on the template Agent but will be ignored: "
@@ -349,7 +356,13 @@ class StrandsAgent:
         # session_manager_provider is configured, the SessionManager handles
         # conversation persistence; otherwise state is held in-memory per thread.
         thread_id = input_data.thread_id or "default"
-        if thread_id not in self._agents_by_thread:
+        # When reuse_agent is set, run the wrapped Agent directly — no per-thread
+        # clone. The clone exists to isolate concurrent threads in a shared
+        # process; in a per-invocation/per-session-isolated runtime (e.g.
+        # AgentCore microVMs) that isolation is already provided, and skipping
+        # the clone preserves constructs that _extract_agent_kwargs cannot
+        # round-trip (notably plugins). See StrandsAgentConfig.reuse_agent.
+        if not self.config.reuse_agent and thread_id not in self._agents_by_thread:
             async with self._thread_init_lock:
                 # Double-check inside the lock: another coroutine may have
                 # completed initialization while we were waiting.
@@ -428,7 +441,11 @@ class StrandsAgent:
                         session_manager=session_manager,
                         **core_kwargs,
                     )
-        strands_agent = self._agents_by_thread[thread_id]
+        strands_agent = (
+            self._template_agent
+            if self.config.reuse_agent
+            else self._agents_by_thread[thread_id]
+        )
 
         # Forward ``RunAgentInput.context`` to the per-thread Strands agent's
         # state so user tools can read it (e.g. catalog/component schemas

--- a/integrations/aws-strands/python/src/ag_ui_strands/config.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/config.py
@@ -129,6 +129,36 @@ class StrandsAgentConfig:
     the frontend produced. Disable only if you manage Strands history
     yourself (e.g. via a custom ``session_manager``).
     """
+    reuse_agent: bool = False
+    """Run the wrapped Agent directly instead of cloning a fresh per-thread
+    ``StrandsAgentCore`` from it.
+
+    By default the adapter treats the wrapped Agent as a *template* and builds
+    one fresh instance per ``thread_id`` so that concurrent threads in a single
+    long-lived process cannot corrupt each other's mutable state. That rebuild
+    goes through ``_extract_agent_kwargs``, which reconstructs the agent from the
+    constructor params it can read back off the instance — a lossy round-trip:
+    anything Strands does not retain as a public attribute is silently dropped.
+    ``plugins`` is the clearest casualty (Strands keeps them in a private
+    ``_plugin_registry`` and discards the original list), so a wrapped Agent
+    built with ``plugins=[...]`` loses them entirely.
+
+    In a per-invocation / per-session-isolated runtime — e.g. AWS Bedrock
+    AgentCore, where each session runs in its own microVM and the host already
+    constructs a fresh Agent per request — the per-thread clone is redundant:
+    isolation is provided by the runtime, and the clone's only observable effect
+    is dropping plugins (and any other construct that does not round-trip). Set
+    this ``True`` in those deployments to run the wrapped Agent as-is, which
+    preserves plugins without the ``agent.plugins = ...`` re-exposure workaround.
+
+    Precondition: one ``StrandsAgent`` must serve a single thread / one
+    concurrent run. The adapter mutates the agent in place each turn (it
+    overwrites ``.messages``, registers proxy/A2UI tools on ``.tool_registry``,
+    and writes ``.state``), so sharing one Agent across concurrent threads under
+    this flag would cause cross-talk. ``session_manager_provider`` is *not*
+    consulted in this mode; configure hooks and a ``session_manager`` directly on
+    the Strands ``Agent`` (``Agent(hooks=..., session_manager=...)``) instead.
+    """
     a2ui: Optional[Dict[str, Any]] = None
     """A2UI auto-injection config — everything A2UI-related in one
     place. When the CopilotKit runtime forwards ``injectA2UITool`` (or

--- a/integrations/aws-strands/python/tests/test_reuse_agent.py
+++ b/integrations/aws-strands/python/tests/test_reuse_agent.py
@@ -1,0 +1,149 @@
+"""Tests for ``StrandsAgentConfig.reuse_agent``.
+
+When set, the adapter runs the wrapped Agent directly instead of cloning a
+fresh per-thread ``StrandsAgentCore``. The clone exists to isolate concurrent
+threads in a shared process; in a per-invocation / per-session-isolated runtime
+(e.g. AWS Bedrock AgentCore microVMs) it is redundant and its only observable
+effect is dropping constructs that ``_extract_agent_kwargs`` cannot round-trip —
+notably ``plugins``, which Strands keeps in a private ``_plugin_registry``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from strands import Agent
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig
+
+
+def _mock_model():
+    m = MagicMock()
+    m.stateful = False
+    return m
+
+
+def _run_input(thread_id: str = "t1"):
+    from ag_ui.core import RunAgentInput, UserMessage
+
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+class _FakeAgent:
+    """Minimal stand-in exposing the surface ``StrandsAgent.run()`` touches."""
+
+    def __init__(self):
+        self.model = _mock_model()
+        self.system_prompt = None
+        self.tool_registry = ToolRegistry()
+        self.messages: list = []
+        self.state = MagicMock()
+        self._session_manager = None
+        # Sentinel for a construct the lossy clone path would NOT preserve.
+        self._plugin_registry = MagicMock(name="plugin_registry")
+        self.stream_calls: list = []
+
+    async def stream_async(self, prompt):
+        self.stream_calls.append(prompt)
+        if False:  # make this an async generator that yields nothing
+            yield
+
+
+@pytest.mark.asyncio
+async def test_reuse_agent_runs_template_without_cloning():
+    """reuse_agent=True runs the wrapped instance and never builds a clone."""
+    template = _FakeAgent()
+    ag = StrandsAgent(
+        template, name="test", config=StrandsAgentConfig(reuse_agent=True)
+    )
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "StrandsAgentCore must not be constructed when reuse_agent=True"
+        )
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _boom):
+        async for _ in ag.run(_run_input("t1")):
+            pass
+
+    # No clone built; the per-thread pool stays empty.
+    assert ag._agents_by_thread == {}
+    # The wrapped instance is what actually ran.
+    assert template.stream_calls, "the wrapped template agent should have been run"
+    # It is the exact instance passed in, so its _plugin_registry — which the
+    # clone path silently drops — is intact.
+    assert ag._template_agent is template
+    assert template._plugin_registry is not None
+
+
+@pytest.mark.asyncio
+async def test_reuse_agent_reuses_same_instance_across_turns():
+    """Successive runs on the same wrapper reuse the one wrapped Agent."""
+    template = _FakeAgent()
+    ag = StrandsAgent(
+        template, name="test", config=StrandsAgentConfig(reuse_agent=True)
+    )
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore") as core:
+        async for _ in ag.run(_run_input("t1")):
+            pass
+        async for _ in ag.run(_run_input("t1")):
+            pass
+        core.assert_not_called()
+
+    assert len(template.stream_calls) == 2
+    assert ag._agents_by_thread == {}
+
+
+@pytest.mark.asyncio
+async def test_reuse_agent_suppresses_template_session_manager_warning(caplog):
+    """Under reuse_agent the template's own session_manager is honoured
+    natively, so the 'will be ignored' footgun warning must NOT fire."""
+    session_manager = MagicMock(name="session_manager")
+    template = Agent(model=_mock_model(), session_manager=session_manager)
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        StrandsAgent(
+            template, name="test", config=StrandsAgentConfig(reuse_agent=True)
+        )
+
+    assert not any("session_manager_provider" in m for m in caplog.messages), (
+        f"unexpected warning under reuse_agent: {caplog.messages}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_still_clones_per_thread():
+    """Without the flag, behaviour is unchanged: a per-thread clone is built."""
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test")  # default config: reuse_agent=False
+
+    captured = {}
+
+    class _CapturingCore:
+        def __init__(self, **kwargs):
+            captured["built"] = True
+            self.tool_registry = ToolRegistry()
+
+        async def stream_async(self, _msg):
+            if False:
+                yield
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        async for _ in ag.run(_run_input("t1")):
+            break
+
+    assert captured.get("built"), "default path must still construct a per-thread clone"
+    assert "t1" in ag._agents_by_thread


### PR DESCRIPTION
## Summary

Adds an opt-in `StrandsAgentConfig.reuse_agent` flag that runs the **wrapped Agent directly** instead of cloning a fresh per-thread `StrandsAgentCore` from it. Default is `False`, so existing behaviour is unchanged.

## Motivation

On each run the adapter rebuilds a per-thread agent from the wrapped one via `_extract_agent_kwargs`, which reconstructs the agent from the constructor params it can read back off the instance (`self.<name>` / `self._<name>`). That round-trip is **lossy**: anything `strands-agents` does not retain as a public attribute is silently dropped.

`plugins` is the clearest casualty. `Agent.__init__` accepts `plugins`, but Strands registers them into a private `self._plugin_registry` and discards the original list — there is no `self.plugins`/`self._plugins`. So a wrapped Agent built with `plugins=[ContextInjector(...)]` loses its plugins on every run, with no error or warning. (The repo already acknowledges this — `tests/test_template_agent_propagation.py` lists `plugins` under "stored as `_plugin_registry`, not forwarded", and `hooks` / `session_manager` already need dedicated forwarding paths for the same reason.)

The per-thread clone exists to isolate concurrent threads inside a single long-lived process. In a **per-invocation / per-session-isolated runtime** — e.g. AWS Bedrock AgentCore, where each session runs in its own microVM and the host constructs a fresh `Agent` per request — that isolation is already provided by the runtime. There, the clone is redundant and its only observable effect is dropping plugins (and any other non-round-tripping construct).

## What this changes

- **`config.py`** — new `reuse_agent: bool = False` with a docstring covering the rationale and the precondition.
- **`agent.py`** — when `reuse_agent` is set, `run()` uses `self._template_agent` directly and skips the per-thread construction. The template's own `session_manager` is honoured natively in this mode, so the "session_manager will be ignored" footgun warning is suppressed when the flag is on.
- **`tests/test_reuse_agent.py`** — covers: runs the wrapped instance without constructing a clone; reuses the same instance across turns; suppresses the session-manager warning under the flag; and confirms the default path still clones per thread.

## Usage notes (documented on the flag)

- **Precondition:** one `StrandsAgent` must serve a single thread / one concurrent run. The adapter mutates the agent in place each turn (overwrites `.messages`, registers proxy/A2UI tools on `.tool_registry`, writes `.state`), so sharing one Agent across concurrent threads under this flag would cause cross-talk. This holds naturally in per-session-isolated runtimes.
- **Hooks / session managers:** configure them directly on the Strands `Agent` (`Agent(hooks=..., session_manager=...)`) rather than via the adapter — the adapter's clone-path forwarding (`StrandsAgent(hooks=...)`, `session_manager_provider`) is skipped in this mode. Plugins then "just work" without the `agent.plugins = ...` re-exposure workaround.

## Test plan

```
cd integrations/aws-strands/python
uv run pytest tests/test_reuse_agent.py tests/test_template_agent_propagation.py \
              tests/test_session_manager.py tests/test_template_hooks_preservation.py
```

All pass (new tests + existing suites; no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)