### PR TITLE
fix(dotnet): don't reuse the provider message id for reasoning events

### DIFF
--- a/sdks/dotnet/src/AGUI.Server/ChatResponseUpdateAGUIExtensions.cs
+++ b/sdks/dotnet/src/AGUI.Server/ChatResponseUpdateAGUIExtensions.cs
@@ -212,19 +212,12 @@ public static class ChatResponseUpdateAGUIExtensions
 
                         if (reasoningContent.ProtectedData is { Length: > 0 } encrypted)
                         {
-                            yield return new ReasoningEncryptedValueEvent
-                            {
-                                Subtype = "message",
-                                EntityId = chatResponse.MessageId ?? string.Empty,
-                                EncryptedValue = encrypted,
-                                RawEvent = raw,
-                            };
+                            yield return reasoningTracker.EmitEncryptedValue(encrypted, raw);
                         }
 
                         if (!string.IsNullOrEmpty(reasoningContent.Text))
                         {
-                            var reasoningMessageId = chatResponse.MessageId ?? AGUIIdGenerator.NewMessageId();
-                            foreach (var openEvt in reasoningTracker.Open(reasoningMessageId))
+                            foreach (var openEvt in reasoningTracker.Open())
                             {
                                 yield return openEvt;
                             }

--- a/sdks/dotnet/src/AGUI.Server/Internal/ReasoningMessageTracker.cs
+++ b/sdks/dotnet/src/AGUI.Server/Internal/ReasoningMessageTracker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using AGUI.Abstractions;
 
 namespace AGUI.Server;
@@ -7,11 +8,15 @@ internal sealed class ReasoningMessageTracker
 {
     private string? _phaseMessageId;
     private string? _currentMessageId;
+    private string? _pendingMessageId;
 
     public bool IsActive => _phaseMessageId is not null;
 
-    public IEnumerable<BaseEvent> Open(string messageId)
+    public IEnumerable<BaseEvent> Open()
     {
+        var messageId = _currentMessageId ?? _pendingMessageId ?? AGUIIdGenerator.NewMessageId();
+        _pendingMessageId = null;
+
         if (_phaseMessageId is null)
         {
             _phaseMessageId = messageId;
@@ -32,8 +37,19 @@ internal sealed class ReasoningMessageTracker
             Delta = delta
         };
 
+    public BaseEvent EmitEncryptedValue(string encryptedValue, JsonElement raw) =>
+        new ReasoningEncryptedValueEvent
+        {
+            Subtype = "message",
+            EntityId = GetMessageIdForEncryptedValue(),
+            EncryptedValue = encryptedValue,
+            RawEvent = raw,
+        };
+
     public IEnumerable<BaseEvent> Close()
     {
+        _pendingMessageId = null;
+
         if (_currentMessageId is { } messageId)
         {
             _currentMessageId = null;
@@ -45,5 +61,15 @@ internal sealed class ReasoningMessageTracker
             _phaseMessageId = null;
             yield return new ReasoningEndEvent { MessageId = phaseId };
         }
+    }
+
+    private string GetMessageIdForEncryptedValue()
+    {
+        if (_currentMessageId is not null)
+        {
+            return _currentMessageId;
+        }
+
+        return _pendingMessageId ??= AGUIIdGenerator.NewMessageId();
     }
 }

--- a/sdks/dotnet/tests/AGUI.Server.UnitTests/ChatResponseUpdateAGUIExtensionsTest.cs
+++ b/sdks/dotnet/tests/AGUI.Server.UnitTests/ChatResponseUpdateAGUIExtensionsTest.cs
@@ -238,6 +238,151 @@ public sealed class ChatResponseUpdateAGUIExtensionsTest
 
     #endregion
 
+    #region Reasoning
+
+    [Fact]
+    public async Task ReasoningThenText_SharingProviderMessageId_EmitDistinctMessageIds()
+    {
+        var updates = ToAsyncEnumerable(
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("thinking")]
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("") { ProtectedData = "signed-blob" }]
+            },
+            new ChatResponseUpdate(ChatRole.Assistant, "visible answer")
+            {
+                MessageId = "msg-1"
+            });
+
+        var events = await CollectEvents(updates);
+
+        var reasoningStartId = events.OfType<ReasoningStartEvent>().Single().MessageId;
+        var reasoningMessageStartId = events.OfType<ReasoningMessageStartEvent>().Single().MessageId;
+        var textMessageId = events.OfType<TextMessageStartEvent>().Single().MessageId;
+        Assert.NotEqual(reasoningStartId, textMessageId);
+        Assert.NotEqual(reasoningMessageStartId, textMessageId);
+        Assert.Equal(reasoningMessageStartId, events.OfType<ReasoningMessageContentEvent>().Single().MessageId);
+        Assert.Equal(reasoningMessageStartId, events.OfType<ReasoningMessageEndEvent>().Single().MessageId);
+        Assert.Equal(reasoningMessageStartId, events.OfType<ReasoningEncryptedValueEvent>().Single().EntityId);
+    }
+
+    [Fact]
+    public async Task ReasoningDeltas_AcrossUpdates_ShareOneReasoningMessageId()
+    {
+        var updates = ToAsyncEnumerable(
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("first ")]
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("second")]
+            });
+
+        var events = await CollectEvents(updates);
+
+        var reasoningMessageId = events.OfType<ReasoningMessageStartEvent>().Single().MessageId;
+        Assert.All(
+            events.OfType<ReasoningMessageContentEvent>(),
+            e => Assert.Equal(reasoningMessageId, e.MessageId));
+    }
+
+    [Fact]
+    public async Task ReasoningBlocks_SeparatedByText_GetDistinctReasoningMessageIds()
+    {
+        var updates = ToAsyncEnumerable(
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("first block")]
+            },
+            new ChatResponseUpdate(ChatRole.Assistant, "interlude")
+            {
+                MessageId = "msg-1"
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("second block")]
+            });
+
+        var events = await CollectEvents(updates);
+
+        var reasoningIds = events.OfType<ReasoningMessageStartEvent>().Select(e => e.MessageId).ToList();
+        Assert.Equal(2, reasoningIds.Count);
+        Assert.NotEqual(reasoningIds[0], reasoningIds[1]);
+    }
+
+    [Fact]
+    public async Task ProtectedData_ArrivingWhileReasoningMessageOpen_BindsEntityIdToReasoningMessage()
+    {
+        var updates = ToAsyncEnumerable(
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("thinking")]
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("") { ProtectedData = "signed-blob" }]
+            });
+
+        var events = await CollectEvents(updates);
+
+        var reasoningMessageId = events.OfType<ReasoningMessageStartEvent>().Single().MessageId;
+        var encrypted = events.OfType<ReasoningEncryptedValueEvent>().Single();
+        Assert.Equal(reasoningMessageId, encrypted.EntityId);
+    }
+
+    [Fact]
+    public async Task ProtectedData_ArrivingBeforeReasoningMessageOpens_BindsEntityIdToReasoningMessage()
+    {
+        var updates = ToAsyncEnumerable(
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("") { ProtectedData = "signed-blob" }]
+            },
+            new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "msg-1",
+                Contents = [new TextReasoningContent("thinking")]
+            },
+            new ChatResponseUpdate(ChatRole.Assistant, "hello")
+            {
+                MessageId = "msg-1"
+            });
+
+        var events = await CollectEvents(updates);
+
+        var encryptedEntityId = events.OfType<ReasoningEncryptedValueEvent>().Single().EntityId;
+        var reasoningMessageId = events.OfType<ReasoningMessageStartEvent>().Single().MessageId;
+        var textMessageId = events.OfType<TextMessageStartEvent>().Single().MessageId;
+
+        Assert.Equal(reasoningMessageId, encryptedEntityId);
+        Assert.NotEqual(textMessageId, encryptedEntityId);
+    }
+
+    #endregion
+
     #region Role Mapping
 
     [Theory]


