### PR TITLE
fix(langgraph): sanitize empty Responses-API content blocks on tool round-trips

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/__init__.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/__init__.py
@@ -16,7 +16,12 @@ from .types import (
     PredictStateTool,
     LangGraphReasoning,
 )
-from .utils import json_safe_stringify, make_json_safe
+from .utils import (
+    json_safe_stringify,
+    make_json_safe,
+    strip_empty_content_blocks,
+    sanitize_messages_for_responses_api,
+)
 from .endpoint import add_langgraph_fastapi_endpoint
 from .middlewares.state_streaming import StateStreamingMiddleware, StateItem
 from .a2ui_tool import (
@@ -53,5 +58,7 @@ __all__ = [
     "StateStreamingMiddleware",
     "StateItem",
     "json_safe_stringify",
-    "make_json_safe"
+    "make_json_safe",
+    "strip_empty_content_blocks",
+    "sanitize_messages_for_responses_api",
 ]

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -653,6 +653,58 @@ def normalize_tool_content(content: Any) -> str:
     return json.dumps(content)
 
 
+def strip_empty_content_blocks(message: BaseMessage) -> BaseMessage:
+    """Drop assistant content blocks that are *empty* streamed Responses-API
+    containers: a ``text`` / ``output_text`` block with no ``text`` field, or a
+    ``refusal`` block with no ``refusal`` field.
+
+    When a Responses-API turn (``ChatOpenAI(use_responses_api=True)``) is *streamed*
+    and ends on a tool call, some OpenAI-compatible providers leave a trailing empty
+    text container on the assistant message — ``{"type": "text", "id": "msg_…",
+    "index": N}`` with **no** ``"text"`` key. On the follow-up tool round-trip,
+    langchain-openai's ``_construct_responses_api_input`` does ``block["text"]`` on
+    it and raises ``KeyError: 'text'``, which aborts the run. These containers carry
+    no content, so dropping them makes the round-trip robust across providers. (Real
+    OpenAI does not emit them; some compatible endpoints — e.g. Fireworks-hosted
+    Qwen — do.)
+
+    Content-bearing blocks are always preserved — including a valid refusal
+    (``{"type": "refusal", "refusal": "…"}``, whose content lives under ``refusal``,
+    not ``text``) and an intentional empty string (``{"type": "text", "text": ""}``).
+    Each block type is keyed to its own content field, so this never drops a block
+    that carries real content. Returns the same instance when there is nothing to
+    strip, so it is cheap to map over an entire history on every turn.
+    """
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        cleaned = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and (
+                    (block.get("type") in ("text", "output_text") and "text" not in block)
+                    or (block.get("type") == "refusal" and "refusal" not in block)
+                )
+            )
+        ]
+        if cleaned != content:
+            return message.model_copy(update={"content": cleaned})
+    return message
+
+
+def sanitize_messages_for_responses_api(messages: List[BaseMessage]) -> List[BaseMessage]:
+    """Apply :func:`strip_empty_content_blocks` to every message in a history.
+
+    Intended to be called inside a LangGraph node on ``state["messages"]`` right
+    before invoking a model configured with ``use_responses_api=True``::
+
+        messages = sanitize_messages_for_responses_api(state["messages"])
+        response = await model.ainvoke([system_message, *messages], config)
+    """
+    return [strip_empty_content_blocks(m) for m in messages]
+
+
 # Used by run() to normalize forwarded_props keys from camelCase (JS frontend convention)
 # to snake_case (Python convention). Appears isolated but is called from agent.py and
 # removing it would silently break all streaming options forwarded from the frontend

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -21,7 +21,104 @@ from ag_ui_langgraph.utils import (
     agui_messages_to_langchain,
     langchain_messages_to_agui,
     normalize_tool_content,
+    strip_empty_content_blocks,
+    sanitize_messages_for_responses_api,
 )
