### PR TITLE
fix(client): allow `onRunFailed` to return `stopPropagation`

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -465,6 +465,46 @@ describe("AgentSubscriber", () => {
       consoleErrorSpy.mockRestore();
     });
 
+    it("should type-check an onRunFailed implementation that returns stopPropagation", async () => {
+      // Regression test for the `onRunFailed` type signature: it must accept the
+      // full `AgentStateMutation` (including `stopPropagation`), not
+      // `Omit<AgentStateMutation, "stopPropagation">`. Unlike `vi.fn().mockReturnValue(...)`
+      // (which erases the return type), this directly-typed implementation only
+      // compiles if `onRunFailed` is allowed to return `stopPropagation`.
+      // No explicit return-type annotation: the object literal below is checked
+      // against `AgentSubscriber["onRunFailed"]`'s contextual return type via
+      // TS excess-property checking, which is exactly what caught the bug.
+      const onRunFailed: AgentSubscriber["onRunFailed"] = () => ({
+        stopPropagation: true,
+      });
+
+      const errorHandlingSubscriber: AgentSubscriber = { onRunFailed };
+
+      class ErrorAgent extends AbstractAgent {
+        run(input: RunAgentInput): Observable<BaseEvent> {
+          return from([
+            {
+              type: EventType.RUN_STARTED,
+              threadId: input.threadId,
+              runId: input.runId,
+            } as RunStartedEvent,
+          ]).pipe(mergeMap(() => throwError(() => new Error("Test error"))));
+        }
+      }
+
+      const errorAgent = new ErrorAgent();
+      errorAgent.subscribe(errorHandlingSubscriber);
+
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+
+      // Runtime already honored stopPropagation from onRunFailed before this fix;
+      // this test's value is that it fails to compile without the type fix.
+      await expect(errorAgent.runAgent({})).resolves.toBeDefined();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
     it("should allow default error behavior when stopPropagation is false", async () => {
       const errorHandlingSubscriber: AgentSubscriber = {
         onRunFailed: vi.fn().mockReturnValue({

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -459,8 +459,7 @@ export abstract class AbstractAgent {
           subscriber.onRunFailed?.({ error, messages, state, agent: this, input }),
       ),
     ).pipe(
-      map((onRunFailedMutation) => {
-        const mutation = onRunFailedMutation as AgentStateMutation;
+      map((mutation) => {
         if (mutation.messages !== undefined || mutation.state !== undefined) {
           if (mutation.messages !== undefined) {
             this.messages = mutation.messages;

--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -61,7 +61,7 @@ export interface AgentSubscriber {
   ): MaybePromise<Omit<AgentStateMutation, "stopPropagation"> | void>;
   onRunFailed?(
     params: { error: Error } & AgentSubscriberParams,
-  ): MaybePromise<Omit<AgentStateMutation, "stopPropagation"> | void>;
+  ): MaybePromise<AgentStateMutation | void>;
   onRunFinalized?(
     params: AgentSubscriberParams,
   ): MaybePromise<Omit<AgentStateMutation, "stopPropagation"> | void>;


### PR DESCRIPTION
### Fixes #2124

## Summary

`onRunFailed` is typed to return `Omit<AgentStateMutation, "stopPropagation"> | void`, so a subscriber can't stop default error propagation for a failed run (e.g. an intentional abort) the way `onEvent`/`onRunErrorEvent`/etc. already can via the full `AgentStateMutation`.

The runtime already supports this — `agent.ts`'s `onError` handler was casting the mutation to `AgentStateMutation` and honoring `stopPropagation` from it — so this is a type-only fix: widen `onRunFailed`'s return type to match. Also removes that now-redundant cast, since `runSubscribersWithMutation`'s declared return type (`Promise<AgentStateMutation>`) already gives the mapped value the correct type.

- `subscriber.ts`: `onRunFailed` now returns `MaybePromise<AgentStateMutation | void>`
- `agent.ts`: dropped the redundant `as AgentStateMutation` cast
- `subscriber.test.ts`: added a regression test — a directly-typed `onRunFailed` implementation returning `{ stopPropagation: true }` as an inferred object literal, which only compiles with this fix (confirmed it fails with `TS2322` on that exact line without it)

## Test plan

- [x] `pnpm vitest run src/agent/__tests__/subscriber.test.ts` — 44/44 pass
- [x] `tsc --noEmit` on the client package shows no new errors (pre-existing unrelated errors confirmed present before this change too)
- [x] Verified in a downstream React Native app: a typed `onRunFailed` subscriber returning `{ stopPropagation: true }` to suppress default handling on an aborted run now compiles