### PR TITLE
feat(kotlin): add the EventEncoder (:kotlin-encoder SDK module)

### DIFF
--- a/sdks/community/kotlin/library/encoder/build.gradle.kts
+++ b/sdks/community/kotlin/library/encoder/build.gradle.kts
@@ -1,0 +1,124 @@
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("maven-publish")
+    id("signing")
+}
+
+// Group and version inherited from parent build.gradle.kts
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+kotlin {
+    // Configure K2 compiler options (mirrors :kotlin-server / :kotlin-client)
+    targets.configureEach {
+        compilations.configureEach {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    freeCompilerArgs.add("-Xexpect-actual-classes")
+                    freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+                    freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+                    freeCompilerArgs.add("-opt-in=kotlinx.serialization.ExperimentalSerializationApi")
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1)
+                }
+            }
+        }
+    }
+
+    // JVM target only: publishes a `kotlin-encoder-jvm` artifact (no Android/iOS, so
+    // no Android SDK is needed to build or publish this module), mirroring how TS
+    // ships `@ag-ui/encoder` and Python ships `ag_ui.encoder` as their own package.
+    jvm {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+                }
+            }
+        }
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":kotlin-core"))
+
+                implementation(libs.kotlinx.serialization.json)
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        val jvmMain by getting
+        val jvmTest by getting
+    }
+}
+
+// Publishing configuration
+publishing {
+    publications {
+        withType<MavenPublication> {
+            version = project.version.toString()
+            pom {
+                name.set("kotlin-encoder")
+                description.set("Event encoder (SSE) for the Agent User Interaction Protocol")
+                url.set("https://github.com/ag-ui-protocol/ag-ui")
+
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("contextablemark")
+                        name.set("Mark Fogle")
+                        email.set("mark@contextable.com")
+                    }
+                }
+
+                scm {
+                    url.set("https://github.com/ag-ui-protocol/ag-ui")
+                    connection.set("scm:git:git://github.com/ag-ui-protocol/ag-ui.git")
+                    developerConnection.set("scm:git:ssh://github.com:ag-ui-protocol/ag-ui.git")
+                }
+            }
+        }
+    }
+}
+
+// Signing configuration
+signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
+    }
+}
+
+// JUnit Platform is configured in the `jvm { testRuns["test"] }` block above (and
+// inherited from the root `subprojects { tasks.withType<Test> }`).
+
+// KMP modules expose `jvmTest`/`allTests` rather than the plain `test` lifecycle
+// task. Provide a `test` alias so `:kotlin-encoder:test` works like the plain-JVM
+// modules.
+tasks.register("test") {
+    group = "verification"
+    description = "Runs the JVM test suite (alias for jvmTest)."
+    dependsOn("jvmTest")
+}