+
+
+class TestStripEmptyContentBlocks(unittest.TestCase):
+    """Tests for strip_empty_content_blocks() / sanitize_messages_for_responses_api().
+
+    Regression coverage for the streamed Responses-API tool-call bug: some
+    OpenAI-compatible providers leave a trailing {"type": "text", "id": "msg_..",
+    "index": N} block with no "text" key, which crashes langchain-openai's
+    _construct_responses_api_input (KeyError: 'text') on the tool round-trip.
+    """
+
+    def test_drops_text_block_missing_text_key(self):
+        # Mirrors the real captured failing AIMessage: reasoning + a valid text
+        # block + a function_call + a trailing empty text container (no "text").
+        msg = AIMessage(
+            id="a1",
+            content=[
+                {"id": "rs_1", "type": "reasoning",
+                 "summary": [{"type": "summary_text", "text": "thinking"}]},
+                {"type": "text", "text": "\n\n", "index": 1},
+                {"type": "function_call", "name": "change_background",
+                 "arguments": "{}", "call_id": "c1", "id": "fc_1"},
+                {"type": "text", "id": "msg_1", "index": 2},  # malformed: no "text"
+            ],
+        )
+        cleaned = strip_empty_content_blocks(msg)
+        assert [b.get("type") for b in cleaned.content] == [
+            "reasoning", "text", "function_call",
+        ]
+        # every surviving text-ish block has a "text" key -> serializer won't KeyError
+        assert all(
+            "text" in b
+            for b in cleaned.content
+            if b.get("type") in ("text", "output_text", "refusal")
+        )
+
+    def test_drops_output_text_and_refusal_without_text(self):
+        msg = AIMessage(id="a2", content=[
+            {"type": "output_text", "id": "m1"},
+            {"type": "refusal", "id": "m2"},
+            {"type": "output_text", "text": "kept"},
+        ])
+        cleaned = strip_empty_content_blocks(msg)
+        assert cleaned.content == [{"type": "output_text", "text": "kept"}]
+
+    def test_preserves_valid_refusal(self):
+        # A valid refusal stores its content under "refusal", not "text", so it has
+        # no "text" key — it must NOT be dropped (only the empty refusal container is).
+        msg = AIMessage(id="a2b", content=[
+            {"type": "refusal", "refusal": "I can't help with that", "id": "m3"},
+            {"type": "text", "id": "msg_empty", "index": 0},  # empty container -> dropped
+        ])
+        cleaned = strip_empty_content_blocks(msg)
+        assert cleaned.content == [
+            {"type": "refusal", "refusal": "I can't help with that", "id": "m3"},
+        ]
+
+    def test_keeps_empty_string_text(self):
+        # An intentional empty string (key present) is distinct from a missing key.
+        msg = AIMessage(id="a2c", content=[{"type": "text", "text": ""}])
+        result = strip_empty_content_blocks(msg)
+        assert result is msg  # nothing to strip -> same instance
+        assert result.content == [{"type": "text", "text": ""}]
+
+    def test_keeps_valid_message_identity(self):
+        msg = AIMessage(id="a3", content=[{"type": "text", "text": "hi"}])
+        result = strip_empty_content_blocks(msg)
+        assert result is msg  # nothing to strip -> same instance
+
+    def test_string_content_passthrough(self):
+        msg = AIMessage(id="a4", content="plain string")
+        result = strip_empty_content_blocks(msg)
+        assert result is msg
+        assert result.content == "plain string"
+
+    def test_does_not_mutate_original(self):
+        msg = AIMessage(id="a5", content=[
+            {"type": "text", "text": "hi"},
+            {"type": "text", "id": "msg_x", "index": 0},
+        ])
+        cleaned = strip_empty_content_blocks(msg)
+        assert len(msg.content) == 2      # original untouched (model_copy, not in place)
+        assert len(cleaned.content) == 1
+
+    def test_sanitize_messages_maps_over_history(self):
+        history = [
+            HumanMessage(id="h1", content="hello"),
+            AIMessage(id="a1", content=[{"type": "text", "id": "msg_1", "index": 0}]),
+            ToolMessage(id="t1", content="", tool_call_id="c1"),
+        ]
+        cleaned = sanitize_messages_for_responses_api(history)
+        assert len(cleaned) == 3
+        assert cleaned[0] is history[0]   # human (str content) unchanged
+        assert cleaned[1].content == []   # empty block dropped
+        assert cleaned[2] is history[2]   # tool (str content) unchanged
 
 
 class TestAguiMessagesToLangchain(unittest.TestCase):


### PR DESCRIPTION
## Problem

When a Responses-API turn (`ChatOpenAI(use_responses_api=True)`) is **streamed** and ends on a tool call, some OpenAI-compatible providers leave a trailing *empty* text container on the assistant message:

```json
{ "type": "text", "id": "msg_…", "index": 2 }
```

Note: no `"text"` key. On the follow-up (tool round-trip) call, langchain-openai's `_construct_responses_api_input` does `block["text"]` on it and raises `KeyError: 'text'`, which aborts the run — the AG-UI stream closes and the client sees `terminated`.

Real OpenAI does not emit these empty containers, so this only surfaces against OpenAI-*compatible* endpoints (observed with Fireworks-hosted Qwen) — i.e. exactly the "point a LangGraph agent at a compatible provider over the Responses API" path.

## Fix

Two exported helpers in `ag_ui_langgraph`:

- **`strip_empty_content_blocks(message)`** — drops empty streamed containers (a `text`/`output_text` block with no `text` field, or a `refusal` block with no `refusal` field) while preserving every content-bearing block. Each block type is keyed to its own content field, so a valid refusal (`{"type": "refusal", "refusal": "…"}`) and an intentional empty string (`{"type": "text", "text": ""}`) are kept. Returns the same instance when nothing changes.
- **`sanitize_messages_for_responses_api(messages)`** — maps the above over a message history. Call it inside a LangGraph node on `state["messages"]` before invoking a model with `use_responses_api=True`:

```python
from ag_ui_langgraph import sanitize_messages_for_responses_api

messages = sanitize_messages_for_responses_api(state["messages"])
response = await model.ainvoke([system_message, *messages], config)
```

The adapter can't fix this centrally: the model is invoked inside the user's node with `state["messages"]` reconstructed by the checkpointer's `add_messages` reducer, so the sanitizer is exposed for node authors to call before a Responses-API invoke.

## Tests

Adds `TestStripEmptyContentBlocks` to `tests/test_message_conversion.py`, covering: the empty-container drop (mirroring the real captured failure — reasoning + text + function_call + empty text block), valid-refusal and empty-string preservation, non-mutation of the original message, and string-content passthrough. Full package suite: **50 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
