### PR TITLE
fix(release): decompress NuGet registration responses

### DIFF
--- a/scripts/release/detect-dotnet-version-changes.sh
+++ b/scripts/release/detect-dotnet-version-changes.sh
@@ -67,7 +67,7 @@ PY
 
   PACKAGE_ID=$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]')
   RESPONSE=$(mktemp)
-  STATUS=$(curl -sS --max-time 30 \
+  STATUS=$(curl --compressed -sS --max-time 30 \
     -w '%{http_code}' \
     -o "$RESPONSE" \
     "https://api.nuget.org/v3/registration5-gz-semver2/${PACKAGE_ID}/index.json" || true)


### PR DESCRIPTION
## Problem

The stable release workflow now fails in `Detect .NET version changes vs NuGet` after the first .NET packages became visible on NuGet. The detector reads from NuGet's `registration5-gz-semver2` endpoint and passes the response body directly to `JSON.parse`.

## Why

That endpoint returns `Content-Encoding: gzip`. While packages were unpublished the detector only saw `404`s and never parsed a successful response. Once `AGUI.Abstractions@0.0.1` existed, the detector got a `200` with compressed bytes and failed with `Unexpected token`.

## Fix

Use `curl --compressed` for the NuGet registration lookup so curl decompresses the response before the Node parser reads it.

Verification:
- Before the patch: `bash scripts/release/detect-dotnet-version-changes.sh` failed with the same gzip parse error from CI.
- After the patch: `bash scripts/release/detect-dotnet-version-changes.sh` exits 0 and reports all six .NET packages up to date, returning `[]`.
- `git diff --check` passed.