--- a/sdks/community/kotlin/library/encoder/src/commonMain/kotlin/com/agui/encoder/EventEncoder.kt
+++ b/sdks/community/kotlin/library/encoder/src/commonMain/kotlin/com/agui/encoder/EventEncoder.kt
@@ -1,0 +1,45 @@
+package com.agui.encoder
+
+import com.agui.core.types.AgUiJson
+import com.agui.core.types.BaseEvent
+import kotlinx.serialization.encodeToString
+
+/**
+ * Encodes AG-UI [BaseEvent]s to the wire form. Mirrors the TypeScript
+ * (`@ag-ui/encoder`) and Python (`ag_ui.encoder`) `EventEncoder`: construct per
+ * request with the client's `Accept` header, then [encode] each event.
+ *
+ * SSE only for now (matching the Python encoder). Protobuf negotiation is a TODO
+ * pending a Kotlin `@ag-ui/proto` codec — see [getContentType].
+ */
+class EventEncoder(private val accept: String? = null) {
+
+    /** Mirrors TS/Python `getContentType()`. Always SSE for now (no Kotlin proto codec yet). */
+    fun getContentType(): String = SSE_CONTENT_TYPE
+    // TODO: negotiate AGUI_MEDIA_TYPE from `accept` once a Kotlin proto
+    // codec exists, matching TS EventEncoder.getContentType()/encodeBinary().
+
+    /** Mirrors TS/Python `encode()`. */
+    fun encode(event: BaseEvent): String = encodeSSE(event)
+
+    /** Canonical SSE framing: `data: {json}\n\n`. Mirrors TS `encodeSSE`. */
+    fun encodeSSE(event: BaseEvent): String =
+        "data: " + encodeToJson(event) + "\n\n"
+
+    /**
+     * The JSON wire body for [event], with **no** SSE framing.
+     *
+     * Use this from transports that add their own framing — e.g. Spring MVC's `SseEmitter` or
+     * Jakarta's `SseEventSink`, which prefix `data:` and append the blank line themselves. Pairing
+     * such a transport with [encode]/[encodeSSE] would double-frame the stream; hand it
+     * [encodeToJson] instead so the SDK stays the single serialization entry point (no need for the
+     * consumer to reach past the encoder to [AgUiJson]/`BaseEvent.serializer()` directly). For raw
+     * byte streaming (FastAPI-style `StreamingResponse`, Ktor `respondBytesWriter`) use [encode].
+     */
+    fun encodeToJson(event: BaseEvent): String = AgUiJson.encodeToString(event)
+
+    companion object {
+        const val SSE_CONTENT_TYPE: String = "text/event-stream"
+        const val AGUI_MEDIA_TYPE: String = "application/vnd.ag-ui.event+proto"
+    }
+}

--- a/sdks/community/kotlin/library/encoder/src/commonTest/kotlin/com/agui/encoder/EventEncoderTest.kt
+++ b/sdks/community/kotlin/library/encoder/src/commonTest/kotlin/com/agui/encoder/EventEncoderTest.kt
@@ -1,0 +1,60 @@
+package com.agui.encoder
+
+import com.agui.core.types.RunStartedEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EventEncoderTest {
+
+    private val event = RunStartedEvent(threadId = "t1", runId = "r1")
+    // Compact JSON with the "type" discriminator first, then declaration order;
+    // null timestamp/rawEvent omitted (AgUiJson has explicitNulls = false).
+    private val expectedJson = """{"type":"RUN_STARTED","threadId":"t1","runId":"r1"}"""
+
+    @Test
+    fun getContentTypeIsEventStreamByDefault() {
+        assertEquals("text/event-stream", EventEncoder().getContentType())
+        assertEquals("text/event-stream", EventEncoder.SSE_CONTENT_TYPE)
+    }
+
+    @Test
+    fun getContentTypeStaysSseEvenWhenProtobufRequested() {
+        // No Kotlin proto codec yet — proto Accept still yields SSE (matches Python).
+        val encoder = EventEncoder(accept = EventEncoder.AGUI_MEDIA_TYPE)
+        assertEquals("text/event-stream", encoder.getContentType())
+    }
+
+    @Test
+    fun encodeProducesCanonicalSseFraming() {
+        // Exact bytes: "data: " prefix (one space), compact JSON, trailing blank line.
+        assertEquals("data: $expectedJson\n\n", EventEncoder().encode(event))
+    }
+
+    @Test
+    fun encodeSseMatchesEncode() {
+        val encoder = EventEncoder()
+        assertEquals(encoder.encode(event), encoder.encodeSSE(event))
+    }
+
+    @Test
+    fun encodeStartsWithDataPrefixAndEndsWithBlankLine() {
+        val encoded = EventEncoder().encode(event)
+        assertTrue(encoded.startsWith("data: "), "must start with 'data: '")
+        assertTrue(encoded.endsWith("\n\n"), "must end with a blank line")
+    }
+
+    @Test
+    fun encodeToJsonProducesUnframedBody() {
+        // No "data: " prefix and no trailing blank line — just the compact JSON body.
+        assertEquals(expectedJson, EventEncoder().encodeToJson(event))
+    }
+
+    @Test
+    fun encodeSseWrapsEncodeToJson() {
+        // encodeSSE is exactly the framed form of encodeToJson (for self-framing transports the
+        // body-only path must yield the same JSON the SSE path carries).
+        val encoder = EventEncoder()
+        assertEquals("data: ${encoder.encodeToJson(event)}\n\n", encoder.encodeSSE(event))
+    }
+}

