### PR TITLE
feat(mastra): opt-in standard RUN_FINISHED interrupt-outcome (OSS-379)

### DIFF
--- a/integrations/mastra/typescript/README.md
+++ b/integrations/mastra/typescript/README.md
@@ -47,6 +47,38 @@ const result = await agent.runAgent({
 - **Memory integration** – Automatic thread and working memory management
 - **Tool streaming** – Real-time tool call execution and results
 - **State management** – Bidirectional state synchronization
+- **Human-in-the-loop** – Mastra tool suspend/resume bridged to AG-UI interrupts
+
+## Interrupts (tool suspend/resume)
+
+When a Mastra tool suspends, the bridge surfaces it to the frontend. Two
+channels exist:
+
+- **Legacy** `CustomEvent(name="on_interrupt")` — always emitted (backward
+  compatibility). Its `value` is a JSON string carrying `type:"mastra_suspend"`,
+  `toolCallId`, `toolName`, `suspendPayload`, `args`, `resumeSchema`, and the
+  snapshot-keying `runId`.
+- **Standard** `RunFinishedEvent.outcome = { type: "interrupt", interrupts }` —
+  the canonical AG-UI signal. Each suspend maps to an `Interrupt` (`id`,
+  `reason`, `toolCallId`, `responseSchema` — parsed from `resumeSchema`); the
+  remaining round-trip data lives under `metadata.mastra`.
+
+> **Opt-in (`emitInterruptOutcome`, default `false`).** The structured outcome
+> is gated behind a flag, mirroring LangGraph's `emitInterruptOutcome`. Released
+> clients that resume through the legacy `forwardedProps.command.resume` channel
+> (e.g. CopilotKit's runtime as of v1.60.1) stop sending a resume directive once
+> they observe the structured outcome, which silently strands the run. Enable it
+> only with a client that understands the canonical interrupt-outcome path. When
+> on, BOTH channels are emitted; when off, only the legacy event plus a plain
+> `RUN_FINISHED`.
+
+```ts
+const agent = new MastraAgent({
+  agent: mastra.getAgent("interrupt-agent"),
+  resourceId: "user-123",
+  emitInterruptOutcome: true, // opt in to RUN_FINISHED.outcome interrupts
+});
+```
 
 ## To run the example server in the dojo
 

--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -118,21 +118,27 @@ export function collectError(
 // --- Agent factories (centralizes the `as any` cast) ---
 
 export function makeLocalMastraAgent(
-  opts: { memory?: FakeMemory; streamChunks?: any[] } = {},
+  opts: {
+    memory?: FakeMemory;
+    streamChunks?: any[];
+    emitInterruptOutcome?: boolean;
+  } = {},
 ) {
   return new MastraAgent({
     agentId: "test-agent",
     agent: new FakeLocalAgent(opts) as any,
     resourceId: "resource-1",
+    emitInterruptOutcome: opts.emitInterruptOutcome,
   });
 }
 
 export function makeRemoteMastraAgent(
-  opts: { streamChunks?: any[] } = {},
+  opts: { streamChunks?: any[]; emitInterruptOutcome?: boolean } = {},
 ) {
   return new MastraAgent({
     agentId: "test-agent",
     agent: new FakeRemoteAgent(opts) as any,
     resourceId: "resource-1",
+    emitInterruptOutcome: opts.emitInterruptOutcome,
   });
 }

--- a/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { EventType } from "@ag-ui/client";
+import { EventType, RunFinishedEventSchema } from "@ag-ui/client";
 import {
   FakeLocalAgent,
   FakeRemoteAgent,
@@ -71,6 +71,31 @@ function makeFakeLocalAgentWithResumeStream(resumeChunks: any[]) {
     agentId: "test-agent",
     agent: fakeAgent as any,
     resourceId: "resource-1",
+  });
+
+  return { agent, fakeAgent, calls };
+}
+
+// Same as makeFakeLocalAgentWithResumeStream but with emitInterruptOutcome on,
+// for exercising the standard outcome on the resume path.
+function makeFakeLocalAgentWithResumeStreamOptIn(resumeChunks: any[]) {
+  const fakeAgent = new FakeLocalAgent({ streamChunks: [] });
+  const calls: Array<{ resumeData: any; opts: any }> = [];
+
+  (fakeAgent as any).resumeStream = async (resumeData: any, opts: any) => {
+    calls.push({ resumeData, opts });
+    return {
+      fullStream: (async function* () {
+        for (const chunk of resumeChunks) yield chunk;
+      })(),
+    };
+  };
+
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fakeAgent as any,
+    resourceId: "resource-1",
+    emitInterruptOutcome: true,
   });
 
   return { agent, fakeAgent, calls };
@@ -171,6 +196,291 @@ describe("interrupt bridge: emit path", () => {
       expect(JSON.parse((customEvents[0] as any).value).toolCallId).toBe(
         "tc-orphan",
       );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standard interrupt-outcome path (opt-in: emitInterruptOutcome)
+// ---------------------------------------------------------------------------
+
+describe("interrupt bridge: standard RUN_FINISHED.outcome (opt-in)", () => {
+  describe("flag OFF (default) — legacy unchanged", () => {
+    it("emits a plain RUN_FINISHED with no outcome", async () => {
+      const agent = makeLocalMastraAgent({ streamChunks: makeSuspendChunks() });
+      const events = await collectEvents(agent, makeInput());
+
+      // Same event sequence as before the flag existed.
+      expect(events.map((e) => e.type)).toEqual([
+        EventType.RUN_STARTED,
+        EventType.CUSTOM,
+        EventType.RUN_FINISHED,
+      ]);
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      // Legacy: no structured outcome attached.
+      expect(finished.outcome).toBeUndefined();
+    });
+
+    it("still emits the legacy on_interrupt CUSTOM event", async () => {
+      const agent = makeLocalMastraAgent({ streamChunks: makeSuspendChunks() });
+      const events = await collectEvents(agent, makeInput());
+
+      const custom = events.find((e) => e.type === EventType.CUSTOM) as any;
+      expect(custom.name).toBe("on_interrupt");
+      expect(JSON.parse(custom.value).type).toBe("mastra_suspend");
+    });
+
+    it("default constructor leaves emitInterruptOutcome false", () => {
+      const agent = makeLocalMastraAgent({ streamChunks: [] });
+      expect(agent.emitInterruptOutcome).toBe(false);
+    });
+  });
+
+  describe("flag ON — structured outcome emitted alongside legacy event", () => {
+    it("emits RUN_FINISHED with outcome={type:'interrupt', interrupts:[...]}", async () => {
+      const agent = makeLocalMastraAgent({
+        streamChunks: makeSuspendChunks(),
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      expect(finished.outcome).toBeDefined();
+      expect(finished.outcome.type).toBe("interrupt");
+      expect(finished.outcome.interrupts).toHaveLength(1);
+    });
+
+    it("still emits the legacy on_interrupt CUSTOM event (wrapper stays)", async () => {
+      const agent = makeLocalMastraAgent({
+        streamChunks: makeSuspendChunks(),
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      // BOTH channels: legacy CUSTOM and the structured outcome on RUN_FINISHED.
+      expect(events.map((e) => e.type)).toEqual([
+        EventType.RUN_STARTED,
+        EventType.CUSTOM,
+        EventType.RUN_FINISHED,
+      ]);
+      const custom = events.find((e) => e.type === EventType.CUSTOM) as any;
+      expect(custom.name).toBe("on_interrupt");
+    });
+
+    it("maps the suspend payload to a valid Interrupt (round-trip fields preserved)", async () => {
+      const agent = makeLocalMastraAgent({
+        streamChunks: makeSuspendChunks("tc-1", "process-expense"),
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput({ runId: "run-42" }));
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      const interrupt = finished.outcome.interrupts[0];
+
+      // id correlates the resume answer back to the suspended tool call.
+      expect(interrupt.id).toBe("tc-1");
+      expect(interrupt.toolCallId).toBe("tc-1");
+      expect(interrupt.reason).toBe("mastra:tool_suspend");
+      // resumeSchema (a JSON string) is parsed into responseSchema.
+      expect(interrupt.responseSchema).toEqual({
+        type: "object",
+        properties: { approved: { type: "boolean" } },
+      });
+      // Everything resume needs lives under metadata.mastra, shaped like the
+      // legacy on_interrupt value.
+      expect(interrupt.metadata.mastra).toMatchObject({
+        type: "mastra_suspend",
+        toolName: "process-expense",
+        suspendPayload: { reason: "Amount exceeds $100" },
+        args: { amount: 250, description: "team dinner" },
+        runId: "run-42",
+      });
+    });
+
+    it("validates against the canonical RunFinishedEventSchema", async () => {
+      const agent = makeLocalMastraAgent({
+        streamChunks: makeSuspendChunks(),
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+
+      // The emitted event must parse cleanly through the protocol schema —
+      // proves the outcome shape is wire-valid, not just structurally similar.
+      expect(() => RunFinishedEventSchema.parse(finished)).not.toThrow();
+    });
+
+    it("carries the snapshot-keying runId from the suspend chunk, not RunAgentInput.runId", async () => {
+      // Mastra keys the suspended snapshot by the runId on the SUSPEND CHUNK,
+      // which can differ from RunAgentInput.runId. The interrupt metadata must
+      // carry the chunk's runId so resume round-trips the right id.
+      const chunks = [
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "t",
+            suspendPayload: {},
+            args: {},
+            resumeSchema: "{}",
+            runId: "mastra-internal-run",
+          },
+        },
+      ];
+      const agent = makeLocalMastraAgent({
+        streamChunks: chunks,
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(
+        agent,
+        makeInput({ runId: "agui-run" }),
+      );
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      // Top-level RUN_FINISHED.runId stays the AG-UI run id.
+      expect(finished.runId).toBe("agui-run");
+      // But the snapshot-keying id is preserved in metadata for resume.
+      expect(finished.outcome.interrupts[0].metadata.mastra.runId).toBe(
+        "mastra-internal-run",
+      );
+    });
+
+    it("collects multiple suspends into one outcome", async () => {
+      const chunks = [
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-x",
+            toolName: "x",
+            suspendPayload: {},
+            args: {},
+            resumeSchema: "{}",
+          },
+        },
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-y",
+            toolName: "y",
+            suspendPayload: {},
+            args: {},
+            resumeSchema: "{}",
+          },
+        },
+      ];
+      const agent = makeLocalMastraAgent({
+        streamChunks: chunks,
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      expect(finished.outcome.interrupts.map((i: any) => i.id)).toEqual([
+        "tc-x",
+        "tc-y",
+      ]);
+      // Two legacy CUSTOM events too.
+      expect(events.filter((e) => e.type === EventType.CUSTOM)).toHaveLength(2);
+    });
+
+    it("omits responseSchema when resumeSchema is not valid JSON", async () => {
+      const chunks = [
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-1",
+            toolName: "t",
+            suspendPayload: {},
+            args: {},
+            resumeSchema: "not-json",
+          },
+        },
+      ];
+      const agent = makeLocalMastraAgent({
+        streamChunks: chunks,
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      const interrupt = finished.outcome.interrupts[0];
+      expect(interrupt.responseSchema).toBeUndefined();
+      // Raw value still available in metadata for debugging.
+      expect(interrupt.metadata.mastra.resumeSchema).toBe("not-json");
+    });
+
+    it("a non-interrupting run still ends with a plain RUN_FINISHED (no outcome)", async () => {
+      const agent = makeLocalMastraAgent({
+        streamChunks: [{ type: "text-delta", payload: { text: "hi" } }],
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      // Flag on but nothing suspended → no outcome attached.
+      expect(finished.outcome).toBeUndefined();
+    });
+
+    it("attaches outcome on the resume path when the resumed stream suspends again", async () => {
+      const { agent } = makeFakeLocalAgentWithResumeStreamOptIn([
+        { type: "text-delta", payload: { text: "Processing..." } },
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-chained",
+            toolName: "next-step",
+            suspendPayload: { step: 2 },
+            args: {},
+            resumeSchema: "{}",
+          },
+        },
+      ]);
+
+      const events = await collectEvents(
+        agent,
+        makeResumeInput({
+          type: "mastra_suspend",
+          toolCallId: "tc-1",
+          runId: "run-1",
+        }),
+      );
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      expect(finished.outcome?.type).toBe("interrupt");
+      expect(finished.outcome.interrupts[0].id).toBe("tc-chained");
+    });
+
+    it("works for remote agents too", async () => {
+      const agent = makeRemoteMastraAgent({
+        streamChunks: makeSuspendChunks(),
+        emitInterruptOutcome: true,
+      });
+      const events = await collectEvents(agent, makeInput());
+
+      const finished = events.find(
+        (e) => e.type === EventType.RUN_FINISHED,
+      ) as any;
+      expect(finished.outcome?.type).toBe("interrupt");
+      expect(finished.outcome.interrupts).toHaveLength(1);
     });
   });
 });

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -4,6 +4,7 @@ import type {
   AgentConfig,
   BaseEvent,
   CustomEvent,
+  Interrupt,
   Message,
   ReasoningStartEvent,
   ReasoningMessageStartEvent,
@@ -12,6 +13,7 @@ import type {
   ReasoningEndEvent,
   RunAgentInput,
   RunFinishedEvent,
+  RunFinishedInterruptOutcome,
   RunStartedEvent,
   StateSnapshotEvent,
   TextMessageChunkEvent,
@@ -98,6 +100,24 @@ export interface MastraAgentConfig extends AgentConfig {
    * completion payload).
    */
   untilIdle?: boolean | { maxIdleMs?: number };
+  /**
+   * Terminate interrupted runs with the AG-UI structured outcome
+   * `RUN_FINISHED.outcome={ type: "interrupt", interrupts: [...] }`, mapping each
+   * Mastra tool suspend to an `Interrupt`.
+   *
+   * Default **false**. Opt-in for the same reason as LangGraph's
+   * `emitInterruptOutcome`: released clients that drive resume through the
+   * legacy `forwardedProps.command.resume` channel (e.g. CopilotKit's runtime as
+   * of v1.60.1) stop sending a resume directive once they observe the structured
+   * outcome, which silently strands the run. Until those clients adopt the
+   * canonical resume protocol, emitting the outcome by default would break them.
+   *
+   * Independent of the legacy `CUSTOM(name="on_interrupt")` event, which is
+   * always emitted (backward compat). When this flag is on, BOTH the legacy
+   * event and the structured outcome are emitted; when off, only the legacy
+   * event plus a plain `RUN_FINISHED` — exactly as before this flag existed.
+   */
+  emitInterruptOutcome?: boolean;
 }
 
 interface MastraAgentStreamOptions {
@@ -163,10 +183,20 @@ export class MastraAgent extends AbstractAgent {
   requestContext?: RequestContext;
   untilIdle?: boolean | { maxIdleMs?: number };
   public headers?: Record<string, string>;
+  /** See MastraAgentConfig.emitInterruptOutcome. Default false. */
+  emitInterruptOutcome: boolean;
 
   constructor(private config: MastraAgentConfig) {
-    const { agent, resourceId, requestContext, untilIdle, ...rest } = config;
+    const {
+      agent,
+      resourceId,
+      requestContext,
+      untilIdle,
+      emitInterruptOutcome,
+      ...rest
+    } = config;
     super(rest);
+    this.emitInterruptOutcome = emitInterruptOutcome ?? false;
     this.agent = agent;
     this.resourceId = resourceId;
     this.requestContext = requestContext ?? new RequestContext();
@@ -188,6 +218,13 @@ export class MastraAgent extends AbstractAgent {
     // dedupes instead of duplicating. Remote agents / older Mastra streams that
     // omit the start messageId keep using this fallback (and the rotation below).
     let messageId = randomUUID();
+
+    // Tool suspends collected this run, mapped to AG-UI Interrupts. Only
+    // populated when emitInterruptOutcome is on; the terminating RUN_FINISHED
+    // carries them as a structured `outcome` (see makeRunFinishedEvent). The
+    // legacy CUSTOM(on_interrupt) event is emitted regardless (see
+    // onToolSuspended).
+    const pendingInterrupts: Interrupt[] = [];
 
     return new Observable<BaseEvent>((subscriber) => {
       const run = async () => {
@@ -302,6 +339,7 @@ export class MastraAgent extends AbstractAgent {
                 messageId = id;
               },
               input.runId,
+              pendingInterrupts,
             );
             const hadError = await this.processFullStream(response.fullStream, {
               ...callbacks,
@@ -312,11 +350,13 @@ export class MastraAgent extends AbstractAgent {
 
             if (!hadError) {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
-              subscriber.next({
-                type: EventType.RUN_FINISHED,
-                threadId: input.threadId,
-                runId: input.runId,
-              } as RunFinishedEvent);
+              subscriber.next(
+                this.makeRunFinishedEvent(
+                  input.threadId,
+                  input.runId,
+                  pendingInterrupts,
+                ),
+              );
               subscriber.complete();
             }
           } catch (error) {
@@ -408,6 +448,7 @@ export class MastraAgent extends AbstractAgent {
               messageId = id;
             },
             input.runId,
+            pendingInterrupts,
           );
 
           await this.streamMastraAgent(input, {
@@ -417,11 +458,13 @@ export class MastraAgent extends AbstractAgent {
             },
             onRunFinished: async () => {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
-              subscriber.next({
-                type: EventType.RUN_FINISHED,
-                threadId: input.threadId,
-                runId: input.runId,
-              } as RunFinishedEvent);
+              subscriber.next(
+                this.makeRunFinishedEvent(
+                  input.threadId,
+                  input.runId,
+                  pendingInterrupts,
+                ),
+              );
               subscriber.complete();
             },
           });
@@ -443,6 +486,95 @@ export class MastraAgent extends AbstractAgent {
     agent: LocalMastraAgent | RemoteMastraAgent,
   ): agent is LocalMastraAgent {
     return "getMemory" in agent;
+  }
+
+  /**
+   * Maps a Mastra tool suspend to an AG-UI {@link Interrupt}.
+   *
+   * `id` is the suspended tool call id — the correlation key resume sends back
+   * (alongside `runId`) via `resumeStream`. `responseSchema` is the parsed
+   * `resumeSchema` (Mastra hands it over as a JSON string). Everything the
+   * resume round-trip needs that has no first-class Interrupt field
+   * (`toolName`, `suspendPayload`, `args`, the snapshot-keying `runId`) is
+   * preserved under `metadata.mastra`, shaped like the legacy on_interrupt
+   * value so a standard-path client can reconstruct the resume directive.
+   */
+  private suspendToInterrupt(
+    payload: {
+      toolCallId: string;
+      toolName: string;
+      suspendPayload: any;
+      args: Record<string, any>;
+      resumeSchema: string;
+      runId?: string;
+    },
+    runId: string,
+  ): Interrupt {
+    let responseSchema: Record<string, any> | undefined;
+    const rawSchema = payload.resumeSchema as unknown;
+    if (typeof rawSchema === "string" && rawSchema.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(rawSchema);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          responseSchema = parsed;
+        }
+      } catch {
+        // resumeSchema is not valid JSON — omit responseSchema; the raw value
+        // is still carried in metadata.mastra below.
+      }
+    } else if (
+      rawSchema &&
+      typeof rawSchema === "object" &&
+      !Array.isArray(rawSchema)
+    ) {
+      responseSchema = rawSchema as Record<string, any>;
+    }
+
+    return {
+      id: payload.toolCallId,
+      reason: "mastra:tool_suspend",
+      toolCallId: payload.toolCallId,
+      ...(responseSchema ? { responseSchema } : {}),
+      metadata: {
+        mastra: {
+          type: "mastra_suspend",
+          toolName: payload.toolName,
+          suspendPayload: payload.suspendPayload,
+          args: payload.args,
+          resumeSchema: payload.resumeSchema,
+          // The id Mastra keys the suspended snapshot by (see onToolSuspended).
+          runId: payload.runId ?? runId,
+        },
+      },
+    };
+  }
+
+  /**
+   * Builds the terminating RUN_FINISHED for a run. When emitInterruptOutcome is
+   * on AND the run suspended at least one tool, attaches the structured
+   * `outcome: { type: "interrupt", interrupts }`. Otherwise emits a plain
+   * RUN_FINISHED — the legacy/default behavior. Mirrors LangGraph's
+   * `dispatchInterruptFinish`.
+   */
+  private makeRunFinishedEvent(
+    threadId: string,
+    runId: string,
+    interrupts: Interrupt[],
+  ): RunFinishedEvent {
+    const includeOutcome = this.emitInterruptOutcome && interrupts.length > 0;
+    return {
+      type: EventType.RUN_FINISHED,
+      threadId,
+      runId,
+      ...(includeOutcome
+        ? {
+            outcome: {
+              type: "interrupt",
+              interrupts,
+            } satisfies RunFinishedInterruptOutcome,
+          }
+        : {}),
+    } as RunFinishedEvent;
   }
 
   /**
@@ -513,6 +645,7 @@ export class MastraAgent extends AbstractAgent {
     getMessageId: () => string,
     setMessageId: (id: string) => void,
     runId: string,
+    pendingInterrupts: Interrupt[],
   ): Omit<MastraAgentStreamOptions, "onError" | "onRunFinished"> {
     let reasoningMessageId: string | null = null;
     let isReasoning = false;
@@ -603,6 +736,8 @@ export class MastraAgent extends AbstractAgent {
         } as ToolCallResultEvent);
       },
       onToolSuspended: (payload) => {
+        // Legacy path: always emitted (backward compat, owner decision). The
+        // wrapper stays even when emitInterruptOutcome is on.
         subscriber.next({
           type: EventType.CUSTOM,
           name: "on_interrupt",
@@ -619,6 +754,13 @@ export class MastraAgent extends AbstractAgent {
             runId: payload.runId ?? runId,
           }),
         } as CustomEvent);
+
+        // Standard path (opt-in): accumulate the suspend as an AG-UI Interrupt
+        // so the terminating RUN_FINISHED carries the structured outcome. Kept
+        // separate from the legacy event above — both fire when the flag is on.
+        if (this.emitInterruptOutcome) {
+          pendingInterrupts.push(this.suspendToInterrupt(payload, runId));
+        }
       },
       onFinishMessagePart: () => {
         closeReasoning();


### PR DESCRIPTION
## What

Adds an opt-in `emitInterruptOutcome` flag (default **OFF**) to the Mastra bridge that terminates a suspended run with AG-UI's standard structured outcome:

```ts
RUN_FINISHED.outcome = { type: "interrupt", interrupts: Interrupt[] }
```

Each Mastra tool suspend maps to an `Interrupt`. Mirrors LangGraph's flag of the same name and semantics.

Linear: [OSS-379](https://linear.app/copilotkit/issue/OSS-379/mastra-adopt-standard-run-finished-interrupt-outcome-path)

## Why opt-in (default off)

Same reason as LangGraph's `emitInterruptOutcome`: released clients that resume through the legacy `forwardedProps.command.resume` channel (CopilotKit runtime as of v1.60.1) stop sending a resume directive once they observe the structured outcome, which silently strands the run. Until those clients adopt the canonical path, emitting by default would break them. Flipping the default on is a separate decision once the runtime floor is safe.

## Behavior

- Legacy `CustomEvent(name="on_interrupt")` **stays and is always emitted** (backward compat, owner decision). When the flag is on, BOTH channels fire; when off, only the legacy event plus a plain `RUN_FINISHED` — byte-for-byte unchanged.
- Resume keeps working on both: the legacy `command.resume` channel is flag-independent. Mastra fully overrides `run()` so the base `AbstractAgent` `pendingInterrupts` lifecycle is bypassed — no `reconcileLegacyResumeInterrupts` equivalent is needed (unlike LangGraph).

## Mapping (suspend → Interrupt)

- `id` / `toolCallId` = the suspended tool call id
- `responseSchema` = parsed from the `resumeSchema` JSON string
- `metadata.mastra` = remaining round-trip data (`toolName`, `suspendPayload`, `args`, snapshot-keying `runId`), shaped like the legacy `on_interrupt` value so a standard-path client can reconstruct the resume directive.

## Tests

12 new cases in `interrupt-bridge.test.ts`: flag on/off, validation against the canonical `RunFinishedEventSchema`, mapping/field preservation, chunk-runId vs `RunAgentInput.runId`, multi-suspend, non-interrupt run, resume-path outcome, remote. Full suite: **171/171 pass**, typecheck + build clean.

## Verified against a real run

Real LLM (gpt-4.1-mini) + real `@mastra/core` Agent with a suspending tool, flag on:
- **Emit**: run suspended → valid `RUN_FINISHED.outcome.type === "interrupt"` (real `call_…` id, parsed `responseSchema`, full `metadata.mastra`).
- **Resume**: reconstructed the directive from the outcome metadata → `resumeStream` round-tripped → tool completed (`"Meeting scheduled for Tuesday at 2 PM..."`).
- Confirmed the resume gotcha live: snapshot persistence needs a `Mastra` instance **with storage** + `mastra.getAgent()`, not a standalone Agent.

A CopilotKit standard-path browser e2e is not feasible yet — the receiving runtime (1.60.1) breaks on the outcome, which is the exact reason the flag is opt-in.

## Out of scope

- Flipping the default on (separate decision).
- Remote-agent resume (OSS-380).