### PR TITLE
fix(dotnet): forward Context and ForwardedProperties from RawRepresentationFactory input (#2151)

### DIFF
--- a/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
@@ -319,6 +319,10 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 Messages = messagesList.AsAGUIMessages().ToList(),
             };
 
+            // Tracks whether the caller hand-supplied Resume via RawRepresentationFactory.
+            // When true, the approval/interrupt translations below yield to it entirely.
+            bool callerSuppliedResume = false;
+
             if (providedInput is not null)
             {
                 if (providedInput.Messages is { Count: > 0 })
@@ -351,12 +355,13 @@ public sealed class AGUIChatClient : DelegatingChatClient
                     input.ForwardedProperties = providedInput.ForwardedProperties;
                 }
 
-                // A caller-supplied Resume takes precedence; the approval-response
-                // translation below already guards on `input.Resume is null`, so it
-                // yields to this. Interrupt responses still append to it.
+                // A caller-supplied Resume is authoritative: both the approval- and
+                // interrupt-response translations below yield to it (see the
+                // callerSuppliedResume guards), so the two resume paths stay symmetric.
                 if (providedInput.Resume is { Count: > 0 })
                 {
                     input.Resume = providedInput.Resume;
+                    callerSuppliedResume = true;
                 }
             }
 
@@ -366,69 +371,94 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 input.Tools = options.Tools.AsAGUITools().ToList();
             }
 
-            // Convert ToolApprovalResponseContent list (passed from AGUIChatClient) to resume payload
-            if (input.Resume is null &&
-                options?.AdditionalProperties?.TryGetValue(AGUIClientInternalKeys.ApprovalResponses, out List<ToolApprovalResponseContent>? approvalResponses) is true
-                && approvalResponses is { Count: > 0 })
+            List<ToolApprovalResponseContent>? approvalResponses = null;
+            List<InterruptResponseContent>? interruptResponses = null;
+            options?.AdditionalProperties?.TryGetValue(AGUIClientInternalKeys.ApprovalResponses, out approvalResponses);
+            options?.AdditionalProperties?.TryGetValue(AGUIClientInternalKeys.InterruptResponses, out interruptResponses);
+
+            if (callerSuppliedResume)
             {
-                var resumeList = new List<AGUIResume>(approvalResponses.Count);
-                foreach (var approvalResponse in approvalResponses)
+                // The caller's Resume wins, so approval/interrupt responses carried by the
+                // last message are not translated over it. Those responses were already
+                // stripped from the outgoing messages, so emit a diagnostic event to make
+                // the drop observable instead of silent.
+                int droppedApprovals = approvalResponses?.Count ?? 0;
+                int droppedInterrupts = interruptResponses?.Count ?? 0;
+                if (droppedApprovals > 0 || droppedInterrupts > 0)
                 {
-                    AGUIToolCallInfo? toolCallInfo = null;
-                    if (approvalResponse.ToolCall is FunctionCallContent tc)
-                    {
-                        toolCallInfo = new AGUIToolCallInfo
+                    Activity.Current?.AddEvent(new ActivityEvent(
+                        "agui.resume.caller_override_dropped_responses",
+                        tags: new ActivityTagsCollection
                         {
-                            CallId = tc.CallId,
-                            Name = tc.Name,
-                            Arguments = tc.Arguments
-                        };
-                    }
-
-                    // Check for a pre-computed result (from client-side tool execution)
-                    string? toolResult = null;
-                    if (approvalResponse.AdditionalProperties?.TryGetValue("result", out object? resultObj) is true)
-                    {
-                        toolResult = resultObj as string;
-                    }
-
-                    resumeList.Add(new AGUIResume
-                    {
-                        InterruptId = approvalResponse.RequestId,
-                        Status = ResumeStatus.Resolved,
-                        Payload = JsonSerializer.SerializeToElement(
-                            new AGUIToolApprovalResumePayload
-                            {
-                                Approved = approvalResponse.Approved,
-                                ToolCall = toolCallInfo,
-                                Result = toolResult
-                            },
-                            jsonSerializerOptions.GetTypeInfo(typeof(AGUIToolApprovalResumePayload)))
-                    });
+                            { "agui.resume.dropped_approval_responses", droppedApprovals },
+                            { "agui.resume.dropped_interrupt_responses", droppedInterrupts },
+                        }));
                 }
