### PR TITLE
fix(ci): sign all TFMs in dotnet package build (fixes CP0003 pack failure)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1241,12 +1241,12 @@ jobs:
         working-directory: sdks/dotnet
         run: |
           set -euo pipefail
-          dotnet build src/AGUI.Abstractions/AGUI.Abstractions.csproj -c Release
-          dotnet build src/AGUI.Formatting/AGUI.Formatting.csproj -c Release
-          dotnet build src/AGUI.Protobuf/AGUI.Protobuf.csproj -c Release
-          dotnet build src/AGUI.Client/AGUI.Client.csproj -c Release
-          dotnet build src/AGUI.Server/AGUI.Server.csproj -c Release
-          dotnet build src/AGUI/AGUI.csproj -c Release
+          dotnet build src/AGUI.Abstractions/AGUI.Abstractions.csproj -c Release --no-incremental
+          dotnet build src/AGUI.Formatting/AGUI.Formatting.csproj -c Release --no-incremental
+          dotnet build src/AGUI.Protobuf/AGUI.Protobuf.csproj -c Release --no-incremental
+          dotnet build src/AGUI.Client/AGUI.Client.csproj -c Release --no-incremental
+          dotnet build src/AGUI.Server/AGUI.Server.csproj -c Release --no-incremental
+          dotnet build src/AGUI/AGUI.csproj -c Release --no-incremental
 
       - name: Pack NuGet packages
         shell: bash


### PR DESCRIPTION
## Root cause

The `publish-dotnet` job in `.github/workflows/publish-release.yml` runs three steps in order:

1. **Run .NET tests** — `dotnet test tests/... -c Release -p:SignAssembly=false`. This builds the src libraries for the Core TFMs (`net8.0`/`net9.0`/`net10.0`) **unsigned** into the shared `-c Release` output.
2. **Build .NET packages** — six `dotnet build src/<Proj>/<Proj>.csproj -c Release`. Signing is ON here (`Directory.Build.props`: `SignAssembly=true` + `AGUI.snk`), but the build is **incremental**, so the Core TFMs are treated as up-to-date and are **not** rebuilt — they stay unsigned. Only `netstandard2.0`/`net472` compile fresh and get strong-name signed.
3. **Pack NuGet packages** — `dotnet pack ... --no-build`. With `EnablePackageValidation=true`, package validation fails with **CP0003**: the `netstandard2.0` DLL is strong-name signed (token `d5950b1d09108385`) while the `net8.0` DLL is unsigned (`null`).

Real failing run: https://github.com/ag-ui-protocol/ag-ui/actions/runs/28566128936 (job `publish-dotnet` → "Pack NuGet packages").

This is **distinct from** the merged LFS-checkout fix (#2078) — different root cause, different step.

## The fix

Add `--no-incremental` to each of the six `dotnet build` lines in the **Build .NET packages** step. This forces every TFM to recompile **signed**, overwriting the unsigned Core-TFM artifacts left behind by the test step, so all packed assemblies share one public key token and pack validation passes. Only that one step is changed — tests, the pack step, and `Directory.Build.props` are untouched.

## Red-green proof (real `windows-latest` runner)

Proven via a throwaway matrix workflow (`fix: [false, true]`) that reproduces the exact contamination path (test step with `SignAssembly=false`, then build with/without `--no-incremental`, then pack). `dotnet` is not available locally, so this ran in CI.

Throwaway run: https://github.com/ag-ui-protocol/ag-ui/actions/runs/28567172848

**RED** — `fix=false` (build WITHOUT `--no-incremental`), Pack step exit code 1:
```
error CP0003: lib/netstandard2.0/AGUI.Abstractions.dll assembly public key token 'd5950b1d09108385' does not match with lib/net8.0/AGUI.Abstractions.dll 'null'.
##[error]Process completed with exit code 1.
```
(The job shows green only because the RED leg's Pack step carries `continue-on-error` — the step itself failed with exit code 1, confirmed in the raw logs.)

**GREEN** — `fix=true` (build WITH `--no-incremental`), Pack step succeeds:
```
Successfully created package 'D:\a\ag-ui\ag-ui\sdks\dotnet\artifacts\nuget\AGUI.Abstractions.0.0.1.nupkg'.
Successfully created package 'D:\a\ag-ui\ag-ui\sdks\dotnet\artifacts\nuget\AGUI.Abstractions.0.0.1.snupkg'.
```
No CP0003. The throwaway branch/workflow are **not** part of this PR and have been deleted.