### PR DESCRIPTION
Fixes #2199

`AsAGUIEventStreamAsync` reused `ChatResponseUpdate.MessageId` for both reasoning and text events. Anthropic stamps the same message id on the thinking and text updates of a turn (they're content blocks of one message), so `REASONING_MESSAGE_*` and `TEXT_MESSAGE_*` went out with the same messageId. `@ag-ui/client` keys messages by id: it skips `TEXT_MESSAGE_START` because the id is already taken by the reasoning message, and the text deltas get appended to the reasoning message instead — the assistant reply never renders. Captured stream and full analysis in #2199.

OpenAI streams don't hit this: the Responses API reports reasoning as a separate output item and the M.E.AI adapter leaves `MessageId` unset on reasoning updates, so reasoning ids were already generated there. This makes Anthropic-shaped streams behave the same way — reasoning message ids are generated, text keeps the provider id.

`ReasoningMessageTracker` now owns the reasoning message id instead of receiving the provider id from the caller. `Open()` mints it, and `REASONING_ENCRYPTED_VALUE` is emitted through the tracker so its `entityId` points at the reasoning message the signature belongs to. A signature can arrive before its block opens, so the id is reserved on first use and the next `Open()` adopts it; `Close()` drops any reservation so a signature-only block (redacted thinking) can't leak its id into a later block.

Added tests covering the Anthropic shape (same `MessageId` on the reasoning, signature, and text updates of a turn): reasoning and text get distinct ids, deltas across updates share one reasoning id, separate blocks get distinct ids, and the encrypted value binds to the reasoning message whether its signature arrives while the block is open or before it opens. Step07 baselines are unchanged — reasoning ids were already generated for that fixture.