### PR TITLE
fix(dotnet): preserve Context and ForwardedProperties from caller-supplied RunAgentInput

### DIFF
--- a/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
@@ -340,6 +340,16 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 {
                     input.ParentRunId = providedInput.ParentRunId;
                 }
+
+                if (providedInput.Context is { Count: > 0 })
+                {
+                    input.Context = providedInput.Context;
+                }
+
+                if (providedInput.ForwardedProperties.ValueKind is not JsonValueKind.Undefined)
+                {
+                    input.ForwardedProperties = providedInput.ForwardedProperties;
+                }
             }
 
             // Convert M.E.AI tools to AG-UI format

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AGUI.Abstractions;
@@ -141,6 +142,43 @@ public sealed class AGUIChatClientTest
         await DrainAsync(client.GetStreamingResponseAsync(history, options));
 
         Assert.Equal(3, transport.LastInput!.Messages.Count);
+    }
+
+    // https://github.com/ag-ui-protocol/ag-ui/issues/2151
+    // A caller-supplied RunAgentInput (via RawRepresentationFactory) must have its
+    // Context and ForwardedProperties carried through onto the request that is sent,
+    // just like Messages/Tools/State/ParentRunId already are.
+    [Fact]
+    public async Task GetStreamingResponse_WithRawRepresentationFactory_PreservesContextAndForwardedProperties()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var forwarded = JsonDocument.Parse("{\"tenant\":\"acme\"}").RootElement.Clone();
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new RunAgentInput
+            {
+                Context = new List<AGUIContext>
+                {
+                    new() { Description = "userId", Value = "u-123" }
+                },
+                ForwardedProperties = forwarded,
+            }
+        };
+
+        await DrainAsync(client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "Hello")], options));
+
+        var sent = transport.LastInput!;
+
+        Assert.NotNull(sent.Context);
+        Assert.Single(sent.Context!);
+        Assert.Equal("userId", sent.Context![0].Description);
+        Assert.Equal("u-123", sent.Context[0].Value);
+
+        Assert.Equal(JsonValueKind.Object, sent.ForwardedProperties.ValueKind);
+        Assert.Equal("acme", sent.ForwardedProperties.GetProperty("tenant").GetString());
     }
 
     // https://github.com/microsoft/agent-framework/issues/5587


### PR DESCRIPTION
Fixes #2151

## Problem

When a caller seeds the outgoing request with a `RunAgentInput` via `ChatOptions.RawRepresentationFactory`, `AGUIChatClient.BuildRunAgentInput` copies `Messages`, `Tools`, `State`, and `ParentRunId` from that input — but **never copies `Context` or `ForwardedProperties`**. Both fields are silently dropped, even though they are part of the same `RunAgentInput` and are documented as caller-supplied run parameters.

```csharp
var providedInput = new RunAgentInput
{
    Context = new List<AGUIContext> { new() { Description = "userId", Value = "u-123" } }
};
var options = new ChatOptions { RawRepresentationFactory = _ => providedInput };
await chatClient.GetStreamingResponseAsync(messages, options, ct);
// Expected: outgoing RunAgentInput.Context contains the userId entry
// Actual:   Context is null/empty over the wire — the entry is lost
```

Affects `AGUI.Client` / `AGUI.Abstractions` 0.0.3.

## Fix

In `BuildRunAgentInput`, carry both fields through with the same guarded treatment as the existing fields:

```csharp
if (providedInput.Context is { Count: > 0 })
{
    input.Context = providedInput.Context;
}

if (providedInput.ForwardedProperties.ValueKind is not JsonValueKind.Undefined)
{
    input.ForwardedProperties = providedInput.ForwardedProperties;
}
```

`ForwardedProperties` is a `JsonElement` value type whose default is `ValueKind == Undefined`, so the guard copies it only when the caller actually set it.

## Tests

- Added `GetStreamingResponse_WithRawRepresentationFactory_PreservesContextAndForwardedProperties` (uses the existing `CapturingTransport` to assert both fields reach the sent `RunAgentInput`).
- TDD-verified: the test fails against the unpatched `BuildRunAgentInput` (`Context` is null) and passes with the fix.
- Full `AGUI.Client.UnitTests` suite green (111 passed, net10.0).