### PR TITLE
fix(langgraph): add emit_raw_events opt-out to curb raw_event payload bloat

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -130,13 +130,16 @@ class LangGraphAgent:
         self.graph = graph
         self.config = config or {}
         self.enable_legacy_on_interrupt_event = enable_legacy_on_interrupt_event
-        # Opt-out: when False, the full underlying LangGraph event is not
-        # piggy-backed onto emitted AG-UI events via ``raw_event``. That raw
-        # copy is attached to nearly every event (and re-serialized each time),
-        # so on graphs with large state it dominates payload size — Function
-        # Health saw ~1.5 MB events (OSS-607). Default True preserves the
-        # existing debugging/compat behavior; this flag does not affect the
-        # explicit ``EventType.RAW`` passthrough channel.
+        # Opt-out for emitting the underlying LangGraph event on the wire.
+        # It rides along two ways, both of which this flag controls:
+        #   1. A full ``RawEvent`` (EventType.RAW) re-emitted for every streamed
+        #      event — the dominant payload cost.
+        #   2. The ``raw_event`` copy piggy-backed onto nearly every other
+        #      emitted AG-UI event (re-serialized each time).
+        # On graphs with large state this dominates payload size — Function
+        # Health saw ~1.5 MB events (OSS-607). When False, (1) is not emitted
+        # and (2) is dropped at dispatch. Default True preserves existing
+        # debugging/compat behavior.
         self.emit_raw_events = emit_raw_events
         # Opt-in: terminate interrupted runs with the AG-UI structured outcome
         # RunFinishedEvent(outcome={"type": "interrupt", ...}). Default False so
@@ -456,9 +459,14 @@ class LangGraphAgent:
                             )
                         )
 
-                yield self._dispatch_event(
-                    RawEvent(type=EventType.RAW, event=event)
-                )
+                # The RAW passthrough re-emits the entire underlying LangGraph
+                # event as a first-class event — the dominant payload cost on
+                # large-state graphs. Suppress it entirely when opted out
+                # (emit_raw_events=False); see __init__.
+                if self.emit_raw_events:
+                    yield self._dispatch_event(
+                        RawEvent(type=EventType.RAW, event=event)
+                    )
 
                 async for single_event in self._handle_single_event(event, state):
                     yield single_event

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -124,12 +124,20 @@ class PreparedStream(TypedDict):
     events_to_dispatch: NotRequired[Optional[List[ProcessedEvents]]]
 
 class LangGraphAgent:
-    def __init__(self, *, name: str, graph: CompiledStateGraph, description: Optional[str] = None, config:  Union[Optional[RunnableConfig], dict] = None, enable_legacy_on_interrupt_event: bool = True, emit_interrupt_outcome: bool = False):
+    def __init__(self, *, name: str, graph: CompiledStateGraph, description: Optional[str] = None, config:  Union[Optional[RunnableConfig], dict] = None, enable_legacy_on_interrupt_event: bool = True, emit_interrupt_outcome: bool = False, emit_raw_events: bool = True):
         self.name = name
         self.description = description
         self.graph = graph
         self.config = config or {}
         self.enable_legacy_on_interrupt_event = enable_legacy_on_interrupt_event
+        # Opt-out: when False, the full underlying LangGraph event is not
+        # piggy-backed onto emitted AG-UI events via ``raw_event``. That raw
+        # copy is attached to nearly every event (and re-serialized each time),
+        # so on graphs with large state it dominates payload size — Function
+        # Health saw ~1.5 MB events (OSS-607). Default True preserves the
+        # existing debugging/compat behavior; this flag does not affect the
+        # explicit ``EventType.RAW`` passthrough channel.
+        self.emit_raw_events = emit_raw_events
         # Opt-in: terminate interrupted runs with the AG-UI structured outcome
         # RunFinishedEvent(outcome={"type": "interrupt", ...}). Default False so
         # released clients that resume via forwardedProps.command.resume keep
