### PR TITLE
fix(claude-agent-sdk): use msg_id for tool-call parent_message_id on fallback path (#2118)

### DIFF
--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/adapter.py
@@ -977,8 +977,11 @@ class ClaudeAgentAdapter:
             
             # Handle complete messages
             if isinstance(message, (AssistantMessage, UserMessage)):
+                # msg_id (used below and passed to handle_tool_use_block()) —
+                # not current_message_id, which is only valid inside the
+                # streaming loop and is already None here.
+                msg_id = current_message_id or str(uuid.uuid4())
                 if isinstance(message, AssistantMessage):
-                    msg_id = current_message_id or str(uuid.uuid4())
                     agui_msg = build_agui_assistant_message(message, msg_id)
                     if agui_msg:
                         upsert_message(agui_msg)
@@ -991,7 +994,7 @@ class ClaudeAgentAdapter:
                             continue
                         updated_state, tool_events = await handle_tool_use_block(
                             block, message, thread_id, run_id, self._per_thread_state.get(thread_id),
-                            parent_message_id=current_message_id,
+                            parent_message_id=msg_id,
                         )
                         if tool_id:
                             processed_tool_ids.add(tool_id)

--- a/integrations/claude-agent-sdk/python/tests/test_adapter.py
+++ b/integrations/claude-agent-sdk/python/tests/test_adapter.py
@@ -18,6 +18,8 @@ from ag_ui_claude_sdk.config import STATE_MANAGEMENT_TOOL_FULL_NAME, AG_UI_MCP_S
 
 from ag_ui_claude_sdk.utils import extract_tool_names
 
+from claude_agent_sdk import AssistantMessage, ToolUseBlock
+
 from .conftest import stream_event, aiter
 
 
@@ -108,6 +110,29 @@ class TestStreamToolCall:
         assert start.tool_call_name == "lookup"  # prefix stripped
         # exactly one END for the one tool call
         assert types.count(EventType.TOOL_CALL_END) == 1
+
+    @pytest.mark.asyncio
+    async def test_subagent_tool_call_gets_parent_message_id(self, make_input):
+        # A complete AssistantMessage, not a StreamEvent, is how a subagent's
+        # own turn arrives — this hits the fallback branch (#2118).
+        adapter = ClaudeAgentAdapter(name="t")
+        subagent_message = AssistantMessage(
+            content=[ToolUseBlock(id="tc-subagent-1", name="mcp__ui__render_ui", input={})],
+            model="claude-haiku-4-5",
+            parent_tool_use_id="tc-agent-call",
+        )
+        events = await _drive(adapter, [subagent_message], make_input)
+        types = _types(events)
+        assert EventType.TOOL_CALL_START in types
+        start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+        assert start.tool_call_name == "render_ui"  # prefix stripped
+        assert start.parent_message_id is not None
+        assert start.parent_message_id != "tc-agent-call"  # not the SDK's parent_tool_use_id
+
+        # The id must also be the one reported in the run's MESSAGES_SNAPSHOT,
+        # i.e. it's a real, stable message id, not an arbitrary placeholder.
+        snapshot = next(e for e in events if e.type == EventType.MESSAGES_SNAPSHOT)
+        assert any(getattr(m, "id", None) == start.parent_message_id for m in snapshot.messages)
 
     @pytest.mark.asyncio
     async def test_frontend_tool_halts_stream(self, make_input):


### PR DESCRIPTION
Fixes #2118.

## Changes

- Compute `msg_id` once, outside the `AssistantMessage`-only branch, in
  the non-streaming fallback path
- Pass `msg_id` (not the stale `current_message_id`, already `None` here)
  as `parent_message_id` to `handle_tool_use_block()`

## Testing

- New test `test_subagent_tool_call_gets_parent_message_id`; confirmed it
  fails on the pre-fix code (`parent_message_id` is `None`)
- Full suite: 107 passed