### PR TITLE
fix(adk-middleware): delegate flush() in RequestStateSessionService

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/request_state_service.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/request_state_service.py
@@ -144,3 +144,17 @@ class RequestStateSessionService(BaseSessionService):
 
     async def append_event(self, session: Session, event: Event) -> Event:
         return await self._inner.append_event(session=session, event=event)
+
+    async def flush(self) -> None:
+        """Delegate to the inner service's flush implementation.
+
+        ADK's ``Runner.close()`` calls ``session_service.flush()`` to persist
+        buffered state in write-behind session services. Without this override,
+        the wrapper inherits ``BaseSessionService.flush`` (a no-op) and any
+        buffering inner service is silently never flushed — causing data loss.
+
+        See https://github.com/ag-ui-protocol/ag-ui/issues/2206.
+        """
+        inner_flush = getattr(self._inner, "flush", None)
+        if inner_flush is not None:
+            await inner_flush()

--- a/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
+++ b/integrations/adk-middleware/python/tests/test_temp_state_extraction.py
@@ -176,6 +176,71 @@ class TestRequestStateSessionService:
         fetched = await wrapper.get_session(app_name="app", user_id="u", session_id="s")
         assert "temp:token" not in fetched.state
 
+    @pytest.mark.asyncio
+    async def test_flush_delegates_to_inner_service(self):
+        """flush() must propagate to the wrapped service — regression for #2206.
+
+        Without delegation, write-behind session services are silently never
+        flushed, causing data loss.
+        """
+        flushed = []
+
+        class BufferingSessionService(InMemorySessionService):
+            async def flush(self) -> None:
+                flushed.append(True)
+
+        inner = BufferingSessionService()
+        wrapper = RequestStateSessionService(inner)
+
+        await wrapper.flush()
+
+        assert flushed == [True], "flush() did not delegate to the inner service"
+
+    @pytest.mark.asyncio
+    async def test_flush_tolerates_inner_without_flush(self):
+        """flush() must not fail when inner service lacks flush (no-op gracefully)."""
+
+        class MinimalSessionService:
+            """A mock that has no flush method at all."""
+
+            async def create_session(self, **kwargs):
+                return None
+
+            async def get_session(self, **kwargs):
+                return None
+
+            async def list_sessions(self, **kwargs):
+                return []
+
+            async def delete_session(self, **kwargs):
+                pass
+
+            async def append_event(self, session, event):
+                return event
+
+        inner = MinimalSessionService()
+        wrapper = RequestStateSessionService(inner)
+
+        # Should not raise — just no-op
+        await wrapper.flush()
+
+    @pytest.mark.asyncio
+    async def test_flush_idempotent_no_state(self):
+        """Calling flush() with no pending state or sessions is a safe no-op."""
+        flushed = []
+
+        class BufferingSessionService(InMemorySessionService):
+            async def flush(self) -> None:
+                flushed.append(True)
+
+        wrapper = RequestStateSessionService(BufferingSessionService())
+
+        # Multiple flushes with no sessions/state
+        await wrapper.flush()
+        await wrapper.flush()
+
+        assert flushed == [True, True], "flush() should delegate every call"
+
 
 # ---------------------------------------------------------------------------
 # ADKAgent wiring: the session service is auto-wrapped at construction time.


### PR DESCRIPTION
Closes #2206

## Summary

`RequestStateSessionService` wraps a caller-provided session service but doesn't override `flush()`, so it inherits the no-op `BaseSessionService.flush`. Any write-behind inner service that buffers state and relies on the `Runner.close()` flush contract silently loses that buffered state — the classic decorator-forgets-to-forward bug.

## Changes

- Add `flush()` that delegates to the inner service when it provides one (`getattr` check keeps duck-typed inner services without `flush()` working as a no-op)
- Regression tests:
  - `test_flush_delegates_to_inner_service` — fails without the fix
  - `test_flush_idempotent_no_state` — every call delegates, fails without the fix
  - `test_flush_tolerates_inner_without_flush` — defensive path

## Notes

Audited the wrapper's other public methods for the same forgot-to-forward pattern — the remaining methods either delegate already or are intentionally request-scoped, so `flush()` is the only gap. Error propagation from the inner flush surfaces through the existing `Runner.close()` handling path, matching how other delegated methods behave.
