### PR TITLE
fix(dojo): surface CrewAI crew_chat/error_flow demos, align CrewAI port (CPK-7722)

### DIFF
--- a/apps/dojo/src/agents.ts
+++ b/apps/dojo/src/agents.ts
@@ -243,15 +243,6 @@ export const agentsIntegrations = {
         subgraphs: "subgraphs",
       },
     ),
-    // A2UI Chat with middleware
-    a2ui_chat: (() => {
-      const agent = new LangGraphAgent({
-        deploymentUrl: envVars.langgraphPythonUrl,
-        graphId: "a2ui_chat",
-      });
-      agent.use(new A2UIMiddleware({ injectA2UITool: true }));
-      return agent;
-    })(),
     a2ui_dynamic_schema: new LangGraphAgent({
       deploymentUrl: envVars.langgraphPythonUrl,
       graphId: "a2ui_dynamic_schema",

--- a/apps/dojo/src/config.ts
+++ b/apps/dojo/src/config.ts
@@ -142,6 +142,19 @@ export const featureConfig: FeatureConfig[] = [
       "Automatic A2UI error recovery — invalid surfaces are regenerated (no wipe), with a tasteful hard-failure fallback",
     tags: ["A2UI", "Error Recovery", "Streaming"],
   }),
+  createFeatureConfig({
+    id: "crew_chat",
+    name: "Crew Chat",
+    description: "Chat with a CrewAI crew wrapped in a dict-state chat flow",
+    tags: ["Chat", "CrewAI", "Streaming"],
+  }),
+  createFeatureConfig({
+    id: "error_flow",
+    name: "Error Flow",
+    description:
+      "Backend flow that raises an error, surfaced to the client as a RunErrorEvent",
+    tags: ["CrewAI", "Error Handling"],
+  }),
 ];
 
 export default featureConfig;

--- a/apps/dojo/src/env.ts
+++ b/apps/dojo/src/env.ts
@@ -57,7 +57,7 @@ export default function getEnvVars(): envVars {
       process.env.LANGGRAPH_TYPESCRIPT_URL || "http://localhost:2024",
     agnoUrl: process.env.AGNO_URL || "http://localhost:9001",
     llamaIndexUrl: process.env.LLAMA_INDEX_URL || "http://localhost:9000",
-    crewAiUrl: process.env.CREW_AI_URL || "http://localhost:9002",
+    crewAiUrl: process.env.CREW_AI_URL || "http://localhost:8003",
     agentSpecUrl: process.env.AGENT_SPEC_URL || "http://localhost:9003",
     pydanticAIUrl: process.env.PYDANTIC_AI_URL || "http://localhost:9000",
     adkMiddlewareUrl: process.env.ADK_MIDDLEWARE_URL || "http://localhost:8000",


### PR DESCRIPTION
## Summary

Fixes three dojo wiring issues for CrewAI, part of the CrewAI Revamp Lane 1 (parent CPK-7726).

Linear: https://linear.app/copilotkit/issue/CPK-7722

### 1. CrewAI's two exclusive demos were unreachable from the UI
`crew_chat` and `error_flow` are CrewAI-exclusive features, but neither could be clicked to. The sidebar silently filters out any feature that has no `featureConfig` entry (`sidebar.tsx`), and these two had none. Everything else was already wired (live page dirs, agents registration, backend). Added the missing `featureConfig` entries in `apps/dojo/src/config.ts`:

- `crew_chat` — "Crew Chat": Chat with a CrewAI crew wrapped in a dict-state chat flow. Tags: Chat, CrewAI, Streaming.
- `error_flow` — "Error Flow": Backend flow that raises an error, surfaced to the client as a RunErrorEvent. Tags: CrewAI, Error Handling.

(The `Feature` union in `types/integration.ts` already contained both ids, so no type change was needed there.)

### 2. Default CrewAI dojo URL did not match the runner port
`env.ts` defaulted `crewAiUrl` to `http://localhost:9002`, but `scripts/run-dojo-everything.js` starts the CrewAI agent on port `8003` (and the e2e workflow waits on 8003). Changed the default from `9002` to `8003`.

### 3. Dead registration cleanup
Removed the dead `a2ui_chat` LangGraph agent registration in `apps/dojo/src/agents.ts` — it appeared in no menu and was unreachable. `A2UIMiddleware` is still used elsewhere so the import remains.

Out of scope (left untouched): `backend_tool_rendering` remains commented out (TODO, no example file).

## Verification

- `tsc --noEmit` on the dojo project is clean after building the workspace packages.