### PR TITLE
docs: add MDMA to Generative UI specs table

### DIFF
--- a/docs/concepts/generative-ui-specs.mdx
+++ b/docs/concepts/generative-ui-specs.mdx
@@ -14,6 +14,7 @@ A2UI, MCP-UI, and Open-JSON-UI are all **generative UI specifications.** Generat
 | **A2UI** | Google | A declarative, LLM-friendly Generative UI spec. JSONL-based and streaming, designed for platform-agnostic rendering. |
 | **Open-JSON-UI** | OpenAI | An open standardization of OpenAI's internal declarative Generative UI schema. |
 | **MCP-UI** | Microsoft + Shopify | A fully open, iframe-based Generative UI standard extending MCP for user-facing experiences. |
+| **[MDMA](https://github.com/MobileReality/mdma)** | Mobile Reality | A Markdown-based, LLM-friendly Generative UI format where interactive components are declared in fenced `mdma` code blocks. Integrates with AG-UI via the community `@mobile-reality/mdma-agui` adapter. |
 
 Despite the naming similarities, **AG-UI is not a generative UI specification** — it's a **User Interaction protocol** that provides the **bi-directional runtime connection** between the agent and the application.
 


### PR DESCRIPTION
Fixes [#2112](https://github.com/ag-ui-protocol/ag-ui/issues/2112)

### What
Adds **MDMA** (Markdown Document with Mounted Applications) to the Generative UI specifications table in `docs/concepts/generative-ui-specs.mdx`.

MDMA is a Markdown-based, LLM-friendly Generative UI format: interactive components (forms, tables, approval gates) are declared in fenced ` ```mdma ``` ` code blocks — streaming-friendly, schema-validated, and PII-aware.

### AG-UI integration
MDMA integrates with AG-UI via the community adapter **`@mobile-reality/mdma-agui`**, which streams MDMA components over the AG-UI protocol and routes user decisions back into the agent run. The row is framed as adapter-based (community), not first-party, to keep it accurate.

### Change
A single appended row to the specs table — docs only, no changes to the surrounding prose or any code.

- Repo: https://github.com/MobileReality/mdma