### PR TITLE
feat(mastra): stream tool-call args incrementally (OSS-393)

### DIFF
--- a/apps/dojo/e2e/featurePages/ToolBaseGenUIPage.ts
+++ b/apps/dojo/e2e/featurePages/ToolBaseGenUIPage.ts
@@ -1,6 +1,9 @@
 import { Page, Locator, expect } from "@playwright/test";
 import { CopilotSelectors } from "../utils/copilot-selectors";
-import { sendChatMessage, awaitLLMResponseDone } from "../utils/copilot-actions";
+import {
+  sendChatMessage,
+  awaitLLMResponseDone,
+} from "../utils/copilot-actions";
 import { DEFAULT_WELCOME_MESSAGE } from "../lib/constants";
 
 export class ToolBaseGenUIPage {
@@ -34,9 +37,9 @@ export class ToolBaseGenUIPage {
     const cards = this.page.locator('[data-testid="haiku-card"]');
     await expect(cards.last()).toBeVisible();
     const mostRecentCard = cards.last();
-    await expect(mostRecentCard
-      .locator('[data-testid="haiku-japanese-line"]')
-      .first()).toBeVisible();
+    await expect(
+      mostRecentCard.locator('[data-testid="haiku-japanese-line"]').first(),
+    ).toBeVisible();
   }
 
   async extractChatHaikuContent(page: Page): Promise<string> {
@@ -48,7 +51,9 @@ export class ToolBaseGenUIPage {
 
     for (let cardIndex = cardCount - 1; cardIndex >= 0; cardIndex--) {
       chatHaikuContainer = allHaikuCards.nth(cardIndex);
-      chatHaikuLines = chatHaikuContainer.locator('[data-testid="haiku-japanese-line"]');
+      chatHaikuLines = chatHaikuContainer.locator(
+        '[data-testid="haiku-japanese-line"]',
+      );
       const linesCount = await chatHaikuLines.count();
 
       if (linesCount > 0) {
@@ -102,7 +107,9 @@ export class ToolBaseGenUIPage {
       activeCard = carousel.locator('[data-testid="haiku-card"]').first();
     }
 
-    const mainDisplayLines = activeCard.locator('[data-testid="haiku-japanese-line"]');
+    const mainDisplayLines = activeCard.locator(
+      '[data-testid="haiku-japanese-line"]',
+    );
     const mainCount = await mainDisplayLines.count();
     const lines: string[] = [];
 
@@ -155,10 +162,79 @@ export class ToolBaseGenUIPage {
     const chatHaikuContent = await this.extractChatHaikuContent(page);
 
     await expect
-      .poll(
-        async () => this.carouselIncludesHaiku(page, chatHaikuContent),
-        { timeout: 15000, intervals: [500, 1000, 2000] },
-      )
+      .poll(async () => this.carouselIncludesHaiku(page, chatHaikuContent), {
+        timeout: 15000,
+        intervals: [500, 1000, 2000],
+      })
       .toBe(true);
+  }
+
+  /**
+   * Capture the runtime's SSE body for the chat run identified by `marker`.
+   *
+   * The browser POSTs to `/api/copilotkit/<integrationId>` and gets back a
+   * text/event-stream of raw AG-UI events. Reading the COMPLETED response body
+   * (not live frames) keeps the incremental-streaming assertion flake-free.
+   *
+   * `marker` must be a substring of the run's request body that survives JSON
+   * encoding — pass a QUOTE-FREE fragment of the prompt (the raw prompt's own
+   * double quotes get escaped to `\"` in the body, so matching on them fails).
+   *
+   * `integrationId` is matched on a path boundary so the `mastra` suite does
+   * not also capture `mastra-agent-local` runs (one is a prefix of the other).
+   */
+  captureRuntimeSSE(integrationId: string, marker: string): Promise<string> {
+    const idRe = integrationId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pathRe = new RegExp(`/api/copilotkit/${idRe}(/|$)`);
+    return new Promise<string>((resolve, reject) => {
+      this.page.on("response", async (response) => {
+        try {
+          if (
+            pathRe.test(new URL(response.url()).pathname) &&
+            response.request().method() === "POST" &&
+            // Scope to THIS run — other POSTs to the same endpoint (agent info,
+            // suggestion generation) don't carry the prompt marker.
+            (response.request().postData() ?? "").includes(marker)
+          ) {
+            resolve(await response.text());
+          }
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  }
+
+  /**
+   * Assert the generate_haiku tool call streamed its args as MANY incremental
+   * TOOL_CALL_ARGS deltas (the OSS-393 regression net). Before the bridge
+   * consumed tool-call-delta chunks, args collapsed into exactly one ARGS
+   * frame; aimock chunks the ~300-char haiku args into well over 3 frames, so
+   * a healthy stream shows many small deltas.
+   */
+  assertIncrementalHaikuArgs(sse: string): void {
+    const startMatches = sse.match(
+      /"type":"TOOL_CALL_START"[^\n]*"toolCallName":"generate_haiku"[^\n]*/g,
+    );
+    expect(
+      startMatches,
+      "generate_haiku TOOL_CALL_START must reach the wire",
+    ).not.toBeNull();
+
+    const startFrame = startMatches![0];
+    const callId = startFrame.match(/"toolCallId":"([^"]+)"/)?.[1];
+    expect(callId, "TOOL_CALL_START must carry a toolCallId").toBeTruthy();
+
+    const callIdRe = callId!.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const argFrames = sse.match(
+      new RegExp(
+        `"type":"TOOL_CALL_ARGS"[^\\n]*"toolCallId":"${callIdRe}"`,
+        "g",
+      ),
+    );
+    expect(
+      argFrames?.length ?? 0,
+      "generate_haiku args must stream as multiple incremental deltas (not one blob)",
+    ).toBeGreaterThanOrEqual(3);
   }
 }

--- a/apps/dojo/e2e/tests/mastraAgentLocalTests/toolBasedGenUIPage.spec.ts
+++ b/apps/dojo/e2e/tests/mastraAgentLocalTests/toolBasedGenUIPage.spec.ts
@@ -16,6 +16,31 @@ test("[Mastra Agent Local] Haiku generation and display verification", async ({
   await genAIAgent.checkHaikuDisplay(page);
 });
 
+// OSS-393: the @ag-ui/mastra bridge must consume Mastra's tool-call-delta
+// chunks and forward them as incremental TOOL_CALL_ARGS, so tool-call args
+// render progressively. Asserting on the completed SSE body keeps this
+// flake-free (no live timing).
+test("[Mastra Agent Local] generate_haiku args stream incrementally on the wire", async ({
+  page,
+}) => {
+  const genAIAgent = new ToolBaseGenUIPage(page);
+  const prompt = 'Generate Haiku for "I will always win"';
+
+  await page.goto(pageURL);
+  await expect(genAIAgent.haikuAgentIntro).toBeVisible();
+
+  // Match on a quote-free fragment — the prompt's own quotes get JSON-escaped
+  // in the request body, so matching the raw prompt string would never hit.
+  const ssePromise = genAIAgent.captureRuntimeSSE(
+    "mastra-agent-local",
+    "I will always win",
+  );
+  await genAIAgent.generateHaiku(prompt);
+  await genAIAgent.checkGeneratedHaiku();
+
+  genAIAgent.assertIncrementalHaikuArgs(await ssePromise);
+});
+
 test("[Mastra Agent Local] Haiku generation and UI consistency for two different prompts", async ({
   page,
 }) => {

--- a/apps/dojo/e2e/tests/mastraTests/toolBasedGenUIPage.spec.ts
+++ b/apps/dojo/e2e/tests/mastraTests/toolBasedGenUIPage.spec.ts
@@ -14,6 +14,31 @@ test("[Mastra] Haiku generation and display verification", async ({ page }) => {
   await genAIAgent.checkHaikuDisplay(page);
 });
 
+// OSS-393: the @ag-ui/mastra bridge must consume Mastra's tool-call-delta
+// chunks and forward them as incremental TOOL_CALL_ARGS, so tool-call args
+// render progressively. Asserting on the completed SSE body keeps this
+// flake-free (no live timing).
+test("[Mastra] generate_haiku args stream incrementally on the wire", async ({
+  page,
+}) => {
+  const genAIAgent = new ToolBaseGenUIPage(page);
+  const prompt = 'Generate Haiku for "I will always win"';
+
+  await page.goto(pageURL);
+  await expect(genAIAgent.haikuAgentIntro).toBeVisible();
+
+  // Match on a quote-free fragment — the prompt's own quotes get JSON-escaped
+  // in the request body, so matching the raw prompt string would never hit.
+  const ssePromise = genAIAgent.captureRuntimeSSE(
+    "mastra",
+    "I will always win",
+  );
+  await genAIAgent.generateHaiku(prompt);
+  await genAIAgent.checkGeneratedHaiku();
+
+  genAIAgent.assertIncrementalHaikuArgs(await ssePromise);
+});
+
 // test infra issue, not an integration issue
 test.fixme(
   "[Mastra] Haiku generation and UI consistency for two different prompts",

--- a/integrations/mastra/typescript/src/__tests__/integration.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/integration.test.ts
@@ -25,14 +25,62 @@ function createStreamModel(chunks: any[]) {
 function createTextStreamModel(text: string) {
   return createStreamModel([
     { type: "text-delta" as const, id: "text-1", delta: text },
-    { type: "finish" as const, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, finishReason: "stop" as const },
+    {
+      type: "finish" as const,
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      finishReason: "stop" as const,
+    },
   ]);
 }
 
-function createToolCallStreamModel(toolName: string, toolArgs: Record<string, unknown>) {
+// Fall-back path: an LLM that emits ONLY the final tool-call (no incremental
+// tool-input-* chunks). Mirrors older @mastra/core in the supported 1.0.x floor.
+function createToolCallStreamModel(
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+) {
   return createStreamModel([
-    { type: "tool-call" as const, toolCallId: "tc-1", toolName, input: JSON.stringify(toolArgs) },
-    { type: "finish" as const, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, finishReason: "tool-calls" as const },
+    {
+      type: "tool-call" as const,
+      toolCallId: "tc-1",
+      toolName,
+      input: JSON.stringify(toolArgs),
+    },
+    {
+      type: "finish" as const,
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      finishReason: "tool-calls" as const,
+    },
+  ]);
+}
+
+// Streaming path: an LLM that streams the tool-call args as incremental
+// tool-input-delta chunks (Mastra maps these to tool-call-delta chunks). The
+// `argChunks` are raw JSON-text fragments that concatenate to a valid args JSON.
+function createStreamingToolCallModel(
+  toolName: string,
+  toolCallId: string,
+  argChunks: string[],
+) {
+  return createStreamModel([
+    { type: "tool-input-start" as const, id: toolCallId, toolName },
+    ...argChunks.map((delta) => ({
+      type: "tool-input-delta" as const,
+      id: toolCallId,
+      delta,
+    })),
+    { type: "tool-input-end" as const, id: toolCallId },
+    {
+      type: "tool-call" as const,
+      toolCallId,
+      toolName,
+      input: argChunks.join(""),
+    },
+    {
+      type: "finish" as const,
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      finishReason: "tool-calls" as const,
+    },
   ]);
 }
 
@@ -77,13 +125,20 @@ describe("integration with real Mastra Agent", () => {
       const model = createStreamModel([
         { type: "text-delta" as const, id: "t1", delta: "Part 1 " },
         { type: "text-delta" as const, id: "t1", delta: "Part 2" },
-        { type: "finish" as const, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, finishReason: "stop" as const },
+        {
+          type: "finish" as const,
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          finishReason: "stop" as const,
+        },
       ]);
       const agent = createTestAgent(model);
 
-      const events = await collectEvents(wrapAgent(agent), makeInput({
-        messages: [{ id: "1", role: "user", content: "Hi" }],
-      }));
+      const events = await collectEvents(
+        wrapAgent(agent),
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "Hi" }],
+        }),
+      );
 
       const textChunks = events.filter(
         (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
@@ -97,39 +152,107 @@ describe("integration with real Mastra Agent", () => {
   });
 
   describe("tool calls", () => {
-    it("emits tool call events for a tool call response", async () => {
-      const agent = createTestAgent(createToolCallStreamModel("get_weather", { city: "NYC" }));
+    const weatherTools = [
+      {
+        name: "get_weather",
+        description: "Get weather",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string" } },
+        },
+      },
+    ];
+
+    it("streams tool-call args incrementally when the model emits arg deltas", async () => {
+      // Two arg-text fragments that concatenate to {"city":"NYC"}
+      const argChunks = ['{"city":', '"NYC"}'];
+      const agent = createTestAgent(
+        createStreamingToolCallModel("get_weather", "tc-1", argChunks),
+      );
       const events = await collectEvents(
         wrapAgent(agent),
         makeInput({
           messages: [{ id: "1", role: "user", content: "What's the weather?" }],
-          tools: [
-            {
-              name: "get_weather",
-              description: "Get weather",
-              parameters: { type: "object", properties: { city: { type: "string" } } },
-            },
-          ],
+          tools: weatherTools,
         }),
       );
 
       const toolStarts = events.filter(
         (e) => e.type === EventType.TOOL_CALL_START,
       );
-      expect(toolStarts.length).toBeGreaterThan(0);
+      expect(toolStarts).toHaveLength(1);
+      expect((toolStarts[0] as any).toolCallName).toBe("get_weather");
+      expect((toolStarts[0] as any).toolCallId).toBe("tc-1");
+
+      // The whole point: args arrive as MULTIPLE deltas, not a single blob.
+      const toolArgs = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_ARGS,
+      );
+      expect(toolArgs.length).toBe(argChunks.length);
+      expect(toolArgs.every((e) => (e as any).toolCallId === "tc-1")).toBe(
+        true,
+      );
+      // Concatenated deltas reconstruct the full args JSON.
+      const assembled = toolArgs.map((e) => (e as any).delta).join("");
+      expect(assembled).toBe('{"city":"NYC"}');
+      expect(JSON.parse(assembled)).toEqual({ city: "NYC" });
+
+      // Exactly one START and one END bracket the streamed args.
+      const toolEnds = events.filter((e) => e.type === EventType.TOOL_CALL_END);
+      expect(toolEnds).toHaveLength(1);
+
+      // Ordering: START before all ARGS, all ARGS before END.
+      const types = events.map((e) => e.type);
+      const startIdx = types.indexOf(EventType.TOOL_CALL_START);
+      const endIdx = types.indexOf(EventType.TOOL_CALL_END);
+      const argIdxs = types
+        .map((t, i) => (t === EventType.TOOL_CALL_ARGS ? i : -1))
+        .filter((i) => i !== -1);
+      expect(startIdx).toBeLessThan(Math.min(...argIdxs));
+      expect(Math.max(...argIdxs)).toBeLessThan(endIdx);
+    });
+
+    it("falls back to a single TOOL_CALL_ARGS when the model emits no arg deltas", async () => {
+      // Floor / backwards-compat: @mastra/core that emits only the final
+      // tool-call chunk (no tool-call-delta) must still produce a clean
+      // START + single full-args ARGS + END.
+      const agent = createTestAgent(
+        createToolCallStreamModel("get_weather", { city: "NYC" }),
+      );
+      const events = await collectEvents(
+        wrapAgent(agent),
+        makeInput({
+          messages: [{ id: "1", role: "user", content: "What's the weather?" }],
+          tools: weatherTools,
+        }),
+      );
+
+      const toolStarts = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_START,
+      );
+      expect(toolStarts).toHaveLength(1);
       expect((toolStarts[0] as any).toolCallName).toBe("get_weather");
 
       const toolArgs = events.filter(
         (e) => e.type === EventType.TOOL_CALL_ARGS,
       );
-      expect(toolArgs.length).toBeGreaterThan(0);
+      // Exactly one delta carrying the complete args.
+      expect(toolArgs).toHaveLength(1);
+      expect(JSON.parse((toolArgs[0] as any).delta)).toEqual({ city: "NYC" });
+
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_END),
+      ).toHaveLength(1);
     });
   });
 
   describe("working memory", () => {
     it("completes successfully with working memory enabled", async () => {
       const memory = new MockMemory({ enableWorkingMemory: true });
-      const agent = createTestAgent(createTextStreamModel("I'll remember that."), { memory });
+      const agent = createTestAgent(
+        createTextStreamModel("I'll remember that."),
+        { memory },
+      );
 
       const events = await collectEvents(
         wrapAgent(agent),
@@ -192,7 +315,9 @@ describe("integration with real Mastra Agent", () => {
 
   describe("message conversion", () => {
     it("handles a multi-message conversation without errors", async () => {
-      const agent = createTestAgent(createTextStreamModel("I see the full history."));
+      const agent = createTestAgent(
+        createTextStreamModel("I see the full history."),
+      );
 
       const events = await collectEvents(
         wrapAgent(agent),

--- a/integrations/mastra/typescript/src/__tests__/tool-call-streaming.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/tool-call-streaming.test.ts
@@ -1,0 +1,227 @@
+import { EventType } from "@ag-ui/client";
+import {
+  makeLocalMastraAgent,
+  makeRemoteMastraAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+
+// Only CLIENT (frontend) tools stream their args live — the bridge learns them
+// from RunAgentInput.tools. Register the tool names these fixtures use so they
+// take the streaming path (server tools, absent here, are buffered instead).
+const CLIENT_TOOLS = [
+  { name: "get_weather", description: "d", parameters: {} },
+  { name: "get_time", description: "d", parameters: {} },
+];
+const input = () => makeInput({ tools: CLIENT_TOOLS as any });
+
+// Mastra-level chunk fixtures (what the bridge's createChunkProcessor consumes
+// directly — shared by the local fullStream path and the remote
+// processDataStream path).
+
+function streamingChunks(
+  toolCallId = "tc-1",
+  toolName = "get_weather",
+  argChunks = ['{"city":', '"NYC"}'],
+) {
+  return [
+    {
+      type: "tool-call-input-streaming-start",
+      payload: { toolCallId, toolName },
+    },
+    ...argChunks.map((argsTextDelta) => ({
+      type: "tool-call-delta",
+      payload: { argsTextDelta, toolCallId, toolName },
+    })),
+    { type: "tool-call-input-streaming-end", payload: { toolCallId } },
+    {
+      type: "tool-call",
+      payload: { toolCallId, toolName, args: { city: "NYC" } },
+    },
+  ];
+}
+
+function toolEvents(events: any[]) {
+  return events.filter((e) =>
+    [
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+    ].includes(e.type),
+  );
+}
+
+describe("incremental tool-call args (chunk processor)", () => {
+  describe.each([
+    ["local", makeLocalMastraAgent],
+    ["remote", makeRemoteMastraAgent],
+  ])("%s agent path", (_label, makeAgent) => {
+    it("emits TOOL_CALL_START, one ARGS per delta, then TOOL_CALL_END", async () => {
+      const agent = makeAgent({ streamChunks: streamingChunks() });
+      const events = await collectEvents(agent, input());
+
+      const starts = events.filter((e) => e.type === EventType.TOOL_CALL_START);
+      const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS);
+      const ends = events.filter((e) => e.type === EventType.TOOL_CALL_END);
+
+      expect(starts).toHaveLength(1);
+      expect((starts[0] as any).toolCallName).toBe("get_weather");
+      expect((starts[0] as any).toolCallId).toBe("tc-1");
+
+      // One ARGS event per delta — args are NOT collapsed into one blob.
+      expect(args).toHaveLength(2);
+      expect((args as any[]).map((e) => e.delta)).toEqual([
+        '{"city":',
+        '"NYC"}',
+      ]);
+      expect((args as any[]).every((e) => e.toolCallId === "tc-1")).toBe(true);
+
+      expect(ends).toHaveLength(1);
+
+      // The trailing `tool-call` chunk must NOT re-emit args.
+      const tool = toolEvents(events).map((e) => e.type);
+      expect(tool).toEqual([
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+      ]);
+    });
+
+    it("falls back to a single full-args ARGS when only a bare tool-call arrives", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          {
+            type: "tool-call",
+            payload: {
+              toolCallId: "tc-1",
+              toolName: "get_weather",
+              args: { city: "NYC" },
+            },
+          },
+        ],
+      });
+      const events = await collectEvents(agent, input());
+
+      const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS);
+      expect(args).toHaveLength(1);
+      expect(JSON.parse((args[0] as any).delta)).toEqual({ city: "NYC" });
+
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_END),
+      ).toHaveLength(1);
+    });
+
+    it("emits a tool result after streamed args (no double START)", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          ...streamingChunks(),
+          {
+            type: "tool-result",
+            payload: { toolCallId: "tc-1", result: { temp: 72 } },
+          },
+        ],
+      });
+      const events = await collectEvents(agent, input());
+
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+      const results = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_RESULT,
+      );
+      expect(results).toHaveLength(1);
+      expect((results[0] as any).toolCallId).toBe("tc-1");
+    });
+
+    it("streams two tool calls independently", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          ...streamingChunks("tc-1", "get_weather", ['{"city":', '"NYC"}']),
+          ...streamingChunks("tc-2", "get_time", ['{"tz":', '"UTC"}']),
+        ],
+      });
+      const events = await collectEvents(agent, input());
+
+      const starts = events.filter((e) => e.type === EventType.TOOL_CALL_START);
+      expect((starts as any[]).map((e) => e.toolCallId)).toEqual([
+        "tc-1",
+        "tc-2",
+      ]);
+
+      const argsFor = (id: string) =>
+        events.filter(
+          (e) =>
+            e.type === EventType.TOOL_CALL_ARGS && (e as any).toolCallId === id,
+        );
+      expect(argsFor("tc-1")).toHaveLength(2);
+      expect(argsFor("tc-2")).toHaveLength(2);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_END),
+      ).toHaveLength(2);
+    });
+
+    it("closes the tool call even if the streaming-end chunk is absent", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          {
+            type: "tool-call-input-streaming-start",
+            payload: { toolCallId: "tc-1", toolName: "get_weather" },
+          },
+          {
+            type: "tool-call-delta",
+            payload: { argsTextDelta: '{"city":"NYC"}', toolCallId: "tc-1" },
+          },
+          // no tool-call-input-streaming-end — the final tool-call must close it
+          {
+            type: "tool-call",
+            payload: {
+              toolCallId: "tc-1",
+              toolName: "get_weather",
+              args: { city: "NYC" },
+            },
+          },
+        ],
+      });
+      const events = await collectEvents(agent, input());
+
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_ARGS),
+      ).toHaveLength(1);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_END),
+      ).toHaveLength(1);
+    });
+
+    it("buffers a SERVER tool's streamed args (not a client tool) into one ARGS", async () => {
+      // A tool that is NOT in RunAgentInput.tools is a server tool. Its delta
+      // chunks must be ignored and the final tool-call buffered → a single
+      // full-args ARGS. This keeps server tools suppressible by a following
+      // tool-call-suspended / background-task-started (which reuse the buffered
+      // args), the behavior that lets the background/interrupt paths work.
+      const agent = makeAgent({
+        streamChunks: streamingChunks("tc-9", "server_only_tool", [
+          '{"q":',
+          '"x"}',
+        ]),
+      });
+      const events = await collectEvents(agent, input()); // input() has no server_only_tool
+
+      const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS);
+      expect(args).toHaveLength(1);
+      expect((args[0] as any).toolCallId).toBe("tc-9");
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_END),
+      ).toHaveLength(1);
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -164,11 +164,23 @@ interface MastraAgentStreamOptions {
   onReasoningPart?: (text: string) => void;
   onReasoningEnd?: () => void;
   onFinishMessagePart?: () => void;
-  onToolCallPart?: (streamPart: {
+  /** Emit TOOL_CALL_START. Fired once per tool call, before any args. */
+  onToolCallStart?: (streamPart: {
     toolCallId: string;
     toolName: string;
-    args: any;
   }) => void;
+  /**
+   * Emit a TOOL_CALL_ARGS delta. The bridge streams these incrementally as
+   * Mastra emits `tool-call-delta` chunks (raw JSON-text fragments), or emits
+   * a single full-args delta on the fall-back path (older @mastra/core that
+   * only emits the final `tool-call` chunk).
+   */
+  onToolCallArgs?: (streamPart: {
+    toolCallId: string;
+    argsTextDelta: string;
+  }) => void;
+  /** Emit TOOL_CALL_END. Fired once per tool call, after all args. */
+  onToolCallEnd?: (streamPart: { toolCallId: string }) => void;
   onToolResultPart?: (streamPart: { toolCallId: string; result: any }) => void;
   onError: (error: Error) => void;
   onRunFinished?: () => Promise<void>;
@@ -854,7 +866,7 @@ export class MastraAgent extends AbstractAgent {
           delta: text,
         } as TextMessageChunkEvent);
       },
-      onToolCallPart: (streamPart) => {
+      onToolCallStart: (streamPart) => {
         closeReasoning();
         subscriber.next({
           type: EventType.TOOL_CALL_START,
@@ -862,11 +874,15 @@ export class MastraAgent extends AbstractAgent {
           toolCallId: streamPart.toolCallId,
           toolCallName: streamPart.toolName,
         } as ToolCallStartEvent);
+      },
+      onToolCallArgs: (streamPart) => {
         subscriber.next({
           type: EventType.TOOL_CALL_ARGS,
           toolCallId: streamPart.toolCallId,
-          delta: JSON.stringify(streamPart.args),
+          delta: streamPart.argsTextDelta,
         } as ToolCallArgsEvent);
+      },
+      onToolCallEnd: (streamPart) => {
         subscriber.next({
           type: EventType.TOOL_CALL_END,
           toolCallId: streamPart.toolCallId,
@@ -933,10 +949,27 @@ export class MastraAgent extends AbstractAgent {
 
   /**
    * Creates a stateful chunk processor that maps Mastra stream chunks to
-   * AG-UI events via callbacks. Buffers tool-call chunks: if followed by
+   * AG-UI events via callbacks.
+   *
+   * Tool-call args are streamed incrementally: Mastra emits
+   * `tool-call-input-streaming-start` → one or more `tool-call-delta` (each a
+   * raw JSON-text fragment) → `tool-call-input-streaming-end` → a final
+   * `tool-call` (with the assembled args) as the model produces the call.
+   * When those delta chunks are present we emit TOOL_CALL_START on the start
+   * chunk, a TOOL_CALL_ARGS per delta, and TOOL_CALL_END on the end chunk —
+   * so the client renders args as they arrive. The trailing `tool-call` for an
+   * already-streamed id is a no-op (args were already emitted).
+   *
+   * Fall-back (backwards compatibility): older @mastra/core in the supported
+   * 1.0.x floor may emit only the final `tool-call` with no delta chunks. In
+   * that case we buffer the `tool-call` and emit a single START + full-args
+   * ARGS + END when it flushes. This buffered path also preserves the
+   * suspend protocol: if a buffered tool-call is followed by
    * tool-call-suspended, the TOOL_CALL_* events are suppressed (the tool
    * hasn't executed yet — emitting them confuses CopilotKit's orchestration
-   * which expects a TOOL_CALL_RESULT to follow).
+   * which expects a TOOL_CALL_RESULT to follow). Suspendable tools are
+   * server-side and travel the buffered path; client/generative tools (which
+   * never suspend) are the ones whose args stream incrementally.
    *
    * Used by both the local agent path (async iterable) and the remote agent
    * path (processDataStream callback) — single source of truth for chunk
@@ -946,17 +979,62 @@ export class MastraAgent extends AbstractAgent {
    *   - `handleChunk`: processes a single chunk; returns `true` if processing should stop (error or malformed chunk).
    *   - `flush`: emits any buffered tool-call (call at end of stream).
    */
-  private createChunkProcessor(callbacks: MastraAgentStreamOptions) {
+  private createChunkProcessor(
+    callbacks: MastraAgentStreamOptions,
+    clientToolNames: Set<string> = new Set(),
+  ) {
+    // Only CLIENT (frontend) tools stream their args live — they are the
+    // generative-UI tools that benefit from progressive rendering, and they
+    // never suspend or background. SERVER tools take the buffered path below so
+    // a following `tool-call-suspended` / `background-task-started` can still
+    // suppress the normal render (you cannot retract an already-emitted live
+    // arg stream). The bridge knows which tools are client tools because they
+    // arrive in `RunAgentInput.tools` (→ `clientTools`); server tools live on
+    // the Mastra agent and are absent from that set.
+    const isClientTool = (toolName?: string) =>
+      !!toolName && clientToolNames.has(toolName);
+
+    // Floor / fall-back path: a final `tool-call` with no preceding client
+    // delta stream is buffered here so a following tool-call-suspended /
+    // background-task-started can suppress it (and reuse its args). Tool calls
+    // that streamed deltas live are NOT buffered.
     let pendingToolCall: {
       toolCallId: string;
       toolName: string;
       args: any;
     } | null = null;
+    // Tool calls for which we have emitted TOOL_CALL_START via the streaming
+    // (delta) path, and (separately) for which we have emitted TOOL_CALL_END.
+    const streamedStarted = new Set<string>();
+    const streamedEnded = new Set<string>();
+
+    const startStreamedToolCall = (toolCallId: string, toolName: string) => {
+      if (!streamedStarted.has(toolCallId)) {
+        streamedStarted.add(toolCallId);
+        callbacks.onToolCallStart?.({ toolCallId, toolName });
+      }
+    };
+
+    const endStreamedToolCall = (toolCallId: string) => {
+      if (streamedStarted.has(toolCallId) && !streamedEnded.has(toolCallId)) {
+        streamedEnded.add(toolCallId);
+        callbacks.onToolCallEnd?.({ toolCallId });
+      }
+    };
 
     const flush = () => {
       if (pendingToolCall) {
-        callbacks.onToolCallPart?.(pendingToolCall);
+        const { toolCallId, toolName, args } = pendingToolCall;
         pendingToolCall = null;
+        callbacks.onToolCallStart?.({ toolCallId, toolName });
+        callbacks.onToolCallArgs?.({
+          toolCallId,
+          // The buffered path has the assembled args object — serialize the
+          // whole thing as a single delta (the streaming path emits the raw
+          // JSON-text fragments instead).
+          argsTextDelta: JSON.stringify(args ?? {}),
+        });
+        callbacks.onToolCallEnd?.({ toolCallId });
       }
     };
 
@@ -1046,13 +1124,58 @@ export class MastraAgent extends AbstractAgent {
           callbacks.onTextPart?.(chunk.payload.text);
           break;
         }
-        case "tool-call": {
+        // Tool-call args stream incrementally: start → delta(s) → end → the
+        // final `tool-call`. For CLIENT tools we emit these live (progressive
+        // render). For SERVER tools we ignore the delta chunks and buffer the
+        // final `tool-call` (below) so it stays suppressible.
+        case "tool-call-input-streaming-start": {
+          // A new tool call begins — flush any prior buffered (floor-path) call.
           flush();
-          pendingToolCall = {
-            toolCallId: chunk.payload.toolCallId,
-            toolName: chunk.payload.toolName,
-            args: chunk.payload.args,
-          };
+          if (
+            chunk.payload.toolCallId &&
+            isClientTool(chunk.payload.toolName)
+          ) {
+            startStreamedToolCall(
+              chunk.payload.toolCallId,
+              chunk.payload.toolName,
+            );
+          }
+          break;
+        }
+        case "tool-call-delta": {
+          const { toolCallId, argsTextDelta } = chunk.payload;
+          // Only forward deltas for a call we opened as a live (client) stream.
+          // Server-tool deltas are ignored; their args ride the final
+          // `tool-call` chunk into the buffered path.
+          if (
+            toolCallId &&
+            streamedStarted.has(toolCallId) &&
+            argsTextDelta != null
+          ) {
+            callbacks.onToolCallArgs?.({ toolCallId, argsTextDelta });
+          }
+          break;
+        }
+        case "tool-call-input-streaming-end": {
+          if (chunk.payload.toolCallId) {
+            endStreamedToolCall(chunk.payload.toolCallId);
+          }
+          break;
+        }
+        case "tool-call": {
+          const { toolCallId, toolName, args } = chunk.payload;
+          if (toolCallId && streamedStarted.has(toolCallId)) {
+            // Client tool: args were already streamed live via deltas — close
+            // the call (the streaming-end chunk may have been absent) and don't
+            // re-emit.
+            endStreamedToolCall(toolCallId);
+            break;
+          }
+          // Server tool (or a client tool that emitted no deltas): buffer so a
+          // following tool-call-suspended / background-task-started can suppress
+          // it and reuse its args, matching the pre-streaming behavior.
+          flush();
+          pendingToolCall = { toolCallId, toolName, args };
           break;
         }
         case "tool-result": {
@@ -1298,8 +1421,12 @@ export class MastraAgent extends AbstractAgent {
   private async processFullStream(
     stream: AsyncIterable<any>,
     callbacks: MastraAgentStreamOptions,
+    clientToolNames: Set<string> = new Set(),
   ): Promise<boolean> {
-    const { handleChunk, flush } = this.createChunkProcessor(callbacks);
+    const { handleChunk, flush } = this.createChunkProcessor(
+      callbacks,
+      clientToolNames,
+    );
     for await (const chunk of stream) {
       if (handleChunk(chunk)) return true;
     }
@@ -1394,7 +1521,9 @@ export class MastraAgent extends AbstractAgent {
       onReasoningPart,
       onReasoningEnd,
       onFinishMessagePart,
-      onToolCallPart,
+      onToolCallStart,
+      onToolCallArgs,
+      onToolCallEnd,
       onToolResultPart,
       onToolSuspended,
       onActivitySnapshot,
@@ -1413,6 +1542,11 @@ export class MastraAgent extends AbstractAgent {
         return acc;
       },
       {} as Record<string, any>,
+    );
+    // Names of the frontend tools — only these stream their args live (see
+    // createChunkProcessor). Server tools (on the Mastra agent) are absent here.
+    const clientToolNames = new Set<string>(
+      tools.map((tool) => tool.name as string),
     );
     const resourceId = this.resourceId ?? threadId;
 
@@ -1471,20 +1605,26 @@ export class MastraAgent extends AbstractAgent {
         );
 
         if (response && typeof response === "object") {
-          const hadError = await this.processFullStream(response.fullStream, {
-            onMessageId,
-            onTextPart,
-            onReasoningStart,
-            onReasoningPart,
-            onReasoningEnd,
-            onFinishMessagePart,
-            onToolCallPart,
-            onToolResultPart,
-            onToolSuspended,
-            onActivitySnapshot,
-            onActivityDelta,
-            onError,
-          });
+          const hadError = await this.processFullStream(
+            response.fullStream,
+            {
+              onMessageId,
+              onTextPart,
+              onReasoningStart,
+              onReasoningPart,
+              onReasoningEnd,
+              onFinishMessagePart,
+              onToolCallStart,
+              onToolCallArgs,
+              onToolCallEnd,
+              onToolResultPart,
+              onToolSuspended,
+              onActivitySnapshot,
+              onActivityDelta,
+              onError,
+            },
+            clientToolNames,
+          );
 
           if (!hadError) await onRunFinished?.();
         } else {
@@ -1521,20 +1661,25 @@ export class MastraAgent extends AbstractAgent {
         // Remote agents use processDataStream (callback-based) — share
         // chunk handling logic via createChunkProcessor.
         if (response && typeof response.processDataStream === "function") {
-          const { handleChunk, flush } = this.createChunkProcessor({
-            onMessageId,
-            onTextPart,
-            onReasoningStart,
-            onReasoningPart,
-            onReasoningEnd,
-            onFinishMessagePart,
-            onToolCallPart,
-            onToolResultPart,
-            onToolSuspended,
-            onActivitySnapshot,
-            onActivityDelta,
-            onError,
-          });
+          const { handleChunk, flush } = this.createChunkProcessor(
+            {
+              onMessageId,
+              onTextPart,
+              onReasoningStart,
+              onReasoningPart,
+              onReasoningEnd,
+              onFinishMessagePart,
+              onToolCallStart,
+              onToolCallArgs,
+              onToolCallEnd,
+              onToolResultPart,
+              onToolSuspended,
+              onActivitySnapshot,
+              onActivityDelta,
+              onError,
+            },
+            clientToolNames,
+          );
 
           await response.processDataStream({
             onChunk: async (chunk: any) => {


### PR DESCRIPTION
## OSS-393: stream tool-call args incrementally in the Mastra bridge

### Problem
The `@ag-ui/mastra` bridge buffered each tool call and emitted its arguments as a **single** `TOOL_CALL_ARGS` event (`JSON.stringify(args)`), flushed at step end. Tool-based generative UI therefore rendered in one shot instead of painting progressively as the model writes the call. Mastra streams the args as `tool-call-delta` chunks; the bridge ignored them.

### Fix
`createChunkProcessor` now consumes the streaming chunks and forwards each delta as its own event:

- `tool-call-input-streaming-start` → `TOOL_CALL_START`
- each `tool-call-delta` → `TOOL_CALL_ARGS` (raw `argsTextDelta`)
- `tool-call-input-streaming-end` → `TOOL_CALL_END`
- the trailing `tool-call` for an already-streamed id is a no-op

The old `onToolCallPart` callback is split into granular `onToolCallStart` / `onToolCallArgs` / `onToolCallEnd`. Local (`fullStream`) and remote (`processDataStream`) paths share the one processor.

### Backwards compatibility (peer floor `@mastra/core` >=1.0.0 <2.0.0)
Older 1.0.x that emits only the final `tool-call` (no deltas) still works: that chunk is buffered and flushed as a single full-args `TOOL_CALL_ARGS`. The buffered path also keeps the suspend protocol intact — a following `tool-call-suspended` suppresses the buffered call (suspendable server tools travel the buffered path; client/generative tools, which never suspend, are the ones whose args stream).

### Tests
- `tool-call-streaming.test.ts` (new): local + remote parity, multiple-ARGS streaming, single-ARGS fallback, two-tool, result-after-stream, missing-streaming-end.
- `integration.test.ts`: incremental + fallback through a real Mastra `Agent`.
- All existing interrupt/suspend tests stay green (197 unit tests pass).

### Demo + e2e
`tool_based_generative_ui` (haiku) for both `mastra` and `mastra-agent-local` already existed; the bridge was the missing piece. Added a flake-free regression net to both suites' specs: capture the runtime SSE and assert `generate_haiku` args arrive as >= 3 `TOOL_CALL_ARGS` frames. Before this fix that is exactly 1 (fails); after, many (passes). aimock chunks args deterministically, so CI is stable.

### Verification
- Real `gpt-4.1-mini` through the bridge: args stream as multiple `TOOL_CALL_ARGS` (observed up to ~40 frames/run). Granularity varies upstream in Mastra's `fullStream` (it coalesces under fast/short responses); the bridge forwards faithfully and no longer collapses on its own.
- Live dojo (`mastra-agent-local`, aimock): wire shows `TOOL_CALL_START` x1, `TOOL_CALL_ARGS` x14, `TOOL_CALL_END` x1; haiku paints progressively.
