### PR TITLE
feat(langgraph): add forwarded props to langgraph runtime context

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -657,6 +657,7 @@ class LangGraphAgent:
         kwargs = self.get_stream_kwargs(
             input=stream_input,
             config=config,
+            context=self._langgraph_context_from_forwarded_props(input.forwarded_props),
             subgraphs=bool(subgraphs_stream_enabled),
             version="v2",
         )
@@ -732,6 +733,7 @@ class LangGraphAgent:
         kwargs = self.get_stream_kwargs(
             input=stream_input,
             config=merged_config,
+            context=self._langgraph_context_from_forwarded_props(input.forwarded_props),
             subgraphs=bool(subgraphs_stream_enabled),
             version="v2",
         )
@@ -1962,6 +1964,25 @@ class LangGraphAgent:
     # Probe the graph's astream_events signature for version-specific support
     # (notably the ``context`` parameter, added in newer LangGraph releases)
     # so this adapter remains backwards-compatible across LangGraph versions.
+    @staticmethod
+    def _langgraph_context_from_forwarded_props(forwarded_props: Any) -> Dict[str, Any]:
+        """Map agent-facing forwarded props into LangGraph runtime context.
+
+        Adapter-control props remain private to this integration; every other
+        forwarded prop is available to a graph's runtime context without
+        requiring an adapter release for each new agent feature.  This is not
+        an identity boundary: callers must authenticate and authorise any
+        tenant/user data independently of these client-controlled values.
+        """
+        if not isinstance(forwarded_props, dict):
+            return {}
+        adapter_control_props = {"command", "node_name", "stream_subgraphs"}
+        return {
+            key: value
+            for key, value in forwarded_props.items()
+            if key not in adapter_control_props
+        }
+
     def get_stream_kwargs(
             self,
             input: Any,

--- a/integrations/langgraph/python/tests/test_get_stream_kwargs.py
+++ b/integrations/langgraph/python/tests/test_get_stream_kwargs.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 
 from ag_ui_langgraph.agent import LangGraphAgent
 
@@ -22,6 +23,32 @@ class _GraphWithoutContext:
 
     def astream_events(self, input, subgraphs=False, version="v2"):
         raise NotImplementedError
+
+
+class _RecordingGraph:
+    nodes = {}
+
+    def __init__(self):
+        self.stream_kwargs = None
+
+    def get_input_jsonschema(self, config):
+        return {"properties": {"messages": {}, "tools": {}}}
+
+    def get_output_jsonschema(self, config):
+        return {"properties": {"messages": {}}}
+
+    def get_config_jsonschema(self):
+        return {"properties": {"configurable": {}}}
+
+    def astream_events(self, input, subgraphs=False, version="v2", config=None, context=None):
+        self.stream_kwargs = {
+            "input": input,
+            "subgraphs": subgraphs,
+            "version": version,
+            "config": config,
+            "context": context,
+        }
+        return object()
 
 
 class GetStreamKwargsTest(unittest.TestCase):
@@ -61,6 +88,46 @@ class GetStreamKwargsTest(unittest.TestCase):
 
         self.assertNotIn("context", kwargs)
         self.assertEqual(kwargs["config"], {"configurable": {"thread_id": "t-3"}})
+
+
+class ForwardedPropsRuntimeContextTest(unittest.IsolatedAsyncioTestCase):
+    async def test_agent_facing_forwarded_props_reach_langgraph_runtime_context(self):
+        graph = _RecordingGraph()
+        agent = LangGraphAgent(name="test", graph=graph)
+        agent.active_run = {"id": "run-1", "mode": "start"}
+        run_input = SimpleNamespace(
+            thread_id="thread-1",
+            run_id="run-1",
+            state={},
+            messages=[],
+            tools=[],
+            context=[],
+            forwarded_props={
+                "deep_thinking": True,
+                "model_options": {"reasoning_effort": "high"},
+                "command": {},
+                "node_name": "adapter-private",
+                "stream_subgraphs": False,
+            },
+            resume=None,
+        )
+        agent_state = SimpleNamespace(values={"messages": []}, tasks=[])
+
+        await agent.prepare_stream(
+            run_input,
+            agent_state,
+            {"configurable": {"thread_id": "thread-1", "tenant": "tenant-a"}},
+        )
+
+        self.assertEqual(
+            graph.stream_kwargs["context"],
+            {
+                "thread_id": "thread-1",
+                "tenant": "tenant-a",
+                "deep_thinking": True,
+                "model_options": {"reasoning_effort": "high"},
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background

Issue #1815 was addressed by #1826, which updated
`LangGraphAgent.get_stream_kwargs()` to support forwarding a `context`
argument to LangGraph, including LangGraph implementations whose
`astream_events()` signature accepts `**kwargs`.

However, #1826 only added the helper-level support. Neither the normal
streaming path nor the regenerate/time-travel path supplied request-level
values to `get_stream_kwargs(context=...)`. Consequently, agent-side
`forwardedProps` could not actually reach LangGraph's
`astream_events(..., context=...)` runtime context.

This PR is a small follow-up to #1826 that wires the missing runtime call path
described above.

Refs #1815
Follow-up to #1826

## Summary

This is a small, backwards-compatible adapter plumbing change, not a major
feature or protocol change.

It forwards agent-facing `forwardedProps` into LangGraph's runtime `context`
when calling `graph.astream_events(...)`.