### PR TITLE
feat(a2ui): unified in-band action handlers — ag-ui toolkit slice (OSS-165)

### DIFF
--- a/middlewares/a2ui-middleware/__tests__/forward-action.test.ts
+++ b/middlewares/a2ui-middleware/__tests__/forward-action.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  AbstractAgent,
+  BaseEvent,
+  EventType,
+  RunAgentInput,
+} from "@ag-ui/client";
+import { Observable, firstValueFrom, toArray } from "rxjs";
+import {
+  A2UIMiddleware,
+  LOG_A2UI_EVENT_TOOL_NAME,
+  RENDER_A2UI_TOOL_NAME,
+} from "../src/index";
+
+/**
+ * Forward (LLM-side) action contract: a native `action.event` button click is
+ * forwarded by the renderer as `forwardedProps.a2uiAction.userAction`, and the
+ * middleware lowers it into synthetic messages the agent's next LLM turn reads.
+ * This locks that inbound transform (the deterministic half of the forward
+ * round-trip verified end-to-end during OSS-165 v2). See PNI-106 for formalizing
+ * this consumption + the v1.0 actionResponse/actionId round-trip.
+ */
+
+class CapturingAgent extends AbstractAgent {
+  runCalls: RunAgentInput[] = [];
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.runCalls.push(input);
+    return new Observable((s) => {
+      s.next({
+        type: EventType.RUN_STARTED,
+        runId: input.runId,
+        threadId: input.threadId,
+      } as BaseEvent);
+      s.next({
+        type: EventType.RUN_FINISHED,
+        runId: input.runId,
+        threadId: input.threadId,
+      } as BaseEvent);
+      s.complete();
+    });
+  }
+}
+
+function makeInput(overrides: Partial<RunAgentInput> = {}): RunAgentInput {
+  return {
+    threadId: "t",
+    runId: "r",
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    state: {},
+    messages: [],
+    ...overrides,
+  };
+}
+const collect = (o: Observable<BaseEvent>) => firstValueFrom(o.pipe(toArray()));
+
+describe("A2UIMiddleware — forward action (LLM-side) inbound contract", () => {
+  const userAction = {
+    name: "book_flight",
+    surfaceId: "flights",
+    sourceComponentId: "book-btn",
+    context: { flightId: "AA123", price: "$412" },
+    timestamp: "2026-07-23T10:00:00Z",
+  };
+
+  it("lowers a forwarded a2uiAction into a log_a2ui_event call + a human-readable result the agent reads", async () => {
+    const mw = new A2UIMiddleware({ injectA2UITool: true });
+    const agent = new CapturingAgent();
+
+    await collect(
+      mw.run(
+        makeInput({
+          messages: [
+            { id: "u1", role: "user", content: "comparing flights" } as any,
+          ],
+          forwardedProps: { a2uiAction: { userAction } },
+        }),
+        agent,
+      ),
+    );
+
+    const seen = agent.runCalls[0];
+
+    // Structured action is preserved verbatim in the synthetic tool call.
+    const toolCall = seen.messages.find(
+      (m: any) =>
+        m.role === "assistant" &&
+        m.toolCalls?.some(
+          (tc: any) => tc.function?.name === LOG_A2UI_EVENT_TOOL_NAME,
+        ),
+    ) as any;
+    expect(toolCall).toBeTruthy();
+    expect(JSON.parse(toolCall.toolCalls[0].function.arguments)).toMatchObject(
+      userAction,
+    );
+
+    // Human-readable result the LLM reads, carrying name + context.
+    const result = seen.messages.find(
+      (m: any) =>
+        m.role === "tool" && /User performed action/.test(m.content ?? ""),
+    ) as any;
+    expect(result).toBeTruthy();
+    expect(result.content).toContain("book_flight");
+    expect(result.content).toContain("AA123");
+
+    // The agent can respond WITH a new surface on this same turn.
+    expect(
+      (seen.tools ?? []).some((t: any) => t.name === RENDER_A2UI_TOOL_NAME),
+    ).toBe(true);
+  });
+
+  it("injects no synthetic action messages when no a2uiAction is forwarded", async () => {
+    const mw = new A2UIMiddleware({ injectA2UITool: true });
+    const agent = new CapturingAgent();
+
+    await collect(
+      mw.run(
+        makeInput({
+          messages: [{ id: "u1", role: "user", content: "hi" } as any],
+        }),
+        agent,
+      ),
+    );
+
+    const seen = agent.runCalls[0];
+    expect(
+      seen.messages.some(
+        (m: any) =>
+          m.role === "tool" && /User performed action/.test(m.content ?? ""),
+      ),
+    ).toBe(false);
+  });
+});

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/action-builders.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/action-builders.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { setValue, toggleValue } from "../index";
+
+describe("setValue action builder", () => {
+  it("builds an agui.setValue functionCall action with path and value", () => {
+    expect(setValue("/showDetails", true)).toEqual({
+      functionCall: { call: "agui.setValue", args: { path: "/showDetails", value: true } },
+    });
+  });
+});
+
+describe("toggleValue action builder", () => {
+  it("builds an agui.toggleValue functionCall action with just a path", () => {
+    expect(toggleValue("/showDetails")).toEqual({
+      functionCall: { call: "agui.toggleValue", args: { path: "/showDetails" } },
+    });
+  });
+
+  it("includes value for an empty↔value (List show/hide) toggle", () => {
+    expect(toggleValue("/details", [{ id: 1 }])).toEqual({
+      functionCall: { call: "agui.toggleValue", args: { path: "/details", value: [{ id: 1 }] } },
+    });
+  });
+});

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/guidance.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/guidance.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_GENERATION_GUIDELINES } from "../index";
+
+describe("DEFAULT_GENERATION_GUIDELINES — local-swap actions (OSS-165 v2)", () => {
+  it("teaches the agui.* functionCall shape for no-round-trip local interactions", () => {
+    expect(DEFAULT_GENERATION_GUIDELINES).toContain("functionCall");
+    expect(DEFAULT_GENERATION_GUIDELINES).toContain("agui.setValue");
+    expect(DEFAULT_GENERATION_GUIDELINES).toContain("agui.toggleValue");
+  });
+});

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/validate.test.ts
@@ -331,3 +331,130 @@ describe("validateA2UIComponents — data bindings", () => {
     expect(r.valid).toBe(true);
   });
 });
