### PR TITLE
fix(aws-strands): reconcile frontend-tool results into the SessionManager store

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -60,10 +60,21 @@ def _extract_agent_kwargs(agent: StrandsAgentCore) -> dict:
     return kwargs
 
 
-def _has_strands_session_manager(agent: Any) -> bool:
-    return (
-        getattr(agent, "session_manager", None) is not None
-        or getattr(agent, "_session_manager", None) is not None
+# Upper bound on the per-agent wire->native map held in session state. Bounds
+# growth from frontend calls that never receive a client result (abandoned HITL)
+# and so are never consumed/pruned. Generous — a thread rarely has this many
+# outstanding frontend calls at once.
+_WIRE_MAP_MAX = 512
+
+
+def _get_strands_session_manager(agent: Any) -> Any:
+    """Return the agent's Strands ``SessionManager``, or ``None``.
+
+    Strands stores it publicly as ``session_manager``; some versions keep a
+    private ``_session_manager`` alias.
+    """
+    return getattr(agent, "session_manager", None) or getattr(
+        agent, "_session_manager", None
     )
 
 
@@ -107,6 +118,12 @@ from .a2ui_tool import (
     plan_a2ui_injection,
 )
 from .client_proxy_tool import sync_proxy_tools
+from .session_reconcile import (
+    AG_UI_WIRE_MAP_STATE_KEY,
+    has_placeholder_results,
+    reconcile_frontend_tool_results,
+    resolve_native_ids,
+)
 from .config import (
     StrandsAgentConfig,
     ToolCallContext,
@@ -730,7 +747,7 @@ class StrandsAgent:
                     strands_messages.append(strands_msg)
 
             # Build a lookup of tool_call_id -> tool_name from the input messages
-            # directly (the assistant message in Run 2 already carries the tool name).
+            # directly (the assistant message in Run 2 already carries the name).
             _tool_call_id_to_name: dict = {}
             for _msg in (input_data.messages or []):
                 if _msg.role == "assistant" and hasattr(_msg, "tool_calls") and _msg.tool_calls:
@@ -858,16 +875,82 @@ class StrandsAgent:
                 f"Starting agent run: thread_id={input_data.thread_id}, run_id={input_data.run_id}, pending_tool_result_ids={pending_tool_result_ids}, message_count={len(input_data.messages)}, strands_message_count={len(strands_messages)}"
             )
 
+            # Collect the real results the client produced for proxied
+            # frontend tools. These arrive in ``RunAgentInput.messages`` on the
+            # continuation run and are used to reconcile the session-persisted
+            # "Forwarded to client" placeholder. A tool result is a frontend
+            # result when its tool name is client-declared, or (for delta-only
+            # payloads that omit the assistant message) when its wire id was
+            # recorded in the wire->native map when the call was emitted.
+            session_manager = _get_strands_session_manager(strands_agent)
+            # The durable wire->native map recorded at emission, read back from
+            # session state (restored from the store on a fresh process).
+            wire_to_native: Dict[str, str] = {}
+            if session_manager is not None:
+                wire_to_native = (
+                    strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+                )
+            # Scope to the TRAILING tool results (this continuation's just-
+            # returned results). ``pending_tool_result_ids`` holds those ids;
+            # without this, a multi-turn continuation re-sends already-reconciled
+            # historical results, which can never be re-corrected and would force
+            # the legacy fallback every turn.
+            frontend_results: List[Dict[str, Any]] = []
+            for msg in (input_data.messages or []):
+                if getattr(msg, "role", None) != "tool":
+                    continue
+                wire_id = getattr(msg, "tool_call_id", None)
+                if not wire_id or wire_id not in pending_tool_result_ids:
+                    continue
+                name = _tool_call_id_to_name.get(wire_id)
+                if name not in frontend_tool_names and wire_id not in wire_to_native:
+                    continue
+                content = msg.content
+                text = (
+                    content
+                    if isinstance(content, str)
+                    else flatten_content_to_text(content)
+                )
+                frontend_results.append({"wire_id": wire_id, "text": text or ""})
+
+            # Translate the client's wire tool_call_id back to the native
+            # toolUseId Strands persisted (they differ for frontend tools — see
+            # the fresh-uuid assignment in the streaming loop). Only reconcile
+            # when there is at least one NON-EMPTY frontend result: a void tool
+            # returns nothing, and the synthetic "executed successfully with no
+            # return value" continuation message conveys that better than an
+            # empty toolResult. When reconciling, void placeholders in the same
+            # turn are still cleared (to "") so the literal "Forwarded to client"
+            # is never fed to the model.
+            resolved_native_results: Dict[str, str] = {}
+            corrected_native_ids: set[str] = set()
+            has_nonvoid_frontend_result = any(
+                (r["text"] or "").strip() for r in frontend_results
+            )
+            if session_manager is not None and self.config.replay_history_into_strands:
+                resolved_native_results = resolve_native_ids(
+                    wire_to_native, frontend_results
+                )
+
             # Reconcile Strands' internal conversation history with
-            # ``RunAgentInput.messages`` when no ``session_manager`` is wired.
-            # Without this, frontend tool results sent by the client never
-            # reach the LLM — Strands sees an open ``toolUse`` from the prior
-            # turn and the LLM re-fires the same tool every run, producing
-            # the "chart loops forever" symptom. With a session manager,
-            # Strands manages history itself, so we leave it alone.
+            # ``RunAgentInput.messages``. Without this, frontend tool results
+            # sent by the client never reach the LLM — Strands sees an open
+            # ``toolUse`` from the prior turn and the LLM re-fires the same tool
+            # every run, producing the "chart loops forever" symptom.
+            #
+            # No session manager: rebuild history in-memory and stream it.
+            # With a session manager (which owns persistence): overwrite the
+            # persisted placeholder toolResult(s) with the real client result
+            # via the session repository, then continue from the corrected
+            # native history — keeping a single source of truth rather than a
+            # placeholder plus a synthetic "tool returned: X" message.
             replay_history = (
-                self.config.replay_history_into_strands
-                and not _has_strands_session_manager(strands_agent)
+                self.config.replay_history_into_strands and session_manager is None
+            )
+            reconcile_session_results = (
+                session_manager is not None
+                and self.config.replay_history_into_strands
+                and has_nonvoid_frontend_result
             )
             if replay_history:
                 native_history = _build_strands_history(input_data.messages)
@@ -901,10 +984,63 @@ class StrandsAgent:
                 # (including ones produced by the frontend) and emits a
                 # proper follow-up turn instead of re-calling the tool.
                 agent_stream = strands_agent.stream_async(None)
+            elif reconcile_session_results:
+                try:
+                    corrected_native_ids = reconcile_frontend_tool_results(
+                        session_manager, strands_agent, resolved_native_results
+                    )
+                except Exception as e:  # noqa: BLE001 — degrade, don't crash the turn
+                    logger.warning(
+                        "Frontend tool result reconciliation failed; falling back to "
+                        f"the legacy continuation path: {e}",
+                        exc_info=True,
+                    )
+                # Continue from the corrected native history only when every
+                # NON-EMPTY frontend result this turn resolved to a native id
+                # (i.e. was present in the wire->native map) AND none of those
+                # placeholders remain uncleared. The scan is scoped to this
+                # turn's results so a stale placeholder from a prior (e.g. void)
+                # turn doesn't force the legacy path. Any shortfall means
+                # forwarding the real result as a synthetic user message is
+                # safer than replaying a stub.
+                non_void_results = [
+                    r for r in frontend_results if (r["text"] or "").strip()
+                ]
+                resolved_non_void = {
+                    native
+                    for native, text in resolved_native_results.items()
+                    if (text or "").strip()
+                }
+                all_non_void_resolved = len(resolved_non_void) == len(non_void_results)
+                # Scan all of this turn's resolved native ids (void included, so a
+                # resolved-but-uncleared void placeholder also blocks) — but not
+                # unrelated historical placeholders.
+                reconciled = all_non_void_resolved and not has_placeholder_results(
+                    getattr(strands_agent, "messages", None) or [],
+                    only_ids=set(resolved_native_results),
+                )
+                agent_stream = strands_agent.stream_async(
+                    None if reconciled else user_message
+                )
             else:
                 # Legacy path: pass only the latest user message and trust
                 # Strands (via session_manager) to track history.
                 agent_stream = strands_agent.stream_async(user_message)
+
+            # Drop only the entries whose placeholder was actually corrected
+            # this turn — they won't recur. Entries that were NOT corrected
+            # (unresolved, or a reconcile that raised) are kept so a later turn
+            # can retry; pruning them would strand the persisted placeholder
+            # forever. (Genuinely-abandoned entries are bounded by the size cap
+            # applied at emission.)
+            if wire_to_native and corrected_native_ids:
+                remaining = {
+                    wire: native
+                    for wire, native in wire_to_native.items()
+                    if native not in corrected_native_ids
+                }
+                if len(remaining) != len(wire_to_native):
+                    strands_agent.state.set(AG_UI_WIRE_MAP_STATE_KEY, remaining)
 
             try:
                 async for event in agent_stream:
@@ -1293,6 +1429,35 @@ class StrandsAgent:
                         elif is_frontend_tool:
                             # Generate new UUID for frontend tools
                             tool_use_id = str(uuid.uuid4())
+                            # Record wire id -> Strands native id on the agent's
+                            # SESSION STATE so a later continuation run — even on
+                            # a different process — can reconcile the persisted
+                            # placeholder (keyed by the native id) with the real
+                            # client result (which arrives keyed by the wire id).
+                            # Strands persists agent state durably at end of run.
+                            # Only maintained when a session manager is actually
+                            # active for this agent (matching the continuation
+                            # read/prune gate); otherwise it would never be read.
+                            if strands_tool_id and _get_strands_session_manager(
+                                strands_agent
+                            ):
+                                _wire_map = dict(
+                                    strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY)
+                                    or {}
+                                )
+                                _wire_map[tool_use_id] = strands_tool_id
+                                # Bound growth: entries for frontend calls that
+                                # never get a client result (abandoned/dismissed
+                                # HITL) are never consumed/pruned. Keep only the
+                                # most-recent ``_WIRE_MAP_MAX`` (insertion order).
+                                if len(_wire_map) > _WIRE_MAP_MAX:
+                                    for _stale in list(_wire_map)[
+                                        : len(_wire_map) - _WIRE_MAP_MAX
+                                    ]:
+                                        _wire_map.pop(_stale, None)
+                                strands_agent.state.set(
+                                    AG_UI_WIRE_MAP_STATE_KEY, _wire_map
+                                )
                         else:
                             # Use Strands' ID for backend tools
                             tool_use_id = strands_tool_id or str(uuid.uuid4())

