### PR TITLE
fix(ci): checkout LFS assets in publish-dotnet release job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1194,6 +1194,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.build.outputs.mode == 'prerelease' && github.ref || 'main' }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Step08_Multimodal integration test reads ag-ui-logo.png, which is
+          # stored via Git LFS. Without the real bytes the snapshot diff fails.
+          lfs: true
           persist-credentials: false
 
       - name: Set up .NET


### PR DESCRIPTION
## Root cause

The `publish-dotnet` job's **Checkout release ref** step in `.github/workflows/publish-release.yml` (line ~1191) used `actions/checkout@v6.0.2` **without `lfs: true`**. The repo's `.gitattributes` tracks `*.png` via Git LFS.

That job runs `dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests` (line ~1234), whose `Step08_MultimodalMessagesTest.PostRun_WithImageUrl_DescribesImage` reads the fixture `sdks/dotnet/tests/AGUI.Hosting.AspNetCore.IntegrationTests/Samples/GettingStarted/ag-ui-logo.png` and base64-encodes its bytes into request/response snapshots verified by the Verify library.

Without LFS hydration, that fixture on disk is the **130-byte LFS pointer text** instead of the real PNG, so all 8 Verify snapshots mismatch and the job fails exit 1.

Failing run: https://github.com/ag-ui-protocol/ag-ui/actions/runs/28564670052/job/84689508973

The PR-level `unit-dotnet-sdk.yml` workflow **already** sets `lfs: true` on its checkout for exactly this reason (with a comment referencing Step08). This mirrors that fix onto the release workflow's dotnet lane.

## Pointer-vs-PNG evidence

**LFS pointer (no-LFS checkout — what CI saw):**
```
version https://git-lfs.github.com/spec/v1
oid sha256:b4bdfc1896f2305268e0c53b5f4ec01b318597672d77ab75de7985569e40e934
size 2298
```
`file` reports `ASCII text`, 129 bytes on disk. The request payload base64-encodes this pointer text — not the image — hence the 8 snapshot mismatches.

**Real PNG (after LFS hydration):**
```
00000000: 8950 4e47 0d0a 1a0a 0000 000d 4948 4452  .PNG........IHDR
```
`file` reports `PNG image data, 78 x 88, 8-bit/color RGBA, non-interlaced`, 2298 bytes — matching the pointer's declared `size 2298`.

## RED / GREEN proof (byte-level)

> **.NET is not installed on the machine used to produce this proof, so a full `dotnet test` run was not possible.** The failure surface here is precisely *"what bytes are on disk for the PNG fixture at test time"* — the byte-level proof below exercises that exact surface, which is what the Verify snapshot diff ultimately depends on.

**RED** — reproduce CI's no-LFS behavior via `GIT_LFS_SKIP_SMUDGE=1 git clone`:
```
=== check-attr ===
...ag-ui-logo.png: filter: lfs
=== file ===
...ag-ui-logo.png: ASCII text
=== head -c 130 ===
version https://git-lfs.github.com/spec/v1
oid sha256:b4bdfc1896f2305268e0c53b5f4ec01b318597672d77ab75de7985569e40e934
size 2298
=== byte size ===
     129 ...ag-ui-logo.png
```

**GREEN** — `git lfs install && git lfs pull`:
```
=== xxd head ===
00000000: 8950 4e47 0d0a 1a0a 0000 000d 4948 4452  .PNG........IHDR
=== file ===
...ag-ui-logo.png: PNG image data, 78 x 88, 8-bit/color RGBA, non-interlaced
=== size ===
    2298 ...ag-ui-logo.png
```

## Per-checkout-step audit

`publish-release.yml` has four checkout steps. Only jobs that actually consume LFS-tracked assets were changed. The **only** LFS-tracked file anywhere under `sdks/` is the single dotnet PNG (`git lfs ls-files` under `sdks/` returns just that one file), so no TS/Python lane needs LFS.

| Line | Step | Job | Changed? | Reason |
|------|------|-----|----------|--------|
| ~191  | Checkout release ref | `build` | No | Detects version changes, runs TS package tests + Python builds. Consumes no LFS asset. |
| ~652  | Checkout release ref | `publish` | No | Downloads prebuilt TS/Python artifacts, publishes to npm/PyPI, creates tags/releases. No tests, no LFS. |
| ~1191 | Checkout release ref | `publish-dotnet` | **Yes** | Runs `AGUI.Hosting.AspNetCore.IntegrationTests` (incl. Step08 reading the LFS PNG). Needs `lfs: true`. |
| ~1565 | Checkout | `notify` | No | Builds a Slack notification message only. No tests, no LFS. |

## Validation note

The release workflow's `dry_run=true` does **not** exercise `publish-dotnet` (its `if:` guard excludes dry_run runs), so this could not be validated via a release dry-run. It is validated by `unit-dotnet-sdk.yml` already running the **same** integration test with `lfs: true`, plus the local byte-level red/green above.
