### PR TITLE
feat(client): add messageFilter to AgentConfig

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-message-filter.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-message-filter.test.ts
@@ -1,0 +1,104 @@
+import { AbstractAgent } from "../agent";
+import { HttpAgent } from "../http";
+import { BaseEvent, Message, RunAgentInput } from "@ag-ui/core";
+import { EMPTY, Observable } from "rxjs";
+
+class RecordingAgent extends AbstractAgent {
+  public capturedMessages: Message[][] = [];
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.capturedMessages.push(input.messages);
+    return EMPTY as Observable<BaseEvent>;
+  }
+}
+
+const userMsg = (id: string, content: string): Message =>
+  ({ id, role: "user", content, toolCalls: [] }) as Message;
+
+const assistantMsg = (id: string, content: string): Message =>
+  ({ id, role: "assistant", content, toolCalls: [] }) as Message;
+
+describe("AgentConfig.messageFilter", () => {
+  it("forwards all messages when messageFilter is not set", async () => {
+    const agent = new RecordingAgent({
+      initialMessages: [userMsg("u1", "hello"), assistantMsg("a1", "hi"), userMsg("u2", "bye")],
+    });
+
+    await agent.runAgent();
+
+    expect(agent.capturedMessages[0]).toHaveLength(3);
+  });
+
+  it("applies messageFilter before forwarding messages to run()", async () => {
+    const agent = new RecordingAgent({
+      initialMessages: [userMsg("u1", "hello"), assistantMsg("a1", "hi"), userMsg("u2", "latest")],
+      messageFilter: (messages) => {
+        const last = [...messages].reverse().find((m) => m.role === "user");
+        return last ? [last] : [];
+      },
+    });
+
+    await agent.runAgent();
+
+    expect(agent.capturedMessages[0]).toHaveLength(1);
+    expect(agent.capturedMessages[0][0]).toMatchObject({ id: "u2", role: "user" });
+  });
+
+  it("does not mutate the agent's stored messages", async () => {
+    const agent = new RecordingAgent({
+      initialMessages: [userMsg("u1", "a"), userMsg("u2", "b"), userMsg("u3", "c")],
+      messageFilter: (messages) => messages.slice(-1),
+    });
+
+    await agent.runAgent();
+
+    expect(agent.capturedMessages[0]).toHaveLength(1);
+    expect(agent.messages).toHaveLength(3);
+  });
+
+  it("excludes activity messages before passing to messageFilter", async () => {
+    const activityMsg = {
+      id: "act1",
+      role: "activity",
+      content: "thinking…",
+    } as unknown as Message;
+    const seen: Message[][] = [];
+
+    const agent = new RecordingAgent({
+      initialMessages: [userMsg("u1", "hello"), activityMsg, userMsg("u2", "world")],
+      messageFilter: (messages) => {
+        seen.push([...messages]);
+        return messages;
+      },
+    });
+
+    await agent.runAgent();
+
+    expect(seen[0].every((m) => m.role !== "activity")).toBe(true);
+    expect(seen[0]).toHaveLength(2);
+  });
+
+  it("preserves messageFilter across clone()", () => {
+    const filter = (messages: Message[]) => messages.slice(-1);
+    const original = new RecordingAgent({
+      initialMessages: [userMsg("u1", "a"), userMsg("u2", "b")],
+      messageFilter: filter,
+    });
+
+    const cloned = original.clone() as RecordingAgent;
+
+    expect((cloned as any)._messageFilter).toBe(filter);
+  });
+
+  it("HttpAgent accepts messageFilter and applies it", async () => {
+    const filter = (messages: Message[]) => messages.slice(-1);
+    const agent = new HttpAgent({
+      url: "https://example.com/agent",
+      initialMessages: [userMsg("u1", "first"), userMsg("u2", "second")],
+      messageFilter: filter,
+    });
+
+    const cloned = agent.clone() as HttpAgent;
+    expect((cloned as any)._messageFilter).toBe(filter);
+  });
+});

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -56,6 +56,7 @@ export abstract class AbstractAgent {
   public state: State;
   private _debug: ResolvedAgentDebugConfig;
   private _debugLogger: DebugLogger | undefined;
+  private _messageFilter?: (messages: Message[]) => Message[];
   public subscribers: AgentSubscriber[] = [];
   public isRunning: boolean = false;
   /** Interrupts emitted by the most recent run that have not yet been resolved.
@@ -86,9 +87,7 @@ export abstract class AbstractAgent {
 
   set debugLogger(value: DebugLogger | boolean | undefined) {
     if (typeof value === "boolean") {
-      this._debugLogger = value
-        ? createDebugLogger(resolveAgentDebugConfig(true))
-        : undefined;
+      this._debugLogger = value ? createDebugLogger(resolveAgentDebugConfig(true)) : undefined;
     } else {
       this._debugLogger = value;
     }
@@ -101,6 +100,7 @@ export abstract class AbstractAgent {
     initialMessages,
     initialState,
     debug,
+    messageFilter,
   }: AgentConfig = {}) {
     this.agentId = agentId;
     this.description = description ?? "";
@@ -109,6 +109,7 @@ export abstract class AbstractAgent {
     this.state = structuredClone_(initialState ?? {});
     this._debug = resolveAgentDebugConfig(debug);
     this._debugLogger = createDebugLogger(this._debug);
+    this._messageFilter = messageFilter;
 
     if (compareVersions(this.maxVersion, "0.0.39") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_39());
@@ -125,7 +126,6 @@ export abstract class AbstractAgent {
     if (compareVersions(this.maxVersion, "0.0.47") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_47());
     }
-
   }
 
   public subscribe(subscriber: AgentSubscriber) {
@@ -380,6 +380,9 @@ export abstract class AbstractAgent {
   protected prepareRunAgentInput(parameters?: RunAgentParameters): RunAgentInput {
     const clonedMessages = structuredClone_(this.messages) as Message[];
     const messagesWithoutActivity = clonedMessages.filter((message) => message.role !== "activity");
+    const messages = this._messageFilter
+      ? this._messageFilter(messagesWithoutActivity)
+      : messagesWithoutActivity;
 
     return {
       threadId: this.threadId,
@@ -388,7 +391,7 @@ export abstract class AbstractAgent {
       context: structuredClone_(parameters?.context ?? []),
       forwardedProps: structuredClone_(parameters?.forwardedProps ?? {}),
       state: structuredClone_(this.state),
-      messages: messagesWithoutActivity,
+      messages,
       ...(parameters?.resume !== undefined ? { resume: structuredClone_(parameters.resume) } : {}),
     };
   }
@@ -396,9 +399,7 @@ export abstract class AbstractAgent {
   protected async onInitialize(input: RunAgentInput, subscribers: AgentSubscriber[]) {
     if (this.pendingInterrupts.length > 0) {
       const resumeIds = new Set((input.resume ?? []).map((r) => r.interruptId));
-      const uncovered = this.pendingInterrupts
-        .map((i) => i.id)
-        .filter((id) => !resumeIds.has(id));
+      const uncovered = this.pendingInterrupts.map((i) => i.id).filter((id) => !resumeIds.has(id));
       if (uncovered.length > 0) {
         throw new AGUIError(
           `Thread has ${uncovered.length} pending interrupt(s) not addressed by resume: ${uncovered.join(", ")}`,
@@ -558,6 +559,7 @@ export abstract class AbstractAgent {
     cloned.state = structuredClone_(this.state);
     cloned._debug = this._debug;
     cloned._debugLogger = this._debugLogger;
+    cloned._messageFilter = this._messageFilter;
     cloned.isRunning = this.isRunning;
     cloned.subscribers = [...this.subscribers];
     cloned.middlewares = [...this.middlewares];

--- a/sdks/typescript/packages/client/src/agent/types.ts
+++ b/sdks/typescript/packages/client/src/agent/types.ts
@@ -37,6 +37,7 @@ export interface AgentConfig {
   initialMessages?: Message[];
   initialState?: State;
   debug?: AgentDebugConfig;
+  messageFilter?: (messages: Message[]) => Message[];
 }
 
 export type HttpAgentFetchFn = (url: string, requestInit: RequestInit) => Promise<Response>;


### PR DESCRIPTION
Fixes #2062                                            
                                                         
Adds an optional `messageFilter` callback to `AgentConfig`, applied in `prepareRunAgentInput` after stripping `activity` messages before each run. Stored messages are not mutated. Filter is preserved across`clone()`.  