--- a/integrations/aws-strands/python/src/ag_ui_strands/client_proxy_tool.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/client_proxy_tool.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 # Attribute set on proxy tools so we can distinguish them from native tools.
 _PROXY_MARKER = "_ag_ui_proxy"
 
+# Placeholder result the proxy returns server-side. The real result is produced
+# on the client and reconciled back in on the following run.
+PROXY_RESULT_PLACEHOLDER = "Forwarded to client"
+
 
 def create_proxy_tool(ag_ui_tool: AgUiTool) -> PythonAgentTool:
     """Convert an AG-UI ``Tool`` into a Strands ``PythonAgentTool``.
@@ -52,7 +56,7 @@ def create_proxy_tool(ag_ui_tool: AgUiTool) -> PythonAgentTool:
         return {
             "toolUseId": tool_use["toolUseId"],
             "status": "success",
-            "content": [{"text": "Forwarded to client"}],
+            "content": [{"text": PROXY_RESULT_PLACEHOLDER}],
         }
 
     # ToolFunc protocol requires __name__

--- a/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
@@ -1,0 +1,150 @@
+"""Reconcile frontend (proxy) tool results into a Strands ``SessionManager``.
+
+Frontend tools are executed on the client, so server-side the proxy returns a
+placeholder ``toolResult`` (``"Forwarded to client"``). The real result only
+arrives on the next run inside ``RunAgentInput.messages``, keyed by the client's
+wire ``tool_call_id`` — which differs from the native ``toolUseId`` Strands
+persisted. The adapter records that wire->native mapping durably on the agent's
+session state (see ``AG_UI_WIRE_MAP_STATE_KEY``), so this module can find the
+persisted placeholder by native id and overwrite it with the real result.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from .client_proxy_tool import PROXY_RESULT_PLACEHOLDER
+
+# Key under which the adapter stores the ``{wire_tool_call_id: native_toolUseId}``
+# map on the Strands agent's session state. Namespaced to avoid clashing with
+# user-managed state keys.
+AG_UI_WIRE_MAP_STATE_KEY = "__ag_ui_wire_to_native__"
+
+
+def resolve_native_ids(
+    wire_to_native: Mapping[str, str],
+    frontend_results: Iterable[Mapping[str, Any]],
+) -> dict[str, str]:
+    """Map client frontend results to Strands-native ``toolUseId``s.
+
+    Frontend tools are emitted under a fresh wire ``tool_call_id`` that differs
+    from the native ``toolUseId`` Strands persists. ``wire_to_native`` is the
+    durable map recorded at emission on the agent's session state and restored
+    on a continuation run (works cross-process and for delta-only payloads,
+    since it is keyed on the wire id the client always sends). Results whose
+    wire id is not in the map are dropped — the caller then degrades to the
+    legacy path rather than guessing.
+
+    Args:
+        wire_to_native: Map of wire ``tool_call_id`` -> native ``toolUseId``.
+        frontend_results: Items with ``wire_id`` and ``text``.
+
+    Returns:
+        Map of native ``toolUseId`` -> real result text (unresolvable dropped).
+    """
+    resolved: dict[str, str] = {}
+    for result in frontend_results:
+        native = wire_to_native.get(result.get("wire_id"))
+        if native is not None:
+            resolved[native] = result.get("text", "")
+    return resolved
+
+
+def reconcile_frontend_tool_results(
+    session_manager: Any,
+    agent: Any,
+    pending_results: Mapping[str, str],
+) -> set[str]:
+    """Overwrite persisted placeholder ``toolResult`` blocks with real results.
+
+    ``pending_results`` MUST be keyed by the Strands-native ``toolUseId`` (use
+    :func:`resolve_native_ids` to translate client wire ids first).
+
+    Args:
+        session_manager: A Strands ``RepositorySessionManager`` (exposes
+            ``session_id`` and ``session_repository``).
+        agent: The Strands agent (exposes ``agent_id``).
+        pending_results: Map of native ``toolUseId`` -> real result text.
+
+    Returns:
+        The set of ``toolUseId``s whose placeholder was corrected (in the store
+        and/or the agent's in-memory history).
+    """
+    session_id = session_manager.session_id
+    agent_id = agent.agent_id
+    repository = session_manager.session_repository
+
+    corrected: set[str] = set()
+    for session_message in repository.list_messages(session_id, agent_id):
+        changed = _correct_message(session_message.message, pending_results)
+        if changed:
+            repository.update_message(session_id, agent_id, session_message)
+            corrected |= changed
+
+    # Correct the agent's live in-memory history too, so a same-process
+    # continuation run (and ``stream_async(None)``) sees the real result
+    # rather than the placeholder.
+    for message in getattr(agent, "messages", None) or []:
+        corrected |= _correct_message(message, pending_results)
+
+    return corrected
+
+
+def has_placeholder_results(messages: Iterable[Any], only_ids: Any = None) -> bool:
+    """Return True if a matching ``toolResult`` is still the proxy stub.
+
+    Used to gate the continuation stream: it is only safe to replay the native
+    history to the model (``stream_async(None)``) when no relevant ``"Forwarded
+    to client"`` placeholder remains to be fed to it.
+
+    Args:
+        messages: The native Strands history to scan.
+        only_ids: If given, restrict the scan to ``toolResult`` blocks whose
+            ``toolUseId`` is in this set — so stale placeholders from prior
+            turns (e.g. intentionally-uncorrected void calls) don't count.
+    """
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        for block in message.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            tool_result = block.get("toolResult")
+            if not isinstance(tool_result, dict):
+                continue
+            if only_ids is not None and tool_result.get("toolUseId") not in only_ids:
+                continue
+            if _is_placeholder(tool_result.get("content")):
+                return True
+    return False
+
+
+def _correct_message(message: Any, pending_results: Mapping[str, str]) -> set[str]:
+    """Rewrite matching placeholder ``toolResult`` blocks in *message* in place.
+
+    Returns the set of ``toolUseId``s whose block was corrected.
+    """
+    if not isinstance(message, dict):
+        return set()
+    changed: set[str] = set()
+    for block in message.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        tool_result = block.get("toolResult")
+        if not isinstance(tool_result, dict):
+            continue
+        tool_use_id = tool_result.get("toolUseId")
+        if tool_use_id in pending_results and _is_placeholder(tool_result.get("content")):
+            tool_result["content"] = [{"text": pending_results[tool_use_id]}]
+            changed.add(tool_use_id)
+    return changed
+
+
+def _is_placeholder(content: Any) -> bool:
+    """Return True if *content* is the proxy's ``"Forwarded to client"`` stub."""
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(block, dict) and block.get("text") == PROXY_RESULT_PLACEHOLDER
+        for block in content
+    )

