### PR TITLE
ci(rust): restore --no-verify on ag-ui-client publish dry-run

### DIFF
--- a/.github/workflows/rust-lint-test.yml
+++ b/.github/workflows/rust-lint-test.yml
@@ -59,7 +59,11 @@ jobs:
         run: cargo publish -p ag-ui-core --dry-run
 
       - name: Publish ag-ui-client dry-run
-        run: cargo publish -p ag-ui-client --dry-run
+        # Documented interim: packaging-only (--no-verify skips the compile-verify).
+        # cargo publish drops the workspace [patch.crates-io] override and would
+        # compile against the stale ag-ui-core 0.1.0 on crates.io. Drop --no-verify
+        # once ag-ui-core is republished to crates.io.
+        run: cargo publish -p ag-ui-client --dry-run --no-verify
 
       - name: Run tests
         run: cargo test --verbose

--- a/sdks/community/rust/crates/ag-ui-client/README.md
+++ b/sdks/community/rust/crates/ag-ui-client/README.md
@@ -11,7 +11,9 @@ For each example make sure to read the instructions on starting the associated A
 
 ### Basic 
 
-```rust
+```rust,no_run
+// no_run: this example connects to a live AG-UI backend (127.0.0.1:3001),
+// which is not available during `cargo test`. It is still compiled/type-checked.
 use std::error::Error;
 use ag_ui_client::{core::types::Message, Agent, HttpAgent, RunAgentParams};
 

--- a/sdks/community/rust/crates/ag-ui-client/tests/http_agent_test.rs
+++ b/sdks/community/rust/crates/ag-ui-client/tests/http_agent_test.rs
@@ -3,6 +3,7 @@ use ag_ui_client::agent::{Agent, RunAgentParams};
 use ag_ui_client::core::types::{Message, Role};
 
 #[tokio::test]
