### PR TITLE
fix(langgraph): don't leak input metadata into model content blocks

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -272,16 +272,6 @@ def _media_source_to_url(source: Union[InputContentDataSource, InputContentUrlSo
     return None
 
 
-def _attach_input_metadata(
-    content_block: Dict[str, Any],
-    item: AGUIContentItem,
-) -> Dict[str, Any]:
-    metadata = getattr(item, "metadata", None)
-    if metadata is not None:
-        content_block["metadata"] = metadata
-    return content_block
-
-
 def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List[Dict[str, Any]]:
     """Convert AG-UI multimodal content to LangChain's multimodal format.
 
@@ -289,21 +279,28 @@ def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List
     VideoInputContent, DocumentInputContent) as well as legacy BinaryInputContent
     for backwards compatibility. All media types are routed through LangChain's
     ``image_url`` format since that is the only media block type LangChain supports.
+
+    AG-UI ``InputContent.metadata`` is intentionally NOT copied onto the content
+    blocks: these blocks are passed straight to the model, and a non-standard
+    top-level ``metadata`` key makes strict OpenAI-compatible providers reject the
+    request with a 400 ("Unexpected keys in a message content image dict"). The
+    metadata is never read back on the LangChain->AG-UI return path, so nothing is
+    lost by keeping the model payload spec-compliant. See issue #2100.
     """
     langchain_content: List[Dict[str, Any]] = []
     for item in content:
         if isinstance(item, TextInputContent):
-            langchain_content.append(_attach_input_metadata({
+            langchain_content.append({
                 "type": "text",
                 "text": item.text
-            }, item))
+            })
         elif isinstance(item, _MEDIA_CONTENT_TYPES):
             url = _media_source_to_url(item.source)
             if url:
-                langchain_content.append(_attach_input_metadata({
+                langchain_content.append({
                     "type": "image_url",
                     "image_url": {"url": url}
-                }, item))
+                })
             else:
                 logger.warning("Dropping %s content: source could not be converted to URL", type(item).__name__)
         elif isinstance(item, BinaryInputContent):
@@ -325,7 +322,7 @@ def convert_agui_multimodal_to_langchain(content: List[AGUIContentItem]) -> List
                 )
                 continue
 
-            langchain_content.append(_attach_input_metadata(content_dict, item))
+            langchain_content.append(content_dict)
 
     return langchain_content
 

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -162,8 +162,16 @@ class TestMultimodalConversion(unittest.TestCase):
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
         )
 
-    def test_agui_input_metadata_to_langchain(self):
-        """Test preserving AG-UI InputContent metadata in LangChain blocks."""
+    def test_agui_input_metadata_not_leaked_to_langchain_blocks(self):
+        """AG-UI InputContent metadata must NOT be attached to the LangChain
+        content blocks handed to the model.
+
+        Attaching a top-level ``metadata`` key produces a non-standard content
+        block (e.g. ``{"type": "image_url", "image_url": {...}, "metadata": {...}}``)
+        that strict OpenAI-compatible providers reject with a 400
+        ("Unexpected keys in a message content image dict"), aborting the run.
+        The block must carry only spec-compliant keys. See issue #2100.
+        """
         content_list = [
             TextInputContent(
                 type="text",
@@ -188,9 +196,20 @@ class TestMultimodalConversion(unittest.TestCase):
 
         lc_content = convert_agui_multimodal_to_langchain(content_list)
 
-        self.assertEqual(lc_content[0]["metadata"], {"source": "prompt"})
-        self.assertEqual(lc_content[1]["metadata"], {"provider_hint": "vision"})
-        self.assertEqual(lc_content[2]["metadata"], {"legacy": True})
+        # No block leaks a top-level "metadata" key into the model payload.
+        for block in lc_content:
+            self.assertNotIn("metadata", block)
+
+        # Blocks remain spec-compliant and otherwise unchanged.
+        self.assertEqual(lc_content[0], {"type": "text", "text": "Describe this image"})
+        self.assertEqual(
+            lc_content[1],
+            {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}},
+        )
+        self.assertEqual(
+            lc_content[2],
+            {"type": "image_url", "image_url": {"url": "https://example.com/legacy.png"}},
+        )
 
     # ── AudioInputContent ───────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #2100

## Problem

`convert_agui_multimodal_to_langchain` in `ag_ui_langgraph/utils.py` attached AG-UI `InputContent.metadata` as a **top-level key** on every LangChain content block:

```json
{ "type": "image_url", "image_url": { "url": "..." }, "metadata": { ... } }
```

Those blocks are passed straight to the model. The OpenAI content-block schema only allows the standard shape, so **strict OpenAI-compatible providers** (observed with Fireworks-hosted Qwen) reject the request:

```
openai.BadRequestError: 400 - Invalid chat format. Unexpected keys in a message content image dict.
```

The run aborts and the client surfaces `agent_run_error_event: "terminated"`. OpenAI itself silently ignores the extra key, so the bug is **invisible against OpenAI** and only appears against OpenAI-*compatible* endpoints. The stock `agentic_chat_multimodal` example fails this way.

## Fix

Stop attaching `metadata` to the model-bound content blocks (removed `_attach_input_metadata`).

This is safe and lossless:
- The metadata is **never read back** on the LangChain→AG-UI return path (`convert_langchain_multimodal_to_agui` ignores it) — it was write-only.
- ag_ui_langgraph wraps a user-supplied graph that calls the model itself, so there is no interception point to strip the key at serialize time — the only clean fix is not to emit it.
- AG-UI messages retain their own `metadata` independently, so nothing is lost on the AG-UI side.

Result: the request body stays spec-compliant across all providers.

## Tests

- Rewrote `test_agui_input_metadata_to_langchain` → `test_agui_input_metadata_not_leaked_to_langchain_blocks`: asserts no block carries a top-level `metadata` key and that blocks remain spec-compliant.
- Full langgraph python suite: **391 passed**, no regressions (round-trip conversion tests included).