### PR TITLE
feat(mastra): expose tracingOptions passthrough + surface execution traceId

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -50,6 +50,10 @@ export class FakeLocalAgent {
   memory: FakeMemory;
   streamChunks: any[];
   resumeChunks: any[] | undefined;
+  // Execution traceId to expose on the stream response (Mastra observability
+  // v-next). Left undefined by default so it doesn't affect tests that don't
+  // opt into it. May be a plain string or a Promise (mirrors the real API).
+  traceId: string | Promise<string> | undefined;
   /** Messages passed to the most recent stream() call (post-diff-filter). */
   lastStreamMessages: any[] | null = null;
   /** Options passed to the most recent stream() call. */
@@ -62,11 +66,13 @@ export class FakeLocalAgent {
       memory?: FakeMemory;
       streamChunks?: any[];
       resumeChunks?: any[];
+      traceId?: string | Promise<string>;
     } = {},
   ) {
     this.memory = opts.memory ?? new FakeMemory();
     this.streamChunks = opts.streamChunks ?? [];
     this.resumeChunks = opts.resumeChunks;
+    this.traceId = opts.traceId;
   }
 
   async getMemory(_opts?: any) {
@@ -78,6 +84,7 @@ export class FakeLocalAgent {
     this.lastStreamOpts = opts;
     const chunks = this.streamChunks;
     return {
+      ...(this.traceId !== undefined ? { traceId: this.traceId } : {}),
       fullStream: (async function* () {
         for (const chunk of chunks) {
           yield chunk;
@@ -90,6 +97,10 @@ export class FakeLocalAgent {
     this.lastResumeOpts = opts;
     const chunks = this.resumeChunks ?? [];
     return {
+      // Mirror stream()'s optional traceId so resume-path traceId surfacing can
+      // be exercised. Additive; undefined by default so existing tests are
+      // unaffected.
+      ...(this.traceId !== undefined ? { traceId: this.traceId } : {}),
       fullStream: (async function* () {
         for (const chunk of chunks) {
           yield chunk;
@@ -105,12 +116,21 @@ export class FakeRemoteAgent {
   // Chunks replayed by resumeStream's processDataStream. When undefined, the
   // remote agent has no resume capability (mirrors older @mastra/client-js).
   resumeChunks: any[] | undefined;
+  // Execution traceId to expose on the stream response. Undefined by default.
+  traceId: string | Promise<string> | undefined;
   // Records every resumeStream(resumeData, opts) call for assertions.
   resumeCalls: Array<{ resumeData: any; opts: any }> = [];
 
-  constructor(opts: { streamChunks?: any[]; resumeChunks?: any[] } = {}) {
+  constructor(
+    opts: {
+      streamChunks?: any[];
+      resumeChunks?: any[];
+      traceId?: string | Promise<string>;
+    } = {},
+  ) {
     this.streamChunks = opts.streamChunks ?? [];
     this.resumeChunks = opts.resumeChunks;
+    this.traceId = opts.traceId;
   }
 
   /** Options passed to the most recent stream() call. */
@@ -121,6 +141,7 @@ export class FakeRemoteAgent {
     this.lastStreamOpts = opts;
     const chunks = this.streamChunks;
     return {
+      ...(this.traceId !== undefined ? { traceId: this.traceId } : {}),
       processDataStream: async ({
         onChunk,
       }: {
@@ -137,6 +158,10 @@ export class FakeRemoteAgent {
     this.resumeCalls.push({ resumeData, opts });
     const chunks = this.resumeChunks ?? [];
     return {
+      // Mirror stream()'s optional traceId so resume-path traceId surfacing can
+      // be exercised. Additive; undefined by default so existing tests are
+      // unaffected.
+      ...(this.traceId !== undefined ? { traceId: this.traceId } : {}),
       processDataStream: async ({
         onChunk,
       }: {

--- a/integrations/mastra/typescript/src/__tests__/tracing-options.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/tracing-options.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import { EventType } from "@ag-ui/client";
+import type { RunFinishedEvent } from "@ag-ui/client";
+import {
+  FakeLocalAgent,
+  FakeRemoteAgent,
+  makeInput,
+  collectEvents,
+} from "./helpers";
+import { MastraAgent } from "../mastra";
+import { getLocalAgents } from "../utils";
+
+// A minimal clean stream: one text chunk then finish, so the run reaches
+// RUN_FINISHED (which carries the execution traceId on `result` when exposed).
+function textChunks() {
+  return [
+    { type: "text-delta", payload: { text: "Hello" } },
+    { type: "finish", payload: {} },
+  ];
+}
+
+function runFinished(events: { type: string }[]): RunFinishedEvent | undefined {
+  return events.find(
+    (e): e is RunFinishedEvent => e.type === EventType.RUN_FINISHED,
+  );
+}
+
+// Drives the resume path exactly the way interrupt-bridge.test.ts does: a
+// resolved resume command carried on forwardedProps.command, which run()
+// normalizes and dispatches to resumeStream.
+function makeResumeInput(
+  interruptEvent: Record<string, any>,
+  resumeData: unknown = { approved: true },
+) {
+  return makeInput({
+    forwardedProps: {
+      command: {
+        resume: resumeData,
+        interruptEvent: JSON.stringify(interruptEvent),
+      },
+    },
+  });
+}
+
+describe("tracingOptions passthrough (inbound)", () => {
+  it("forwards tracingOptions into local agent.stream()", async () => {
+    const fake = new FakeLocalAgent({ streamChunks: textChunks() });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+      tracingOptions: { traceId: "trace-abc", metadata: { source: "ui" } },
+    });
+
+    await collectEvents(agent, makeInput());
+
+    expect(fake.lastStreamOpts?.tracingOptions).toEqual({
+      traceId: "trace-abc",
+      metadata: { source: "ui" },
+    });
+  });
+
+  it("forwards tracingOptions into remote agent.stream()", async () => {
+    const fake = new FakeRemoteAgent({ streamChunks: textChunks() });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+      tracingOptions: { traceId: "trace-remote" },
+    });
+
+    await collectEvents(agent, makeInput());
+
+    expect(fake.lastStreamOpts?.tracingOptions).toEqual({
+      traceId: "trace-remote",
+    });
+  });
+
+  it("omits tracingOptions when not configured", async () => {
+    const fake = new FakeLocalAgent({ streamChunks: textChunks() });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    await collectEvents(agent, makeInput());
+
+    expect(fake.lastStreamOpts).toBeTruthy();
+    expect("tracingOptions" in fake.lastStreamOpts).toBe(false);
+  });
+
+  it("omits tracingOptions when not configured (remote path)", async () => {
+    const fake = new FakeRemoteAgent({ streamChunks: textChunks() });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    await collectEvents(agent, makeInput());
+
+    expect(fake.lastStreamOpts).toBeTruthy();
+    expect("tracingOptions" in fake.lastStreamOpts).toBe(false);
+  });
+
+  it("forwards tracingOptions into resumeStream()'s options on the resume path", async () => {
+    // Resume is driven the same way interrupt-bridge.test.ts does: a resolved
+    // command on forwardedProps.command. resumeChunks makes resumeStream return
+    // a valid fullStream so the run reaches RUN_FINISHED.
+    const fake = new FakeLocalAgent({
+      streamChunks: [],
+      resumeChunks: [{ type: "text-delta", payload: { text: "Approved." } }],
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+      tracingOptions: { traceId: "resume-trace", metadata: { source: "ui" } },
+    });
+
+    await collectEvents(
+      agent,
+      makeResumeInput({
+        type: "mastra_suspend",
+        toolCallId: "tc-1",
+        runId: "run-1",
+      }),
+    );
+
+    expect(fake.lastResumeOpts).toBeTruthy();
+    expect(fake.lastResumeOpts.tracingOptions).toEqual({
+      traceId: "resume-trace",
+      metadata: { source: "ui" },
+    });
+  });
+});
+
+describe("execution traceId surfacing (outbound)", () => {
+  it("surfaces traceId on RUN_FINISHED.result (local)", async () => {
+    const fake = new FakeLocalAgent({
+      streamChunks: textChunks(),
+      traceId: "exec-trace-1",
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished?.result).toEqual({ traceId: "exec-trace-1" });
+  });
+
+  it("surfaces traceId on RUN_FINISHED.result (remote)", async () => {
+    const fake = new FakeRemoteAgent({
+      streamChunks: textChunks(),
+      traceId: "exec-trace-remote",
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished?.result).toEqual({ traceId: "exec-trace-remote" });
+  });
+
+  it("awaits a Promise-valued traceId", async () => {
+    const fake = new FakeLocalAgent({
+      streamChunks: textChunks(),
+      traceId: Promise.resolve("async-trace"),
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished?.result).toEqual({ traceId: "async-trace" });
+  });
+
+  it("leaves RUN_FINISHED.result unset when the response exposes no traceId", async () => {
+    const fake = new FakeLocalAgent({ streamChunks: textChunks() });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished).toBeTruthy();
+    expect(finished?.result).toBeUndefined();
+  });
+
+  it("round-trips an injected inbound traceId onto RUN_FINISHED.result", async () => {
+    // Documented round-trip: a client injects a self-chosen traceId via
+    // tracingOptions, the execution anchors under it, and the same id is
+    // surfaced back on RUN_FINISHED.result so the client can correlate.
+    const roundTripId = "client-chosen-trace";
+    const fake = new FakeLocalAgent({
+      streamChunks: textChunks(),
+      traceId: roundTripId,
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+      tracingOptions: { traceId: roundTripId },
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    // Injected inbound…
+    expect(fake.lastStreamOpts?.tracingOptions).toEqual({
+      traceId: roundTripId,
+    });
+    // …and the same id surfaced back out.
+    const finished = runFinished(events);
+    expect(finished?.result).toEqual({ traceId: roundTripId });
+  });
+
+  it("leaves RUN_FINISHED.result unset when the response traceId is an empty string", async () => {
+    // resolveTraceId guards with `length > 0`, so "" must not surface a result.
+    const fake = new FakeLocalAgent({
+      streamChunks: textChunks(),
+      traceId: "",
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished).toBeTruthy();
+    expect(finished?.result).toBeUndefined();
+  });
+
+  it("completes with RUN_FINISHED (result unset) when the traceId Promise rejects", async () => {
+    // resolveTraceId swallows a rejecting traceId read so it never blocks
+    // RUN_FINISHED. Pre-attach a no-op catch so the rejection we hand in is
+    // never flagged as unhandled by the test runner (resolveTraceId awaits the
+    // SAME promise, so awaiting a handled rejection still throws inside its
+    // try/catch as intended).
+    const rejecting = Promise.reject(new Error("boom"));
+    rejecting.catch(() => {});
+    const fake = new FakeLocalAgent({
+      streamChunks: textChunks(),
+      traceId: rejecting as unknown as Promise<string>,
+    });
+    const agent = new MastraAgent({
+      agentId: "test-agent",
+      agent: fake as any,
+      resourceId: "resource-1",
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    const finished = runFinished(events);
+    expect(finished).toBeTruthy();
+    expect(finished?.result).toBeUndefined();
+  });
+});
+
+describe("getLocalAgents forwards tracingOptions", () => {
+  it("threads tracingOptions onto each constructed agent", async () => {
+    const fake = new FakeLocalAgent({ streamChunks: textChunks() });
+    const mastra = {
+      listAgents: () => ({ "test-agent": fake }),
+    } as any;
+
+    const agents = getLocalAgents({
+      mastra,
+      resourceId: "resource-1",
+      tracingOptions: { traceId: "cfg-trace" },
+    });
+
+    const agent = agents["test-agent"] as MastraAgent;
+    expect(agent.tracingOptions).toEqual({ traceId: "cfg-trace" });
+
+    await collectEvents(agent, makeInput());
+    expect(fake.lastStreamOpts?.tracingOptions).toEqual({
+      traceId: "cfg-trace",
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/copilotkit.ts
+++ b/integrations/mastra/typescript/src/copilotkit.ts
@@ -14,7 +14,7 @@ import {
   RequestContext,
 } from "@mastra/core/request-context";
 import { ContextWithMastra, registerApiRoute } from "@mastra/core/server";
-import { MastraAgent } from "./mastra";
+import { MastraAgent, MastraTracingOptions } from "./mastra";
 
 /**
  * `Omit` that distributes over each member of a union, so a discriminated union
@@ -44,10 +44,17 @@ export function registerCopilotKit({
   setContext,
   agents,
   cors,
+  tracingOptions,
   ...runtimeOptions
 }: {
   path: string;
   resourceId: string;
+  /**
+   * Mastra tracing options forwarded to each agent run (default-agent path
+   * only; ignored when `agents` is supplied since those are pre-constructed).
+   * See MastraAgentConfig.tracingOptions.
+   */
+  tracingOptions?: MastraTracingOptions;
   /**
    * @deprecated The v2 CopilotKit runtime handler used internally has no
    * service-adapter slot (AG-UI agents don't use one), so this option is
@@ -88,11 +95,13 @@ export function registerCopilotKit({
         agents ||
         MastraAgent.getLocalAgents({
           resourceId:
-            requestContext.get<typeof MASTRA_RESOURCE_ID_KEY, string | undefined>(
-              MASTRA_RESOURCE_ID_KEY,
-            ) ?? resourceId,
+            requestContext.get<
+              typeof MASTRA_RESOURCE_ID_KEY,
+              string | undefined
+            >(MASTRA_RESOURCE_ID_KEY) ?? resourceId,
           mastra,
           requestContext,
+          tracingOptions,
         });
 
       const runtime = new CopilotRuntime({

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -317,10 +317,46 @@ function extractLastAssistantText(uiMessages: unknown): string | undefined {
 export const MASTRA_OBSERVATIONAL_MEMORY_ACTIVITY_TYPE =
   "mastra-observational-memory";
 
+/**
+ * Mastra tracing options threaded into the underlying `agent.stream(...)` /
+ * `agent.resumeStream(...)` call. Typed structurally (not against
+ * `@mastra/core`) so the bridge compiles on any supported core in the peer
+ * range — cores predating observability v-next simply ignore an unknown
+ * `tracingOptions` key. Mirrors Mastra's `TracingOptions`:
+ *   - `traceId`: a caller-chosen trace id to anchor the run under (lets a client
+ *     self-assign a trace it already knows, e.g. to attach feedback later).
+ *   - `metadata`: arbitrary key/values attached to the run's root trace span.
+ */
+export interface MastraTracingOptions {
+  traceId?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface MastraAgentConfig extends AgentConfig {
   agent: LocalMastraAgent | RemoteMastraAgent;
   resourceId?: string;
   requestContext?: RequestContext;
+  /**
+   * Forward Mastra tracing options into the run's `agent.stream(...)` (and the
+   * resume path). Chiefly lets a caller inject a self-chosen `traceId` so the
+   * Mastra execution trace is anchored to an id the client already knows,
+   * enabling trace-centric feedback/scores (`createFeedback({ traceId })`).
+   *
+   * NOT per-run: this config (and any `traceId` in it) is stored once on the
+   * agent instance and reused verbatim for EVERY run of that instance. So a
+   * config-level `tracingOptions.traceId` is applied to every run, not to a
+   * single run, meaning a caller who sets a fixed `traceId` here and reuses one
+   * `MastraAgent` across many runs collapses all those runs onto a single trace.
+   * Callers who want a distinct traceId per run should construct a fresh agent
+   * per run (the `registerCopilotKit` / `getLocalAgents` path already does this,
+   * since agents are constructed inside the per-request route handler).
+   *
+   * The OUTBOUND execution traceId surfaced on `RUN_FINISHED.result` IS per-run:
+   * when no inbound `traceId` is set, Mastra generates one for that run, which
+   * the bridge surfaces back to the client (see {@link makeRunFinishedEvent}).
+   * Inert on cores that predate Mastra observability v-next.
+   */
+  tracingOptions?: MastraTracingOptions;
   /**
    * Opt into Mastra's `untilIdle` run mode (local agents only). When set, the
    * bridge passes `untilIdle` to `agent.stream(...)`, which subscribes to the
@@ -463,7 +499,13 @@ interface MastraAgentStreamOptions {
   onToolCallEnd?: (streamPart: { toolCallId: string }) => void;
   onToolResultPart?: (streamPart: { toolCallId: string; result: any }) => void;
   onError: (error: Error) => void;
-  onRunFinished?: () => Promise<void>;
+  /**
+   * Terminate the run with RUN_FINISHED. Receives the Mastra execution traceId
+   * (Mastra observability v-next) when the consumed stream exposed one, so the
+   * bridge can surface it on `RUN_FINISHED.result` (see makeRunFinishedEvent).
+   * traceId is undefined on cores/streams that don't expose one.
+   */
+  onRunFinished?: (traceId?: string) => Promise<void>;
   onToolSuspended: (payload: {
     toolCallId: string;
     toolName: string;
@@ -520,6 +562,7 @@ export class MastraAgent extends AbstractAgent {
   requestContext?: RequestContext;
   untilIdle?: boolean | { maxIdleMs?: number };
   observationalMemory?: boolean;
+  tracingOptions?: MastraTracingOptions;
   public headers?: Record<string, string>;
   /** See MastraAgentConfig.emitInterruptOutcome. Default true. */
   emitInterruptOutcome: boolean;
@@ -555,6 +598,7 @@ export class MastraAgent extends AbstractAgent {
       resourceId,
       requestContext,
       untilIdle,
+      tracingOptions,
       emitInterruptOutcome,
       a2ui,
       remoteClient,
@@ -572,6 +616,7 @@ export class MastraAgent extends AbstractAgent {
     this.remoteClient = remoteClient;
     this.useProcessedFinalText = useProcessedFinalText ?? false;
     this.observationalMemory = observationalMemory;
+    this.tracingOptions = tracingOptions;
   }
 
   public clone() {
@@ -716,6 +761,9 @@ export class MastraAgent extends AbstractAgent {
             },
             requestContext: resumeRequestContext,
           };
+          if (this.tracingOptions) {
+            resumeOptions.tracingOptions = this.tracingOptions;
+          }
           if (this.headers && Object.keys(this.headers).length > 0) {
             resumeOptions.modelSettings = {
               ...((resumeOptions.modelSettings as
@@ -741,13 +789,14 @@ export class MastraAgent extends AbstractAgent {
           // interrupt outcome when emitInterruptOutcome is on (e.g. a chained
           // interrupt in the resumed stream), so the resumed-run tail is
           // identical for local and remote.
-          const finishResume = async () => {
+          const finishResume = async (traceId?: string) => {
             await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
             subscriber.next(
               this.makeRunFinishedEvent(
                 input.threadId,
                 input.runId,
                 pendingInterrupts,
+                traceId,
               ),
             );
             subscriber.complete();
@@ -785,7 +834,7 @@ export class MastraAgent extends AbstractAgent {
               );
 
               if (!hadError) {
-                await finishResume();
+                await finishResume(await this.resolveTraceId(response));
               }
             } else {
               // Remote resume round-trips the suspend state + resume command
@@ -838,7 +887,7 @@ export class MastraAgent extends AbstractAgent {
 
               if (!stopped) {
                 flush();
-                await finishResume();
+                await finishResume(await this.resolveTraceId(response));
               }
             }
           } catch (error) {
@@ -875,13 +924,14 @@ export class MastraAgent extends AbstractAgent {
             onError: (error) => {
               subscriber.error(error);
             },
-            onRunFinished: async () => {
+            onRunFinished: async (traceId) => {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
               subscriber.next(
                 this.makeRunFinishedEvent(
                   input.threadId,
                   input.runId,
                   pendingInterrupts,
+                  traceId,
                 ),
               );
               subscriber.complete();
@@ -980,17 +1030,25 @@ export class MastraAgent extends AbstractAgent {
    * `outcome: { type: "interrupt", interrupts }`. Otherwise emits a plain
    * RUN_FINISHED — the legacy/default behavior. Mirrors LangGraph's
    * `dispatchInterruptFinish`.
+   *
+   * When the run exposed a Mastra execution traceId (Mastra observability
+   * v-next), it is surfaced on `RUN_FINISHED.result` as `{ traceId }` so the
+   * client/runtime can correlate the produced assistant message with its trace
+   * (e.g. to anchor trace-centric feedback/scores). `result` is left unset
+   * otherwise, preserving the prior event shape.
    */
   private makeRunFinishedEvent(
     threadId: string,
     runId: string,
     interrupts: Interrupt[],
+    traceId?: string,
   ): RunFinishedEvent {
     const includeOutcome = this.emitInterruptOutcome && interrupts.length > 0;
     return {
       type: EventType.RUN_FINISHED,
       threadId,
       runId,
+      ...(traceId ? { result: { traceId } } : {}),
       ...(includeOutcome
         ? {
             outcome: {
@@ -2490,6 +2548,33 @@ export class MastraAgent extends AbstractAgent {
   }
 
   /**
+   * Reads the Mastra execution traceId off a consumed stream response, if any.
+   *
+   * `traceId` is exposed by Mastra observability v-next on the stream response
+   * (`MastraModelOutput.traceId`); it may be a plain string or a Promise that
+   * resolves after the stream is consumed, so we await a thenable. Probed
+   * structurally so the bridge stays compatible with cores / remote clients
+   * that don't expose it (they simply yield undefined). Best-effort: a read
+   * that throws is swallowed so it never blocks RUN_FINISHED.
+   */
+  private async resolveTraceId(response: unknown): Promise<string | undefined> {
+    if (!response || typeof response !== "object") return undefined;
+    try {
+      const raw = (response as { traceId?: unknown }).traceId;
+      const traceId =
+        raw && typeof (raw as PromiseLike<unknown>).then === "function"
+          ? await (raw as PromiseLike<unknown>)
+          : raw;
+      return typeof traceId === "string" && traceId.length > 0
+        ? traceId
+        : undefined;
+    } catch (error) {
+      console.warn("[MastraAgent] Failed to read execution traceId:", error);
+      return undefined;
+    }
+  }
+
+  /**
    * Streams a local or remote Mastra agent, emitting AG-UI events via callbacks.
    * For local agents, iterates fullStream with processFullStream.
    * For remote agents, uses processDataStream with createChunkProcessor.
@@ -2631,6 +2716,9 @@ export class MastraAgent extends AbstractAgent {
         if (this.untilIdle) {
           streamOptions.untilIdle = this.untilIdle;
         }
+        if (this.tracingOptions) {
+          streamOptions.tracingOptions = this.tracingOptions;
+        }
         if (this.headers && Object.keys(this.headers).length > 0) {
           streamOptions.modelSettings = {
             ...((streamOptions.modelSettings as
@@ -2669,7 +2757,10 @@ export class MastraAgent extends AbstractAgent {
             initialState,
           );
 
-          if (!hadError) await onRunFinished?.();
+          if (!hadError) {
+            const traceId = await this.resolveTraceId(response);
+            await onRunFinished?.(traceId);
+          }
         } else {
           throw new Error("Invalid response from local agent");
         }
@@ -2688,6 +2779,9 @@ export class MastraAgent extends AbstractAgent {
           clientTools,
           requestContext,
         };
+        if (this.tracingOptions) {
+          streamOptions.tracingOptions = this.tracingOptions;
+        }
         if (this.headers && Object.keys(this.headers).length > 0) {
           streamOptions.modelSettings = {
             ...((streamOptions.modelSettings as
@@ -2734,7 +2828,10 @@ export class MastraAgent extends AbstractAgent {
             },
           });
           if (!stopped) flush();
-          if (!stopped) await onRunFinished?.();
+          if (!stopped) {
+            const traceId = await this.resolveTraceId(response);
+            await onRunFinished?.(traceId);
+          }
         } else {
           throw new Error("Invalid response from remote agent");
         }

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -10,7 +10,7 @@ import type { Mastra } from "@mastra/core";
 import type { CoreMessage } from "@mastra/core/llm";
 import { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import { RequestContext } from "@mastra/core/request-context";
-import { MastraAgent } from "./mastra";
+import { MastraAgent, MastraTracingOptions } from "./mastra";
 
 /**
  * CoreMessage extended with an optional `id` field.
@@ -199,12 +199,15 @@ export interface GetRemoteAgentsOptions {
    * streams. See `MastraAgentConfig.observationalMemory`.
    */
   observationalMemory?: boolean | string[];
+  /** Mastra tracing options forwarded to each run. See MastraAgentConfig.tracingOptions. */
+  tracingOptions?: MastraTracingOptions;
 }
 
 export async function getRemoteAgents({
   mastraClient,
   resourceId,
   observationalMemory,
+  tracingOptions,
 }: GetRemoteAgentsOptions): Promise<Record<string, AbstractAgent>> {
   const agents = await mastraClient.listAgents();
 
@@ -227,6 +230,7 @@ export async function getRemoteAgents({
         observationalMemory: wantsObservationalMemory(agentId)
           ? true
           : undefined,
+        tracingOptions,
       });
 
       return acc;
@@ -252,6 +256,8 @@ export interface GetLocalAgentsOptions {
    * Default OFF. See `MastraAgentConfig.observationalMemory`.
    */
   observationalMemory?: boolean | string[];
+  /** Mastra tracing options forwarded to each run. See MastraAgentConfig.tracingOptions. */
+  tracingOptions?: MastraTracingOptions;
 }
 
 export function getLocalAgents({
@@ -260,6 +266,7 @@ export function getLocalAgents({
   requestContext,
   untilIdle,
   observationalMemory,
+  tracingOptions,
 }: GetLocalAgentsOptions): Record<string, AbstractAgent> {
   const agents = mastra.listAgents() || {};
 
@@ -283,6 +290,7 @@ export function getLocalAgents({
         observationalMemory: wantsObservationalMemory(agentId)
           ? true
           : undefined,
+        tracingOptions,
       });
       return acc;
     },
@@ -297,6 +305,8 @@ export interface GetLocalAgentOptions {
   agentId: string;
   resourceId: string;
   requestContext?: RequestContext;
+  /** Mastra tracing options forwarded to the run. See MastraAgentConfig.tracingOptions. */
+  tracingOptions?: MastraTracingOptions;
 }
 
 export function getLocalAgent({
@@ -304,6 +314,7 @@ export function getLocalAgent({
   agentId,
   resourceId,
   requestContext,
+  tracingOptions,
 }: GetLocalAgentOptions) {
   const agent = mastra.getAgent(agentId);
   if (!agent) {
@@ -314,6 +325,7 @@ export function getLocalAgent({
     agent,
     resourceId,
     requestContext,
+    tracingOptions,
   }) as AbstractAgent;
 }
 
@@ -322,6 +334,8 @@ export interface GetNetworkOptions {
   networkId: string;
   resourceId: string;
   requestContext?: RequestContext;
+  /** Mastra tracing options forwarded to the run. See MastraAgentConfig.tracingOptions. */
+  tracingOptions?: MastraTracingOptions;
 }
 
 export function getNetwork({
@@ -329,6 +343,7 @@ export function getNetwork({
   networkId,
   resourceId,
   requestContext,
+  tracingOptions,
 }: GetNetworkOptions) {
   const network = mastra.getAgent(networkId);
   if (!network) {
@@ -339,5 +354,6 @@ export function getNetwork({
     agent: network as unknown as LocalMastraAgent,
     resourceId,
     requestContext,
+    tracingOptions,
   }) as AbstractAgent;
 }


### PR DESCRIPTION
Closes #2019.

## What

Exposes Mastra tracing through `@ag-ui/mastra`, both directions:

- **Inbound** — a new `tracingOptions` passthrough lets a caller inject Mastra `tracingOptions` (chiefly a caller-chosen `traceId`) into the underlying `agent.stream()` / `resumeStream()` call. Threaded through `MastraAgentConfig`, `getLocalAgents` / `getLocalAgent` / `getNetwork` / `getRemoteAgents`, and `registerCopilotKit`.
- **Outbound** — the resulting execution `traceId` (`MastraModelOutput.traceId`) is surfaced back to the client on `RUN_FINISHED.result` as `{ traceId }`, so a run can be correlated with its Mastra trace (e.g. to anchor trace-centric feedback/scores via `createFeedback({ traceId })`).

Together these unblock trace-anchored feedback for AG-UI / CopilotKit frontends, which previously could neither inject a `traceId` nor read the generated one.

## How

- `resolveTraceId` reads `response.traceId` structurally (awaits a thenable), so it stays inert on `@mastra/core` versions that predate observability v-next.
- Structural `MastraTracingOptions` type, no `@mastra/core` version coupling.
- Surfaced via `RUN_FINISHED.result` (already `z.any()` in `@ag-ui/core`) — no protocol/schema change.
- Wired on local + remote stream paths and the resume path.
- A config-level `traceId` applies to every run of that agent instance (documented); per-run distinct traces come from the per-request `getLocalAgents` construction path.

## Tests

New `tracing-options.test.ts` covers inbound (local / remote / resume), outbound `RUN_FINISHED.result`, the inbound→outbound round-trip, remote-negative, empty-string guard, and Promise + rejection-safety. Full package suite green (228 tests).

## Notes

- No collision with the merged #2061 (copilotkit runtime revamp); this only adds an option.
- Not e2e-tested in the dojo: Mastra tracing needs a configured observability backend; unit coverage is the proof (mirrors prior Mastra interrupt-outcome reasoning).