### PR TITLE
fix(aws-strands): forward plugins to per-thread agents

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -22,6 +22,10 @@ from strands.session import SessionManager
 # "session_manager" is excluded: it is supplied per-thread via
 # StrandsAgentConfig.session_manager_provider (see run()). Forwarding a
 # template-level session_manager would make every thread share one session_id.
+# "plugins" is excluded: Strands consumes the plugin list during init and
+# retains only a _plugin_registry — the original objects are not stored as
+# self.plugins/self._plugins, so they cannot be auto-extracted. They are
+# supplied per-thread via the explicit StrandsAgent(plugins=...) kwarg.
 _AGUI_EXPLICIT_PARAMS = {
     "self",
     "model",
@@ -30,6 +34,7 @@ _AGUI_EXPLICIT_PARAMS = {
     "messages",
     "hooks",
     "session_manager",
+    "plugins",
 }
 
 
@@ -280,6 +285,7 @@ class StrandsAgent:
         description: str = "",
         config: "StrandsAgentConfig | None" = None,
         hooks: "list | None" = None,
+        plugins: "list | None" = None,
     ):
         # Store template agent configuration for creating fresh instances
         self._model = agent.model
@@ -303,6 +309,26 @@ class StrandsAgent:
         # the caller and forward them to every per-thread instance so any
         # observability / loop-cap / policy-enforcement hook actually fires.
         self._hooks = list(hooks) if hooks else []
+
+        # Strands plugins forwarded to each per-thread StrandsAgentCore.
+        #
+        # Same rationale as ``hooks`` above: ``plugins`` is a valid
+        # ``Agent.__init__`` parameter, but Strands consumes the list during
+        # init — registering each plugin's tools and hooks into the agent's
+        # registries — and stores only a ``_plugin_registry``. The original
+        # list of plugin objects is not retained as ``self.plugins`` /
+        # ``self._plugins``, so ``_extract_agent_kwargs`` cannot recover it
+        # from the template. The template Agent never serves a request, so a
+        # plugin registered there never runs its ``init_agent`` /
+        # before-invocation hooks on the per-thread agents that do. This
+        # silently breaks plugins whose behavior depends on those hooks — e.g.
+        # ``AgentSkills``, whose skill metadata is injected and whose
+        # filesystem skills are loaded in ``init_agent``; without forwarding,
+        # its activation tool leaks through (tools ARE copied) but reports
+        # "skill not found" because no skills were ever loaded. We therefore
+        # take plugins directly from the caller and forward them to every
+        # per-thread instance.
+        self._plugins = list(plugins) if plugins else []
 
         self.name = name
         self.description = description
@@ -421,6 +447,12 @@ class StrandsAgent:
                     core_kwargs = dict(self._agent_kwargs)
                     if self._hooks:
                         core_kwargs["hooks"] = list(self._hooks)