+
+describe("validateA2UIComponents — functionCall actions (OSS-165 v2)", () => {
+  it("does not flag a functionCall's write-target path as an unresolved binding", () => {
+    // `agui.setValue`'s `path` arg is a WRITE target — it need not exist in the
+    // data model yet (setValue creates/sets it). The binding collector must not
+    // mistake the args map for a `{path}` read-binding.
+    const comps = [
+      { id: "root", component: "Column", children: ["btn"] },
+      {
+        id: "btn",
+        component: "Button",
+        child: "t",
+        action: { functionCall: { call: "agui.setValue", args: { path: "/notInData", value: true } } },
+      },
+      { id: "t", component: "Text", text: "Toggle" },
+    ];
+    const r = validateA2UIComponents({ components: comps, data: {} });
+    expect(r.errors.some((e) => e.code === "unresolved_binding")).toBe(false);
+    expect(r.valid).toBe(true);
+  });
+
+  it("still validates a nested {path} read-binding used as a functionCall arg value", () => {
+    // `setValue("/target", { path: "/missingSource" })` copies from a read source
+    // resolved at click time; a source that does not resolve is a genuine broken
+    // binding and must still be flagged, even though the target path is exempt.
+    const comps = [
+      { id: "root", component: "Column", children: ["btn"] },
+      {
+        id: "btn",
+        component: "Button",
+        child: "t",
+        action: {
+          functionCall: {
+            call: "agui.setValue",
+            args: { path: "/target", value: { path: "/missingSource" } },
+          },
+        },
+      },
+      { id: "t", component: "Text", text: "Copy" },
+    ];
+    const r = validateA2UIComponents({ components: comps, data: {} });
+    expect(r.errors.some((e) => e.code === "unresolved_binding" && /\/missingSource/.test(e.message))).toBe(true);
+  });
+});
+
+describe("validateA2UIComponents — agui.* functionCall vocabulary (OSS-165 v2)", () => {
+  it("flags an unknown agui.* function name", () => {
+    const comps = [
+      {
+        id: "root",
+        component: "Button",
+        child: "t",
+        action: { functionCall: { call: "agui.setValu", args: { path: "/x", value: 1 } } },
+      },
+      { id: "t", component: "Text", text: "Go" },
+    ];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.errors.some((e) => e.code === "invalid_function_call" && /agui\.setValu/.test(e.message))).toBe(true);
+  });
+
+  it("flags an agui.setValue missing a required arg", () => {
+    const comps = [
+      {
+        id: "root",
+        component: "Button",
+        child: "t",
+        action: { functionCall: { call: "agui.setValue", args: { path: "/x" } } }, // no value
+      },
+      { id: "t", component: "Text", text: "Go" },
+    ];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.errors.some((e) => e.code === "invalid_function_call" && /value/.test(e.message))).toBe(true);
+  });
+
+  it("flags an agui.toggleValue missing its required path arg", () => {
+    const comps = [
+      {
+        id: "root",
+        component: "Button",
+        child: "t",
+        action: { functionCall: { call: "agui.toggleValue", args: {} } },
+      },
+      { id: "t", component: "Text", text: "Go" },
+    ];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.errors.some((e) => e.code === "invalid_function_call" && /path/.test(e.message))).toBe(true);
+  });
+
+  it("does not reject a non-agui functionCall (e.g. a built-in openUrl)", () => {
+    // The vocabulary check is scoped to `agui.*`; native/built-in or app-registered
+    // functions are legitimate and must not be flagged.
+    const comps = [
+      {
+        id: "root",
+        component: "Button",
+        child: "t",
+        action: { functionCall: { call: "openUrl", args: { url: "https://a2ui.org" } } },
+      },
+      { id: "t", component: "Text", text: "Help" },
+    ];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.errors.some((e) => e.code === "invalid_function_call")).toBe(false);
+  });
+
+  it("accepts well-formed agui.setValue and agui.toggleValue actions", () => {
+    const comps = [
+      { id: "root", component: "Column", children: ["b1", "b2"] },
+      {
+        id: "b1",
+        component: "Button",
+        child: "t1",
+        action: { functionCall: { call: "agui.setValue", args: { path: "/x", value: true } } },
+      },
+      {
+        id: "b2",
+        component: "Button",
+        child: "t2",
+        action: { functionCall: { call: "agui.toggleValue", args: { path: "/y" } } },
+      },
+      { id: "t1", component: "Text", text: "Set" },
+      { id: "t2", component: "Text", text: "Toggle" },
+    ];
+    const r = validateA2UIComponents({ components: comps });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+});

