### PR TITLE
fix(mastra): sanitize forwarded message ids for the OpenAI Responses API

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -644,4 +644,60 @@ describe("convertAGUIMessagesToMastra", () => {
       expect("id" in result[2]).toBe(false);
     });
   });
+
+  describe("message id sanitization (OpenAI Responses API charset)", () => {
+    // AI SDK v5's `openai(model)` defaults to the Responses API, which rejects
+    // any `input[].id` outside `^[A-Za-z0-9_-]+$`. Client-minted ids replayed as
+    // prior-turn history must be coerced or the whole multi-turn request 400s
+    // (AI_APICallError: Invalid 'input[N].id').
+
+    it("leaves an already-valid id unchanged (common case is a no-op)", () => {
+      const messages: Message[] = [
+        { id: "msg-AD-dWkWJNkAbXmQx", role: "user", content: "hi" },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect((result[0] as any).id).toBe("msg-AD-dWkWJNkAbXmQx");
+    });
+
+    it("replaces out-of-charset characters with dashes for all roles", () => {
+      const messages: Message[] = [
+        { id: "msg+AD/dWk=", role: "user", content: "hi" },
+        {
+          id: "msg:with.dots",
+          role: "assistant",
+          content: "hello",
+          toolCalls: [],
+        },
+        {
+          id: "tool id⚡",
+          role: "tool",
+          content: "result",
+          toolCallId: "tc-1",
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect((result[0] as any).id).toBe("msg-AD-dWk-");
+      expect((result[1] as any).id).toBe("msg-with-dots");
+      expect((result[2] as any).id).toBe("tool-id-");
+      // Every sanitized id is now Responses-API-legal.
+      for (const msg of result) {
+        expect((msg as any).id).toMatch(/^[A-Za-z0-9_-]+$/);
+      }
+    });
+
+    it("is deterministic so Mastra's upsert-by-id dedup still matches", () => {
+      const messages: Message[] = [
+        { id: "msg+AD/dWk=", role: "user", content: "hi" },
+      ];
+
+      const first = convertAGUIMessagesToMastra(messages);
+      const second = convertAGUIMessagesToMastra(messages);
+
+      expect((first[0] as any).id).toBe((second[0] as any).id);
+    });
+  });
 });

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -21,6 +21,29 @@ import { MastraAgent, MastraTracingOptions } from "./mastra";
  */
 type CoreMessageWithId = CoreMessage & { id?: string };
 
+/**
+ * Coerce an AG-UI message id into the charset the OpenAI Responses API accepts
+ * for `input[].id` (`^[A-Za-z0-9_-]+$`). Client-minted ids (e.g. CopilotKit's
+ * `msg-…`) can contain characters the Responses API rejects; once such an id is
+ * replayed as prior-turn history (turn 2+), the request 400s wholesale
+ * (`AI_APICallError: Invalid 'input[N].id'`), which breaks every multi-turn
+ * chat on a Responses-API model. AI SDK v5's `openai(model)` defaults to that
+ * API, so this hits any Mastra agent using the default provider.
+ *
+ * The mapping is deterministic and idempotent: an already-valid id is returned
+ * unchanged (the common case — Mastra-minted assistant ids are UUIDs, a no-op),
+ * and any given id always maps to the same sanitized value. That determinism is
+ * load-bearing for Mastra's history dedup (see convertAGUIMessagesToMastra): a
+ * message is sanitized identically every time it passes through this converter —
+ * both when first stored and when re-sent — so upsert-by-id still matches.
+ */
+const RESPONSES_API_ID_CHARSET = /^[A-Za-z0-9_-]+$/;
+function toModelSafeMessageId(id: string): string {
+  return RESPONSES_API_ID_CHARSET.test(id)
+    ? id
+    : id.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
 function mediaSourceToUrl(
   source: InputContentDataSource | InputContentUrlSource,
 ): string {
@@ -127,7 +150,10 @@ export function convertAGUIMessagesToMastra(
   //   - processInput filters historical messages whose IDs match the input IDs
   //   - storage.saveMessages upserts by ID, so re-sent history won't duplicate
   // The `id` key is omitted when undefined so it doesn't defeat Mastra's
-  // `"id" in message` check.
+  // `"id" in message` check. Preserved ids are routed through
+  // `toModelSafeMessageId` so a client-minted id can't 400 the OpenAI Responses
+  // API when it is replayed as `input[].id` on later turns (deterministic, so
+  // dedup is unaffected).
   const result: CoreMessageWithId[] = [];
 
   for (const message of messages) {
@@ -146,14 +172,18 @@ export function convertAGUIMessagesToMastra(
         });
       }
       result.push({
-        ...(message.id !== undefined ? { id: message.id } : {}),
+        ...(message.id !== undefined
+          ? { id: toModelSafeMessageId(message.id) }
+          : {}),
         role: "assistant",
         content: parts,
       } as CoreMessage);
     } else if (message.role === "user") {
       const userContent = toMastraContent(message.content);
       result.push({
-        ...(message.id !== undefined ? { id: message.id } : {}),
+        ...(message.id !== undefined
+          ? { id: toModelSafeMessageId(message.id) }
+          : {}),
         role: "user",
         content: userContent,
       } as CoreMessage);
@@ -170,7 +200,9 @@ export function convertAGUIMessagesToMastra(
         }
       }
       result.push({
-        ...(message.id !== undefined ? { id: message.id } : {}),
+        ...(message.id !== undefined
+          ? { id: toModelSafeMessageId(message.id) }
+          : {}),
         role: "tool",
         content: [
           {


### PR DESCRIPTION
## What

Fixes a hard `AI_APICallError` that breaks **multi-turn chat on every Mastra agent using the default OpenAI provider** (AI SDK v5's `openai(model)` resolves to the Responses API):

> AI_APICallError: Invalid 'input[N].id': 'msg-…'. Expected an ID that contains letters, numbers, underscores, or dashes, but this value contained additional characters.

Turn 1 works; every turn after returns nothing.

## Root cause

`convertAGUIMessagesToMastra` forwards the AG-UI message `id` onto each `CoreMessage` (load-bearing for Mastra's upsert-by-id history dedup). On turn 2+, a prior client-minted id (e.g. CopilotKit's `msg-…`, which can carry characters outside `^[A-Za-z0-9_-]+$`) is replayed as `input[].id` and rejected by the Responses API, 400-ing the whole request.

## Fix

Route the preserved id through `toModelSafeMessageId`: an already-valid id passes through unchanged (the common case — Mastra-minted assistant ids are UUIDs, a no-op), otherwise out-of-charset chars are replaced with `-`. The mapping is deterministic and idempotent, so a message sanitizes identically on first store and on re-send and Mastra's dedup still matches. Only surfaces on the Responses API (`input[]`).

## Tests

`message-conversion.test.ts` — valid-id no-op, out-of-charset replacement across user/assistant/tool roles, determinism. Full `@ag-ui/mastra` suite green (19 files, 303 tests) via `nx test @ag-ui/mastra`.

## Refs

- Surfaced on the mastra v1 bridge — Linear **OSS-381** (umbrella).
- Companion showcase PR (CopilotKit) with the newly-enabled-cell fixes: https://github.com/CopilotKit/CopilotKit/pull/6103

🤖 Generated with [Claude Code](https://claude.com/claude-code)