+                    # Same falsy-omission rule as ``hooks``: only forward
+                    # ``plugins`` when the caller supplied some, so we never
+                    # pass ``plugins=None`` / ``plugins=[]`` (which a future
+                    # StrandsAgentCore could interpret as "disable defaults").
+                    if self._plugins:
+                        core_kwargs["plugins"] = list(self._plugins)
                     self._agents_by_thread[thread_id] = StrandsAgentCore(
                         model=self._model,
                         system_prompt=self._system_prompt,

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -65,7 +65,7 @@ _UNTESTABLE_VIA_SENTINEL = {
     "tools",              # handled via tool_registry
     "system_prompt",      # handled explicitly
     "session_manager",    # excluded; see StrandsAgentConfig.session_manager_provider
-    "plugins",            # stored as _plugin_registry, not forwarded
+    "plugins",            # explicit StrandsAgent(plugins=...) kwarg; see test_template_plugins_preservation
     "structured_output_model",  # template Agent rejects a MagicMock sentinel here
     "trace_attributes",         # Strands merges into a dict, losing sentinel identity
 }

--- a/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
+++ b/integrations/aws-strands/python/tests/test_template_plugins_preservation.py
@@ -1,0 +1,187 @@
+"""Tests that plugins passed to the adapter are forwarded to per-thread instances.
+
+The StrandsAgent adapter constructs a fresh ``strands.Agent`` per ``thread_id``
+from a template Agent. ``plugins`` is a valid ``Agent.__init__`` parameter, but
+Strands consumes the list during init (registering each plugin's tools and
+hooks) and retains only a ``_plugin_registry`` — the original plugin objects
+are not stored as ``self.plugins`` / ``self._plugins``, so
+``_extract_agent_kwargs`` cannot recover them from the template. The template
+Agent never serves a request, so a plugin registered there never runs its
+``init_agent`` / before-invocation hooks on the per-thread agents that do.
+
+This silently breaks plugins whose behavior lives in those hooks — most
+visibly ``AgentSkills``, whose ``skills`` activation tool leaks through
+(tools ARE copied) but reports "skill not found" because no skills were ever
+loaded (loading happens in ``init_agent``).
+
+Each test below is written to FAIL on the pre-fix code (plugins dropped) and
+PASS once plugins are forwarded to per-thread instances via the explicit
+``StrandsAgent(plugins=...)`` kwarg. Mirrors ``test_template_hooks_preservation.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ag_ui.core import RunErrorEvent
+from strands import Agent
+from strands.models.model import Model
+from strands.plugins import Plugin
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+
+
+def _mock_model():
+    """Build a spec'd Model mock so Strands' isinstance checks succeed."""
+    m = MagicMock(spec=Model)
+    m.stateful = False
+    return m
+
+
+def _run_input(thread_id: str = "t1"):
+    from ag_ui.core import RunAgentInput, UserMessage
+
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hello")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+class _CapturingCore:
+    """Replacement for StrandsAgentCore that records constructor kwargs."""
+
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.tool_registry = ToolRegistry()
+
+    async def stream_async(self, _msg: str, **_kwargs):
+        if False:
+            yield
+
+
+async def _drive_run(ag: StrandsAgent, thread_id: str):
+    events = []
+    async for ev in ag.run(_run_input(thread_id)):
+        events.append(ev)
+        if thread_id in ag._agents_by_thread:
+            break
+    return events
+
+
+async def _trigger_thread_creation(ag: StrandsAgent, thread_id: str):
+    """Drive ag.run() until the per-thread agent is constructed."""
+    events = await _drive_run(ag, thread_id)
+    run_errors = [ev for ev in events if isinstance(ev, RunErrorEvent)]
+    assert not run_errors, (
+        f"ag.run() emitted RunErrorEvent(s) before per-thread agent was "
+        f"constructed for thread_id={thread_id!r}: {run_errors!r}."
+    )
+    instance = ag._agents_by_thread.get(thread_id)
+    assert instance is not None, (
+        f"per-thread agent for thread_id={thread_id!r} was not created by "
+        f"ag.run(); _agents_by_thread keys={list(ag._agents_by_thread)!r}."
+    )
+    return instance
+
+
+class _InitCountingPlugin(Plugin):
+    """Minimal plugin that records how many agents it was initialized on.
+
+    ``init_agent`` is invoked by Strands' plugin registry once per agent the
+    plugin is attached to. Counting those calls proves the plugin was not just
+    forwarded as a kwarg but actually wired into each per-thread agent.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.init_count = 0
+
+    @property
+    def name(self) -> str:
+        return "init-counting-plugin"
+
+    def init_agent(self, agent) -> None:
+        self.init_count += 1
+
+
+@pytest.mark.asyncio
+async def test_template_plugins_forwarded_to_per_thread_agent():
+    """Plugins passed to StrandsAgent(plugins=...) must be forwarded to every
+    per-thread StrandsAgentCore instance.
+
+    Without it, any plugin whose behavior lives in init_agent /
+    before-invocation hooks (e.g. AgentSkills) silently never runs, because
+    only per-thread agents serve requests, not the template.
+    """
+    plugin = _InitCountingPlugin()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" in instance.init_kwargs, (
+        "plugins kwarg not passed to per-thread StrandsAgentCore — "
+        "any Plugin registered on the wrapper will never run its hooks."
+    )
+    assert plugin in instance.init_kwargs["plugins"], (
+        f"plugin missing from per-thread plugins list; "
+        f"got {instance.init_kwargs.get('plugins')}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "plugins_value,label",
+    [
+        (None, "plugins kwarg omitted (plugins=None default)"),
+        ([], "explicit empty list (plugins=[])"),
+    ],
+    ids=["default-none", "explicit-empty-list"],
+)
+async def test_no_plugins_kwarg_is_omitted_for_falsy_input(plugins_value, label):
+    """When the caller supplies no plugins (omitting the kwarg or passing []),
+    the wrapper must omit the ``plugins`` kwarg entirely when constructing each
+    per-thread StrandsAgentCore — not forward ``None`` / ``[]``, which a future
+    Strands version might interpret as "disable defaults"."""
+    template = Agent(model=_mock_model())
+    kwargs = {} if plugins_value is None else {"plugins": plugins_value}
+    ag = StrandsAgent(template, name="test", **kwargs)
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" not in instance.init_kwargs, (
+        f"[{label}] expected 'plugins' kwarg to be OMITTED from "
+        f"StrandsAgentCore(**kwargs), but it was forwarded with value "
+        f"{instance.init_kwargs.get('plugins')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plugins_init_agent_fires_per_thread_with_real_core():
+    """Against the real strands.Agent: a plugin passed via
+    StrandsAgent(plugins=[...]) must have its ``init_agent`` invoked once per
+    per-thread agent — proving the plugin is genuinely wired into each thread,
+    not just forwarded as a kwarg."""
+    plugin = _InitCountingPlugin()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    # Real StrandsAgentCore (no patch): each per-thread construction runs the
+    # plugin registry, which calls plugin.init_agent(agent) exactly once.
+    await _trigger_thread_creation(ag, "thread-a")
+    await _trigger_thread_creation(ag, "thread-b")
+
+    assert plugin.init_count == 2, (
+        f"expected plugin.init_agent() to fire once per per-thread agent "
+        f"(2 threads); got {plugin.init_count}. Either the plugins kwarg "
+        "wasn't forwarded, or Strands changed its plugin-registry semantics."
+    )