--- a/sdks/typescript/packages/a2ui-toolkit/src/index.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/index.ts
@@ -52,6 +52,41 @@ export function updateDataModel(
 }
 
 // ---------------------------------------------------------------------------
+// Action builders (agui.* local-swap functionCalls) — OSS-165 v2
+//
+// A local swap is authored in-band as a native A2UI `action.functionCall`
+// referencing a CopilotKit-registered, framework-agnostic data-write function.
+// These builders centralise the `agui.*` name so authoring code never hardcodes
+// the wire string.
+// ---------------------------------------------------------------------------
+
+/** An A2UI component `action` value carrying a client-side functionCall. */
+export type A2UIFunctionCallAction = {
+  functionCall: { call: string; args: Record<string, unknown> };
+};
+
+/**
+ * Build an ``agui.setValue`` local-swap action. On click the renderer writes
+ * ``value`` into the surface data model at ``path`` with no agent round-trip.
+ * ``value`` may be a literal or a ``{ path }`` binding resolved at click time.
+ */
+export function setValue(path: string, value: unknown): A2UIFunctionCallAction {
+  return { functionCall: { call: "agui.setValue", args: { path, value } } };
+}
+
+/**
+ * Build an ``agui.toggleValue`` local-swap action. On click the renderer reads
+ * the current value at ``path`` and writes its negation (boolean) or toggles it
+ * between empty and ``value`` (e.g. a data-bound ``List``), with no agent
+ * round-trip. Omit ``value`` for a plain boolean toggle.
+ */
+export function toggleValue(path: string, value?: unknown): A2UIFunctionCallAction {
+  const args: Record<string, unknown> = { path };
+  if (value !== undefined) args.value = value;
+  return { functionCall: { call: "agui.toggleValue", args } };
+}
+
+// ---------------------------------------------------------------------------
 // Inner render_a2ui tool definition
 // ---------------------------------------------------------------------------
 
