### PR TITLE
fix(go-sdk): add optional name to TEXT_MESSAGE_START/CHUNK events

### DIFF
--- a/sdks/community/go/pkg/core/events/additional_events_test.go
+++ b/sdks/community/go/pkg/core/events/additional_events_test.go
@@ -70,6 +70,14 @@ func TestTextMessageChunkEvent(t *testing.T) {
 		assert.Equal(t, messageID, *event.MessageID)
 		assert.Equal(t, role, *event.Role)
 		assert.Equal(t, delta, *event.Delta)
+		assert.Nil(t, event.Name)
+	})
+
+	t.Run("WithChunkName", func(t *testing.T) {
+		event := NewTextMessageChunkEvent(nil, nil, nil).WithChunkName("research-agent")
+
+		assert.NotNil(t, event.Name)
+		assert.Equal(t, "research-agent", *event.Name)
 	})
 
 	t.Run("Validate", func(t *testing.T) {
@@ -88,6 +96,10 @@ func TestTextMessageChunkEvent(t *testing.T) {
 		// Valid - messageID without delta is allowed for chunks
 		event = NewTextMessageChunkEvent(&messageID, nil, nil)
 		assert.NoError(t, event.Validate())
+
+		// Valid - name alone is enough to identify the author of a chunk
+		event = NewTextMessageChunkEvent(nil, nil, nil).WithChunkName("research-agent")
+		assert.NoError(t, event.Validate())
 	})
 
 	t.Run("ToJSON", func(t *testing.T) {
@@ -95,7 +107,7 @@ func TestTextMessageChunkEvent(t *testing.T) {
 		role := "assistant"
 		delta := "Hello world"
 
-		event := NewTextMessageChunkEvent(&messageID, &role, &delta)
+		event := NewTextMessageChunkEvent(&messageID, &role, &delta).WithChunkName("research-agent")
 
 		jsonData, err := event.ToJSON()
 		require.NoError(t, err)
@@ -108,6 +120,28 @@ func TestTextMessageChunkEvent(t *testing.T) {
 		assert.Equal(t, "msg-123", decoded["messageId"])
 		assert.Equal(t, "assistant", decoded["role"])
 		assert.Equal(t, "Hello world", decoded["delta"])
+		assert.Equal(t, "research-agent", decoded["name"])
+
+		// Omitted name stays off the wire
+		event = NewTextMessageChunkEvent(&messageID, &role, &delta)
+		jsonData, err = event.ToJSON()
+		require.NoError(t, err)
+
+		decoded = map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(jsonData, &decoded))
+		_, hasName := decoded["name"]
+		assert.False(t, hasName, "expected \"name\" to be omitted when unset")
+	})
+
+	t.Run("DecodeRoundTrip", func(t *testing.T) {
+		raw := []byte(`{"type":"TEXT_MESSAGE_CHUNK","messageId":"msg-123","role":"assistant","delta":"Hello","name":"research-agent"}`)
+
+		var decoded TextMessageChunkEvent
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+
+		require.NotNil(t, decoded.Name)
+		assert.Equal(t, "research-agent", *decoded.Name)
+		assert.NoError(t, decoded.Validate())
 	})
 }
 

--- a/sdks/community/go/pkg/core/events/events_test.go
+++ b/sdks/community/go/pkg/core/events/events_test.go
@@ -239,12 +239,35 @@ func TestMessageEvents(t *testing.T) {
 		assert.Equal(t, EventTypeTextMessageStart, event.Type())
 		assert.Equal(t, messageID, event.MessageID)
 		assert.Equal(t, &role, event.Role)
+		assert.Empty(t, event.Name)
 		assert.NoError(t, event.Validate())
 
 		// Test without role
 		event2 := NewTextMessageStartEvent(messageID)
 		assert.Nil(t, event2.Role)
 		assert.NoError(t, event2.Validate())
+
+		// Test with name
+		name := "research-agent"
+		event3 := NewTextMessageStartEvent(messageID, WithRole("assistant"), WithName(name))
+		assert.Equal(t, name, event3.Name)
+		assert.NoError(t, event3.Validate())
+
+		jsonData, err := event3.ToJSON()
+		require.NoError(t, err)
+
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal(jsonData, &decoded))
+		assert.Equal(t, name, decoded["name"])
+
+		// Test that omitting the name keeps it off the wire
+		jsonData, err = event2.ToJSON()
+		require.NoError(t, err)
+
+		decoded = map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(jsonData, &decoded))
+		_, hasName := decoded["name"]
+		assert.False(t, hasName, "expected \"name\" to be omitted when unset")
 
 		// Test validation error
 		event.MessageID = ""