--- a/integrations/aws-strands/python/tests/test_a2ui_tool.py
+++ b/integrations/aws-strands/python/tests/test_a2ui_tool.py
@@ -467,7 +467,7 @@ def _build_agent(thread_id: str, stream_events: list, config=None) -> StrandsAge
     mock_inner.tool_registry = ToolRegistry()
     mock_inner.session_manager = None
     # Without this a bare MagicMock auto-creates a truthy `_session_manager`,
-    # flipping `_has_strands_session_manager` True and silently routing every
+    # making `_get_strands_session_manager` return it and silently routing every
     # test through the legacy (non-replay) path instead of the default
     # `replay_history_into_strands` one.
     mock_inner._session_manager = None

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import copy
 from unittest.mock import MagicMock, patch
 
 import pytest
+from strands.agent.state import AgentState
 from strands.session import SessionManager
 
+from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+
 from ag_ui.core import (
+    AssistantMessage,
     EventType,
+    FunctionCall,
     RunAgentInput,
     Tool,
+    ToolCall,
     ToolMessage,
     UserMessage,
 )
@@ -82,6 +89,7 @@ class _MockStrandsAgentWithPrivateSessionManager:
         self._session_manager = session_manager
         self.tool_registry = MagicMock()
         self.tool_registry.registry = {}