@@ -432,6 +467,18 @@ in the button's action. Paths are resolved to their current values at click time
 
 To pre-fill form values, pass initial data via the "data" tool argument:
   "data": { "form": { "name": "Markus" } }
+
+LOCAL INTERACTIONS (no agent round-trip):
+For interactions that only update local surface state — toggling visibility,
+switching a value, revealing details — use a client-side "functionCall" action
+instead of an "event", so the change applies instantly with no server round-trip:
+  - Set a value:    "action": { "functionCall": { "call": "agui.setValue", "args": { "path": "/showDetails", "value": true } } }
+  - Toggle a value: "action": { "functionCall": { "call": "agui.toggleValue", "args": { "path": "/showDetails" } } }
+"path" is the data-model location to write; components bound to it re-render.
+There is no data-bound "visible" flag: to SHOW/HIDE a region, bind a List to a
+path and toggle its array between empty and its items (agui.toggleValue with a
+"value"). Use an "event" action (NOT functionCall) when the agent must handle the
+interaction or when the change requires re-structuring the component tree.
 
 FORM EXAMPLE (editable text field with pre-filled value + submit button):
   "components": [

--- a/sdks/typescript/packages/a2ui-toolkit/src/validate.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/validate.ts
@@ -24,7 +24,8 @@ export interface A2UIValidationError {
     | "missing_required_prop"
     | "unresolved_child"
     | "child_cycle"
-    | "unresolved_binding";
+    | "unresolved_binding"
+    | "invalid_function_call";
   /** A JSON-pointer-ish locator, e.g. `components[2].component`. */
   path: string;
   /** Human/LLM-readable description (fed back to the sub-agent on retry). */
@@ -183,6 +184,31 @@ export function validateA2UIComponents(input: ValidateA2UIInput): ValidateA2UIRe
             path: `components[${i}]`,
             message: `Binding path '${p}' does not resolve in the data model`,
           });
+        }
+      });
+
+      // Fail loud on a malformed CopilotKit-layer `agui.*` local-swap functionCall
+      // (OSS-165 v2) — an unknown function name is almost always a typo/drift and
+      // would blow up at render time as `INVALID_FUNCTION_CALL`; a missing required
+      // arg would no-op silently.
+      collectAguiFunctionCalls(comp).forEach(({ call, args }) => {
+        const required = KNOWN_AGUI_FUNCTIONS[call];
+        if (!required) {
+          errors.push({
+            code: "invalid_function_call",
+            path: `components[${i}]`,
+            message: `Unknown agui function '${call}'`,
+          });
+          return;
+        }
+        for (const arg of required) {
+          if (!(arg in args)) {
+            errors.push({
+              code: "invalid_function_call",
+              path: `components[${i}]`,
+              message: `agui function '${call}' is missing required arg '${arg}'`,
+            });
+          }
         }
       });
     }
@@ -374,11 +400,49 @@ function findChildCycles(components: Array<Record<string, unknown>>, catalog?: A
   return [...cycles.values()];
 }
 
