### PR TITLE
chore(kotlin-sdk): add spec-compliant InputContent types (image/audio/video/document)

### DIFF
--- a/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Types.kt
+++ b/sdks/community/kotlin/library/core/src/commonMain/kotlin/com/agui/core/types/Types.kt
@@ -351,6 +351,95 @@ data class BinaryInputContent(
     }
 }
 
+// ============== Spec-Compliant Media Content Types ==============
+
+/**
+ * Base class for the source of spec-compliant media content (image/audio/video/document).
+ * Discriminated by the "type" field: "data" or "url".
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("type")
+sealed class InputContentSource
+
+/**
+ * Inline base64-encoded data source.
+ *
+ * @param value Base64-encoded content
+ * @param mimeType MIME type of the content (e.g., "image/png")
+ */
+@Serializable
+@SerialName("data")
+data class InputContentDataSource(
+    val value: String,
+    val mimeType: String
+) : InputContentSource()
+
+/**
+ * URL reference source.
+ *
+ * @param value URL pointing to the content
+ * @param mimeType Optional MIME type hint
+ */
+@Serializable
+@SerialName("url")
+data class InputContentUrlSource(
+    val value: String,
+    val mimeType: String? = null
+) : InputContentSource()
+
+/**
+ * An image in a multimodal user message.
+ *
+ * @param source The data or URL source for the image
+ * @param metadata Optional opaque metadata
+ */
+@Serializable
+@SerialName("image")
+data class ImageInputContent(
+    val source: InputContentSource,
+    val metadata: JsonElement? = null
+) : InputContent()
+
+/**
+ * Audio content in a multimodal user message.
+ *
+ * @param source The data or URL source for the audio
+ * @param metadata Optional opaque metadata
+ */
+@Serializable
+@SerialName("audio")
+data class AudioInputContent(
+    val source: InputContentSource,
+    val metadata: JsonElement? = null
+) : InputContent()
+
+/**
+ * Video content in a multimodal user message.
+ *
+ * @param source The data or URL source for the video
+ * @param metadata Optional opaque metadata
+ */
+@Serializable
+@SerialName("video")
+data class VideoInputContent(
+    val source: InputContentSource,
+    val metadata: JsonElement? = null
+) : InputContent()
+
+/**
+ * A document in a multimodal user message.
+ *
+ * @param source The data or URL source for the document
+ * @param metadata Optional opaque metadata
+ */
+@Serializable
+@SerialName("document")
+data class DocumentInputContent(
+    val source: InputContentSource,
+    val metadata: JsonElement? = null
+) : InputContent()
+
 
 /**
  * Represents a State - just a simple type alias at least for now

--- a/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InputContentSpecTest.kt
+++ b/sdks/community/kotlin/library/core/src/commonTest/kotlin/com/agui/tests/InputContentSpecTest.kt
@@ -1,0 +1,260 @@
+package com.agui.tests
+
+import com.agui.core.types.*
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+/**
+ * Verifies that the spec-compliant InputContent types (image/audio/video/document)
+ * round-trip correctly and produce JSON that matches @ag-ui/client output byte-for-byte.
+ */
+class InputContentSpecTest {
+
+    private val json = AgUiJson
+
+    // ── InputContentSource ───────────────────────────────────────────────────
+
+    @Test
+    fun testDataSourceRoundTrip() {
+        val src = InputContentDataSource(value = "SGVsbG8=", mimeType = "image/png")
+        val encoded = json.encodeToString(InputContentSource.serializer(), src)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("data", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("SGVsbG8=", obj["value"]?.jsonPrimitive?.content)
+        assertEquals("image/png", obj["mimeType"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContentSource.serializer(), encoded)
+        assertEquals(src, decoded)
+    }
+
+    @Test
+    fun testUrlSourceRoundTrip() {
+        val src = InputContentUrlSource(value = "https://example.com/img.png", mimeType = "image/png")
+        val encoded = json.encodeToString(InputContentSource.serializer(), src)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("url", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("https://example.com/img.png", obj["value"]?.jsonPrimitive?.content)
+        assertEquals("image/png", obj["mimeType"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContentSource.serializer(), encoded)
+        assertEquals(src, decoded)
+    }
+
+    @Test
+    fun testUrlSourceWithoutMimeType() {
+        val src = InputContentUrlSource(value = "https://example.com/doc.pdf")
+        val encoded = json.encodeToString(InputContentSource.serializer(), src)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("url", obj["type"]?.jsonPrimitive?.content)
+        // explicitNulls = false → mimeType absent when null
+        assertFalse(obj.containsKey("mimeType"))
+
+        val decoded = json.decodeFromString(InputContentSource.serializer(), encoded)
+        assertEquals(src, decoded)
+    }
+
+    // ── Spec media InputContent types ────────────────────────────────────────
+
+    @Test
+    fun testImageInputContentDataSource() {
+        val content = ImageInputContent(
+            source = InputContentDataSource(value = "SGVsbG8=", mimeType = "image/jpeg")
+        )
+        val encoded = json.encodeToString(InputContent.serializer(), content)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("image", obj["type"]?.jsonPrimitive?.content)
+        assertFalse(obj.containsKey("metadata"))
+
+        val source = obj["source"]?.jsonObject
+        assertNotNull(source)
+        assertEquals("data", source["type"]?.jsonPrimitive?.content)
+        assertEquals("SGVsbG8=", source["value"]?.jsonPrimitive?.content)
+        assertEquals("image/jpeg", source["mimeType"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContent.serializer(), encoded)
+        assertEquals(content, decoded)
+    }
+
+    @Test
+    fun testImageInputContentUrlSource() {
+        val content = ImageInputContent(
+            source = InputContentUrlSource(value = "https://example.com/photo.png", mimeType = "image/png"),
+            metadata = buildJsonObject { put("alt", "a photo") }
+        )
+        val encoded = json.encodeToString(InputContent.serializer(), content)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("image", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("a photo", obj["metadata"]?.jsonObject?.get("alt")?.jsonPrimitive?.content)
+
+        val source = obj["source"]?.jsonObject
+        assertNotNull(source)
+        assertEquals("url", source["type"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContent.serializer(), encoded)
+        assertEquals(content, decoded)
+    }
+
+    @Test
+    fun testAudioInputContent() {
+        val content = AudioInputContent(
+            source = InputContentDataSource(value = "UklGRg==", mimeType = "audio/wav")
+        )
+        val encoded = json.encodeToString(InputContent.serializer(), content)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("audio", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("data", obj["source"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContent.serializer(), encoded)
+        assertEquals(content, decoded)
+    }
+
+    @Test
+    fun testVideoInputContent() {
+        val content = VideoInputContent(
+            source = InputContentUrlSource(value = "https://example.com/clip.mp4", mimeType = "video/mp4")
+        )
+        val encoded = json.encodeToString(InputContent.serializer(), content)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("video", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("url", obj["source"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContent.serializer(), encoded)
+        assertEquals(content, decoded)
+    }
+
+    @Test
+    fun testDocumentInputContent() {
+        val content = DocumentInputContent(
+            source = InputContentDataSource(value = "JVBERi0=", mimeType = "application/pdf")
+        )
+        val encoded = json.encodeToString(InputContent.serializer(), content)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("document", obj["type"]?.jsonPrimitive?.content)
+        assertEquals("data", obj["source"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(InputContent.serializer(), encoded)
+        assertEquals(content, decoded)
+    }
+
+    // ── Multimodal UserMessage with spec types ────────────────────────────────
+
+    @Test
+    fun testMultimodalUserMessageWithImageAndText() {
+        val parts: List<InputContent> = listOf(
+            TextInputContent(text = "Describe this image:"),
+            ImageInputContent(
+                source = InputContentUrlSource(
+                    value = "https://example.com/chart.png",
+                    mimeType = "image/png"
+                )
+            )
+        )
+        val message = UserMessage.multimodal(id = "msg_spec_1", parts = parts)
+
+        val encoded = json.encodeToString<Message>(message)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        val contentArray = obj["content"]?.jsonArray
+        assertNotNull(contentArray)
+        assertEquals(2, contentArray.size)
+
+        assertEquals("text", contentArray[0].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals("image", contentArray[1].jsonObject["type"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<Message>(encoded) as UserMessage
+        assertTrue(decoded.isMultimodal)
+        assertEquals(2, decoded.contentParts?.size)
+        assertTrue(decoded.contentParts!![0] is TextInputContent)
+        assertTrue(decoded.contentParts!![1] is ImageInputContent)
+    }
+
+    @Test
+    fun testMultimodalUserMessageWithDocument() {
+        val parts: List<InputContent> = listOf(
+            TextInputContent(text = "Summarize this document:"),
+            DocumentInputContent(
+                source = InputContentDataSource(value = "JVBERi0=", mimeType = "application/pdf"),
+                metadata = buildJsonObject { put("filename", "report.pdf") }
+            )
+        )
+        val message = UserMessage.multimodal(id = "msg_spec_2", parts = parts)
+
+        val encoded = json.encodeToString<Message>(message)
+        val contentArray = json.parseToJsonElement(encoded).jsonObject["content"]?.jsonArray
+        assertNotNull(contentArray)
+
+        val docPart = contentArray[1].jsonObject
+        assertEquals("document", docPart["type"]?.jsonPrimitive?.content)
+        assertEquals("report.pdf", docPart["metadata"]?.jsonObject?.get("filename")?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString<Message>(encoded) as UserMessage
+        val docContent = decoded.contentParts!![1] as DocumentInputContent
+        assertEquals("application/pdf", (docContent.source as InputContentDataSource).mimeType)
+    }
+
+    // ── Deserialization from raw JSON (web client wire format) ────────────────
+
+    @Test
+    fun testDeserializeWebClientWireFormat() {
+        // Exact JSON shape that @ag-ui/client emits for a document message
+        val wireJson = """
+            [
+              {"type":"text","text":"Please review:"},
+              {"type":"document","source":{"type":"data","value":"JVBERi0=","mimeType":"application/pdf"},"metadata":{"title":"Q3 Report"}}
+            ]
+        """.trimIndent()
+
+        val parts = json.decodeFromString(ListSerializer(InputContent.serializer()), wireJson)
+        assertEquals(2, parts.size)
+
+        val text = parts[0] as TextInputContent
+        assertEquals("Please review:", text.text)
+
+        val doc = parts[1] as DocumentInputContent
+        val src = doc.source as InputContentDataSource
+        assertEquals("JVBERi0=", src.value)
+        assertEquals("application/pdf", src.mimeType)
+        assertEquals("Q3 Report", doc.metadata?.jsonObject?.get("title")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun testDeserializeImageUrlWireFormat() {
+        val wireJson = """
+            {"type":"image","source":{"type":"url","value":"https://cdn.example.com/img.webp"}}
+        """.trimIndent()
+
+        val content = json.decodeFromString(InputContent.serializer(), wireJson) as ImageInputContent
+        val src = content.source as InputContentUrlSource
+        assertEquals("https://cdn.example.com/img.webp", src.value)
+        assertNull(src.mimeType)
+        assertNull(content.metadata)
+    }
+
+    // ── Mixed legacy + spec types in one message ──────────────────────────────
+
+    @Test
+    fun testMixedLegacyAndSpecTypes() {
+        val parts: List<InputContent> = listOf(
+            TextInputContent(text = "Here are two attachments:"),
+            BinaryInputContent(mimeType = "image/png", url = "https://example.com/legacy.png"),
+            DocumentInputContent(source = InputContentDataSource(value = "abc=", mimeType = "text/plain"))
+        )
+        val message = UserMessage.multimodal(id = "mixed_msg", parts = parts)
+        val encoded = json.encodeToString<Message>(message)
+        val decoded = json.decodeFromString<Message>(encoded) as UserMessage
+
+        assertEquals(3, decoded.contentParts?.size)
+        assertTrue(decoded.contentParts!![0] is TextInputContent)
+        assertTrue(decoded.contentParts!![1] is BinaryInputContent)
+        assertTrue(decoded.contentParts!![2] is DocumentInputContent)
+    }
+}


### PR DESCRIPTION
Fixes Issue: https://github.com/ag-ui-protocol/ag-ui/issues/2133

## Summary

- Adds `InputContentSource` sealed class (`data` / `url` variants) mirroring the AG-UI spec `InputContentSourceSchema`
- Adds `ImageInputContent`, `AudioInputContent`, `VideoInputContent`, `DocumentInputContent` — each carrying `source: InputContentSource` and optional `metadata: JsonElement?`
- `BinaryInputContent` (legacy `type: "binary"`) is unchanged; all four new types coexist with it in the `InputContent` sealed hierarchy
- 13 new tests in `InputContentSpecTest` covering round-trips, wire-format deserialization matching `@ag-ui/client` output, and mixed legacy+spec arrays



## Test plan

- [x] `./gradlew :kotlin-core:jvmTest` passes (verified locally — all 13 new tests green, no regressions)
- [x] Spot-check: deserialize a raw `@ag-ui/client` multimodal message JSON with a `document` content part
- [x] Confirm `BinaryInputContent` existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
