### PR TITLE
chore(core): export AGUIEventInput input-side event union

### DIFF
--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -361,6 +361,17 @@ export const EventSchemas = z.discriminatedUnion("type", [
 
 export type BaseEvent = z.infer<typeof BaseEventSchema>;
 export type AGUIEvent = z.infer<typeof EventSchemas>;
+/**
+ * Input-side counterpart to {@link AGUIEvent}.
+ *
+ * `AGUIEvent` is the parsed/output shape (`z.infer`), where every field with a
+ * schema default is required. `AGUIEventInput` is the pre-parse shape
+ * (`z.input`), where defaulted fields are optional. Emitters constructing
+ * events to hand to `EventSchemas.parse` should type against this union so the
+ * compiler checks the discriminated payload without forcing them to restate
+ * defaults.
+ */
+export type AGUIEventInput = z.input<typeof EventSchemas>;
 export type BaseEventFields = z.infer<typeof BaseEventSchema>;
 export type AGUIEventByType = {
   [EventType.TEXT_MESSAGE_START]: TextMessageStartEvent;


### PR DESCRIPTION
## What

Adds one export to `@ag-ui/core`:

```ts
export type AGUIEventInput = z.input<typeof EventSchemas>;
```

## Why

`@ag-ui/core` already has the right per-event primitive — `EventProps<Schema> = Omit<z.input<Schema>, "type">` — but the only union it exports is `AGUIEvent = z.infer<typeof EventSchemas>`, which is the **output** (post-parse) shape where every field carrying a schema default is required.

Emitters that construct events to hand to `EventSchemas.parse` want the **input** shape, where defaulted fields are optional. Without an input-side union they either lose compiler checking or are forced to restate defaults. `AGUIEventInput` gives them the discriminated input union directly.

## Notes

- Additive and non-breaking — new type only, no changes to existing exports or runtime.
- Automatically part of the public surface via the existing `export * from "./events"` in the package barrel.
- Scoped deliberately to the union; the internal `EventProps<Schema>` helper stays unexported.