### PR TITLE
feat(python): token usage producers for LangGraph + AWS Strands (OSS-351) [blocked on ag-ui-protocol release]

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -9,7 +9,7 @@ import inspect
 import json
 import logging
 import uuid
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from strands import Agent as StrandsAgentCore
 from strands.session import SessionManager
@@ -90,6 +90,7 @@ from ag_ui.core import (
     TextMessageContentEvent,
     TextMessageEndEvent,
     TextMessageStartEvent,
+    TokenUsage,
     ToolCall,
     ToolCallArgsEvent,
     ToolCallEndEvent,
@@ -107,6 +108,7 @@ from .a2ui_tool import (
     plan_a2ui_injection,
 )
 from .client_proxy_tool import sync_proxy_tools
+from .usage import token_usage_from_strands
 from .config import (
     StrandsAgentConfig,
     ToolCallContext,
@@ -129,6 +131,25 @@ def _coerce_text(content: Any) -> str:
 def _coerce_id(value: Any) -> str:
     """Return ``value`` if it is a non-empty string, else a fresh UUID."""
     return value if isinstance(value, str) and value else str(uuid.uuid4())
+
+
+def _strands_model_identity(strands_agent: Any) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort ``(provider, model_id)`` for a Strands agent's model, used to
+    label token usage. Provider is derived from the model class name (e.g.
+    ``BedrockModel`` -> ``bedrock``); model id from the model config. Returns
+    ``(None, None)`` on anything unexpected so usage still flows unlabeled.
+    """
+    try:
+        model = getattr(strands_agent, "model", None)
+        if model is None:
+            return (None, None)
+        cls = type(model).__name__
+        provider = cls[:-5].lower() if cls.endswith("Model") and len(cls) > 5 else None
+        config = model.get_config() if hasattr(model, "get_config") else getattr(model, "config", None)
+        model_id = config.get("model_id") if isinstance(config, dict) else None
+        return (provider, model_id if isinstance(model_id, str) else None)
+    except Exception:
+        return (None, None)
 
 
 def _build_snapshot_messages(input_messages: List[Any]) -> List[Any]:
@@ -906,6 +927,12 @@ class StrandsAgent:
                 # Strands (via session_manager) to track history.
                 agent_stream = strands_agent.stream_async(user_message)
 
+            # Provider-reported token usage, accumulated across the run and
+            # attached to the terminal RUN_FINISHED. Populated from the Strands
+            # AgentResult's metrics.accumulated_usage on the final "result" event.
+            run_usage: List[TokenUsage] = []
+            usage_provider, usage_model = _strands_model_identity(strands_agent)
+
             try:
                 async for event in agent_stream:
                     # If we've halted, consume remaining events silently to allow proper cleanup
@@ -913,6 +940,24 @@ class StrandsAgent:
                         continue
 
                     logger.debug(f"Received event: {event}")
+
+                    # Capture token usage from the terminal AgentResult. Done
+                    # before the lifecycle skips below so it is never missed,
+                    # regardless of which other keys the event also carries.
+                    result_obj = event.get("result") if isinstance(event, dict) else None
+                    if result_obj is not None:
+                        try:
+                            metrics = getattr(result_obj, "metrics", None)
+                            accumulated = getattr(metrics, "accumulated_usage", None)
+                            entry = token_usage_from_strands(
+                                accumulated,
+                                provider=usage_provider,
+                                model=usage_model,
+                            )
+                            if entry is not None:
+                                run_usage.append(entry)
+                        except Exception:  # pragma: no cover - defensive
+                            logger.debug("token usage capture skipped", exc_info=True)
 
                     # Skip lifecycle events
                     if event.get("init_event_loop") or event.get("start_event_loop"):
@@ -1819,6 +1864,7 @@ class StrandsAgent:
                 type=EventType.RUN_FINISHED,
                 thread_id=input_data.thread_id,
                 run_id=input_data.run_id,
+                usage=run_usage or None,
             )
 
         except Exception as e:

--- a/integrations/aws-strands/python/src/ag_ui_strands/usage.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/usage.py
@@ -1,0 +1,57 @@
+"""Map Strands accumulated token usage into an AG-UI ``TokenUsage``.
+
+Kept dependency-free (only ``ag_ui.core``) so the numeric-only mapping stays
+isolated from the streaming logic and is unit-testable without the Strands SDK.
+Only numeric counts (+ optional provider/model labels) are read — never
+prompt/completion content.
+"""
+from typing import Any, Optional
+
+from ag_ui.core import TokenUsage
+
+
+def _int(value: Any) -> Optional[int]:
+    # bool is a subclass of int in Python — exclude it so a stray True/False
+    # never becomes a token count.
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def token_usage_from_strands(
+    accumulated_usage: Any,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Optional[TokenUsage]:
+    """Build a ``TokenUsage`` from a Strands ``EventLoopMetrics.accumulated_usage``.
+
+    ``accumulated_usage`` is Strands' ``Usage`` mapping
+    (``{"inputTokens", "outputTokens", "totalTokens", ...}``). Accepts a dict or
+    an attribute-style object. Returns ``None`` when no numeric count is present
+    so callers can omit usage rather than report zeros.
+    """
+    if not accumulated_usage:
+        return None
+
+    if isinstance(accumulated_usage, dict):
+        get = accumulated_usage.get
+    else:
+        get = lambda key, default=None: getattr(accumulated_usage, key, default)
+
+    input_tokens = _int(get("inputTokens"))
+    output_tokens = _int(get("outputTokens"))
+    total_tokens = _int(get("totalTokens"))
+    cached_input_tokens = _int(get("cacheReadInputTokens"))
+
+    if input_tokens is None and output_tokens is None and total_tokens is None:
+        return None
+
+    return TokenUsage(
+        provider=provider,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cached_input_tokens=cached_input_tokens,
+    )

--- a/integrations/aws-strands/python/tests/test_run_finished_usage.py
+++ b/integrations/aws-strands/python/tests/test_run_finished_usage.py
@@ -1,0 +1,96 @@
+"""Wiring test: Strands AgentResult usage -> RUN_FINISHED.usage.
+
+Drives the real StrandsAgent.run() with a mocked stream that yields a terminal
+`{"result": AgentResult}` event carrying metrics.accumulated_usage.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ag_ui.core import EventType
+from ag_ui_strands.agent import StrandsAgent
+
+
+class BedrockModel:
+    """Model whose class name maps to provider "bedrock" and whose config
+    carries a model id."""
+
+    def get_config(self):
+        return {"model_id": "claude-sonnet-4"}
+
+
+class _Metrics:
+    def __init__(self, usage):
+        self.accumulated_usage = usage
+
+
+class _Result:
+    def __init__(self, usage):
+        self.metrics = _Metrics(usage)
+
+
+class _MockStrandsAgent:
+    def __init__(self, events, model=None):
+        self.events = events
+        self.model = model if model is not None else MagicMock()
+        self.system_prompt = "test"
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.record_direct_tool_call = True
+
+    async def stream_async(self, _message):
+        for event in self.events:
+            yield event
+
+
+def _make_input():
+    i = MagicMock()
+    i.thread_id = "test-thread"
+    i.run_id = "test-run"
+    i.state = {}
+    i.messages = []
+    i.tools = []
+    return i
+
+
+def _build(events, model=None):
+    agent = StrandsAgent(_MockStrandsAgent(events, model), name="test", description="test")
+    agent._agents_by_thread["test-thread"] = _MockStrandsAgent(events, model)
+    return agent
+
+
+async def _run_finished(agent):
+    finished = None
+    async for ev in agent.run(_make_input()):
+        if ev.type == EventType.RUN_FINISHED:
+            finished = ev
+    return finished
+
+
+@pytest.mark.asyncio
+async def test_usage_surfaced_and_labelled_on_run_finished():
+    events = [
+        {"data": "hi"},
+        {"result": _Result({"inputTokens": 100, "outputTokens": 50, "totalTokens": 150})},
+        {"complete": True},
+    ]
+    finished = await _run_finished(_build(events, model=BedrockModel()))
+    assert finished is not None
+    assert finished.usage is not None
+    assert len(finished.usage) == 1
+    entry = finished.usage[0]
+    assert entry.input_tokens == 100
+    assert entry.output_tokens == 50
+    assert entry.total_tokens == 150
+    assert entry.provider == "bedrock"
+    assert entry.model == "claude-sonnet-4"
+
+
+@pytest.mark.asyncio
+async def test_no_usage_when_result_absent():
+    events = [{"data": "hi"}, {"complete": True}]
+    finished = await _run_finished(_build(events))
+    assert finished is not None
+    assert finished.usage is None

--- a/integrations/aws-strands/python/tests/test_usage.py
+++ b/integrations/aws-strands/python/tests/test_usage.py
@@ -1,0 +1,52 @@
+"""Unit tests for the Strands -> AG-UI token usage mapping.
+
+Imports the leaf `usage` module directly by path so the test does not pull in
+the strands-dependent package `__init__`. Only `ag_ui.core` + pydantic needed.
+"""
+import importlib.util
+import pathlib
+import unittest
+
+_USAGE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "ag_ui_strands" / "usage.py"
+)
+_spec = importlib.util.spec_from_file_location("ag_ui_strands_usage_under_test", _USAGE_PATH)
+usage = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(usage)
+
+
+class TokenUsageFromStrandsTest(unittest.TestCase):
+    def test_maps_accumulated_usage_dict(self):
+        u = usage.token_usage_from_strands(
+            {"inputTokens": 100, "outputTokens": 50, "totalTokens": 150},
+            provider="bedrock",
+            model="claude-sonnet-4",
+        )
+        self.assertEqual(u.provider, "bedrock")
+        self.assertEqual(u.model, "claude-sonnet-4")
+        self.assertEqual(u.input_tokens, 100)
+        self.assertEqual(u.output_tokens, 50)
+        self.assertEqual(u.total_tokens, 150)
+
+    def test_maps_cache_read_tokens_when_present(self):
+        u = usage.token_usage_from_strands(
+            {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15, "cacheReadInputTokens": 4},
+        )
+        self.assertEqual(u.cached_input_tokens, 4)
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(usage.token_usage_from_strands(None))
+        self.assertIsNone(usage.token_usage_from_strands({}))
+
+    def test_returns_none_when_no_numeric_counts(self):
+        self.assertIsNone(usage.token_usage_from_strands({"inputTokens": None}))
+
+    def test_ignores_bool_masquerading_as_int(self):
+        # bool is a subclass of int in Python; must not be treated as a count.
+        u = usage.token_usage_from_strands({"inputTokens": True, "totalTokens": 7})
+        self.assertIsNone(u.input_tokens)
+        self.assertEqual(u.total_tokens, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -57,6 +57,7 @@ from ag_ui.core import (
     RunFinishedEvent,
     RunFinishedInterruptOutcome,
     RunStartedEvent,
+    TokenUsage,
     StateDeltaEvent,
     StateSnapshotEvent,
     StepFinishedEvent,
@@ -76,6 +77,7 @@ from ag_ui.core import (
     ReasoningEncryptedValueEvent,
 )
 from .interrupts import lg_interrupts_to_agui, DEFAULT_RESUME_SENTINEL_CANCELLED, DEFAULT_RESUME_SENTINEL_MAP
+from .usage import token_usage_from_chunk, aggregate_token_usage
 from ag_ui.encoder import EventEncoder
 from ag_ui_a2ui_toolkit import split_a2ui_schema_context
 
@@ -204,6 +206,7 @@ class LangGraphAgent:
             "streamed_tool_call_ids": set(),
             "model_made_tool_call": False,
             "state_reliable": True,
+            "usage": [],
         }
         self.active_run = INITIAL_ACTIVE_RUN
         try:
@@ -1150,6 +1153,7 @@ class LangGraphAgent:
                 thread_id=thread_id,
                 run_id=run_id,
                 outcome=outcome,
+                usage=self._collect_run_usage(),
             )
         )
         return events
