### PR TITLE
fix(client): let MESSAGES_SNAPSHOT replace activity messages it carries

### DIFF
--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -479,6 +479,18 @@ displayed to users.
 | ---------- | ------------------------ |
 | `messages` | Array of message objects |
 
+`activity` and `reasoning` messages are all-or-nothing inside a
+`MessagesSnapshot`. If the snapshot carries any message of that role, it is the
+complete set for that role: entries it repeats replace the client's copies, and
+ones it leaves out are removed. If it carries none, the snapshot says nothing
+about that role and the client keeps the messages it already has.
+
+Both roles are client-side by default, so leaving them out is safe. Activity
+messages never travel back to the agent — they are stripped from `RunAgentInput`
+— and reasoning usually exists only as streamed `Reasoning` events. A backend
+that tracks neither simply omits them from the snapshot, and nothing the client
+holds is lost.
+
 ## Activity Events
 
 Activity Events expose structured, in-progress activity updates that occur

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -554,11 +554,11 @@ describe("MESSAGES_SNAPSHOT with snapshot-supplied reasoning", () => {
 });
 
 describe("MESSAGES_SNAPSHOT with snapshot-supplied activity", () => {
-  // A backend may include activity messages in the snapshot. Activity ids are
-  // minted by ACTIVITY_* events rather than by the snapshot, so an id the
-  // snapshot carries is the same message the client already holds: the snapshot
-  // is the source of truth for it and normal replace semantics apply. Activity
-  // messages the snapshot does not mention stay untouched.
+  // A snapshot is a snapshot of every message, so once it carries any activity
+  // the backend is declaring the complete activity set: entries it repeats are
+  // replaced and ones it leaves out are dropped. A snapshot that carries no
+  // activity says nothing about it, and the client's activity is preserved —
+  // the same all-or-nothing rule `snapshotHasReasoning` applies to reasoning.
 
   it("replaces an existing activity message with the snapshot version", async () => {
     const msgs = await applySnapshot(
@@ -594,11 +594,11 @@ describe("MESSAGES_SNAPSHOT with snapshot-supplied activity", () => {
     expect(activity.content?.tasks).toEqual(["fresh"]);
   });
 
-  it("preserves a local activity the snapshot does not mention while replacing one it does", async () => {
+  it("drops a local activity the snapshot leaves out once the snapshot carries activity", async () => {
     const msgs = await applySnapshot(
       [
         { id: "m1", role: "user", content: "hello" },
-        { id: "act-local", role: "activity", activityType: "PLAN", content: { tasks: ["local"] } },
+        { id: "act-gone", role: "activity", activityType: "PLAN", content: { tasks: ["gone"] } },
         { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["stale"] } },
       ] as Message[],
       [
@@ -607,10 +607,26 @@ describe("MESSAGES_SNAPSHOT with snapshot-supplied activity", () => {
       ] as Message[],
     );
 
-    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-local", "act-1"]);
-    const local = msgs.find((m) => m.id === "act-local")! as { content?: { tasks?: string[] } };
-    const replaced = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
-    expect(local.content?.tasks).toEqual(["local"]);
-    expect(replaced.content?.tasks).toEqual(["fresh"]);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-1"]);
+    const activity = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
+    expect(activity.content?.tasks).toEqual(["fresh"]);
+  });
+
+  it("keeps client activity when the snapshot carries none", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["local"] } },
+        { id: "a1", role: "assistant", content: "hi" },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "a1", role: "assistant", content: "hi" },
+      ] as Message[],
+    );
+
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-1", "a1"]);
+    const activity = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
+    expect(activity.content?.tasks).toEqual(["local"]);
   });
 });

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -1,12 +1,7 @@
 import { Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { firstValueFrom } from "rxjs";
-import {
-  BaseEvent,
-  EventType,
-  Message,
-  RunAgentInput,
-} from "@ag-ui/core";
+import { BaseEvent, EventType, Message, RunAgentInput } from "@ag-ui/core";
 import { defaultApplyEvents } from "../default";
 import { AbstractAgent } from "@/agent";
 import { AgentStateMutation } from "@/agent/subscriber";
@@ -110,7 +105,10 @@ describe("defaultApplyEvents with activity events", () => {
     expect(updates.length).toBe(3);
     expect(updates[0]?.messages?.[0]?.content).toEqual({ operations: [] });
     expect(updates[1]?.messages?.[0]?.content?.operations).toEqual([firstOperation]);
-    expect(updates[2]?.messages?.[0]?.content?.operations).toEqual([firstOperation, secondOperation]);
+    expect(updates[2]?.messages?.[0]?.content?.operations).toEqual([
+      firstOperation,
+      secondOperation,
+    ]);
   });
 
   it("does not replace existing activity message when replace is false", async () => {
@@ -150,7 +148,12 @@ describe("defaultApplyEvents with activity events", () => {
 
   it("replaces existing activity message when replace is true", async () => {
     const initial = [
-      { id: "activity-1", role: "activity" as const, activityType: "PLAN", content: { tasks: ["initial"] } },
+      {
+        id: "activity-1",
+        role: "activity" as const,
+        activityType: "PLAN",
+        content: { tasks: ["initial"] },
+      },
     ] as Message[];
 
     const updates = await emitAndCollect(initial, (events$) => {
@@ -422,7 +425,12 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
         { id: "m1", role: "user", content: "create a dashboard" },
         { id: "asst-1", role: "assistant", content: "I'll create that for you" },
         { id: "tool-stream", role: "tool", content: '{"a2ui": true}' },
-        { id: "act-1", role: "activity", activityType: "A2UI_SURFACE", content: { surface: "dashboard" } },
+        {
+          id: "act-1",
+          role: "activity",
+          activityType: "A2UI_SURFACE",
+          content: { surface: "dashboard" },
+        },
         { id: "asst-2", role: "assistant", content: "Here's your dashboard" },
       ] as Message[],
       [
@@ -433,9 +441,7 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       ],
     );
 
-    expect(msgs.map((m) => m.id)).toEqual([
-      "m1", "asst-1", "act-1", "asst-2", "tool-canon",
-    ]);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "asst-1", "act-1", "asst-2", "tool-canon"]);
   });
 });
 
@@ -544,5 +550,67 @@ describe("MESSAGES_SNAPSHOT with snapshot-supplied reasoning", () => {
     expect(msgs.filter((m) => m.role === "reasoning").length).toBe(1);
     const reasoning = msgs.find((m) => m.id === "r1")! as { encryptedValue?: string };
     expect(reasoning.encryptedValue).toBe("enc-1");
+  });
+});
+
+describe("MESSAGES_SNAPSHOT with snapshot-supplied activity", () => {
+  // A backend may include activity messages in the snapshot. Activity ids are
+  // minted by ACTIVITY_* events rather than by the snapshot, so an id the
+  // snapshot carries is the same message the client already holds: the snapshot
+  // is the source of truth for it and normal replace semantics apply. Activity
+  // messages the snapshot does not mention stay untouched.
+
+  it("replaces an existing activity message with the snapshot version", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["stale"] } },
+        { id: "a1", role: "assistant", content: "hi" },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["fresh"] } },
+        { id: "a1", role: "assistant", content: "hi" },
+      ] as Message[],
+    );
+
+    expect(msgs.filter((m) => m.role === "activity").length).toBe(1);
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-1", "a1"]);
+    const activity = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
+    expect(activity.content?.tasks).toEqual(["fresh"]);
+  });
+
+  it("appends an activity message the client does not have yet", async () => {
+    const msgs = await applySnapshot(
+      [{ id: "m1", role: "user", content: "hello" }] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["fresh"] } },
+      ] as Message[],
+    );
+
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-1"]);
+    const activity = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
+    expect(activity.content?.tasks).toEqual(["fresh"]);
+  });
+
+  it("preserves a local activity the snapshot does not mention while replacing one it does", async () => {
+    const msgs = await applySnapshot(
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-local", role: "activity", activityType: "PLAN", content: { tasks: ["local"] } },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["stale"] } },
+      ] as Message[],
+      [
+        { id: "m1", role: "user", content: "hello" },
+        { id: "act-1", role: "activity", activityType: "PLAN", content: { tasks: ["fresh"] } },
+      ] as Message[],
+    );
+
+    expect(msgs.map((m) => m.id)).toEqual(["m1", "act-local", "act-1"]);
+    const local = msgs.find((m) => m.id === "act-local")! as { content?: { tasks?: string[] } };
+    const replaced = msgs.find((m) => m.id === "act-1")! as { content?: { tasks?: string[] } };
+    expect(local.content?.tasks).toEqual(["local"]);
+    expect(replaced.content?.tasks).toEqual(["fresh"]);
   });
 });

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -595,17 +595,17 @@ export const defaultApplyEvents = (
             // snapshot.
             const snapshotMap = new Map(newMessages.map((m) => [m.id, m]));
 
-            // `activity` messages are usually client-only — most backends leave
-            // them out of MESSAGES_SNAPSHOT, so a local activity the snapshot
-            // does not mention is preserved. But a backend may include them (the
-            // message type is part of the snapshot payload in every SDK), and an
-            // id it carries is the same message the client already holds, since
-            // activity ids come from ACTIVITY_* events rather than being minted
-            // by the snapshot. So when the snapshot names an activity message,
-            // it is the source of truth for it and normal replace semantics
-            // apply — otherwise the snapshot copy would be silently dropped for
-            // activities the client already has while still being appended for
-            // ones it does not, which is inconsistent.
+            // `activity` messages are only sometimes client-only. They never
+            // travel back to the backend — `prepareRunAgentInput` strips them
+            // from RunAgentInput — so a backend that does not track them cannot
+            // put them in the snapshot, and the local copies must be preserved.
+            // But a backend that does track them re-delivers the whole set it
+            // owns. Since a MESSAGES_SNAPSHOT is a snapshot of every message,
+            // once it carries any activity the backend is declaring the complete
+            // activity set, and one it leaves out has been removed — preserving
+            // it would make the local copy undeletable. So when the snapshot
+            // itself carries activity, treat it as the source of truth for
+            // activity messages and apply the normal replace semantics.
             //
             // `reasoning` messages are only sometimes client-only. Most backends
             // never include reasoning in the snapshot (it exists purely as
@@ -618,9 +618,10 @@ export const defaultApplyEvents = (
             // copy would render the same reasoning twice. So when the snapshot
             // itself carries reasoning, treat it as the source of truth for
             // reasoning messages too and apply the normal replace semantics.
+            const snapshotHasActivity = newMessages.some((m) => m.role === "activity");
             const snapshotHasReasoning = newMessages.some((m) => m.role === "reasoning");
             const isPreservedClientOnly = (m: Message) =>
-              (m.role === "activity" && !snapshotMap.has(m.id)) ||
+              (m.role === "activity" && !snapshotHasActivity) ||
               (m.role === "reasoning" && !snapshotHasReasoning);
 
             // Step 1 + 2: Keep preserved client-only messages as-is, keep

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -595,8 +595,17 @@ export const defaultApplyEvents = (
             // snapshot.
             const snapshotMap = new Map(newMessages.map((m) => [m.id, m]));
 
-            // `activity` messages are always client-only — backends never include
-            // them in MESSAGES_SNAPSHOT — so they are always preserved.
+            // `activity` messages are usually client-only — most backends leave
+            // them out of MESSAGES_SNAPSHOT, so a local activity the snapshot
+            // does not mention is preserved. But a backend may include them (the
+            // message type is part of the snapshot payload in every SDK), and an
+            // id it carries is the same message the client already holds, since
+            // activity ids come from ACTIVITY_* events rather than being minted
+            // by the snapshot. So when the snapshot names an activity message,
+            // it is the source of truth for it and normal replace semantics
+            // apply — otherwise the snapshot copy would be silently dropped for
+            // activities the client already has while still being appended for
+            // ones it does not, which is inconsistent.
             //
             // `reasoning` messages are only sometimes client-only. Most backends
             // never include reasoning in the snapshot (it exists purely as
@@ -611,7 +620,8 @@ export const defaultApplyEvents = (
             // reasoning messages too and apply the normal replace semantics.
             const snapshotHasReasoning = newMessages.some((m) => m.role === "reasoning");
             const isPreservedClientOnly = (m: Message) =>
-              m.role === "activity" || (m.role === "reasoning" && !snapshotHasReasoning);
+              (m.role === "activity" && !snapshotMap.has(m.id)) ||
+              (m.role === "reasoning" && !snapshotHasReasoning);
 
             // Step 1 + 2: Keep preserved client-only messages as-is, keep
             // messages present in the snapshot (replaced with snapshot version),


### PR DESCRIPTION
## Description

Fixes #2149.

In the `MESSAGES_SNAPSHOT` branch of `defaultApplyEvents`, the preservation predicate treated every activity message as client-only:

```ts
const isPreservedClientOnly = (m: Message) =>
  m.role === "activity" || (m.role === "reasoning" && !snapshotHasReasoning);
```

so a snapshot copy of an activity message was never applied over the local one. The append step directly below it, however, does add activity messages the snapshot carries when the client doesn't already have them. The snapshot was therefore honoured only half the time for activity: new ones were appended, existing ones silently discarded — while every other message type is replaced.

The comment above the predicate asserted the opposite invariant ("backends never include them in MESSAGES_SNAPSHOT"), and the test suite encoded it — across the activity tests an activity message only ever appeared in the client list, never in the snapshot payload — so the snapshot-carries-activity path had no coverage.

## Semantics

Activity is now gated by `snapshotHasActivity` exactly as reasoning is gated by `snapshotHasReasoning`: **all-or-nothing**. A `MESSAGES_SNAPSHOT` is a snapshot of every message, so once it carries any activity the backend is declaring the complete activity set — entries it repeats are replaced, and ones it leaves out are removed. A snapshot that carries no activity says nothing about activity, and the client keeps what it has.

This converged during review of #2149 (thanks @dlyz). An earlier revision of this PR matched by id instead — preserving any activity the snapshot did not name — but that makes an activity message undeletable: a snapshot could never remove one, and a snapshot that cannot remove a message is not a snapshot.

Dropping unnamed activity is safe because activity never round-trips: `prepareRunAgentInput` filters `role !== "activity"` out of `RunAgentInput`, so a backend that does not track activity cannot put any in a snapshot — `snapshotHasActivity` stays false and nothing is dropped. The trade-off is the one reasoning already has today: a backend that stores activity but sends only part of it in a snapshot drops the rest on the client.

Worth noting the two roles reach the same rule for different reasons. Reasoning *needs* all-or-nothing because streamed and snapshot ids are not stable, so id-matching cannot work. Activity ids are stable — they come from `messageId` on the `ACTIVITY_*` events — so id-matching would have worked; all-or-nothing is chosen for the ownership semantics, not out of necessity.

## Changes

- `sdks/typescript/packages/client/src/apply/default.ts` — `snapshotHasActivity` gates activity in `isPreservedClientOnly`; the comment now states the actual invariant.
- `sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts` — new `MESSAGES_SNAPSHOT with snapshot-supplied activity` block, four cases:
  - an activity message present in both the client list and the snapshot is replaced with the snapshot version
  - an activity message present only in the snapshot is appended
  - a local activity the snapshot leaves out is dropped once the snapshot carries activity
  - client activity is preserved when the snapshot carries none
- `docs/concepts/events.mdx` — pins the rule for `activity` and `reasoning` under `MessagesSnapshot`, so it is defined protocol behaviour rather than client-implementation detail (per review).

## Verification

Windows 11, Node 22.17.1, pnpm 10.33.4:

- before: with `act-1` in both the client list and the snapshot, the snapshot copy was dropped and the stale local one kept; the same message present only in the snapshot was appended; a non-activity message in the identical situation was replaced
- after: the snapshot owns activity whenever it carries any, and is silent about it otherwise
- `default.activity.test.ts` — 27 tests pass (23 existing, unchanged, plus 4 new)
- the rest of the `@ag-ui/client` suite is unaffected

The pre-existing failure of `esm-interop.test.ts` on Windows is unrelated to this change and is addressed separately in #2183.
