### PR TITLE
fix(aws-strands): preserve frontend tool call IDs

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1267,8 +1267,8 @@ class StrandsAgent:
                         strands_tool_id = tool_use.get("toolUseId")
                         _raw_in = tool_use.get("input", "")
 
-                        # Generate unique ID for frontend tools (to avoid ID conflicts across requests)
-                        # Use Strands' ID for backend tools (so result lookup works)
+                        # Preserve Strands' ID for every tool so wire events,
+                        # snapshots, and restored tool results can correlate.
                         is_frontend_tool = tool_name in frontend_tool_names
 
                         # Check if we've already seen this tool (by Strands' internal ID)
@@ -1281,11 +1281,8 @@ class StrandsAgent:
                         if existing_entry:
                             # Reuse the existing ID
                             tool_use_id = existing_entry
-                        elif is_frontend_tool:
-                            # Generate new UUID for frontend tools
-                            tool_use_id = str(uuid.uuid4())
                         else:
-                            # Use Strands' ID for backend tools
+                            # Fall back only when the provider omitted an ID.
                             tool_use_id = strands_tool_id or str(uuid.uuid4())
 
                         logger.debug(

--- a/integrations/aws-strands/python/tests/test_messages_snapshot_message_id_rotation.py
+++ b/integrations/aws-strands/python/tests/test_messages_snapshot_message_id_rotation.py
@@ -158,3 +158,39 @@ class TestSequentialToolCallsHaveDistinctMessageIds:
                 f"tool_call {tc_id}: wire parent_message_id={parent_id} "
                 f"!= snapshot assistant id={snap_pairs[tc_id]}"
             )
+
+
+async def test_frontend_tool_keeps_strands_id_on_wire_and_in_snapshot():
+    """Frontend calls must preserve the provider id across persistence."""
+    thread_id = "frontend-stable-id"
+    stream = [
+        {
+            "current_tool_use": {
+                "name": "frontend_tool",
+                "toolUseId": "st-frontend",
+                "input": {},
+            }
+        },
+        {"event": {"contentBlockStop": {}}},
+    ]
+    agent = _build_agent(thread_id, stream)
+    inp = RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="run the frontend tool")],
+        tools=[Tool(name="frontend_tool", description="f", parameters={})],
+        context=[],
+        forwarded_props={},
+    )
+    events = await _collect(agent, inp)
+
+    start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+    assert start.tool_call_id == "st-frontend"
+
+    snapshots = [e for e in events if e.type == EventType.MESSAGES_SNAPSHOT]
+    final = snapshots[-1].messages
+    assistant = next(
+        m for m in final if isinstance(m, AssistantMessage) and m.tool_calls
+    )
+    assert assistant.tool_calls[0].id == "st-frontend"

--- a/integrations/aws-strands/typescript/src/__tests__/messages-snapshot.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/messages-snapshot.test.ts
@@ -97,6 +97,41 @@ describe("MESSAGES_SNAPSHOT — after tool-call end", () => {
     expect(assistant.toolCalls![0]!.function.name).toBe("backend_tool");
   });
 
+  it("uses Strands toolUseId for frontend tool events and snapshots", async () => {
+    const events: AgentStreamEvent[] = [
+      stream.toolUseStart("tooluse_frontend_1", "render_card"),
+      stream.toolUseDelta('{"title":"Hello"}'),
+      stream.blockStop(),
+    ];
+    const agent = scriptedStrandsAgent(events);
+    const output = await collect(
+      agent,
+      minimalRunInput({
+        tools: [
+          {
+            name: "render_card",
+            description: "Render a card in the frontend",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    );
+
+    const start = output.find(
+      (e) => e.type === EventType.TOOL_CALL_START,
+    ) as unknown as { toolCallId: string };
+    expect(start.toolCallId).toBe("tooluse_frontend_1");
+
+    const snapshots = output.filter(
+      (e) => e.type === EventType.MESSAGES_SNAPSHOT,
+    ) as unknown as Array<{ messages: Array<Record<string, unknown>> }>;
+    const last = snapshots[snapshots.length - 1]!.messages;
+    const assistant = last.find((m) => m.role === "assistant") as {
+      toolCalls?: Array<{ id: string }>;
+    };
+    expect(assistant.toolCalls![0]!.id).toBe("tooluse_frontend_1");
+  });
+
   it("skipMessagesSnapshot suppresses the per-tool snapshot", async () => {
     const block = new ToolUseBlock({
       name: "quiet_tool",

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -211,18 +211,17 @@ function _errorMessage(e: unknown): string {
  *
  * - If we've already seen this Strands tool (by internal id), reuse the
  *   existing AG-UI id so every envelope event carries the same id.
- * - Frontend tools get a fresh UUID to avoid cross-request collisions.
- * - Backend tools reuse Strands' own id so result lookup works.
+ * - Frontend and backend tools reuse Strands' own id so streamed events,
+ *   persisted snapshots, and restored tool results can all correlate.
+ * - If the provider omitted an id, fall back to a fresh UUID.
  */
 function _resolveToolUseId(
   seen: Map<string, SeenToolCall>,
   strandsToolId: string,
-  isFrontendTool: boolean,
 ): string {
   for (const [tid, data] of seen) {
     if (data.strandsToolId === strandsToolId) return tid;
   }
-  if (isFrontendTool) return uuid();
   return strandsToolId || uuid();
 }
 
@@ -1209,11 +1208,7 @@ export class StrandsAgent {
               const { name: toolName, toolUseId: strandsToolId } =
                 currentToolUse;
               const isFrontendTool = frontendToolNames.has(toolName);
-              const toolUseId = _resolveToolUseId(
-                toolCallsSeen,
-                strandsToolId,
-                isFrontendTool,
-              );
+              const toolUseId = _resolveToolUseId(toolCallsSeen, strandsToolId);
 
               let entry = toolCallsSeen.get(toolUseId);
               if (!entry) {
@@ -1381,11 +1376,7 @@ export class StrandsAgent {
                 }
               }
               const isFrontendTool = frontendToolNames.has(toolName);
-              const toolUseId = _resolveToolUseId(
-                toolCallsSeen,
-                strandsToolId,
-                isFrontendTool,
-              );
+              const toolUseId = _resolveToolUseId(toolCallsSeen, strandsToolId);
               const argsStr =
                 typeof parsedInput === "string"
                   ? parsedInput
@@ -1547,11 +1538,7 @@ export class StrandsAgent {
           if (kind === "toolUseBlock") {
             const block = event as unknown as ToolUseBlock;
             const isFrontendTool = frontendToolNames.has(block.name);
-            const toolUseId = _resolveToolUseId(
-              toolCallsSeen,
-              block.toolUseId,
-              isFrontendTool,
-            );
+            const toolUseId = _resolveToolUseId(toolCallsSeen, block.toolUseId);
             const argsStr =
               typeof block.input === "string"
                 ? block.input


### PR DESCRIPTION
Fixes #2121.

## Summary
- preserve the Strands `toolUseId` for frontend tool calls in both the Python and TypeScript adapters instead of replacing it with a per-run UUID
- keep streamed tool-call events, persisted `MESSAGES_SNAPSHOT` entries, and restored tool results on the same stable ID
- retain UUID generation only when the provider does not supply an ID
- add regression coverage for the wire event and persisted snapshot in both runtimes

## Testing
- Python AWS Strands suite: 154 passed, 2 skipped
- TypeScript AWS Strands suite through Nx: 242 passed
- TypeScript AWS Strands typecheck through Nx
- `git diff --check`