@@ -1162,7 +1166,18 @@ class LangGraphAgent:
             type=EventType.RUN_FINISHED,
             thread_id=thread_id,
             run_id=run_id,
+            usage=self._collect_run_usage(),
         )
+
+    def _collect_run_usage(self) -> Optional[List[TokenUsage]]:
+        """Aggregate accumulated per-call usage for the terminal event.
+
+        Returns ``None`` (omitted field) when no provider usage was reported,
+        so consumers can treat missing usage as "not measured" rather than zero.
+        """
+        raw = self.active_run.get("usage", []) if self.active_run else []
+        aggregated = aggregate_token_usage(raw)
+        return aggregated or None
 
     def _build_command_from_agui_resume(
         self,
@@ -1252,6 +1267,21 @@ class LangGraphAgent:
 
             response_metadata = _chunk_get(chunk_raw, "response_metadata", None) or {}
             tool_call_chunks_list = _chunk_get(chunk_raw, "tool_call_chunks", None) or []
+
+            # Capture provider-reported token usage. LangChain attaches
+            # `usage_metadata` to the final streamed chunk (the one that also
+            # carries `finish_reason`), so this must run *before* the
+            # finish-reason early return below or usage would be dropped.
+            usage_metadata = _chunk_get(chunk_raw, "usage_metadata", None)
+            if usage_metadata:
+                ls_metadata = event.get("metadata") or {}
+                usage_entry = token_usage_from_chunk(
+                    usage_metadata,
+                    provider=ls_metadata.get("ls_provider"),
+                    model=ls_metadata.get("ls_model_name"),
+                )
+                if usage_entry is not None:
+                    self.active_run.setdefault("usage", []).append(usage_entry)
 
             if response_metadata.get('finish_reason', None):
                 return

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -2,6 +2,8 @@ from typing import TypedDict, Optional, List, Any, Dict, Set, Union, Literal
 from typing_extensions import NotRequired
 from enum import Enum
 
+from ag_ui.core import TokenUsage
+
 class LangGraphEventTypes(str, Enum):
     OnChainStart = "on_chain_start"
     OnChainStream = "on_chain_stream"
@@ -70,6 +72,10 @@ RunMetadata = TypedDict("RunMetadata", {
     "streamed_tool_call_ids": NotRequired[Set[str]],
     "model_made_tool_call": NotRequired[bool],
     "state_reliable": NotRequired[bool],
+    # Per-LLM-call token usage accumulated across the run from provider-reported
+    # numeric metadata; aggregated per (provider, model) and attached to the
+    # terminal RUN_FINISHED event. Never holds prompt/completion content.
+    "usage": NotRequired[List[TokenUsage]],
     # Message / state data
     "manually_emitted_state": NotRequired[Optional[State]],
     # Reasoning / thinking

--- a/integrations/langgraph/python/ag_ui_langgraph/usage.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/usage.py
@@ -1,0 +1,72 @@
+"""Map LangChain/LangGraph token usage metadata into AG-UI ``TokenUsage``.
+
+Kept dependency-free (only ``ag_ui.core``) so it can be unit-tested without the
+full LangGraph runtime, and so the numeric-only mapping stays isolated from the
+streaming logic. Only provider/model labels and numeric counts are read — never
+prompt/completion content.
+"""
+from typing import Any, Dict, List, Optional
+
+from ag_ui.core import TokenUsage
+
+# Numeric fields summed during aggregation.
+_COUNT_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "reasoning_tokens",
+    "cached_input_tokens",
+)
+
+
+def token_usage_from_chunk(
+    usage_metadata: Optional[Dict[str, Any]],
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+) -> Optional[TokenUsage]:
+    """Build a ``TokenUsage`` from a LangChain ``usage_metadata`` mapping.
+
+    Returns ``None`` when no usage metadata is present, so callers can skip
+    emitting empty usage rather than reporting zeros.
+    """
+    if not usage_metadata:
+        return None
+
+    input_details = usage_metadata.get("input_token_details") or {}
+    output_details = usage_metadata.get("output_token_details") or {}
+
+    return TokenUsage(
+        provider=provider,
+        model=model,
+        input_tokens=usage_metadata.get("input_tokens"),
+        output_tokens=usage_metadata.get("output_tokens"),
+        total_tokens=usage_metadata.get("total_tokens"),
+        reasoning_tokens=output_details.get("reasoning"),
+        cached_input_tokens=input_details.get("cache_read"),
+    )
+
+
+def aggregate_token_usage(entries: List[TokenUsage]) -> List[TokenUsage]:
+    """Sum per-call usage into one entry per ``(provider, model)`` pair.
+
+    Order follows first appearance. A count field stays ``None`` when no member
+    of the group reported it (so "not reported" is distinguishable from zero).
+    """
+    grouped: Dict[tuple, TokenUsage] = {}
+    order: List[tuple] = []
+
+    for entry in entries:
+        key = (entry.provider, entry.model)
+        if key not in grouped:
+            grouped[key] = TokenUsage(provider=entry.provider, model=entry.model)
+            order.append(key)
+        target = grouped[key]
+        for field in _COUNT_FIELDS:
+            value = getattr(entry, field)
+            if value is None:
+                continue
+            current = getattr(target, field)
+            setattr(target, field, (current or 0) + value)
+
+    return [grouped[key] for key in order]

--- a/integrations/langgraph/python/tests/test_run_finished_usage_wiring.py
+++ b/integrations/langgraph/python/tests/test_run_finished_usage_wiring.py
@@ -1,0 +1,95 @@
+"""End-to-end wiring: OnChatModelStream usage_metadata -> RUN_FINISHED.usage.
+
+Drives the real `_handle_single_event` chunk handler with fake final chunks
+(carrying `usage_metadata` + `finish_reason`, as LangChain delivers them) and
+asserts the terminal event produced by `_emit_success_finish` carries the
+aggregated usage.
+"""
+import asyncio
+import unittest
+
+from ag_ui.core import EventType
+
+from tests._helpers import make_agent
+
+
+class _FakeFinalChunk:
+    """Stand-in for a LangChain AIMessageChunk final chunk (attribute access)."""
+
+    def __init__(self, usage_metadata):
+        self.response_metadata = {"finish_reason": "stop"}
+        self.tool_call_chunks = []
+        self.usage_metadata = usage_metadata
+        self.content = ""
+        self.id = "msg-1"
+
+
+def _finish_event(usage_metadata, provider, model):
+    return {
+        "event": "on_chat_model_stream",
+        "metadata": {
+            "ls_provider": provider,
+            "ls_model_name": model,
+            "emit-messages": True,
+            "emit-tool-calls": True,
+        },
+        "data": {"chunk": _FakeFinalChunk(usage_metadata)},
+    }
+
+
+def _feed(agent, event):
+    async def drain():
+        async for _ in agent._handle_single_event(event, {}):
+            pass
+
+    asyncio.run(drain())
+
+
+class RunFinishedUsageWiringTest(unittest.TestCase):
+    def _fresh_agent(self):
+        agent = make_agent()
+        agent.active_run = {"id": "run-1", "usage": []}
+        agent.messages_in_process = {}
+        return agent
+
+    def test_single_call_usage_reaches_run_finished(self):
+        agent = self._fresh_agent()
+        _feed(
+            agent,
+            _finish_event(
+                {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+                provider="anthropic",
+                model="claude-sonnet-4",
+            ),
+        )
+        event = agent._emit_success_finish(thread_id="t-1", run_id="run-1")
+        self.assertEqual(event.type, EventType.RUN_FINISHED)
+        self.assertIsNotNone(event.usage)
+        self.assertEqual(len(event.usage), 1)
+        self.assertEqual(event.usage[0].provider, "anthropic")
+        self.assertEqual(event.usage[0].total_tokens, 150)
+
+    def test_multiple_calls_same_model_are_aggregated(self):
+        agent = self._fresh_agent()
+        for _ in range(2):
+            _feed(
+                agent,
+                _finish_event(
+                    {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                    provider="openai",
+                    model="gpt-4o",
+                ),
+            )
+        event = agent._emit_success_finish(thread_id="t-1", run_id="run-1")
+        self.assertEqual(len(event.usage), 1)
+        self.assertEqual(event.usage[0].input_tokens, 200)
+        self.assertEqual(event.usage[0].total_tokens, 240)
+
+    def test_run_without_usage_omits_field(self):
+        agent = self._fresh_agent()
+        event = agent._emit_success_finish(thread_id="t-1", run_id="run-1")
+        self.assertIsNone(event.usage)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_usage.py
+++ b/integrations/langgraph/python/tests/test_usage.py
@@ -1,0 +1,96 @@
+"""Unit tests for the LangGraph -> AG-UI token usage mapping.
+
+Imports the leaf `usage` module directly by path so the test does not pull in
+the langgraph-dependent package `__init__`. Only `ag_ui.core` + pydantic are
+required on the path.
+"""
+import importlib.util
+import pathlib
+import unittest
+
+_USAGE_PATH = pathlib.Path(__file__).resolve().parents[1] / "ag_ui_langgraph" / "usage.py"
+_spec = importlib.util.spec_from_file_location("ag_ui_langgraph_usage_under_test", _USAGE_PATH)
+usage = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(usage)
+
+
+class TokenUsageFromChunkTest(unittest.TestCase):
+    def test_maps_core_and_detail_fields(self):
+        u = usage.token_usage_from_chunk(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_token_details": {"cache_read": 10},
+                "output_token_details": {"reasoning": 20},
+            },
+            provider="anthropic",
+            model="claude-sonnet-4",
+        )
+        self.assertEqual(u.provider, "anthropic")
+        self.assertEqual(u.model, "claude-sonnet-4")
+        self.assertEqual(u.input_tokens, 100)
+        self.assertEqual(u.output_tokens, 50)
+        self.assertEqual(u.total_tokens, 150)
+        self.assertEqual(u.cached_input_tokens, 10)
+        self.assertEqual(u.reasoning_tokens, 20)
+
+    def test_returns_none_for_empty_metadata(self):
+        self.assertIsNone(usage.token_usage_from_chunk(None, provider="p", model="m"))
+        self.assertIsNone(usage.token_usage_from_chunk({}, provider="p", model="m"))
+
+    def test_omits_absent_fields(self):
+        u = usage.token_usage_from_chunk(
+            {"input_tokens": 5}, provider=None, model=None
+        )
+        dumped = u.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped, {"inputTokens": 5})
+
+
+class AggregateTokenUsageTest(unittest.TestCase):
+    def test_sums_entries_for_same_provider_model(self):
+        entries = [
+            usage.token_usage_from_chunk(
+                {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                provider="openai",
+                model="gpt-4o",
+            ),
+            usage.token_usage_from_chunk(
+                {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                provider="openai",
+                model="gpt-4o",
+            ),
+        ]
+        agg = usage.aggregate_token_usage(entries)
+        self.assertEqual(len(agg), 1)
+        self.assertEqual(agg[0].input_tokens, 110)
+        self.assertEqual(agg[0].output_tokens, 25)
+        self.assertEqual(agg[0].total_tokens, 135)
+
+    def test_keeps_distinct_models_separate_and_ordered(self):
+        entries = [
+            usage.token_usage_from_chunk({"input_tokens": 1}, provider="openai", model="gpt-4o"),
+            usage.token_usage_from_chunk({"input_tokens": 2}, provider="openai", model="gpt-4o-mini"),
+            usage.token_usage_from_chunk({"input_tokens": 3}, provider="openai", model="gpt-4o"),
+        ]
+        agg = usage.aggregate_token_usage(entries)
+        self.assertEqual([u.model for u in agg], ["gpt-4o", "gpt-4o-mini"])
+        self.assertEqual(agg[0].input_tokens, 4)
+        self.assertEqual(agg[1].input_tokens, 2)
+
+    def test_empty_input_returns_empty_list(self):
+        self.assertEqual(usage.aggregate_token_usage([]), [])
+
+    def test_field_none_when_absent_in_all_group_members(self):
+        entries = [
+            usage.token_usage_from_chunk({"input_tokens": 1}, provider="p", model="m"),
+            usage.token_usage_from_chunk({"input_tokens": 2}, provider="p", model="m"),
+        ]
+        agg = usage.aggregate_token_usage(entries)
+        self.assertEqual(agg[0].input_tokens, 3)
+        # output_tokens was never reported -> stays None, not 0
+        self.assertIsNone(agg[0].output_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> [!WARNING]
> **Draft — blocked on a release. CI will be red until the steps below are done.**
> These integrations install the **published** `ag-ui-protocol` from PyPI, so `TokenUsage` (added by #2188) is not importable here yet.

## Summary

Follow-up to #2188. Adds the **Python** integration producers that populate the AG-UI `usage` field on `RUN_FINISHED`, completing OSS-351 for Python.

- **LangGraph (python)** — maps `usage_metadata` from chat-model stream chunks (dependency-free `usage.py` + agent wiring).
- **AWS Strands (python)** — reads `AgentResult.metrics.accumulated_usage` from the terminal `result` event; labels provider from the model class + model config.

Numeric counts and `provider`/`model` labels only — never prompts, completions, messages, or identifiers.

## ⛔ Release ordering — do NOT merge until

1. **Merge #2188** (the protocol contract, incl. `ag_ui.core.TokenUsage`).
2. **Release `ag-ui-protocol`** to PyPI with `TokenUsage` (cut from `sdks/python`).
3. **Bump the `ag-ui-protocol` pin** in `integrations/langgraph/python/pyproject.toml` and `integrations/aws-strands/python/pyproject.toml` to that release, and refresh each `uv.lock`.

Only after step 3 will `uv sync` install a protocol package that exposes `TokenUsage`, so the `langgraph-python` / `aws-strands-python` CI jobs can pass. Until then this PR is expected red — that's why it's a draft.

## Testing (already done locally)

Validated against a local `sdks/python` build (via `PYTHONPATH`): unit tests for the usage mappers, wiring tests driving the real `run()` to a `RUN_FINISHED` carrying usage, and full integration suites green. The LangGraph-python path was additionally **verified end-to-end against a live OpenAI model** (real provider/model + token counts).

Refs #604. Depends on #2188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
