### PR TITLE
fix(mastra): forward input.context to tools + re-set on resume (OSS-392)

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/context-forwarding.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/context-forwarding.test.ts
@@ -8,16 +8,10 @@ import {
   collectEvents,
 } from "./helpers";
 
-// ---------------------------------------------------------------------------
-// OSS-392: input.context must be forwarded onto Mastra's RequestContext under
-// the "ag-ui" key, reachable by tools via `execute(input, { requestContext })`,
-// on the initial run AND after resume on BOTH the local and remote paths.
-//
-// These tests read the context BACK through the exact RequestContext.get()
-// channel a Mastra tool uses — not merely asserting the option is present — so
-// they prove reachability, not plumbing. (A real-LLM run with a tool that calls
-// requestContext.get("ag-ui") covers the live Mastra runtime end-to-end.)
-// ---------------------------------------------------------------------------
+// input.context must be forwarded onto the RequestContext under "ag-ui",
+// reachable by tools, on the initial run and after resume (local + remote).
+// These read the context back through the same requestContext.get("ag-ui")
+// channel a tool uses, so they prove reachability rather than plumbing.
 
 const CONTEXT_A: Context[] = [{ description: "tier", value: "premium" }];
 const CONTEXT_B: Context[] = [{ description: "tier", value: "enterprise" }];
@@ -80,7 +74,7 @@ function standardResumeInput(context: Context[]) {
   } as any);
 }
 
