### PR TITLE
fix(security): don't combine allow_credentials with wildcard CORS origin (#1939, #1940)

### DIFF
--- a/integrations/adk-middleware/python/tests/server_setup.py
+++ b/integrations/adk-middleware/python/tests/server_setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Test server for ADK middleware with AG-UI client."""
 
+import os
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
@@ -18,11 +19,18 @@ from google.adk.agents import Agent
 # Create FastAPI app
 app = FastAPI(title="ADK Middleware Test Server")
 
-# Add CORS middleware for browser-based AG-UI clients
+# Add CORS middleware for browser-based AG-UI clients.
+# Origins come from CORS_ALLOW_ORIGINS (comma-separated) and default to the "*"
+# wildcard for local testing. Credentials are only enabled for explicit,
+# non-wildcard origins — a wildcard can never be combined with
+# allow_credentials=True (any site could then read authenticated responses).
+_origins = [o.strip() for o in os.getenv("CORS_ALLOW_ORIGINS", "").split(",") if o.strip()]
+cors_origins = _origins or ["*"]  # Configure appropriately for production
+is_wildcard = "*" in cors_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Configure appropriately for production
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials=bool(_origins) and not is_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/integrations/aws-strands/python/examples/server/__init__.py
+++ b/integrations/aws-strands/python/examples/server/__init__.py
@@ -40,11 +40,18 @@ from .api import (
 # Create main app
 app = FastAPI(title='AWS Strands Integration 2 - Dojo')
 
-# Add CORS
+# Add CORS.
+# Origins come from CORS_ALLOW_ORIGINS (comma-separated) and default to the "*"
+# wildcard for local development. Credentials are only enabled for explicit,
+# non-wildcard origins — a wildcard can never be combined with
+# allow_credentials=True (any site could then read authenticated responses).
+_origins = [o.strip() for o in os.getenv("CORS_ALLOW_ORIGINS", "").split(",") if o.strip()]
+cors_origins = _origins or ["*"]
+is_wildcard = "*" in cors_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials=bool(_origins) and not is_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -205,6 +205,7 @@ def create_strands_app(
     agent: "Any",
     path: str = "/",
     ping_path: str | None = "/ping",
+    origins: Optional[List[str]] = None,
 ) -> "Any":
     """Create a FastAPI app with a single Strands agent endpoint and optional ping endpoint.
 
