### PR TITLE
Harden CI: scope app-token permissions + fix Rust workflow path

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -122,6 +122,12 @@ jobs:
         with:
           app-id: "3877599"
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          # Scope the app token to only what this workflow uses, instead of
+          # inheriting the app installation's blanket permissions (zizmor
+          # github-app). contents:write creates/deletes the canary ref;
+          # actions:write dispatches publish-release.yml and reads its run.
+          permission-contents: write
+          permission-actions: write
 
       - name: Compute canary branch name
         id: slug

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -199,6 +199,12 @@ jobs:
         with:
           app-id: "3877599"
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          # Scope the app token to only what this workflow uses, instead of
+          # inheriting the app installation's blanket permissions (zizmor
+          # github-app). contents:write pushes the release/next branch;
+          # pull-requests:write creates/updates the release PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Configure git credentials for push
         if: inputs.dry_run != true && steps.bump.outputs.changed_count != '0'

--- a/.github/workflows/rust-lint-test.yml
+++ b/.github/workflows/rust-lint-test.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - "crates/**"
-      - ".github/workflows/rust.yml"
-      - "tests/**"
-      - "Cargo.toml"
-      - ".cargo/**"
+      - "sdks/community/rust/crates/**"
+      - "sdks/community/rust/**/tests/**"
+      - "sdks/community/rust/Cargo.toml"
+      - "sdks/community/rust/.cargo/**"
+      - ".github/workflows/rust-lint-test.yml"
   pull_request:
     branches: [ "main" ]
     paths:
@@ -20,7 +20,7 @@ on:
 
 defaults:
   run:
-    working-directory: ./rust
+    working-directory: ./sdks/community/rust
 
 permissions:
   contents: read


### PR DESCRIPTION
Two independent CI-workflow fixes, each with a local red→green proof.

## 1. zizmor `github-app`: scope the app-token permissions

The `create-github-app-token` v2→v3 migration surfaced 2 zizmor `error[github-app]` findings — the minted GitHub App token inherits the app installation's **blanket** permissions in `canary.yml` and `prepare-release.yml`. Fix: add the minimal scoped `permission-<name>` inputs each workflow actually uses.

- **canary.yml** — `permission-contents: write` (create/delete the canary ref) + `permission-actions: write` (dispatch `publish-release.yml` and read its run).
- **prepare-release.yml** — `permission-contents: write` (push `release/next`) + `permission-pull-requests: write` (create/update the release PR).

### RED (before) — `uvx zizmor` (== CI: latest, `--persona=auditor`, repo `.github/zizmor.yml`)
```
error[github-app]: dangerous use of GitHub App tokens
   --> .github/workflows/canary.yml:121:15
    |               ^^^ app token inherits blanket installation permissions
    = tip: specify at least one `permission-<name>` input to limit the token's permissions

error[github-app]: dangerous use of GitHub App tokens
   --> .github/workflows/prepare-release.yml:198:15
    |               ^^^ app token inherits blanket installation permissions

7 findings (1 unsafe fixes): 2 informational, 1 low, 1 medium, 3 high
```

### GREEN (after) — same command, same two files
```
$ uvx zizmor ... canary.yml prepare-release.yml | grep -c 'error\[github-app\]'
0

5 findings (1 unsafe fixes): 2 informational, 1 low, 1 medium, 1 high
```
The 2 `github-app` errors are gone (high count 3→1; the remaining high is a separate pre-existing `secrets-outside-env` finding, out of scope here).

## 2. Rust SDK Tests: wrong `working-directory`

The "Rust SDK Tests" workflow (`rust-lint-test.yml`) set `defaults.run.working-directory: ./rust`, but the crate actually lives at `sdks/community/rust`. Every `cargo` step (build/fmt/clippy/publish/test) ran in a nonexistent directory. Also fixed the stale `push:` trigger paths (top-level `crates/**`, `Cargo.toml`, `rust.yml`) to match the `sdks/community/rust` layout the `pull_request:` paths already use.

### RED (before) — the referenced path does not exist
```
$ ls -d rust                       # ./rust
ls: rust: No such file or directory
$ ls -d sdks/community/rust        # actual crate root
sdks/community/rust/     (Cargo.toml, Cargo.lock, crates/)
$ grep 'working-directory' .github/workflows/rust-lint-test.yml
    working-directory: ./rust      # <- points at the nonexistent dir
```

### GREEN (after)
```
$ grep 'working-directory' .github/workflows/rust-lint-test.yml
    working-directory: ./sdks/community/rust
$ ls -d sdks/community/rust/Cargo.toml   # resolves
sdks/community/rust/Cargo.toml
```
`cargo` steps now run in the real crate root.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)