-
-                input.Resume = resumeList;
             }
-
-            // Convert InterruptResponseContent list to resume entries.
-            if (options?.AdditionalProperties?.TryGetValue(AGUIClientInternalKeys.InterruptResponses, out List<InterruptResponseContent>? interruptResponses) is true
-                && interruptResponses is { Count: > 0 })
+            else
             {
-                var resumeList = input.Resume is { Count: > 0 } existing
-                    ? new List<AGUIResume>(existing)
-                    : new List<AGUIResume>(interruptResponses.Count);
-
-                foreach (var ir in interruptResponses)
+                // Convert ToolApprovalResponseContent list (passed from AGUIChatClient) to resume payload
+                if (approvalResponses is { Count: > 0 })
                 {
-                    resumeList.Add(new AGUIResume
+                    var resumeList = new List<AGUIResume>(approvalResponses.Count);
+                    foreach (var approvalResponse in approvalResponses)
                     {
-                        InterruptId = ir.RequestId,
-                        Status = ResumeStatus.Resolved,
-                        Payload = ir.Payload,
-                    });
+                        AGUIToolCallInfo? toolCallInfo = null;
+                        if (approvalResponse.ToolCall is FunctionCallContent tc)
+                        {
+                            toolCallInfo = new AGUIToolCallInfo
+                            {
+                                CallId = tc.CallId,
+                                Name = tc.Name,
+                                Arguments = tc.Arguments
+                            };
+                        }
+
+                        // Check for a pre-computed result (from client-side tool execution)
+                        string? toolResult = null;
+                        if (approvalResponse.AdditionalProperties?.TryGetValue("result", out object? resultObj) is true)
+                        {
+                            toolResult = resultObj as string;
+                        }
+
+                        resumeList.Add(new AGUIResume
+                        {
+                            InterruptId = approvalResponse.RequestId,
+                            Status = ResumeStatus.Resolved,
+                            Payload = JsonSerializer.SerializeToElement(
+                                new AGUIToolApprovalResumePayload
+                                {
+                                    Approved = approvalResponse.Approved,
+                                    ToolCall = toolCallInfo,
+                                    Result = toolResult
+                                },
+                                jsonSerializerOptions.GetTypeInfo(typeof(AGUIToolApprovalResumePayload)))
+                        });
+                    }
+
+                    input.Resume = resumeList;
                 }
 
-                input.Resume = resumeList;
+                // Convert InterruptResponseContent list to resume entries, appending to any
+                // approval-derived entries produced above.
+                if (interruptResponses is { Count: > 0 })
+                {
+                    var resumeList = input.Resume is { Count: > 0 } existing
+                        ? new List<AGUIResume>(existing)
+                        : new List<AGUIResume>(interruptResponses.Count);
+
+                    foreach (var ir in interruptResponses)
+                    {
+                        resumeList.Add(new AGUIResume
+                        {
+                            InterruptId = ir.RequestId,
+                            Status = ResumeStatus.Resolved,
+                            Payload = ir.Payload,
+                        });
+                    }
+
+                    input.Resume = resumeList;
+                }
             }
 
             return input;

--- a/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
@@ -340,6 +340,16 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 {
                     input.ParentRunId = providedInput.ParentRunId;
                 }
+
+                if (providedInput.Context is { Count: > 0 })
+                {
+                    input.Context = providedInput.Context;
+                }
+
+                if (providedInput.ForwardedProperties.ValueKind != JsonValueKind.Undefined)
+                {
+                    input.ForwardedProperties = providedInput.ForwardedProperties;
+                }
             }
 
             // Convert M.E.AI tools to AG-UI format

--- a/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
@@ -350,6 +350,14 @@ public sealed class AGUIChatClient : DelegatingChatClient
                 {
                     input.ForwardedProperties = providedInput.ForwardedProperties;
                 }
