### PR TITLE
fix(core): accept null parentMessageId on tool-call events

### DIFF
--- a/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  EventSchemas,
+  EventType,
+  ToolCallChunkEventSchema,
+  type ToolCallStartEvent,
+  type ToolCallStartEventProps,
+  ToolCallStartEventSchema,
+} from "../events";
+
+describe("ToolCallStartEventSchema — parentMessageId is optional and back-compat", () => {
+  it("parses an event with no parentMessageId", () => {
+    const parsed = ToolCallStartEventSchema.parse({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+    });
+    expect(parsed.parentMessageId).toBeUndefined();
+  });
+
+  it("accepts an explicit `parentMessageId: null` and normalizes it to undefined", () => {
+    // Cross-language back-compat: the .NET Microsoft Agent Framework adapter
+    // (System.Text.Json) serializes the optional `parentMessageId` as JSON
+    // `null` rather than omitting it. Treating null as "field omitted" keeps
+    // .NET→TS wire interop working instead of aborting the run on the first
+    // tool call.
+    const parsed = ToolCallStartEventSchema.parse({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+      parentMessageId: null,
+    });
+    expect(parsed.parentMessageId).toBeUndefined();
+  });
+
+  it("preserves a real string parentMessageId", () => {
+    const parsed = ToolCallStartEventSchema.parse({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+      parentMessageId: "msg-1",
+    });
+    expect(parsed.parentMessageId).toBe("msg-1");
+  });
+
+  it("normalizes `parentMessageId: null` through the EventSchemas union", () => {
+    // EventSchemas is what the HTTP transport validates each streamed event
+    // against — the exact path that surfaced the null in the wild.
+    const parsed = EventSchemas.parse({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+      parentMessageId: null,
+    });
+    expect(parsed.type).toBe(EventType.TOOL_CALL_START);
+    if (parsed.type === EventType.TOOL_CALL_START) {
+      expect(parsed.parentMessageId).toBeUndefined();
+    }
+  });
+});
+
+describe("ToolCallChunkEventSchema — parentMessageId accepts null", () => {
+  it("accepts an explicit `parentMessageId: null` and normalizes it to undefined", () => {
+    const parsed = ToolCallChunkEventSchema.parse({
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: "tc-1",
+      parentMessageId: null,
+    });
+    expect(parsed.parentMessageId).toBeUndefined();
+  });
+});
+
+describe("ToolCallStart — public type contract is not broken (compile-time)", () => {
+  it("keeps the consumer (output) type identical and only widens the input", () => {
+    // The `const x: Type = {...}` annotations below are the assertion — they are
+    // checked by `tsc`, so any breaking change to the inferred type fails the
+    // build, not just this runtime assert.
+
+    // Consumer/output type (`z.infer`) is UNCHANGED: `parentMessageId` stays an
+    // OPTIONAL key (omittable) whose value is `string | undefined` — never null.
+    const consumerOmits: ToolCallStartEvent = {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+    };
+    const read: string | undefined = consumerOmits.parentMessageId;
+    expect(read).toBeUndefined();
+
+    // Construction/props type (`z.input`) only WIDENS — `null` is now accepted
+    // ALONGSIDE the previously-valid string and omitted forms. This is additive:
+    // every input that compiled before still compiles.
+    const propsWithNull: ToolCallStartEventProps = {
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+      parentMessageId: null,
+    };
+    const propsWithString: ToolCallStartEventProps = {
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+      parentMessageId: "msg-1",
+    };
+    const propsOmitted: ToolCallStartEventProps = {
+      toolCallId: "tc-1",
+      toolCallName: "get_weather",
+    };
+    expect(propsWithNull.parentMessageId).toBeNull();
+    expect(propsWithString.parentMessageId).toBe("msg-1");
+    expect(propsOmitted.parentMessageId).toBeUndefined();
+  });
+});

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -122,7 +122,15 @@ export const ToolCallStartEventSchema = BaseEventSchema.extend({
   type: z.literal(EventType.TOOL_CALL_START),
   toolCallId: z.string(),
   toolCallName: z.string(),
-  parentMessageId: z.string().optional(),
+  // Accept `null` and treat it as omitted, so producers that serialize optional
+  // fields as JSON `null` (e.g. the .NET Microsoft Agent Framework adapter,
+  // whose System.Text.Json emits `"parentMessageId": null`) still validate
+  // instead of aborting the run on the first tool call.
+  parentMessageId: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? undefined),
 });
 
 export const ToolCallArgsEventSchema = BaseEventSchema.extend({
@@ -148,7 +156,12 @@ export const ToolCallChunkEventSchema = BaseEventSchema.extend({
   type: z.literal(EventType.TOOL_CALL_CHUNK),
   toolCallId: z.string().optional(),
   toolCallName: z.string().optional(),
-  parentMessageId: z.string().optional(),
+  // Accept `null` as omitted — same cross-language quirk as TOOL_CALL_START.
+  parentMessageId: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? undefined),
   delta: z.string().optional(),
 });
 
@@ -243,7 +256,9 @@ export const RunFinishedEventSchema = BaseEventSchema.extend({
   // Accept `null` and treat it as omitted, so producers like the Pydantic-based
   // Python SDK that serialize via `model_dump()` (without `exclude_none=True`)
   // and emit `"outcome": null` for the legacy no-outcome case still validate.
-  outcome: RunFinishedOutcomeSchema.nullable().optional().transform((v) => v ?? undefined),
+  outcome: RunFinishedOutcomeSchema.nullable()
+    .optional()
+    .transform((v) => v ?? undefined),
 });
 
 export const RunErrorEventSchema = BaseEventSchema.extend({


### PR DESCRIPTION
## Problem

`ToolCallStartEventSchema` and `ToolCallChunkEventSchema` declare `parentMessageId` as `z.string().optional()`, which accepts an *omitted* field but rejects JSON `null`. Cross-language producers that serialize absent optional fields as `null` (rather than omitting them) therefore fail validation.

Concrete case: the **.NET Microsoft Agent Framework** adapter (System.Text.Json) emits `"parentMessageId": null` on `TOOL_CALL_START`, so `HttpAgent`'s per-event re-validation throws on the first tool call —

```
invalid_type — expected "string", received "null", path: ["parentMessageId"]
```

— and the entire run aborts. Reported downstream in CopilotKit/CopilotKit#2788.

## Fix

Accept `null` and normalize it to `undefined`, exactly mirroring the existing `RunFinishedEvent.outcome` fix in this same file (added for the Python SDK's `model_dump()` emitting `null`):

```ts
parentMessageId: z.string().nullable().optional().transform((v) => v ?? undefined),
```

Applied to both `ToolCallStartEventSchema` and `ToolCallChunkEventSchema`.

## No breaking changes to the API contract

- **Output type is identical.** `z.infer` keeps `parentMessageId` an *optional* key valued `string | undefined` — the transform strips `null` before it reaches consumers.
- **Input/props type only widens.** `z.input` (and therefore `ToolCallStartEventProps`) now *also* accepts `null`, alongside the previously-valid string/omitted forms. Purely additive — every input that compiled before still compiles.
- **Runtime back-compat.** `omitted → undefined` and `string → string` are unchanged; `null → undefined` is the only new behavior (it previously threw). Discriminated-union parsing via `EventSchemas` is intact.

A compile-time contract test pins both the output and input types so any future regression fails the build.

## Tests

Adds `sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts`: null normalization (both events + through the `EventSchemas` union that surfaced the bug in the wild), string preservation, omitted, and the type-contract guard. Full `@ag-ui/core` suite: **119 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)