### PR TITLE
fix(crewai): #2260 review follow-up hardening (8 minors)

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/__init__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__init__.py
@@ -16,10 +16,10 @@ from .sdk import (
 
 # CREW_ENTERPRISE_EVENT_LISTENER = CrewEnterpriseEventListener()
 
-# CPK-7717 defect 5: the Crew chat path was undiscoverable — the four
-# symbols below (the crew-endpoint factory, its input-prep helper, the
-# flow, and the exit signal) were absent from the package top level.
-# Export them alongside the pre-existing flow-path surface.
+# The Crew chat path was undiscoverable — the four symbols below (the
+# crew-endpoint factory, its input-prep helper, the flow, and the exit
+# signal) were absent from the package top level. Export them alongside
+# the pre-existing flow-path surface.
 __all__ = [
   "add_crewai_flow_fastapi_endpoint",
   "add_crewai_crew_fastapi_endpoint",

--- a/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
@@ -1,4 +1,4 @@
-"""Runtime capability detection for the CrewAI AG-UI bridge (CPK-7718).
+"""Runtime capability detection for the CrewAI AG-UI bridge.
 
 crewai's public surface shifted across the 0.x -> 1.x boundary. Rather than
 gate code paths on ``crewai.__version__`` (brittle — a version string is not a
@@ -46,7 +46,15 @@ def _first_module(candidates: list[str]) -> tuple[Any, str | None]:
     for name in candidates:
         try:
             return importlib.import_module(name), name
-        except Exception:  # noqa: BLE001 - any import failure is "not here"
+        except (ImportError, ModuleNotFoundError):
+            # Only "module genuinely not here" is a soft miss (fall through to
+            # the next candidate). A DIFFERENT error raised while importing an
+            # existing module — e.g. a real bug inside ``crewai.events`` (a
+            # SyntaxError, an AttributeError from a broken re-export, a failing
+            # top-level side effect) — must NOT be swallowed: doing so
+            # misreports a genuinely broken install as "install crewai>=1.0".
+            # ``ModuleNotFoundError`` is an ``ImportError`` subclass; both are
+            # listed for clarity.
             continue
     return None, None
 
@@ -107,7 +115,7 @@ _event_bus_has_flush = bool(crewai_event_bus is not None and callable(getattr(cr
 
 
 # --------------------------------------------------------------------------
-# StreamFrame streaming contract resolution (CPK-7719)
+# StreamFrame streaming contract resolution
 # --------------------------------------------------------------------------
 # crewai landed a public, ordered streaming envelope — ``StreamFrame`` and the
 # ``AsyncStreamSession`` returned by ``Flow.astream()`` — in 1.6.0 (hardened in
@@ -131,8 +139,8 @@ StreamFrame = (
 # The scoped stream-sink API (``crewai.events.stream_context``) landed together
 # with ``StreamFrame`` in 1.6. The bridge registers its OWN sink so the frame
 # translator receives the RAW AG-UI / lifecycle event object (source + exact
-# payload) rather than the ``to_serializable``-mangled ``frame.data`` snapshot
-# (CPK-7719 review blocker 1). ``publish_stream_event`` invokes every sink
+# payload) rather than the ``to_serializable``-mangled ``frame.data`` snapshot.
+# ``publish_stream_event`` invokes every sink
 # synchronously on ``emit``, so a sink parked by ``event_id`` is guaranteed
 # populated before the corresponding frame is dequeued.
 _STREAM_CONTEXT_MODULE, _STREAM_CONTEXT_MODULE_NAME = _first_module(
@@ -161,7 +169,7 @@ _stream_frame_available = (
 def flow_supports_stream_frames(flow: Any) -> bool:
     """Return True when ``flow`` can be driven via the StreamFrame contract.
 
-    Two conditions, both required (CPK-7719):
+    Two conditions, both required:
 
     * The installed crewai exposes ``StreamFrame`` (resolved once at import) —
       i.e. crewai >= 1.6. On 1.0-1.5 this is ``None`` and we fall back.

--- a/integrations/crew-ai/python/ag_ui_crewai/_copyutil.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_copyutil.py
@@ -1,4 +1,4 @@
-"""Safe deep-copy of crewai objects (CPK-7718 #10).
+"""Safe deep-copy of crewai objects.
 
 crewai 1.13+ made ``Flow`` (and ``Crew``) Pydantic ``BaseModel``s that now
 carry non-deep-copyable runtime state — a ``memory`` (``UnifiedMemory``) field
@@ -60,17 +60,53 @@ def _deepcopy_pinning_uncopyable(obj: object) -> object:
     return copy.deepcopy(obj, memo)
 
 
+def _assert_state_isolated(original: object, copied: object, what: str) -> None:
+    """Fail loudly if the per-request conversation ``_state`` was NOT isolated.
+
+    :func:`_deepcopy_pinning_uncopyable` pins uncopyable values by reference at
+    TOP-LEVEL-FIELD granularity. If a single field/private-attr
+    value transitively holds BOTH the conversation ``_state`` AND some
+    uncopyable object (a lock, a thread pool), the whole field is pinned — so
+    the copy would SHARE ``_state`` with the original and per-request isolation
+    would be SILENTLY lost (every concurrent request mutating one shared state).
+    The entire reason ``safe_deepcopy`` exists is to isolate that ``_state``, so
+    assert it post-copy and fail loud rather than serve cross-request bleed.
+
+    Only checked when BOTH objects actually carry a non-None ``_state`` (crewai
+    ``Flow`` instances do; a copied ``Crew`` or a test stub may not) — absent or
+    ``None`` ``_state`` is nothing to isolate and is left alone.
+    """
+    original_state = getattr(original, "_state", None)
+    copied_state = getattr(copied, "_state", None)
+    if original_state is None or copied_state is None:
+        return
+    if copied_state is original_state:
+        raise RuntimeError(
+            f"ag-ui-crewai: safe_deepcopy of a {what} did NOT isolate its "
+            "conversation `_state` (copy._state is original._state). A "
+            "top-level field pinned by the deep-copy fallback transitively "
+            "held both `_state` and an uncopyable object, collapsing "
+            "per-request isolation — concurrent requests would share and "
+            "corrupt one another's state. This is a hard correctness failure, "
+            "not a degradation; refusing to serve a non-isolated copy."
+        )
+
+
 def safe_deepcopy(obj: object, *, what: str = "crewai object") -> object:
     """Return an isolated deep-copy of ``obj``, tolerating crewai's copy bugs.
 
     Uses plain ``copy.deepcopy`` on healthy builds; on the first failure it
-    latches to the pin-and-share fallback and warns once.
+    latches to the pin-and-share fallback and warns once. Either way the
+    per-request conversation ``_state`` MUST end up isolated — asserted
+    fail-loud post-copy.
     """
     global _NEEDS_PIN  # pylint: disable=global-statement
     if _NEEDS_PIN:
-        return _deepcopy_pinning_uncopyable(obj)
+        copied = _deepcopy_pinning_uncopyable(obj)
+        _assert_state_isolated(obj, copied, what)
+        return copied
     try:
-        return copy.deepcopy(obj)
+        copied = copy.deepcopy(obj)
     except Exception:  # noqa: BLE001 - fall back to the pin-and-share path
         _NEEDS_PIN = True
         _LOGGER.warning(
@@ -81,13 +117,15 @@ def safe_deepcopy(obj: object, *, what: str = "crewai object") -> object:
             "silenced.",
             what,
         )
-        return _deepcopy_pinning_uncopyable(obj)
+        copied = _deepcopy_pinning_uncopyable(obj)
+    _assert_state_isolated(obj, copied, what)
+    return copied
 
 
 def rebind_bound_methods(target: object, attr: str = "_methods") -> None:
     """Rebind the bound callables in ``target.<attr>`` to ``target`` itself.
 
-    CPK-7718 #11 (crewai 1.15 per-request isolation bug). crewai 1.x drives a
+    crewai 1.15 per-request isolation bug. crewai 1.x drives a
     Flow's ``@start`` / ``@listen`` methods through a ``_methods`` dict of
     BOUND methods, each captured against the instance at construction time
     (``method.__get__(self, type(self))`` in ``_class_bound_methods``). The

--- a/integrations/crew-ai/python/ag_ui_crewai/_env.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_env.py
@@ -1,17 +1,14 @@
 """Shared env-var parse helpers for ag_ui_crewai.
 
-CR8 MEDIUM — circular import: prior to this module, ``crews.py``
-imported ``_parse_env_float`` from ``endpoint.py`` via a function-local
-import to sidestep the module-load cycle (``endpoint`` imports
-``ChatWithCrewFlow`` from ``crews`` at the top level). The function-local
-workaround is fragile — on a cold ``__pycache__`` the first-run import
-can fail if both modules try to resolve each other simultaneously — and
-leaks import plumbing into a hot path.
-
-Extracting the shared helper here gives both ``endpoint`` and ``crews``
-a neutral third module to import from at module load time, eliminating
-the cycle entirely. This module intentionally has NO imports from
-``endpoint`` or ``crews``; it must remain a leaf.
+Prior to this module, ``crews.py`` imported ``_parse_env_float`` from
+``endpoint.py`` via a function-local import to sidestep the module-load cycle
+(``endpoint`` imports ``ChatWithCrewFlow`` from ``crews`` at the top level).
+That workaround was fragile (a cold-``__pycache__`` first run could fail when
+both modules resolve each other simultaneously) and leaked import plumbing into
+a hot path. Extracting the shared helper here gives both ``endpoint`` and
+``crews`` a neutral third module to import from at load time, eliminating the
+cycle. This module intentionally has NO imports from ``endpoint`` or ``crews``;
+it must remain a leaf.
 """
 
 import math

--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -1,4 +1,4 @@
-"""Translate crewai stream events into AG-UI wire events (CPK-7719).
+"""Translate crewai stream events into AG-UI wire events.
 
 crewai's public streaming contract (``StreamFrame`` / ``AsyncStreamSession``,
 landed 1.6.0) emits one ordered frame per event a flow raises. The frame gives
@@ -7,7 +7,7 @@ by our scoped stream sink, keyed by ``event.event_id == StreamFrame.id``) gives
 us the EXACT payload. This module is the SINGLE translation seam that maps the
 raw events the bridge cares about onto AG-UI events.
 
-Why raw events, not ``frame.data`` (CPK-7719 review blocker 1):
+Why raw events, not ``frame.data``:
 ``StreamFrame.data`` is ``event.to_json(exclude=...)`` -> crewai's
 ``to_serializable(max_depth=5)``, which (a) ``repr()``-quotes anything at depth
 >= 5 (plain strings become ``"'text'"``) and (b) recursively drops any dict key
@@ -26,14 +26,26 @@ Two raw event sources feed us (verified against the 1.15.7 wheel):
   ``EventType`` string and whose typed attributes (``snapshot`` / ``delta`` /
   ``message_id`` / ...) carry the verbatim, un-serialized payload.
 
-OUTER-flow filtering (CPK-7719 review blockers 2 + 3): a ``crew.kickoff`` inside
+OUTER-flow filtering: a ``crew.kickoff`` inside
 a flow method drives a NESTED flow whose own lifecycle/method events leak onto
 the same scoped sink. The driver filters those out by source identity BEFORE
 they reach this translator (only events whose ``source is flow_copy`` are parked
 in the lookup buffer), so the translator never sees nested frames. This mirrors
 the legacy listener's ``source is flow_copy`` gate and needs no depth counter.
 
-SWAPPABLE EMISSION SHAPE (cross-lane constraint, CPK-7719): CrewAI is currently
+UPSTREAM FRAME RETENTION: crewai's ``AsyncStreamSession``
+(``crewai.types.streaming.StreamSessionBase``) appends EVERY iterated frame to
+its ``self._frames`` list and keeps them for the session's life (to back its
+``.frames`` / ``.result`` replay accessors) — we cannot drop consumed frames
+without forking upstream, and doing so would break those accessors. The growth
+is bounded per-request (one session per run, torn down when the request ends),
+NOT a cross-request leak. The bridge's OWN raw-event lookup buffer does not
+share this behavior: ``endpoint._run_flow_frame_stream`` ``pop``s each parked
+raw event by ``frame.id`` the moment its frame is consumed, so our buffer stays
+proportional to in-flight (not total) frames. If a future crewai release makes
+frame retention opt-out, revisit the session consumption in ``endpoint.py``.
+
+SWAPPABLE EMISSION SHAPE: CrewAI is currently
 the only integration emitting TEXT_MESSAGE_CHUNK / TOOL_CALL_CHUNK (chunks)
 rather than the START/CONTENT/END triples the six other integrations emit. That
 final choice belongs to a Parity-lane ticket, not this migration. The translator
@@ -43,13 +55,13 @@ byte-for-byte behavior-preserving on that channel. The ``"triples"`` strategy is
 a deliberate NotImplementedError placeholder — the Parity ticket owns wiring it
 up and flipping the default.
 
-MCP EVENTS (PNI-130) are the ONE exception to "chunks-only": crewai's discrete
+MCP EVENTS are the ONE exception to "chunks-only": crewai's discrete
 MCP tool executions (name + full args + result arrive together, not streamed)
 map to canonical ``TOOL_CALL_START/ARGS/END/RESULT`` triples via the shared
 ``mcp.translate_mcp_event`` seam, and MCP lifecycle events map to ``CUSTOM``.
 This is independent of the ``emission_shape`` strategy above (which governs only
 the streaming LLM text / tool-call channel); see the wire-shape note in
-``mcp.py`` for why discrete MCP calls use triples regardless of PNI-136.
+``mcp.py`` for why discrete MCP calls use triples.
 """
 
 from __future__ import annotations
@@ -116,7 +128,7 @@ class StreamFrameTranslator:
         self._run_id = run_id
         self._state_provider = state_provider
         self.emission_shape = emission_shape
-        # Run-lifecycle idempotency (CPK-7719). A single AG-UI HTTP run must
+        # Run-lifecycle idempotency. A single AG-UI HTTP run must
         # emit EXACTLY ONE ``RUN_STARTED`` (first) and ONE ``RUN_FINISHED``
         # (last). Nested-flow lifecycle events are already filtered out by the
         # driver's source gate, so no depth counter is needed; these flags are
@@ -176,7 +188,7 @@ class StreamFrameTranslator:
         if event_type == _METHOD_FINISHED:
             return self._method_finished_events(event)
 
-        # PNI-130: crewai's first-class MCP events (crewai >= 1.4). Emitted with
+        # crewai's first-class MCP events (crewai >= 1.4). Emitted with
         # the agent/crew as source (not the flow), so the driver's sink parks
         # them by TYPE rather than source identity; here they map to TOOL_CALL_*
         # (tool executions) and CUSTOM (lifecycle) via the shared translator.
@@ -212,7 +224,7 @@ class StreamFrameTranslator:
         return []
 
     def finalize(self) -> list[Any]:
-        """Belt-and-braces terminal (CPK-7719 review blocker 3).
+        """Belt-and-braces terminal.
 
         Called once when the frame stream exhausts cleanly. If the run opened
         (RUN_STARTED) but no outer ``flow_finished`` closed it — e.g. the outer
@@ -283,10 +295,10 @@ class StreamFrameTranslator:
                     delta=getattr(event, "delta", None),
                 )
             ]
-        # TODO(CPK Parity lane): emit TEXT_MESSAGE_START / _CONTENT / _END
-        # triples here to match the other six integrations. That cross-lane
-        # decision is owned by the Parity ticket; do NOT flip the default in
-        # this migration (it must stay behavior-preserving on the wire).
+        # TODO(Parity lane): emit TEXT_MESSAGE_START / _CONTENT / _END
+        # triples here to match the other six integrations. Do NOT flip the
+        # default in this migration (it must stay behavior-preserving on the
+        # wire).
         raise NotImplementedError(
             "emission_shape='triples' is a Parity-lane placeholder; "
             "the StreamFrame migration ships the behavior-preserving "
@@ -303,7 +315,7 @@ class StreamFrameTranslator:
                     delta=getattr(event, "delta", None),
                 )
             ]
-        # TODO(CPK Parity lane): TOOL_CALL_START / _ARGS / _END triples — see
+        # TODO(Parity lane): TOOL_CALL_START / _ARGS / _END triples — see
         # the note in ``_text_events``.
         raise NotImplementedError(
             "emission_shape='triples' is a Parity-lane placeholder; "

--- a/integrations/crew-ai/python/ag_ui_crewai/crews.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/crews.py
@@ -5,8 +5,8 @@ import weakref
 from typing import Any, Protocol, cast, runtime_checkable
 from crewai import Crew, Flow
 from crewai.flow import start
-# CPK-7718: the five crew-chat helpers moved from ``crewai.cli.crew_chat``
-# (crewai 0.x - 1.14) to ``crewai.utilities.crew_chat`` (crewai 1.15+).
+# The five crew-chat helpers moved from ``crewai.cli.crew_chat`` (crewai
+# 0.x - 1.14) to ``crewai.utilities.crew_chat`` (crewai 1.15+).
 # ``_capabilities`` probes both locations (new path first) so the crew-serving
 # path works across the whole ``crewai>=1.0`` floor. The module-level aliases
 # below are preserved so tests can patch ``crews.crew_chat_*`` by name.
@@ -17,9 +17,9 @@ from ._capabilities import (
   build_system_message as crew_chat_build_system_message,
   create_tool_function as crew_chat_create_tool_function,
 )
-# ``litellm`` is a DIRECT dependency of ag-ui-crewai (CPK-7718 #6): crewai
-# moved it to the optional ``crewai[litellm]`` extra at 1.0.0, so importing it
-# ourselves keeps ``acompletion`` resolvable regardless of crewai extras.
+# ``litellm`` is a DIRECT dependency of ag-ui-crewai: crewai moved it to the
+# optional ``crewai[litellm]`` extra at 1.0.0, so importing it ourselves keeps
+# ``acompletion`` resolvable regardless of crewai extras.
 from litellm import acompletion
 from ._env import _parse_env_float
 from ._copyutil import safe_deepcopy
@@ -30,28 +30,18 @@ from .sdk import (
 )
 
 # Cache of generated chat-input schemas, keyed by the ``@CrewBase``
-# instance passed to ``add_crewai_crew_fastapi_endpoint`` (CPK-7717
-# review round 3, finding 2).
+# instance passed to ``add_crewai_crew_fastapi_endpoint``.
 #
-# The store maps ``id(crew) -> (weakref.ref(crew, evict_cb), schema)``.
-# Keying by ``id`` alone was unsafe (CPython reuses ``id`` values after
-# GC), and a ``WeakKeyDictionary`` keyed on the crew object was ALSO
-# unsafe: it keys by ``__eq__`` / ``__hash__``, so two distinct-but-equal
-# crew objects (e.g. value-based ``@dataclass``-style wrappers) collapse
-# to one entry and cross-serve each other's schema. Combining the two —
-# an ``id`` key plus a STRICT-IDENTITY weakref check — fixes both:
-#
-#   * ``evict_cb`` pops the ``id`` entry the moment its referent is
-#     garbage-collected, so a later ``id`` reuse can never inherit a
-#     stale schema.
-#   * On read we only return the schema when the stored ``ref() is crew``
-#     (strict identity, and still alive); anything else is a miss and the
-#     stale entry is dropped so we regenerate.
-#
-# Genuinely NON-weak-referenceable crews are simply NOT cached: retaining
-# a strong reference to keep the ``id`` stable would leak every such
-# wrapper for the process lifetime, so we prefer correctness (regenerate)
-# over the caching win for that rare shape.
+# Maps ``id(crew) -> (weakref.ref(crew, evict_cb), schema)``. ``id`` alone is
+# unsafe (CPython reuses ``id`` values after GC), and a ``WeakKeyDictionary``
+# keyed on the crew is ALSO unsafe: it keys by ``__eq__`` / ``__hash__``, so
+# two distinct-but-equal crew objects collapse to one entry and cross-serve
+# each other's schema. An ``id`` key plus a STRICT-IDENTITY weakref check fixes
+# both: ``evict_cb`` pops the entry the moment its referent is collected (so a
+# later ``id`` reuse can't inherit a stale schema), and reads only hit when the
+# stored ``ref() is crew``. Non-weak-referenceable crews are NOT cached —
+# pinning a strong reference to keep the ``id`` stable would leak the wrapper
+# for the process lifetime, so we regenerate instead.
 _CREW_INPUTS_CACHE: "dict[int, tuple[weakref.ref, Any]]" = {}
 
 
@@ -112,11 +102,11 @@ class CrewBaseInstance(Protocol):
     crew wrapper exposing a ``crew()`` factory that builds the underlying
     :class:`crewai.Crew` — NOT a bare :class:`crewai.Crew`, which has no
     ``.crew()`` factory (annotating the parameter as ``Crew`` was actively
-    misleading; CPK-7717 defect 5).
+    misleading).
 
-    The protocol pins ONLY ``crew()`` — the single structural essential
-    (CPK-7717 review round 3, finding 3). Name handling is deliberately
-    left OUT of the protocol and delegated to :func:`_read_crew_name`,
+    The protocol pins ONLY ``crew()`` — the single structural essential.
+    Name handling is deliberately left OUT of the protocol and delegated
+    to :func:`_read_crew_name`,
     which accepts a real ``@CrewBase`` instance's ``_crew_name`` OR a
     hand-rolled ``.name``. Requiring ``_crew_name`` in the protocol (as an
     earlier round did) wrongly rejected the repo's own ``CrewChatCrew``
@@ -139,7 +129,7 @@ def _read_crew_name(crew: Any) -> str:
     as the crew tool's function name, so a missing/empty/non-string name
     would raise a Pydantic validation error deep inside
     ``generate_crew_chat_inputs``. Fail loudly here with an actionable
-    message instead (CPK-7717 review round 2, finding 2).
+    message instead.
     """
     for attr in ("name", "_crew_name"):
         value = getattr(crew, attr, None)
@@ -172,15 +162,14 @@ def _llm_timeout_seconds() -> float | None:
     and any other non-finite float is treated as unparseable and falls back
     to the default — ``float('nan') > 0`` is False, which would otherwise
     silently disable the guard. Mirrors the NaN handling in
-    ``endpoint._flow_timeout_seconds`` (R5 HIGH #1).
+    ``endpoint._flow_timeout_seconds``.
 
-    CR7 LOW: delegates to ``_env._parse_env_float`` so the three
-    env-parsed float helpers (flow ceiling / cancel-join ceiling / LLM
-    read timeout) share a single parse + policy path rather than
-    triplicating the scaffolding. CR8 MEDIUM: the helper lives on a
-    neutral ``_env`` module (rather than ``endpoint``) so we can
-    import it at module load time without a circular dependency
-    (``endpoint`` imports ``ChatWithCrewFlow`` from ``crews``).
+    Delegates to ``_env._parse_env_float`` so the three env-parsed float
+    helpers (flow ceiling / cancel-join ceiling / LLM read timeout) share a
+    single parse + policy path. The helper lives on the neutral ``_env``
+    module (not ``endpoint``) so it can be imported at module load time
+    without a circular dependency (``endpoint`` imports ``ChatWithCrewFlow``
+    from ``crews``).
     """
     return _parse_env_float(
         "AGUI_CREWAI_LLM_TIMEOUT_SECONDS",
@@ -213,8 +202,8 @@ class ChatWithCrewFlow(Flow):
         super().__init__()
 
 
-        # CPK-7718 #10: ``Crew`` is a Pydantic BaseModel carrying
-        # non-deep-copyable runtime state (memory / locks) in crewai 1.15.x, so
+        # ``Crew`` is a Pydantic BaseModel carrying non-deep-copyable
+        # runtime state (memory / locks) in crewai 1.15.x, so
         # a plain ``copy.deepcopy`` crashes. ``safe_deepcopy`` falls back to
         # pinning those shared objects by reference while still isolating
         # copyable state.
@@ -226,15 +215,14 @@ class ChatWithCrewFlow(Flow):
         # Read the crew name from the real ``@CrewBase`` accessor
         # (``_crew_name``) or a hand-rolled ``.name`` — never ``crew.name``
         # unconditionally, which AttributeErrors on a real @CrewBase
-        # instance (CPK-7717 review round 2, finding 2). Fails loudly with
-        # an actionable message if neither yields a usable non-empty name,
-        # rather than passing ``None`` into ``ChatInputs`` (validation
-        # error deep in ``generate_crew_chat_inputs``).
+        # instance. Fails loudly with an actionable message if neither yields
+        # a usable non-empty name, rather than passing ``None`` into
+        # ``ChatInputs`` (validation error deep in ``generate_crew_chat_inputs``).
         self.crew_name = _read_crew_name(crew)
         self.chat_llm = crew_chat_initialize_chat_llm(self.crew)
 
-        # Identity-safe cache keyed on the crew object itself (finding 3),
-        # not ``id(crew)`` which is reused after GC.
+        # Identity-safe cache keyed on the crew object itself, not
+        # ``id(crew)`` which is reused after GC.
         cached = _crew_inputs_cache_get(crew)
         if cached is None:
             self.crew_chat_inputs = crew_chat_generate_crew_chat_inputs(
@@ -252,26 +240,22 @@ class ChatWithCrewFlow(Flow):
     def _completion_llm_kwargs(self) -> dict:
         """Return the connection kwargs for a litellm ``acompletion`` call.
 
-        Defect 1 (CPK-7717): the completion call sites previously passed
-        the raw ``self.crew.chat_llm`` model STRING to ``acompletion``,
-        which drops the credentials/endpoint that ``initialize_chat_llm``
-        resolved. litellm then falls back to environment/default
-        credentials, breaking local and self-hosted models
-        (CopilotKit#2742).
-
-        Round-2 review finding 1: forwarding only ``model`` / ``api_key``
-        / ``base_url`` still dropped ``api_base`` / ``api_version`` and the
-        provider-specific ``additional_params`` — so Azure and other
-        custom-endpoint users still hit the wrong endpoint. crewai's own
+        Passing the raw ``self.crew.chat_llm`` model STRING to ``acompletion``
+        drops the credentials/endpoint that ``initialize_chat_llm`` resolved
+        (litellm then falls back to environment/default credentials, breaking
+        local and self-hosted models), and forwarding only ``model`` /
+        ``api_key`` / ``base_url`` still drops ``api_base`` / ``api_version``
+        and the provider-specific ``additional_params`` — so custom-endpoint
+        (e.g. Azure) users hit the wrong endpoint. crewai's own
         ``LLM._prepare_completion_params`` forwards the connection fields
         (``api_base``, ``base_url``, ``api_version``, ``api_key``), the
         generation config (``temperature``, ``top_p``, ``n``, ``stop``,
         ``max_tokens``/``max_completion_tokens``, ``presence_penalty``,
         ``frequency_penalty``, ``logit_bias``, ``response_format``, ``seed``,
         ``logprobs``, ``top_logprobs``, ``reasoning_effort``) AND spreads
-        ``additional_params`` (see ``crewai/llm.py``); we mirror all of that
-        here so both completion call sites behave exactly the way
-        ``generate_crew_chat_inputs`` does (it drives the same LLM object).
+        ``additional_params``; we mirror all of that here so both completion
+        call sites behave exactly the way ``generate_crew_chat_inputs`` does
+        (it drives the same LLM object).
 
         Defensive: ``getattr`` with a fall back to the crew's model string
         keeps the helper working if ``chat_llm`` was not resolved (e.g. in
@@ -316,16 +300,12 @@ class ChatWithCrewFlow(Flow):
     def _completion_call_params(self, **call_owned: Any) -> dict:
         """Build the FULL kwargs dict for one ``acompletion`` call.
 
-        Defect 1 (CPK-7717 review round 3): ``_completion_llm_kwargs``
-        spreads the crewai ``LLM.additional_params``, which legitimately
-        may contain keys each ``chat()`` call site ALSO sets explicitly —
-        ``messages`` / ``tools`` / ``tool_choice`` / ``stream`` /
-        ``timeout`` / ``parallel_tool_calls`` (e.g.
-        ``LLM(model="gpt-4o", parallel_tool_calls=True)`` puts
-        ``parallel_tool_calls`` in ``additional_params``). Passing such a
-        key both via ``**connection`` AND as an explicit ``kw=`` argument
-        raised ``TypeError: acompletion() got multiple values for keyword
-        argument``.
+        ``_completion_llm_kwargs`` spreads the crewai ``LLM.additional_params``,
+        which legitimately may contain keys each ``chat()`` call site ALSO sets
+        explicitly — ``messages`` / ``tools`` / ``tool_choice`` / ``stream`` /
+        ``timeout`` / ``parallel_tool_calls``. Passing such a key both via
+        ``**connection`` AND as an explicit ``kw=`` argument raised
+        ``TypeError: acompletion() got multiple values for keyword argument``.
 
         We funnel EVERYTHING through one dict here and let the CALL-OWNED
         settings win over anything from ``additional_params`` (they are
@@ -381,16 +361,22 @@ class ChatWithCrewFlow(Flow):
                 # run the crew
                 crew_function = crew_chat_create_tool_function(self.crew, messages)
                 args = json.loads(message["tool_calls"][0]["function"]["arguments"])
-                # CPK-7719 (CPK-7717 defect 3 follow-up): ``crew_function`` is a
-                # SYNCHRONOUS ``crew.kickoff`` run. Calling it inline on the
-                # event loop blocked SSE flushing and prevented
-                # AGUI_CREWAI_FLOW_TIMEOUT_SECONDS / client-disconnect
+                # ``crew_function`` is a SYNCHRONOUS ``crew.kickoff`` run.
+                # Calling it inline on the event loop blocked SSE flushing and
+                # prevented AGUI_CREWAI_FLOW_TIMEOUT_SECONDS / client-disconnect
                 # cancellation from firing until the crew returned. Offload it
                 # to a worker thread so frames keep flushing and the wall-clock
                 # ceiling / aclose() teardown can fire DURING the crew run.
                 # ``asyncio.to_thread`` copies the current contextvars (the
                 # scoped StreamFrame sink and ``flow_context``), so crew events
                 # still stream and ``copilotkit_*`` helpers keep working.
+                #
+                # Cancelling the awaiting coroutine (client disconnect / flow
+                # ceiling) UNBLOCKS this ``await`` but does NOT stop the worker
+                # thread — Python cannot interrupt a running thread. A
+                # disconnected crew run keeps executing (and burning LLM tokens)
+                # to completion in the background; only the coroutine's wait is
+                # torn down. Bounding the crew run itself is upstream-crewai work.
                 result = await asyncio.to_thread(crew_function, **args)
 
                 if isinstance(result, str):
@@ -408,34 +394,26 @@ class ChatWithCrewFlow(Flow):
                     "tool_call_id": message["tool_calls"][0]["id"]
                 })
 
-                # Defect 3 (CPK-7717): surface the state mutation from the
-                # crew run so a StateSnapshotEvent reaches the bridge as
-                # soon as the crew output is applied, rather than only at
-                # method-finish. NOTE on granularity: this emits ONE
-                # snapshot after the crew result lands. Per-tool /
-                # intermediate mutations *inside* the crew run are not yet
-                # surfaced as discrete events here (they DO now stream as
-                # crewai StreamFrames on the StreamFrame path, but the bridge
-                # translator drops crew/agent/task frames to stay
+                # Surface the state mutation from the crew run so a
+                # StateSnapshotEvent reaches the bridge as soon as the crew
+                # output is applied, rather than only at method-finish. This
+                # emits ONE snapshot after the crew result lands; per-tool /
+                # intermediate mutations inside the crew run are not surfaced
+                # as discrete events here (they stream as crewai StreamFrames,
+                # but the translator drops crew/agent/task frames to stay
                 # behavior-preserving — surfacing them is a Parity-lane
-                # decision). The synchronous-kickoff blocker CPK-7719 called
-                # out is RESOLVED above: ``crew_function`` now runs via
-                # ``asyncio.to_thread`` so the ceiling / cancellation fire
-                # during the crew run.
+                # decision).
                 await copilotkit_emit_state(self.state)
 
-                # Defect 2 (CPK-7717): a backend tool result on its own
-                # leaves the assistant silent — the single-pass @start()
-                # chat had no follow-up completion after the crew tool ran
-                # (the crew_exit branch below always had one). Issue a
-                # streamed follow-up so the assistant produces text about
-                # the crew result. ``tool_choice="none"`` forces a text
-                # answer, mirroring the crew_exit branch. LIMITATION: it
-                # also blocks tool chaining — the assistant cannot call a
-                # frontend action after a crew run, so "run the crew, then
-                # update the UI" is unreachable on this path. Documented in
-                # README next to the timeout wording; allowing bounded tool
-                # re-entry here is future work.
+                # A backend tool result on its own leaves the assistant silent
+                # — the single-pass @start() chat had no follow-up completion
+                # after the crew tool ran. Issue a streamed follow-up so the
+                # assistant produces text about the crew result.
+                # ``tool_choice="none"`` forces a text answer, mirroring the
+                # crew_exit branch. LIMITATION: it also blocks tool chaining —
+                # the assistant cannot call a frontend action after a crew run,
+                # so "run the crew, then update the UI" is unreachable on this
+                # path. Allowing bounded tool re-entry here is future work.
                 response = await copilotkit_stream(
                     await acompletion(
                         **self._completion_call_params(

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -14,10 +14,10 @@ from fastapi.responses import StreamingResponse
 from ._env import _parse_env_float
 from ._copyutil import safe_deepcopy, rebind_bound_methods
 
-# CPK-7718: the flow/method lifecycle events, the event bus, and the listener
-# base moved from ``crewai.utilities.events`` (crewai 0.x) to ``crewai.events``
-# (crewai 1.x). ``_capabilities`` resolves whichever location exists and caches
-# the crewai capability probe (run once at import).
+# The flow/method lifecycle events, the event bus, and the listener base moved
+# from ``crewai.utilities.events`` (crewai 0.x) to ``crewai.events`` (crewai
+# 1.x). ``_capabilities`` resolves whichever location exists and caches the
+# crewai capability probe (run once at import).
 from ._capabilities import (
     CAPABILITIES,
     FlowStartedEvent,
@@ -72,20 +72,15 @@ from .crews import ChatWithCrewFlow, CrewBaseInstance
 
 _LOGGER = logging.getLogger(__name__)
 
-# Explicit ``__all__`` so ``from .endpoint import *`` only exposes the
-# public surface (the FastAPI helpers + ``crewai_prepare_inputs``). Module
-# sentinels like ``_UNSET`` and private helpers (``_cancel_and_join``,
-# ``_run_flow_event_stream``, ``_flow_timeout_seconds`` …) already have
-# leading underscores and would be excluded from star-imports, but
-# pinning ``__all__`` makes the public contract documentation-grade
-# (R5 LOW #20) so downstream consumers can rely on it.
+# Explicit ``__all__`` so ``from .endpoint import *`` only exposes the public
+# surface (the FastAPI helpers + ``crewai_prepare_inputs``). Private helpers
+# already have leading underscores and would be excluded from star-imports;
+# pinning ``__all__`` makes the public contract explicit.
 #
-# ``create_queue`` / ``get_queue`` / ``delete_queue`` are intentionally
-# NOT exported (CR6-7 LOW #1): they are internal plumbing keyed by
-# ``id(flow)`` and exposing them makes it look like downstream code may
-# safely hook the queue lifecycle, which it cannot. Tests that need them
-# import via ``ag_ui_crewai.endpoint`` by attribute access, which still
-# works regardless of ``__all__``.
+# ``create_queue`` / ``get_queue`` / ``delete_queue`` are intentionally NOT
+# exported: they are internal plumbing and exposing them would imply downstream
+# code may safely hook the queue lifecycle, which it cannot. Tests that need
+# them import via attribute access, which works regardless of ``__all__``.
 __all__ = [
     "add_crewai_flow_fastapi_endpoint",
     "add_crewai_crew_fastapi_endpoint",
@@ -95,17 +90,16 @@ __all__ = [
 ]
 
 
-# ``CrewBaseInstance`` (the structural type for a ``@CrewBase`` crew) now
-# lives in ``crews.py`` alongside ``ChatWithCrewFlow`` — which also
-# annotates its constructor with it — and is imported above. It stays in
-# ``__all__`` so downstream callers keep importing it from
-# ``ag_ui_crewai.endpoint`` (CPK-7717 review round 2, finding 2).
+# ``CrewBaseInstance`` (the structural type for a ``@CrewBase`` crew) lives in
+# ``crews.py`` alongside ``ChatWithCrewFlow`` — which also annotates its
+# constructor with it — and is imported above. It stays in ``__all__`` so
+# downstream callers keep importing it from ``ag_ui_crewai.endpoint``.
 
-# Sentinel to distinguish "no item delivered" from a legitimate ``None``
-# queue payload (the happy-path stream-end sentinel). Used by the
-# cancel-race guard in ``_run_flow_event_stream`` (finding #1 HIGH H1)
-# where an item may have been delivered to ``get_task`` between
-# ``asyncio.wait`` returning and the ``finally`` clause cancelling it.
+# Sentinel to distinguish "no item delivered" from a legitimate ``None`` queue
+# payload (the happy-path stream-end sentinel). Used by the cancel-race guard
+# in ``_run_flow_event_stream`` where an item may have been delivered to
+# ``get_task`` between ``asyncio.wait`` returning and the ``finally`` clause
+# cancelling it.
 _UNSET = object()
 
 
@@ -114,14 +108,10 @@ class _KickoffCancelled(Exception):
     state via an external path (e.g. a cooperating task cancelled the
     ``kickoff_task`` out from under the generator).
 
-    CR8 HIGH #2: pre-fix, when ``kickoff_task.done() and
-    kickoff_task.cancelled()`` in the main-loop fast path, the code
-    silently fell through (drained the queue and broke out), closing
-    the stream with no ``RUN_ERROR`` event. Clients could not
-    distinguish "flow finished successfully" from "flow was cancelled
-    out from under us". Raising this sentinel from the fast path lets
-    the error-handling block emit ``AGUI_CREWAI_KICKOFF_CANCELLED`` so
-    the client gets a correlated, categorised error.
+    Raising this from the main-loop fast path lets the error-handling block
+    emit ``AGUI_CREWAI_KICKOFF_CANCELLED`` so the client can distinguish "flow
+    finished successfully" from "flow was cancelled out from under us" rather
+    than seeing the stream close with no ``RUN_ERROR`` event.
     """
 
 
@@ -131,48 +121,39 @@ class _CeilingExceeded(Exception):
     Distinguishes the ceiling-fired path (our ``asyncio.wait`` / monotonic
     deadline produced the timeout) from an upstream ``TimeoutError`` that
     bubbled out of ``kickoff_async`` (e.g. a LiteLLM/httpx read timeout).
-
-    CR7 CRITICAL: prior to this split, both paths emitted
-    ``AGUI_CREWAI_FLOW_TIMEOUT`` with a "exceeded ceiling=..." message —
-    which is correct for the ceiling-fired case but an outright lie for the
-    upstream-timeout-with-ceiling-disabled case (the ceiling did not fire,
-    an upstream read timeout did). Downstream log consumers and dashboards
-    treat ``AGUI_CREWAI_FLOW_TIMEOUT`` as "we hit our configured ceiling",
-    so conflating upstream failures under that code makes alerting lie.
+    Downstream consumers treat ``AGUI_CREWAI_FLOW_TIMEOUT`` as "we hit our
+    configured ceiling", so upstream failures must not be conflated under that
+    code or alerting lies.
     """
 
-# Process-wide global registry of in-flight flow queues, keyed by a
-# per-flow ``uuid.uuid4().hex`` stored on the flow as the
-# ``_agui_queue_key`` attribute (CR8 MEDIUM). Writes are serialised via
-# ``QUEUES_LOCK``; reads go through ``get_queue`` which relies on
-# GIL-atomic ``dict.get`` (see ``get_queue`` for the full contract).
-# Between tests this dict is cleared by the autouse
+# Process-wide global registry of in-flight flow queues, keyed by a per-flow
+# ``uuid.uuid4().hex`` stored on the flow as the ``_agui_queue_key`` attribute.
+# Writes are serialised via ``QUEUES_LOCK``; reads go through ``get_queue``
+# which relies on GIL-atomic ``dict.get`` (see ``get_queue`` for the full
+# contract). Between tests this dict is cleared by the autouse
 # ``_clear_endpoint_queues`` fixture in ``tests/conftest.py``.
 #
-# CR8 MEDIUM rationale: prior versions keyed by ``id(flow)``. CPython
-# reuses ``id`` values aggressively once an object is garbage-collected,
-# which left a theoretical (though hard to exploit) window where a
-# late-arriving listener callback for a torn-down flow could route its
-# event onto a NEW flow's queue whose ``id`` happened to match. UUID
-# keys eliminate the collision concern entirely — each flow gets a
-# fresh hex key that is never reused across the process lifetime.
+# UUID keys rather than ``id(flow)``: CPython reuses ``id`` values once an
+# object is garbage-collected, which left a window where a late listener
+# callback for a torn-down flow could route its event onto a NEW flow's queue
+# whose ``id`` happened to match. A fresh hex key is never reused across the
+# process lifetime, eliminating the collision concern entirely.
 QUEUES = {}
 QUEUES_LOCK = asyncio.Lock()
 
-# CPK-7718 breaking change #2: crewai 1.x no longer dispatches event-bus
-# handlers inline on the caller's thread. Sync handlers (all of ours) are now
-# submitted to a ThreadPoolExecutor; only ``LLMStreamChunkEvent`` keeps the
-# inline path. Every ``Bridged*`` handler in
-# ``FastAPICrewFlowEventListener.setup_listeners`` therefore runs on a WORKER
+# crewai 1.x no longer dispatches event-bus handlers inline on the caller's
+# thread. Sync handlers (all of ours) are now submitted to a ThreadPoolExecutor;
+# only ``LLMStreamChunkEvent`` keeps the inline path. Every ``Bridged*`` handler
+# in ``FastAPICrewFlowEventListener.setup_listeners`` therefore runs on a WORKER
 # thread and must reach the per-request ``asyncio.Queue`` via
 # ``loop.call_soon_threadsafe`` — a bare ``put_nowait`` from off-loop corrupts
 # the queue's getter-wakeup. We capture the request's running loop in
 # ``create_queue`` (which is awaited on that loop) and stash it here, keyed by
 # the same UUID as ``QUEUES``.
 #
-# NOTE (CPK-7719): the StreamFrame integration removes this listener entirely,
-# so this loop-capture + call_soon_threadsafe plumbing is the INTERIM
-# thread-safe fix, not the final design.
+# The StreamFrame integration removes this listener entirely, so this
+# loop-capture + call_soon_threadsafe plumbing is the interim thread-safe fix,
+# not the final design.
 QUEUE_LOOPS: dict = {}
 
 # Attribute name we set on flow objects to carry their per-request queue
@@ -192,32 +173,29 @@ _DEFAULT_FLOW_TIMEOUT_SECONDS = 600.0
 # *before* kickoff_async has actually returned. Give the task a short grace
 # period to complete cleanly before we force-cancel it in _cancel_and_join.
 # This grace window is drawn from the SHARED ``_cancel_join_timeout_seconds``
-# teardown budget (finding #7): total upper bound on teardown from entry to
+# teardown budget: total upper bound on teardown from entry to
 # ``_cancel_and_join`` is one ceiling window, not ``grace + join``.
 _CANCEL_GRACE_SECONDS = 1.0
 
 # If a cancelled task refuses to terminate within this window, log a warning
 # so operators have visibility into stuck cancellations instead of a silent
-# swallow. Default override-able via ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS``
-# so operators can tune it under disconnect-heavy load (finding #8).
+# swallow. Override-able via ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS`` so
+# operators can tune it under disconnect-heavy load.
 _CANCEL_JOIN_TIMEOUT_SECONDS = 10.0
 
-# Caps on the happy-path drain (R5 HIGH #3). Unconditional
-# ``_DRAIN_MAX_PASSES`` loop with an ``asyncio.sleep(0)`` between passes
-# and a wall-clock ``_DRAIN_BUDGET_SECONDS`` ceiling that short-circuits
-# the loop when the budget is exhausted mid-pass.
-#
-# CR8 LOW: hoisted from function scope to module scope alongside the
-# other tuning constants so operators grepping for tunables find them
-# all in one place.
+# Caps on the happy-path drain: an ``_DRAIN_MAX_PASSES`` loop with an
+# ``asyncio.sleep(0)`` between passes and a wall-clock ``_DRAIN_BUDGET_SECONDS``
+# ceiling that short-circuits the loop when the budget is exhausted mid-pass.
+# Kept at module scope alongside the other tuning constants so operators
+# grepping for tunables find them all in one place.
 _DRAIN_MAX_PASSES = 10
 _DRAIN_BUDGET_SECONDS = 0.050
 
-# Regex to sanitize exception class names before embedding them in a
-# ``code`` field. Peer events' codes match ``^[A-Z][A-Z0-9_]+$``; a
-# custom exception with dynamically-generated or unicode name (e.g.
-# ``class WeirdError42(Exception): pass``) must be forced into that
-# shape before going on the wire. CR8 MEDIUM.
+# Regex to sanitize exception class names before embedding them in a ``code``
+# field. Peer events' codes match ``^[A-Z][A-Z0-9_]+$``; a custom exception
+# with a dynamically-generated or unicode name (e.g.
+# ``class WeirdError42(Exception): pass``) must be forced into that shape
+# before going on the wire.
 _CODE_SANITIZE_RE = re.compile(r"[^A-Z0-9_]")
 
 
@@ -230,19 +208,16 @@ def _sanitize_exception_code(name: str) -> str:
     Python). Upper-case the name and replace any character that is not
     an ASCII uppercase letter, digit, or underscore with ``_`` so the
     composed code stays greppable and regex-matchable by downstream
-    alerting. CR8 MEDIUM.
+    alerting.
     """
     sanitized = _CODE_SANITIZE_RE.sub("_", name.upper())
-    # CR9 LOW: collapse runs of underscores into a single underscore
-    # (a class name like ``weird exception`` would otherwise produce
-    # ``WEIRD_EXCEPTION`` which is fine, but a unicode name like
-    # ``ErrorXé`` sanitizes to ``ERRORX_`` and a name like ``Error__X``
-    # would produce ``ERROR__X`` — collapse both consistently). Strip
+    # Collapse runs of underscores into a single underscore and strip
     # leading/trailing underscores so the result respects the peer
-    # convention. If the sanitized-and-stripped result is empty or does
-    # NOT start with ``[A-Z]`` (e.g. the class name was digits-only or
-    # all-unicode) prefix ``E_`` so the composed code still matches
-    # ``^[A-Z][A-Z0-9_]+$``.
+    # convention (e.g. a unicode name like ``ErrorXé`` sanitizes to
+    # ``ERRORX_``, and ``Error__X`` to ``ERROR__X``). If the
+    # sanitized-and-stripped result is empty or does NOT start with
+    # ``[A-Z]`` (e.g. the class name was digits-only or all-unicode)
+    # prefix ``E_`` so the composed code still matches ``^[A-Z][A-Z0-9_]+$``.
     sanitized = re.sub(r"_+", "_", sanitized).strip("_")
     if not sanitized or not sanitized[0].isascii() or not sanitized[0].isalpha():
         sanitized = f"E_{sanitized}" if sanitized else "E"
@@ -252,16 +227,13 @@ def _sanitize_exception_code(name: str) -> str:
 def _stamp_correlation_ids(event: object, *, thread_id: str, run_id: str) -> None:
     """Stamp ``thread_id`` / ``run_id`` on ``event`` if the fields exist.
 
-    CR9 MEDIUM: the main-loop previously only rewrote these ids on
-    ``RUN_STARTED`` / ``RUN_FINISHED`` — any future ag-ui.core event
-    that also carries thread/run correlation (e.g. RUN_ERROR on the
-    error path) would ship the listener's ``"?"`` placeholders unless
-    stamped here. Rather than enumerate event types, probe attributes
-    with ``hasattr`` so new correlated events are covered automatically.
-    Events without these fields (StepStartedEvent, MessagesSnapshotEvent,
-    etc.) are left untouched — they do not carry correlation on the
-    wire today. Model ``__setattr__`` on Pydantic events is allowed by
-    ``model_config`` (no frozen).
+    Probe attributes with ``hasattr`` rather than enumerate event types so any
+    event carrying thread/run correlation (RUN_STARTED / RUN_FINISHED today,
+    plus any future correlated event) is covered automatically and does not
+    ship the listener's ``"?"`` placeholders. Events without these fields
+    (StepStartedEvent, MessagesSnapshotEvent, etc.) are left untouched. Model
+    ``__setattr__`` on Pydantic events is allowed by ``model_config`` (no
+    frozen).
     """
     if hasattr(event, "thread_id"):
         try:
@@ -281,7 +253,7 @@ def _flow_timeout_seconds() -> float | None:
     A non-positive value (e.g. ``0`` or ``-1``) disables the ceiling. A
     NaN or any other non-finite value is treated as unparseable and falls
     back to the default — ``float('nan') > 0`` is False, which would
-    otherwise silently disable the ceiling (finding #17).
+    otherwise silently disable the ceiling.
     """
     return _parse_env_float(
         "AGUI_CREWAI_FLOW_TIMEOUT_SECONDS",
@@ -295,37 +267,27 @@ def _cancel_join_timeout_seconds() -> float:
 
     Exists so that operators running disconnect-heavy workloads can tune
     the per-request teardown window via
-    ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS`` without redeploying code
-    (finding #8). Non-finite or non-positive values fall back to the
-    conservative default so a fat-fingered env var cannot disable the
-    ceiling entirely.
+    ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS`` without redeploying code.
+    Non-finite or non-positive values fall back to the conservative default
+    so a fat-fingered env var cannot disable the ceiling entirely.
 
-    Intentional divergence from the flow-timeout / LLM-timeout helpers
-    (CR7 LOW): those helpers treat ``<=0`` as "disable the ceiling" and
-    return ``None``. Cancel-join MUST always have a bounded positive
-    value — disabling it would make teardown able to block indefinitely
-    and break client-disconnect semantics, so the safer fallback here
-    is to silently use the default rather than surface a ``None`` that
-    the caller would then have to defend against at every use site.
+    Intentional divergence from the flow-timeout / LLM-timeout helpers: those
+    treat ``<=0`` as "disable the ceiling" and return ``None``. Cancel-join
+    MUST always have a bounded positive value — disabling it would let
+    teardown block indefinitely and break client-disconnect semantics, so the
+    safer fallback here is to silently use the default rather than surface a
+    ``None`` that the caller would then have to defend against everywhere.
     """
     result = _parse_env_float(
         "AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS",
         _CANCEL_JOIN_TIMEOUT_SECONDS,
         allow_disable=False,
     )
-    # ``allow_disable=False`` guarantees a non-None return, but the
-    # signature of ``_parse_env_float`` is ``float | None`` — narrow
-    # here so callers can use the float without a type assertion.
-    # CR8 LOW: ``assert`` is stripped under ``python -O``; use an
-    # explicit defensive guard that collapses to the default on the
-    # (impossible) None path rather than silently returning None to
-    # the caller under -O. CR9 LOW: kept (not removed) — this is an
-    # assertion-in-code-form. ``allow_disable=False`` guarantees
-    # non-None today, but a future refactor that widens the contract
-    # (or that introduces a fallback branch that returns None) would
-    # fall through to this guard rather than propagate ``None`` to
-    # every call site. Cheaper to keep than to audit every caller
-    # again.
+    # ``allow_disable=False`` guarantees a non-None return today, but the
+    # signature of ``_parse_env_float`` is ``float | None``. This defensive
+    # guard (rather than an ``assert``, which is stripped under ``python -O``)
+    # narrows the type and keeps callers safe if a future refactor widens the
+    # contract to return ``None``.
     if result is None:  # pragma: no cover - defensive; allow_disable=False guarantees non-None today
         return _CANCEL_JOIN_TIMEOUT_SECONDS
     return result
@@ -348,19 +310,19 @@ async def _cancel_and_join(
     - A SINGLE shared monotonic deadline (``_cancel_join_timeout_seconds``)
       bounds the combined wait of (grace window + force-cancel join +
       outer-cancel recovery). There is one ceiling window for the entire
-      teardown, not three (finding #7).
+      teardown, not three.
     - If ``allow_grace`` and the task is mid-flight on a happy path, wait up
       to ``min(_CANCEL_GRACE_SECONDS, remaining-budget)`` for it to finish
       on its own (the FlowFinishedEvent listener enqueues ``None``
       microseconds before ``kickoff_async`` actually returns). A quick
       ``sleep(0)`` + ``task.done()`` probe fast-paths the common case where
       the task is microseconds from returning, so happy-path requests do
-      NOT systematically pay the 1s grace latency tax (finding #9).
+      NOT systematically pay the 1s grace latency tax.
     - The grace wait is SHIELDED and protected by the same outer-cancel
-      recovery pattern used post-grace (finding #5). If the caller is
-      cancelled during the grace wait, ``task.cancel()`` still fires via
-      the ``finally`` and the task is cleanly unwound within the remaining
-      budget; we don't leave a cancelled-but-unjoined task behind.
+      recovery pattern used post-grace. If the caller is cancelled during
+      the grace wait, ``task.cancel()`` still fires via the ``finally`` and
+      the task is cleanly unwound within the remaining budget; we don't
+      leave a cancelled-but-unjoined task behind.
     - We deliberately do NOT catch ``BaseException``. ``SystemExit`` /
       ``KeyboardInterrupt`` / ``CancelledError`` must propagate; we only
       swallow ``TimeoutError`` (explicitly) and recoverable ``Exception``
@@ -376,12 +338,11 @@ async def _cancel_and_join(
     if task is None:
         return
     if task.done():
-        # CR8 LOW: if the task is already done with a stored exception
-        # (e.g. kickoff raised before the generator reached this
-        # teardown path), defensively call ``.exception()`` so the
-        # exception is marked retrieved and does NOT surface as a
-        # "Task exception was never retrieved" GC warning. ``.exception()``
-        # is only safe on a non-cancelled done task.
+        # If the task is already done with a stored exception (e.g. kickoff
+        # raised before the generator reached this teardown path),
+        # defensively call ``.exception()`` so it is marked retrieved and
+        # does NOT surface as a "Task exception was never retrieved" GC
+        # warning. ``.exception()`` is only safe on a non-cancelled done task.
         if not task.cancelled():
             try:
                 task.exception()
@@ -390,7 +351,7 @@ async def _cancel_and_join(
         return
 
     # Shared monotonic deadline covering the ENTIRE teardown — grace
-    # window, force-cancel join, and outer-cancel recovery (finding #7).
+    # window, force-cancel join, and outer-cancel recovery.
     ceiling = _cancel_join_timeout_seconds()
     deadline = time.monotonic() + ceiling
 
@@ -399,11 +360,11 @@ async def _cancel_and_join(
 
     try:
         if allow_grace:
-            # Fast-path probe (finding #9): let the task advance a tick
-            # before paying the 1s grace wait. The common case is that
-            # ``kickoff_async`` is microseconds from returning once the
-            # listener has enqueued the ``None`` sentinel; yielding once
-            # usually lets the task complete without blocking.
+            # Fast-path probe: let the task advance a tick before paying the
+            # 1s grace wait. The common case is that ``kickoff_async`` is
+            # microseconds from returning once the listener has enqueued the
+            # ``None`` sentinel; yielding once usually lets the task complete
+            # without blocking.
             await asyncio.sleep(0)
             if task.done():
                 return
@@ -421,14 +382,10 @@ async def _cancel_and_join(
                     )
                     return
                 except (asyncio.TimeoutError, TimeoutError):
-                    # Happy path did not complete in time; fall through to
+                    # Happy path did not complete in time; log at the
+                    # grace-expired boundary so operators diagnosing stuck
+                    # teardown see a signal, then fall through to
                     # force-cancel below.
-                    #
-                    # CR8 MEDIUM: emit a debug log before silently
-                    # falling through so operators diagnosing stuck
-                    # teardown see a signal at the grace-expired
-                    # boundary (other branches in this function log;
-                    # this one was the only silent fall-through).
                     _LOGGER.debug(
                         "CrewAI kickoff grace window expired "
                         "thread=%s run=%s grace=%gs; "
@@ -439,29 +396,26 @@ async def _cancel_and_join(
                     )
                 except asyncio.CancelledError as grace_outer_cancel:
                     # Outer-cancel during the grace wait. Mirror the
-                    # post-grace recovery pattern (finding #5): ensure
-                    # task.cancel() fires within the remaining budget and
-                    # await its unwind so we do not leave a
-                    # cancelled-but-unjoined task behind.
+                    # post-grace recovery pattern: ensure task.cancel() fires
+                    # within the remaining budget and await its unwind so we
+                    # do not leave a cancelled-but-unjoined task behind.
                     #
-                    # R5 HIGH #2: capture the CancelledError *instance* so
-                    # we can re-raise it with ``.args`` and traceback
-                    # intact. Raising the bare class (``raise
-                    # asyncio.CancelledError``) loses the message and the
-                    # chained traceback of the original cancel.
+                    # Capture the CancelledError *instance* so we can re-raise
+                    # it with ``.args`` and traceback intact; raising the bare
+                    # class would lose the message and chained traceback of
+                    # the original cancel.
                     current = asyncio.current_task()
                     uncancel = getattr(current, "uncancel", None)
                     if callable(uncancel):
                         uncancel()
                     grace_teardown: asyncio.Future | None = None
-                    # CR7 LOW (retrieve task exception): if the task
-                    # happened to complete during the grace wait we
-                    # skip the teardown/drain path entirely; defensively
-                    # call ``task.exception()`` so a stored exception
-                    # is marked retrieved and does NOT surface as a GC
-                    # "Task exception was never retrieved" warning when
-                    # we re-raise below. ``exception()`` is only safe
-                    # on a non-cancelled done task.
+                    # If the task happened to complete during the grace wait
+                    # we skip the teardown/drain path entirely; defensively
+                    # call ``task.exception()`` so a stored exception is
+                    # marked retrieved and does NOT surface as a GC "Task
+                    # exception was never retrieved" warning when we re-raise
+                    # below. ``exception()`` is only safe on a non-cancelled
+                    # done task.
                     if task.done() and not task.cancelled():
                         try:
                             task.exception()
@@ -475,14 +429,13 @@ async def _cancel_and_join(
                                 timeout=_remaining(),
                             )
                         )
-                        # CR9 MEDIUM: if the recovery wait below times
-                        # out and we re-raise ``grace_outer_cancel``,
-                        # the stored ``TimeoutError`` on ``grace_teardown``
-                        # is never retrieved by anyone and the GC logs
-                        # ``Task exception was never retrieved``. Attach
-                        # a done-callback that drains the stored
-                        # exception so the future is left clean regardless
-                        # of the code path we exit through.
+                        # If the recovery wait below times out and we
+                        # re-raise ``grace_outer_cancel``, the stored
+                        # ``TimeoutError`` on ``grace_teardown`` would never
+                        # be retrieved and the GC logs ``Task exception was
+                        # never retrieved``. Attach a done-callback that
+                        # drains the stored exception so the future is left
+                        # clean regardless of the code path we exit through.
                         grace_teardown.add_done_callback(
                             lambda f: f.exception() if not f.cancelled() else None
                         )
@@ -498,21 +451,19 @@ async def _cancel_and_join(
                         except asyncio.CancelledError:
                             # Recovery wait itself cancelled. The inner
                             # ``asyncio.gather(task, return_exceptions=True)``
-                            # already swallows any task exception into
-                            # its result list, so there is nothing to
-                            # "drain" from ``grace_teardown.exception()``
-                            # (CR8 MEDIUM — the prior drain log never
-                            # fired with a useful value; removed). Just
-                            # propagate the outer cancel.
+                            # already swallows any task exception into its
+                            # result list, so there is nothing to drain from
+                            # ``grace_teardown.exception()``. Just propagate
+                            # the outer cancel.
                             raise
-                        # CR8 MEDIUM: no exception-drain log on normal
-                        # completion either — ``gather(return_exceptions=True)``
-                        # has already retrieved any task exception into
-                        # its result list, so ``grace_teardown.exception()``
-                        # here is always ``None`` / a bare TimeoutError
-                        # from ``wait_for`` (already handled above).
+                        # No exception-drain on normal completion either —
+                        # ``gather(return_exceptions=True)`` has already
+                        # retrieved any task exception into its result list,
+                        # so ``grace_teardown.exception()`` here is always
+                        # ``None`` / a bare TimeoutError from ``wait_for``
+                        # (already handled above).
                     # Re-raise the ORIGINAL outer cancel instance so args
-                    # and traceback propagate intact (R5 HIGH #2).
+                    # and traceback propagate intact.
                     raise grace_outer_cancel
                 except Exception as grace_exc:  # pylint: disable=broad-exception-caught
                     # The task itself raised during the grace wait. It has
@@ -548,12 +499,12 @@ async def _cancel_and_join(
                 timeout=_remaining(),
             )
         )
-        # CR9 MEDIUM: if the recovery wait below times out and we
-        # re-raise ``outer_cancel``, the stored ``TimeoutError`` on
-        # ``teardown`` is never retrieved by anyone and the GC logs
-        # ``Task exception was never retrieved``. Attach a done-callback
-        # that drains the stored exception so the future is left clean
-        # regardless of the code path we exit through.
+        # If the recovery wait below times out and we re-raise
+        # ``outer_cancel``, the stored ``TimeoutError`` on ``teardown`` would
+        # never be retrieved and the GC logs ``Task exception was never
+        # retrieved``. Attach a done-callback that drains the stored exception
+        # so the future is left clean regardless of the code path we exit
+        # through.
         teardown.add_done_callback(
             lambda f: f.exception() if not f.cancelled() else None
         )
@@ -563,7 +514,7 @@ async def _cancel_and_join(
             # Outer scope was cancelled. On Python 3.11+, we must uncancel
             # the current task before issuing another ``await`` — otherwise
             # the next ``await`` re-raises CancelledError immediately and
-            # the bounded recovery wait is a no-op (finding #2).
+            # the bounded recovery wait is a no-op.
             current = asyncio.current_task()
             uncancel = getattr(current, "uncancel", None)
             if callable(uncancel):
@@ -583,7 +534,7 @@ async def _cancel_and_join(
             except Exception as recov_exc:  # pylint: disable=broad-exception-caught
                 # A non-timeout, non-cancel error surfaced from the
                 # recovery wait; surface it in DEBUG logs rather than
-                # swallowing silently (finding #10).
+                # swallowing silently.
                 _LOGGER.debug(
                     "CrewAI cancel-recovery wait swallowed %s "
                     "(thread=%s run=%s)",
@@ -591,16 +542,13 @@ async def _cancel_and_join(
                     thread_id,
                     run_id,
                 )
-            # CR8 MEDIUM: the prior ``_drain`` callback on ``teardown``
-            # was effectively dead code. ``asyncio.gather(task,
-            # return_exceptions=True)`` already swallows ``task``'s
-            # exception into its result list, so ``teardown.exception()``
-            # here only surfaces a ``TimeoutError`` from ``wait_for``
-            # (already handled above) or ``None``. Nothing to drain.
-            # Re-raise the original CancelledError so traceback and
-            # ``.args`` context propagate intact to the outer scope
-            # (finding #14). A bare ``raise`` would reference ``outer_cancel``
-            # via the active handler; using the captured name is explicit.
+            # ``asyncio.gather(task, return_exceptions=True)`` already
+            # swallows ``task``'s exception into its result list, so
+            # ``teardown.exception()`` here only surfaces a ``TimeoutError``
+            # from ``wait_for`` (already handled above) or ``None`` — nothing
+            # to drain. Re-raise the original CancelledError (via the captured
+            # name, for explicitness) so traceback and ``.args`` context
+            # propagate intact to the outer scope.
             raise outer_cancel
         except (asyncio.TimeoutError, TimeoutError):
             _log_stuck_cancel(
@@ -613,9 +561,7 @@ async def _cancel_and_join(
         # Last-ditch: if the task is still running (e.g. we were cancelled
         # before reaching ``task.cancel()`` above), schedule cancellation
         # so we don't leak a running kickoff_async. ``Task.cancel()`` is
-        # idempotent on a done task, so the pre-R5 ``cancellation_scheduled``
-        # guard was redundant with ``task.done()`` — simplified per R5 LOW
-        # #15.
+        # idempotent on a done task.
         if task is not None and not task.done():
             task.cancel()
 
@@ -632,16 +578,16 @@ def _log_stuck_cancel(
     Centralised so the message format, fields, and distinguishing context are
     identical at both call sites.
 
-    ``ceiling`` is passed explicitly rather than re-read from the env
-    (R5 MEDIUM #7) so the logged value matches the deadline that actually
-    governed this teardown — an operator who flips
-    ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS`` mid-request will still see
-    the ceiling that was in effect for the stuck task.
+    ``ceiling`` is passed explicitly rather than re-read from the env so the
+    logged value matches the deadline that actually governed this teardown —
+    an operator who flips ``AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS``
+    mid-request will still see the ceiling that was in effect for the stuck
+    task.
     """
     suffix = " (after outer cancel)" if after_outer_cancel else ""
-    # %g matches _format_timeout_message (R5 LOW #13) so grep/alerting
-    # patterns that compare the two numeric formats don't have to special
-    # case trailing zeros.
+    # %g matches _format_timeout_message so grep/alerting patterns that
+    # compare the two numeric formats don't have to special-case trailing
+    # zeros.
     _LOGGER.warning(
         "CrewAI kickoff task did not terminate within %gs of cancel%s"
         " thread=%s run=%s",
@@ -655,30 +601,21 @@ def _log_stuck_cancel(
 async def create_queue(flow: object) -> asyncio.Queue:
     """Create a queue for a flow and stamp the flow with its UUID key.
 
-    CR8 MEDIUM: keys are ``uuid.uuid4().hex`` rather than ``id(flow)``
-    so the registry cannot suffer from id-reuse collisions after a flow
-    is garbage-collected. The key is stored on the flow as
-    ``_agui_queue_key`` so listener callbacks that receive a flow via
-    the event bus can look up the queue without threading the key
-    through another side channel.
+    Keys are ``uuid.uuid4().hex`` rather than ``id(flow)`` so the registry
+    cannot suffer from id-reuse collisions after a flow is garbage-collected.
+    The key is stored on the flow as ``_agui_queue_key`` so listener callbacks
+    that receive a flow via the event bus can look up the queue without
+    threading the key through another side channel.
     """
     queue_key = uuid.uuid4().hex
-    # CR9 LOW: register the queue in the module-level mapping BEFORE
-    # stamping the key on the flow. The pre-fix order (stamp first,
-    # then lock+insert) left a window — however small — where
-    # ``get_queue(flow)`` could observe the attribute and then miss
-    # the (not-yet-inserted) key in ``QUEUES``, returning ``None``
-    # and silently dropping an event. Reversing the order closes the
-    # window: the flow is not visible as "has a queue key" until
-    # there is a queue to look up.
-    # ``setattr`` rather than direct ``flow._agui_queue_key = ...`` so
-    # pylint / type-checkers don't flag the private-attribute write on
-    # an arbitrary ``object``; crewai ``Flow`` instances accept
-    # arbitrary attribute writes but the static-typing path must stay
-    # clean.
+    # Register the queue in the module-level mapping BEFORE stamping the key on
+    # the flow. Stamping first would leave a window where ``get_queue(flow)``
+    # could observe the attribute yet miss the not-yet-inserted key in
+    # ``QUEUES``, returning ``None`` and silently dropping an event. The flow
+    # is not visible as "has a queue key" until there is a queue to look up.
     # Capture the request's running loop so off-thread listener callbacks can
-    # enqueue via ``loop.call_soon_threadsafe`` (CPK-7718 #2). ``create_queue``
-    # is always awaited on the request loop, so this is that loop.
+    # enqueue via ``loop.call_soon_threadsafe``. ``create_queue`` is always
+    # awaited on the request loop, so this is that loop.
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:  # pragma: no cover - create_queue is always awaited
@@ -687,18 +624,18 @@ async def create_queue(flow: object) -> asyncio.Queue:
         queue = asyncio.Queue()
         QUEUES[queue_key] = queue
         QUEUE_LOOPS[queue_key] = loop
-        # Stamp only AFTER the queue is registered under its key so
-        # a concurrent ``get_queue(flow)`` never observes the attr
-        # pointing at a not-yet-present entry.
+        # Stamp only AFTER the queue is registered under its key so a
+        # concurrent ``get_queue(flow)`` never observes the attr pointing at a
+        # not-yet-present entry.
         #
-        # CPK-7718 #8: crewai 1.13+ made ``Flow`` a Pydantic ``BaseModel``.
-        # Try a normal ``setattr`` first (it honours any custom
-        # ``__setattr__`` — some callers/tests instrument the write — and works
-        # on crewai 1.15.x, which accepts our underscore-prefixed key); if a
-        # stricter Pydantic ``Flow`` rejects the undeclared attribute, fall back
-        # to ``object.__setattr__`` which bypasses Pydantic entirely. Either
-        # way the key lands in the instance ``__dict__`` and reads back via
-        # plain ``getattr`` (see ``get_queue``).
+        # crewai 1.13+ made ``Flow`` a Pydantic ``BaseModel``. Try a normal
+        # ``setattr`` first (it honours any custom ``__setattr__`` — some
+        # callers/tests instrument the write — and works on crewai 1.15.x,
+        # which accepts our underscore-prefixed key); if a stricter Pydantic
+        # ``Flow`` rejects the undeclared attribute, fall back to
+        # ``object.__setattr__`` which bypasses Pydantic entirely. Either way
+        # the key lands in the instance ``__dict__`` and reads back via plain
+        # ``getattr`` (see ``get_queue``).
         try:
             setattr(flow, _QUEUE_KEY_ATTR, queue_key)
         except (ValueError, AttributeError, TypeError):
@@ -709,54 +646,41 @@ async def create_queue(flow: object) -> asyncio.Queue:
 def get_queue(flow: object) -> asyncio.Queue | None:
     """Get the queue for a flow.
 
-    CR6-7 MEDIUM: ``QUEUES_LOCK`` is intentionally NOT taken here.
+    ``QUEUES_LOCK`` is intentionally NOT taken here.
 
     Contract:
-    * ``QUEUES`` is a plain ``dict`` keyed by the per-flow UUID hex
-      stored on the flow as ``_agui_queue_key`` (CR8 MEDIUM). CPython's
-      GIL makes ``dict.get(k)`` atomic at the bytecode level — we
-      cannot observe a half-constructed mapping. CR7 LOW: this assumes
-      a CPython-with-GIL interpreter. Free-threaded CPython 3.13+ (PEP
-      703, opt-in ``--disable-gil``) removes the bytecode-atomicity
-      guarantee and would require wrapping the read in a
-      ``threading.Lock`` (or migrating ``QUEUES`` to a thread-safe
-      mapping). This is forward-compat documentation only — the module
-      does not ship free-thread support today.
-    * CR7 MEDIUM (threading model): crewai's ``CrewAIEventsBus`` emits
-      listener callbacks SYNCHRONOUSLY from whatever call stack raised
-      the event. In our code path the events are raised from within
-      ``kickoff_async`` — which we ``await`` on the event loop — so in
-      practice listeners always run on the loop thread. The prior
-      docstring warned callers that callbacks may run from a non-loop
-      thread, which implied ``queue.put_nowait`` in the listener
-      callbacks was unsafe. That warning was conservative to the point
-      of being misleading: in the current architecture every listener
-      callback fires on the loop thread, so ``put_nowait`` is the right
-      primitive. If crewai ever invokes the bus from a worker thread
-      (e.g. a future background-executor feature), every ``put_nowait``
-      call site in ``FastAPICrewFlowEventListener.setup_listeners`` must
-      be revisited and converted to ``loop.call_soon_threadsafe`` — but
-      there is no such path today.
+    * ``QUEUES`` is a plain ``dict`` keyed by the per-flow UUID hex stored on
+      the flow as ``_agui_queue_key``. CPython's GIL makes ``dict.get(k)``
+      atomic at the bytecode level — we cannot observe a half-constructed
+      mapping. This assumes a CPython-with-GIL interpreter; free-threaded
+      CPython 3.13+ (PEP 703, opt-in ``--disable-gil``) removes that
+      bytecode-atomicity guarantee and would require wrapping the read in a
+      ``threading.Lock`` (or a thread-safe mapping). Forward-compat note only —
+      the module does not ship free-thread support today.
+    * Threading model: crewai's ``CrewAIEventsBus`` emits listener callbacks
+      synchronously from whatever call stack raised the event. Our events are
+      raised from within ``kickoff_async`` — which we ``await`` on the event
+      loop — so in practice every listener callback fires on the loop thread
+      and ``put_nowait`` is the right primitive. If crewai ever invokes the
+      bus from a worker thread (a future background-executor feature), every
+      ``put_nowait`` call site in
+      ``FastAPICrewFlowEventListener.setup_listeners`` must be revisited and
+      converted to ``loop.call_soon_threadsafe``.
     * This function is called from TWO contexts:
-      (a) Synchronous crewai event-listener callbacks. Those run on the
-          event loop thread (see threading model note above), but via
-          synchronous call stacks where we cannot ``await`` — hence no
-          ``QUEUES_LOCK`` acquisition.
-      (b) The async endpoint code paths, which always take
-          ``QUEUES_LOCK`` for writes (``create_queue``, ``delete_queue``)
-          but not reads.
-    * The one race that remains is SEMANTIC rather than data-structural:
-      a late listener callback that fires after ``delete_queue`` has
-      removed the entry will observe ``None`` and silently no-op. This
-      is the intended behaviour — an event for a torn-down flow has
-      nowhere to land. The ``_cancel_and_join`` teardown widens the
-      window during which late callbacks can arrive after delete, but
-      does not change the semantics: late events were already lost on
-      the happy-path, and continue to be lost here.
-    * A flow that was never registered with ``create_queue`` (e.g. a
-      listener callback routed to an unrelated Flow) will not carry
-      the ``_agui_queue_key`` attribute; we default to ``None`` and
-      the ``get`` returns ``None`` as intended.
+      (a) Synchronous crewai event-listener callbacks. Those run on the event
+          loop thread but via synchronous call stacks where we cannot
+          ``await`` — hence no ``QUEUES_LOCK`` acquisition.
+      (b) The async endpoint code paths, which always take ``QUEUES_LOCK`` for
+          writes (``create_queue``, ``delete_queue``) but not reads.
+    * The one race that remains is SEMANTIC rather than data-structural: a
+      late listener callback that fires after ``delete_queue`` removed the
+      entry observes ``None`` and silently no-ops. This is intended — an event
+      for a torn-down flow has nowhere to land. ``_cancel_and_join`` teardown
+      widens the window during which late callbacks can arrive after delete
+      but does not change the semantics.
+    * A flow that was never registered with ``create_queue`` will not carry
+      the ``_agui_queue_key`` attribute; we default to ``None`` and the
+      ``get`` returns ``None`` as intended.
     """
     queue_key = getattr(flow, _QUEUE_KEY_ATTR, None)
     if queue_key is None:
@@ -779,10 +703,10 @@ def _get_queue_loop(flow: object) -> "asyncio.AbstractEventLoop | None":
 def _enqueue(source: object, event: object) -> None:
     """Thread-safely enqueue ``event`` onto ``source``'s per-request queue.
 
-    CPK-7718 #2: crewai 1.x dispatches our sync bus handlers on a
-    ThreadPoolExecutor worker thread, so a bare ``queue.put_nowait`` would run
-    off the queue's owning loop and corrupt the getter-wakeup. We hop back onto
-    the captured request loop via ``call_soon_threadsafe``. If we happen to
+    crewai 1.x dispatches our sync bus handlers on a ThreadPoolExecutor worker
+    thread, so a bare ``queue.put_nowait`` would run off the queue's owning
+    loop and corrupt the getter-wakeup. We hop back onto the captured request
+    loop via ``call_soon_threadsafe``. If we happen to
     already be on that loop (e.g. a future inline-dispatch path, or a unit test
     driving the listener directly on the loop thread) we put directly to keep
     behaviour synchronous. If no loop was captured, fall back to a direct put.
@@ -826,12 +750,11 @@ def _copy_flow(flow: object) -> object:
 
     Delegates to ``_copyutil.safe_deepcopy`` — plain ``copy.deepcopy`` on
     healthy crewai builds, pin-and-share fallback on the crewai 1.15.x
-    ``Flow`` deep-copy bug (CPK-7718 #10, a NEW breaking change beyond the
-    enumerated nine, found by running the suite on the 1.15.7 wheel). Isolation
-    of the per-request conversation state is preserved either way.
+    ``Flow`` deep-copy bug (found by running the suite on the 1.15.7 wheel).
+    Isolation of the per-request conversation state is preserved either way.
 
-    CPK-7718 #11: when the pin-and-share fallback runs, the copy SHARES the
-    original's ``_methods`` dict (its bound ``@start`` / ``@listen`` methods
+    When the pin-and-share fallback runs, the copy SHARES the original's
+    ``_methods`` dict (its bound ``@start`` / ``@listen`` methods
     trial-deep-copy-fail because they reference the uncopyable ``memory`` via
     ``__self__``, so the dict is pinned by reference). crewai 1.x executes
     ``self._methods[name]`` — still bound to the ORIGINAL — so
@@ -848,7 +771,7 @@ def _copy_flow(flow: object) -> object:
 
 
 async def _flush_event_bus() -> None:
-    """Best-effort run-end flush of the crewai event bus (CPK-7718 #5).
+    """Best-effort run-end flush of the crewai event bus.
 
     crewai 1.x dispatches sync handlers off-thread and can drop in-flight
     handlers at run end; ``flush(timeout=...)`` waits for them so resources
@@ -880,8 +803,8 @@ GLOBAL_EVENT_LISTENER = None
 # knows whether a terminal snapshot is still owed.
 _LAST_NODE_SUPPRESSED_ATTR = "_ag_ui_last_node_suppressed"
 
-# PNI-130: process-wide warn-once guard for the "MCP event with no active flow
-# in context" legacy-path drop (see ``_on_mcp_event`` in ``setup_listeners``).
+# Process-wide warn-once guard for the "MCP event with no active flow in
+# context" legacy-path drop (see ``_on_mcp_event`` in ``setup_listeners``).
 _MCP_NO_FLOW_WARNED = False
 
 
@@ -897,11 +820,18 @@ def _flow_state_snapshot(state: object) -> dict:
         return state.model_dump()
     return {}
 
-class FastAPICrewFlowEventListener(BaseEventListener):
+
+# When crewai's events package doesn't resolve, ``BaseEventListener`` is None;
+# subclassing None crashes at import time. Fall back to a plain ``object`` so the
+# package still imports (as an inert listener) and the capability warning surfaces.
+_EventListenerBase = BaseEventListener if BaseEventListener is not None else object
+
+
+class FastAPICrewFlowEventListener(_EventListenerBase):
     """FastAPI CrewFlow event listener.
 
-    WARNING (CR8 MEDIUM): do NOT construct this class directly in
-    application code. ``add_crewai_flow_fastapi_endpoint`` and
+    WARNING: do NOT construct this class directly in application code.
+    ``add_crewai_flow_fastapi_endpoint`` and
     ``add_crewai_crew_fastapi_endpoint`` auto-instantiate a process-wide
     singleton the first time either is called; constructing a second
     instance manually (and then calling a factory) registers DUPLICATE
@@ -917,21 +847,19 @@ class FastAPICrewFlowEventListener(BaseEventListener):
     def setup_listeners(self, crewai_event_bus):
         """Setup listeners for the FastAPI CrewFlow event listener.
 
-        CPK-7718 #2: every callback below runs on a ThreadPoolExecutor WORKER
-        thread under crewai 1.x (sync handlers are no longer dispatched inline
-        on the caller's thread). All queue writes therefore go through
-        ``_enqueue``, which hops back onto the request loop via
-        ``call_soon_threadsafe``. The ``None`` happy-path sentinel is enqueued
-        the same way so it stays ordered behind the ``RUN_FINISHED`` event on
-        the loop.
+        Every callback below runs on a ThreadPoolExecutor WORKER thread under
+        crewai 1.x (sync handlers are no longer dispatched inline on the
+        caller's thread). All queue writes therefore go through ``_enqueue``,
+        which hops back onto the request loop via ``call_soon_threadsafe``. The
+        ``None`` happy-path sentinel is enqueued the same way so it stays
+        ordered behind the ``RUN_FINISHED`` event on the loop.
 
-        CPK-7718 #3: crewai 1.x dispatch is now EXACT-TYPE (keyed on
-        ``type(event)``), not ``isinstance`` — a handler registered on a base
-        class silently stops receiving subclasses. Every ``.on(...)`` below is
-        registered on the EXACT event type we emit / crewai emits (the
-        lifecycle events and our concrete ``Bridged*`` classes), so exact-type
-        dispatch delivers to each handler as before. No handler is registered
-        on a shared base class.
+        crewai 1.x dispatch is now EXACT-TYPE (keyed on ``type(event)``), not
+        ``isinstance`` — a handler registered on a base class silently stops
+        receiving subclasses. Every ``.on(...)`` below is registered on the
+        EXACT event type we emit / crewai emits, so exact-type dispatch
+        delivers to each handler as before. No handler is registered on a
+        shared base class.
         """
         @crewai_event_bus.on(FlowStartedEvent)
         def _(source, event):  # pylint: disable=unused-argument
@@ -1057,17 +985,17 @@ class FastAPICrewFlowEventListener(BaseEventListener):
                 )
             )
 
-        # PNI-130: surface crewai's first-class MCP events (crewai >= 1.4) on the
-        # LEGACY bus-listener transport (crewai 1.4-1.5, StreamFrame absent).
-        # crewai emits MCP events with the agent/crew as ``source`` (NOT the
-        # Flow), so we resolve the active run via ``flow_context`` -- the same
-        # contextvar the run driver sets -- and enqueue thread-safely through
-        # ``_enqueue`` (CPK-7718 #2: handlers run on a ThreadPoolExecutor worker
-        # thread under crewai 1.x). On the StreamFrame path (crewai >= 1.6) no
-        # per-run queue is created, so ``_enqueue`` finds no queue and this is an
-        # inert no-op there; that path surfaces MCP events via the frame sink +
-        # StreamFrameTranslator instead. Below 1.4 (no ``crewai.mcp``) this logs
-        # one warning and registers nothing.
+        # Surface crewai's first-class MCP events (crewai >= 1.4) on the LEGACY
+        # bus-listener transport (crewai 1.4-1.5, StreamFrame absent). crewai
+        # emits MCP events with the agent/crew as ``source`` (NOT the Flow), so
+        # we resolve the active run via ``flow_context`` -- the same contextvar
+        # the run driver sets -- and enqueue thread-safely through ``_enqueue``
+        # (handlers run on a ThreadPoolExecutor worker thread under crewai 1.x).
+        # On the StreamFrame path (crewai >= 1.6) no per-run queue is created,
+        # so ``_enqueue`` finds no queue and this is an inert no-op there; that
+        # path surfaces MCP events via the frame sink + StreamFrameTranslator
+        # instead. Below 1.4 (no ``crewai.mcp``) this logs one warning and
+        # registers nothing.
         def _on_mcp_event(event):
             # Receives the RAW crewai MCP event. Resolve the active run via
             # ``flow_context`` (crewai copies the emitting context -- incl. this
@@ -1104,24 +1032,21 @@ class FastAPICrewFlowEventListener(BaseEventListener):
 def _format_timeout_message(timeout: float | None) -> str:
     """Build the ``TimeoutError`` message for the flow-ceiling path.
 
-    Extracted (finding #13) so the two TimeoutError construction sites and
-    the client-facing error message derive from a single source of truth.
+    Extracted so the two TimeoutError construction sites and the client-facing
+    error message derive from a single source of truth.
 
-    ``timeout`` is always a finite positive value here — the flow-ceiling
-    code paths that raise ``TimeoutError`` are guarded by ``timeout is not
-    None``. Using ``%g`` (up to 6 significant digits, no trailing zeros)
-    avoids the truncation of sub-decisecond values that ``%.1f`` produces
-    (finding #14). For ``0.2``, ``%g`` renders ``0.2``; for ``0.25``,
-    ``0.25``; for ``600``, ``600``.
+    ``timeout`` is always a finite positive value here — the flow-ceiling code
+    paths that raise ``TimeoutError`` are guarded by ``timeout is not None``.
+    Using ``%g`` (up to 6 significant digits, no trailing zeros) avoids the
+    truncation of sub-decisecond values that ``%.1f`` produces. For ``0.2``,
+    ``%g`` renders ``0.2``; for ``0.25``, ``0.25``; for ``600``, ``600``.
     """
     return f"CrewAI flow exceeded {timeout:g}s ceiling"
 
 
-# Per-alias WARN dedup (CR7 MEDIUM): ``_field_alias`` previously claimed
-# "Emit a single WARN" but fired on every call, producing per-event log
-# spam under a misconfigured ag-ui.core upgrade. Track ``(model_name,
-# field_name)`` tuples that have already warned so the log stays
-# actionable (one line per divergence) rather than noise.
+# Per-alias WARN dedup: track ``(model_name, field_name)`` tuples that have
+# already warned so ``_field_alias`` logs one line per divergence rather than
+# per-event spam under a misconfigured ag-ui.core upgrade.
 _ALIAS_WARN_SEEN: set[tuple[str, str]] = set()
 
 
@@ -1129,18 +1054,17 @@ def _field_alias(model_cls, field_name: str, default: str) -> str:
     """Return the serialization alias for ``field_name`` on ``model_cls``.
 
     Pydantic models in ag-ui.core set camelCase aliases via an alias
-    generator; we derive the wire name here so a future rename of the
-    alias policy propagates automatically (finding #30) instead of
-    silently diverging from this module's hardcoded camelCase literals.
-    Falls back to ``default`` if the model does not declare the field
-    (keeps the code path stable under library upgrades).
+    generator; we derive the wire name here so a future rename of the alias
+    policy propagates automatically instead of silently diverging from this
+    module's hardcoded camelCase literals. Falls back to ``default`` if the
+    model does not declare the field (keeps the code path stable under library
+    upgrades).
 
-    R5 LOW #16 / CR7 MEDIUM: if BOTH ``serialization_alias`` and
-    ``alias`` are ``None`` on an existing field, that almost certainly
-    means Pydantic internals changed and our alias inference is
-    silently wrong. Emit ONE WARN per (model, field) tuple (tracked in
-    the module-level ``_ALIAS_WARN_SEEN`` set) so the divergence is
-    visible in the log without spamming a line per request / per event.
+    If BOTH ``serialization_alias`` and ``alias`` are ``None`` on an existing
+    field, that almost certainly means Pydantic internals changed and our
+    alias inference is silently wrong. Emit ONE WARN per (model, field) tuple
+    (tracked in ``_ALIAS_WARN_SEEN``) so the divergence is visible without
+    spamming a line per request / per event.
     """
     try:
         field = model_cls.model_fields[field_name]
@@ -1150,9 +1074,9 @@ def _field_alias(model_cls, field_name: str, default: str) -> str:
     # ``serialization_alias``; prefer the latter if set.
     serialization_alias = getattr(field, "serialization_alias", None)
     basic_alias = getattr(field, "alias", None)
-    # CR8 LOW: use an explicit None check rather than ``or`` so an empty
-    # string (legal, if unusual) on ``serialization_alias`` does not
-    # silently fall through to ``basic_alias``.
+    # Use an explicit None check rather than ``or`` so an empty string (legal,
+    # if unusual) on ``serialization_alias`` does not silently fall through to
+    # ``basic_alias``.
     alias = (
         serialization_alias
         if serialization_alias is not None
@@ -1181,28 +1105,23 @@ def _run_error_extras(input_data: RunAgentInput) -> dict:
     """Return the extras kwargs for a RunErrorEvent, camelCased to match
     peer events' wire format.
 
-    ``ConfiguredBaseModel`` uses ``extra="allow"`` — extras bypass the
-    alias generator, so pre-camelCased keys are required to line up with
-    declared-field peers (``RunStartedEvent.thread_id`` / ``run_id`` emit
-    as ``threadId`` / ``runId`` via the alias generator). Finding #3.
+    ``ConfiguredBaseModel`` uses ``extra="allow"`` — extras bypass the alias
+    generator, so pre-camelCased keys are required to line up with
+    declared-field peers (``RunStartedEvent.thread_id`` / ``run_id`` emit as
+    ``threadId`` / ``runId`` via the alias generator). The alias names are
+    derived from ``RunStartedEvent.model_fields`` so a rename of the alias
+    policy in ag-ui.core does not silently regress this module.
 
-    The alias names are derived from ``RunStartedEvent.model_fields``
-    (finding #30) so a rename of the alias policy in ag-ui.core does not
-    silently regress this module.
-
-    LOAD-BEARING ASSUMPTION (CR6-7 LOW #2): ``RunStartedEvent`` and
-    ``RunErrorEvent`` share the same alias-generator policy (both derive
-    from ``ConfiguredBaseModel`` in ag-ui.core). We derive the alias
-    names from ``RunStartedEvent.model_fields`` and apply them to
-    ``RunErrorEvent`` extras on the premise that the wire name for
-    ``thread_id`` / ``run_id`` is IDENTICAL across the two models. If
-    ag-ui.core ever splits the alias policy per-model (e.g. a future
-    event keeps ``thread_id`` snake_case), this derivation silently
-    diverges: extras on ``RunErrorEvent`` would be camelCased while the
-    declared fields on the same event would not. The failure mode is
-    subtle (wire format mismatch, not a crash) so verifying the shared
-    policy at test time is the right escalation point rather than
-    asserting it dynamically here.
+    LOAD-BEARING ASSUMPTION: ``RunStartedEvent`` and ``RunErrorEvent`` share
+    the same alias-generator policy (both derive from ``ConfiguredBaseModel``).
+    We derive the alias names from ``RunStartedEvent.model_fields`` and apply
+    them to ``RunErrorEvent`` extras on the premise that the wire name for
+    ``thread_id`` / ``run_id`` is IDENTICAL across the two models. If ag-ui.core
+    ever splits the alias policy per-model, this derivation silently diverges
+    (extras camelCased while declared fields are not). The failure mode is
+    subtle (wire format mismatch, not a crash), so verifying the shared policy
+    at test time is the right escalation point rather than asserting it
+    dynamically here.
     """
     thread_alias = _field_alias(RunStartedEvent, "thread_id", "threadId")
     run_alias = _field_alias(RunStartedEvent, "run_id", "runId")
@@ -1230,38 +1149,41 @@ async def _run_flow_event_stream(
     * reads from the per-flow queue with a wall-clock deadline;
     * surfaces timeouts and other exceptions as a ``RunErrorEvent`` whose
       ``message`` carries thread/run correlation AND whose event-level
-      extras (``threadId`` / ``runId``) mirror the peer events' wire
-      format (finding #3);
+      extras (``threadId`` / ``runId``) mirror the peer events' wire format;
     * on exit, cancels the kickoff task, drops the queue, and resets the
       context var — unconditionally, even if the outer scope is cancelled.
     """
-    # CR7 MEDIUM (resource leak): ``create_queue`` registers an entry in
-    # the module-level ``QUEUES`` mapping keyed by ``id(flow_copy)``. If
-    # ``flow_context.set`` raises between ``create_queue`` and the main
-    # ``try:`` block, the registered queue is orphaned — nothing deletes
-    # it, and the next request whose ``id(flow)`` collides inherits a
-    # stale reference. Wrap both in a narrow ``try/except`` that
-    # ``delete_queue``'s on failure so the registration is symmetric.
+    # ``create_queue`` registers an entry in the module-level ``QUEUES``
+    # mapping. If ``flow_context.set`` raises between ``create_queue`` and the
+    # main ``try:`` block, the registered queue is orphaned — nothing deletes
+    # it. Wrap both in a narrow ``try/except`` that ``delete_queue``'s on
+    # failure so the registration is symmetric.
     queue = await create_queue(flow_copy)
     try:
         token = flow_context.set(flow_copy)
-    except BaseException:
-        # ``flow_context.set`` is ``contextvars.ContextVar.set`` which
-        # does not raise in normal paths, but we defend against a future
-        # refactor / wrapper that could. On failure the queue entry is
-        # now orphaned — drop it before propagating so we do not leak.
+    except BaseException as exc:
+        # ``flow_context.set`` is ``contextvars.ContextVar.set`` which does not
+        # raise in normal paths, but we defend against a future refactor /
+        # wrapper that could. On failure the queue entry is now orphaned —
+        # drop it before propagating so we do not leak.
         #
-        # CR9 HIGH: if the BaseException we caught is a CancelledError
-        # on Python 3.11+, a bare ``await delete_queue(flow_copy)`` will
-        # re-raise CancelledError on entry because ``Task.cancelling()``
-        # is still non-zero — the cleanup never runs and the queue leaks.
-        # Mirror the ``_cancel_and_join`` pattern (lines 364-367,
-        # 459-462): call ``asyncio.current_task().uncancel()`` via
-        # ``getattr`` (3.10-compat) before the cleanup await so the
-        # teardown completes before we re-raise the original exception.
+        # If the caught BaseException is a CancelledError on Python 3.11+, a
+        # bare ``await delete_queue(flow_copy)`` would re-raise CancelledError
+        # on entry (``Task.cancelling()`` is still non-zero), the cleanup never
+        # runs, and the queue leaks. Mirror the ``_cancel_and_join`` pattern:
+        # call ``asyncio.current_task().uncancel()`` via ``getattr``
+        # (3.10-compat) before the cleanup await so teardown completes before
+        # we re-raise.
+        #
+        # Gate the uncancel on the exception ACTUALLY being a CancelledError. A
+        # non-cancel BaseException leaves ``Task.cancelling()`` at whatever a
+        # genuine concurrent cancel set it to; unconditionally uncancelling
+        # would consume a cancellation level that isn't ours, so a real pending
+        # cancel would need an extra ``cancel()`` to take hold. Only the
+        # CancelledError path is entitled to consume the level.
         current = asyncio.current_task()
         uncancel = getattr(current, "uncancel", None)
-        if callable(uncancel):
+        if isinstance(exc, asyncio.CancelledError) and callable(uncancel):
             uncancel()
         await delete_queue(flow_copy)
         raise
@@ -1288,48 +1210,38 @@ async def _run_flow_event_stream(
             )
 
             # ``_DRAIN_MAX_PASSES`` / ``_DRAIN_BUDGET_SECONDS`` are
-            # module-level constants (CR8 LOW) so the tuning surface
-            # is grouped with the other env-var-backed ceilings above.
+            # module-level constants so the tuning surface is grouped with the
+            # other env-var-backed ceilings above.
             async def _drain_queue_until_sentinel_or_empty():
                 """Async-generator: drain queued items until sentinel or quiet.
 
                 This is an ``async def`` generator (``yield``s encoded
-                frames); it does NOT return a boolean. Callers should
-                iterate with ``async for`` and rely on their outer control
-                flow to decide what happens after the drain. An empty
-                iteration means either (a) the ``None`` sentinel was
-                consumed or (b) the queue quiesced within the drain
-                budget. (R5 HIGH #4: docstring was stale — previously
-                claimed ``Returns True`` which is syntactically impossible
-                for a generator.)
+                frames); it does NOT return a boolean. Callers iterate with
+                ``async for`` and rely on their outer control flow to decide
+                what happens after the drain. An empty iteration means either
+                (a) the ``None`` sentinel was consumed or (b) the queue
+                quiesced within the drain budget.
 
-                Algorithm (CR6-6 LOW #1 — docstring rewritten to match
-                the actual implementation; pre-fix text still described
-                the legacy 2-pass "probe once more" shape):
-                * Each pass drains any currently-queued items via
-                  non-blocking ``get_nowait``. If the ``None`` sentinel
-                  appears we stop immediately.
+                Algorithm:
+                * Each pass drains any currently-queued items via non-blocking
+                  ``get_nowait``. If the ``None`` sentinel appears we stop
+                  immediately.
                 * After each pass we yield one scheduler tick
                   (``asyncio.sleep(0)``) — UNCONDITIONALLY, regardless of
-                  whether the pass drained anything — so any
-                  ``call_soon`` / ``call_later(0)`` chained by a
-                  listener has a chance to run before we probe again.
-                * We loop up to ``_DRAIN_MAX_PASSES`` (10) passes or
-                  until the cumulative ``_DRAIN_BUDGET_SECONDS`` wall
-                  clock is exhausted — whichever comes first. This
-                  covers listener chains that need multiple scheduler
-                  ticks to materialise their enqueue (e.g. a listener
-                  callback that itself schedules another ``call_soon``).
-                * Budget-exhaustion mid-pass is logged at DEBUG so
-                  operators can correlate dropped events; the hard pass
-                  cap is likewise logged so a pathological listener that
-                  keeps enqueueing forever is visible.
-
-                Pre-fix behaviour (R5 HIGH #3): a 2-pass early-return
-                dropped late-arriving items that needed more than a
-                single ``sleep(0)`` tick to land. R6 (CR6-6 LOW #4)
-                widened the cap from 5 to 10 to cover the listener-chain
-                scenarios observed in the R4/R5 history.
+                  whether the pass drained anything — so any ``call_soon`` /
+                  ``call_later(0)`` chained by a listener has a chance to run
+                  before we probe again.
+                * We loop up to ``_DRAIN_MAX_PASSES`` passes or until the
+                  cumulative ``_DRAIN_BUDGET_SECONDS`` wall clock is exhausted
+                  — whichever comes first. This covers listener chains that
+                  need multiple scheduler ticks to materialise their enqueue
+                  (e.g. a listener callback that itself schedules another
+                  ``call_soon``). A single-tick early-return would drop
+                  late-arriving items needing more than one ``sleep(0)`` tick.
+                * Budget-exhaustion mid-pass is logged at DEBUG so operators
+                  can correlate dropped events; the hard pass cap is likewise
+                  logged so a pathological listener that keeps enqueueing
+                  forever is visible.
                 """
                 drain_deadline = time.monotonic() + _DRAIN_BUDGET_SECONDS
                 drained_anything_ever = False
@@ -1345,17 +1257,15 @@ async def _run_flow_event_stream(
                         if item_local is None:
                             # Sentinel consumed — happy-path terminator.
                             return
-                        # CR9 MEDIUM: stamp thread/run correlation on
-                        # ANY event whose schema carries those fields,
-                        # not just RUN_STARTED / RUN_FINISHED. The
-                        # listener enqueues ``"?"`` placeholders for
-                        # events it constructs (RunStarted/Finished),
-                        # but a future ag-ui.core event that also
-                        # carries correlation would otherwise ship the
-                        # stale ``"?"``s unchanged. ``_stamp_correlation_ids``
-                        # is a no-op for today's extras events
-                        # (StepStarted, MessagesSnapshot, ...) since
-                        # they don't declare the fields.
+                        # Stamp thread/run correlation on ANY event whose
+                        # schema carries those fields. The listener enqueues
+                        # ``"?"`` placeholders for the events it constructs
+                        # (RunStarted/Finished); a future ag-ui.core event that
+                        # also carries correlation would otherwise ship the
+                        # stale ``"?"``s. ``_stamp_correlation_ids`` is a no-op
+                        # for today's extras events (StepStarted,
+                        # MessagesSnapshot, ...) since they don't declare the
+                        # fields.
                         _stamp_correlation_ids(
                             item_local,
                             thread_id=input_data.thread_id,
@@ -1380,13 +1290,11 @@ async def _run_flow_event_stream(
 
                     # Yield a tick so any ``call_soon`` / ``call_later(0)``
                     # callback chained by a listener has a chance to run.
-                    # R5 HIGH #3: unconditionally continue up to
-                    # ``_DRAIN_MAX_PASSES`` (regardless of whether this
-                    # pass drained anything) so a listener that needs >1
-                    # scheduler tick to enqueue — e.g. one that itself
-                    # schedules another ``call_soon`` — is not silently
-                    # dropped. The pre-fix 2-pass early-return was the
-                    # off-by-one: a 3-tick-delayed enqueue lost its event.
+                    # Unconditionally continue up to ``_DRAIN_MAX_PASSES``
+                    # (regardless of whether this pass drained anything) so a
+                    # listener that needs >1 scheduler tick to enqueue — e.g.
+                    # one that itself schedules another ``call_soon`` — is not
+                    # silently dropped.
                     await asyncio.sleep(0)
                 # Hard pass cap reached — surface at DEBUG for operators
                 # investigating dropped events. The happy-path common case
@@ -1406,48 +1314,40 @@ async def _run_flow_event_stream(
                 # ``queue.get()`` until the flow-timeout ceiling, and users
                 # would see ``AGUI_CREWAI_FLOW_TIMEOUT`` instead of the real
                 # traceback. We use ``await kickoff_task`` (rather than
-                # ``raise kickoff_task.exception()``) so the original
-                # traceback is preserved — finding #4: re-raising the
-                # stored exception via ``raise exc`` starts a new
-                # traceback chain whose innermost frame is this ``raise``
-                # line, hiding the real origin.
+                # ``raise kickoff_task.exception()``) so the original traceback
+                # is preserved — re-raising the stored exception starts a new
+                # traceback chain whose innermost frame is the ``raise`` line,
+                # hiding the real origin.
                 if kickoff_task.done():
-                    # CR8 HIGH #2: if the task was cancelled externally,
-                    # surface it as a categorised RUN_ERROR so the
-                    # client can distinguish "completed successfully"
-                    # from "cancelled out from under us". Pre-fix this
-                    # fell through to the happy-path drain+break,
-                    # closing the stream with no error event at all.
+                    # If the task was cancelled externally, surface it as a
+                    # categorised RUN_ERROR so the client can distinguish
+                    # "completed successfully" from "cancelled out from under
+                    # us" rather than closing the stream with no error event.
                     if kickoff_task.cancelled():
                         raise _KickoffCancelled(
                             "CrewAI kickoff task was cancelled"
                         )
-                    # Guard against ``.exception()`` raising
-                    # CancelledError if the task was cancelled externally
-                    # (finding #2): only read ``.exception()`` on a
-                    # non-cancelled task. R5 LOW #12: dropped the
-                    # unused ``kickoff_exc`` local — its only role was
-                    # the None check, which is inlined here.
+                    # Guard against ``.exception()`` raising CancelledError if
+                    # the task was cancelled externally: only read
+                    # ``.exception()`` on a non-cancelled task.
                     if kickoff_task.exception() is not None:
-                        # ``await`` re-raises the stored exception
-                        # WITH its original traceback intact.
+                        # ``await`` re-raises the stored exception WITH its
+                        # original traceback intact.
                         await kickoff_task
                     # Happy path: task finished without error. Drain any
-                    # remaining queue items (for example the ``None``
-                    # sentinel enqueued by the FlowFinishedEvent listener),
-                    # then break. Critically we do NOT fall through to
-                    # ``asyncio.wait({get_task, kickoff_task}, ...)``
-                    # below, because that wait would return immediately
-                    # (kickoff_task is already done) and cause a CPU spin
-                    # (finding #1).
+                    # remaining queue items (e.g. the ``None`` sentinel
+                    # enqueued by the FlowFinishedEvent listener), then break.
+                    # Critically we do NOT fall through to
+                    # ``asyncio.wait({get_task, kickoff_task}, ...)`` below,
+                    # because that wait would return immediately (kickoff_task
+                    # is already done) and cause a CPU spin.
                     async for encoded in _drain_queue_until_sentinel_or_empty():
                         yield encoded
-                    # ``allow_grace`` only matters while the task is in
-                    # flight (`_cancel_and_join` short-circuits if the
-                    # task is already done). We leave the default False
-                    # here rather than setting True on the inline-sentinel
-                    # branch — the value is dead either way (finding
-                    # #15), and an explicit False is less misleading.
+                    # ``allow_grace`` only matters while the task is in flight
+                    # (``_cancel_and_join`` short-circuits if the task is
+                    # already done), so the default False is left here; the
+                    # value is dead either way and an explicit False is less
+                    # misleading.
                     break
 
                 get_task = asyncio.ensure_future(queue.get())
@@ -1477,12 +1377,9 @@ async def _run_flow_event_stream(
                             _format_timeout_message(timeout)
                         )
 
-                    # Prefer propagating the kickoff exception (if any)
-                    # over consuming a queued event — the exception is
-                    # the real story. Guard against CancelledError
-                    # (finding #2). R5 LOW #12: dropped the unused
-                    # ``kickoff_exc`` local in favour of the inline
-                    # None check, same semantics.
+                    # Prefer propagating the kickoff exception (if any) over
+                    # consuming a queued event — the exception is the real
+                    # story. Guard against CancelledError.
                     if (
                         kickoff_task in done
                         and not kickoff_task.cancelled()
@@ -1491,19 +1388,16 @@ async def _run_flow_event_stream(
                         await kickoff_task
 
                     if get_task in done:
-                        # CR9 LOW: narrow guard against CancelledError
-                        # on ``get_task.result()``. The happy-path ``done``
-                        # membership check normally implies the task
-                        # completed normally, but a concurrent outer-cancel
-                        # that propagated into ``get_task`` after
-                        # ``asyncio.wait`` returned can leave it
-                        # ``done()`` AND ``cancelled()`` — reading
-                        # ``.result()`` then raises CancelledError, which
-                        # would bypass the ``except _CeilingExceeded`` /
-                        # ``except Exception`` handlers below. Fall back
-                        # to the ``_UNSET`` sentinel so the next loop
-                        # iteration hits the ``kickoff_task.done()``
-                        # fast path.
+                        # Narrow guard against CancelledError on
+                        # ``get_task.result()``. The ``done`` membership check
+                        # normally implies the task completed normally, but a
+                        # concurrent outer-cancel that propagated into
+                        # ``get_task`` after ``asyncio.wait`` returned can
+                        # leave it ``done()`` AND ``cancelled()`` — reading
+                        # ``.result()`` then raises CancelledError, bypassing
+                        # the ``except`` handlers below. Fall back to the
+                        # ``_UNSET`` sentinel so the next loop iteration hits
+                        # the ``kickoff_task.done()`` fast path.
                         try:
                             item = get_task.result()
                         except asyncio.CancelledError:
@@ -1511,32 +1405,29 @@ async def _run_flow_event_stream(
                     else:
                         # kickoff finished without error but no item was
                         # enqueued yet; the top-of-loop guard on the next
-                        # iteration will observe ``kickoff_task.done()``
-                        # and drain via the fast path above (no spin —
-                        # finding #1).
+                        # iteration will observe ``kickoff_task.done()`` and
+                        # drain via the fast path above (no spin).
                         pass
                 finally:
-                    # Cancel-race guard (finding #1 HIGH H1): between
-                    # ``asyncio.wait`` returning and us cancelling
-                    # ``get_task``, the queue may have delivered an item
-                    # to the getter. If we blindly cancel, that item is
+                    # Cancel-race guard: between ``asyncio.wait`` returning and
+                    # us cancelling ``get_task``, the queue may have delivered
+                    # an item to the getter. If we blindly cancel, that item is
                     # dropped. Check ``get_task.done()`` first and, if so,
-                    # harvest the result (even when the primary branch
-                    # above did not because ``get_task`` was not in
-                    # ``done`` — e.g. it completed between ``asyncio.wait``
-                    # returning and this ``finally``).
+                    # harvest the result (even when the primary branch above
+                    # did not because ``get_task`` was not in ``done`` — e.g.
+                    # it completed between ``asyncio.wait`` returning and this
+                    # ``finally``).
                     if not get_task.done():
                         get_task.cancel()
                     elif item is _UNSET and not get_task.cancelled():
                         try:
                             pending_item = get_task.result()
                         except Exception:  # noqa: BLE001
-                            # R5 MEDIUM #6: narrow from BaseException.
-                            # ``queue.get()`` cannot produce SystemExit /
-                            # KeyboardInterrupt / CancelledError through
-                            # its result path in practice; if anything
-                            # does it is a runtime bug we should not
-                            # swallow. ``Exception`` keeps the
+                            # Narrow from BaseException. ``queue.get()`` cannot
+                            # produce SystemExit / KeyboardInterrupt /
+                            # CancelledError through its result path in
+                            # practice; if anything does it is a runtime bug we
+                            # should not swallow. ``Exception`` keeps the
                             # defensive-harvest intent without masking
                             # control-flow exceptions.
                             pending_item = _UNSET
@@ -1557,10 +1448,10 @@ async def _run_flow_event_stream(
                     allow_grace = True
                     break
 
-                # CR9 MEDIUM: stamp correlation on any event whose
-                # schema declares the fields (see _stamp_correlation_ids).
-                # RUN_STARTED / RUN_FINISHED always do; future
-                # correlated events are covered automatically.
+                # Stamp correlation on any event whose schema declares the
+                # fields (see _stamp_correlation_ids). RUN_STARTED /
+                # RUN_FINISHED always do; future correlated events are covered
+                # automatically.
                 _stamp_correlation_ids(
                     item,
                     thread_id=input_data.thread_id,
@@ -1570,11 +1461,10 @@ async def _run_flow_event_stream(
                 yield encoder.encode(item)
 
         except _KickoffCancelled:
-            # CR8 HIGH #2: kickoff task was cancelled externally (not by
-            # our teardown path, which propagates CancelledError through
-            # to the outer scope). Emit a categorised RUN_ERROR so the
-            # client can distinguish an external cancel from a clean
-            # finish.
+            # Kickoff task was cancelled externally (not by our teardown path,
+            # which propagates CancelledError through to the outer scope).
+            # Emit a categorised RUN_ERROR so the client can distinguish an
+            # external cancel from a clean finish.
             _LOGGER.warning(
                 "CrewAI kickoff cancelled externally thread=%s run=%s",
                 input_data.thread_id,
@@ -1582,12 +1472,9 @@ async def _run_flow_event_stream(
             )
             message = (
                 f"thread={input_data.thread_id} run={input_data.run_id}: "
-                # CR9 LOW: align wording with the internal sentinel
-                # message ("CrewAI kickoff task was cancelled") so the
-                # code (``AGUI_CREWAI_KICKOFF_CANCELLED``), the
-                # server-side log ("kickoff cancelled externally"),
-                # and the client-facing message all agree on
-                # "kickoff" rather than mixing "flow" and "kickoff".
+                # Align wording with the internal sentinel message so the code
+                # (``AGUI_CREWAI_KICKOFF_CANCELLED``), the server-side log, and
+                # the client-facing message all agree on "kickoff".
                 f"CrewAI kickoff was cancelled"
             )
             yield encoder.encode(
@@ -1598,22 +1485,20 @@ async def _run_flow_event_stream(
                 )
             )
         except _CeilingExceeded as ceiling_exc:
-            # Ceiling-fired path (CR7 CRITICAL): our configured flow
-            # deadline tripped. Message / code must advertise the ceiling
-            # actually in force so downstream alerting can trust the
-            # signal. ``timeout`` is guaranteed finite positive here — the
-            # only sites that raise ``_CeilingExceeded`` are guarded by a
-            # deadline that requires a positive ``timeout``.
+            # Ceiling-fired path: our configured flow deadline tripped. Message
+            # / code must advertise the ceiling actually in force so downstream
+            # alerting can trust the signal. ``timeout`` is guaranteed finite
+            # positive here — the only sites that raise ``_CeilingExceeded``
+            # are guarded by a deadline that requires a positive ``timeout``.
             ceiling_display = f"{timeout:g}s"
             _LOGGER.warning(
                 "CrewAI flow exceeded ceiling thread=%s run=%s ceiling=%s detail=%s",
                 input_data.thread_id,
                 input_data.run_id,
                 ceiling_display,
-                # R5 / CR7 LOW: include the helper's descriptive message
-                # in the server-side log so traceback / grep lines carry
-                # the human-readable form without the client needing to
-                # round-trip through the exception repr.
+                # Include the helper's descriptive message in the server-side
+                # log so traceback / grep lines carry the human-readable form
+                # without the client round-tripping through the exception repr.
                 ceiling_exc.args[0] if ceiling_exc.args else "",
             )
             message = (
@@ -1628,17 +1513,16 @@ async def _run_flow_event_stream(
                 )
             )
         except (asyncio.TimeoutError, TimeoutError) as upstream_exc:
-            # Upstream timeout path (CR7 CRITICAL): a ``TimeoutError``
-            # bubbled out of ``kickoff_async`` itself — typically a
-            # LiteLLM/httpx read timeout. Our ceiling did NOT fire; we
-            # MUST NOT advertise ``AGUI_CREWAI_FLOW_TIMEOUT``, which
-            # downstream consumers treat as "we hit the configured
-            # ceiling". Use a distinct code + message so alerting can
-            # distinguish the two failure modes.
+            # Upstream timeout path: a ``TimeoutError`` bubbled out of
+            # ``kickoff_async`` itself — typically a LiteLLM/httpx read
+            # timeout. Our ceiling did NOT fire; we MUST NOT advertise
+            # ``AGUI_CREWAI_FLOW_TIMEOUT``, which downstream consumers treat as
+            # "we hit the configured ceiling". Use a distinct code + message so
+            # alerting can distinguish the two failure modes.
             #
-            # ``timeout`` here can be anything (finite ceiling or
-            # ``None`` when disabled). We surface it for operator context
-            # but make clear the ceiling did not fire.
+            # ``timeout`` here can be anything (finite ceiling or ``None`` when
+            # disabled). We surface it for operator context but make clear the
+            # ceiling did not fire.
             ceiling_display = (
                 "disabled" if timeout is None else f"{timeout:g}s"
             )
@@ -1671,22 +1555,18 @@ async def _run_flow_event_stream(
                 input_data.run_id,
                 type(e).__name__,
             )
-            # Tight message (finding #5): the exception class name already
-            # lives in ``code`` (AGUI_CREWAI_FLOW_ERROR_<Class>); the
-            # run_id already appears once as a prefix — do not duplicate.
-            # R5 LOW #19: ``_`` separator rather than ``:`` so the code
-            # field matches the ``^[A-Z][A-Z0-9_]+$`` convention used by
-            # peer events (the ``:`` was an artefact of an earlier
-            # pass-through of ``type.__name__``).
+            # Tight message: the exception class name already lives in
+            # ``code`` (AGUI_CREWAI_FLOW_ERROR_<Class>) and the run_id already
+            # appears once as a prefix — do not duplicate.
             message = (
                 f"thread={input_data.thread_id} run={input_data.run_id}: "
                 f"CrewAI flow failed; see server logs"
             )
-            # CR8 MEDIUM: sanitize the exception class name before
-            # embedding it in the ``code`` field. Python exception
-            # classes can have dynamically-generated or unicode names,
-            # which would violate the ``^[A-Z][A-Z0-9_]+$`` convention
-            # peer events follow and break downstream regex-matchers.
+            # Sanitize the exception class name before embedding it in the
+            # ``code`` field. Python exception classes can have
+            # dynamically-generated or unicode names, which would violate the
+            # ``^[A-Z][A-Z0-9_]+$`` convention peer events follow and break
+            # downstream regex-matchers.
             sanitized_name = _sanitize_exception_code(type(e).__name__)
             yield encoder.encode(
                 RunErrorEvent(
@@ -1708,10 +1588,10 @@ async def _run_flow_event_stream(
                 allow_grace=allow_grace,
             )
         finally:
-            # CPK-7718 #5: flush the crewai event bus at run end so in-flight
-            # off-thread handlers settle before we drop the queue / reset the
-            # context var (crewai 1.x can otherwise drop them). Best-effort and
-            # a no-op on crewai builds without ``flush``.
+            # Flush the crewai event bus at run end so in-flight off-thread
+            # handlers settle before we drop the queue / reset the context var
+            # (crewai 1.x can otherwise drop them). Best-effort and a no-op on
+            # crewai builds without ``flush``.
             try:
                 await _flush_event_bus()
             finally:
@@ -1729,25 +1609,35 @@ async def _aclose_stream_session(
 ) -> None:
     """Best-effort ``aclose()`` teardown for a crewai ``AsyncStreamSession``.
 
-    CPK-7719: ``aclose()`` replaces the legacy ``_cancel_and_join`` machinery on
-    the StreamFrame path — it cancels the background kickoff task crewai spawns
+    ``aclose()`` replaces the legacy ``_cancel_and_join`` machinery on the
+    StreamFrame path — it cancels the background kickoff task crewai spawns
     inside ``astream`` and closes the frame iterator. The OBSERVABLE behavior
     (client-disconnect tears the run down, no leaked kickoff) must not regress.
 
-    Mirrors the ``_cancel_and_join`` uncancel dance (finding #2): on Python
-    3.11+ a bare ``await session.aclose()`` in a ``finally`` reached via outer
-    cancellation would re-raise ``CancelledError`` on entry (``Task.cancelling()``
-    is still non-zero), so ``aclose`` would never run and the kickoff task would
-    leak. We ``uncancel`` (via ``getattr`` for 3.10 compat) so the teardown
+    Mirrors the ``_cancel_and_join`` uncancel dance: on Python 3.11+ a bare
+    ``await session.aclose()`` in a ``finally`` reached via outer cancellation
+    would re-raise ``CancelledError`` on entry (``Task.cancelling()`` is still
+    non-zero), so ``aclose`` would never run and the kickoff task would leak.
+    We ``uncancel`` (via ``getattr`` for 3.10 compat) so the teardown
     completes; the original in-flight cancellation resumes propagating once the
     generator's ``finally`` unwinds.
     """
     aclose = getattr(session, "aclose", None)
     if not callable(aclose):
         return
+    # Uncancel ONLY when a cancellation is actually pending on this task. An
+    # unconditional ``uncancel()`` would consume a cancellation LEVEL even on
+    # the happy-path teardown (``aclose`` reached with no outer cancel) — a
+    # level that isn't ours to consume, so a later legitimate cancel would then
+    # need one extra ``cancel()`` to take effect. The uncancel dance exists
+    # only to let the ``await aclose()`` below run when we were reached VIA an
+    # outer cancel (on 3.11+ a bare await in that state re-raises on entry).
+    # ``cancelling()`` is 3.11+; on 3.10 it's absent and ``uncancel`` is too,
+    # so the guard is a no-op there (the bare await works on 3.10 regardless).
     current = asyncio.current_task()
     uncancel = getattr(current, "uncancel", None)
-    if callable(uncancel):
+    cancelling = getattr(current, "cancelling", None)
+    if callable(uncancel) and callable(cancelling) and cancelling() > 0:
         uncancel()
     try:
         await aclose()
@@ -1765,7 +1655,7 @@ async def _aclose_stream_session(
 
 
 async def _drain_frames_after_finish(aiter: Any) -> None:
-    """Drain the terminal tail of a frame stream after RUN_FINISHED (CPK-7719 #5).
+    """Drain the terminal tail of a frame stream after RUN_FINISHED.
 
     crewai enqueues its end sentinel only AFTER ``kickoff_async`` fully returns —
     result recorded, trace batch finalized — see ``create_async_frame_generator``
@@ -1818,8 +1708,8 @@ async def _run_flow_frame_stream(
     inputs: dict,
     timeout: float | None,
 ):
-    """StreamFrame-path driver (CPK-7719): drive ``flow.astream`` and yield
-    encoded AG-UI events.
+    """StreamFrame-path driver: drive ``flow.astream`` and yield encoded AG-UI
+    events.
 
     The behavior-preserving replacement for ``_run_flow_event_stream`` on crewai
     >= 1.6. Instead of a process-global bus listener enqueuing onto a per-flow
@@ -1843,10 +1733,10 @@ async def _run_flow_frame_stream(
     ``event_bus._prepare_event`` calls ``publish_stream_event`` on every
     ``emit``.
 
-    Payload + identity come from the RAW event, not ``frame.data`` (CPK-7719
-    review blockers 1/2/3). We register our OWN scoped sink that parks the raw
-    event object keyed by ``event.event_id`` — but ONLY when ``source is
-    flow_copy``, so a nested ``crew.kickoff``'s own flow's lifecycle/method
+    Payload + identity come from the RAW event, not ``frame.data``. We register
+    our OWN scoped sink that parks the raw event object keyed by
+    ``event.event_id`` — but ONLY when ``source is flow_copy``, so a nested
+    ``crew.kickoff``'s own flow's lifecycle/method
     events (which leak onto this same sink via the copied contextvars) are
     excluded. The frame stream then supplies ORDERING; for each frame we look
     up the parked raw event by ``frame.id`` and translate it. A frame with no
@@ -1866,8 +1756,8 @@ async def _run_flow_frame_stream(
     )
     # Raw-event lookup buffer, populated by our scoped sink below. Keyed by
     # ``event.event_id`` (== ``StreamFrame.id``). Only OUTER-flow events land
-    # here (source gate), which is exactly the nested-flow filter for blockers
-    # 2/3 — nested frames find nothing here and are dropped.
+    # here (source gate), which is exactly the nested-flow filter: nested
+    # frames find nothing here and are dropped.
     raw_events: dict[str, Any] = {}
 
     def _sink(source: Any, event: Any) -> None:
@@ -1875,8 +1765,8 @@ async def _run_flow_frame_stream(
         # flows emit with a DIFFERENT source (verified on the 1.15.7 wheel), and
         # our own ``Bridged*`` events are emitted with ``flow_copy`` as source.
         #
-        # PNI-130: crewai's MCP events are emitted with the agent/crew as source
-        # (NOT flow_copy), so the source gate alone would drop them. Park them by
+        # crewai's MCP events are emitted with the agent/crew as source (NOT
+        # flow_copy), so the source gate alone would drop them. Park them by
         # TYPE too. This sink is context-scoped (crewai.events.stream_context), so
         # only THIS run's MCP events (including those from nested crews) reach it
         # -- no cross-run leakage -- and the type gate keeps nested-flow LIFECYCLE
@@ -1888,8 +1778,8 @@ async def _run_flow_frame_stream(
 
     # Predeclared before the ``try`` so the ``finally`` teardown is always safe
     # to reference even if sink registration or ``astream``/``__aiter__`` raises
-    # before assignment (CPK-7719 #4). ``flow_context`` is set ABOVE and reset in
-    # the ``finally`` — mirroring the legacy path's token-then-finally discipline.
+    # before assignment. ``flow_context`` is set ABOVE and reset in the
+    # ``finally`` — mirroring the legacy path's token-then-finally discipline.
     sink_token = None
     session = None
     try:
@@ -1897,9 +1787,9 @@ async def _run_flow_frame_stream(
             # Register the sink and open the stream INSIDE the ``try`` so a
             # raising ``astream``/``__aiter__`` (a) is caught and mapped through
             # the RUN_ERROR taxonomy below instead of escaping the generator with
-            # no terminal event, and (b) never leaks the ``flow_context`` token —
-            # both confirmed by the CPK-7719 review probe. Register BEFORE the
-            # first ``__anext__``: crewai's astream spawns the flow-running task
+            # no terminal event, and (b) never leaks the ``flow_context`` token.
+            # Register BEFORE the first ``__anext__``: crewai's astream spawns
+            # the flow-running task
             # on first iteration and copies the CURRENT context, so the sink must
             # already be in scope to reach the flow's emits. Guarded so a partial
             # install (no sink API) degrades rather than crashing.
@@ -1918,28 +1808,20 @@ async def _run_flow_frame_stream(
                 # scoped stream sink / background kickoff task tear down cleanly;
                 # ``aclose()`` in the ``finally`` then fully drains the task.
                 #
-                # CPK-7721 review #8 — cross-version note (``requires-python``
-                # floor is 3.10). ``wait_for`` internals differ:
-                #   * 3.12+: for ``timeout > 0`` it ``await``s the coroutine
-                #     INLINE (``async with timeouts.timeout(...)``), no Task wrap,
-                #     no context copy. (The ``ensure_future`` wrap survives only
-                #     on the ``timeout <= 0`` branch, which we never reach — the
-                #     ``remaining <= 0`` guard above raises first.)
-                #   * 3.10/3.11: ``wait_for`` UNCONDITIONALLY does
-                #     ``fut = ensure_future(fut)``, wrapping ``__anext__`` in a
-                #     Task and copying the current context per read.
-                # The per-read context copy on 3.10/3.11 is HARMLESS here: our
-                # ``_sink`` is registered (above) BEFORE this loop, so every
-                # per-read context copy inherits it and crewai's ``publish_stream_event``
-                # still reaches it; and both our own and crewai's sink-token
-                # ``reset``s happen OUTSIDE the wrapped ``__anext__`` boundary, so
-                # no token is reset in a foreign context. Verified against the
-                # 1.15.7 wheel on 3.12 and by emulating the 3.10/3.11
-                # ``ensure_future`` wrap (identical wire output, clean
-                # ``flow_context`` reset). Do NOT swap this for a hand-rolled
-                # ``ensure_future`` + ``asyncio.wait``: that would lose the
-                # cancel-and-await-unwind semantics ``wait_for`` gives us on
-                # timeout.
+                # Cross-version note (``requires-python`` floor is 3.10):
+                # ``wait_for`` internals differ. On 3.12+ it awaits the
+                # coroutine inline (no Task wrap, no context copy); on 3.10/3.11
+                # it unconditionally does ``fut = ensure_future(fut)``, wrapping
+                # ``__anext__`` in a Task and copying the current context per
+                # read. The per-read context copy on 3.10/3.11 is HARMLESS here:
+                # our ``_sink`` is registered (above) BEFORE this loop, so every
+                # per-read context copy inherits it and crewai's
+                # ``publish_stream_event`` still reaches it; and both our own and
+                # crewai's sink-token ``reset``s happen OUTSIDE the wrapped
+                # ``__anext__`` boundary, so no token is reset in a foreign
+                # context. Do NOT swap this for a hand-rolled ``ensure_future``
+                # + ``asyncio.wait``: that would lose the cancel-and-await-unwind
+                # semantics ``wait_for`` gives us on timeout.
                 if deadline is not None:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
@@ -1954,10 +1836,9 @@ async def _run_flow_frame_stream(
                         # ``wait_for``'s own timeout fires only once the
                         # deadline is reached; an upstream ``TimeoutError``
                         # raised by the flow propagates BEFORE that. Use the
-                        # wall clock to disambiguate (CR7 CRITICAL parity):
-                        # at/past the deadline => our ceiling; earlier => an
-                        # upstream read timeout that must NOT masquerade as
-                        # AGUI_CREWAI_FLOW_TIMEOUT.
+                        # wall clock to disambiguate: at/past the deadline =>
+                        # our ceiling; earlier => an upstream read timeout that
+                        # must NOT masquerade as AGUI_CREWAI_FLOW_TIMEOUT.
                         if time.monotonic() >= deadline:
                             raise _CeilingExceeded(
                                 _format_timeout_message(timeout)
@@ -1987,14 +1868,14 @@ async def _run_flow_frame_stream(
                 if translator.run_finished:
                     # RUN_FINISHED just emitted. Do NOT break-then-aclose(): that
                     # cancels crewai's still-finalizing kickoff task on every
-                    # happy-path run (CPK-7719 #5). Drain the terminal tail to
+                    # happy-path run. Drain the terminal tail to
                     # natural exhaustion (bounded by the cancel grace) so the run
                     # task completes and the ``finally`` aclose() is a no-op.
                     await _drain_frames_after_finish(aiter)
                     break
 
-            # Belt-and-braces terminal (CPK-7719 blocker 3): the stream can
-            # exhaust with the run open but no outer ``flow_finished`` — e.g. the
+            # Belt-and-braces terminal: the stream can exhaust with the run
+            # open but no outer ``flow_finished`` — e.g. the
             # outer method caught a nested-flow error and returned, or a flow
             # paused for human feedback. Emit the missing RUN_FINISHED so the
             # client never sees a run that never ends. The RUN_ERROR paths below
@@ -2030,7 +1911,7 @@ async def _run_flow_frame_stream(
         except (asyncio.TimeoutError, TimeoutError) as upstream_exc:
             # An upstream ``TimeoutError`` bubbled out of the flow (e.g. a
             # LiteLLM/httpx read timeout) — NOT our ceiling. Distinct code so
-            # alerting can tell the two apart (CR7 CRITICAL parity).
+            # alerting can tell the two apart.
             ceiling_display = (
                 "disabled" if timeout is None else f"{timeout:g}s"
             )
@@ -2131,7 +2012,19 @@ def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
     # Set up the global event listener singleton
     # we are doing this here because calling add_crewai_flow_fastapi_endpoint is a clear indicator
     # that we are not running on CrewAI enterprise
-    if GLOBAL_EVENT_LISTENER is None:
+    #
+    # On the StreamFrame path (crewai >= 1.6) the driver consumes ordered
+    # frames via its own scoped sink and never creates a per-flow queue, so
+    # every event this listener bridges would dispatch on crewai's
+    # ThreadPoolExecutor only to hit ``get_queue(source) -> None`` and no-op —
+    # pure wasted dispatch. Skip registering it when the StreamFrame contract is
+    # available. The legacy bus-listener path is still selected PER-FLOW by
+    # ``flow_supports_stream_frames`` for a flow lacking ``astream`` (e.g. the
+    # kickoff_async-only test doubles) — those doubles emit no crewai bus
+    # events, so the listener produces nothing for them regardless; when a real
+    # legacy deployment needs it, ``stream_frame_available`` is False and it is
+    # registered as before.
+    if GLOBAL_EVENT_LISTENER is None and not CAPABILITIES.stream_frame_available:
         GLOBAL_EVENT_LISTENER = FastAPICrewFlowEventListener()
 
     @app.post(path)
@@ -2179,24 +2072,24 @@ def add_crewai_crew_fastapi_endpoint(
     equivalent wrapper — NOT a bare :class:`crewai.Crew`. The deferred
     ``ChatWithCrewFlow`` construction calls ``crew.crew()`` and reads the
     crew name via ``_read_crew_name`` (which accepts either a
-    ``@CrewBase``'s ``_crew_name`` or a hand-rolled ``.name``; CPK-7717
-    defect 5 / review round 3).
+    ``@CrewBase``'s ``_crew_name`` or a hand-rolled ``.name``).
 
     ChatWithCrewFlow construction is deferred to first request because the
     constructor calls crew_chat_generate_crew_chat_inputs which makes an LLM
     call. At import time the LLM mock server may not be running yet.
     """
     global GLOBAL_EVENT_LISTENER # pylint: disable=global-statement
-    if GLOBAL_EVENT_LISTENER is None:
+    # Skip the legacy bus listener on the StreamFrame path (see the rationale
+    # in ``add_crewai_flow_fastapi_endpoint``).
+    if GLOBAL_EVENT_LISTENER is None and not CAPABILITIES.stream_frame_available:
         GLOBAL_EVENT_LISTENER = FastAPICrewFlowEventListener()
 
     _cached_flow = None
     # Dedicated per-endpoint lock so two concurrent first-requests cannot
     # both call ``ChatWithCrewFlow(crew=crew)`` — which issues a real LLM
-    # call — and waste API budget / memory (finding #6). Not sharing
-    # QUEUES_LOCK: the flow-construction critical section is independent
-    # of queue lifecycle and should not serialise per-request queue
-    # teardown.
+    # call — and waste API budget / memory. Not sharing QUEUES_LOCK: the
+    # flow-construction critical section is independent of queue lifecycle
+    # and should not serialise per-request queue teardown.
     _flow_lock = asyncio.Lock()
 
     async def _get_flow():
@@ -2249,17 +2142,17 @@ def crewai_prepare_inputs(  # pylint: disable=unused-argument, too-many-argument
     forwarded_props: Any = None,
 ):
     """Default merge state for CrewAI"""
-    # PNI-139 review — ``RunAgentInput.state`` is typed ``Any`` and required, so
-    # a client may legally send ``state: null`` or a non-mapping value. The
-    # ``{**state}`` spread below would raise ``TypeError`` on such input, and
-    # because this helper runs in the endpoint body BEFORE the
-    # ``StreamingResponse`` is constructed, that crash escapes the RUN_ERROR
-    # taxonomy as an uncorrelated 500. Coerce a non-mapping state to an empty
-    # dict so the run proceeds instead of dying opaquely.
+    # ``RunAgentInput.state`` is typed ``Any`` and required, so a client may
+    # legally send ``state: null`` or a non-mapping value. The ``{**state}``
+    # spread below would raise ``TypeError`` on such input, and because this
+    # helper runs in the endpoint body BEFORE the ``StreamingResponse`` is
+    # constructed, that crash escapes the RUN_ERROR taxonomy as an uncorrelated
+    # 500. Coerce a non-mapping state to an empty dict so the run proceeds
+    # instead of dying opaquely.
     if not isinstance(state, dict):
         state = {}
 
-    # CPK-7721 review #7 — multimodal / non-text content passes through RAW here.
+    # Multimodal / non-text content passes through RAW here.
     #
     # ``message.model_dump()`` serializes each message verbatim, including any
     # AG-UI content PARTS (e.g. ``{"type": "image", "source": {...}}``) carried
@@ -2267,15 +2160,14 @@ def crewai_prepare_inputs(  # pylint: disable=unused-argument, too-many-argument
     # LiteLLM, which expects OpenAI's ``{"type": "image_url", "image_url": {...}}``
     # shape — so a multimodal input can hard-fail downstream.
     #
-    # This is NEW exposure as of the TS ``maxVersion`` bump to 0.0.57 (this PR):
-    # the older compat middleware FLATTENED array content to a plain string
-    # before it reached the bridge (multimodal worked, but degraded to text). At
-    # 0.0.57 that middleware is off, so the parts arrive un-normalized.
+    # This is NEW exposure as of the TS ``maxVersion`` bump to 0.0.57: the older
+    # compat middleware FLATTENED array content to a plain string before it
+    # reached the bridge (multimodal worked, but degraded to text). At 0.0.57
+    # that middleware is off, so the parts arrive un-normalized.
     #
-    # Converting content parts to LiteLLM's shape is a PARITY-LANE concern
-    # (CPK-7718 / CPK-7721 parity tickets), NOT this migration — do not add image
-    # normalization here. Left as a documented passthrough until the Parity lane
-    # owns it.
+    # Converting content parts to LiteLLM's shape is a parity-lane concern, NOT
+    # this migration — do not add image normalization here. Left as a
+    # documented passthrough until the parity lane owns it.
     messages = [message.model_dump() for message in messages]
 
     if len(messages) > 0:
@@ -2289,7 +2181,7 @@ def crewai_prepare_inputs(  # pylint: disable=unused-argument, too-many-argument
         }
     } for tool in tools]
 
-    # PNI-139 — thread ``forwardedProps`` into the run.
+    # Thread ``forwardedProps`` into the run.
     #
     # Frontend callers send these keys in camelCase; downstream flow / tool
     # code reads snake_case, so normalize before merging (parity with the
@@ -2306,8 +2198,8 @@ def crewai_prepare_inputs(  # pylint: disable=unused-argument, too-many-argument
             camel_to_snake(k): v for k, v in forwarded_props.items()
         }
 
-    # PNI-139 — thread ``input.context`` into the run so agent code and tools
-    # can read it from state. Serialize each entry to a plain dict so the flow
+    # Thread ``input.context`` into the run so agent code and tools can read it
+    # from state. Serialize each entry to a plain dict so the flow
     # state stays JSON-safe and tools can read ``entry["value"]`` directly.
     context_list = [entry.model_dump() for entry in context] if context else []
 
@@ -2317,9 +2209,9 @@ def crewai_prepare_inputs(  # pylint: disable=unused-argument, too-many-argument
         **normalized_forwarded_props,
         **state,
         "messages": messages,
-        # PNI-139 — expose frontend tools at a top-level ``tools`` key too.
-        # crewai has historically only surfaced them under
-        # ``copilotkit.actions``; the top-level key gives framework-neutral
+        # Expose frontend tools at a top-level ``tools`` key too. crewai has
+        # historically only surfaced them under ``copilotkit.actions``; the
+        # top-level key gives framework-neutral
         # agent code a stable place to read them (parity with LangGraph's
         # ``ag_ui_state["tools"]``). ``copilotkit.actions`` is kept for
         # backward compatibility.

--- a/integrations/crew-ai/python/ag_ui_crewai/events.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/events.py
@@ -2,7 +2,7 @@
 This file is used to bridge the events from the crewai event bus to the ag-ui event bus.
 """
 
-# CPK-7718: ``BaseEvent`` moved from ``crewai.utilities.events.base_events``
+# ``BaseEvent`` moved from ``crewai.utilities.events.base_events``
 # (crewai 0.x) to ``crewai.events.base_events`` (crewai 1.x) and is no longer
 # re-exported at the events-package root. ``_capabilities`` resolves whichever
 # location exists.
@@ -14,14 +14,40 @@ from ag_ui.core.events import (
   StateSnapshotEvent
 )
 
-class BridgedToolCallChunkEvent(BaseEvent, ToolCallChunkEvent):
+# When ``crewai``'s events package doesn't resolve, ``BaseEvent`` is ``None``.
+# Subclassing ``None`` (``class X(None, ...)``) crashes at
+# class-definition (import) time with an opaque
+# ``TypeError: NoneType takes no arguments`` — so the friendly, actionable
+# ``_capabilities.warn_on_gaps`` warning (already logged at import naming
+# ``crewai>=1.0``) never reaches the operator, who instead sees the raw
+# TypeError. Degrade to a plain ``object`` base so importing the package does
+# NOT hard-crash (fewer capabilities, not a crash): the ``Bridged*`` events are
+# only ever emitted / dispatched on the event-bus path, which is itself
+# unavailable when the crewai events package didn't resolve, so a non-crewai
+# base here is inert rather than wrong.
+#
+# The fallback is an empty sibling class, NOT ``object``: the ``Bridged*``
+# classes list the base FIRST (``class X(_BridgedBase, ToolCallChunkEvent)``),
+# and ``object`` cannot precede a subclass-of-object in the base list (it must
+# be last in any MRO) — ``(object, ToolCallChunkEvent)`` raises
+# ``TypeError: Cannot create a consistent MRO``. An empty sibling class linearizes
+# cleanly ahead of the ag-ui event model just like the real crewai ``BaseEvent``
+# (a sibling ``BaseModel``) does.
+class _InertBridgedBase:
+    """Inert stand-in for crewai's ``BaseEvent`` when its events package didn't resolve."""
+
+
+_BridgedBase = BaseEvent if BaseEvent is not None else _InertBridgedBase
+
+
+class BridgedToolCallChunkEvent(_BridgedBase, ToolCallChunkEvent):
     """Bridged tool call chunk event"""
 
-class BridgedTextMessageChunkEvent(BaseEvent, TextMessageChunkEvent):
+class BridgedTextMessageChunkEvent(_BridgedBase, TextMessageChunkEvent):
     """Bridged text message chunk event"""
 
-class BridgedCustomEvent(BaseEvent, CustomEvent):
+class BridgedCustomEvent(_BridgedBase, CustomEvent):
     """Bridged custom event"""
 
-class BridgedStateSnapshotEvent(BaseEvent, StateSnapshotEvent):
+class BridgedStateSnapshotEvent(_BridgedBase, StateSnapshotEvent):
     """Bridged state snapshot event"""

--- a/integrations/crew-ai/python/ag_ui_crewai/mcp.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/mcp.py
@@ -1,4 +1,4 @@
-"""MCP (Model Context Protocol) event bridging for ag_ui_crewai (PNI-130).
+"""MCP (Model Context Protocol) event bridging for ag_ui_crewai.
 
 CrewAI gained first-class MCP support in 1.4.0: ``Agent(mcps=[...])`` accepting
 config objects, ``crewai.mcp.MCPServer{Stdio,HTTP,SSE}``, and a family of
@@ -25,22 +25,20 @@ the StreamFrame frame-translator (``_frames.StreamFrameTranslator``, crewai
 could leak across runs or races on the process-wide listener, which protects
 cancellation/teardown.
 
-Capability detection is runtime-only (PNI-130 hard rule): ``crewai_mcp_available``
-probes ``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal -- rather than
+Capability detection is runtime-only: ``crewai_mcp_available`` probes
+``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal -- rather than
 version-gating on a version string. ``Agent.mcps`` is deliberately NOT probed:
 it exists from crewai 1.0.0 as ``list[str]`` and cannot distinguish 1.0 from
 1.4. Below 1.4 the probe fails, ``register_mcp_listeners`` logs one warning and
 is a clean no-op.
 
-Wire-shape note (PNI-136 / PNI-145): the granular ``TOOL_CALL_START``/``ARGS``/
-``END``/``RESULT`` shape is the protocol-canonical representation of a discrete
-(non-streaming) tool call and matches the START/CONTENT/END triples the six
-non-crewai integrations emit. PNI-136's chunks-vs-triples wire-shape decision
-was still In Progress and PNI-145's StreamFrame translator defaults text /
+Wire-shape note: the granular ``TOOL_CALL_START``/``ARGS``/``END``/``RESULT``
+shape is the protocol-canonical representation of a discrete (non-streaming)
+tool call and matches the START/CONTENT/END triples the six non-crewai
+integrations emit. The StreamFrame translator defaults streaming text /
 LLM-tool-call emission to ``chunks``; MCP executions are discrete (name + full
 args + result arrive together), so triples are the natural fit here regardless
-of how that decision lands for streaming LLM tool calls. Documented as an
-assumption; revisit if PNI-136 mandates chunks for MCP too.
+of how the chunks-vs-triples decision lands for streaming LLM tool calls.
 """
 
 import json
@@ -382,7 +380,7 @@ def _translate_mcp_event_impl(event: Any) -> List[BaseEvent]:
 def crewai_mcp_available() -> bool:
     """Return True when crewai>=1.4 first-class MCP support is importable.
 
-    Probes ``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal (PNI-130).
+    Probes ``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal.
     Only ``ImportError`` (crewai < 1.4, module absent) is treated as
     "unavailable"; any OTHER exception is a real breakage and is allowed to
     propagate rather than being silently mislabelled as "too old".

--- a/integrations/crew-ai/python/ag_ui_crewai/sdk.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/sdk.py
@@ -25,7 +25,7 @@ from litellm.types.utils import (
 )
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from crewai.flow.flow import FlowState
-# CPK-7718: the event bus moved from ``crewai.utilities.events`` (0.x) to
+# The event bus moved from ``crewai.utilities.events`` (0.x) to
 # ``crewai.events`` (1.x); ``_capabilities`` resolves whichever exists.
 from ._capabilities import crewai_event_bus
 from pydantic import BaseModel, Field, TypeAdapter

--- a/integrations/crew-ai/python/tests/conftest.py
+++ b/integrations/crew-ai/python/tests/conftest.py
@@ -5,7 +5,7 @@ global crewai event-bus listener singleton) from test-to-test leakage. A
 ghost queue from one test is harmless in isolation, but in a long test
 suite it can obscure the provenance of flaky teardown races.
 
-Intentionally we do NOT swallow the import error (finding #27). If
+Intentionally we do NOT swallow the import error. If
 ``ag_ui_crewai.endpoint`` cannot be imported, every downstream test will
 fail with the same traceback — a clearer diagnostic than a confused test
 suite running against a half-initialised module.
@@ -18,16 +18,15 @@ import pytest
 from ag_ui_crewai import endpoint as ep
 
 # The crewai global event bus — used below to clear handlers registered by our
-# listener singleton so they don't accumulate across tests (R5 MEDIUM #10).
-# CPK-7718: the bus moved from ``crewai.utilities.events`` (0.x) to
+# listener singleton so they don't accumulate across tests.
+# The bus moved from ``crewai.utilities.events`` (0.x) to
 # ``crewai.events`` (1.x); ``_capabilities`` resolves whichever exists.
 from ag_ui_crewai._capabilities import crewai_event_bus as _crewai_event_bus
 
-# CPK-7718 #4: crewai 1.0.0 split the single ``_handlers`` mapping into
+# crewai 1.0.0 split the single ``_handlers`` mapping into
 # ``_sync_handlers`` / ``_async_handlers``. The autouse fixture below snapshots
 # whichever handler dict(s) the installed crewai exposes so listener isolation
-# keeps working across BOTH the 0.x single-dict and the 1.x split-dict shapes
-# (resolves the TODO(CPK-7718) that used to live here).
+# keeps working across BOTH the 0.x single-dict and the 1.x split-dict shapes.
 _HANDLER_ATTRS = ("_sync_handlers", "_async_handlers", "_handlers")
 
 
@@ -40,40 +39,28 @@ def _clear_endpoint_queues():
     lifetime of the process; the endpoint module caches its listener in
     ``GLOBAL_EVENT_LISTENER`` to avoid double-registration. Between
     tests we clear the QUEUES dict, clear the event-bus handlers
-    registered by the listener (R5 MEDIUM #10 — listeners accumulate
-    otherwise, and previously the only isolation was nulling the
-    reference which let older handlers keep firing), and reset the
+    registered by the listener (they accumulate otherwise, since nulling
+    the reference alone lets older handlers keep firing), and reset the
     listener reference so a test that patches or probes
-    ``GLOBAL_EVENT_LISTENER`` starts from a known-clean baseline
-    (finding #22).
+    ``GLOBAL_EVENT_LISTENER`` starts from a known-clean baseline.
 
-    R5 MEDIUM #10 details: the crewai ``CrewAIEventsBus`` exposes a
-    private ``_handlers`` dict keyed by event type. Nulling
-    ``GLOBAL_EVENT_LISTENER`` only drops our Python-side reference —
-    the handlers it registered on the bus persist for the process
-    lifetime. Over a long suite this accumulates duplicate listeners
-    that all enqueue onto ``QUEUES`` (now empty, so the ``None`` guard
-    saves us), but the CPU cost and the signal confusion grow with
-    suite length. Reaching into ``_handlers`` directly is a pragmatic
-    workaround — crewai does not expose a public teardown API.
-
-    CPK-7718 #4 (resolved): crewai 1.0.0 split the single ``_handlers``
-    mapping into ``_sync_handlers`` / ``_async_handlers``. The
-    snapshot/restore helpers below iterate ``_HANDLER_ATTRS`` and act on
-    whichever dict(s) the installed crewai exposes, so listener isolation
-    keeps working across BOTH the 0.x single-dict and the 1.x split-dict
-    shapes rather than silently degrading to a no-op on 1.x.
+    Nulling ``GLOBAL_EVENT_LISTENER`` only drops our Python-side
+    reference — the handlers it registered on the bus persist for the
+    process lifetime, so over a long suite duplicate listeners
+    accumulate. Reaching into the private ``_handlers`` dict directly is
+    a pragmatic workaround; crewai exposes no public teardown API. crewai
+    1.0.0 further split ``_handlers`` into ``_sync_handlers`` /
+    ``_async_handlers``, so the snapshot/restore helpers below iterate
+    ``_HANDLER_ATTRS`` to keep isolation working across both shapes.
     """
 
-    # CR9 MEDIUM: ``handlers.clear()`` on the process-wide event bus
-    # wipes ALL handlers — including any registered by another
-    # library importing crewai in the same process. Snapshot the
-    # handlers dict (key -> list of callables) at setup and restore
-    # it on teardown so we only drop what tests registered, not
-    # pre-existing subscribers. We deep-copy the lists (``list(v)``)
-    # because crewai mutates them in-place via ``append`` during
-    # listener registration — a shallow ``dict(...)`` snapshot would
-    # still observe our appends post-setup.
+    # ``handlers.clear()`` on the process-wide event bus wipes ALL
+    # handlers — including any registered by another library importing
+    # crewai in the same process. Snapshot the handlers at setup and
+    # restore on teardown so we only drop what tests registered, not
+    # pre-existing subscribers. Copy each list because crewai mutates it
+    # in-place via ``append`` during listener registration — a shallow
+    # ``dict(...)`` snapshot would still observe our appends post-setup.
     def _snapshot_handlers():
         if _crewai_event_bus is None:
             return None
@@ -83,9 +70,9 @@ def _clear_endpoint_queues():
             if handlers is None:
                 continue
             try:
-                # CPK-7718 #4: crewai 1.x stores handlers as ``frozenset`` (the
-                # bus does set-union on registration); ``copy.copy`` preserves
-                # that container type, whereas a ``list(...)`` snapshot would
+                # crewai 1.x stores handlers as ``frozenset`` (the bus does
+                # set-union on registration); ``copy.copy`` preserves that
+                # container type, whereas a ``list(...)`` snapshot would
                 # corrupt it and break ``_register_handler`` on restore.
                 snapshot[attr] = {k: copy.copy(v) for k, v in handlers.items()}
             except Exception:  # pragma: no cover - defensive
@@ -110,10 +97,9 @@ def _clear_endpoint_queues():
     handlers_snapshot = _snapshot_handlers()
 
     ep.QUEUES.clear()
-    # CR9 MEDIUM: clear our module-level ``_ALIAS_WARN_SEEN`` dedup set
-    # alongside ``QUEUES`` so a prior test that observed an alias
-    # divergence does not suppress the warning (and its log assertion)
-    # in a later test.
+    # Clear our module-level ``_ALIAS_WARN_SEEN`` dedup set alongside
+    # ``QUEUES`` so a prior test that observed an alias divergence does
+    # not suppress the warning (and its log assertion) in a later test.
     try:
         ep._ALIAS_WARN_SEEN.clear()
     except AttributeError:  # pragma: no cover - symbol removed in refactor
@@ -121,9 +107,9 @@ def _clear_endpoint_queues():
     # Reset singleton; the next test that calls ``add_crewai_*`` will
     # create a fresh FastAPICrewFlowEventListener. Also restore the
     # event-bus handlers from the pre-test snapshot so stale listeners
-    # from prior tests don't keep firing and skewing queue counts
-    # (R5 MEDIUM #10) — while leaving any pre-existing subscribers
-    # from other libraries untouched (CR9 MEDIUM).
+    # from prior tests don't keep firing and skewing queue counts,
+    # while leaving any pre-existing subscribers from other libraries
+    # untouched.
     ep.GLOBAL_EVENT_LISTENER = None
     _restore_handlers(handlers_snapshot)
     try:

--- a/integrations/crew-ai/python/tests/test_capabilities.py
+++ b/integrations/crew-ai/python/tests/test_capabilities.py
@@ -1,0 +1,123 @@
+"""Capability-detection + import-resilience suite.
+
+Covers two graceful-degradation invariants of the crewai capability layer:
+
+* ``_first_module`` treats "module not found" as a soft miss (fall through to
+  the next candidate) but PROPAGATES a genuinely broken import inside an
+  existing module — so a real bug is not misreported as "install crewai>=1.0".
+* When the crewai events package doesn't resolve (``BaseEvent`` /
+  ``BaseEventListener`` are ``None``), importing ``ag_ui_crewai.events`` /
+  ``ag_ui_crewai.endpoint`` degrades to a plain ``object`` base rather than
+  crashing at class-definition time with an opaque
+  ``TypeError: NoneType takes no arguments`` (fewer capabilities, not a crash).
+"""
+
+import importlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from ag_ui_crewai import _capabilities as cap
+
+
+def _run_isolated(script: str) -> subprocess.CompletedProcess:
+    """Run ``script`` in a fresh interpreter (this venv's python).
+
+    The degradation checks below force a crewai event symbol to ``None`` and
+    ``importlib.reload`` ``events`` / ``endpoint``, which rebinds their classes
+    — doing that in-process poisons exact-type event dispatch for the rest of
+    the suite. A subprocess isolates the reload completely.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+# --------------------------------------------------------------------------
+# _first_module: soft-miss on ImportError, propagate everything else
+# --------------------------------------------------------------------------
+
+def test_first_module_returns_none_for_genuinely_missing_modules():
+    """A list of non-existent modules is a soft miss -> (None, None)."""
+    module, name = cap._first_module(
+        ["ag_ui_crewai._definitely_not_a_real_module_xyz"]
+    )
+    assert module is None
+    assert name is None
+
+
+def test_first_module_resolves_first_importable_candidate():
+    """The first importable candidate wins; earlier misses are skipped."""
+    module, name = cap._first_module(
+        ["ag_ui_crewai._definitely_not_a_real_module_xyz", "json"]
+    )
+    assert name == "json"
+    assert module is importlib.import_module("json")
+
+
+def test_first_module_propagates_non_import_error(monkeypatch):
+    """A NON-ImportError raised while importing an existing module must NOT be
+    swallowed — otherwise a real bug inside e.g.
+    ``crewai.events`` is misreported as a missing module. A bare ``except:``
+    would swallow this ``ValueError``; the narrowed
+    ``except (ImportError, ModuleNotFoundError)`` lets it surface."""
+
+    def _boom(_name):
+        raise ValueError("broken top-level import side effect")
+
+    monkeypatch.setattr(cap.importlib, "import_module", _boom)
+    with pytest.raises(ValueError, match="broken top-level"):
+        cap._first_module(["crewai.events"])
+
+
+# --------------------------------------------------------------------------
+# events / endpoint import degrades (does not crash) when the crewai event
+# symbols are None
+# --------------------------------------------------------------------------
+
+def test_events_module_degrades_when_base_event_missing():
+    """With ``_capabilities.BaseEvent`` forced to ``None``, reloading
+    ``ag_ui_crewai.events`` must NOT raise ``TypeError: NoneType takes no
+    arguments`` — the ``Bridged*`` classes fall back to an ``object`` base."""
+    result = _run_isolated(
+        """
+        import importlib
+        import ag_ui_crewai._capabilities as cap
+        import ag_ui_crewai.events as events_mod
+        cap.BaseEvent = None
+        importlib.reload(events_mod)
+        # Fell back to the inert sibling base (not crewai's BaseEvent).
+        assert events_mod._BridgedBase is events_mod._InertBridgedBase
+        # Class definition succeeded (no opaque TypeError / MRO error at import).
+        assert issubclass(events_mod.BridgedToolCallChunkEvent, events_mod._InertBridgedBase)
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_endpoint_module_degrades_when_base_event_listener_missing():
+    """With ``_capabilities.BaseEventListener`` forced to ``None``, reloading
+    ``ag_ui_crewai.endpoint`` must NOT crash at class-definition time — the
+    listener falls back to an ``object`` base (inert, since the bus is also
+    unavailable in that scenario)."""
+    result = _run_isolated(
+        """
+        import importlib
+        import ag_ui_crewai._capabilities as cap
+        import ag_ui_crewai.endpoint as endpoint_mod
+        cap.BaseEventListener = None
+        importlib.reload(endpoint_mod)
+        assert endpoint_mod._EventListenerBase is object, endpoint_mod._EventListenerBase
+        assert endpoint_mod.FastAPICrewFlowEventListener is not None
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/integrations/crew-ai/python/tests/test_copyutil.py
+++ b/integrations/crew-ai/python/tests/test_copyutil.py
@@ -1,0 +1,92 @@
+"""Safe deep-copy isolation suite (``ag_ui_crewai._copyutil``).
+
+Covers the ``safe_deepcopy`` contract the per-request flow/crew COPY relies on:
+plain ``copy.deepcopy`` on healthy objects, the pin-and-share fallback when an
+object carries non-deep-copyable runtime state, and a FAIL-LOUD guard that
+refuses to serve a copy whose conversation ``_state`` was not actually
+isolated from the original.
+"""
+
+import threading
+
+import pytest
+
+from ag_ui_crewai import _copyutil
+
+
+@pytest.fixture(autouse=True)
+def _reset_needs_pin_latch():
+    """``_copyutil._NEEDS_PIN`` is a process-global latch: once any earlier
+    ``safe_deepcopy`` hits an uncopyable object it stays True for the process,
+    which would make the healthy-path test below silently run the pin-and-share
+    fallback instead of the plain ``copy.deepcopy`` it names (depending on suite
+    order). Reset it around every test in this module so each one deterministically
+    exercises its named path regardless of order."""
+    _copyutil._NEEDS_PIN = False
+    yield
+    _copyutil._NEEDS_PIN = False
+
+
+class _Isolatable:
+    """Minimal object carrying an isolatable ``_state`` (like a crewai Flow)."""
+
+    def __init__(self):
+        self._state = {"messages": []}
+
+
+def test_safe_deepcopy_isolates_state_on_healthy_object():
+    """The happy path deep-copies ``_state`` so the copy is isolated."""
+    original = _Isolatable()
+    copied = _copyutil.safe_deepcopy(original, what="flow")
+    assert copied is not original
+    assert copied._state is not original._state
+    # Mutating the copy does not bleed into the original (real isolation).
+    copied._state["messages"].append("x")
+    assert original._state["messages"] == []
+    # Proves this test exercised the plain-deepcopy path, not the pin fallback
+    # (a healthy object never latches _NEEDS_PIN).
+    assert _copyutil._NEEDS_PIN is False
+
+
+def test_safe_deepcopy_pins_uncopyable_but_still_isolates_state():
+    """An object holding BOTH an uncopyable lock (in one field) AND ``_state``
+    (in a DIFFERENT field) copies via the pin-and-share fallback: the lock is
+    pinned by reference while ``_state`` is still deep-copied / isolated."""
+
+    class _WithLock:
+        def __init__(self):
+            self._state = {"messages": []}
+            self._lock = threading.Lock()  # not deep-copyable
+
+    original = _WithLock()
+    copied = _copyutil.safe_deepcopy(original, what="flow")
+    # Lock is shared by reference (pinned); state is isolated.
+    assert copied._lock is original._lock
+    assert copied._state is not original._state
+
+
+def test_assert_state_isolated_raises_when_state_shared():
+    """The fail-loud guard raises when a copy SHARES ``_state`` with the
+    original — the silent isolation-loss the top-level-granular pinning could
+    otherwise produce."""
+    original = _Isolatable()
+    not_isolated = _Isolatable()
+    # Simulate the pin-and-share collapse: copy ended up sharing _state.
+    not_isolated._state = original._state
+    with pytest.raises(RuntimeError, match="did NOT isolate"):
+        _copyutil._assert_state_isolated(original, not_isolated, "flow")
+
+
+def test_assert_state_isolated_noop_when_isolated_or_stateless():
+    """The guard is a no-op when ``_state`` is isolated, or when either side
+    lacks a ``_state`` (a copied ``Crew`` / test stub) — nothing to isolate."""
+    a, b = _Isolatable(), _Isolatable()
+    # Isolated: distinct _state objects -> no raise.
+    _copyutil._assert_state_isolated(a, b, "flow")
+
+    class _NoState:
+        pass
+
+    # Missing _state on either side -> no raise.
+    _copyutil._assert_state_isolated(_NoState(), b, "crew")
+    _copyutil._assert_state_isolated(a, _NoState(), "crew")

--- a/integrations/crew-ai/python/tests/test_crew_chat.py
+++ b/integrations/crew-ai/python/tests/test_crew_chat.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# CPK-7718 #7: the crew-chat helpers (and the two ``generate_*_with_ai``
+# The crew-chat helpers (and the two ``generate_*_with_ai``
 # network helpers ``_stub_llm_network`` patches) moved from
 # ``crewai.cli.crew_chat`` (0.x - 1.14) to ``crewai.utilities.crew_chat``
 # (1.15+). Resolve whichever the installed crewai exposes so the stub patches
@@ -78,10 +78,10 @@ def _stub_llm_network():
     """Stub ONLY crewai's LLM-calling description helpers so the real
     ``generate_crew_chat_inputs`` + real ``ChatInputs`` still run offline.
 
-    The reviewer's key objection to the prior module was that it replaced
-    ``crew_chat_generate_crew_chat_inputs`` wholesale, so the real
-    ``ChatInputs`` construction (and the ``crew_name`` it validates) never
-    ran. Here we patch one level deeper — the two functions that make the
+    The prior approach replaced ``crew_chat_generate_crew_chat_inputs``
+    wholesale, so the real ``ChatInputs`` construction (and the
+    ``crew_name`` it validates) never ran. Here we patch one level
+    deeper — the two functions that make the
     actual ``chat_llm.call`` network requests — leaving the generator and
     the Pydantic model untouched.
     """
@@ -100,7 +100,7 @@ def _make_real_crewbase(cls_name="ResearchCrew"):
 
     crewai's ``@CrewBase`` sets ``_crew_name`` (to the class ``__name__``)
     and exposes a ``crew()`` factory — it does NOT expose ``.name``. That
-    is exactly the shape the round-2 name-read fix must handle.
+    is exactly the shape the name-read fix must handle.
     """
     @CrewBase
     class _Crew:
@@ -224,13 +224,13 @@ def _new_crew_flow(*, chat_llm=None, crew_model="crew-model-string"):
 
 async def test_chat_runs_crew_and_records_string_output():
     """A crew tool call runs the crew fn, records its string result, appends a
-    ``tool`` message, then (CPK-7717 defect 2) issues a follow-up completion so
-    the assistant speaks. Strengthened from the pre-fix 2-message version that
+    ``tool`` message, then issues a follow-up completion so the assistant
+    speaks. Strengthened from the pre-fix 2-message version that
     encoded the silent-assistant bug."""
     async def _fake_acompletion(**_kwargs):
         return object()
 
-    # Stateful stream mock: turn 1 names the crew tool; the defect-2 follow-up
+    # Stateful stream mock: turn 1 names the crew tool; the follow-up
     # turn returns plain text.
     stream_calls = {"n": 0}
 
@@ -286,7 +286,7 @@ async def test_chat_runs_crew_and_records_string_output():
 
     assert captured["args"] == {"topic": "ai"}
     assert state["outputs"] == "CREW OUTPUT"
-    # Three messages: assistant tool-call, tool result, defect-2 follow-up text.
+    # Three messages: assistant tool-call, tool result, follow-up text.
     assert len(state["messages"]) == 3
     tool_message = state["messages"][1]
     assert tool_message["role"] == "tool"
@@ -349,11 +349,11 @@ async def test_chat_crew_output_from_raw_attribute():
 
 def test_completion_llm_kwargs_forwards_all_connection_fields_real_llm():
     """A REAL ``crewai.LLM`` carrying custom connection settings has ALL of
-    them forwarded (round-2 finding 1) — model, api_key, api_base, api_version —
-    plus provider-specific ``additional_params`` spread. The reviewer's repro
+    them forwarded — model, api_key, api_base, api_version — plus
+    provider-specific ``additional_params`` spread. The failing case
     built exactly this LLM and saw only model+api_key.
 
-    CPK-7718: the model string is ``gpt-4o`` rather than ``azure/deployment``
+    The model string is ``gpt-4o`` rather than ``azure/deployment``
     because crewai 1.x eagerly loads a NATIVE provider for ``azure/*`` that
     requires the ``crewai[azure-ai-inference]`` extra — unrelated to the
     (provider-agnostic) field forwarding under test. On crewai 1.x ``LLM``
@@ -381,9 +381,9 @@ def test_completion_llm_kwargs_forwards_all_connection_fields_real_llm():
 
 def test_completion_llm_kwargs_forwards_base_url_when_set_real_llm():
     """A REAL ``crewai.LLM`` with ``base_url`` (local/self-hosted) forwards
-    it (the original CopilotKit#2742 local-model repro).
+    it (the original local-model repro).
 
-    CPK-7718: crewai 1.x normalises the stored ``base_url`` (e.g. appends
+    crewai 1.x normalises the stored ``base_url`` (e.g. appends
     ``/v1``), so we assert the forwarded value matches the LLM's OWN
     ``base_url`` attribute rather than a hard-coded literal — the point under
     test is that ``_completion_llm_kwargs`` forwards whatever the LLM exposes,
@@ -414,8 +414,8 @@ def test_completion_llm_kwargs_falls_back_when_llm_unresolved():
 
 
 def test_completion_llm_kwargs_forwards_generation_config_real_llm():
-    """A REAL ``crewai.LLM`` carrying generation config has it forwarded
-    (round-4 finding 1). crewai's own ``LLM._prepare_completion_params``
+    """A REAL ``crewai.LLM`` carrying generation config has it forwarded.
+    crewai's own ``LLM._prepare_completion_params``
     forwards temperature/top_p/max_tokens/etc., so the bridge must too or
     the config is silently replaced by provider defaults. ``temperature=0``
     (falsy but meaningful) survives; the empty default ``stop=[]`` is not
@@ -438,7 +438,7 @@ def test_completion_llm_kwargs_forwards_generation_config_real_llm():
 
 async def test_chat_forwards_connection_fields_to_acompletion_real_llm():
     """Both completion call sites receive the resolved connection fields
-    from a REAL ``crewai.LLM`` — the crew-run turn AND the defect-2
+    from a REAL ``crewai.LLM`` — the crew-run turn AND the
     follow-up."""
     calls = []
 
@@ -470,7 +470,7 @@ async def test_chat_forwards_connection_fields_to_acompletion_real_llm():
     async def _noop_emit_state(_state):
         return True
 
-    # CPK-7718: ``gpt-4o`` (not ``azure/deployment``) — crewai 1.x eagerly
+    # ``gpt-4o`` (not ``azure/deployment``) — crewai 1.x eagerly
     # loads a native azure provider needing an extra; the forwarding under test
     # is provider-agnostic. ``api_version`` rides ``additional_params`` on 1.x.
     real_llm = LLM(model="gpt-4o", api_key="secret",
@@ -494,7 +494,7 @@ async def test_chat_forwards_connection_fields_to_acompletion_real_llm():
         assert call["api_key"] == "secret"
         assert call["api_base"] == "https://azure.example"
         assert call["api_version"] == "2024-02-01"
-    # The follow-up (defect 2) forces text, not another tool call.
+    # The follow-up forces text, not another tool call.
     assert calls[1]["tool_choice"] == "none"
 
 
@@ -502,9 +502,9 @@ async def test_additional_params_do_not_collide_with_call_owned_kwargs():
     """A REAL ``crewai.LLM`` whose ``additional_params`` include keys the
     ``chat()`` call sites ALSO set explicitly must NOT raise ``TypeError:
     got multiple values for keyword argument`` — and the CALL-OWNED values
-    must win (round-3 finding 1).
+    must win.
 
-    The reviewer's repro was ``LLM(model="gpt-4o",
+    The repro was ``LLM(model="gpt-4o",
     parallel_tool_calls=True)``: crewai routes ``parallel_tool_calls`` into
     ``additional_params``, which the old code spread into the same
     ``acompletion(**kwargs, parallel_tool_calls=False, ...)`` call. Here we
@@ -512,7 +512,7 @@ async def test_additional_params_do_not_collide_with_call_owned_kwargs():
     into ``additional_params`` and assert the framework's own values are
     used, plus a benign custom param survives."""
     # ``api_key`` is supplied because crewai 1.0.x's native OpenAI provider
-    # validates ``OPENAI_API_KEY`` at construction time (CPK-7718 floor test);
+    # validates ``OPENAI_API_KEY`` at construction time;
     # it goes to the LLM's ``api_key`` attr, not ``additional_params``, so the
     # collision preconditions below are unaffected.
     real_llm = LLM(
@@ -582,7 +582,7 @@ async def test_additional_params_do_not_collide_with_call_owned_kwargs():
         assert isinstance(call["tools"], list) and call["tools"]
         # Benign custom additional_param is still forwarded.
         assert call["foo_custom"] == "bar"
-    # The follow-up (defect 2) turn sets tool_choice explicitly, so the
+    # The follow-up turn sets tool_choice explicitly, so the
     # call-owned "none" overrides the additional_params "SHOULD_LOSE"
     # sentinel — proving call-owned tool_choice wins on collision.
     assert calls[1]["tool_choice"] == "none"
@@ -594,7 +594,7 @@ async def test_additional_params_do_not_collide_with_call_owned_kwargs():
 
 async def test_crew_run_emits_state_snapshot():
     """Running the crew emits a STATE_SNAPSHOT reflecting the applied
-    output, routed to the bridge via the endpoint listener (defect 3)."""
+    output, routed to the bridge via the endpoint listener."""
     async def _fake_acompletion(**_kwargs):
         return object()
 
@@ -645,7 +645,7 @@ async def test_crew_run_emits_state_snapshot():
 
 
 async def test_crew_run_executes_off_the_event_loop():
-    """CPK-7719 (CPK-7717 defect 3 follow-up): the synchronous ``crew.kickoff``
+    """The synchronous ``crew.kickoff``
     tool function runs on a WORKER thread (``asyncio.to_thread``), not inline on
     the event loop — so SSE flushing / the wall-clock ceiling / client-disconnect
     cancellation can fire DURING the crew run instead of being blocked until it
@@ -723,7 +723,7 @@ def test_real_crewbase_matches_structural_protocol():
 
 
 def test_protocol_accepts_name_only_and_crew_name_only_wrappers():
-    """The protocol pins ONLY ``crew()`` (round-3 finding 3), so BOTH
+    """The protocol pins ONLY ``crew()``, so BOTH
     supported shapes conform: the repo's own ``CrewChatCrew`` (which
     exposes ``.name`` only, no ``_crew_name``) AND a real ``@CrewBase``
     instance (which exposes ``_crew_name`` only, no ``.name``). Requiring
@@ -751,7 +751,7 @@ def test_real_crewbase_direct_construction_reads_crew_name_and_builds_chatinputs
     """Constructing ``ChatWithCrewFlow`` from a REAL ``@CrewBase`` reads the
     name off ``_crew_name`` (not ``.name`` — which does not exist on a real
     @CrewBase and previously AttributeError'd) and feeds it into a REAL
-    ``ChatInputs`` with no validation error (round-2 finding 2)."""
+    ``ChatInputs`` with no validation error."""
     crews_mod._CREW_INPUTS_CACHE.clear()
 
     real = _make_real_crewbase(cls_name="ResearchCrew")
@@ -769,7 +769,7 @@ def test_real_crewbase_endpoint_triggers_lazy_flow_without_attribute_error():
     ``ChatWithCrewFlow(crew=...)`` construction — the exact site that
     AttributeError'd on ``crew.name`` before the fix. The request must
     complete (HTTP 200), proving the real ``_crew_name`` read and real
-    ``ChatInputs`` construction succeed end-to-end (round-2 finding 2)."""
+    ``ChatInputs`` construction succeed end-to-end."""
     real = _make_real_crewbase(cls_name="EndpointCrew")
 
     async def _fake_acompletion(**_kwargs):
@@ -800,7 +800,7 @@ def test_unnamed_crew_raises_clear_error():
     """A crew exposing ``crew()`` but neither a non-empty ``name`` nor
     ``_crew_name`` raises a CLEAR ``ValueError`` — never ``None`` into
     ``ChatInputs`` (which would surface as an opaque Pydantic validation
-    error deep in ``generate_crew_chat_inputs``) — round-2 finding 2."""
+    error deep in ``generate_crew_chat_inputs``)."""
     class _Unnamed:
         def crew(self):
             return type("C", (), {"chat_llm": LLM(model="gpt-4o", api_key="k")})()
@@ -855,22 +855,65 @@ def test_same_crew_reuses_cached_inputs_real_crewbase():
     assert gen_spy.call_count == 1
 
 
+def test_constructor_regenerates_inputs_after_cache_eviction():
+    """CONSTRUCTOR-level regenerate-on-miss.
+
+    The GC test below was narrowed to a direct cache-helper assertion because
+    crewai pins the constructing frame (so a real crew never GCs mid-test); it
+    no longer exercised the ``ChatWithCrewFlow.__init__`` path that MISSES the
+    cache and REGENERATES. This restores that end-to-end constructor coverage
+    by evicting the cache entry (the exact post-state the weakref ``evict_cb``
+    leaves after a GC) and asserting the NEXT construction for the SAME crew
+    re-runs the real ``generate_crew_chat_inputs`` rather than serving a stale
+    schema."""
+    crews_mod._CREW_INPUTS_CACHE.clear()
+
+    real = _make_real_crewbase(cls_name="RegenCrew")
+    wrapped = crews_mod.crew_chat_generate_crew_chat_inputs
+
+    with _stub_llm_network():
+        with patch.object(
+            crews_mod, "crew_chat_generate_crew_chat_inputs",
+            side_effect=wrapped,
+        ) as gen_spy:
+            f1 = crews_mod.ChatWithCrewFlow(crew=real)
+            # First construction generated + cached.
+            assert gen_spy.call_count == 1
+            assert id(real) in crews_mod._CREW_INPUTS_CACHE
+
+            # Evict the entry, mirroring the weakref evict_cb firing on GC.
+            crews_mod._CREW_INPUTS_CACHE.pop(id(real), None)
+
+            # Constructing again for the SAME crew misses the (evicted) cache
+            # and REGENERATES — the constructor invariant the narrowed GC test
+            # stopped covering.
+            f2 = crews_mod.ChatWithCrewFlow(crew=real)
+            assert gen_spy.call_count == 2
+
+    # A fresh schema object was produced on the regenerate (not the stale one),
+    # and it is re-cached.
+    assert f1.crew_chat_inputs is not f2.crew_chat_inputs
+    assert crews_mod._crew_inputs_cache_get(real) is f2.crew_chat_inputs
+
+    crews_mod._CREW_INPUTS_CACHE.clear()
+
+
 def test_cache_evicts_on_gc_and_regenerates_for_new_crew():
     """The cache maps ``id(crew) -> (weakref.ref(crew, evict_cb), schema)``,
     so when a weakref-able crew is garbage-collected the ``evict_cb`` pops
     its entry — eliminating the ``id(crew)`` reuse hazard where a freshly
     allocated wrapper inherits a collected wrapper's id and is silently
-    served the wrong schema (round-3 finding 2). A brand-new crew therefore
+    served the wrong schema. A brand-new crew therefore
     regenerates rather than receiving the old schema.
 
-    CPK-7718: on crewai 1.x, constructing a real ``ChatWithCrewFlow`` can no
+    On crewai 1.x, constructing a real ``ChatWithCrewFlow`` can no
     longer be used to drive this invariant — crewai retains a traceback frame
     from ``generate_crew_chat_inputs`` that pins the constructing frame (and
     thus the ``crew`` local) alive, so a real crew is never collected during
     the test regardless of wrapper type. We therefore exercise the eviction
     mechanism DIRECTLY against the cache helpers (``_crew_inputs_cache_set`` /
     ``_crew_inputs_cache_get`` / the ``evict_cb``), which is exactly the
-    round-3 id-reuse-safety logic under test — no crewai frame retention in the
+    id-reuse-safety logic under test — no crewai frame retention in the
     path."""
     crews_mod._CREW_INPUTS_CACHE.clear()
 
@@ -905,7 +948,7 @@ def test_cache_evicts_on_gc_and_regenerates_for_new_crew():
 
 def test_distinct_but_equal_crews_get_distinct_schemas_no_cross_serve():
     """Two DISTINCT-BUT-EQUAL crew wrappers (value-based ``__eq__`` /
-    ``__hash__``) must receive DISTINCT schemas (round-3 finding 2). The
+    ``__hash__``) must receive DISTINCT schemas. The
     prior ``WeakKeyDictionary`` keyed by ``__eq__`` / ``__hash__`` and so
     collapsed the two to one entry, cross-serving the first crew's schema
     to the second. The ``id(crew)`` key keys on identity, so each wrapper
@@ -940,7 +983,7 @@ def test_non_weakrefable_crew_is_not_cached_no_permanent_entry():
     ``__weakref__``) is NOT cached — the set path skips it rather than
     pinning a strong reference forever (which would leak the wrapper).
     Constructing multiple flows for such crews therefore accumulates NO
-    permanent cache entries (round-3 finding 2). ``crew()`` returns a REAL
+    permanent cache entries. ``crew()`` returns a REAL
     ``crewai.Crew`` and the real ``generate_crew_chat_inputs`` runs."""
     crews_mod._CREW_INPUTS_CACHE.clear()
 
@@ -974,7 +1017,7 @@ def test_non_weakrefable_crew_is_not_cached_no_permanent_entry():
 
 def test_crew_path_symbols_exported_from_package_top_level():
     """The previously-hidden Crew-path symbols are importable from the
-    package top level and declared in ``__all__`` (defect 5)."""
+    package top level and declared in ``__all__``."""
     import ag_ui_crewai as pkg
 
     for name in (
@@ -988,7 +1031,7 @@ def test_crew_path_symbols_exported_from_package_top_level():
 
 
 # --------------------------------------------------------------------------
-# CPK-7718 #11: per-request flow COPY seeds state before ``@start`` runs
+# per-request flow COPY seeds state before ``@start`` runs
 # --------------------------------------------------------------------------
 
 class _CrewShapedFlow(Flow):
@@ -1012,7 +1055,7 @@ class _CrewShapedFlow(Flow):
 
 
 async def test_copied_crew_flow_kickoff_seeds_state_before_start_runs():
-    """CPK-7718 #11: a per-request COPY of a crew-shaped Flow, driven through
+    """A per-request COPY of a crew-shaped Flow, driven through
     the REAL ``crewai_prepare_inputs`` -> ``kickoff_async(inputs=...)`` seam the
     crew endpoint uses, must seed ``messages`` / ``copilotkit`` into the COPY's
     ``self.state`` BEFORE ``@start`` runs.

--- a/integrations/crew-ai/python/tests/test_llm_timeout.py
+++ b/integrations/crew-ai/python/tests/test_llm_timeout.py
@@ -1,5 +1,5 @@
 """
-Regression tests for Defect A follow-up: ensure LiteLLM streaming calls in
+Regression tests ensuring LiteLLM streaming calls in
 ``crews.py`` are made with an explicit read timeout so a half-open TCP stream
 cannot hang the request forever.
 
@@ -25,7 +25,7 @@ def _patch_instance_state(flow, state):
     Flow.state is a class-level descriptor, so a naive attribute assignment
     goes through the descriptor's ``__set__``. Rather than mutate the shared
     class (which is unsafe under ``pytest-xdist`` and other parallel test
-    runners — finding #9), we rebind the instance's ``__class__`` to a
+    runners), we rebind the instance's ``__class__`` to a
     freshly-minted subclass that declares ``state`` as a plain property
     reading from ``flow._state``. The subclass is per-instance, so two
     parallel tests patching two different ``flow`` instances cannot race on
@@ -54,15 +54,15 @@ def test_default_llm_timeout_is_set(monkeypatch):
     """With no env var, the default is a finite positive number in a
     sane range. Pinning against a literal (not the same constant we
     import) so a silent regression that swaps ``_DEFAULT_LLM_TIMEOUT_SECONDS``
-    to ``None`` or a bogus value is caught (finding #24 — the previous
+    to ``None`` or a bogus value is caught (the previous
     ``value == _DEFAULT_LLM_TIMEOUT_SECONDS`` compared the import to
     itself, a tautology).
     """
     monkeypatch.delenv("AGUI_CREWAI_LLM_TIMEOUT_SECONDS", raising=False)
     value = _llm_timeout_seconds()
     # Must be a finite positive float. ``isinstance(value, float)`` already
-    # rules out ``None`` (R5 LOW #21: dropped the redundant separate
-    # ``is not None`` assertion — same guarantee from the type check).
+    # rules out ``None`` (the redundant separate ``is not None``
+    # assertion was dropped — same guarantee from the type check).
     assert isinstance(value, float)
     assert value > 0.0
     # Anchor against a fixed range rather than the module constant so a
@@ -95,7 +95,7 @@ def test_llm_timeout_bad_value_falls_back_to_default(monkeypatch):
 
 
 def test_llm_timeout_nan_falls_back_to_default(monkeypatch):
-    """R5 HIGH #1: ``float('nan') > 0`` is False, which would silently
+    """``float('nan') > 0`` is False, which would silently
     disable the LLM read timeout. A NaN env var must fall back to the
     default, mirroring the NaN guard in ``endpoint._flow_timeout_seconds``.
     """
@@ -108,7 +108,7 @@ def test_llm_timeout_nan_falls_back_to_default(monkeypatch):
 
 
 def test_llm_timeout_infinity_falls_back_to_default(monkeypatch):
-    """R5 HIGH #1 (defence in depth): ``float('inf')`` IS greater than 0
+    """Defence in depth: ``float('inf')`` IS greater than 0
     but would disable any practical ceiling. ``math.isfinite`` rejects it;
     pin the behaviour so a regression to a naïve ``value > 0`` check is
     caught.
@@ -168,7 +168,7 @@ async def test_acompletion_called_with_timeout_kwarg():
     assert "timeout" in kwargs, f"acompletion call missing timeout kwarg: {kwargs}"
     # With the default env, the timeout is the module default — lock the
     # value in so a regression that silently disables the default (None) is
-    # caught loudly. This is finding #4: reject the "None or >0" tautology.
+    # caught loudly, rejecting the "None or >0" tautology.
     assert kwargs["timeout"] == _DEFAULT_LLM_TIMEOUT_SECONDS
 
 

--- a/integrations/crew-ai/python/tests/test_mcp.py
+++ b/integrations/crew-ai/python/tests/test_mcp.py
@@ -1,4 +1,4 @@
-"""Tests for the MCP -> AG-UI event bridge (PNI-130).
+"""Tests for the MCP -> AG-UI event bridge.
 
 ``translate_mcp_event`` is stateless (mints fresh ids per call, so not pure) and
 dispatches on the crewai event's ``type`` string, so these tests drive it with

--- a/integrations/crew-ai/python/tests/test_message_translation.py
+++ b/integrations/crew-ai/python/tests/test_message_translation.py
@@ -130,7 +130,7 @@ def test_prepare_inputs_merges_incoming_state():
 
 
 # --------------------------------------------------------------------------
-# PNI-139 — context / forwardedProps / top-level tools forwarding
+# context / forwardedProps / top-level tools forwarding
 # --------------------------------------------------------------------------
 
 def test_prepare_inputs_threads_context_into_state():

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -34,7 +34,7 @@ from ag_ui_crewai.sdk import (
 async def _settle_bus(emit_result=None):
     """Let off-thread crewai 1.x event-bus handlers land on the queue.
 
-    CPK-7718 #2: crewai 1.x dispatches our sync listener callbacks on a
+    crewai 1.x dispatches our sync listener callbacks on a
     ThreadPoolExecutor worker thread, and ``_enqueue`` hops the result back
     onto the loop via ``call_soon_threadsafe``. A test that emits then drains
     synchronously must wait for the handler to finish AND give the loop one
@@ -332,7 +332,7 @@ async def test_listener_emits_messages_and_state_snapshot_on_method_finish():
 
 
 # --------------------------------------------------------------------------
-# StreamFrame path (CPK-7719): flow.astream() -> frame translator -> wire
+# StreamFrame path: flow.astream() -> frame translator -> wire
 # --------------------------------------------------------------------------
 
 # Tests that drive a REAL crewai ``Flow.astream`` require the StreamFrame
@@ -365,7 +365,7 @@ async def _collect(agen):
 def _ev(type, event_id=None, **attrs):  # noqa: A002 - mirror event.type
     """A RAW crewai/bridge event stand-in the translator reads by attribute.
 
-    The translator now consumes raw event objects (CPK-7719 blocker 1), so a
+    The translator now consumes raw event objects, so a
     lifecycle event is any object exposing ``.type`` (+ ``.method_name`` etc.)
     and a bridge event exposes its typed payload attributes directly — no
     ``to_serializable`` ``frame.data`` in the loop."""
@@ -389,7 +389,7 @@ class _FakeStreamSession:
         self._source = source
         self._hang = hang
         self.aclosed = False
-        # CPK-7719 #5 instrumentation: how many frames the driver actually
+        # Instrumentation: how many frames the driver actually
         # consumed, and whether the iterator was drained to natural exhaustion
         # (vs stopped early via break + aclose).
         self.frames_yielded = 0
@@ -593,7 +593,7 @@ def _make_run_input(thread_id="t-1", run_id="r-1"):
     )
 
 
-# -- CPK-7719: ONE RUN_STARTED / ONE RUN_FINISHED per HTTP run --------------
+# -- ONE RUN_STARTED / ONE RUN_FINISHED per HTTP run --------------
 
 class _InnerKickoffFlow(Flow):
     """Stands in for the ``crew.kickoff`` a ``ChatWithCrewFlow.chat`` runs
@@ -610,7 +610,7 @@ class _InnerKickoffFlow(Flow):
 class _TwoCompletionCrewFlow(Flow):
     """A real Flow that performs TWO internal operations in ONE run — exactly
     the crew-tool path shape (``crew.kickoff`` off the event loop, then a
-    defect-2 follow-up completion). The nested kickoff runs via
+    follow-up completion). The nested kickoff runs via
     ``asyncio.to_thread`` (as the bridge offloads ``crew.kickoff``), which
     copies the scoped stream-sink contextvar, so the inner flow's
     ``flow_started`` / ``flow_finished`` frames land on THIS run's sink."""
@@ -620,7 +620,7 @@ class _TwoCompletionCrewFlow(Flow):
         # Completion #1 surrogate: the nested (crew) kickoff. Off the loop, as
         # ``crews.py`` runs ``crew_function`` via ``asyncio.to_thread``.
         await asyncio.to_thread(lambda: _InnerKickoffFlow().kickoff())
-        # Completion #2 (CPK-7717 defect 2): the follow-up completion that
+        # Completion #2: the follow-up completion that
         # makes the assistant speak about the crew result. ``copilotkit_stream``
         # emits this as a bridged TEXT_MESSAGE_CHUNK on the same sink.
         f = flow_context.get(None)
@@ -634,8 +634,8 @@ class _TwoCompletionCrewFlow(Flow):
 
 @requires_stream_frames
 async def test_frame_path_two_completions_emit_single_run_lifecycle():
-    """CPK-7719: a run whose flow method performs two internal completions —
-    a nested (crew) kickoff plus a defect-2 follow-up — must emit EXACTLY ONE
+    """A run whose flow method performs two internal completions —
+    a nested (crew) kickoff plus a follow-up — must emit EXACTLY ONE
     RUN_STARTED (first) and ONE RUN_FINISHED (last), with the follow-up text
     streaming in between.
 
@@ -661,14 +661,14 @@ async def test_frame_path_two_completions_emit_single_run_lifecycle():
     assert types[0] == "RUN_STARTED"
     assert types[-1] == "RUN_FINISHED"
 
-    # The defect-2 follow-up text reaches the client, inside the run.
+    # The follow-up text reaches the client, inside the run.
     assert "TEXT_MESSAGE_CHUNK" in types, types
     follow = next(p for p in payloads if p["type"] == "TEXT_MESSAGE_CHUNK")
     assert follow["delta"] == "Crew is done."
     assert types.index("TEXT_MESSAGE_CHUNK") < types.index("RUN_FINISHED")
 
 
-# -- CPK-7719 review blockers: raw-payload fidelity, nested non-leak, terminal
+# -- Review invariants: raw-payload fidelity, nested non-leak, terminal
 
 
 class _ProgressiveStateFlow(Flow):
@@ -690,7 +690,7 @@ class _ProgressiveStateFlow(Flow):
 
 @requires_stream_frames
 async def test_frame_path_progressive_state_snapshot_is_verbatim():
-    """CPK-7719 blocker 1: the intermediate STATE_SNAPSHOT must equal the LIVE
+    """The intermediate STATE_SNAPSHOT must equal the LIVE
     state ``copilotkit_emit_state`` was given — no ``repr()`` quoting of strings
     at depth >= 5, no dropping of user keys named ``type`` / ``timestamp``.
 
@@ -738,7 +738,7 @@ class _NestedNoLeakFlow(Flow):
 
 @requires_stream_frames
 async def test_frame_path_nested_flow_frames_do_not_leak():
-    """CPK-7719 blocker 2: a nested kickoff must NOT inject a second
+    """A nested kickoff must NOT inject a second
     STEP_STARTED / MESSAGES_SNAPSHOT / STATE_SNAPSHOT / STEP_FINISHED built from
     the OUTER flow's state. The outer run has exactly ONE method, so each of
     those appears exactly once — matching the legacy (``source is flow_copy``)
@@ -791,7 +791,7 @@ class _OuterCatchesNestedErrorFlow(Flow):
 
 @requires_stream_frames
 async def test_frame_path_nested_error_still_terminates_run():
-    """CPK-7719 blocker 3: a nested flow that raises (so its ``flow_finished``
+    """A nested flow that raises (so its ``flow_finished``
     is never emitted) while the outer method catches and continues must STILL
     terminate the run — exactly one RUN_STARTED and a final RUN_FINISHED (or
     RUN_ERROR), never a run that ends with neither.
@@ -819,7 +819,7 @@ async def test_frame_path_nested_error_still_terminates_run():
     assert "RUN_FINISHED" in types or "RUN_ERROR" in types, types
 
 
-# -- CPK-7718 #11: per-request flow COPY seeds state before @start runs ------
+# -- per-request flow COPY seeds state before @start runs ------
 
 class _StateReadingFlow(Flow[CopilotKitState]):
     """A real crewai Flow shaped like the served example flows
@@ -841,7 +841,7 @@ class _StateReadingFlow(Flow[CopilotKitState]):
 
 @requires_stream_frames
 async def test_copied_example_flow_astream_seeds_state_before_start_runs():
-    """CPK-7718 #11 (flow-demo path): a per-request COPY of an example-shaped
+    """Flow-demo path: a per-request COPY of an example-shaped
     ``Flow[CopilotKitState]``, driven through the REAL
     ``crewai_prepare_inputs`` -> ``flow.astream(inputs=...)`` seam
     ``add_crewai_flow_fastapi_endpoint`` uses on crewai 1.6+, must seed
@@ -980,10 +980,10 @@ async def test_frame_path_aclose_called_on_early_generator_close():
     assert session.aclosed is True
 
 
-# -- CPK-7719 #4: raising astream is mapped to RUN_ERROR + no contextvar leak --
+# -- raising astream is mapped to RUN_ERROR + no contextvar leak --
 
 async def test_frame_path_raising_astream_emits_run_error_and_resets_context():
-    """CPK-7719 #4: if ``astream`` (or ``__aiter__``) raises, the driver must
+    """If ``astream`` (or ``__aiter__``) raises, the driver must
     (a) map it through the RUN_ERROR taxonomy — not let it escape the generator
     with no terminal event — and (b) never leak the ``flow_context`` token into
     the caller's context. Pre-fix, ``astream()``/``__aiter__()`` sat before the
@@ -1018,10 +1018,10 @@ async def test_frame_path_raising_astream_emits_run_error_and_resets_context():
     assert flow_context.get(None) is None
 
 
-# -- CPK-7719 #5: drain the terminal tail; don't cancel kickoff mid-finalize ---
+# -- drain the terminal tail; don't cancel kickoff mid-finalize ---
 
 async def test_frame_path_drains_tail_after_run_finished():
-    """CPK-7719 #5: after RUN_FINISHED the driver drains the frame stream to
+    """After RUN_FINISHED the driver drains the frame stream to
     natural exhaustion (so crewai's kickoff task finishes finalization) instead
     of breaking immediately and letting aclose() cancel it. A frame arriving
     AFTER flow_finished is consumed (drained) but produces no wire event."""
@@ -1063,7 +1063,7 @@ async def test_frame_path_drains_tail_after_run_finished():
 
 @requires_stream_frames
 async def test_frame_path_does_not_cancel_kickoff_after_finish():
-    """CPK-7719 #5 (real Flow): on the happy path the kickoff task must finish
+    """Real Flow: on the happy path the kickoff task must finish
     finalization — result recorded, not cancelled. Pre-fix the driver broke on
     RUN_FINISHED and the finally's aclose() cancelled the still-finalizing task
     on EVERY run (session ended is_cancelled=True with no result); verified
@@ -1100,7 +1100,7 @@ async def test_frame_path_does_not_cancel_kickoff_after_finish():
     assert session.result == "RESULT"
 
 
-# -- PNI-130: MCP events surface through the SHIPPED frame-path sink ----------
+# -- MCP events surface through the SHIPPED frame-path sink ----------
 
 class _MCPEmittingFlow(Flow):
     """Emits crewai MCP events (connection lifecycle + a tool execution) with a
@@ -1134,7 +1134,7 @@ class _MCPEmittingFlow(Flow):
 
 @requires_stream_frames
 async def test_frame_path_surfaces_mcp_tool_calls():
-    """PNI-130: agent-sourced MCP events surface through the real
+    """Agent-sourced MCP events surface through the real
     ``_run_flow_frame_stream`` sink as TOOL_CALL_* (tool executions) and CUSTOM
     (connection lifecycle), inside a single RUN_STARTED/RUN_FINISHED envelope."""
     from ag_ui.encoder import EventEncoder

--- a/integrations/crew-ai/python/tests/test_task_cancellation.py
+++ b/integrations/crew-ai/python/tests/test_task_cancellation.py
@@ -1,5 +1,5 @@
 """
-Tests for Defect B: orphaned kickoff task and missing timeout in the CrewAI
+Tests for the orphaned kickoff task and missing timeout in the CrewAI
 FastAPI endpoint.
 
 The event-generator in ``add_crewai_flow_fastapi_endpoint`` used to spawn the
@@ -72,7 +72,7 @@ class _HangingFlow:
 class _ExplodingFlow:
     """A flow whose ``kickoff_async`` raises immediately.
 
-    Used to pin down finding #3: kickoff-task exceptions must be raced
+    Used to pin down that kickoff-task exceptions must be raced
     against the queue and surfaced as ``RUN_ERROR`` promptly, not held
     hostage by the flow-timeout ceiling.
     """
@@ -95,8 +95,8 @@ class _FakeCrew:
     to be accepted by ``add_crewai_crew_fastapi_endpoint`` as the ``crew``
     argument. To catch accidental surface-additions (a future refactor
     that starts calling ``crew.<method>`` at request time would silently
-    "succeed" under a plain stub), we raise on any attribute access.
-    Finding #12 — spy pattern.
+    "succeed" under a plain stub), we raise on any attribute access
+    (spy pattern).
     """
 
     def __getattr__(self, name):  # noqa: D401
@@ -183,7 +183,7 @@ def _parse_sse_payloads(raw: str) -> list[dict]:
         ]
         if not data_lines:
             continue
-        # Defensive invariant (finding #13): each SSE frame produced by
+        # Defensive invariant: each SSE frame produced by
         # EventEncoder carries exactly one ``data:`` line per payload.
         # A regression that pretty-prints JSON (inserting embedded blank
         # lines) would split the frame across the ``\n\n`` separator and
@@ -208,8 +208,8 @@ def _parse_sse_payloads(raw: str) -> list[dict]:
 
 class _CompletingFlow:
     """A flow whose ``kickoff_async`` returns cleanly WITHOUT the listener
-    having enqueued a ``None`` sentinel. Used to pin the CPU-spin regression
-    (finding #1): if the main loop keeps re-creating get_task and waiting on
+    having enqueued a ``None`` sentinel. Used to pin the CPU-spin regression:
+    if the main loop keeps re-creating get_task and waiting on
     ``{get_task, kickoff_task}`` after ``kickoff_task.done()``, it spins.
     """
 
@@ -338,7 +338,7 @@ async def test_flow_timeout_env_var_bounds_execution(monkeypatch, factory):
     # exposed as event-level extras. We emit extras camelCased (``threadId``
     # / ``runId``) so the wire format lines up with peer events
     # (RunStartedEvent / RunFinishedEvent) whose declared fields are
-    # camelCased by the alias generator. Finding #3: snake_case extras on
+    # camelCased by the alias generator. snake_case extras on
     # RunErrorEvent were a protocol inconsistency.
     assert "t-1" in error_msg and "r-1" in error_msg, (
         f"RunErrorEvent message should carry thread/run correlation; got: {error_msg!r}"
@@ -365,7 +365,7 @@ async def test_flow_timeout_env_var_bounds_execution(monkeypatch, factory):
         f"got: {err.get('code')!r}"
     )
 
-    # Finding #8: RUN_ERROR must be terminal on the timeout path. A regression
+    # RUN_ERROR must be terminal on the timeout path. A regression
     # that emits both RUN_FINISHED and RUN_ERROR would still parse — this
     # assertion pins the contract that only RUN_ERROR appears.
     all_types = [p.get("type") for p in payloads]
@@ -377,7 +377,7 @@ async def test_flow_timeout_env_var_bounds_execution(monkeypatch, factory):
         f"RUN_ERROR must be the terminal event on the timeout path; "
         f"got trailing type={payloads[-1].get('type')!r} all={all_types!r}"
     )
-    # Finding #4: the previous assertion scanned for ``event:`` header
+    # The previous assertion scanned for ``event:`` header
     # lines, but EventEncoder's SSE format emits only ``data:`` frames —
     # the scan is vacuously empty, so the assertion was silently passing
     # regardless of whether RUN_FINISHED was present at the wire layer.
@@ -389,7 +389,7 @@ async def test_flow_timeout_env_var_bounds_execution(monkeypatch, factory):
 async def test_kickoff_exception_is_surfaced_promptly(monkeypatch, factory):
     """If ``kickoff_async`` itself raises, the stream must surface the real
     cause as a ``RUN_ERROR`` event without waiting for the flow-timeout
-    ceiling to fire. Red-green pin for finding #3.
+    ceiling to fire.
     """
     # Set a generous flow ceiling so that if the fix regresses (loop blocks on
     # queue.get instead of racing the kickoff task), the test would have to
@@ -418,8 +418,7 @@ async def test_kickoff_exception_is_surfaced_promptly(monkeypatch, factory):
             drained.append(chunk)
 
     # 15s is dramatically shorter than the 30s env-var ceiling; if the
-    # kickoff race is missing or broken, this wait_for raises (finding
-    # #20: earlier comment said 5s but was already bumped to 15s).
+    # kickoff race is missing or broken, this wait_for raises.
     await asyncio.wait_for(_drain(), timeout=15.0)
 
     parts = [p.decode("utf-8", errors="replace") if isinstance(p, (bytes, bytearray)) else p
@@ -441,7 +440,7 @@ async def test_kickoff_exception_is_surfaced_promptly(monkeypatch, factory):
         f"kickoff exceptions should use the FLOW_ERROR code family, not "
         f"FLOW_TIMEOUT; got code={code!r}"
     )
-    # CR8 MEDIUM: ``_sanitize_exception_code`` upper-cases the class name
+    # ``_sanitize_exception_code`` upper-cases the class name
     # and replaces non ``[A-Z0-9_]`` characters with underscore so the
     # composed code field matches the ``^[A-Z][A-Z0-9_]+$`` convention
     # peer events follow. ``RuntimeError`` is pure-ASCII alnum so it
@@ -453,7 +452,7 @@ async def test_kickoff_exception_is_surfaced_promptly(monkeypatch, factory):
 
     # Coarse message: must carry correlation; must NOT leak the raw
     # exception repr (which contained our unique marker) NOR duplicate the
-    # class name (which already lives in the ``code`` field). Finding #5.
+    # class name (which already lives in the ``code`` field).
     message = err.get("message", "")
     assert "t-1" in message and "r-1" in message, (
         f"RunErrorEvent message should carry thread/run correlation; got: {message!r}"
@@ -473,21 +472,18 @@ async def test_kickoff_exception_is_surfaced_promptly(monkeypatch, factory):
         f"in code={code!r}); got: {message!r}"
     )
 
-    # Correlation extras should still be present, camelCased (finding #3).
+    # Correlation extras should still be present, camelCased.
     assert err.get("threadId") == "t-1", err
     assert err.get("runId") == "r-1", err
     assert "thread_id" not in err, err
     assert "run_id" not in err, err
 
 
-# -- R3 additions ----------------------------------------------------------
-
-
 @pytest.mark.parametrize("factory", ["flow", "crew"])
 async def test_happy_path_no_spin_when_kickoff_completes_without_sentinel(
     monkeypatch, factory
 ):
-    """Finding #1: if ``kickoff_async`` returns cleanly but no ``None``
+    """If ``kickoff_async`` returns cleanly but no ``None``
     sentinel is enqueued (listener disabled, misfire, or future refactor),
     the generator must NOT spin on ``asyncio.wait({get_task, kickoff_task})``
     — which always returns immediately because ``kickoff_task`` is already
@@ -530,7 +526,7 @@ async def test_happy_path_no_spin_when_kickoff_completes_without_sentinel(
 
     assert flow.done.is_set(), "kickoff must have completed"
 
-    # Positive pin (finding #11): the happy-path-no-sentinel flow
+    # Positive pin: the happy-path-no-sentinel flow
     # should produce an empty payload list (the flow emits nothing, no
     # listeners fire, no ``None`` sentinel is delivered). Asserting
     # ``payloads == []`` pins that we neither drop nor fabricate events
@@ -554,7 +550,7 @@ async def test_happy_path_no_spin_when_kickoff_completes_without_sentinel(
 
 @pytest.mark.parametrize("factory", ["flow", "crew"])
 async def test_run_error_wire_format_camelcase_extras(monkeypatch, factory):
-    """Finding #3: verify by-alias round-trip of the RunErrorEvent wire
+    """Verify by-alias round-trip of the RunErrorEvent wire
     payload. ``threadId`` / ``runId`` must be present, snake_case variants
     must not. A targeted assertion — independent of the broader timeout test
     — so a regression to snake_case is caught even if other assertions drift.
@@ -599,12 +595,12 @@ async def test_run_error_wire_format_camelcase_extras(monkeypatch, factory):
 class _RaceFlow:
     """Flow that completes quickly after enqueueing a single event.
 
-    Used to pin the cancel-race invariant (R4 HIGH #1): the main loop
+    Used to pin the cancel-race invariant: the main loop
     must not silently drop an item delivered to ``get_task`` between
     ``asyncio.wait`` returning and the ``finally`` cancelling it.
 
-    CR6-7 LOW #3 / CR6-6 LOW #2: the registry is supplied by the test
-    rather than held in a module-level global. A module-level global
+    The registry is supplied by the test rather than held in a
+    module-level global. A module-level global
     ``dict`` is xdist-unsafe (process-parallel workers share import-time
     state via ``pickle``-ish boundaries, but mutating module state
     across parametrized cases serialised on one worker is still a
@@ -633,7 +629,7 @@ class _RaceFlow:
 
 @pytest.fixture
 def _race_queue_registry() -> dict:
-    """Per-test queue registry for ``_RaceFlow`` (CR6-7 LOW #3).
+    """Per-test queue registry for ``_RaceFlow``.
 
     Replaces the prior module-level ``_MODULE_QUEUE_REGISTRY`` global.
     Scoping to the test fixture keeps the side-channel local to the
@@ -647,7 +643,7 @@ def _race_queue_registry() -> dict:
 async def test_cancel_race_does_not_drop_delivered_queue_item(
     monkeypatch, factory, _race_queue_registry
 ):
-    """R4 HIGH #1: if ``get_task`` is cancelled but had already been
+    """If ``get_task`` is cancelled but had already been
     delivered a queue item, the item must be yielded (or the cancel must
     not happen). The cancel-race guard in the ``finally`` clause harvests
     ``get_task.result()`` before discarding.
@@ -658,7 +654,7 @@ async def test_cancel_race_does_not_drop_delivered_queue_item(
     same scheduler tick; we simulate the timing by running many rounds
     and asserting that the event is delivered every time.
 
-    Amplification-style probe (CR6-6 LOW #3): this test runs 10
+    Amplification-style probe: this test runs 10
     independent rounds to amplify the timing-dependent race signal.
     The regression it pins does not reproduce deterministically in
     userspace — the scheduler may or may not surface the race on any
@@ -734,11 +730,11 @@ class _LateEnqueueFlow:
     before returning from ``kickoff_async``. The enqueue fires the scheduler
     tick AFTER ``kickoff_task.done()`` becomes true.
 
-    Used to pin R4 MEDIUM #3: the happy-path drain must not break on the
+    Used to pin that the happy-path drain must not break on the
     first empty probe — it must yield once and probe again to catch a
     late-arriving listener enqueue (otherwise the event is silently dropped).
 
-    R5 MEDIUM #9: the deferred-put task is retained on the instance so
+    The deferred-put task is retained on the instance so
     tests can cancel/await it during cleanup; a fire-and-forget
     ``create_task`` would occasionally leave a pending task on the loop
     at test teardown.
@@ -775,7 +771,7 @@ class _LateEnqueueFlow:
                 q.put_nowait(event)
 
         # Retain a handle so tests can tear the task down deterministically
-        # (R5 MEDIUM #9: previously fire-and-forget).
+        # (previously fire-and-forget).
         self._deferred_task = asyncio.create_task(_deferred_put())
         self.done.set()
 
@@ -795,7 +791,7 @@ class _LateEnqueueFlow:
 async def test_happy_path_drain_captures_late_listener_enqueue(
     monkeypatch, _race_queue_registry
 ):
-    """R4 MEDIUM #3: after ``kickoff_task.done()``, the drain loop must
+    """After ``kickoff_task.done()``, the drain loop must
     yield to the event loop and re-probe the queue — otherwise a
     listener that enqueues in the tick immediately after kickoff's
     return is silently dropped.
@@ -853,7 +849,7 @@ async def test_happy_path_drain_captures_late_listener_enqueue(
         f"got types={types!r}"
     )
 
-    # R5 MEDIUM #9: await the deferred enqueue task so it does not leak
+    # Await the deferred enqueue task so it does not leak
     # into later tests as a pending task on the event loop.
     await flow.await_deferred()
 
@@ -862,14 +858,14 @@ async def test_happy_path_drain_captures_late_listener_enqueue(
 async def test_happy_path_drain_captures_multi_tick_late_enqueue(
     monkeypatch, delay_ticks, _race_queue_registry
 ):
-    """R5 HIGH #3 red-green: a listener enqueue that needs >1 scheduler
+    """A listener enqueue that needs >1 scheduler
     tick after ``kickoff_task.done()`` to materialise must still be
-    delivered. Pre-R5 the drain performed at most 2 passes (with a
+    delivered. The prior drain performed at most 2 passes (with a
     single ``sleep(0)`` between) and early-returned on the first empty
     pass — a listener whose ``call_soon`` chain fires 3+ ticks later
     would be silently dropped.
 
-    Post-R5 the drain keeps looping while any pass drains something OR
+    Now the drain keeps looping while any pass drains something OR
     while we have consecutive-empty budget (two empty passes) AND the
     ``_DRAIN_MAX_PASSES`` / ``_DRAIN_BUDGET_SECONDS`` caps remain.
     """
@@ -925,7 +921,7 @@ async def test_happy_path_drain_captures_multi_tick_late_enqueue(
 
 
 def test_flow_timeout_nan_falls_back_to_default(monkeypatch):
-    """R4 LOW #17: ``float('nan') > 0`` is False, which would silently
+    """``float('nan') > 0`` is False, which would silently
     disable the ceiling. A NaN env var must fall back to the default.
     """
     from ag_ui_crewai import endpoint as ep
@@ -939,7 +935,7 @@ def test_flow_timeout_nan_falls_back_to_default(monkeypatch):
 
 
 def test_cancel_join_timeout_env_override(monkeypatch):
-    """R4 MEDIUM #8: operators must be able to tune the teardown ceiling
+    """Operators must be able to tune the teardown ceiling
     via AGUI_CREWAI_CANCEL_JOIN_TIMEOUT_SECONDS to reduce tail latency
     under disconnect-heavy load.
     """
@@ -962,11 +958,11 @@ def test_cancel_join_timeout_env_override(monkeypatch):
 
 
 async def test_get_flow_is_serialized_under_concurrent_first_requests(monkeypatch):
-    """R4 MEDIUM #6: two concurrent first-requests must not both
+    """Two concurrent first-requests must not both
     construct ``ChatWithCrewFlow`` — that constructor issues a real LLM
     call and is expensive.
 
-    Scope note (R5 MEDIUM #5): ``ChatWithCrewFlow.__init__`` is
+    Scope note: ``ChatWithCrewFlow.__init__`` is
     synchronous. The constructor IS slow (it issues a real LLM call), but
     from the event loop's perspective it runs to completion on a single
     tick — it cannot interleave with another coroutine via ``await``.
@@ -988,8 +984,8 @@ async def test_get_flow_is_serialized_under_concurrent_first_requests(monkeypatc
     interleave their reads of ``_cached_flow`` if ``_get_flow`` awaits
     any schedulable work between the check and the cache write.
 
-    CR6-7 LOW #5: reviewer suggested strengthening by monkeypatching
-    ``__init__`` to include ``await asyncio.sleep(0)``. That is
+    Strengthening this by monkeypatching ``__init__`` to include
+    ``await asyncio.sleep(0)`` was considered. That is
     syntactically impossible — Python's sync ``__init__`` cannot host
     an ``await`` — and the ``_get_flow`` double-check inside the
     ``async with`` critical section means a no-op lock substitute still
@@ -1067,7 +1063,7 @@ async def test_get_flow_is_serialized_under_concurrent_first_requests(monkeypatc
 
 
 async def test_cancel_and_join_outer_cancel_bounded_by_monotonic_deadline(monkeypatch):
-    """Finding #2 + #7: verify the teardown window stays bounded when the
+    """Verify the teardown window stays bounded when the
     outer scope is cancelled mid-teardown. The post-fix implementation
     uses a shared monotonic deadline, so the combined wait of the inner
     shielded ``wait_for`` plus the CancelledError-branch ``wait_for`` must
@@ -1076,7 +1072,7 @@ async def test_cancel_and_join_outer_cancel_bounded_by_monotonic_deadline(monkey
     """
     # Shrink the teardown ceiling so the test is fast and the regression
     # signature (2x → 1x) is clearly distinguishable from scheduling jitter.
-    # CR7 MEDIUM: drive this via the public env var rather than stabbing
+    # Drive this via the public env var rather than stabbing
     # the module constant — that exercises the full parse pipeline in
     # ``_cancel_join_timeout_seconds`` (float(), isfinite, >0 guard)
     # rather than short-circuiting it at the constant-read site.
@@ -1117,18 +1113,18 @@ async def test_cancel_and_join_outer_cancel_bounded_by_monotonic_deadline(monkey
     # Outer cancel: triggers the CancelledError branch inside _cancel_and_join.
     driver.cancel()
 
-    # R5 LOW #17: use ``time.monotonic()`` for parity with
-    # ``_cancel_and_join``'s internal deadline math; ``loop.time()`` was
-    # an unnecessary divergence and on some platforms has different
-    # resolution characteristics than ``time.monotonic()``.
+    # Use ``time.monotonic()`` for parity with ``_cancel_and_join``'s
+    # internal deadline math; ``loop.time()`` was an unnecessary
+    # divergence and on some platforms has different resolution
+    # characteristics than ``time.monotonic()``.
     # Resolve the ceiling through the helper that reads the env var, so
     # the bound matches what ``_cancel_and_join`` actually uses under
-    # the monkeypatched env (CR7 MEDIUM).
+    # the monkeypatched env.
     ceiling = ep._cancel_join_timeout_seconds()
 
     start = time.monotonic()
     try:
-        # CR8 MEDIUM: bound = ceiling * 3.0 rather than ``ceiling +
+        # bound = ceiling * 3.0 rather than ``ceiling +
         # 0.4``. With ceiling=0.5 the additive slack (0.4s) leaves
         # only ~0.4s of CI scheduler jitter before the test flakes;
         # ``* 3.0`` scales with the ceiling and is strictly tighter
@@ -1152,8 +1148,7 @@ async def test_cancel_and_join_outer_cancel_bounded_by_monotonic_deadline(monkey
     assert elapsed <= bound, (
         f"_cancel_and_join outer-cancel teardown exceeded single-ceiling "
         f"window; elapsed={elapsed:.3f}s, "
-        f"ceiling={ceiling}s bound={bound}s "
-        f"(finding #7 regression)"
+        f"ceiling={ceiling}s bound={bound}s"
     )
 
     # Clean up the absorb-cancel task cleanly.
@@ -1176,7 +1171,7 @@ class _UpstreamTimeoutFlow:
     (``timeout=None``) — otherwise the ``timeout:g`` formatting crashes
     with ``TypeError: unsupported format string passed to
     NoneType.__format__`` and the client sees an abruptly terminated
-    stream instead of a correlated RunErrorEvent. CR6-4 LOW.
+    stream instead of a correlated RunErrorEvent.
     """
 
     def __init__(self) -> None:
@@ -1196,7 +1191,7 @@ class _UpstreamTimeoutFlow:
 async def test_upstream_timeout_distinct_from_ceiling_timeout_when_ceiling_disabled(
     monkeypatch, factory
 ):
-    """CR7 CRITICAL: upstream ``TimeoutError`` bubbling out of
+    """Upstream ``TimeoutError`` bubbling out of
     ``kickoff_async`` must NOT be classified as a flow-ceiling timeout
     when the ceiling is disabled.
 
@@ -1274,7 +1269,7 @@ async def test_upstream_timeout_distinct_from_ceiling_timeout_when_ceiling_disab
         f"RunErrorEvent must not surface a NoneType-formatting error; "
         f"got: {error_msg!r}"
     )
-    # CR7 CRITICAL: the code must distinguish upstream timeouts from
+    # The code must distinguish upstream timeouts from
     # ceiling-fired timeouts. This is the load-bearing assertion —
     # pre-fix emitted AGUI_CREWAI_FLOW_TIMEOUT here, which is what
     # downstream alerting treats as "our configured ceiling tripped".
@@ -1309,7 +1304,7 @@ async def test_upstream_timeout_distinct_from_ceiling_timeout_when_ceiling_disab
 class _HangingLongerThanCeilingFlow:
     """A flow whose ``kickoff_async`` hangs longer than our ceiling.
 
-    Used to pin the ceiling-fired path (CR7 CRITICAL): our monotonic
+    Used to pin the ceiling-fired path: our monotonic
     deadline / ``asyncio.wait`` timeout must raise ``_CeilingExceeded``
     (not a bare ``TimeoutError``) so the dedicated handler emits
     ``AGUI_CREWAI_FLOW_TIMEOUT`` with "exceeded ceiling=<value>s".
@@ -1335,7 +1330,7 @@ class _HangingLongerThanCeilingFlow:
 async def test_ceiling_fired_emits_flow_timeout_code_distinct_from_upstream(
     monkeypatch, factory
 ):
-    """CR7 CRITICAL: the ceiling-fired path must keep emitting
+    """The ceiling-fired path must keep emitting
     ``AGUI_CREWAI_FLOW_TIMEOUT`` with "exceeded ceiling=<value>s".
 
     Complement to ``test_upstream_timeout_distinct_from_ceiling_timeout``
@@ -1414,13 +1409,8 @@ async def test_ceiling_fired_emits_flow_timeout_code_distinct_from_upstream(
     )
 
 
-# -- CR8 round additions ----------------------------------------------------
-
-
 async def test_cancelled_kickoff_emits_run_error(monkeypatch):
-    """CR8 HIGH #2 red-green pin.
-
-    If ``kickoff_task`` enters the main-loop fast path in a
+    """If ``kickoff_task`` enters the main-loop fast path in a
     ``done() and cancelled()`` state, the stream MUST emit a
     ``RUN_ERROR`` event with ``code=AGUI_CREWAI_KICKOFF_CANCELLED``
     before closing. Pre-fix the code silently fell through (drained,
@@ -1447,7 +1437,7 @@ async def test_cancelled_kickoff_emits_run_error(monkeypatch):
     flow = _HangingFlow()
 
     # Wrap ``asyncio.create_task`` scoped to the endpoint module so the
-    # task returned to the generator is pre-cancelled. CR9 HIGH: we
+    # task returned to the generator is pre-cancelled. We
     # patch ``ep.asyncio.create_task`` rather than the global
     # ``asyncio.create_task`` to narrow the blast radius — a broad patch
     # on the shared asyncio module can be observed by any concurrent
@@ -1525,7 +1515,7 @@ class _WeirdExceptionFlow:
     """A flow whose ``kickoff_async`` raises a custom exception whose
     ``__name__`` contains characters outside ``[A-Z0-9_]``.
 
-    Used to pin CR8 MEDIUM (sanitize exception class name). The
+    Used to pin sanitization of the exception class name. The
     composed ``code`` field must match the ``^[A-Z][A-Z0-9_]+$``
     convention peer events follow — a raw ``type(e).__name__`` with
     lowercase letters or digits mid-name or even unicode could
@@ -1543,7 +1533,7 @@ class _WeirdExceptionFlow:
 
 
 async def test_custom_exception_class_name_is_sanitized_in_code(monkeypatch):
-    """CR8 MEDIUM red-green: the ``code`` field on a generic
+    """The ``code`` field on a generic
     FLOW_ERROR must be sanitized so exotic exception class names do
     not violate the ``^[A-Z][A-Z0-9_]+$`` convention peer events use.
 
@@ -1605,7 +1595,7 @@ async def test_custom_exception_class_name_is_sanitized_in_code(monkeypatch):
 
 
 def test_sanitize_exception_code_direct():
-    """CR8 MEDIUM unit test: sanitize replaces non ``[A-Z0-9_]`` chars
+    """Sanitize replaces non ``[A-Z0-9_]`` chars
     with ``_`` and upper-cases the result.
 
     Covers edge cases the integration test above cannot easily
@@ -1621,20 +1611,20 @@ def test_sanitize_exception_code_direct():
     assert _sanitize_exception_code("my-error") == "MY_ERROR"
     # Unicode: non-ASCII characters replaced with _, then the trailing
     # underscore is stripped so the composed wire code doesn't end in
-    # ``_`` (CR9 LOW — the prior output ``ERRORX_`` produced wire codes
+    # ``_`` (the prior output ``ERRORX_`` produced wire codes
     # like ``AGUI_CREWAI_FLOW_ERROR_ERRORX_`` with a trailing
     # underscore that looked ugly in alerting).
     assert _sanitize_exception_code("ErrorX\u00e9") == "ERRORX"
     # Spaces replaced.
     assert _sanitize_exception_code("Weird Exception") == "WEIRD_EXCEPTION"
-    # CR9 LOW: consecutive non-[A-Z0-9_] runs collapse to a single
+    # Consecutive non-[A-Z0-9_] runs collapse to a single
     # underscore so the composed code stays greppable — prior behaviour
     # produced ``WEIRD___EXCEPTION`` for a name like "Weird---Exception".
     assert _sanitize_exception_code("Weird---Exception") == "WEIRD_EXCEPTION"
-    # CR9 LOW: leading/trailing underscores stripped.
+    # Leading/trailing underscores stripped.
     assert _sanitize_exception_code("_leading") == "LEADING"
     assert _sanitize_exception_code("trailing_") == "TRAILING"
-    # CR9 LOW: if the cleaned result is empty or does not start with
+    # If the cleaned result is empty or does not start with
     # [A-Z] (all-digits / all-unicode), prefix ``E_`` so the composed
     # wire code still matches ``^[A-Z][A-Z0-9_]+$``.
     assert _sanitize_exception_code("42").startswith("E_")
@@ -1645,7 +1635,7 @@ def test_sanitize_exception_code_direct():
 
 
 def test_run_started_and_run_error_share_alias_policy():
-    """CR8 LOW (alias policy pin): ``_run_error_extras`` derives the
+    """Alias policy pin: ``_run_error_extras`` derives the
     wire-level ``threadId`` / ``runId`` aliases from
     ``RunStartedEvent.model_fields`` on the load-bearing assumption
     that ``RunStartedEvent`` and ``RunErrorEvent`` share the same
@@ -1693,11 +1683,8 @@ def test_run_started_and_run_error_share_alias_policy():
         )
 
 
-# -- CR9 round additions ----------------------------------------------------
-
-
 def test_stamp_correlation_ids_covers_events_with_the_fields():
-    """CR9 MEDIUM red-green: the correlation-id stamp helper must
+    """The correlation-id stamp helper must
     stamp ANY event object that declares ``thread_id`` / ``run_id``
     fields, not only the ``RUN_STARTED`` / ``RUN_FINISHED`` pair the
     pre-fix main-loop enumerated by type code. Future ag-ui.core events
@@ -1722,7 +1709,7 @@ def test_stamp_correlation_ids_covers_events_with_the_fields():
 
 
 def test_stamp_correlation_ids_noop_for_events_without_the_fields():
-    """CR9 MEDIUM: events whose schema does not declare the fields
+    """Events whose schema does not declare the fields
     (StepStartedEvent, MessagesSnapshotEvent, etc.) must be left
     UNTOUCHED — we do not add stray ``thread_id`` / ``run_id``
     attributes that would change their wire format on-write.
@@ -1739,7 +1726,7 @@ def test_stamp_correlation_ids_noop_for_events_without_the_fields():
 
 
 async def test_create_queue_stamp_ordering_no_stamped_but_unregistered_window(monkeypatch):
-    """CR9 LOW red-green: ``create_queue`` must insert into ``QUEUES``
+    """``create_queue`` must insert into ``QUEUES``
     BEFORE stamping ``_agui_queue_key`` on the flow so a concurrent
     ``get_queue(flow)`` never observes the attr pointing at a
     not-yet-inserted key.
@@ -1775,7 +1762,7 @@ async def test_create_queue_stamp_ordering_no_stamped_but_unregistered_window(mo
 
 
 async def test_get_task_result_cancelled_falls_back_to_unset(monkeypatch):
-    """CR9 LOW red-green: if ``get_task`` completes but is cancelled
+    """If ``get_task`` completes but is cancelled
     (e.g. a concurrent outer-cancel propagated into it), reading
     ``get_task.result()`` raises CancelledError. Pre-fix that bypassed
     the ``except _CeilingExceeded`` / ``except Exception`` handlers in
@@ -1801,7 +1788,7 @@ async def test_get_task_result_cancelled_falls_back_to_unset(monkeypatch):
 
 
 async def test_teardown_future_exception_is_retrieved_on_timeout():
-    """CR9 MEDIUM red-green: the post-grace / grace-path teardown
+    """The post-grace / grace-path teardown
     futures must mark their stored ``TimeoutError`` as retrieved so the
     GC does not log ``Task exception was never retrieved`` when the
     recovery wait is itself cancelled and we re-raise the outer cancel
@@ -1857,7 +1844,7 @@ async def test_teardown_future_exception_is_retrieved_on_timeout():
 
 
 async def test_conftest_preserves_external_bus_handlers_across_tests():
-    """CR9 MEDIUM red-green: the autouse conftest fixture must
+    """The autouse conftest fixture must
     snapshot/restore the crewai bus handlers rather than ``clear()``
     them wholesale. Prior behaviour wiped ALL handlers between tests —
     including any registered by another library in the same process.
@@ -1868,7 +1855,7 @@ async def test_conftest_preserves_external_bus_handlers_across_tests():
     then asserting the handler is still present at teardown — approximated
     here by re-reading the dict at the end of the test body.
 
-    CPK-7718 #4: crewai 1.0.0 split ``_handlers`` into ``_sync_handlers`` /
+    crewai 1.0.0 split ``_handlers`` into ``_sync_handlers`` /
     ``_async_handlers``; probe whichever the installed crewai exposes.
     """
     from ag_ui_crewai import endpoint as ep  # noqa: F401 - ensures conftest imported
@@ -1901,15 +1888,14 @@ async def test_conftest_preserves_external_bus_handlers_across_tests():
         # by direct observation: the stale GLOBAL wipe would blow away
         # the external key; a correct snapshot/restore preserves it.
         assert handlers.get(sentinel_key) == [sentinel_handler], (
-            "external subscriber dropped by conftest wipe; CR9 MEDIUM "
-            "regression"
+            "external subscriber dropped by conftest wipe regression"
         )
     finally:
         handlers.pop(sentinel_key, None)
 
 
 def test_alias_warn_seen_is_cleared_by_autouse_fixture():
-    """CR9 MEDIUM: the autouse fixture must reset the
+    """The autouse fixture must reset the
     ``_ALIAS_WARN_SEEN`` dedup set between tests so a prior test that
     observed an alias divergence does not suppress the WARN in a later
     test. We verify the fixture invariant at test start — the set
@@ -1918,13 +1904,13 @@ def test_alias_warn_seen_is_cleared_by_autouse_fixture():
     from ag_ui_crewai import endpoint as ep
 
     assert ep._ALIAS_WARN_SEEN == set(), (
-        "autouse fixture did not clear _ALIAS_WARN_SEEN; CR9 MEDIUM "
-        f"regression. leftover={ep._ALIAS_WARN_SEEN!r}"
+        "autouse fixture did not clear _ALIAS_WARN_SEEN; "
+        f"leftover={ep._ALIAS_WARN_SEEN!r}"
     )
 
 
 async def test_run_started_finished_have_correct_thread_id_via_stamp_helper():
-    """CR9 MEDIUM integration red-green: a flow whose
+    """A flow whose
     ``FlowStartedEvent`` fires must ship a ``RunStartedEvent`` on the
     wire whose ``thread_id`` / ``run_id`` carry the input-data
     correlation — NOT the listener's ``"?"`` placeholders. The
@@ -1988,7 +1974,7 @@ async def test_run_started_finished_have_correct_thread_id_via_stamp_helper():
 
 
 def test_kickoff_cancelled_message_wording_aligned_with_code():
-    """CR9 LOW red-green: the client-facing RunErrorEvent message on
+    """The client-facing RunErrorEvent message on
     the externally-cancelled-kickoff path must say "kickoff was
     cancelled" — aligning with the internal ``_KickoffCancelled``
     sentinel ("CrewAI kickoff task was cancelled"), the wire code
@@ -2004,7 +1990,7 @@ def test_kickoff_cancelled_message_wording_aligned_with_code():
     ) else inspect.getsource(ep)
     # Pre-fix wording should no longer appear; new wording must appear.
     assert "CrewAI flow was cancelled" not in src, (
-        "stale 'flow was cancelled' wording found; CR9 LOW "
+        "stale 'flow was cancelled' wording found; "
         "alignment regression"
     )
     assert "CrewAI kickoff was cancelled" in src, (


### PR DESCRIPTION
## CrewAI bridge — #2260 review follow-up hardening (8 minors)

**Why:** the #2260 review (crewai 1.x + StreamFrame) flagged three blockers and five should-fixes (all landed in #2260) plus a tail of **minor** hardening items that were deferred. This PR clears that tail. No behavior change to the happy path — these are resilience, correctness-under-edge, and hygiene fixes. Full suite **108 pass** (44 cancellation/timeout intact); crew-ai Playwright e2e re-run green (18 pass + `error_flow` skip).

### The 8 items
1. **Guarded `uncancel()`** — was called unconditionally in the frame-stream teardown, which could consume a cancellation level that wasn't ours. Now only when there's a real cancellation in flight (`cancelling() > 0` / inside a `CancelledError` handler), matching `_cancel_and_join`.
2. **Graceful capability degradation** — when `crewai` `BaseEvent`/`BaseEventListener` resolve to `None` on an unexpected wheel, the old code crashed at class-definition time (`TypeError: NoneType takes no arguments`), so the friendly "you need crewai ≥ X" warning never reached the operator. Now degrades to an inert base and warns, matching the stated "fewer capabilities, not a crash" posture.
3. **Narrowed `_first_module` except** — the capability probe swallowed *every* exception, so a genuinely broken import inside `crewai.events` misreported as "install crewai>=1.0". Narrowed to `(ImportError, ModuleNotFoundError)` so real errors surface.
4. **Skip the legacy bus listener on the StreamFrame path** — it was still registered even when `stream_frame_available`, so every bridged event paid a wasted `ThreadPoolExecutor` dispatch into a `get_queue → None` no-op. Skipped when the frame path is active (verified the fallback still emits no bus events, so no regression).
5. **Frame-retention note** — documented that `AsyncStreamSession._frames` retention is upstream crewai behavior (not ours), and noted our own `raw_events` buffer already pops consumed entries.
6. **Fail-loud copy isolation** — `_copyutil.safe_deepcopy` now asserts `copy._state is not original._state` post-copy, so a field-level pin that silently shared per-request state fails loudly instead of leaking isolation.
7. **Restored constructor-level cache coverage** — the GC test had narrowed to a direct cache-helper assertion; added `test_constructor_regenerates_inputs_after_cache_eviction` to cover the constructor invariant.
8. **`to_thread` cancellation note** — documented that a disconnected `crew.kickoff` running under `asyncio.to_thread` keeps burning tokens to completion (the worker thread can't be interrupted).

### Tests
New: `tests/test_capabilities.py` (5 — `_first_module` behavior + import-degradation, the latter isolated in a subprocess since in-process reload poisons exact-type dispatch), `tests/test_copyutil.py` (4 — healthy isolation, pin-and-share, fail-loud guard, no-op), `tests/test_crew_chat.py` (+1). `uv run pytest -q` → 108 pass; ruff + `uv lock --check` clean.

### Not here
The Conversational-Flows rewrite (PNI-144) that these were originally batched under is **descoped** — Conversational Flows can't back the AG-UI crew path on crewai 1.15.7 (experimental, sync-only stream, no tool model); revisit tracked in PNI-178. `ChatWithCrewFlow` stays.
