### PR TITLE
docs(kotlin): fix Maven coordinates and version in Kotlin SDK docs

### DIFF
--- a/docs/sdk/kotlin/client/overview.mdx
+++ b/docs/sdk/kotlin/client/overview.mdx
@@ -11,7 +11,7 @@ The `kotlin-client` module provides high-level agent implementations and client 
 
 ```kotlin
 dependencies {
-    implementation("com.agui:kotlin-client:0.2.1")
+    implementation("com.ag-ui.community:kotlin-client:0.4.1")
 }
 ```
 

--- a/docs/sdk/kotlin/core/overview.mdx
+++ b/docs/sdk/kotlin/core/overview.mdx
@@ -11,7 +11,7 @@ The `kotlin-core` module provides the fundamental building blocks of the AG-UI p
 
 ```kotlin
 dependencies {
-    implementation("com.agui:kotlin-core:0.2.1")
+    implementation("com.ag-ui.community:kotlin-core:0.4.1")
 }
 ```
 

--- a/docs/sdk/kotlin/overview.mdx
+++ b/docs/sdk/kotlin/overview.mdx
@@ -15,7 +15,7 @@ Add the SDK to your Gradle project:
 ```kotlin
 dependencies {
     // Complete SDK with all modules (recommended)
-    implementation("com.agui:kotlin-client:0.2.1")
+    implementation("com.ag-ui.community:kotlin-client:0.4.1")
 }
 ```
 
@@ -26,10 +26,10 @@ For advanced use cases where you only need specific modules:
 ```kotlin
 dependencies {
     // Core protocol types only (advanced)
-    implementation("com.agui:kotlin-core:0.2.1")
+    implementation("com.ag-ui.community:kotlin-core:0.4.1")
     
     // Tools framework only (advanced) 
-    implementation("com.agui:kotlin-tools:0.2.1")
+    implementation("com.ag-ui.community:kotlin-tools:0.4.1")
 }
 ```
 

--- a/docs/sdk/kotlin/tools/overview.mdx
+++ b/docs/sdk/kotlin/tools/overview.mdx
@@ -11,7 +11,7 @@ The `kotlin-tools` module provides a framework for executing client-side tools t
 
 ```kotlin
 dependencies {
-    implementation("com.agui:kotlin-tools:0.2.1")
+    implementation("com.ag-ui.community:kotlin-tools:0.4.1")
 }
 ```
 

--- a/sdks/community/kotlin/build.gradle.kts
+++ b/sdks/community/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 // Group and version from gradle.properties
 group = findProperty("group")?.toString() ?: "com.ag-ui.community"
-version = "0.1.0"
+version = "0.4.1"
 
 repositories {
     google()


### PR DESCRIPTION
## Summary

Fixes #2110. The Kotlin SDK docs told users to depend on `com.agui:kotlin-client:0.2.1` (and the `-core`/`-tools` artifacts), which fails to resolve — exactly the error reported in the issue:

```
> Could not find com.agui:kotlin-client:0.2.1.
```

Two independent problems:

1. **Wrong group ID** — the artifacts are published under `com.ag-ui.community`, not `com.agui`. Confirmed against the build's single source of truth (`sdks/community/kotlin/library/build.gradle.kts`: `group = "com.ag-ui.community"`).
2. **Wrong version** — `0.2.1` was **never published**. The earliest release on Maven Central is `0.2.3`; the latest is `0.4.1`.

## Changes

- Update all four Kotlin doc overview pages (`overview`, `core`, `client`, `tools`) to `com.ag-ui.community:<artifact>:0.4.1`.
- Align the root `sdks/community/kotlin/build.gradle.kts` version (`0.1.0` → `0.4.1`) with the library modules' single source of truth (the version that is actually published).

The `import com.agui.*` lines are intentionally left untouched — those are the real source package names and are correct; only the Maven coordinates were wrong.

## Verification

Confirmed the published versions directly from Maven Central metadata for all three artifacts under `com.ag-ui.community`:

```
0.2.3 → 0.2.4 → 0.2.5 → 0.2.6 → 0.2.7 → 0.3.0 → 0.4.0 → 0.4.1 (latest)
```