+
+                // A caller-supplied Resume takes precedence; the approval-response
+                // translation below already guards on `input.Resume is null`, so it
+                // yields to this. Interrupt responses still append to it.
+                if (providedInput.Resume is { Count: > 0 })
+                {
+                    input.Resume = providedInput.Resume;
+                }
             }
 
             // Convert M.E.AI tools to AG-UI format

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AGUI.Abstractions;
@@ -141,6 +142,44 @@ public sealed class AGUIChatClientTest
         await DrainAsync(client.GetStreamingResponseAsync(history, options));
 
         Assert.Equal(3, transport.LastInput!.Messages.Count);
+    }
+
+    // https://github.com/ag-ui-protocol/ag-ui/issues/2151
+    // A caller-supplied RunAgentInput (via RawRepresentationFactory) must forward
+    // Context and ForwardedProperties onto the request actually sent, alongside
+    // the already-forwarded Messages/Tools/State/ParentRunId.
+    [Fact]
+    public async Task GetStreamingResponse_RawRepresentationFactory_ForwardsContextAndForwardedProperties()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var forwardedProperties = JsonDocument.Parse("{\"tenant\":\"acme\"}").RootElement.Clone();
+
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new RunAgentInput
+            {
+                Context = new List<AGUIContext>
+                {
+                    new() { Description = "userId", Value = "u-123" },
+                },
+                ForwardedProperties = forwardedProperties,
+            },
+        };
+
+        var history = new List<ChatMessage> { new(ChatRole.User, "Hello") };
+        await DrainAsync(client.GetStreamingResponseAsync(history, options));
+
+        var sent = transport.LastInput!;
+
+        Assert.NotNull(sent.Context);
+        var context = Assert.Single(sent.Context!);
+        Assert.Equal("userId", context.Description);
+        Assert.Equal("u-123", context.Value);
+
+        Assert.Equal(JsonValueKind.Object, sent.ForwardedProperties.ValueKind);
+        Assert.Equal("acme", sent.ForwardedProperties.GetProperty("tenant").GetString());
     }
 
     // https://github.com/microsoft/agent-framework/issues/5587

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
@@ -182,6 +182,68 @@ public sealed class AGUIChatClientTest
         Assert.Equal("acme", sent.ForwardedProperties.GetProperty("tenant").GetString());
     }
 
+    // A caller-supplied Resume (via RawRepresentationFactory) must be forwarded too,
+    // like the other RunAgentInput fields (#2177 review follow-up).
+    [Fact]
+    public async Task GetStreamingResponse_RawRepresentationFactory_ForwardsResume()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new RunAgentInput
+            {
+                Resume = new List<AGUIResume>
+                {
+                    new() { InterruptId = "caller-interrupt", Status = ResumeStatus.Resolved },
+                },
+            },
+        };
+
+        var history = new List<ChatMessage> { new(ChatRole.User, "Hello") };
+        await DrainAsync(client.GetStreamingResponseAsync(history, options));
+
+        var resume = transport.LastInput!.Resume;
+        Assert.NotNull(resume);
+        var entry = Assert.Single(resume!);
+        Assert.Equal("caller-interrupt", entry.InterruptId);
+    }
+
+    // A caller-supplied Resume takes precedence over the approval-response
+    // translation (the `input.Resume is null` guard yields to it) (#2177).
+    [Fact]
+    public async Task GetStreamingResponse_CallerResume_TakesPrecedenceOverApprovalResponses()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new RunAgentInput
+            {
+                Resume = new List<AGUIResume>
+                {
+                    new() { InterruptId = "caller-interrupt", Status = ResumeStatus.Resolved },
+                },
+            },
+        };
+
+        var toolCall = new FunctionCallContent("call-1", "someTool", new Dictionary<string, object?>());
+        var history = new List<ChatMessage>
+        {
+            new(ChatRole.User, [new ToolApprovalResponseContent("req-approval", approved: true, toolCall)]),
+        };
+
+        await DrainAsync(client.GetStreamingResponseAsync(history, options));
+
+        // The caller's Resume wins; the approval response is not translated over it.
+        var resume = transport.LastInput!.Resume;
+        Assert.NotNull(resume);
+        var entry = Assert.Single(resume!);
+        Assert.Equal("caller-interrupt", entry.InterruptId);
+    }
+
     // https://github.com/microsoft/agent-framework/issues/5587
     [Fact]
     public async Task AGUIChatClient_ToolCallResultWithPlainTextContent_DoesNotParseAsJson()

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
@@ -211,7 +211,7 @@ public sealed class AGUIChatClientTest
     }
 
     // A caller-supplied Resume takes precedence over the approval-response