+        self.state = AgentState()
         self.stream_prompts = []
 
     async def stream_async(self, prompt):
@@ -261,7 +269,11 @@ class TestSessionManagerProvider:
         assert any("returned None" in msg for msg in caplog.messages)
 
     @pytest.mark.asyncio
-    async def test_private_session_manager_disables_replay_history(self):
+    async def test_session_manager_plain_turn_does_not_replay_history(self):
+        """On a plain (non-frontend-tool) turn, a session manager owns history:
+        the adapter must not clobber ``messages`` and just streams the user
+        message. (Frontend-tool continuations are reconciled instead — see
+        ``TestSessionFrontendToolReconciliation``.)"""
         mock_session_manager = _mock_session_manager()
         provider = MagicMock(return_value=mock_session_manager)
         agent = _make_base_agent(session_manager_provider=provider)
@@ -281,15 +293,15 @@ class TestSessionManagerProvider:
 class _MockSessionAgentWithHistory:
     """Session-manager-backed mock that records ``stream_async`` prompts and
     exposes a native Strands ``messages`` history (as a real session manager
-    would). ``replay_history_into_strands`` is suppressed when a session
-    manager is present, so this exercises the legacy
-    ``stream_async(user_message)`` path."""
+    would). Used for continuations with no non-empty frontend-tool result to
+    reconcile, which take the legacy ``stream_async(user_message)`` path."""
 
     def __init__(self, session_manager, messages=None):
         self._session_manager = session_manager
         self.messages = messages if messages is not None else []
         self.tool_registry = MagicMock()
         self.tool_registry.registry = {}
+        self.state = AgentState()
         self.stream_prompts = []
 
     async def stream_async(self, prompt):
@@ -388,3 +400,529 @@ class TestFrontendToolContinuation:
             "setBackground executed successfully with no return value."
         ]
         assert "Hello" not in instance.stream_prompts
+
+
+class _MockSessionAgentReal:
+    """Session-manager-backed mock exposing a real ``session_manager`` (public
+    attribute, like ``StrandsAgentCore``) plus an ``agent_id`` and native
+    ``messages``, so the frontend-tool reconciliation path can run against a
+    real session repository."""
+
+    def __init__(self, session_manager, agent_id="default", messages=None):
+        self.session_manager = session_manager
+        self.agent_id = agent_id
+        self.messages = messages if messages is not None else []
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.state = AgentState()
+        self.stream_prompts = []
+
+    async def stream_async(self, prompt):
+        self.stream_prompts.append(prompt)
+        return
+        yield  # pragma: no cover
+
+
+def _seed_session(sm, agent_id, messages):
+    from strands.types.session import SessionAgent, SessionMessage
+
+    sm.session_repository.create_agent(
+        sm.session_id,
+        SessionAgent(agent_id=agent_id, state={}, conversation_manager_state={}),
+    )
+    for index, message in enumerate(messages):
+        sm.session_repository.create_message(
+            sm.session_id, agent_id, SessionMessage(message=message, message_id=index)
+        )
+
+
+def _store_tool_use(native_id, name, tool_input=None):
+    return {
+        "role": "assistant",
+        "content": [
+            {"toolUse": {"toolUseId": native_id, "name": name, "input": tool_input or {}}}
+        ],
+    }
+
+
+def _store_placeholder(native_id, text="Forwarded to client"):
+    return {
+        "role": "user",
+        "content": [
+            {
+                "toolResult": {
+                    "toolUseId": native_id,
+                    "status": "success",
+                    "content": [{"text": text}],
+                }
+            }
+        ],
+    }
+
+
+def _payload_assistant(wire_id, name, args="{}"):
+    return AssistantMessage(
+        id="a-" + wire_id,
+        role="assistant",
+        content="",
+        tool_calls=[
+            ToolCall(
+                id=wire_id,
+                type="function",
+                function=FunctionCall(name=name, arguments=args),
+            )
+        ],
+    )
+
+
+def _payload_tool(wire_id, content):
+    return ToolMessage(id="t-" + wire_id, role="tool", content=content, tool_call_id=wire_id)
+
+
+def _result_content(sm, agent_id, index):
+    persisted = sm.session_repository.list_messages(sm.session_id, agent_id)
+    return persisted[index].message["content"]
+
+
+async def _run_session_continuation(sm, agent_id, messages, tools, wire_map, store):
+    """Drive run() for a continuation and return the mock agent instance."""
+    _seed_session(sm, agent_id, store)
+    provider = MagicMock(return_value=sm)
+    agent = _make_base_agent(session_manager_provider=provider)
+    input_data = RunAgentInput(
+        thread_id=sm.session_id,
+        run_id="run-2",
+        state={},
+        messages=messages,
+        tools=tools,
+        context=[],
+        forwarded_props={},
+    )
+    instance = _MockSessionAgentReal(
+        sm, agent_id=agent_id, messages=copy.deepcopy(store)
+    )
+    # The wire->native map lives on the agent's session state (durable), set on
+    # the prior emission run. Seed it directly to simulate that.
+    if wire_map:
+        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, dict(wire_map))
+    with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+        MockCore.return_value = instance
+        await _collect_events(agent, input_data)
+    return instance
+
+
+class _MockStreamingAgent:
+    """Mock whose ``stream_async`` replays canned Strands events, exercising the
+    real tool-call handling in ``run()`` (including wire->native map capture)."""
+
+    def __init__(self, events, session_manager=None):
+        self._events = events
+        self.session_manager = session_manager
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.state = AgentState()
+        self.messages = []
+
+    async def stream_async(self, *args, **kwargs):
+        for event in self._events:
+            yield event
+
+
+class TestWireToNativeMapCapture:
+    @pytest.mark.asyncio
+    async def test_emission_populates_wire_to_native_map(self):
+        # Driving a frontend tool-call event through run() must record the fresh
+        # wire id -> Strands native toolUseId, which reconciliation later relies
+        # on. (Primary resolution path's data source.) Capture is gated on a
+        # session manager being configured.
+        agent = _make_base_agent(
+            session_manager_provider=MagicMock(return_value=_mock_session_manager())
+        )
+        input_data = RunAgentInput(
+            thread_id="t-emit",
+            run_id="r1",
+            state={},
+            messages=[UserMessage(id="u1", content="please approve")],
+            tools=[_frontend_tool("approve")],
+            context=[],
+            forwarded_props={},
+        )
+        instance = _MockStreamingAgent(
+            [{"current_tool_use": {"name": "approve", "toolUseId": "native-1", "input": {}}}],
+            session_manager=_mock_session_manager(),
+        )
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        wire_map = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+        assert list(wire_map.values()) == ["native-1"]
+
+    @pytest.mark.asyncio
+    async def test_wire_map_is_size_capped(self, monkeypatch):
+        # Abandoned frontend calls are never consumed/pruned, so the map is
+        # bounded at emission: an emission over the cap drops the oldest entries.
+        import ag_ui_strands.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_WIRE_MAP_MAX", 2)
+        agent = _make_base_agent(
+            session_manager_provider=MagicMock(return_value=_mock_session_manager())
+        )
+        input_data = RunAgentInput(
+            thread_id="t-cap",
+            run_id="r1",
+            state={},
+            messages=[UserMessage(id="u1", content="approve")],
+            tools=[_frontend_tool("approve")],
+            context=[],
+            forwarded_props={},
+        )
+        instance = _MockStreamingAgent(
+            [{"current_tool_use": {"name": "approve", "toolUseId": "native-new", "input": {}}}],
+            session_manager=_mock_session_manager(),
+        )
+        # Pre-seed a full map (oldest first).
+        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"w-a": "n-a", "w-b": "n-b"})
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        wire_map = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+        assert len(wire_map) == 2
+        assert "w-a" not in wire_map  # oldest evicted
+        assert "native-new" in wire_map.values()
+
+
+class TestSessionFrontendToolReconciliation:
+    """Approach (B): on a session-manager continuation carrying a real frontend
+    tool result, the persisted ``"Forwarded to client"`` placeholder is
+    overwritten with the real result (found via the wire->native id map, since
+    the client's wire id differs from Strands' native toolUseId) and the model
+    continues from the corrected native history (``stream_async(None)``)."""
+
+    @pytest.mark.asyncio
+    async def test_reconciles_via_wire_to_native_map_delta_only(self, tmp_path):
+        # Native id in the store differs from the client's wire id, and the
+        # payload is delta-only (no assistant message) — only the wire->native
+        # map can bridge them. This is the E1 regression: keying on the wire id
+        # would match nothing and stream the uncorrected placeholder.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-map", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[_payload_tool("wire-1", '{"approved": false}')],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
+        )
+        assert instance.stream_prompts == [None]
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
+            {"text": '{"approved": false}'}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_wire_map_degrades_to_legacy(self, tmp_path):
+        # No durable wire->native map for this result's wire id (e.g. a session
+        # created before this feature): the wire id can't be resolved, so the
+        # adapter degrades to the legacy synthetic-message path and leaves the
+        # placeholder rather than streaming a stub.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-nomap", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-2", "setColor", '{"color": "blue"}'),
+                _payload_tool("wire-2", "ok"),
+            ],
+            tools=[_frontend_tool("setColor")],
+            wire_map={},  # nothing recorded -> unresolvable
+            store=[
+                _store_tool_use("native-2", "setColor", {"color": "blue"}),
+                _store_placeholder("native-2"),
+            ],
+        )
+        assert instance.stream_prompts != [None]
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
+            {"text": "Forwarded to client"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_mixed_void_and_real_clears_both_placeholders(self, tmp_path):
+        # A void call in the same turn as a real one: the void placeholder must
+        # be cleared (to "") rather than left as the literal "Forwarded to
+        # client" fed to the model.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-mixed", storage_dir=str(tmp_path))
+        store = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"toolUseId": "native-A", "name": "doThing", "input": {}}},
+                    {"toolUse": {"toolUseId": "native-B", "name": "approve", "input": {}}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    _store_placeholder("native-A")["content"][0],
+                    _store_placeholder("native-B")["content"][0],
+                ],
+            },
+        ]
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-A", "doThing"),
+                _payload_assistant("wire-B", "approve"),
+                _payload_tool("wire-A", ""),  # void
+                _payload_tool("wire-B", '{"approved": true}'),  # real
+            ],
+            tools=[_frontend_tool("doThing"), _frontend_tool("approve")],
+            wire_map={"wire-A": "native-A", "wire-B": "native-B"},
+            store=store,
+        )
+        assert instance.stream_prompts == [None]
+        results = _result_content(sm, "default", 1)
+        assert results[0]["toolResult"]["content"] == [{"text": ""}]  # void cleared
+        assert results[1]["toolResult"]["content"] == [{"text": '{"approved": true}'}]
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_reconciles_only_the_trailing_result(self, tmp_path):
+        # The client re-sends full history: two earlier identical approve() calls
+        # (already reconciled, and whose wire->native entries were pruned) plus
+        # the just-returned one. Only the trailing result may gate
+        # reconciliation. This PINS trailing-scoping: without it, the historical
+        # calls would be re-collected, fail to resolve (their entries are gone
+        # from the durable map), and force the legacy fallback every turn.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-multi", storage_dir=str(tmp_path))
+        store = [
+            _store_tool_use("native-o1", "approve", {}),
+            _store_placeholder("native-o1", text="OLD1"),  # already corrected
+            _store_tool_use("native-o2", "approve", {}),
+            _store_placeholder("native-o2", text="OLD2"),  # already corrected
+            _store_tool_use("native-new", "approve", {}),
+            _store_placeholder("native-new"),  # this turn's placeholder
+        ]
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-o1", "approve", "{}"),
+                _payload_tool("wire-o1", "OLD1"),
+                _payload_assistant("wire-o2", "approve", "{}"),
+                _payload_tool("wire-o2", "OLD2"),
+                _payload_assistant("wire-new", "approve", "{}"),
+                _payload_tool("wire-new", '{"approved": true}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-new": "native-new"},  # historical entries already pruned
+            store=store,
+        )
+        assert instance.stream_prompts == [None]
+        results = sm.session_repository.list_messages(sm.session_id, "default")
+        assert results[1].message["content"][0]["toolResult"]["content"] == [{"text": "OLD1"}]
+        assert results[3].message["content"][0]["toolResult"]["content"] == [{"text": "OLD2"}]
+        assert results[5].message["content"][0]["toolResult"]["content"] == [
+            {"text": '{"approved": true}'}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_partially_resolvable_turn_falls_back_to_legacy(self, tmp_path):
+        # Two frontend results in one turn, both recognized as frontend, but only
+        # one resolves to a native id (wire-2 is not in the map and its
+        # name+args match no stored toolUse). Streaming None would feed wire-2's
+        # uncorrected placeholder to the model, so the adapter falls back.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-partial", storage_dir=str(tmp_path))
+        store = [
+            _store_tool_use("native-1", "approve", {}),
+            _store_placeholder("native-1"),
+        ]
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve", "{}"),
+                _payload_assistant("wire-2", "approve", '{"x": 1}'),  # no store match
+                _payload_tool("wire-1", "R1"),
+                _payload_tool("wire-2", "R2"),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},  # wire-2 missing -> unresolvable
+            store=store,
+        )
+        # Not all non-void results resolved -> legacy fallback: a single
+        # synthetic user message (not None/empty). The resolvable result's store
+        # placeholder is still corrected (partial correction is safe — the value
+        # is real); only the model-facing continuation falls back.
+        assert instance.stream_prompts == ["approve returned: R2"]
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
+            {"text": "R1"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_historical_void_placeholder_does_not_block_reconcile(self, tmp_path):
+        # A prior void frontend call left a permanent placeholder in the store.
+        # It must NOT block reconciling THIS turn's real result (the gate is
+        # scoped to this turn's results, not the whole history).
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-histvoid", storage_dir=str(tmp_path))
+        store = [
+            _store_tool_use("native-void", "ping"),
+            _store_placeholder("native-void"),  # old void call, never corrected
+            _store_tool_use("native-new", "approve"),
+            _store_placeholder("native-new"),
+        ]
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-new", "approve"),
+                _payload_tool("wire-new", '{"approved": true}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-new": "native-new"},
+            store=store,
+        )
+        assert instance.stream_prompts == [None]
+        results = sm.session_repository.list_messages(sm.session_id, "default")
+        assert results[3].message["content"][0]["toolResult"]["content"] == [
+            {"text": '{"approved": true}'}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_wire_to_native_map_pruned_after_reconcile(self, tmp_path):
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-prune", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_tool("wire-1", '{"approved": true}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1", "wire-other": "native-other"},
+            store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
+        )
+
+        # The corrected wire id is pruned from the durable state map; unrelated
+        # outstanding entries are kept.
+        remaining = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+        assert "wire-1" not in remaining
+        assert remaining == {"wire-other": "native-other"}
+
+    @pytest.mark.asyncio
+    async def test_reconcile_failure_keeps_map_and_falls_back(self, tmp_path):
+        # If reconciliation raises, the wire->native entry must NOT be pruned
+        # (so a later turn can retry) and the run must degrade to the legacy
+        # path rather than streaming an uncorrected stub.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-reconfail", storage_dir=str(tmp_path))
+        with patch(
+            "ag_ui_strands.agent.reconcile_frontend_tool_results",
+            side_effect=RuntimeError("boom"),
+        ):
+            instance = await _run_session_continuation(
+                sm,
+                "default",
+                messages=[
+                    _payload_assistant("wire-1", "approve"),
+                    _payload_tool("wire-1", '{"approved": true}'),
+                ],
+                tools=[_frontend_tool("approve")],
+                wire_map={"wire-1": "native-1"},
+                store=[
+                    _store_tool_use("native-1", "approve"),
+                    _store_placeholder("native-1"),
+                ],
+            )
+
+        assert instance.stream_prompts != [None]  # legacy fallback on error
+        remaining = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+        assert remaining == {"wire-1": "native-1"}  # entry kept for retry
+
+    @pytest.mark.asyncio
+    async def test_unmapped_results_do_not_corrupt_store_and_fall_back(self, tmp_path):
+        # Two same-turn calls with no durable wire->native entries: neither
+        # resolves, so nothing is written (no corruption) and the turn degrades
+        # to the legacy path.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-collide", storage_dir=str(tmp_path))
+        store = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"toolUseId": "native-1", "name": "approve", "input": {}}},
+                    {"toolUse": {"toolUseId": "native-2", "name": "approve", "input": {}}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    _store_placeholder("native-1")["content"][0],
+                    _store_placeholder("native-2")["content"][0],
+                ],
+            },
+        ]
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_assistant("wire-2", "approve"),
+                _payload_tool("wire-1", "R1"),
+                _payload_tool("wire-2", "R2"),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={},  # nothing recorded -> unresolvable
+            store=store,
+        )
+        assert instance.stream_prompts != [None]  # unresolvable -> legacy
+        results = sm.session_repository.list_messages(sm.session_id, "default")[1].message[
+            "content"
+        ]
+        # Neither placeholder was overwritten with the wrong result.
+        assert results[0]["toolResult"]["content"] == [{"text": "Forwarded to client"}]
+        assert results[1]["toolResult"]["content"] == [{"text": "Forwarded to client"}]
+
+    @pytest.mark.asyncio
+    async def test_already_reconciled_result_streams_none_idempotently(self, tmp_path):
+        # The result resolves to a native id whose stored toolResult is already a
+        # real value (not the placeholder). There is nothing to correct and no
+        # placeholder remains, so streaming the clean native history is safe; the
+        # idempotency guard leaves the stored value untouched (first result wins).
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-idem", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-Z", "approve"),
+                _payload_tool("wire-Z", '{"approved": false}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-Z": "native-Z"},
+            store=[
+                _store_tool_use("native-Z", "approve"),
+                _store_placeholder("native-Z", text="already real"),
+            ],
+        )
+        assert instance.stream_prompts == [None]
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
+            {"text": "already real"}
+        ]

--- a/integrations/aws-strands/python/tests/test_session_reconcile.py
+++ b/integrations/aws-strands/python/tests/test_session_reconcile.py
@@ -1,0 +1,231 @@
+"""Tests for reconciling frontend-tool results into a Strands SessionManager.
+
+Frontend (proxy) tools return a ``"Forwarded to client"`` placeholder result
+server-side; the real result only arrives on the next run inside
+``RunAgentInput.messages``. These tests exercise the helper that overwrites the
+persisted placeholder ``toolResult`` with the real client result so the session
+store (and the agent's in-memory history) hold the true value.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from strands.session.file_session_manager import FileSessionManager
+from strands.types.session import SessionAgent, SessionMessage
+
+from ag_ui_strands.session_reconcile import (
+    has_placeholder_results,
+    reconcile_frontend_tool_results,
+    resolve_native_ids,
+)
+
+PLACEHOLDER = "Forwarded to client"
+
+
+def _make_session(tmp_path, session_id="s1", agent_id="default"):
+    sm = FileSessionManager(session_id=session_id, storage_dir=str(tmp_path))
+    sm.session_repository.create_agent(
+        session_id,
+        SessionAgent(agent_id=agent_id, state={}, conversation_manager_state={}),
+    )
+    return sm
+
+
+def _seed(sm, agent_id, index, message):
+    sm.session_repository.create_message(
+        sm.session_id, agent_id, SessionMessage(message=message, message_id=index)
+    )
+
+
+def _tool_result_block(tool_use_id, text):
+    return {
+        "toolResult": {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"text": text}],
+        }
+    }
+
+
+def test_reconcile_overwrites_persisted_placeholder_in_store(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(sm, agent_id, 0, {"role": "user", "content": [{"text": "set it"}]})
+    _seed(
+        sm,
+        agent_id,
+        1,
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "tu-1", "name": "approve", "input": {}}}],
+        },
+    )
+    _seed(
+        sm,
+        agent_id,
+        2,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": '{"approved": false}'}
+    )
+
+    assert corrected == {"tu-1"}
+    persisted = sm.session_repository.list_messages(sm.session_id, agent_id)
+    result_block = persisted[2].message["content"][0]["toolResult"]
+    assert result_block["content"] == [{"text": '{"approved": false}'}]
+
+
+def test_reconcile_returns_set_of_corrected_tool_use_ids(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+    agent = SimpleNamespace(
+        agent_id=agent_id,
+        messages=[{"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]}],
+    )
+
+    corrected = reconcile_frontend_tool_results(sm, agent, {"tu-1": "R", "tu-absent": "X"})
+
+    assert corrected == {"tu-1"}
+
+
+def test_reconcile_corrects_in_memory_agent_messages(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(sm, agent_id, 0, {"role": "user", "content": [{"text": "set it"}]})
+    _seed(
+        sm,
+        agent_id,
+        1,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+
+    # The cached agent still holds the placeholder in its live message list.
+    agent = SimpleNamespace(
+        agent_id=agent_id,
+        messages=[
+            {"role": "user", "content": [{"text": "set it"}]},
+            {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+        ],
+    )
+
+    reconcile_frontend_tool_results(sm, agent, {"tu-1": '{"approved": true}'})
+
+    in_memory = agent.messages[1]["content"][0]["toolResult"]
+    assert in_memory["content"] == [{"text": '{"approved": true}'}]
+
+
+def test_reconcile_handles_parallel_tool_calls_in_one_message(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "tu-1", "name": "a", "input": {}}},
+                {"toolUse": {"toolUseId": "tu-2", "name": "b", "input": {}}},
+            ],
+        },
+    )
+    _seed(
+        sm,
+        agent_id,
+        1,
+        {
+            "role": "user",
+            "content": [
+                _tool_result_block("tu-1", PLACEHOLDER),
+                _tool_result_block("tu-2", PLACEHOLDER),
+            ],
+        },
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": "R1", "tu-2": "R2"}
+    )
+
+    assert corrected == {"tu-1", "tu-2"}
+    blocks = sm.session_repository.list_messages(sm.session_id, agent_id)[1].message[
+        "content"
+    ]
+    assert blocks[0]["toolResult"]["content"] == [{"text": "R1"}]
+    assert blocks[1]["toolResult"]["content"] == [{"text": "R2"}]
+
+
+def test_resolve_maps_wire_id_to_native_id():
+    # Client speaks the wire id; the store holds the native id. The durable
+    # wire->native map (from session state) bridges them.
+    resolved = resolve_native_ids(
+        wire_to_native={"wire-1": "native-1", "wire-2": "native-2"},
+        frontend_results=[
+            {"wire_id": "wire-1", "text": "R1"},
+            {"wire_id": "wire-2", "text": "R2"},
+        ],
+    )
+    assert resolved == {"native-1": "R1", "native-2": "R2"}
+
+
+def test_resolve_skips_results_absent_from_map():
+    # A wire id not in the map (fresh session with no recorded mapping, or a
+    # pruned entry) is dropped — the caller then degrades to the legacy path.
+    resolved = resolve_native_ids(
+        wire_to_native={"wire-1": "native-1"},
+        frontend_results=[
+            {"wire_id": "wire-1", "text": "R1"},
+            {"wire_id": "wire-unknown", "text": "R2"},
+        ],
+    )
+    assert resolved == {"native-1": "R1"}
+
+
+def test_has_placeholder_results_detects_remaining_stub():
+    assert has_placeholder_results(
+        [{"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]}]
+    )
+    assert not has_placeholder_results(
+        [{"role": "user", "content": [_tool_result_block("tu-1", "real result")]}]
+    )
+    assert not has_placeholder_results([])
+
+
+def test_has_placeholder_results_scopes_to_only_ids():
+    messages = [
+        {"role": "user", "content": [_tool_result_block("tu-old", PLACEHOLDER)]},
+        {"role": "user", "content": [_tool_result_block("tu-new", "real")]},
+    ]
+    # A stale placeholder for tu-old must not count when scoped to tu-new.
+    assert not has_placeholder_results(messages, only_ids={"tu-new"})
+    assert has_placeholder_results(messages, only_ids={"tu-old"})
+
+
+def test_reconcile_leaves_non_placeholder_results_untouched(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", "already the real result")]},
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    corrected = reconcile_frontend_tool_results(sm, agent, {"tu-1": "SHOULD NOT APPLY"})
+
+    assert corrected == set()
+    block = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
+        "content"
+    ][0]["toolResult"]
+    assert block["content"] == [{"text": "already the real result"}]

--- a/integrations/aws-strands/python/tests/test_wire_map_persistence.py
+++ b/integrations/aws-strands/python/tests/test_wire_map_persistence.py
@@ -1,0 +1,88 @@
+"""Durability guarantee for the wire->native map.
+
+The reconciliation design records the ``{wire_tool_call_id: native_toolUseId}``
+map on the Strands agent's session state so a continuation run — even on a
+different process — can find the persisted placeholder. That only works if
+Strands actually persists agent state to the durable store after a run that
+executed a tool. This drives a REAL ``strands.Agent`` with a REAL
+``FileSessionManager`` and a stub model (no network) to prove it end to end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from strands import Agent
+from strands.models.model import Model
+from strands.session.file_session_manager import FileSessionManager
+from strands.tools.tools import PythonAgentTool
+
+from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+
+
+class _StubModel(Model):
+    """Emits a tool call on turn 1, then a final text answer on turn 2."""
+
+    def __init__(self):
+        self._turn = 0
+
+    def get_config(self):
+        return {}
+
+    def update_config(self, **kwargs):
+        pass
+
+    async def structured_output(self, output_model, prompt, **kwargs):
+        if False:
+            yield {}
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        self._turn += 1
+        if self._turn == 1:
+            yield {"messageStart": {"role": "assistant"}}
+            yield {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": "native-xyz", "name": "approveTool"}}
+                }
+            }
+            yield {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"messageStart": {"role": "assistant"}}
+            yield {"contentBlockDelta": {"delta": {"text": "Done."}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+def _proxy_func(tool_use, **_kwargs):
+    return {
+        "toolUseId": tool_use["toolUseId"],
+        "status": "success",
+        "content": [{"text": "Forwarded to client"}],
+    }
+
+
+_proxy_func.__name__ = "approveTool"
+
+
+@pytest.mark.asyncio
+async def test_agent_state_wire_map_persists_across_a_tool_using_run(tmp_path):
+    sm = FileSessionManager(session_id="s1", storage_dir=str(tmp_path))
+    tool = PythonAgentTool(
+        tool_name="approveTool",
+        tool_spec={"name": "approveTool", "description": "x", "inputSchema": {"json": {}}},
+        tool_func=_proxy_func,
+    )
+    agent = Agent(model=_StubModel(), tools=[tool], session_manager=sm, agent_id="default")
+
+    agent.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-xyz"})
+
+    # Consume to completion — models the adapter's frontend-tool halt drain,
+    # which lets the invocation finish so AfterInvocationEvent -> sync_agent runs.
+    async for _ in agent.stream_async("please approve"):
+        pass
+
+    # Read the map back from the DURABLE store (fresh repository read).
+    persisted = sm.session_repository.read_agent("s1", "default")
+    assert persisted is not None
+    assert persisted.state.get(AG_UI_WIRE_MAP_STATE_KEY) == {"wire-1": "native-xyz"}


### PR DESCRIPTION
## Problem

In the `ag_ui_strands` Python adapter, frontend (client-executed) tools used with a Strands `SessionManager` left the persisted session permanently wrong. The proxy returns a `"Forwarded to client"` placeholder server-side; that placeholder was persisted as the canonical `toolResult` and the real client result was never reconciled back into the store — so on continuation runs the stub was re-fed to the model.

The non-obvious root cause: **the client speaks a different tool-call id than the one Strands persists.** For frontend tools the adapter mints a fresh wire `tool_call_id` (to avoid cross-request id conflicts) and sends that to the client, while Strands persists its own native `toolUseId`. Keying reconciliation on the client id therefore matches nothing in the store.

## Fix

Bridge the two ids **durably**, then reconcile by native id:

1. **Emission:** record a `{wire_id: native_id}` map on the agent's Strands **session state** (`__ag_ui_wire_to_native__`) — persisted durably by the SessionManager, size-capped, and only maintained when a session manager is active.
2. **Continuation (including a fresh process / multi-worker):** restore the map from session state, resolve the client's wire id → native id, overwrite the persisted `"Forwarded to client"` placeholder via `session_repository.update_message`, prune the corrected entries, and continue from the corrected native history (`stream_async(None)`) only when no relevant placeholder remains.
3. **Safe degrade:** anything unmapped/unresolved (a session created before this fix, or a delta-only payload with no recorded mapping) falls back to the pre-existing synthetic-message path — the live turn still works; only the persisted stub is left as-is.

- **No session manager:** unchanged (in-memory history replay via `replay_history_into_strands`).
- **Void frontend tools:** unchanged (existing behavior).

## Tests

- New `tests/test_session_reconcile.py` (unit: resolution, reconciliation, scoped placeholder gate) and `tests/test_wire_map_persistence.py` (a real `Agent` + real `FileSessionManager` + stub model proving the map survives to the durable store across a tool-using run).
- Expanded `tests/test_session_manager.py`: wire→native resolution (incl. delta-only), map population/prune, mixed void+real, multi-turn trailing-scope, reconcile-failure fallback, no-map degrade.
- Full package suite: **176 passed, 2 skipped.**

## Scope / follow-ups

- Python adapter only. TypeScript parity is a separate effort — the TS SDK is snapshot-based with no per-message update, so it's a different implementation, not a port.
- Refs #2222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