--- a/integrations/aws-strands/python/uv.lock
+++ b/integrations/aws-strands/python/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.12, <3.14"
 
 [[package]]
 name = "ag-ui-a2ui-toolkit"
-version = "0.0.3"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/b1/ea7ad7f0b3d1b20388d072ffbe4416577b4d4ab5471d45dfc04791a91602/ag_ui_a2ui_toolkit-0.0.3.tar.gz", hash = "sha256:468f25473ac00d098878da54c0069b7fa27dc63b4c1ff61315d4349a324c2fb7", size = 14785, upload-time = "2026-06-09T06:18:18.163Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ce/85f3960a83d962e5690bc0f27a3baf3bf1602edc2b0603085928c964ea14/ag_ui_a2ui_toolkit-0.0.4.tar.gz", hash = "sha256:172e2724e53df8173685a3fb896a6e5175eea06e1dc166c715db110ba4beba76", size = 18960, upload-time = "2026-06-17T13:34:28.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/75/fc87bdf81bb1bf6d0fac09179e8bb17807d1bc5b3c0e8640f32e843b0857/ag_ui_a2ui_toolkit-0.0.3-py3-none-any.whl", hash = "sha256:e0354bd361c09f342fbe671cf870cbd19fdcb1b27e7a5bb2d8a392a4f00c2ba9", size = 16739, upload-time = "2026-06-09T06:18:17.316Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7a/acf85b01cd996bd011b71e181fd9f3daff5396fc3b7d78ba9445bfc08ecf/ag_ui_a2ui_toolkit-0.0.4-py3-none-any.whl", hash = "sha256:236fc511e1ec2399bcda0c14a109b3fb0a0c3e3988c18ef1918745b1c1535e30", size = 21315, upload-time = "2026-06-17T13:34:29.505Z" },
 ]
 
 [[package]]
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ag-ui-strands"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-a2ui-toolkit" },
@@ -41,7 +41,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.3" },
+    { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.4" },
     { name = "ag-ui-protocol", specifier = ">=0.1.18" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "strands-agents", specifier = ">=1.15.0" },
@@ -649,6 +649,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -762,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.18.0"
+version = "1.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -774,12 +802,13 @@ dependencies = [
     { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/58/08665fc8d5330fc32727793c39ad019f6cc3f75272ede3629dd67b4fe6a5/strands_agents-1.18.0.tar.gz", hash = "sha256:85bd251d50de5d441cc2578068b4656ca86bdbaa1764e292d56b0edf0cf54c52", size = 521216, upload-time = "2025-11-21T21:30:26.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/05/5eb8431ff340739b1c21b0da7d19ec9604b9c4953a1c4638df915321573c/strands_agents-1.47.0.tar.gz", hash = "sha256:97770cb6beb6e5fd1a58849f41201eb7edb43fd67ad3de6544ada2f342c2bcf0", size = 1157139, upload-time = "2026-07-10T14:45:05.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/37/79c63bf7ac194754748fc42b5c9fb8f964dc742d92c19052e6cc74fede39/strands_agents-1.18.0-py3-none-any.whl", hash = "sha256:c9cf9662b24344413d204a7ee60d3e3ab88791568e9f572020901eb3df9b6b5e", size = 255594, upload-time = "2025-11-21T21:30:24.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/ceae892c5823bea9254160efc02a4553f2ced9d183676110c03c3a9ff0f3/strands_agents-1.47.0-py3-none-any.whl", hash = "sha256:1f6ce17404ff02079244ad7a4a180a2a7150546275e4b91187d71472ba8fe3f2", size = 600611, upload-time = "2026-07-10T14:45:03.942Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #2129


### Problem

`StrandsAgent` builds a fresh `strands.Agent` per `thread_id` from a template
Agent, copying constructor params via `_extract_agent_kwargs`. `plugins` is a
valid `Agent.__init__` parameter, but Strands **consumes** the plugin list
during init (registering each plugin's tools and hooks) and retains only a
`_plugin_registry` — the original plugin objects are **not** stored as
`self.plugins` / `self._plugins`, so `_extract_agent_kwargs` cannot recover
them from the template.

The template Agent never serves a request, so a plugin registered on it never
runs its `init_agent` / before-invocation hooks on the per-thread agents that
actually do. This silently breaks any plugin whose behavior lives in those
hooks.

**Most visible symptom — `AgentSkills`:** the plugin's `skills` activation
tool leaks through to per-thread agents (tools ARE copied), so the model sees
the tool and calls it, but every activation returns `Skill '<name>' not found.
Available skills:` (empty) — because skill loading happens in `init_agent`,
which never ran on the per-thread agent. The skill metadata is also never
injected into the per-thread system prompt.

This mirrors the exact class of bug already fixed for `hooks` in this adapter.

### Fix

Same shape as the existing `hooks` handling:

1. Add an explicit `plugins: list | None = None` kwarg to `StrandsAgent.__init__`.
2. Add `"plugins"` to `_AGUI_EXPLICIT_PARAMS` so it is not auto-extracted from
   the template (it can't be — see above).
3. Forward `plugins` to every per-thread `StrandsAgentCore`, omitting the
   kwarg when falsy (same rule as `hooks`, so we never pass `plugins=None` /
   `plugins=[]` which a future Strands could read as "disable defaults").

### Usage after the fix

```python
from strands import Agent, AgentSkills
from ag_ui_strands import StrandsAgent

template = Agent(model=..., system_prompt=..., tools=[...])
adapter = StrandsAgent(
    template, name="my-agent",
    plugins=[AgentSkills(skills="./skills/")],   # now forwarded per-thread
)
```

### Tests

Adds `tests/test_template_plugins_preservation.py` (mirrors
`test_template_hooks_preservation.py`):

- forwarding: a plugin passed to `StrandsAgent(plugins=[...])` appears in the
  per-thread `StrandsAgentCore` kwargs;
- falsy-omission: `plugins=None` / `plugins=[]` → kwarg omitted entirely
  (parametrized);
- real-core: against the real `strands.Agent`, the plugin's `init_agent` fires
  **once per thread** (proves genuine wiring, not just kwarg plumbing).

All three fail on pre-fix code and pass after. Updates one comment in
`test_template_agent_propagation.py` (`plugins` is now forwarded via explicit
kwarg rather than "not forwarded").

Full existing suite: no new failures introduced by this change.
(Note: `test_template_param_round_trips[interventions]` fails on current `main`
independent of this PR — a newer Strands `Agent` param the sentinel test
doesn't yet handle.)

### CONTRIBUTING note

The guide asks to file an issue first for non-trivial work. Suggest opening a
short issue ("aws-strands Python: plugins dropped on per-thread agents; breaks
AgentSkills") and linking this PR, or ask a code owner to assign.

---

## How to push (from a machine with GitHub auth)

Two artifacts in this dir:

- `0001-forward-plugins.patch` — `git format-patch` output
- `plugins-fix.bundle` — git bundle carrying the branch

**Option A — apply the patch onto a fresh clone of your fork:**
```bash
git clone git@github.com:<you>/ag-ui.git && cd ag-ui
git checkout -b fix/aws-strands-forward-plugins
git am /path/to/0001-forward-plugins.patch
git push -u origin fix/aws-strands-forward-plugins
gh pr create --repo ag-ui-protocol/ag-ui --title "fix(aws-strands): forward plugins to per-thread agents" --body-file PR.md
```

**Option B — pull the branch from the bundle:**
```bash
cd ag-ui   # your fork clone
git fetch /path/to/plugins-fix.bundle fix/aws-strands-forward-plugins:fix/aws-strands-forward-plugins
git push -u origin fix/aws-strands-forward-plugins
```

**Verify before pushing:**
```bash
cd integrations/aws-strands/python
uv venv --python 3.12 .venv && source .venv/bin/activate
uv pip install -e . pytest pytest-asyncio
python -m pytest tests/test_template_plugins_preservation.py -q   # 4 passed
```