### PR TITLE
fix(release): decouple prepare-release dotnet test from shipping version

### DIFF
--- a/scripts/release/prepare-release.test.ts
+++ b/scripts/release/prepare-release.test.ts
@@ -1,9 +1,31 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const SCRIPT = join(process.cwd(), "scripts/release/prepare-release.ts");
+const DOTNET_PROPS = "sdks/dotnet/Directory.Build.props";
+
+// Read the .NET shared VersionPrefix from ground truth rather than hardcoding
+// the shipping version. Hardcoding it made this test chase every prod version
+// bump (e.g. it broke when the packages went 0.0.1 -> 0.0.3); deriving the
+// expected values from the real props file keeps the test focused on what
+// prepare-release.ts actually does — parse the current version and apply the
+// requested semver bump — without tracking releases.
+function currentDotnetVersion(): string {
+  const content = readFileSync(join(process.cwd(), DOTNET_PROPS), "utf8");
+  const match = content.match(
+    /<VersionPrefix(?:\s+[^>]*)?>([^<]+)<\/VersionPrefix>/,
+  );
+  assert.ok(match, `Cannot read <VersionPrefix> from ${DOTNET_PROPS}`);
+  return match[1];
+}
+
+function bumpMinor(version: string): string {
+  const [major, minor] = version.split(".").map((n) => parseInt(n, 10));
+  return `${major}.${minor + 1}.0`;
+}
 
 async function runPrepareRelease(
   args: string[],
@@ -31,6 +53,9 @@ test(
   "dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props",
   { timeout: 30_000 },
   async () => {
+    const expectedOldVersion = currentDotnetVersion();
+    const expectedNewVersion = bumpMinor(expectedOldVersion);
+
     const result = await runPrepareRelease([
       "--scope",
       "sdk-dotnet",
@@ -54,9 +79,9 @@ test(
       ],
     );
     for (const pkg of output.packages) {
-      assert.equal(pkg.oldVersion, "0.0.1");
-      assert.equal(pkg.newVersion, "0.1.0");
-      assert.equal(pkg.file, "sdks/dotnet/Directory.Build.props");
+      assert.equal(pkg.oldVersion, expectedOldVersion);
+      assert.equal(pkg.newVersion, expectedNewVersion);
+      assert.equal(pkg.file, DOTNET_PROPS);
       assert.equal(pkg.ecosystem, "dotnet");
     }
   },


### PR DESCRIPTION
## Problem

The **Test Release Scripts** workflow (`.github/workflows/test-release-scripts.yml`, job `test`) runs `node --test --import tsx scripts/release/*.test.ts`. The test `dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props` in `scripts/release/prepare-release.test.ts` was failing:

```
'0.0.3' !== '0.0.1'
```

Root cause: `prepare-release.ts` reads the **real** `<VersionPrefix>` from `sdks/dotnet/Directory.Build.props`. The test hardcoded `oldVersion === "0.0.1"` and `newVersion === "0.1.0"`. When the .NET packages shipped `0.0.3`, the test broke — it was chasing the production version rather than verifying behavior. Bumping the literal to `0.0.3` would just re-introduce the same fragility on the next release.

## Fix

Derive the expected values from ground truth instead of hardcoding the shipping version:

- Read the current `<VersionPrefix>` from `sdks/dotnet/Directory.Build.props`.
- Assert `oldVersion` equals that value.
- Assert `newVersion` equals its minor bump.

The test now verifies what `prepare-release.ts` actually does — parse the current version and apply the requested semver bump — and no longer tracks releases.

Note: the `0.0.1`/`0.1.0` literals in `generate-ai-release-notes.test.ts` are self-contained input fixtures for the release-notes generator (they do not read the props file), so they were left untouched.

## Red-Green Proof

Real failure surface exercised: `node --test --import tsx` (the actual CI invocation), not a fake.

### RED (unmodified code)

```
✖ dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props (176.3035ms)
ℹ tests 1
ℹ pass 0
ℹ fail 1

✖ failing tests:

test at scripts/release/prepare-release.test.ts:2:1607
✖ dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props (176.3035ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

  '0.0.3' !== '0.0.1'

      at TestContext.<anonymous> (scripts/release/prepare-release.test.ts:57:14)
    code: 'ERR_ASSERTION',
    actual: '0.0.3',
    expected: '0.0.1',
    operator: 'strictEqual',
```

### GREEN (fixed test, single file)

```
✔ dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props (100.932917ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

### GREEN (full suite — CI parity: `node --test --import tsx scripts/release/*.test.ts`)

```
✔ dry-run bumps sdk-dotnet shared VersionPrefix from Directory.Build.props (123.651708ms)
ℹ tests 90
ℹ pass 90
ℹ fail 0
```

Was 89 pass / 1 fail → now 90 pass / 0 fail. Prettier clean.