### PR TITLE
fix(langgraph): carry ToolMessage.error onto the LangChain status flag

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -404,6 +404,9 @@ def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]
                 id=message.id,
                 content=message.content,
                 tool_call_id=message.tool_call_id,
+                # Carry the AG-UI failure signal onto LangChain's tool-result status, so a
+                # client-reported tool failure is not delivered to the model as a success.
+                status="error" if message.error else "success",
             ))
         else:
             raise ValueError(f"Unsupported message role: {role}")

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -82,6 +82,22 @@ class TestAguiMessagesToLangchain(unittest.TestCase):
         assert isinstance(result[0], ToolMessage)
         assert result[0].content == "42"
         assert result[0].tool_call_id == "tc1"
+        # A tool result with no error maps to LangChain's default "success" status.
+        assert result[0].status == "success"
+
+    def test_tool_message_error_maps_to_status(self):
+        # A client-reported tool failure must reach the model as an error, not a
+        # silent success -- AG-UI's ToolMessage.error becomes status="error".
+        msg = AGUIToolMessage(
+            id="t1",
+            role="tool",
+            content="Tool failed: invalid id",
+            tool_call_id="tc1",
+            error="invalid id",
+        )
+        result = agui_messages_to_langchain([msg])
+        assert isinstance(result[0], ToolMessage)
+        assert result[0].status == "error"
 
     def test_multimodal_with_url(self):
         msg = AGUIUserMessage(

--- a/integrations/langgraph/typescript/src/message-conversion.test.ts
+++ b/integrations/langgraph/typescript/src/message-conversion.test.ts
@@ -78,6 +78,23 @@ describe("Message Conversion - All Types", () => {
       expect(result[0].type).toBe("tool");
       expect(result[0].content).toBe("42");
       expect(result[0].tool_call_id).toBe("tc1");
+      // A tool result with no error maps to LangChain's default "success" status.
+      expect(result[0].status).toBe("success");
+    });
+
+    it("should map a tool message error onto LangChain's status flag", () => {
+      // A client-reported tool failure must reach the model as an error, not a
+      // silent success — AG-UI's ToolMessage.error becomes status: "error".
+      const msg: Message = {
+        id: "t1",
+        role: "tool",
+        content: "Tool failed: invalid id",
+        toolCallId: "tc1",
+        error: "invalid id",
+      };
+      const result: any[] = aguiMessagesToLangChain([msg]);
+      expect(result[0].type).toBe("tool");
+      expect(result[0].status).toBe("error");
     });
 
     it("should throw for unsupported role", () => {

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -435,6 +435,9 @@ export function aguiMessagesToLangChain(messages: Message[]): LangGraphMessage[]
           type: message.role,
           tool_call_id: message.toolCallId,
           id: message.id,
+          // Carry the AG-UI failure signal onto LangChain's tool-result status, so a
+          // client-reported tool failure is not delivered to the model as a success.
+          status: message.error ? "error" : "success",
         } as LangGraphMessage);
         break;
       default:


### PR DESCRIPTION
Fixes #2226.

## Problem

Both langgraph adapters drop AG-UI's `ToolMessage.error` when they convert an incoming tool message to a LangChain `ToolMessage`. LangChain has a `status` field (`"success" | "error"`) for exactly this, and providers such as `langchain_anthropic` map it onto the model's tool-result flag. With the field dropped, a client-reported tool failure reaches the model as a success. The impact is provider-dependent, so it is invisible on Gemini and shows up on Anthropic.

## Fix

Map `error` onto `status` in both adapters: `"error"` when the AG-UI `error` field is set, else `"success"`.

- TypeScript — `integrations/langgraph/typescript/src/utils.ts`, the `tool` branch of `aguiMessagesToLangChain`. The langgraph-sdk `ToolMessage` type already types `status?: "error" | "success"`.
- Python — `integrations/langgraph/python/ag_ui_langgraph/utils.py`, the `tool` branch of `agui_messages_to_langchain`.

The AG-UI `ToolMessage` schema already has `error` in both languages, so no type changes are needed.

## Scope

This PR maps the flag only. The two open questions from the issue — preserving the `error` text and round-tripping it back to the client — look like a separate protocol topic and are left out here.

## Tests

A test is added on each side, next to the existing tool-message conversion tests.

- TS: `message-conversion.test.ts` — full package suite green, 265 tests.
- Python: `test_message_conversion.py` — `unittest discover tests` green, 43 tests.
