### PR TITLE
fix(dotnet): skip symbols for metapackage

### DIFF
--- a/sdks/dotnet/src/AGUI/AGUI.csproj
+++ b/sdks/dotnet/src/AGUI/AGUI.csproj
@@ -8,6 +8,7 @@
     <Description>Umbrella package for the AG-UI .NET SDK, including client, server, formatting, protobuf, and protocol abstractions.</Description>
     <PackageTags>$(PackageTags);sdk;umbrella</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

The .NET release workflow published the real `0.0.1` NuGet packages, then failed while pushing `AGUI.0.0.1.snupkg` because the symbol package contained no `.pdb` files.

## Why

`AGUI` is an umbrella/metapackage with `<IncludeBuildOutput>false</IncludeBuildOutput>`, so it intentionally has no assembly output and therefore no symbols. The shared SDK package settings still enabled `.snupkg` creation for it.

## Fix

Opt the `AGUI` metapackage out of symbol package generation by setting `<IncludeSymbols>false</IncludeSymbols>` in `AGUI.csproj`. The actual library packages continue to inherit `IncludeSymbols=true`.

Verification:
- `dotnet msbuild sdks/dotnet/src/AGUI/AGUI.csproj -getProperty:IncludeSymbols -p:Configuration=Release` -> `false`
- `dotnet msbuild` property check across the five library packages -> `true`
- `git diff --check`

Note: local `dotnet pack` hung in this environment, so I killed that verifier and used MSBuild property evaluation instead.