### PR TITLE
chore(release): correct crewai buildSystem after the Poetry->uv migration

### DIFF
--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -140,7 +140,7 @@
       "description": "CrewAI integration (Python)",
       "sharedVersion": false,
       "packages": [
-        { "name": "ag-ui-crewai", "path": "integrations/crew-ai/python", "ecosystem": "python", "buildSystem": "poetry" }
+        { "name": "ag-ui-crewai", "path": "integrations/crew-ai/python", "ecosystem": "python", "buildSystem": "uv" }
       ]
     },
     "integration-langchain": {


### PR DESCRIPTION
PR #2251 (`1ccd83cf`) migrated `integrations/crew-ai/python` from Poetry to uv, converting its `pyproject.toml` from `[tool.poetry]` to PEP 621 `[project]` — but `scripts/release/release.config.json` still declares:

```json
{ "name": "ag-ui-crewai", "path": "integrations/crew-ai/python", "ecosystem": "python", "buildSystem": "poetry" }
```

`verify-config-manifest-names.sh` reads the package name from `[tool.poetry]` when `buildSystem` is `poetry`, so it can no longer resolve a name:

```
ERROR: missing key 'poetry' in integrations/crew-ai/python/pyproject.toml
ERROR: [integration-crewai-py] ag-ui-crewai: could not read name from integrations/crew-ai/python/pyproject.toml
```

One word: `poetry` → `uv`.

## Why this shipped green

`Lint Release Workflows` only triggers on `scripts/release/**`, `nx.json`, or the three release workflow files. PR #2251 touched none of those, so the guard never ran on it. Its last run on `main` was 2026-07-22, before the migration — so `main` has been latently red since 2026-07-27, and **any PR touching `scripts/release/**` inherits the failure** (that is how it surfaced, on #2247).

## Verification

Reproduced on plain `main`, then confirmed fixed. All four release guards pass:

- `verify-config-manifest-names.sh` — every package name matches its manifest
- `verify-release-scope-dropdowns.sh` — dropdowns + notify-job ecosystem case
- `verify-nx-release-allowlist.sh` — nx.json matches config

Audited **all ten** Python scopes for the same drift; crewai was the only mismatch. No scope declares `poetry` now.

## Two follow-ups, deliberately not in this PR

1. **The guard cannot see the change that breaks it.** Its path filter watches the config side but not the manifests it validates against, so a manifest-only edit breaks it invisibly — exactly what happened here. Worth adding the referenced manifests to `paths:`, or running the job unconditionally.
2. **The `poetry` build path is now dead code.** No scope uses it, but `publish-release.yml` still branches on `buildSystem == "poetry"` to call `poetry build`. Safe to leave, worth pruning eventually.