+/**
+ * The CopilotKit-layer `agui.*` local-swap function vocabulary (OSS-165 v2),
+ * mapped to their required arg names. Kept here so the validator (retry gate)
+ * and the authoring builders agree on what's valid.
+ */
+const KNOWN_AGUI_FUNCTIONS: Record<string, string[]> = {
+  "agui.setValue": ["path", "value"],
+  "agui.toggleValue": ["path"],
+};
+
+/** A single `agui.*` functionCall descriptor found in a component. */
+interface AguiFunctionCall {
+  call: string;
+  args: Record<string, unknown>;
+}
+
+/** Recursively collect `{call, args}` descriptors whose `call` is `agui.*`-namespaced. */
+function collectAguiFunctionCalls(node: unknown, acc: AguiFunctionCall[] = []): AguiFunctionCall[] {
+  if (Array.isArray(node)) {
+    node.forEach((v) => collectAguiFunctionCalls(v, acc));
+  } else if (isObject(node)) {
+    if (typeof node.call === "string" && node.call.startsWith("agui.") && isObject(node.args)) {
+      acc.push({ call: node.call, args: node.args });
+    }
+    for (const v of Object.values(node)) collectAguiFunctionCalls(v, acc);
+  }
+  return acc;
+}
+
 /** Recursively collect absolute (`/…`) binding paths from a component's props. */
 function collectAbsoluteBindingPaths(node: unknown, acc: string[] = []): string[] {
   if (Array.isArray(node)) {
     node.forEach((v) => collectAbsoluteBindingPaths(v, acc));
   } else if (isObject(node)) {
+    // A functionCall descriptor (`{call, args}`) carries function INPUTS, not
+    // data bindings: e.g. `agui.setValue`'s `path` arg is a WRITE target that
+    // need not resolve in the data model. So the args map must not be read as a
+    // `{path}` binding. Only nested `{path}` arg VALUES are genuine read-bindings
+    // (e.g. `setValue("/target", { path: "/source" })`) — recurse into those.
+    if (typeof node.call === "string" && isObject(node.args)) {
+      for (const v of Object.values(node.args)) collectAbsoluteBindingPaths(v, acc);
+      return acc;
+    }
     if (typeof node.path === "string" && node.path.startsWith("/")) acc.push(node.path);
     for (const [k, v] of Object.entries(node)) {
       if (k === "path") continue;


### PR DESCRIPTION
## What

Ag-ui–side slice of **unified in-band A2UI action handlers** (OSS-165). Lets an agent ship a **local, no-round-trip** interaction by authoring a native `action.functionCall` referencing a small `agui.*` data-write vocabulary, delivered **in-band** in the component JSON (one path for static + dynamic; no side-channel).

Renderer-side registration of the `agui.*` functions is the **CopilotKit handoff** (separate repo) — this PR is the framework-agnostic ag-ui layer.

## Commits

- **feat(a2ui-toolkit):** `setValue` / `toggleValue` authoring builders (emit `action.functionCall`, centralise the `agui.*` name); `validateA2UIComponents` now accepts `action.functionCall` — doesn't mis-flag a write-target `path` as an unresolved binding, still validates nested `{path}` read-bindings in arg values, and **fails loud** (`invalid_function_call`) on an unknown `agui.*` fn / missing required arg; generation guidance teaches the local-swap shape.
- **test(a2ui-middleware):** locks the **forward (LLM-side)** action inbound contract (`a2uiAction.userAction` → synthetic `log_a2ui_event` + human-readable result + `render_a2ui` available on the turn).

## Verification

- `@ag-ui/a2ui-toolkit`: **111 tests**, typecheck + build clean.
- `@ag-ui/a2ui-middleware`: **100 tests** (incl. the new forward-contract test) — no downstream breakage.
- **Real `@a2ui/web_core`** (headless): the prototyped `agui.*` functions execute against a real surface — setValue (literal + path-bound copy), toggleValue (boolean + List show/hide), reactive notify; the shipped builder's output executes end-to-end.
- **Real LLMs:** OpenAI (gpt-4o) and Gemini (2.5-flash) both author correct `agui.*` local swaps under the new guidance; validator accepts/rejects correctly; web_core executes them.

## Scope / follow-ups

- **Handoff (CopilotKit repo):** register `agui.setValue`/`agui.toggleValue` in the renderer catalog (shared, framework-agnostic module → React first, Angular/Vue fast-follow), Python helpers, docs (#4821).
- **Forward-path formalization** (naming alignment + v1.0 `actionResponse`/`actionId`) tracked separately as **PNI-106**.

Related: OSS-165 · PNI-106 · CopilotKit#4821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