-    // translation (the `input.Resume is null` guard yields to it) (#2177).
+    // translation (the callerSuppliedResume guard yields to it) (#2177).
     [Fact]
     public async Task GetStreamingResponse_CallerResume_TakesPrecedenceOverApprovalResponses()
     {
@@ -238,6 +238,40 @@ public sealed class AGUIChatClientTest
         await DrainAsync(client.GetStreamingResponseAsync(history, options));
 
         // The caller's Resume wins; the approval response is not translated over it.
+        var resume = transport.LastInput!.Resume;
+        Assert.NotNull(resume);
+        var entry = Assert.Single(resume!);
+        Assert.Equal("caller-interrupt", entry.InterruptId);
+    }
+
+    // A caller-supplied Resume takes precedence over the interrupt-response translation
+    // too, matching the approval path. Previously the interrupt block appended
+    // unconditionally, so a caller Resume dropped approvals but kept interrupts (#2177).
+    [Fact]
+    public async Task GetStreamingResponse_CallerResume_TakesPrecedenceOverInterruptResponses()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var options = new ChatOptions
+        {
+            RawRepresentationFactory = _ => new RunAgentInput
+            {
+                Resume = new List<AGUIResume>
+                {
+                    new() { InterruptId = "caller-interrupt", Status = ResumeStatus.Resolved },
+                },
+            },
+        };
+
+        var history = new List<ChatMessage>
+        {
+            new(ChatRole.User, [new InterruptResponseContent("req-interrupt")]),
+        };
+
+        await DrainAsync(client.GetStreamingResponseAsync(history, options));
+
+        // The caller's Resume wins; the interrupt response is not appended over it.
         var resume = transport.LastInput!.Resume;
         Assert.NotNull(resume);
         var entry = Assert.Single(resume!);


### PR DESCRIPTION
Fixes #2151.

## Problem

When a caller seeds the outgoing request via `ChatOptions.RawRepresentationFactory` (a `RunAgentInput`), `AGUIChatClientHandler.BuildRunAgentInput` copies `Messages`, `Tools`, `State` and `ParentRunId` onto the request it actually sends — but never reads `Context` or `ForwardedProperties`. Both are silently dropped, so caller-supplied run context/props never reach the AG-UI server.

## Fix

Forward the two missing fields inside the existing `providedInput is not null` block, mirroring the surrounding pattern:

```csharp
if (providedInput.Context is { Count: > 0 })
{
    input.Context = providedInput.Context;
}

if (providedInput.ForwardedProperties.ValueKind != JsonValueKind.Undefined)
{
    input.ForwardedProperties = providedInput.ForwardedProperties;
}
```

`Context` is `IList<AGUIContext>?` (guarded on non-empty) and `ForwardedProperties` is a non-nullable `JsonElement` (default `ValueKind` is `Undefined`, so the guard skips an unset value).

## Testing

- New unit test in `AGUIChatClientTest` using the existing `CapturingTransport` to assert both `Context` and `ForwardedProperties` survive onto the `RunAgentInput` sent to the transport.
- **TDD-verified**: the test fails on the pre-fix code (`Assert.NotNull` on `Context` → null) and passes after the fix.
- Full `AGUI.Client.UnitTests` suite green: **111/111** (net10.0). Ran locally with `.NET 10.0.100` (`dotnet test … /p:SignAssembly=false`, since the test-only `InternalsVisibleTo` is gated on unsigned builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
