### PR TITLE
fix(mastra): surface token usage on RUN_FINISHED event

### DIFF
--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -506,8 +506,9 @@ interface MastraAgentStreamOptions {
    * (Mastra observability v-next) when the consumed stream exposed one, so the
    * bridge can surface it on `RUN_FINISHED.result` (see makeRunFinishedEvent).
    * traceId is undefined on cores/streams that don't expose one.
+   * usage carries per-run token counts when the underlying model reported them.
    */
-  onRunFinished?: (traceId?: string) => Promise<void>;
+  onRunFinished?: (traceId?: string, usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }) => Promise<void>;
   onToolSuspended: (payload: {
     toolCallId: string;
     toolName: string;
@@ -926,7 +927,7 @@ export class MastraAgent extends AbstractAgent {
             onError: (error) => {
               subscriber.error(error);
             },
-            onRunFinished: async (traceId) => {
+            onRunFinished: async (traceId, usage) => {
               await this.emitWorkingMemorySnapshot(subscriber, input.threadId);
               subscriber.next(
                 this.makeRunFinishedEvent(
@@ -934,6 +935,7 @@ export class MastraAgent extends AbstractAgent {
                   input.runId,
                   pendingInterrupts,
                   traceId,
+                  usage,
                 ),
               );
               subscriber.complete();
@@ -1044,6 +1046,7 @@ export class MastraAgent extends AbstractAgent {
     runId: string,
     interrupts: Interrupt[],
     traceId?: string,
+    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number },
   ): RunFinishedEvent {
     const includeOutcome = this.emitInterruptOutcome && interrupts.length > 0;
     return {
@@ -1051,6 +1054,7 @@ export class MastraAgent extends AbstractAgent {
       threadId,
       runId,
       ...(traceId ? { result: { traceId } } : {}),
+      ...(usage ? { usage } : {}),
       ...(includeOutcome
         ? {
             outcome: {
@@ -2761,7 +2765,8 @@ export class MastraAgent extends AbstractAgent {
 
           if (!hadError) {
             const traceId = await this.resolveTraceId(response);
-            await onRunFinished?.(traceId);
+            const usage = await (response as any).usage?.catch?.(() => undefined);
+            await onRunFinished?.(traceId, usage);
           }
         } else {
           throw new Error("Invalid response from local agent");

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -259,6 +259,13 @@ export const RunFinishedEventSchema = BaseEventSchema.extend({
   outcome: RunFinishedOutcomeSchema.nullable()
     .optional()
     .transform((v) => v ?? undefined),
+  usage: z
+    .object({
+      inputTokens: z.number().optional(),
+      outputTokens: z.number().optional(),
+      totalTokens: z.number().optional(),
+    })
+    .optional(),
 });
 
 export const RunErrorEventSchema = BaseEventSchema.extend({


### PR DESCRIPTION
## Summary

The \`@ag-ui/mastra\` bridge currently emits \`RUN_FINISHED\` without token usage data, even though Mastra's \`agent.stream()\` result exposes a \`usage\` promise and the AG-UI protocol spec states the event should carry token counts (ref #604).

## Root cause

Two issues:

1. **Bridge** (\`@ag-ui/mastra\`): After \`processFullStream\` returns for a local agent, the \`response\` object (Mastra stream result) has a \`usage\` field — a \`DelayedPromise\` that is already resolved by the time streaming ends. The bridge never reads it.

2. **Schema** (\`@ag-ui/core\`): \`RunFinishedEventSchema\` did not declare a \`usage\` field, so Zod's discriminated union parse (used by \`@ag-ui/client\` to validate incoming SSE events) stripped the field before it reached the \`onRunFinishedEvent\` callback — even after the bridge fix.

## Fix

**\`@ag-ui/mastra\`** — after \`processFullStream\` completes without error, resolve \`response.usage\` and thread it through \`onRunFinished\` → \`makeRunFinishedEvent\` → \`RUN_FINISHED\`:
- \`onRunFinished\` callback gains an optional \`usage\` parameter
- \`makeRunFinishedEvent\` accepts and spreads \`usage\` onto the event when present
- \`streamMastraAgent\` resolves \`response.usage\` (with a catch for robustness) and passes it through

**\`@ag-ui/core\`** — adds \`usage?: { inputTokens?, outputTokens?, totalTokens? }\` to \`RunFinishedEventSchema\` so the field survives client-side schema validation.

Both changes are additive and fully backward-compatible: clients that don't read \`usage\` are unaffected, and \`usage\` is only set when the model actually reports token counts.

## Testing

Verified locally against a Mastra agent backed by a Claude Sonnet model: \`RUN_FINISHED\` now carries \`{ inputTokens, outputTokens, totalTokens }\` on every completed run, and the value is accessible in \`onRunFinishedEvent({ event })\`.

Fixes #604