-describe("context forwarding (OSS-392): initial run", () => {
+describe("context forwarding: initial run", () => {
   it("forwards input.context onto requestContext for a local agent", async () => {
     const { agent, fake } = makeLocal({
       streamChunks: [{ type: "text-delta", payload: { text: "hi" } }],
@@ -112,7 +106,7 @@ describe("context forwarding (OSS-392): initial run", () => {
   });
 });
 
-describe("context forwarding (OSS-392): resume re-sets context", () => {
+describe("context forwarding: resume re-sets context", () => {
   it("forwards the resume request's context on a local legacy-channel resume", async () => {
     const { agent, fake } = makeLocal({
       resumeChunks: [{ type: "text-delta", payload: { text: "approved" } }],
@@ -145,12 +139,9 @@ describe("context forwarding (OSS-392): resume re-sets context", () => {
   });
 });
 
-describe("context forwarding (OSS-392): resume does not reuse a stale context", () => {
-  // The bug this guards: the resume path reused the constructor/initial-run
-  // requestContext verbatim and never re-set input.context, so a resume request
-  // carrying a NEW context silently saw the prior turn's value. We reuse a
-  // single agent instance (shared this.requestContext) across an initial run
-  // then a resume, and assert the resume sees the fresh context, not the stale.
+describe("context forwarding: resume does not reuse a stale context", () => {
+  // Reuse one agent instance (shared requestContext) across an initial run then
+  // a resume, asserting the resume sees the fresh context, not the prior turn's.
 
   it("local resume overwrites the prior run's context (does not drop the new one)", async () => {
     const fake = new FakeLocalAgent({

--- a/integrations/mastra/typescript/src/__tests__/context-forwarding.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/context-forwarding.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import type { Context } from "@ag-ui/client";
+import { MastraAgent } from "../mastra";
+import {
+  FakeLocalAgent,
+  FakeRemoteAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+
+// ---------------------------------------------------------------------------
+// OSS-392: input.context must be forwarded onto Mastra's RequestContext under
+// the "ag-ui" key, reachable by tools via `execute(input, { requestContext })`,
+// on the initial run AND after resume on BOTH the local and remote paths.
+//
+// These tests read the context BACK through the exact RequestContext.get()
+// channel a Mastra tool uses — not merely asserting the option is present — so
+// they prove reachability, not plumbing. (A real-LLM run with a tool that calls
+// requestContext.get("ag-ui") covers the live Mastra runtime end-to-end.)
+// ---------------------------------------------------------------------------
+
+const CONTEXT_A: Context[] = [{ description: "tier", value: "premium" }];
+const CONTEXT_B: Context[] = [{ description: "tier", value: "enterprise" }];
+
+/** Reads the forwarded context back the same way a tool's execute would. */
+function readForwardedContext(opts: any): Context[] | undefined {
+  const reqCtx = opts?.requestContext;
+  if (!reqCtx || typeof reqCtx.get !== "function") return undefined;
+  return reqCtx.get("ag-ui")?.context;
+}
+
+function makeLocal(opts: { streamChunks?: any[]; resumeChunks?: any[] } = {}) {
+  const fake = new FakeLocalAgent(opts);
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fake as any,
+    resourceId: "resource-1",
+  });
+  return { agent, fake };
+}
+
+function makeRemote(opts: { streamChunks?: any[]; resumeChunks?: any[] } = {}) {
+  const fake = new FakeRemoteAgent(opts);
+  const agent = new MastraAgent({
+    agentId: "test-agent",
+    agent: fake as any,
+    resourceId: "resource-1",
+  });
+  return { agent, fake };
+}
+
+/** Legacy resume command (forwardedProps.command), as CopilotKit < 1.61.2 sends. */
+function legacyResumeInput(context: Context[]) {
+  return makeInput({
+    context,
+    forwardedProps: {
+      command: {
+        resume: { approved: true },
+        interruptEvent: JSON.stringify({
+          type: "mastra_suspend",
+          toolCallId: "tc-1",
+          runId: "mastra-run-xyz",
+        }),
+      },
+    },
+  });
+}
+
+/** Standard resume channel (RunAgentInput.resume), as CopilotKit >= 1.61.2 sends. */
+function standardResumeInput(context: Context[]) {
+  return makeInput({
+    context,
+    resume: [
+      {
+        interruptId: "mastra-run-xyz::tc-1",
+        status: "resolved",
+        payload: { approved: true },
+      },
+    ],
+  } as any);
+}
+
+describe("context forwarding (OSS-392): initial run", () => {
+  it("forwards input.context onto requestContext for a local agent", async () => {
+    const { agent, fake } = makeLocal({
+      streamChunks: [{ type: "text-delta", payload: { text: "hi" } }],
+    });
+
+    await collectEvents(agent, makeInput({ context: CONTEXT_A }));
+
+    expect(readForwardedContext(fake.lastStreamOpts)).toEqual(CONTEXT_A);
+  });
+
+  it("forwards input.context onto requestContext for a remote agent", async () => {
+    const { agent, fake } = makeRemote({
+      streamChunks: [{ type: "text-delta", payload: { text: "hi" } }],
+    });
+
+    await collectEvents(agent, makeInput({ context: CONTEXT_A }));
+
+    expect(readForwardedContext(fake.lastStreamOpts)).toEqual(CONTEXT_A);
+  });
+
+  it("forwards an empty context as []", async () => {
+    const { agent, fake } = makeLocal({
+      streamChunks: [{ type: "text-delta", payload: { text: "hi" } }],
+    });
+
+    await collectEvents(agent, makeInput({ context: [] }));
+
+    expect(readForwardedContext(fake.lastStreamOpts)).toEqual([]);
+  });
+});
+
+describe("context forwarding (OSS-392): resume re-sets context", () => {
+  it("forwards the resume request's context on a local legacy-channel resume", async () => {
+    const { agent, fake } = makeLocal({
+      resumeChunks: [{ type: "text-delta", payload: { text: "approved" } }],
+    });
+
+    await collectEvents(agent, legacyResumeInput(CONTEXT_B));
+
+    expect(readForwardedContext(fake.lastResumeOpts)).toEqual(CONTEXT_B);
+  });
+
+  it("forwards the resume request's context on a local standard-channel resume", async () => {
+    const { agent, fake } = makeLocal({
+      resumeChunks: [{ type: "text-delta", payload: { text: "approved" } }],
+    });
+
+    await collectEvents(agent, standardResumeInput(CONTEXT_B));
+
+    expect(readForwardedContext(fake.lastResumeOpts)).toEqual(CONTEXT_B);
+  });
+
+  it("forwards the resume request's context on a remote resume", async () => {
+    const { agent, fake } = makeRemote({
+      resumeChunks: [{ type: "text-delta", payload: { text: "approved" } }],
+    });
+
+    await collectEvents(agent, legacyResumeInput(CONTEXT_B));
+
+    expect(fake.resumeCalls).toHaveLength(1);
+    expect(readForwardedContext(fake.resumeCalls[0].opts)).toEqual(CONTEXT_B);
+  });
+});
+
+describe("context forwarding (OSS-392): resume does not reuse a stale context", () => {
+  // The bug this guards: the resume path reused the constructor/initial-run
+  // requestContext verbatim and never re-set input.context, so a resume request
+  // carrying a NEW context silently saw the prior turn's value. We reuse a
+  // single agent instance (shared this.requestContext) across an initial run
+  // then a resume, and assert the resume sees the fresh context, not the stale.
+
+  it("local resume overwrites the prior run's context (does not drop the new one)", async () => {
+    const fake = new FakeLocalAgent({
+      streamChunks: [{ type: "text-delta", payload: { text: "first" } }],
+      resumeChunks: [{ type: "text-delta", payload: { text: "resumed" } }],
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    // Initial run sets context A on the shared requestContext.
+    await collectEvents(agent, makeInput({ context: CONTEXT_A }));
+    expect(readForwardedContext(fake.lastStreamOpts)).toEqual(CONTEXT_A);
+
+    // Resume carries a DIFFERENT context B — it must be re-set, not dropped.
+    await collectEvents(agent, legacyResumeInput(CONTEXT_B));
+    expect(readForwardedContext(fake.lastResumeOpts)).toEqual(CONTEXT_B);
+  });
+
+  it("remote resume overwrites the prior run's context (does not drop the new one)", async () => {
+    const fake = new FakeRemoteAgent({
+      streamChunks: [{ type: "text-delta", payload: { text: "first" } }],
+      resumeChunks: [{ type: "text-delta", payload: { text: "resumed" } }],
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    await collectEvents(agent, makeInput({ context: CONTEXT_A }));
+    expect(readForwardedContext(fake.lastStreamOpts)).toEqual(CONTEXT_A);
+
+    await collectEvents(agent, legacyResumeInput(CONTEXT_B));
+    expect(fake.resumeCalls).toHaveLength(1);
+    expect(readForwardedContext(fake.resumeCalls[0].opts)).toEqual(CONTEXT_B);
+  });
+});

--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -29,21 +29,42 @@ export class FakeMemory {
 export class FakeLocalAgent {
   memory: FakeMemory;
   streamChunks: any[];
+  resumeChunks: any[] | undefined;
   /** Messages passed to the most recent stream() call (post-diff-filter). */
   lastStreamMessages: any[] | null = null;
+  /** Options passed to the most recent stream() call. */
+  lastStreamOpts: any = null;
+  /** Options passed to the most recent resumeStream() call. */
+  lastResumeOpts: any = null;
 
-  constructor(opts: { memory?: FakeMemory; streamChunks?: any[] } = {}) {
+  constructor(
+    opts: { memory?: FakeMemory; streamChunks?: any[]; resumeChunks?: any[] } = {},
+  ) {
     this.memory = opts.memory ?? new FakeMemory();
     this.streamChunks = opts.streamChunks ?? [];
+    this.resumeChunks = opts.resumeChunks;
   }
 
   async getMemory(_opts?: any) {
     return this.memory;
   }
 
-  async stream(messages: any, _opts?: any) {
+  async stream(messages: any, opts?: any) {
     this.lastStreamMessages = messages;
+    this.lastStreamOpts = opts;
     const chunks = this.streamChunks;
+    return {
+      fullStream: (async function* () {
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      })(),
+    };
+  }
+
+  async resumeStream(_resumeData: any, opts?: any) {
+    this.lastResumeOpts = opts;
+    const chunks = this.resumeChunks ?? [];
     return {
       fullStream: (async function* () {
         for (const chunk of chunks) {
@@ -68,8 +89,12 @@ export class FakeRemoteAgent {
     this.resumeChunks = opts.resumeChunks;
   }
 
-  async stream(messages: any, _opts?: any) {
+  /** Options passed to the most recent stream() call. */
+  lastStreamOpts: any = null;
+
+  async stream(messages: any, opts?: any) {
     this.lastStreamMessages = messages;
+    this.lastStreamOpts = opts;
     const chunks = this.streamChunks;
     return {
       processDataStream: async ({
@@ -143,6 +168,7 @@ export function makeLocalMastraAgent(
   opts: {
     memory?: FakeMemory;
     streamChunks?: any[];
+    resumeChunks?: any[];
     emitInterruptOutcome?: boolean;
   } = {},
 ) {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -240,6 +240,31 @@ export class MastraAgent extends AbstractAgent {
     return cloned;
   }
 
+  /**
+   * Forwards the AG-UI `RunAgentInput.context` onto Mastra's `RequestContext`
+   * under the reserved `"ag-ui"` key, shaped `{ context }`. This is the channel
+   * a Mastra tool reads it back from — `execute(input, { requestContext })`
+   * receives the same RequestContext we pass to `agent.stream()` /
+   * `agent.resumeStream()`, so a tool does:
+   *
+   *   const { context } = requestContext.get("ag-ui") ?? {};
+   *
+   * It is also visible to dynamic `instructions`/option functions, which Mastra
+   * invokes with `{ requestContext }`. This is the idiomatic peer of LangGraph's
+   * graph-state context channel (`state["ag-ui"].context`).
+   *
+   * Called on EVERY entry path — initial stream, local resume, AND remote
+   * resume — because a resumed run carries a *fresh* `input.context` that must
+   * replace whatever was set on the prior turn. The resume paths previously
+   * reused `this.requestContext` verbatim and silently dropped the new context
+   * (OSS-392); routing every path through here closes that drop.
+   */
+  private applyInputContext(context: RunAgentInput["context"]): RequestContext {
+    this.requestContext ??= new RequestContext();
+    this.requestContext.set("ag-ui", { context });
+    return this.requestContext;
+  }
+
   run(input: RunAgentInput): Observable<BaseEvent> {
     // Fallback id used only until Mastra announces the persisted message id on
     // the start / step-start chunk (see onMessageId). Adopting Mastra's id
@@ -343,6 +368,12 @@ export class MastraAgent extends AbstractAgent {
             return;
           }
 
+          // Forward THIS run's context onto the RequestContext before resuming.
+          // The resume request carries a fresh `input.context`; without re-setting
+          // it here the resumed stream (local or remote) would reuse the prior
+          // turn's value and drop the new context (OSS-392).
+          const resumeRequestContext = this.applyInputContext(input.context);
+
           // Resume options are shared verbatim by the local and remote paths.
           // Mastra keys the suspended snapshot by the runId surfaced on the
           // suspend chunk (round-tripped here as interruptEvent.runId), NOT the
@@ -357,7 +388,7 @@ export class MastraAgent extends AbstractAgent {
               thread: input.threadId,
               resource: this.resourceId ?? input.threadId,
             },
-            requestContext: this.requestContext,
+            requestContext: resumeRequestContext,
           };
           if (this.headers && Object.keys(this.headers).length > 0) {
             resumeOptions.modelSettings = {
@@ -1422,8 +1453,7 @@ export class MastraAgent extends AbstractAgent {
       messagesToSend,
       messages,
     );
-    this.requestContext?.set("ag-ui", { context: inputContext });
-    const requestContext = this.requestContext;
+    const requestContext = this.applyInputContext(inputContext);
 
     if (this.isLocalMastraAgent(this.agent)) {
       try {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -241,23 +241,10 @@ export class MastraAgent extends AbstractAgent {
   }
 
   /**
-   * Forwards the AG-UI `RunAgentInput.context` onto Mastra's `RequestContext`
-   * under the reserved `"ag-ui"` key, shaped `{ context }`. This is the channel
-   * a Mastra tool reads it back from — `execute(input, { requestContext })`
-   * receives the same RequestContext we pass to `agent.stream()` /
-   * `agent.resumeStream()`, so a tool does:
-   *
-   *   const { context } = requestContext.get("ag-ui") ?? {};
-   *
-   * It is also visible to dynamic `instructions`/option functions, which Mastra
-   * invokes with `{ requestContext }`. This is the idiomatic peer of LangGraph's
-   * graph-state context channel (`state["ag-ui"].context`).
-   *
-   * Called on EVERY entry path — initial stream, local resume, AND remote
-   * resume — because a resumed run carries a *fresh* `input.context` that must
-   * replace whatever was set on the prior turn. The resume paths previously
-   * reused `this.requestContext` verbatim and silently dropped the new context
-   * (OSS-392); routing every path through here closes that drop.
+   * Forwards `input.context` onto the Mastra RequestContext under "ag-ui", so a
+   * tool reads it via `requestContext.get("ag-ui").context`. Called on every
+   * entry path (initial stream + both resume paths) so a resumed run forwards
+   * its own context instead of reusing the prior turn's.
    */
   private applyInputContext(context: RunAgentInput["context"]): RequestContext {
     this.requestContext ??= new RequestContext();
@@ -368,10 +355,7 @@ export class MastraAgent extends AbstractAgent {
             return;
           }
 
-          // Forward THIS run's context onto the RequestContext before resuming.
-          // The resume request carries a fresh `input.context`; without re-setting
-          // it here the resumed stream (local or remote) would reuse the prior
-          // turn's value and drop the new context (OSS-392).
+          // Re-set this run's context so resume forwards it, not the prior turn's.
           const resumeRequestContext = this.applyInputContext(input.context);
 
           // Resume options are shared verbatim by the local and remote paths.


### PR DESCRIPTION
## OSS-392: forward `input.context` into the Mastra agent properly (fix resume drop)

Linear: [OSS-392](https://linear.app/copilotkit/issue/OSS-392/mastra-forward-inputcontext-into-the-agent-properly-fix-resume-drop)

### Problem
The bridge set `RunAgentInput.context` on Mastra's `RequestContext` under the `"ag-ui"` key on the **initial stream path only**. The resume paths — both local and the OSS-380 remote path — reused `this.requestContext` verbatim and never re-set the resumed run's fresh `input.context`, **silently dropping it**.

### Verification first (mechanism was unproven)
Confirmed against `@mastra/core` 1.47.0 (types + a real `Agent` run) that the `RequestContext` passed to `agent.stream()` / `agent.resumeStream()` is the same instance Mastra hands to a tool's `execute(input, { requestContext })` (`ToolExecutionContext.requestContext`) and to dynamic `instructions`. So `requestContext` **is** the correct, tool-reachable channel — no need for `runtimeContext` or injecting context into the system prompt. A tool reads it back via:

```ts
const { context } = requestContext.get("ag-ui") ?? {};
```

This is the idiomatic peer of LangGraph's graph-state context channel (`state["ag-ui"].context`).

### Fix
Route **every** entry path (initial stream, local resume, remote resume) through a single `applyInputContext()` helper that sets `{ context }` under `"ag-ui"`. The decline path (`resume === false`) needs no forwarding — no agent runs.

### Tests
`context-forwarding.test.ts` reads the context **back** through the same `requestContext.get("ag-ui").context` API a tool uses (not merely asserting the option is present), on:
- initial run (local + remote)
- resume (local legacy `forwardedProps.command` channel + standard `RunAgentInput.resume` channel, and remote)
- a **stale-context regression**: one agent instance, initial run with context A then resume with context B — the resume must see B, not the stale A.

Negative control while developing: reverting just the resume fix failed exactly the 5 resume tests and left the 3 initial-run tests green, confirming the fix is load-bearing.

Also verified against a **real `@mastra/core` Agent** (mock model emits a tool call; a real tool reads `requestContext.get("ag-ui")`) — the tool observed the forwarded context end-to-end.

### Checks
194/194 mastra tests pass, `tsc --noEmit` clean, build clean.

### Out of scope
Tool-call streaming progress (OSS-393).
