### PR TITLE
chore(dotnet): bump AGUI.* to 0.0.4 for first signed release

### DIFF
--- a/sdks/dotnet/Directory.Build.props
+++ b/sdks/dotnet/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
-    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.0.3</VersionPrefix>
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.0.4</VersionPrefix>
     <Authors>AG-UI Protocol</Authors>
     <Company>AG-UI Protocol</Company>
     <Product>AG-UI .NET SDK</Product>


### PR DESCRIPTION
## What

Bumps the shared `VersionPrefix` **0.0.3 → 0.0.4** in `sdks/dotnet/Directory.Build.props` (re-releases all five `AGUI.*` packages).

## Why

This is the **release trigger** for the first **author-signed** .NET packages (Ref: OSS-440). NuGet.org versions are immutable, so the existing unsigned 0.0.3 can't be re-signed in place — signed packages must ship as a new version.

## ⚠️ Merging this publishes signed packages

The signing seam (merged in #2139) is now live on `main` with `SIGNING_PROVIDER=keyvault`, so **merging this PR triggers the stable `publish-dotnet` release**, which author-signs the packages with the DigiCert cert in Azure Key Vault and publishes **0.0.4** to nuget.org.

Prerequisites (all confirmed): RBAC granted to the CI App Registration on `cpk-signing-kv` · nuget-env secrets + `SIGNING_PROVIDER=keyvault` set · cert registered on the `ag-ui-protocol` org · **canary prerelease signed & verified green**.

After merge: confirm 0.0.4 shows as **signed** on nuget.org; optionally unlist the unsigned 0.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