@@ -163,6 +171,7 @@ class LangGraphAgent:
                 config=dict(self.config) if self.config else None,
                 enable_legacy_on_interrupt_event=self.enable_legacy_on_interrupt_event,
                 emit_interrupt_outcome=self.emit_interrupt_outcome,
+                emit_raw_events=self.emit_raw_events,
             )
         except TypeError as exc:
             raise TypeError(
@@ -175,7 +184,12 @@ class LangGraphAgent:
         if event.type == EventType.RAW:
             event.event = make_json_safe(event.event)
         elif event.raw_event:
-            event.raw_event = make_json_safe(event.raw_event)
+            if self.emit_raw_events:
+                event.raw_event = make_json_safe(event.raw_event)
+            else:
+                # Drop the piggy-backed raw copy entirely (also skips the
+                # make_json_safe pass). See emit_raw_events in __init__.
+                event.raw_event = None
 
         return event
 

--- a/integrations/langgraph/python/tests/test_clone.py
+++ b/integrations/langgraph/python/tests/test_clone.py
@@ -9,8 +9,8 @@ from ag_ui_langgraph import LangGraphAgent
 class SubclassAgent(LangGraphAgent):
     """Test subclass that adds custom behavior."""
 
-    def __init__(self, *, name, graph, description=None, config=None, enable_legacy_on_interrupt_event=True, emit_interrupt_outcome=False, custom_flag=False):
-        super().__init__(name=name, graph=graph, description=description, config=config, enable_legacy_on_interrupt_event=enable_legacy_on_interrupt_event, emit_interrupt_outcome=emit_interrupt_outcome)
+    def __init__(self, *, name, graph, description=None, config=None, enable_legacy_on_interrupt_event=True, emit_interrupt_outcome=False, emit_raw_events=True, custom_flag=False):
+        super().__init__(name=name, graph=graph, description=description, config=config, enable_legacy_on_interrupt_event=enable_legacy_on_interrupt_event, emit_interrupt_outcome=emit_interrupt_outcome, emit_raw_events=emit_raw_events)
         self.custom_flag = custom_flag
 
     def custom_method(self):

--- a/integrations/langgraph/python/tests/test_raw_event_optout.py
+++ b/integrations/langgraph/python/tests/test_raw_event_optout.py
@@ -10,7 +10,7 @@ at the single ``_dispatch_event`` choke point, while leaving the explicit
 import unittest
 from unittest.mock import MagicMock
 
-from ag_ui.core import EventType, RawEvent, TextMessageEndEvent
+from ag_ui.core import EventType, TextMessageEndEvent
 
 from ag_ui_langgraph import LangGraphAgent
 
@@ -40,13 +40,10 @@ class TestEmitRawEventsOptOut(unittest.TestCase):
         out = agent._dispatch_event(ev)
         self.assertIsNone(out.raw_event)
 
-    def test_opt_out_leaves_explicit_raw_event_type_untouched(self):
-        # EventType.RAW is an explicit, opt-in passthrough channel — not the
-        # piggy-backed raw_event — so the opt-out must not empty its payload.
-        agent = _make_agent(emit_raw_events=False)
-        ev = RawEvent(type=EventType.RAW, event={"explicit": "raw"})
-        out = agent._dispatch_event(ev)
-        self.assertEqual(out.event, {"explicit": "raw"})
+    # Note: the RAW passthrough events (EventType.RAW) are suppressed at the
+    # emission layer in _handle_stream_events, not in _dispatch_event — see
+    # test_raw_event_payload_size.py, which asserts zero RAW events (and a
+    # >=90% wire-payload reduction) when opted out over the real pipeline.
 
     def test_clone_preserves_emit_raw_events(self):
         agent = _make_agent(emit_raw_events=False)

--- a/integrations/langgraph/python/tests/test_raw_event_optout.py
+++ b/integrations/langgraph/python/tests/test_raw_event_optout.py
@@ -1,0 +1,58 @@
+"""Tests for the ``emit_raw_events`` opt-out (OSS-607).
+
+The LangGraph integration piggy-backs the full underlying LangGraph event onto
+almost every emitted AG-UI event via ``raw_event``. On graphs with large state
+this inflates payloads (Function Health reported ~1.5 MB events). Constructing
+the agent with ``emit_raw_events=False`` strips that piggy-backed ``raw_event``
+at the single ``_dispatch_event`` choke point, while leaving the explicit
+``EventType.RAW`` passthrough channel untouched.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ag_ui.core import EventType, RawEvent, TextMessageEndEvent
+
+from ag_ui_langgraph import LangGraphAgent
+
+
+def _make_agent(**kwargs):
+    graph = MagicMock()
+    graph.nodes = {}
+    return LangGraphAgent(name="test", graph=graph, **kwargs)
+
+
+class TestEmitRawEventsOptOut(unittest.TestCase):
+    def test_default_is_on_and_preserves_raw_event(self):
+        agent = _make_agent()
+        self.assertTrue(agent.emit_raw_events)
+        ev = TextMessageEndEvent(
+            type=EventType.TEXT_MESSAGE_END, message_id="m1", raw_event={"big": "payload"}
+        )
+        out = agent._dispatch_event(ev)
+        self.assertEqual(out.raw_event, {"big": "payload"})
+
+    def test_opt_out_strips_piggybacked_raw_event(self):
+        agent = _make_agent(emit_raw_events=False)
+        self.assertFalse(agent.emit_raw_events)
+        ev = TextMessageEndEvent(
+            type=EventType.TEXT_MESSAGE_END, message_id="m1", raw_event={"big": "payload"}
+        )
+        out = agent._dispatch_event(ev)
+        self.assertIsNone(out.raw_event)
+
+    def test_opt_out_leaves_explicit_raw_event_type_untouched(self):
+        # EventType.RAW is an explicit, opt-in passthrough channel — not the
+        # piggy-backed raw_event — so the opt-out must not empty its payload.
+        agent = _make_agent(emit_raw_events=False)
+        ev = RawEvent(type=EventType.RAW, event={"explicit": "raw"})
+        out = agent._dispatch_event(ev)
+        self.assertEqual(out.event, {"explicit": "raw"})
+
+    def test_clone_preserves_emit_raw_events(self):
+        agent = _make_agent(emit_raw_events=False)
+        cloned = agent.clone()
+        self.assertFalse(cloned.emit_raw_events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_raw_event_payload_size.py
+++ b/integrations/langgraph/python/tests/test_raw_event_payload_size.py
@@ -1,0 +1,154 @@
+"""End-to-end payload-size measurement for the emit_raw_events opt-out (OSS-607).
+
+Unlike test_raw_event_optout.py (which calls _dispatch_event directly), this
+drives the *real* streaming pipeline — `_handle_stream_events` →
+`_handle_single_event` → `_dispatch_event` — with a synthetic LangGraph event
+stream whose events carry a large payload (the data that becomes `raw_event`),
+then encodes every emitted AG-UI event with the real `EventEncoder` (the exact
+call `endpoint.py` makes to write SSE) and measures the on-the-wire byte total.
+
+Asserts the opt-out (1) removes `raw_event` from every emitted event and
+(2) shrinks the encoded payload by an order of magnitude.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessageChunk
+
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.encoder import EventEncoder
+
+from ag_ui_langgraph.agent import LangGraphAgent
+
+# ~50 KB blob per streamed event, standing in for the large LangGraph
+# state/metadata that rides along on `raw_event` on a big-state graph.
+_BLOB_CHARS = 50_000
+_BIG_BLOB = {"lab_results": "x" * _BLOB_CHARS}
+
+
+def _make_agent(**kwargs):
+    from langgraph.graph.state import CompiledStateGraph
+
+    graph = MagicMock(spec=CompiledStateGraph)
+    graph.config_specs = []
+    graph.nodes = {}
+    state = MagicMock()
+    state.values = {"messages": [], "copilotkit": {}}
+    state.tasks = []
+    state.next = []
+    state.metadata = {"writes": {}}
+    graph.aget_state = AsyncMock(return_value=state)
+    return LangGraphAgent(name="test", graph=graph, **kwargs)
+
+
+def _text_stream_event(text):
+    """A LangGraph on_chat_model_stream event carrying a large side payload.
+
+    The entire event dict becomes `raw_event` on the emitted AG-UI text event,
+    so the blob in `data` is what inflates the wire payload.
+    """
+    # Real streamed chunks carry an id (the transient run-- id); the text
+    # message id is derived from it, so it must be set.
+    chunk = AIMessageChunk(content=text, id="run--msg1")
+    chunk.response_metadata = {}
+    chunk.tool_call_chunks = []
+    return {
+        "event": "on_chat_model_stream",
+        "run_id": "run1",
+        "metadata": {"langgraph_node": "model"},
+        "data": {"chunk": chunk, "state_blob": _BIG_BLOB},
+        "name": "model",
+        "parent_ids": [],
+        "tags": [],
+    }
+
+
+async def _run_and_measure(emit_raw_events):
+    agent = _make_agent(emit_raw_events=emit_raw_events)
+    encoder = EventEncoder()
+
+    stream_events = [_text_stream_event("hello "), _text_stream_event("world")]
+
+    async def fake_stream():
+        for ev in stream_events:
+            yield ev
+
+    final_state = MagicMock()
+    final_state.values = {"messages": [], "copilotkit": {}}
+    final_state.tasks = []
+    final_state.next = []
+    final_state.metadata = {"writes": {}}
+
+    mock_prepared = {
+        "state": {"messages": [], "copilotkit": {}},
+        "stream": fake_stream(),
+        "config": {"configurable": {"thread_id": "t1"}},
+    }
+
+    def fake_get_state_snapshot(state):
+        if isinstance(state, dict):
+            return state
+        return getattr(state, "values", {}) or {}
+
+    with patch.object(agent, "prepare_stream", AsyncMock(return_value=mock_prepared)), \
+         patch.object(agent.graph, "aget_state", AsyncMock(return_value=final_state)), \
+         patch.object(agent, "get_state_snapshot", side_effect=fake_get_state_snapshot):
+        input_data = RunAgentInput(
+            thread_id="t1",
+            run_id="run1",
+            messages=[],
+            state={},
+            tools=[],
+            context=[],
+            forwarded_props={},
+        )
+        emitted = [ev async for ev in agent._handle_stream_events(input_data)]
+
+    wire_bytes = sum(len(encoder.encode(ev).encode("utf-8")) for ev in emitted)
+    events_with_raw = [ev for ev in emitted if getattr(ev, "raw_event", None) is not None]
+    raw_events = [ev for ev in emitted if ev.type == EventType.RAW]
+    return emitted, wire_bytes, events_with_raw, raw_events
+
+
+class TestRawEventPayloadSize(unittest.IsolatedAsyncioTestCase):
+    async def test_opt_out_removes_raw_event_and_shrinks_wire_payload(self):
+        emitted_on, bytes_on, raw_on, raw_evts_on = await _run_and_measure(emit_raw_events=True)
+        emitted_off, bytes_off, raw_off, raw_evts_off = await _run_and_measure(emit_raw_events=False)
+
+        # Default ON: both raw carriers are present — the RAW passthrough events
+        # and the piggy-backed raw_event — and the blob is on the wire. These
+        # guard the fixture: if the pipeline stops carrying raw data they fail.
+        self.assertGreater(len(raw_evts_on), 0, "expected RAW passthrough events on the default path")
+        self.assertGreater(len(raw_on), 0, "expected piggy-backed raw_event on the default path")
+        self.assertGreater(
+            bytes_on, _BLOB_CHARS,
+            f"expected the raw blob on the wire (>{_BLOB_CHARS}B), got {bytes_on}B",
+        )
+
+        # Opt-out: no RAW passthrough events, no piggy-backed raw_event on any
+        # emitted event, and the wire payload collapses by an order of magnitude.
+        self.assertEqual(len(raw_evts_off), 0, "opt-out must suppress RAW passthrough events")
+        self.assertEqual(len(raw_off), 0, "opt-out must strip raw_event from every event")
+        self.assertLess(
+            bytes_off, bytes_on * 0.1,
+            f"expected >=90% payload reduction; on={bytes_on}B off={bytes_off}B",
+        )
+
+        # The opt-out only removes raw data — every non-RAW AG-UI event still
+        # emitted on the default path is still emitted when opted out.
+        self.assertEqual(
+            [e.type for e in emitted_on if e.type != EventType.RAW],
+            [e.type for e in emitted_off],
+            "opt-out must only drop RAW events, not any functional event",
+        )
+
+        # Emit the measured numbers so the reduction is visible in test output.
+        print(
+            f"\n[OSS-607] wire bytes: on={bytes_on:,}  off={bytes_off:,}  "
+            f"reduction={100 * (1 - bytes_off / bytes_on):.1f}%  "
+            f"(RAW events: on={len(raw_evts_on)} off={len(raw_evts_off)})"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The LangGraph integration puts the **full underlying LangGraph event** on the wire two ways, and there was **no way to turn either off** (`LangGraphAgent.__init__` exposed no such option):

1. A first-class **`RawEvent` (`EventType.RAW`) re-emitted for every streamed event** — the dominant cost.
2. The **`raw_event` copy piggy-backed** onto nearly every other emitted AG-UI event, re-serialized (`make_json_safe`) each time.

On graphs with large state this dominates payload size — **Function Health reported ~1.5 MB events**. This adds an opt-out.

## Change

New constructor flag **`emit_raw_events: bool = True`** on `LangGraphAgent`. When `False`:
- the RAW passthrough event is **not emitted** (`_handle_stream_events`), and
- the piggy-backed `raw_event` is **dropped at the single `_dispatch_event` choke point** (also skips `make_json_safe`).

Threaded through `clone()`. **Default stays `True`** — no behavior change unless you opt out. Functional (non-RAW) events are untouched.

```python
agent = LangGraphAgent(name="my-agent", graph=graph, emit_raw_events=False)
```

## Testing

**End-to-end payload measurement** (`tests/test_raw_event_payload_size.py`) — drives the real `_handle_stream_events` → `EventEncoder` pipeline (the exact call `endpoint.py` makes for SSE) with a large-payload stream, and asserts the opt-out emits **zero** RAW events, strips `raw_event` from every event, and cuts the encoded wire payload by **≥90%**. Measured:

```
[OSS-607] wire bytes: on=252,695  off=589  reduction=99.8%  (RAW events: on=2 off=0)
```

**Unit** (`tests/test_raw_event_optout.py`) — default preserves `raw_event`; opt-out sets it to `None`; `clone()` carries the flag.

**Full suite green:** `uv run pytest tests/` → **395 passed, 5 subtests passed** (includes the 3 updated `test_clone.py` cases).

> Note: an earlier revision of this PR only handled carrier (2); the e2e byte measurement above is what surfaced that carrier (1) — the RAW passthrough — was ~60% of the remaining payload, and is now gated too.

## Notes / follow-ups

- **Default choice:** kept `True` to avoid breaking any consumer that reads RAW events / `raw_event`. A future major could flip to off-by-default.
- **Not in this PR (second half of OSS-607):** trimming large `STATE_SNAPSHOT` / subgraph state. With raw events off the remaining payload is dominated by legitimate snapshot state, so this is only needed if a customer's *state itself* is oversized — wants a real capture to decide.
- **TypeScript parity:** the TS LangGraph agent has the same two carriers; a matching `emitRawEvents` option is a sensible follow-up (kept out to stay focused on the reported Python case).

Ref: OSS-607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