@@ -212,6 +213,10 @@ def create_strands_app(
         agent: The StrandsAgent instance
         path: Path for the agent endpoint (default: "/")
         ping_path: Path for the ping endpoint (default: "/ping"). Pass None to disable.
+        origins: Allowed CORS origins. Defaults to ``["*"]`` (wildcard) for local
+            development. Credentials are only enabled when explicit, non-wildcard
+            origins are supplied — a wildcard origin can never be combined with
+            ``allow_credentials=True``.
     """
     from fastapi import FastAPI
     from .endpoint import add_strands_fastapi_endpoint, add_ping
@@ -220,10 +225,12 @@ def create_strands_app(
 
     # Add CORS middleware
     from fastapi.middleware.cors import CORSMiddleware
+    cors_origins = origins or ["*"]
+    is_wildcard = "*" in cors_origins
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=cors_origins,
+        allow_credentials=bool(origins) and not is_wildcard,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/integrations/claude-agent-sdk/python/examples/server.py
+++ b/integrations/claude-agent-sdk/python/examples/server.py
@@ -20,10 +20,17 @@ from agents.tool_based_generative_ui import create_tool_based_generative_ui_adap
 
 app = FastAPI(title="Claude Agent SDK Server")
 
+# Allowed CORS origins come from CORS_ALLOW_ORIGINS (comma-separated) and default
+# to the "*" wildcard for local development. Credentials are only enabled for
+# explicit, non-wildcard origins — a wildcard can never be combined with
+# allow_credentials=True (any site could then read authenticated responses).
+_origins = [o.strip() for o in os.getenv("CORS_ALLOW_ORIGINS", "").split(",") if o.strip()]
+cors_origins = _origins or ["*"]
+is_wildcard = "*" in cors_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials=bool(_origins) and not is_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/integrations/langroid/python/examples/server/__main__.py
+++ b/integrations/langroid/python/examples/server/__main__.py
@@ -12,10 +12,17 @@ from .api.shared_state import app as shared_state_app
 
 app = FastAPI(title="Langroid AG-UI Examples Server")
 
+# Allowed CORS origins come from CORS_ALLOW_ORIGINS (comma-separated) and default
+# to the "*" wildcard for local development. Credentials are only enabled for
+# explicit, non-wildcard origins — a wildcard can never be combined with
+# allow_credentials=True (any site could then read authenticated responses).
+_origins = [o.strip() for o in os.getenv("CORS_ALLOW_ORIGINS", "").split(",") if o.strip()]
+cors_origins = _origins or ["*"]
+is_wildcard = "*" in cors_origins
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials=bool(_origins) and not is_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
+++ b/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
@@ -53,15 +53,30 @@ def add_langroid_fastapi_endpoint(
         }
 
 
-def create_langroid_app(agent: LangroidAgent, path: str = "/") -> FastAPI:
-    """Create a FastAPI app with a single Langroid agent endpoint."""
+def create_langroid_app(
+    agent: LangroidAgent,
+    path: str = "/",
+    origins: list[str] | None = None,
+) -> FastAPI:
+    """Create a FastAPI app with a single Langroid agent endpoint.
+
+    Args:
+        agent: The Langroid agent to serve.
+        path: Path for the agent endpoint (default: "/").
+        origins: Allowed CORS origins. Defaults to ``["*"]`` (wildcard) for local
+            development. Credentials are only enabled when explicit, non-wildcard
+            origins are supplied — a wildcard origin can never be combined with
+            ``allow_credentials=True``.
+    """
     app = FastAPI(title=f"Langroid - {agent.name}")
-    
+
     # Add CORS middleware
+    cors_origins = origins or ["*"]
+    is_wildcard = "*" in cors_origins
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=cors_origins,
+        allow_credentials=bool(origins) and not is_wildcard,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
+++ b/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
@@ -41,7 +41,10 @@ def add_langroid_fastapi_endpoint(
             media_type=encoder.get_content_type()
         )
 
-    @app.get(f"{path}/health")
+    # Strip any trailing slash so a root path ("/") yields "/health", not "//health".
+    health_path = f"{path.rstrip('/')}/health"
+
+    @app.get(health_path)
     def health():
         """Health check."""
         return {

--- a/integrations/langroid/python/tests/test_endpoint.py
+++ b/integrations/langroid/python/tests/test_endpoint.py
@@ -48,6 +48,46 @@ class TestCreateLangroidApp(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class TestCreateLangroidAppCors(unittest.TestCase):
+    """CORS credentials must never be combined with a wildcard origin."""
+
+    def _health_cors_response(self, app, origin):
+        client = TestClient(app)
+        return client.get("/health", headers={"Origin": origin})
+
+    def test_wildcard_default_disables_credentials(self):
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test")
+        app = create_langroid_app(agent)
+
+        response = self._health_cors_response(app, "https://evil.example")
+        # Wildcard reflects "*" and must NOT allow credentials.
+        self.assertEqual(response.headers.get("access-control-allow-origin"), "*")
+        self.assertNotIn("access-control-allow-credentials", response.headers)
+
+    def test_explicit_origins_enable_credentials(self):
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test")
+        app = create_langroid_app(agent, origins=["https://app.example"])
+
+        response = self._health_cors_response(app, "https://app.example")
+        self.assertEqual(
+            response.headers.get("access-control-allow-origin"), "https://app.example"
+        )
+        self.assertEqual(
+            response.headers.get("access-control-allow-credentials"), "true"
+        )
+
+    def test_wildcard_in_explicit_origins_disables_credentials(self):
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test")
+        app = create_langroid_app(agent, origins=["*"])
+
+        response = self._health_cors_response(app, "https://evil.example")
+        self.assertEqual(response.headers.get("access-control-allow-origin"), "*")
+        self.assertNotIn("access-control-allow-credentials", response.headers)
+
+
 class TestAddLangroidFastapiEndpoint(unittest.TestCase):
     """Test add_langroid_fastapi_endpoint function."""
 

--- a/integrations/langroid/python/tests/test_endpoint.py
+++ b/integrations/langroid/python/tests/test_endpoint.py
@@ -47,6 +47,18 @@ class TestCreateLangroidApp(unittest.TestCase):
         response = client.get("/chat/health")
         self.assertEqual(response.status_code, 200)
 
+    def test_root_path_health_has_no_double_slash(self):
+        # With the default root path ("/") the health route must be reachable at
+        # "/health" (i.e. not registered as "//health").
+        mock_agent = MagicMock()
+        agent = LangroidAgent(agent=mock_agent, name="test", description="")
+        app = create_langroid_app(agent)  # path defaults to "/"
+        client = TestClient(app)
+
+        self.assertEqual(client.get("/health").status_code, 200)
+        # The route must be registered exactly as "/health".
+        self.assertIn("/health", [r.path for r in app.routes])
+
 
 class TestCreateLangroidAppCors(unittest.TestCase):
     """CORS credentials must never be combined with a wildcard origin."""


### PR DESCRIPTION
## The vulnerability

Several Python integrations configured Starlette/FastAPI `CORSMiddleware` with **both** `allow_origins=["*"]` **and** `allow_credentials=True`. When credentials are enabled, Starlette reflects the caller's `Origin` back and returns `Access-Control-Allow-Credentials: true`, so **any website** can make credentialed cross-origin requests to the agent server and read the responses. Combining a wildcard origin with credentials defeats the same-origin protection CORS is supposed to provide.

Closes #1939 (aws-strands) and closes #1940 (langroid). Follow-up to #1931, which fixed the TypeScript aws-strands side.

## The fix

Mirror the already-correct `watsonx` pattern in `integrations/watsonx/python/src/ag_ui_watsonx/utils.py` (and the TS fix in #1931): derive the origin set, treat `"*"` as a wildcard, and **only enable credentials for explicit, non-wildcard origins**. Wildcard origins are still allowed for local dev — they just can never be combined with `allow_credentials=True`.

```python
cors_origins = origins or ["*"]
is_wildcard = "*" in cors_origins
app.add_middleware(
    CORSMiddleware,
    allow_origins=cors_origins,
    allow_credentials=bool(origins) and not is_wildcard,
    ...
)
```

Behavior across inputs (verified):

| origins input | allow_origins | allow_credentials |
|---|---|---|
| unset / empty / `"*"` | `["*"]` | `False` (safe dev default) |
| explicit non-wildcard | the list | `True` |
| list containing `"*"` | the list | `False` |

## Files changed

**Shipped adapter source** (now accept an `origins` parameter, wired through the guard like watsonx):
- `integrations/aws-strands/python/src/ag_ui_strands/utils.py` — `create_strands_app`
- `integrations/langroid/python/src/ag_ui_langroid/endpoint.py` — `create_langroid_app`

**Example/test servers** (hardened — read `CORS_ALLOW_ORIGINS`, comma-separated; default to the safe wildcard-without-credentials):
- `integrations/aws-strands/python/examples/server/__init__.py`
- `integrations/langroid/python/examples/server/__main__.py`
- `integrations/claude-agent-sdk/python/examples/server.py`
- `integrations/adk-middleware/python/tests/server_setup.py`

**Tests:**
- `integrations/langroid/python/tests/test_endpoint.py` — 3 CORS regression tests (wildcard default → no credentials; explicit origins → credentials; wildcard in an explicit list → no credentials).

`integrations/adk-middleware/python/examples/other/complete_setup.py` was intentionally **left untouched** — it already uses explicit localhost origins, which is the intended safe configuration.

## Verification
- Langroid: full suite passes (46 tests, incl. the 3 new CORS tests).
- aws-strands: 157 passed; the single failure (`test_template_param_round_trips[interventions]`) is pre-existing on `origin/main` (a `strands-agents` version-drift issue) and unrelated to this change.
- All changed files `py_compile` clean; an independent adversarial review confirmed the guard logic, import correctness, and caller compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)