### PR TITLE
fix(mastra): default import fast-json-patch

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -27,7 +27,7 @@ import { AbstractAgent, EventType } from "@ag-ui/client";
 import type { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import { RequestContext } from "@mastra/core/request-context";
 import { randomUUID } from "@ag-ui/client";
-import { compare } from "fast-json-patch";
+import jsonpatch from "fast-json-patch";
 import { parsePartialJson } from "@ai-sdk/ui-utils";
 import { Observable } from "rxjs";
 import type { MastraClient } from "@mastra/client-js";
@@ -43,6 +43,8 @@ import {
   getNetwork,
 } from "./utils";
 import { planA2UIInjection, type A2UIInjectConfig } from "./a2ui-tool";
+
+const { compare } = jsonpatch;
 
 type RemoteMastraAgent = ReturnType<MastraClient["getAgent"]>;
 


### PR DESCRIPTION
## Problem

`@ag-ui/mastra`'s ESM build imports `compare` as a named export from `fast-json-patch`. `fast-json-patch` is CommonJS, so Node ESM environments can fail with `Named export 'compare' not found` when loading the Mastra CopilotKit bridge.

## Why

Mastra deploy output loads the package ESM artifact directly, so local bundler interop does not hide the CommonJS boundary.

## Fix

Default-import `fast-json-patch` and destructure `compare` from the module namespace. This keeps runtime behavior unchanged while making the emitted ESM Node-compatible.

Validation:
- `COREPACK_HOME=/private/tmp/corepack-cache PNPM_CONFIG_IGNORE_SCRIPTS=true corepack pnpm --filter @ag-ui/mastra... build`
- `node --input-type=module -e "await import('/Users/tylerslaton/Code/ag-ui/integrations/mastra/typescript/dist/copilotkit.mjs'); console.log('mastra copilotkit esm ok')"`
- `COREPACK_HOME=/private/tmp/corepack-cache PNPM_CONFIG_IGNORE_SCRIPTS=true corepack pnpm --filter @ag-ui/mastra typecheck`
- `COREPACK_HOME=/private/tmp/corepack-cache PNPM_CONFIG_IGNORE_SCRIPTS=true corepack pnpm --filter @ag-ui/mastra test` (19 files, 300 tests)

Known unrelated check failure:
- `COREPACK_HOME=/private/tmp/corepack-cache PNPM_CONFIG_IGNORE_SCRIPTS=true corepack pnpm --filter @ag-ui/mastra test:exports` still fails on the existing `@ag-ui/mastra/a2ui` Node 10 resolution entry; Node 16 CJS/ESM and bundler resolution are green.