+#[ignore = "requires a live AG-UI backend (localhost:3001); not provided in CI"]
 async fn test_http_agent_basic_functionality() {
     env_logger::init();
 
@@ -54,6 +55,7 @@ async fn test_http_agent_basic_functionality() {
 }
 
 #[tokio::test]
+#[ignore = "requires a live AG-UI backend (localhost:3001); not provided in CI"]
 async fn test_http_agent_tool_calls() {
     // Create an HttpAgent
     let agent = HttpAgent::builder()

--- a/sdks/community/rust/crates/ag-ui-client/tests/sse_test.rs
+++ b/sdks/community/rust/crates/ag-ui-client/tests/sse_test.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::time::Duration;
 
 #[tokio::test]
+#[ignore = "requires a live external SSE service (httpbun.org); not provided in CI"]
 async fn test_sse_with_httpbun() {
     // Create a reqwest client
     let client = Client::new();
@@ -66,6 +67,7 @@ async fn test_sse_with_httpbun() {
 }
 
 #[tokio::test]
+#[ignore = "requires a live external SSE service (sse.dev); not provided in CI"]
 async fn test_sse_with_json_data() {
     // Create a reqwest client
     let client = Client::new();


### PR DESCRIPTION
## What

The "Rust SDK Tests" CI check runs `cargo publish -p ag-ui-client --dry-run` **without** `--no-verify`, so it hard-fails on main. `cargo publish` strips the workspace `[patch.crates-io]` override and compiles today's `ag-ui-client` against the stale published `ag-ui-core 0.1.0` on crates.io, which no longer has the types the current client imports.

This step is only ever meant to be packaging-only. Per our rust workflow runbook the documented interim is to run it with `--no-verify` (package, skip the compile-verify) until someone cuts a fresh `ag-ui-core` release to crates.io. The workflow drifted off that. We are not building a crates.io release lane for this dormant community crate right now, so this restores the intended interim.

## Change (that one step only)

Before:
```yaml
      - name: Publish ag-ui-client dry-run
        run: cargo publish -p ag-ui-client --dry-run
```

After:
```yaml
      - name: Publish ag-ui-client dry-run
        # Documented interim: packaging-only (--no-verify skips the compile-verify).
        # cargo publish drops the workspace [patch.crates-io] override and would
        # compile against the stale ag-ui-core 0.1.0 on crates.io. Drop --no-verify
        # once ag-ui-core is republished to crates.io.
        run: cargo publish -p ag-ui-client --dry-run --no-verify
```

Nothing else in the file or repo is touched. The separate `ag-ui-core` dry-run step is left as-is.

## Local red-green proof

Ran the exact command CI runs, in `sdks/community/rust/`.

**RED** — `cargo publish -p ag-ui-client --dry-run`:
```
   Packaging ag-ui-client v0.1.0 (.../crates/ag-ui-client)
   Verifying ag-ui-client v0.1.0 (.../crates/ag-ui-client)
error[E0432]: unresolved import `ag_ui_core::types::AgentId`
  |
8 | use ag_ui_core::types::AgentId;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `AgentId` in `types`
...
error: could not compile `ag-ui-client` (lib) due to 5 previous errors
error: failed to verify package tarball
exit=101
```

**GREEN** — `cargo publish -p ag-ui-client --dry-run --no-verify`:
```
   Packaging ag-ui-client v0.1.0 (.../crates/ag-ui-client)
    Packaged 23 files, 155.3KiB (33.8KiB compressed)
   Uploading ag-ui-client v0.1.0 (.../crates/ag-ui-client)
warning: aborting upload due to dry run
exit=0
```

Packaging succeeds, compile-verify skipped, no E0432. cargo 1.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: green the `Run tests` step too

The `--no-verify` fix above cleared the publish dry-run step, which uncovered a pre-existing failure in the job's next step, `Run tests` (`cargo test --verbose`). Two things fail purely because CI provides no live backend:

- **Integration tests** hitting a live AG-UI server / external SSE services:
  - `test_http_agent_basic_functionality`, `test_http_agent_tool_calls` (`localhost:3001` AG-UI backend) — panic with `ConnectionRefused` / HTTP 404, exit 101.
  - `test_sse_with_httpbun`, `test_sse_with_json_data` (external `httpbun.org` / `sse.dev` SSE services).
- **README doctest** — the `Basic` example connects to `127.0.0.1:3001` and runs the agent (HTTP 404 without a server).

Fix (matching the crate's style, no CI infra built): add `#[ignore = "requires a live ... backend; not provided in CI"]` to each live-backend test, and mark the README example fence `rust,no_run` so it still compiles/type-checks but does not execute.

**Unit tests keep running** — `ag-ui-core/tests/unit.rs` (13), `sse::tests` (4), `types::ids` (1), and the negative-path `test_http_agent_error_handling` (asserts a connect failure against an unreachable port) all still run and pass.

### Local red-green proof — `cargo test --verbose` in `sdks/community/rust/`

**RED** (before):
```
running 3 tests
test test_http_agent_error_handling ... ok
test test_http_agent_tool_calls ... FAILED
test test_http_agent_basic_functionality ... FAILED
...
Agent run failed: Some(HttpStatus { status: 404, context: "...Cannot POST /..." })
test result: FAILED. 1 passed; 2 failed; 0 ignored
error: test failed, to rerun pass `-p ag-ui-client --test http_agent_test`
$ echo $?  ->  101
```
(and the README doctest additionally failed once the integration binary got past: `crates/ag-ui-client/src/../README.md - (line 14) ... FAILED`)

**GREEN** (after):
```
test test_http_agent_basic_functionality ... ignored, requires a live AG-UI backend (localhost:3001); not provided in CI
test test_http_agent_tool_calls ... ignored, requires a live AG-UI backend (localhost:3001); not provided in CI
test test_http_agent_error_handling ... ok
test result: ok. 1 passed; 0 failed; 2 ignored

test test_sse_with_httpbun ... ignored, requires a live external SSE service (httpbun.org); not provided in CI
test test_sse_with_json_data ... ignored, requires a live external SSE service (sse.dev); not provided in CI
test result: ok. 0 passed; 0 failed; 2 ignored

test result: ok. 13 passed; 0 failed  (ag-ui-core unit.rs)
test result: ok. 4 passed; 0 failed   (sse::tests)
   Doc-tests ag_ui_client
test crates/ag-ui-client/src/../README.md - (line 14) - compile ... ok
test result: ok. 3 passed; 0 failed
$ echo $?  ->  0
```
`cargo fmt -- --check` and `cargo clippy -- -D warnings` also pass locally.