--- a/sdks/community/go/pkg/core/events/message_events.go
+++ b/sdks/community/go/pkg/core/events/message_events.go
@@ -10,6 +10,7 @@ type TextMessageStartEvent struct {
 	*BaseEvent
 	MessageID string  `json:"messageId"`
 	Role      *string `json:"role,omitempty"`
+	Name      string  `json:"name,omitempty"`
 }
 
 // NewTextMessageStartEvent creates a new text message start event
@@ -33,6 +34,13 @@ type TextMessageStartOption func(*TextMessageStartEvent)
 func WithRole(role string) TextMessageStartOption {
 	return func(e *TextMessageStartEvent) {
 		e.Role = &role
+	}
+}
+
+// WithName sets the sender name for the message (e.g. a sub-agent author).
+func WithName(name string) TextMessageStartOption {
+	return func(e *TextMessageStartEvent) {
+		e.Name = name
 	}
 }
 
@@ -192,6 +200,7 @@ type TextMessageChunkEvent struct {
 	MessageID *string `json:"messageId,omitempty"`
 	Role      *string `json:"role,omitempty"`
 	Delta     *string `json:"delta,omitempty"`
+	Name      *string `json:"name,omitempty"`
 }
 
 // NewTextMessageChunkEvent creates a new text message chunk event
@@ -222,6 +231,12 @@ func (e *TextMessageChunkEvent) WithChunkDelta(delta string) *TextMessageChunkEv
 	return e
 }
 
