### PR TITLE
fix: harden dotnet NuGet release follow-up

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1305,34 +1305,48 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VERIFY_FAILED=""
-          while read -r pkg; do
-            NAME=$(echo "$pkg" | jq -r '.name')
-            VERSION=$(echo "$pkg" | jq -r '.version')
-            LOWER_NAME=$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]')
-            LOWER_VERSION=$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')
-            URL="https://api.nuget.org/v3-flatcontainer/${LOWER_NAME}/${LOWER_VERSION}/${LOWER_NAME}.${LOWER_VERSION}.nupkg"
-            OK=0
-            for ATTEMPT in 1 2 3 4 5 6; do
-              if curl -fsSL -o /dev/null "$URL"; then
-                OK=1
-                break
+
+          MAX_WAIT_SECONDS=900
+          SLEEP_SECONDS=15
+          START_SECONDS=$(date +%s)
+          MISSING_PACKAGES=$(mktemp)
+          jq -c '.[]' dotnet-packages.json > "$MISSING_PACKAGES"
+
+          while true; do
+            NEXT_MISSING=$(mktemp)
+
+            while read -r pkg; do
+              NAME=$(echo "$pkg" | jq -r '.name')
+              VERSION=$(echo "$pkg" | jq -r '.version')
+              LOWER_NAME=$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]')
+              LOWER_VERSION=$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')
+              URL="https://api.nuget.org/v3-flatcontainer/${LOWER_NAME}/${LOWER_VERSION}/${LOWER_NAME}.${LOWER_VERSION}.nupkg"
+
+              if curl -fsSL -o /dev/null "$URL" 2>/dev/null; then
+                echo "::notice::PUBLISHED: ${NAME}@${VERSION}"
+              else
+                echo "$pkg" >> "$NEXT_MISSING"
               fi
-              if [ "$ATTEMPT" -lt 6 ]; then
-                sleep 10
-              fi
-            done
-            if [ "$OK" -eq 1 ]; then
-              echo "::notice::PUBLISHED: ${NAME}@${VERSION}"
-            else
-              echo "::error::${NAME}@${VERSION} not visible on NuGet after 6 attempts"
-              VERIFY_FAILED="${VERIFY_FAILED} ${NAME}"
+            done < "$MISSING_PACKAGES"
+
+            if [ ! -s "$NEXT_MISSING" ]; then
+              rm -f "$MISSING_PACKAGES" "$NEXT_MISSING"
+              break
             fi
-          done < <(jq -c '.[]' dotnet-packages.json)
-          if [ -n "$VERIFY_FAILED" ]; then
-            echo "::error::NuGet verification failed for:${VERIFY_FAILED}"
-            exit 1
-          fi
+
+            NOW_SECONDS=$(date +%s)
+            ELAPSED_SECONDS=$((NOW_SECONDS - START_SECONDS))
+            if [ "$ELAPSED_SECONDS" -ge "$MAX_WAIT_SECONDS" ]; then
+              echo "::error::NuGet verification timed out after ${ELAPSED_SECONDS}s waiting for:"
+              jq -r '. | "- \(.name)@\(.version)"' "$NEXT_MISSING"
+              exit 1
+            fi
+
+            REMAINING_COUNT=$(wc -l < "$NEXT_MISSING" | tr -d ' ')
+            echo "::notice::Waiting for ${REMAINING_COUNT} NuGet package(s) to become visible after ${ELAPSED_SECONDS}s"
+            mv "$NEXT_MISSING" "$MISSING_PACKAGES"
+            sleep "$SLEEP_SECONDS"
+          done
 
       - name: Configure git
         if: needs.build.outputs.mode != 'prerelease'

--- a/sdks/dotnet/Directory.Build.props
+++ b/sdks/dotnet/Directory.Build.props
@@ -51,7 +51,7 @@
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <None Include="$(MSBuildThisFileDirectory)PACKAGE.md" Pack="true" PackagePath="\README.md" />
-    <None Include="$(MSBuildThisFileDirectory)..\..\docs\logo\AG-UI logo_light.png" Pack="true" PackagePath="\icon.png" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\docs\logo\AG-UI logo_dark.png" Pack="true" PackagePath="\icon.png" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net472' ">


### PR DESCRIPTION
## Problem

The .NET publish job can successfully push NuGet packages but still fail when NuGet flat-container indexing takes longer than the current per-package one-minute verification window. The package icon also used the white AG-UI mark, which disappears on NuGet light backgrounds.

## Why

A false-negative visibility failure skips the later release bookkeeping steps even though the package push succeeded. NuGet package icons are also single assets, so the packed icon needs to be visible on the default light UI.

## Fix

Replace the per-package visibility retry with a global 15-minute retry loop over the remaining missing packages, so packages that index late can still clear verification. Swap the packed icon to the existing dark AG-UI mark asset; the purple kite app icon is not used.

Verification:
- `actionlint .github/workflows/publish-release.yml`
- `bash scripts/release/verify-config-manifest-names.sh`
- `bash scripts/release/verify-release-scope-dropdowns.sh`
- `bash scripts/release/verify-nx-release-allowlist.sh`
- `shellcheck --severity=warning scripts/release/*.sh`
- `git diff --check`