### PR TITLE
fix(langgraph/python): import ag_ui_langgraph without FastAPI installed (#2067)

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/__init__.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/__init__.py
@@ -17,7 +17,13 @@ from .types import (
     LangGraphReasoning,
 )
 from .utils import json_safe_stringify, make_json_safe
-from .endpoint import add_langgraph_fastapi_endpoint
+try:
+    from .endpoint import add_langgraph_fastapi_endpoint
+except ImportError:
+    # FastAPI is an optional dependency — only the HTTP endpoint helper needs it.
+    # The adapter itself (LangGraphAgent.run) is a FastAPI-free in-process async
+    # generator, so importing the package must not require the web stack. (gh #2067)
+    add_langgraph_fastapi_endpoint = None
 from .middlewares.state_streaming import StateStreamingMiddleware, StateItem
 from .a2ui_tool import (
     get_a2ui_tools,

--- a/integrations/langgraph/python/tests/test_import_without_fastapi.py
+++ b/integrations/langgraph/python/tests/test_import_without_fastapi.py
@@ -1,0 +1,74 @@
+"""ag_ui_langgraph must import without FastAPI installed (gh #2067).
+
+FastAPI is an optional dependency (only the HTTP endpoint helper in endpoint.py
+uses it), but __init__.py eagerly imported .endpoint, so `import ag_ui_langgraph`
+/ `from ag_ui_langgraph import LangGraphAgent` raised ModuleNotFoundError when
+FastAPI wasn't installed — breaking every purely in-process consumer that just
+iterates LangGraphAgent.run() to render AG-UI events locally.
+"""
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+# Runs in a fresh subprocess so blocking `fastapi` doesn't disturb the rest of the
+# suite (which installs FastAPI for the endpoint tests).
+_SCRIPT = textwrap.dedent(
+    """
+    import importlib.abc
+    import sys
+
+    class _Blocker(importlib.abc.MetaPathFinder):
+        _blocked = ("fastapi", "starlette")
+
+        def find_spec(self, name, path=None, target=None):
+            top = name.split(".", 1)[0]
+            if top in self._blocked:
+                raise ImportError(f"blocked '{name}' to simulate FastAPI being absent")
+            return None
+
+    sys.meta_path.insert(0, _Blocker())
+    for mod in list(sys.modules):
+        top = mod.split(".", 1)[0]
+        if top in ("fastapi", "starlette", "ag_ui_langgraph"):
+            del sys.modules[mod]
+
+    # Sanity: FastAPI really is unreachable in this subprocess.
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        raise SystemExit("test setup bug: fastapi was still importable")
+
+    import ag_ui_langgraph
+    from ag_ui_langgraph import LangGraphAgent, add_langgraph_fastapi_endpoint
+
+    assert LangGraphAgent is not None, "LangGraphAgent must import without FastAPI"
+    assert add_langgraph_fastapi_endpoint is None, (
+        "add_langgraph_fastapi_endpoint should be None when FastAPI is absent"
+    )
+    print("OK")
+    """
+)
+
+
+class TestImportWithoutFastAPI(unittest.TestCase):
+    def test_package_imports_when_fastapi_is_absent(self):
+        result = subprocess.run(
+            [sys.executable, "-c", _SCRIPT],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"importing ag_ui_langgraph without FastAPI failed:\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+        )
+        self.assertIn("OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2067.

## Problem

FastAPI is declared an **optional** dependency of `ag-ui-langgraph` (only the HTTP endpoint helper in `endpoint.py` uses it), but `ag_ui_langgraph/__init__.py` eagerly imports `.endpoint`. So a purely in-process consumer — one that just iterates `LangGraphAgent.run()` to render AG-UI events locally (a terminal or Jupyter renderer, say) — can't import the package without the web stack:

```bash
pip install ag-ui-langgraph langgraph      # note: NOT the [fastapi] extra
python -c "from ag_ui_langgraph import LangGraphAgent"
# ModuleNotFoundError: No module named 'fastapi'
#   File ".../ag_ui_langgraph/__init__.py", line 20, in <module>
#     from .endpoint import add_langgraph_fastapi_endpoint
```

`endpoint.py` is the **only** module importing `fastapi`/`starlette`; the adapter itself (`agent.py`, `types.py`, `utils.py`, `a2ui_tool.py`, `middlewares/`) is already FastAPI-free.

## Fix

Guard the optional endpoint import:

```python
try:
    from .endpoint import add_langgraph_fastapi_endpoint
except ImportError:
    # FastAPI is an optional dependency — only the HTTP endpoint helper needs it.
    add_langgraph_fastapi_endpoint = None
```

`add_langgraph_fastapi_endpoint` stays in `__all__` and is simply `None` until FastAPI is present, so the served path is unchanged.

## Tests

Adds `tests/test_import_without_fastapi.py` — a regression test that blocks `fastapi`/`starlette` in a subprocess and asserts `LangGraphAgent` imports and `add_langgraph_fastapi_endpoint is None`. Verified the existing `test_deprecation_warnings.py` and `test_endpoint_health_path.py` still pass (the guard doesn't touch the served path), and the **full Python suite passes (380 tests)**.

<sub>Context: I filed #2067 two weeks ago with this diagnosis and offered to PR; sending it now since the change is small and ready. Happy to adjust to whatever you prefer.</sub>