--- a/sdks/community/kotlin/library/settings.gradle.kts
+++ b/sdks/community/kotlin/library/settings.gradle.kts
@@ -22,9 +22,11 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":kotlin-core")
 include(":kotlin-client")
 include(":kotlin-tools")
+include(":kotlin-encoder")
 
 // Map module directories to artifact names
 project(":kotlin-core").projectDir = file("core")
 project(":kotlin-client").projectDir = file("client")
 project(":kotlin-tools").projectDir = file("tools")
+project(":kotlin-encoder").projectDir = file("encoder")
 


### PR DESCRIPTION
Addressing #2170

Adds a small **`:kotlin-encoder`** module to the community Kotlin SDK — the server-side
serialization primitive the Kotlin SDK was missing, present in both reference SDKs:

| | TypeScript (`@ag-ui/encoder`) | Python (`ag_ui.encoder`) | **Kotlin (this PR)** |
|---|---|---|---|
| content-type negotiation | `getContentType()` | `get_content_type()` | `getContentType()` |
| encode to SSE | `encode()` / `encodeSSE()` | `encode()` / `_encode_sse()` | `encode()` / `encodeSSE()` |
| SSE frame | `data: {json}\n\n` | `data: {json}\n\n` | `data: {json}\n\n` |
| proto | yes (`@ag-ui/proto`) | media type only, no codec | TODO (SSE-only, like Python) |

Plus `encodeToJson(event)` — the unframed JSON body — for transports that add their own SSE
framing (Spring MVC `SseEmitter`, Jakarta `SseEventSink`), so they don't double-frame and the
SDK stays the single serialization entry point.


## Details

- New module `sdks/community/kotlin/library/encoder/`, wired in `settings.gradle.kts` as
  `:kotlin-encoder` (dir `encoder/`). KMP with a **JVM target only** → artifact
  `com.ag-ui.community:kotlin-encoder-jvm`. Depends only on `:kotlin-core`.
- `class EventEncoder(accept: String? = null)`; reuses `com.agui.core.types.{BaseEvent, AgUiJson}`;
  no changes to existing modules beyond the one `settings.gradle.kts` include.
- Byte-exact unit tests (`EventEncoderTest`) covering `getContentType()` (incl. the proto-Accept →
  still-SSE case), `encode`/`encodeSSE` framing, and `encodeToJson` body-only output.

## Scope / not in this PR

Deliberately **encoder-only**. Kotlin server-starter examples (Ktor + Spring Boot, following the
`integrations/server-starter/{python,typescript}` layout) are ready as a **follow-up** if the
maintainers want them — kept out to keep this focused and easy to review.

## Validated against two real consumers

This encoder was built into two real AG-UI servers and streamed through live before this PR: a
**Kotlin + Ktor + Koog** agent and a **Java + Spring + Google ADK** app. No encoder changes were
needed. Two small **`kotlin-core`** (not encoder) ergonomics follow-ups surfaced in both, offered
separately if welcome — deliberately kept out of this PR to keep it focused:

1. Re-export `kotlinx-serialization-json` as `api` in `kotlin-core` — a server must decode
   `RunAgentInput` via `AgUiJson`, but the json dep isn't transitively on the compile classpath today.
2. Add `@JvmOverloads` to the event constructors — Java/ADK consumers otherwise pass explicit trailing
   `null`s for the optional params.

## Notes

- SSE-only for now, matching the Python encoder; proto negotiation is a documented `TODO` pending
  a Kotlin proto codec.
- Happy to adjust package name / coordinates to match your conventions.
