### PR TITLE
fix(mastra): ESM-safe import of fast-json-patch (OSS-432)

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -27,7 +27,10 @@ import { AbstractAgent, EventType } from "@ag-ui/client";
 import type { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import { RequestContext } from "@mastra/core/request-context";
 import { randomUUID } from "@ag-ui/client";
-import { compare } from "fast-json-patch";
+// fast-json-patch@3.1.1 is CJS with no exports map, so a named ESM import
+// (`import { compare }`) fails under Node ESM. Default-import then destructure.
+import fastJsonPatch from "fast-json-patch";
+const { compare } = fastJsonPatch;
 import { parsePartialJson } from "@ai-sdk/ui-utils";
 import { Observable } from "rxjs";
 import type { MastraClient } from "@mastra/client-js";


### PR DESCRIPTION
## Problem

`@ag-ui/mastra` ships ESM that does `import { compare } from "fast-json-patch"`. `fast-json-patch@3.1.1` is old-style CJS (no `exports` map, `main: index.js`), so Node's ESM loader cannot resolve a **named** import from it and throws:

```
SyntaxError: Named export 'compare' not found. The requested module 'fast-json-patch' is a CommonJS module...
```

This shipped broken in both `@ag-ui/mastra@1.1.0-alpha.0` and `1.1.0` stable — any clean ESM consumer (`"type": "module"`) crashes on import. The `compare` use came in with the STATE_DELTA / shared-state work (OSS-414).

## Fix

Default-import the CJS module, then destructure — this resolves the named binding through CJS interop and emits ESM-safe output:

```ts
import fastJsonPatch from "fast-json-patch";
const { compare } = fastJsonPatch;
```

Only one named import from a CJS dep existed in the shipped bridge (`mastra.ts`). The remaining `fast-json-patch` use is in a test file (`applyPatch`), which is transpiled by vitest and never shipped.

## Verification

- **Build clean** (`nx build @ag-ui/mastra`).
- **Emitted dist ESM** no longer does a named import — `dist/mastra-*.mjs` now emits `import a from "fast-json-patch"`.
- **Clean ESM consumer**: imported the built `dist/index.mjs` from a plain `"type": "module"` Node context — loads fine, no `Named export 'compare' not found`.
- **Unit tests**: 300 passed (19 files), including the STATE_DELTA tests that exercise `compare`.

Fixes OSS-432. Unblocks the showcase (OSS-381) and ui-dojo (OSS-89) bumps to `@ag-ui/mastra@1.1.0-alpha.0`.