+// WithChunkName sets the sender name for the chunk.
+func (e *TextMessageChunkEvent) WithChunkName(name string) *TextMessageChunkEvent {
+	e.Name = &name
+	return e
+}
+
 // Validate validates the text message chunk event
 func (e *TextMessageChunkEvent) Validate() error {
 	if err := e.BaseEvent.Validate(); err != nil {
@@ -229,8 +244,8 @@ func (e *TextMessageChunkEvent) Validate() error {
 	}
 
 	// At least one field should be present
-	if e.MessageID == nil && e.Role == nil && e.Delta == nil {
-		return fmt.Errorf("TextMessageChunkEvent validation failed: at least one of messageId, role, or delta must be present")
+	if e.MessageID == nil && e.Role == nil && e.Delta == nil && e.Name == nil {
+		return fmt.Errorf("TextMessageChunkEvent validation failed: at least one of messageId, role, delta, or name must be present")
 	}
 
 	return nil


### PR DESCRIPTION
# fix(go-sdk): add optional `name` to `TEXT_MESSAGE_START` / `TEXT_MESSAGE_CHUNK` events

Fixes #2142

## Summary

Brings the Go community SDK in line with the canonical AG-UI protocol as defined in TypeScript (`@ag-ui/core`) and Python (`ag_ui.core`), both of which already carry an optional `name` on `TEXT_MESSAGE_START` and `TEXT_MESSAGE_CHUNK`.

Without this field, Go servers cannot identify the sub-agent that authored a live streaming message — a critical piece of context when a root agent delegates to sub-agents and the UI needs to label the stream with the correct author instead of an anonymous "assistant". Today this forces downstream projects to either omit author on live streams (worse UX than history, which already carries `types.Message.Name`) or ship a local shim that reimplements `ToJSON` / `MarshalJSON` until upstream catches up.

Cross-SDK parity after this change:

| Surface                    | TypeScript     | Python                | Go community SDK |
| -------------------------- | -------------- | --------------------- | ---------------- |
| `Message.name`             | yes            | yes                   | yes              |
| `TEXT_MESSAGE_START.name`  | yes (optional) | yes (`Optional[str]`) | **yes (this PR)** |
| `TEXT_MESSAGE_CHUNK.name`  | yes (optional) | yes (`Optional[str]`) | **yes (this PR)** |

## Changes

All changes are contained in `sdks/community/go/pkg/core/events`:

- **`message_events.go`**
  - `TextMessageStartEvent` gains `Name string` with `json:"name,omitempty"`.
  - New `WithName(name string) TextMessageStartOption` alongside `WithRole` / `WithAutoMessageID`.
  - `TextMessageChunkEvent` gains `Name *string` with `json:"name,omitempty"` — pointer style, consistent with the struct's other optional fields (`MessageID` / `Role` / `Delta`).
  - New fluent setter `(*TextMessageChunkEvent).WithChunkName(name string) *TextMessageChunkEvent`, matching the existing `WithChunk*` group.
  - `TextMessageChunkEvent.Validate` now accepts a chunk carrying only `name` (previously required at least one of `messageId` / `role` / `delta`), mirroring TS/Python where all four chunk fields are optional.

- **`events_test.go`** — `TestMessageEvents/TextMessageStartEvent` extended with `WithName` construction, `ToJSON` round-trip when name is set, and assertion that `"name"` is omitted from the wire JSON when unset.

- **`additional_events_test.go`** — `TestTextMessageChunkEvent` extended with:
  - a new `WithChunkName` sub-test,
  - a `Validate` case for a name-only chunk,
  - a `ToJSON` case with `"name"` set and a negative case confirming omission,
  - a new `DecodeRoundTrip` sub-test that `json.Unmarshal`s a wire blob containing `"name"` into `TextMessageChunkEvent` — exercising the pathway used by `decoder.go` and `encoding/json/json_decoder.go`.

## Backwards compatibility

- `NewTextMessageChunkEvent(messageID, role, delta)` signature is intentionally unchanged. Author tagging on chunks is opt-in via `.WithChunkName(...)`.
- Existing call sites in `events_test.go` and `additional_events_test.go` continue to compile and pass unchanged.
- `Validate` becomes strictly more permissive (accepts one additional field), so no previously-valid chunk becomes invalid.

## Wire format

Identical to TypeScript and Python — camelCase `"name"`, omitted when unset:

```json
{ "type": "TEXT_MESSAGE_START", "messageId": "msg-1", "role": "assistant", "name": "research-agent" }
{ "type": "TEXT_MESSAGE_CHUNK", "messageId": "msg-1", "delta": "hi",       "name": "research-agent" }
```

The two decoders (`events/decoder.go`, `encoding/json/json_decoder.go`) already `json.Unmarshal` into these structs, so the new tag flows through without any additional plumbing.

Canonical references:

- TypeScript: `sdks/typescript/packages/core/src/events.ts` — `TextMessageStartEventSchema` and `TextMessageChunkEventSchema` both include `name: z.string().optional()`.
- Python: `sdks/python/ag_ui/core/events.py` — `TextMessageStartEvent.name: Optional[str] = None` and `TextMessageChunkEvent.name: Optional[str] = None`.

## Test plan

- [x] `go test ./pkg/core/events/... -run 'TestMessageEvents|TestTextMessageChunkEvent' -v` — new sub-tests pass locally.
- [x] `go test ./pkg/core/events/...` — full package green, no regressions.
- [x] `go vet ./...` clean on the touched files (pre-existing `ST1000` package-comment warning on `message_events.go` is unrelated and out of scope).

Example that now compiles and produces a spec-conformant event:

```go
evt := events.NewTextMessageStartEvent(
    "msg-1",
    events.WithRole("assistant"),
    events.WithName("research-agent"),
)
b, _ := evt.ToJSON()
// {"type":"TEXT_MESSAGE_START","messageId":"msg-1","role":"assistant","name":"research-agent","timestamp":...}
```