### PR TITLE
feat(dojo): support Authorization header for the agno integration

### DIFF
--- a/apps/dojo/src/agents.ts
+++ b/apps/dojo/src/agents.ts
@@ -366,7 +366,13 @@ export const agentsIntegrations = {
 
   agno: async () =>
     mapAgents(
-      (path) => new AgnoAgent({ url: `${envVars.agnoUrl}/${path}/agui` }),
+      (path) =>
+        new AgnoAgent({
+          url: `${envVars.agnoUrl}/${path}/agui`,
+          ...(envVars.agnoAuthToken && {
+            headers: { Authorization: `Bearer ${envVars.agnoAuthToken}` },
+          }),
+        }),
       {
         agentic_chat: "agentic_chat",
         agentic_chat_reasoning: "agentic_chat_reasoning",

--- a/apps/dojo/src/env.ts
+++ b/apps/dojo/src/env.ts
@@ -7,6 +7,7 @@ type envVars = {
   langgraphFastApiUrl: string;
   langgraphTypescriptUrl: string;
   agnoUrl: string;
+  agnoAuthToken: string;
   springAiUrl: string;
   llamaIndexUrl: string;
   crewAiUrl: string;
@@ -56,6 +57,7 @@ export default function getEnvVars(): envVars {
     langgraphTypescriptUrl:
       process.env.LANGGRAPH_TYPESCRIPT_URL || "http://localhost:2024",
     agnoUrl: process.env.AGNO_URL || "http://localhost:9001",
+    agnoAuthToken: process.env.AGNO_AUTH_TOKEN || "",
     llamaIndexUrl: process.env.LLAMA_INDEX_URL || "http://localhost:9000",
     crewAiUrl: process.env.CREW_AI_URL || "http://localhost:9002",
     agentSpecUrl: process.env.AGENT_SPEC_URL || "http://localhost:9003",

--- a/integrations/agno/typescript/README.md
+++ b/integrations/agno/typescript/README.md
@@ -29,6 +29,14 @@ const result = await agent.runAgent({
 });
 ```
 
+## Dojo
+
+To run the [dojo](https://github.com/ag-ui-protocol/ag-ui/tree/main/apps/dojo) against a secured AgentOS (e.g. `OS_SECURITY_KEY`, JWT middleware, or platform access tokens), set `AGNO_AUTH_TOKEN` — every agno request will then carry an `Authorization: Bearer` header:
+
+```bash
+AGNO_URL=http://localhost:9001 AGNO_AUTH_TOKEN=<your-key-or-token> pnpm dev
+```
+
 ## Features
 
 - **HTTP connectivity** – Direct connection to Agno agent servers

--- a/integrations/agno/typescript/README.md
+++ b/integrations/agno/typescript/README.md
@@ -31,7 +31,7 @@ const result = await agent.runAgent({
 
 ## Dojo
 
-To run the [dojo](https://github.com/ag-ui-protocol/ag-ui/tree/main/apps/dojo) against a secured AgentOS (e.g. `OS_SECURITY_KEY`, JWT middleware, or platform access tokens), set `AGNO_AUTH_TOKEN` — every agno request will then carry an `Authorization: Bearer` header:
+To run the [dojo](https://github.com/ag-ui-protocol/ag-ui/tree/main/apps/dojo) against a secured AgentOS (e.g. `OS_SECURITY_KEY`, JWT middleware, or platform access tokens), set `AGNO_AUTH_TOKEN` — every agno request will then carry an `Authorization: Bearer <token>` header:
 
 ```bash
 AGNO_URL=http://localhost:9001 AGNO_AUTH_TOKEN=<your-key-or-token> pnpm dev


### PR DESCRIPTION
## What

Adds an opt-in `AGNO_AUTH_TOKEN` env var to the dojo's agno integration. When set, every dojo→agno request carries `Authorization: Bearer <token>`. When unset, behavior is byte-identical to today.

Fixes #2130

## Why

Agno v2.7 ([agno-agi/agno#8747](https://github.com/agno-agi/agno/pull/8747)) put agno's AG-UI endpoint behind AgentOS's central auth middleware, so deployments using `OS_SECURITY_KEY`, JWT auth, or platform access tokens now return `401` to anonymous requests. The dojo builds its `AgnoAgent` instances from `AGNO_URL` alone — there is no way to attach a credential — which means the stock dojo cannot connect to *any* secured agno backend. This PR closes that gap with a single opt-in env var, while unsecured setups keep working exactly as before.

We chose this approach because the SDK already supports it end-to-end — no new machinery needed ([agno#8747 review](https://github.com/agno-agi/agno/pull/8747#discussion_r3535035220)):

> Note the SDK already supports this: HttpAgent (which AgnoAgent extends) accepts headers in its config […] We need to update the dojo demo app to add the env plumbing, which is a one-line change there.

## Design

- Follows the watsonx credential pattern ([#1665](https://github.com/ag-ui-protocol/ag-ui/pull/1665)): env var read in `env.ts` with an `|| ""` default, consumed in the `agents.ts` factory.
- No SDK or integration-package changes — `HttpAgent` already sends configured `headers` on every request; `@ag-ui/agno` stays a thin subclass.
- `agents.ts` is `server-only` and the var is not `NEXT_PUBLIC_`-prefixed, so the token never reaches the browser.

## Testing

No sidebar feature is added, so no new e2e suite per CONTRIBUTING. Verified instead (Node 22, pnpm 10.33.4):

| Check | Result |
|---|---|
| `pnpm run build` (nx, 34 projects) | ✅ pass |
| `pnpm generate-content-json` + `git diff --exit-code src/files.json` | ✅ unchanged |
| Root `pnpm run test` | ✅ 31/32 — sole failure is `@ag-ui/cross-language-tests`, which needs a local .NET SDK and fails identically on unmodified main |
| agno Playwright e2e (`tests/agnoTests`, 10 tests) with `AGNO_AUTH_TOKEN` unset | ✅ 10/10 — no-op regression proof |

Live against agno v2.7.0:

| Backend | Dojo | Result |
|---|---|---|
| `OS_SECURITY_KEY` set | no token | ❌ `HTTP 401 {"detail":"Authorization header required"}` |
| `OS_SECURITY_KEY` set | `AGNO_AUTH_TOKEN` set | ✅ chat streams normally |
| open (no key) | no token | ✅ identical to today |