### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit config for ag-ui-protocol/ag-ui.
+# High-signal reviews on real contributor code, low noise, plus repo-specific
+# checks for the restructured SDK/integration layout.
+language: en-US
+tone_instructions: >-
+  Be concise and technical. Skip praise and filler; focus on correctness,
+  security, regressions, and repo conventions. Prefer one high-signal comment
+  over several minor ones.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  poem: false
+  sequence_diagrams: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches: [main]
+    ignore_title_keywords:
+      - "chore(release)"
+      - "chore: release"
+
+  path_filters:
+    - "!**/*.lock"
+    - "!**/pnpm-lock.yaml"
+    - "!**/uv.lock"
+    - "!**/Cargo.lock"
+    - "!**/dist/**"
+    - "!**/*.min.*"
+    - "!**/__snapshots__/**"
+    - "!**/fixtures/**"
+    - "!**/*.generated.*"
+
+  path_instructions:
+    - path: "sdks/**"
+      instructions: >-
+        The repo restructured: SDKs live under sdks/<lang>/ and integrations at the
+        top level. Flag additions under the retired top-level typescript-sdk/ or
+        python-sdk/ prefixes. sdks/community/java is intentionally a .gitkeep only —
+        the in-repo Java SDK was removed in favor of the external ag-ui-4j project;
+        flag PRs that re-introduce Java SDK source here.
+        When a change ports or claims parity with another SDK ("matches the TS/Python
+        version"), verify direction against the ACTUAL reference implementation, not
+        the PR description.
+    - path: "integrations/**/langgraph/**"
+      instructions: >-
+        For graph routing changes: ending the graph (goto END) on a frontend/HITL
+        tool call is the intended handoff to the frontend, not a dropped tool.
+        Flag re-routing an unresolved tool call that could break the
+        tool_call<->ToolMessage pairing or loop a node.
+
+  tools:
+    gitleaks: { enabled: true }
+    semgrep: { enabled: true }
+    actionlint: { enabled: true }
+
+knowledge_base:
+  learnings: { scope: auto }
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds a CodeRabbit config for this repo (CodeRabbit is free for public repos; this makes reviews repo-aware from the start).

## What this does
- **`profile: chill`** + ignore release PRs + **`path_filters`** (lockfiles, dist, snapshots, fixtures) — keeps review budget on real contributor code.
- **Enables `gitleaks` / `semgrep` / `actionlint`** — secret + SAST + workflow linting, complementing the existing `zizmor` / fork-PR-alert.
- **`path_instructions`** for the restructured layout, flagged inline on every PR:
  - additions under the retired top-level `typescript-sdk/` or `python-sdk/` prefixes (SDKs now live under `sdks/<lang>/`)
  - re-introducing in-repo Java SDK source under `sdks/community/java` (that SDK was moved to the external ag-ui-4j project)
  - LangGraph routing: `goto END` on a frontend/HITL tool call is the intended handoff, not a dropped tool
  - verify cross-SDK parity claims by **direction against the actual reference**, not the PR description

## Notes
- Advisory only — nothing auto-merges/closes.
- CodeRabbit validates its own config, so it should confirm the schema on this PR.
- Companion to CopilotKit/CopilotKit#6077 (same approach; different retired paths + no mirror rule since ag-ui docs are canonical here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)