### PR TITLE
feat(crewai): surface MCP tool calls as TOOL_CALL_* events (PNI-130)

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -37,11 +37,19 @@ SWAPPABLE EMISSION SHAPE (cross-lane constraint, CPK-7719): CrewAI is currently
 the only integration emitting TEXT_MESSAGE_CHUNK / TOOL_CALL_CHUNK (chunks)
 rather than the START/CONTENT/END triples the six other integrations emit. That
 final choice belongs to a Parity-lane ticket, not this migration. The translator
-therefore routes text / tool-call emission through a single ``emission_shape``
-strategy that DEFAULTS to ``"chunks"`` so this change is byte-for-byte
-behavior-preserving on the wire. The ``"triples"`` strategy is a deliberate
-NotImplementedError placeholder — the Parity ticket owns wiring it up and
-flipping the default.
+therefore routes LLM text / LLM-tool-call emission through a single
+``emission_shape`` strategy that DEFAULTS to ``"chunks"`` so this migration is
+byte-for-byte behavior-preserving on that channel. The ``"triples"`` strategy is
+a deliberate NotImplementedError placeholder — the Parity ticket owns wiring it
+up and flipping the default.
+
+MCP EVENTS (PNI-130) are the ONE exception to "chunks-only": crewai's discrete
+MCP tool executions (name + full args + result arrive together, not streamed)
+map to canonical ``TOOL_CALL_START/ARGS/END/RESULT`` triples via the shared
+``mcp.translate_mcp_event`` seam, and MCP lifecycle events map to ``CUSTOM``.
+This is independent of the ``emission_shape`` strategy above (which governs only
+the streaming LLM text / tool-call channel); see the wire-shape note in
+``mcp.py`` for why discrete MCP calls use triples regardless of PNI-136.
 """
 
 from __future__ import annotations
@@ -65,6 +73,7 @@ from ag_ui.core.events import (
 )
 
 from .sdk import litellm_messages_to_ag_ui_messages
+from .mcp import is_mcp_event, translate_mcp_event
 
 # crewai lifecycle-event ``type`` strings. Pinned as constants so a rename
 # upstream surfaces here rather than silently producing no wire events.
@@ -166,6 +175,13 @@ class StreamFrameTranslator:
             ]
         if event_type == _METHOD_FINISHED:
             return self._method_finished_events(event)
+
+        # PNI-130: crewai's first-class MCP events (crewai >= 1.4). Emitted with
+        # the agent/crew as source (not the flow), so the driver's sink parks
+        # them by TYPE rather than source identity; here they map to TOOL_CALL_*
+        # (tool executions) and CUSTOM (lifecycle) via the shared translator.
+        if is_mcp_event(event):
+            return translate_mcp_event(event)
 
         # Bridge-emitted events carry the AG-UI EventType string as ``.type``
         # and the verbatim payload on typed attributes (no ``to_serializable``).

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -30,6 +30,7 @@ from ._capabilities import (
     reset_stream_sinks,
 )
 from ._frames import StreamFrameTranslator
+from .mcp import is_mcp_event, register_mcp_listeners, translate_mcp_event
 from crewai.flow.flow import Flow
 
 from ag_ui.core import (
@@ -868,6 +869,10 @@ async def _flush_event_bus() -> None:
 
 GLOBAL_EVENT_LISTENER = None
 
+# PNI-130: process-wide warn-once guard for the "MCP event with no active flow
+# in context" legacy-path drop (see ``_on_mcp_event`` in ``setup_listeners``).
+_MCP_NO_FLOW_WARNED = False
+
 class FastAPICrewFlowEventListener(BaseEventListener):
     """FastAPI CrewFlow event listener.
 
@@ -1006,6 +1011,49 @@ class FastAPICrewFlowEventListener(BaseEventListener):
                     snapshot=event.snapshot
                 )
             )
+
+        # PNI-130: surface crewai's first-class MCP events (crewai >= 1.4) on the
+        # LEGACY bus-listener transport (crewai 1.4-1.5, StreamFrame absent).
+        # crewai emits MCP events with the agent/crew as ``source`` (NOT the
+        # Flow), so we resolve the active run via ``flow_context`` -- the same
+        # contextvar the run driver sets -- and enqueue thread-safely through
+        # ``_enqueue`` (CPK-7718 #2: handlers run on a ThreadPoolExecutor worker
+        # thread under crewai 1.x). On the StreamFrame path (crewai >= 1.6) no
+        # per-run queue is created, so ``_enqueue`` finds no queue and this is an
+        # inert no-op there; that path surfaces MCP events via the frame sink +
+        # StreamFrameTranslator instead. Below 1.4 (no ``crewai.mcp``) this logs
+        # one warning and registers nothing.
+        def _on_mcp_event(event):
+            # Receives the RAW crewai MCP event. Resolve the active run via
+            # ``flow_context`` (crewai copies the emitting context -- incl. this
+            # package's ``flow_context``, set by the run driver before the
+            # kickoff task -- into the handler's worker thread) and enqueue only
+            # when that run has a live queue.
+            flow = flow_context.get(None)
+            if flow is None:
+                # crewai's context copy makes this unexpected under the FastAPI
+                # bridge; a genuinely context-less emit (a stray event outside a
+                # run, or a future propagation regression) would otherwise vanish
+                # silently. Warn ONCE (naming the raw crewai type), not per event.
+                global _MCP_NO_FLOW_WARNED  # pylint: disable=global-statement
+                if not _MCP_NO_FLOW_WARNED:
+                    _MCP_NO_FLOW_WARNED = True
+                    _LOGGER.warning(
+                        "ag-ui-crewai: crewai MCP event %s emitted with no active "
+                        "flow in context; dropping. MCP tool calls will not "
+                        "surface on the legacy transport if this recurs.",
+                        getattr(event, "type", None),
+                    )
+                return
+            # On the StreamFrame path (crewai >= 1.6) no per-run queue exists --
+            # MCP is surfaced via the frame sink there -- so skip translation
+            # entirely rather than translate-and-discard.
+            if get_queue(flow) is None:
+                return
+            for agui_event in translate_mcp_event(event):
+                _enqueue(flow, agui_event)
+
+        register_mcp_listeners(crewai_event_bus, _on_mcp_event)
 
 
 def _format_timeout_message(timeout: float | None) -> str:
@@ -1781,7 +1829,14 @@ async def _run_flow_frame_stream(
         # ``source is flow_copy`` isolates the outer run: nested ``crew.kickoff``
         # flows emit with a DIFFERENT source (verified on the 1.15.7 wheel), and
         # our own ``Bridged*`` events are emitted with ``flow_copy`` as source.
-        if source is flow_copy:
+        #
+        # PNI-130: crewai's MCP events are emitted with the agent/crew as source
+        # (NOT flow_copy), so the source gate alone would drop them. Park them by
+        # TYPE too. This sink is context-scoped (crewai.events.stream_context), so
+        # only THIS run's MCP events (including those from nested crews) reach it
+        # -- no cross-run leakage -- and the type gate keeps nested-flow LIFECYCLE
+        # events (still source != flow_copy) filtered out as before.
+        if source is flow_copy or is_mcp_event(event):
             event_id = getattr(event, "event_id", None)
             if event_id is not None:
                 raw_events[event_id] = event

--- a/integrations/crew-ai/python/ag_ui_crewai/mcp.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/mcp.py
@@ -1,0 +1,456 @@
+"""MCP (Model Context Protocol) event bridging for ag_ui_crewai (PNI-130).
+
+CrewAI gained first-class MCP support in 1.4.0: ``Agent(mcps=[...])`` accepting
+config objects, ``crewai.mcp.MCPServer{Stdio,HTTP,SSE}``, and a family of
+``MCP*Event`` types emitted on the crewai event bus. This module is the single
+translation seam that maps those crewai events onto AG-UI protocol events:
+
+* MCP *tool executions* -> ``TOOL_CALL_*`` events, so an MCP tool call renders
+  in the UI like any other tool call. A discrete execution is surfaced
+  atomically on completion/failure as ``TOOL_CALL_START`` -> ``TOOL_CALL_ARGS``
+  -> ``TOOL_CALL_END`` -> ``TOOL_CALL_RESULT`` (see ``_tool_call_events`` for why
+  atomic-at-completion, not start/end correlation). A FAILED execution ALSO
+  emits a ``CUSTOM`` ``mcp_tool_execution_failed`` event so a client can tell a
+  failure apart from a success (the result content alone cannot be trusted to).
+* MCP *lifecycle* events (server connect started/completed/failed, config-fetch
+  failure, and the tool-execution "started" signal) -> ``CUSTOM`` events, which
+  the UI can surface as activity without confusing them with real tool calls.
+
+The translator is stateless (dispatches on ``event.type`` and reads fields via
+``getattr``; it mints fresh ids per call, so it is not pure), and is shared
+verbatim by BOTH bridge transports:
+the StreamFrame frame-translator (``_frames.StreamFrameTranslator``, crewai
+>= 1.6) and the legacy event-bus listener (``endpoint.setup_listeners``, crewai
+1.4-1.5). Statelessness also keeps it free of any per-run correlation map that
+could leak across runs or races on the process-wide listener, which protects
+cancellation/teardown.
+
+Capability detection is runtime-only (PNI-130 hard rule): ``crewai_mcp_available``
+probes ``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal -- rather than
+version-gating on a version string. ``Agent.mcps`` is deliberately NOT probed:
+it exists from crewai 1.0.0 as ``list[str]`` and cannot distinguish 1.0 from
+1.4. Below 1.4 the probe fails, ``register_mcp_listeners`` logs one warning and
+is a clean no-op.
+
+Wire-shape note (PNI-136 / PNI-145): the granular ``TOOL_CALL_START``/``ARGS``/
+``END``/``RESULT`` shape is the protocol-canonical representation of a discrete
+(non-streaming) tool call and matches the START/CONTENT/END triples the six
+non-crewai integrations emit. PNI-136's chunks-vs-triples wire-shape decision
+was still In Progress and PNI-145's StreamFrame translator defaults text /
+LLM-tool-call emission to ``chunks``; MCP executions are discrete (name + full
+args + result arrive together), so triples are the natural fit here regardless
+of how that decision lands for streaming LLM tool calls. Documented as an
+assumption; revisit if PNI-136 mandates chunks for MCP too.
+"""
+
+import json
+import logging
+import uuid
+from typing import Any, Callable, List
+
+from ag_ui.core import EventType
+from ag_ui.core.events import (
+    BaseEvent,
+    CustomEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+
+from ._capabilities import CAPABILITIES
+
+_LOGGER = logging.getLogger(__name__)
+
+# crewai MCP event ``type`` discriminators. These are the stable ``Literal``
+# values on the crewai ``MCP*Event`` classes (crewai/events/types/mcp_events.py).
+# Dispatching on the string keeps ``translate_mcp_event`` decoupled from
+# importing crewai, so the translation logic is unit-testable without crewai
+# (let alone crewai>=1.4) installed.
+MCP_CONNECTION_STARTED = "mcp_connection_started"
+MCP_CONNECTION_COMPLETED = "mcp_connection_completed"
+MCP_CONNECTION_FAILED = "mcp_connection_failed"
+MCP_TOOL_EXECUTION_STARTED = "mcp_tool_execution_started"
+MCP_TOOL_EXECUTION_COMPLETED = "mcp_tool_execution_completed"
+MCP_TOOL_EXECUTION_FAILED = "mcp_tool_execution_failed"
+MCP_CONFIG_FETCH_FAILED = "mcp_config_fetch_failed"
+
+# The full set, used by ``is_mcp_event`` to widen the StreamFrame sink's
+# source gate (MCP events are emitted with the agent/crew as ``source``, not the
+# Flow, so the sink must park them by TYPE rather than by source identity).
+MCP_EVENT_TYPES = frozenset(
+    {
+        MCP_CONNECTION_STARTED,
+        MCP_CONNECTION_COMPLETED,
+        MCP_CONNECTION_FAILED,
+        MCP_TOOL_EXECUTION_STARTED,
+        MCP_TOOL_EXECUTION_COMPLETED,
+        MCP_TOOL_EXECUTION_FAILED,
+        MCP_CONFIG_FETCH_FAILED,
+    }
+)
+
+# The 7 crewai MCP event class names, re-homed at ``crewai.events`` in 1.x. Held
+# as strings so listener registration can resolve them lazily (only on crewai
+# >= 1.4, gated by the probe).
+_MCP_EVENT_CLASS_NAMES = (
+    "MCPConnectionStartedEvent",
+    "MCPConnectionCompletedEvent",
+    "MCPConnectionFailedEvent",
+    "MCPToolExecutionStartedEvent",
+    "MCPToolExecutionCompletedEvent",
+    "MCPToolExecutionFailedEvent",
+    "MCPConfigFetchFailedEvent",
+)
+
+# Warn-once dedup, keyed by message (mirrors the spirit of the endpoint's other
+# one-shot warnings). A long-running server that registers many endpoints emits
+# each distinct MCP warning at most once.
+_WARNED: set = set()
+
+
+def is_mcp_event(event: Any) -> bool:
+    """Return True when ``event`` is a crewai MCP event we translate."""
+    return getattr(event, "type", None) in MCP_EVENT_TYPES
+
+
+# Max container nesting ``_json_safe`` descends before flattening the rest to a
+# placeholder. Well above any realistic MCP payload, well below CPython's
+# recursion limit, so pathologically deep input degrades instead of raising.
+_JSON_SAFE_MAX_DEPTH = 64
+
+
+def _json_safe(value: Any, _ancestors: frozenset = frozenset(), _depth: int = 0) -> Any:
+    """Coerce an arbitrary value into a bounded, JSON-native Python structure.
+
+    This is the single serialization-hardening primitive for the whole module:
+    ``_args_delta`` / ``_result_content`` / ``_custom`` all route through it, so
+    the "cannot raise" contract is guaranteed in ONE place rather than by
+    scattered ``try/except`` guards. The output contains only ``dict`` / ``list``
+    / ``str`` / ``int`` / ``float`` / ``bool`` / ``None``, so a subsequent
+    ``json.dumps`` (or ``encoder.encode``) on it can neither hit a non-JSON type
+    NOR recurse unboundedly.
+
+    Three guards make it total:
+
+    * A non-primitive, non-container leaf (an ``Exception``, a ``datetime``) is
+      ``str``-coerced -- shallow, so it cannot itself recurse.
+    * ``_ancestors`` tracks the ids of containers on the CURRENT path, so a
+      circular reference becomes ``"<circular>"``. A shared (non-cyclic)
+      reference is NOT flagged (the path set is copied per descent).
+    * ``_depth`` bounds nesting at ``_JSON_SAFE_MAX_DEPTH``; past it a container
+      becomes the CONSTANT ``"<max-depth>"`` (never ``str(container)``, which
+      would re-enter C-level recursion), so deep acyclic input cannot exhaust the
+      stack.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if id(value) in _ancestors:
+        return "<circular>"
+    if _depth >= _JSON_SAFE_MAX_DEPTH:
+        return "<max-depth>"
+    if isinstance(value, dict):
+        nxt = _ancestors | {id(value)}
+        return {str(k): _json_safe(v, nxt, _depth + 1) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        nxt = _ancestors | {id(value)}
+        return [_json_safe(v, nxt, _depth + 1) for v in value]
+    return str(value)
+
+
+def _text(value: Any) -> str:
+    """Coerce a value to ``str`` for a required AG-UI string field.
+
+    ``None`` -> ``""`` so an explicit ``tool_name=None`` (crewai types it ``str``,
+    but a fork / bug could pass ``None``) never trips pydantic validation on the
+    required ``ToolCallStartEvent.tool_call_name``.
+    """
+    return "" if value is None else str(value)
+
+
+def _args_delta(tool_args: Any) -> str:
+    """Serialise MCP tool args to the ``ToolCallArgsEvent.delta`` string.
+
+    Only crewai's own ``None`` default (a tool invoked with no args) becomes
+    ``"{}"``; a real falsy value is preserved (``{}`` stays ``{}``, ``0``/``""``
+    are serialised verbatim). Routing through ``_json_safe`` first bounds depth
+    and cycles, so ``json.dumps`` on the result cannot raise (contract upheld in
+    one place).
+    """
+    return json.dumps(_json_safe({} if tool_args is None else tool_args))
+
+
+def _result_content(value: Any) -> str:
+    """Coerce an MCP tool result / error to ``ToolCallResultEvent.content``.
+
+    ``content`` must be a ``str``. ``None`` (a tool that returned nothing)
+    becomes ``""`` rather than the literal ``"null"``. Strings pass through
+    verbatim; everything else is JSON-encoded via ``_json_safe`` (bounded,
+    cannot raise).
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(_json_safe(value))
+
+
+def _custom(name: str, value: Any) -> CustomEvent:
+    return CustomEvent(type=EventType.CUSTOM, name=name, value=_json_safe(value))
+
+
+def _lifecycle_value(event: Any, fields: tuple) -> dict:
+    """Project the named attributes of ``event`` into a plain dict.
+
+    Intentionally forgiving (``getattr`` with ``None`` default) so a minor
+    crewai field rename does not crash the bridge -- a missing field surfaces as
+    ``None`` in the CUSTOM payload instead.
+    """
+    return {field: getattr(event, field, None) for field in fields}
+
+
+def _tool_call_events(
+    name: str,
+    args: Any,
+    *,
+    result: Any = None,
+    error: Any = None,
+    failed: bool = False,
+) -> List[BaseEvent]:
+    """Build the atomic ``TOOL_CALL_*`` sequence for one MCP tool execution.
+
+    crewai's ``MCPToolExecution{Started,Completed,Failed}Event`` carry no tool
+    call id, so a "started" event cannot be correlated to its matching
+    "completed"/"failed" event without stateful bookkeeping keyed on
+    (server, tool, args) -- fragile under repeated/concurrent calls and prone to
+    leaking across runs on the process-wide listener. Instead the call is
+    surfaced atomically at completion/failure, where crewai hands us the tool
+    name, args, AND result/error together. A fresh ``tool_call_id`` ties the
+    events together; the in-flight signal is carried separately by the
+    ``mcp_tool_execution_started`` CUSTOM event.
+
+    On failure (``failed=True``) the RESULT carries the error text; the caller
+    (``translate_mcp_event``) appends a trailing ``mcp_tool_execution_failed``
+    CUSTOM event so a client can distinguish a failure from a success (a RESULT
+    alone cannot be trusted to signal failure). This builder returns only the
+    four TOOL_CALL_* events.
+    """
+    tool_call_id = uuid.uuid4().hex
+    events: List[BaseEvent] = [
+        ToolCallStartEvent(
+            type=EventType.TOOL_CALL_START,
+            tool_call_id=tool_call_id,
+            tool_call_name=_text(name),
+        ),
+        ToolCallArgsEvent(
+            type=EventType.TOOL_CALL_ARGS,
+            tool_call_id=tool_call_id,
+            delta=_args_delta(args),
+        ),
+        ToolCallEndEvent(
+            type=EventType.TOOL_CALL_END,
+            tool_call_id=tool_call_id,
+        ),
+        ToolCallResultEvent(
+            type=EventType.TOOL_CALL_RESULT,
+            message_id=uuid.uuid4().hex,
+            tool_call_id=tool_call_id,
+            content=_result_content(error if failed else result),
+            role="tool",
+        ),
+    ]
+    return events
+
+
+def translate_mcp_event(event: Any) -> List[BaseEvent]:
+    """Translate a single crewai MCP event into AG-UI events.
+
+    Stateless (mints fresh ids per call, so not pure). Unknown / missing event
+    types return ``[]`` (forward-compatible no-op).
+
+    Top-level backstop for the "cannot raise" contract: the field-level guards
+    (``_json_safe`` for payloads, ``_text`` for required string fields) cover the
+    realistic inputs, and this ``try/except`` is the last line so that ANY
+    unforeseen pathological event degrades to a dropped translation (``[]`` +
+    one debug line) rather than faulting the run -- on the StreamFrame path an
+    escaping exception becomes an ``AGUI_CREWAI_FLOW_ERROR`` for the whole run.
+    A masked coding bug still shows up as an empty result in the unit tests,
+    which assert exact event sequences.
+    """
+    try:
+        return _translate_mcp_event_impl(event)
+    except Exception as exc:  # noqa: BLE001 - last-resort "cannot raise" backstop
+        _LOGGER.debug(
+            "ag-ui-crewai: failed to translate MCP event %s (%s); dropping.",
+            getattr(event, "type", None),
+            type(exc).__name__,
+        )
+        return []
+
+
+def _translate_mcp_event_impl(event: Any) -> List[BaseEvent]:
+    etype = getattr(event, "type", None)
+
+    if etype == MCP_TOOL_EXECUTION_COMPLETED:
+        return _tool_call_events(
+            getattr(event, "tool_name", ""),
+            getattr(event, "tool_args", None),
+            result=getattr(event, "result", None),
+        )
+
+    if etype == MCP_TOOL_EXECUTION_FAILED:
+        events = _tool_call_events(
+            getattr(event, "tool_name", ""),
+            getattr(event, "tool_args", None),
+            error=getattr(event, "error", None),
+            failed=True,
+        )
+        events.append(
+            _custom(
+                MCP_TOOL_EXECUTION_FAILED,
+                {
+                    "server_name": getattr(event, "server_name", None),
+                    "tool_name": getattr(event, "tool_name", None),
+                    "error": getattr(event, "error", None),
+                    "error_type": getattr(event, "error_type", None),
+                },
+            )
+        )
+        return events
+
+    if etype == MCP_TOOL_EXECUTION_STARTED:
+        return [
+            _custom(
+                MCP_TOOL_EXECUTION_STARTED,
+                {
+                    "server_name": getattr(event, "server_name", None),
+                    "tool_name": getattr(event, "tool_name", None),
+                    "tool_args": getattr(event, "tool_args", None),
+                },
+            )
+        ]
+
+    if etype == MCP_CONNECTION_STARTED:
+        return [
+            _custom(
+                MCP_CONNECTION_STARTED,
+                _lifecycle_value(
+                    event,
+                    ("server_name", "server_url", "transport_type", "is_reconnect"),
+                ),
+            )
+        ]
+
+    if etype == MCP_CONNECTION_COMPLETED:
+        return [
+            _custom(
+                MCP_CONNECTION_COMPLETED,
+                _lifecycle_value(
+                    event,
+                    (
+                        "server_name",
+                        "server_url",
+                        "transport_type",
+                        "connection_duration_ms",
+                        "is_reconnect",
+                    ),
+                ),
+            )
+        ]
+
+    if etype == MCP_CONNECTION_FAILED:
+        return [
+            _custom(
+                MCP_CONNECTION_FAILED,
+                _lifecycle_value(
+                    event, ("server_name", "server_url", "error", "error_type")
+                ),
+            )
+        ]
+
+    if etype == MCP_CONFIG_FETCH_FAILED:
+        return [
+            _custom(
+                MCP_CONFIG_FETCH_FAILED,
+                _lifecycle_value(event, ("slug", "error", "error_type")),
+            )
+        ]
+
+    return []
+
+
+def crewai_mcp_available() -> bool:
+    """Return True when crewai>=1.4 first-class MCP support is importable.
+
+    Probes ``crewai.mcp.MCPServerStdio`` -- the clean 1.4.0 signal (PNI-130).
+    Only ``ImportError`` (crewai < 1.4, module absent) is treated as
+    "unavailable"; any OTHER exception is a real breakage and is allowed to
+    propagate rather than being silently mislabelled as "too old".
+    """
+    try:
+        from crewai.mcp import MCPServerStdio  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+
+        return True
+    except ImportError:
+        return False
+
+
+def _warn_once(message: str, *args: Any) -> None:
+    key = message % args if args else message
+    if key in _WARNED:
+        return
+    _WARNED.add(key)
+    _LOGGER.warning(message, *args)
+
+
+def register_mcp_listeners(
+    crewai_event_bus: Any,
+    on_mcp_event: Callable[[Any], None],
+) -> bool:
+    """Register crewai MCP event listeners for the LEGACY bus transport.
+
+    Used by the legacy event-bus transport (crewai 1.4-1.5, where the
+    StreamFrame contract is absent). ``on_mcp_event`` is injected by ``endpoint``
+    and receives the RAW crewai MCP event; the endpoint resolves the active run
+    (MCP events are emitted with the agent/crew as ``source``, not the Flow, so
+    it resolves via ``flow_context``), and translates + enqueues ONLY when that
+    run has a live queue -- so on the StreamFrame path (no per-run queue; that
+    path surfaces MCP via the frame sink) this handler does no wasted
+    translation. Passing the raw event (rather than pre-translating here) keeps
+    this module free of any import-time crewai / endpoint dependency and lets the
+    endpoint skip translation entirely when there is nothing to enqueue.
+
+    Returns True if listeners were registered (crewai>=1.4 MCP present); False
+    otherwise. On older crewai a single process-wide warning is logged and the
+    call is a clean no-op.
+    """
+    if not crewai_mcp_available():
+        _warn_once(
+            "ag-ui-crewai: MCP tool-call surfacing requires crewai>=1.4.0 "
+            "(crewai.mcp); installed crewai version is %s. MCP events will not "
+            "be surfaced as TOOL_CALL_*/CUSTOM events.",
+            CAPABILITIES.crewai_version,
+        )
+        return False
+
+    try:
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        _events = importlib.import_module("crewai.events")
+        event_types = [getattr(_events, name, None) for name in _MCP_EVENT_CLASS_NAMES]
+        if any(t is None for t in event_types):
+            raise ImportError("one or more MCP event classes are missing")
+    except ImportError:  # MCP present but the event surface moved/renamed
+        _warn_once(
+            "ag-ui-crewai: crewai.mcp is present but the MCP event classes could "
+            "not be resolved from crewai.events; MCP events will not be surfaced."
+        )
+        return False
+
+    def _handler(source: Any, event: Any) -> None:  # pylint: disable=unused-argument
+        on_mcp_event(event)
+
+    for event_type in event_types:
+        crewai_event_bus.on(event_type)(_handler)
+
+    return True

--- a/integrations/crew-ai/python/tests/test_mcp.py
+++ b/integrations/crew-ai/python/tests/test_mcp.py
@@ -1,0 +1,618 @@
+"""Tests for the MCP -> AG-UI event bridge (PNI-130).
+
+``translate_mcp_event`` is stateless (mints fresh ids per call, so not pure) and
+dispatches on the crewai event's ``type`` string, so these tests drive it with
+lightweight ``SimpleNamespace`` fakes -- no crewai>=1.4 MCP surface required. The
+registration path is exercised with a fake event bus and an injected raw-event
+callback. The StreamFrame seam is exercised through the real
+``_frames.StreamFrameTranslator``.
+"""
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from ag_ui.core import EventType
+
+from ag_ui_crewai import mcp
+from ag_ui_crewai._frames import StreamFrameTranslator
+
+
+# ---------------------------------------------------------------------------
+# helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeBus:
+    """Fake crewai event bus. ``on(EventType)`` returns a decorator that records
+    (event_type, handler) pairs, matching crewai's decorator API."""
+
+    def __init__(self):
+        self.registered = []
+
+    def on(self, event_type):
+        def _decorator(handler):
+            self.registered.append((event_type, handler))
+            return handler
+
+        return _decorator
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_dedup():
+    """Isolate the process-wide warn-once dedup set between tests."""
+    mcp._WARNED.clear()
+    yield
+    mcp._WARNED.clear()
+
+
+def _completed(**kw):
+    base = dict(
+        type="mcp_tool_execution_completed",
+        server_name="files",
+        tool_name="read_file",
+        tool_args={"path": "/tmp/x"},
+        result={"content": "hello"},
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# translate_mcp_event -- tool executions -> TOOL_CALL_*
+# ---------------------------------------------------------------------------
+
+
+def test_tool_execution_completed_maps_to_tool_call_sequence():
+    events = mcp.translate_mcp_event(_completed())
+
+    assert [e.type for e in events] == [
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+    ]
+    start, args, end, result = events
+    assert start.tool_call_id == args.tool_call_id == end.tool_call_id == result.tool_call_id
+    assert start.tool_call_name == "read_file"
+    assert json.loads(args.delta) == {"path": "/tmp/x"}
+    assert json.loads(result.content) == {"content": "hello"}
+    assert result.role == "tool"
+    assert result.message_id
+
+
+def test_tool_execution_completed_none_result_is_empty_string():
+    events = mcp.translate_mcp_event(_completed(result=None))
+    # None result -> "" (not the literal "null").
+    assert events[3].content == ""
+
+
+def test_tool_result_non_str_is_json_encoded():
+    events = mcp.translate_mcp_event(_completed(result=[1, 2, 3]))
+    assert json.loads(events[3].content) == [1, 2, 3]
+
+
+def test_tool_execution_failed_is_distinguishable_from_success():
+    event = SimpleNamespace(
+        type="mcp_tool_execution_failed",
+        server_name="files",
+        tool_name="read_file",
+        tool_args=None,
+        error="boom: connection reset",
+        error_type="server_error",
+    )
+
+    events = mcp.translate_mcp_event(event)
+
+    # START/ARGS/END/RESULT (result carries the error text) + a CUSTOM failure
+    # marker so a client can tell failure from success.
+    assert [e.type for e in events] == [
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+        EventType.CUSTOM,
+    ]
+    assert events[1].delta == "{}"  # None args -> empty JSON object
+    assert events[3].content == "boom: connection reset"
+    failed = events[4]
+    assert failed.name == "mcp_tool_execution_failed"
+    assert failed.value["error"] == "boom: connection reset"
+    assert failed.value["error_type"] == "server_error"
+    assert failed.value["tool_name"] == "read_file"
+
+
+def test_args_empty_dict_and_populated_are_preserved():
+    assert mcp.translate_mcp_event(_completed(tool_args={})) [1].delta == "{}"
+    assert json.loads(
+        mcp.translate_mcp_event(_completed(tool_args={"a": 1}))[1].delta
+    ) == {"a": 1}
+
+
+def test_tool_execution_started_maps_to_custom_activity():
+    event = SimpleNamespace(
+        type="mcp_tool_execution_started",
+        server_name="files",
+        tool_name="read_file",
+        tool_args={"path": "/tmp/x"},
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    assert custom.type == EventType.CUSTOM
+    assert custom.name == "mcp_tool_execution_started"
+    assert custom.value == {
+        "server_name": "files",
+        "tool_name": "read_file",
+        "tool_args": {"path": "/tmp/x"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# translate_mcp_event -- lifecycle -> CUSTOM
+# ---------------------------------------------------------------------------
+
+
+def test_connection_started_maps_to_custom():
+    event = SimpleNamespace(
+        type="mcp_connection_started",
+        server_name="files",
+        server_url=None,
+        transport_type="stdio",
+        is_reconnect=False,
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    assert custom.name == "mcp_connection_started"
+    assert custom.value == {
+        "server_name": "files",
+        "server_url": None,
+        "transport_type": "stdio",
+        "is_reconnect": False,
+    }
+
+
+def test_connection_completed_carries_duration():
+    event = SimpleNamespace(
+        type="mcp_connection_completed",
+        server_name="files",
+        server_url="http://x",
+        transport_type="http",
+        connection_duration_ms=12.5,
+        is_reconnect=True,
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    assert custom.name == "mcp_connection_completed"
+    assert custom.value["connection_duration_ms"] == 12.5
+    assert custom.value["is_reconnect"] is True
+
+
+def test_connection_failed_maps_to_custom():
+    event = SimpleNamespace(
+        type="mcp_connection_failed",
+        server_name="files",
+        server_url=None,
+        error="timeout",
+        error_type="timeout",
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    assert custom.name == "mcp_connection_failed"
+    assert custom.value["error"] == "timeout"
+    assert custom.value["error_type"] == "timeout"
+
+
+def test_config_fetch_failed_maps_to_custom():
+    event = SimpleNamespace(
+        type="mcp_config_fetch_failed",
+        slug="acme/files",
+        error="not connected",
+        error_type="not_connected",
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    assert custom.name == "mcp_config_fetch_failed"
+    assert custom.value == {
+        "slug": "acme/files",
+        "error": "not connected",
+        "error_type": "not_connected",
+    }
+
+
+def test_unknown_event_type_is_noop():
+    assert mcp.translate_mcp_event(SimpleNamespace(type="something_else")) == []
+    assert mcp.translate_mcp_event(SimpleNamespace()) == []
+
+
+# ---------------------------------------------------------------------------
+# is_mcp_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "etype",
+    [
+        "mcp_connection_started",
+        "mcp_connection_completed",
+        "mcp_connection_failed",
+        "mcp_tool_execution_started",
+        "mcp_tool_execution_completed",
+        "mcp_tool_execution_failed",
+        "mcp_config_fetch_failed",
+    ],
+)
+def test_is_mcp_event_true_for_mcp_types(etype):
+    assert mcp.is_mcp_event(SimpleNamespace(type=etype)) is True
+
+
+@pytest.mark.parametrize("etype", ["flow_started", "text_message_chunk", None, "cc_env"])
+def test_is_mcp_event_false_for_others(etype):
+    assert mcp.is_mcp_event(SimpleNamespace(type=etype)) is False
+
+
+# ---------------------------------------------------------------------------
+# probe + registration
+# ---------------------------------------------------------------------------
+
+
+def test_crewai_mcp_available_returns_bool():
+    assert isinstance(mcp.crewai_mcp_available(), bool)
+
+
+def test_register_noop_and_warns_when_mcp_unavailable(monkeypatch, caplog):
+    monkeypatch.setattr(mcp, "crewai_mcp_available", lambda: False)
+    bus = _FakeBus()
+
+    with caplog.at_level("WARNING"):
+        result = mcp.register_mcp_listeners(bus, lambda event: None)
+
+    assert result is False
+    assert bus.registered == []
+    assert any("requires crewai>=1.4" in r.message for r in caplog.records)
+
+
+def test_register_warning_is_emitted_once(monkeypatch, caplog):
+    monkeypatch.setattr(mcp, "crewai_mcp_available", lambda: False)
+    bus = _FakeBus()
+    with caplog.at_level("WARNING"):
+        mcp.register_mcp_listeners(bus, lambda event: None)
+        mcp.register_mcp_listeners(bus, lambda event: None)
+    warnings = [r for r in caplog.records if "requires crewai>=1.4" in r.message]
+    assert len(warnings) == 1
+
+
+def _install_fake_crewai_events(monkeypatch, *, with_classes=True):
+    module = types.ModuleType("crewai.events")
+    if with_classes:
+        for name in mcp._MCP_EVENT_CLASS_NAMES:
+            setattr(module, name, type(name, (), {}))
+    monkeypatch.setitem(sys.modules, "crewai.events", module)
+    return module
+
+
+def test_register_wires_all_mcp_event_types_when_available(monkeypatch):
+    monkeypatch.setattr(mcp, "crewai_mcp_available", lambda: True)
+    _install_fake_crewai_events(monkeypatch)
+    bus = _FakeBus()
+
+    result = mcp.register_mcp_listeners(bus, lambda event: None)
+
+    assert result is True
+    assert len(bus.registered) == 7
+    # The 7 registrations cover the 7 distinct MCP event classes, not dups.
+    registered_types = {t for t, _ in bus.registered}
+    import sys as _sys
+
+    expected = {
+        getattr(_sys.modules["crewai.events"], name)
+        for name in mcp._MCP_EVENT_CLASS_NAMES
+    }
+    assert registered_types == expected
+
+
+def test_register_warns_once_when_event_classes_missing(monkeypatch, caplog):
+    monkeypatch.setattr(mcp, "crewai_mcp_available", lambda: True)
+    _install_fake_crewai_events(monkeypatch, with_classes=False)
+    bus = _FakeBus()
+
+    with caplog.at_level("WARNING"):
+        r1 = mcp.register_mcp_listeners(bus, lambda event: None)
+        r2 = mcp.register_mcp_listeners(bus, lambda event: None)
+
+    assert r1 is False and r2 is False
+    assert bus.registered == []
+    warnings = [r for r in caplog.records if "could not be resolved" in r.message]
+    assert len(warnings) == 1
+
+
+def test_registered_handler_forwards_raw_event(monkeypatch):
+    # The bus handler forwards the RAW crewai event to the injected callback;
+    # translation happens in the endpoint (only when a run queue exists).
+    monkeypatch.setattr(mcp, "crewai_mcp_available", lambda: True)
+    _install_fake_crewai_events(monkeypatch)
+    bus = _FakeBus()
+    received = []
+
+    mcp.register_mcp_listeners(bus, received.append)
+    handler = bus.registered[0][1]
+
+    raw = _completed(result="ok")
+    handler(object(), raw)
+
+    assert received == [raw]
+
+
+# ---------------------------------------------------------------------------
+# StreamFrame seam (_frames.StreamFrameTranslator routes MCP via the shared
+# translator)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_frame_translator_surfaces_mcp_tool_call():
+    translator = StreamFrameTranslator(
+        thread_id="t1", run_id="r1", state_provider=lambda: {}
+    )
+    events = translator.translate(_completed(result="ok"))
+    assert [e.type for e in events] == [
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+    ]
+
+
+def test_stream_frame_translator_surfaces_mcp_lifecycle():
+    translator = StreamFrameTranslator(
+        thread_id="t1", run_id="r1", state_provider=lambda: {}
+    )
+    events = translator.translate(
+        SimpleNamespace(
+            type="mcp_connection_started",
+            server_name="files",
+            server_url=None,
+            transport_type="stdio",
+            is_reconnect=False,
+        )
+    )
+    assert len(events) == 1
+    assert events[0].type == EventType.CUSTOM
+    assert events[0].name == "mcp_connection_started"
+
+
+# ---------------------------------------------------------------------------
+# failure-path + serialization hardening
+# ---------------------------------------------------------------------------
+
+
+def test_failed_shares_one_tool_call_id_and_none_error_is_empty():
+    event = SimpleNamespace(
+        type="mcp_tool_execution_failed",
+        server_name="files",
+        tool_name="t",
+        tool_args=None,
+        error=None,  # a failure with no error string
+        error_type=None,
+    )
+    events = mcp.translate_mcp_event(event)
+    start, args, end, result, custom = events
+    assert start.tool_call_id == args.tool_call_id == end.tool_call_id == result.tool_call_id
+    # None error -> "" result content; the CUSTOM marker is what signals failure.
+    assert result.content == ""
+    assert custom.type == EventType.CUSTOM
+    assert custom.name == "mcp_tool_execution_failed"
+
+
+def test_failed_non_string_error_is_coerced():
+    event = SimpleNamespace(
+        type="mcp_tool_execution_failed",
+        server_name="files",
+        tool_name="t",
+        tool_args={},
+        error=ValueError("bad"),  # non-string, non-JSON-native
+        error_type="server_error",
+    )
+    events = mcp.translate_mcp_event(event)
+    result, custom = events[3], events[4]
+    # RESULT content is a string (json-encoded / str-coerced), never raises.
+    assert isinstance(result.content, str) and "bad" in result.content
+    # CUSTOM value is fully JSON-serialisable (the Exception was coerced).
+    json.dumps(custom.value)
+
+
+def test_args_circular_reference_does_not_raise():
+    circular: dict = {}
+    circular["self"] = circular
+    events = mcp.translate_mcp_event(_completed(tool_args=circular))
+    # Degrades to a string rather than faulting translation.
+    assert isinstance(events[1].delta, str)
+
+
+def test_started_circular_tool_args_does_not_raise():
+    # The STARTED CUSTOM payload routes raw tool_args through _json_safe; a
+    # circular reference must degrade to "<circular>", not raise RecursionError.
+    circular: dict = {}
+    circular["self"] = circular
+    event = SimpleNamespace(
+        type="mcp_tool_execution_started",
+        server_name="files",
+        tool_name="t",
+        tool_args=circular,
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    json.dumps(custom.value)  # must not raise
+    assert custom.value["tool_args"]["self"] == "<circular>"
+
+
+def test_json_safe_preserves_shared_non_circular_refs():
+    shared = {"k": "v"}
+    out = mcp._json_safe({"a": shared, "b": shared})
+    # A shared (non-cyclic) reference must NOT be flagged as circular.
+    assert out == {"a": {"k": "v"}, "b": {"k": "v"}}
+
+
+def test_json_safe_bounds_deeply_nested_acyclic_input():
+    # Deep (acyclic) nest FAR past CPython's ~1000 recursion limit; the depth
+    # cap must flatten it to a constant placeholder rather than RecursionError,
+    # and the result must be JSON-serialisable without deep recursion either.
+    deep: dict = {}
+    node = deep
+    for _ in range(5000):
+        child: dict = {}
+        node["n"] = child
+        node = child
+    out = mcp._json_safe(deep)
+    assert json.dumps(out)  # must not raise (bounded structure)
+    # The tail past the cap collapses to the "<max-depth>" placeholder.
+    assert "<max-depth>" in json.dumps(out)
+
+
+def test_args_delta_deeply_nested_does_not_raise():
+    deep: dict = {}
+    node = deep
+    for _ in range(5000):
+        child: dict = {}
+        node["n"] = child
+        node = child
+    delta = mcp.translate_mcp_event(_completed(tool_args=deep))[1].delta
+    assert isinstance(delta, str) and json.loads(delta) is not None
+
+
+def test_tool_name_none_does_not_break_validation():
+    # An explicit tool_name=None must not trip the required str field.
+    event = SimpleNamespace(
+        type="mcp_tool_execution_completed",
+        server_name="files",
+        tool_name=None,
+        tool_args={},
+        result="ok",
+    )
+    events = mcp.translate_mcp_event(event)
+    assert events[0].type == EventType.TOOL_CALL_START
+    assert events[0].tool_call_name == ""
+
+
+def test_custom_value_is_json_serialisable_even_with_exotic_fields():
+    event = SimpleNamespace(
+        type="mcp_connection_failed",
+        server_name="files",
+        server_url=None,
+        error=RuntimeError("boom"),  # exotic leaf
+        error_type=None,
+    )
+    (custom,) = mcp.translate_mcp_event(event)
+    json.dumps(custom.value)  # must not raise
+    assert "boom" in custom.value["error"]
+
+
+# ---------------------------------------------------------------------------
+# integration: real crewai (skipped when crewai.mcp / astream absent)
+# ---------------------------------------------------------------------------
+
+
+def _real_flow_emitting_mcp(events_module):
+    """Build a real crewai Flow whose @start method emits an MCP connection +
+    an MCP tool-execution-completed event with a NON-flow source (as crewai
+    core does)."""
+    from crewai import Flow
+    from crewai.flow.flow import start
+
+    bus = events_module.crewai_event_bus
+    completed_cls = events_module.MCPToolExecutionCompletedEvent
+    connected_cls = events_module.MCPConnectionStartedEvent
+
+    class _Agent:  # non-flow source, like crewai's agent/crew
+        pass
+
+    agent = _Agent()
+
+    class _F(Flow):
+        @start()
+        def go(self):
+            bus.emit(agent, connected_cls(server_name="files", transport_type="stdio"))
+            bus.emit(
+                agent,
+                completed_cls(
+                    server_name="files",
+                    tool_name="read_file",
+                    tool_args={"path": "/x"},
+                    result="hello",
+                ),
+            )
+            return "done"
+
+    return _F()
+
+
+def test_integration_legacy_bus_seam_resolves_via_flow_context():
+    """crewai dispatches sync bus handlers on a worker thread but copies the
+    emitting contextvars, so the legacy-path handler resolves the run via
+    ``flow_context`` (refutes the 'contextvars do not propagate' hypothesis)."""
+    pytest.importorskip("crewai.mcp")
+    import asyncio
+
+    events_module = pytest.importorskip("crewai.events")
+    from ag_ui_crewai.context import flow_context
+
+    flow = _real_flow_emitting_mcp(events_module)
+    resolved = []
+
+    @events_module.crewai_event_bus.on(events_module.MCPToolExecutionCompletedEvent)
+    def _(source, event):  # noqa: ANN001
+        resolved.append(flow_context.get(None))
+
+    async def _run():
+        token = flow_context.set(flow)
+        try:
+            await asyncio.create_task(flow.kickoff_async())
+            flush = getattr(events_module.crewai_event_bus, "flush", None)
+            if callable(flush):
+                await asyncio.get_running_loop().run_in_executor(None, lambda: flush(5.0))
+        finally:
+            flow_context.reset(token)
+
+    asyncio.run(_run())
+    assert resolved and resolved[0] is flow
+
+
+def test_integration_stream_frame_seam_surfaces_mcp_as_tool_call():
+    """Drive a real ``flow.astream`` and run its frames through the widened sink
+    + StreamFrameTranslator exactly as ``endpoint._run_flow_frame_stream`` does;
+    the agent-sourced MCP events must surface as TOOL_CALL_* / CUSTOM."""
+    caps = pytest.importorskip("ag_ui_crewai._capabilities")
+    pytest.importorskip("crewai.mcp")
+    if not getattr(caps, "_stream_frame_available", False):
+        pytest.skip("crewai StreamFrame contract unavailable (<1.6)")
+    import asyncio
+
+    events_module = pytest.importorskip("crewai.events")
+    from crewai.events.stream_context import add_stream_sink, reset_stream_sinks
+
+    flow = _real_flow_emitting_mcp(events_module)
+    raw: dict = {}
+
+    def _sink(source, event):  # mirror endpoint._sink widened gate
+        if source is flow or mcp.is_mcp_event(event):
+            eid = getattr(event, "event_id", None)
+            if eid is not None:
+                raw[eid] = event
+
+    translator = StreamFrameTranslator(
+        thread_id="t", run_id="r", state_provider=lambda: getattr(flow, "state", {})
+    )
+    out = []
+
+    async def _run():
+        token = add_stream_sink(_sink)
+        try:
+            async for frame in flow.astream(inputs={}):
+                ev = raw.pop(frame.id, None)
+                if ev is None:
+                    continue
+                for e in translator.translate(ev):
+                    out.append(e.type)
+        finally:
+            reset_stream_sinks(token)
+
+    asyncio.run(_run())
+    assert EventType.TOOL_CALL_START in out
+    assert EventType.TOOL_CALL_RESULT in out
+    assert out.count(EventType.RUN_STARTED) == 1
+    assert out.count(EventType.RUN_FINISHED) == 1

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -1098,3 +1098,70 @@ async def test_frame_path_does_not_cancel_kickoff_after_finish():
     # The kickoff task completed normally rather than being cancelled by aclose.
     assert session.is_cancelled is False
     assert session.result == "RESULT"
+
+
+# -- PNI-130: MCP events surface through the SHIPPED frame-path sink ----------
+
+class _MCPEmittingFlow(Flow):
+    """Emits crewai MCP events (connection lifecycle + a tool execution) with a
+    NON-flow source, exactly as crewai core does. The frame-path ``_sink`` must
+    therefore park them by TYPE (``is_mcp_event``), not by ``source is flow``."""
+
+    @start()
+    def go(self):
+        from ag_ui_crewai._capabilities import crewai_event_bus
+        from crewai.events import (
+            MCPConnectionStartedEvent,
+            MCPToolExecutionCompletedEvent,
+        )
+
+        agent = SimpleNamespace()  # non-flow source, like a crew/agent
+        crewai_event_bus.emit(
+            agent,
+            MCPConnectionStartedEvent(server_name="files", transport_type="stdio"),
+        )
+        crewai_event_bus.emit(
+            agent,
+            MCPToolExecutionCompletedEvent(
+                server_name="files",
+                tool_name="read_file",
+                tool_args={"path": "/x"},
+                result="hello",
+            ),
+        )
+        return "done"
+
+
+@requires_stream_frames
+async def test_frame_path_surfaces_mcp_tool_calls():
+    """PNI-130: agent-sourced MCP events surface through the real
+    ``_run_flow_frame_stream`` sink as TOOL_CALL_* (tool executions) and CUSTOM
+    (connection lifecycle), inside a single RUN_STARTED/RUN_FINISHED envelope."""
+    from ag_ui.encoder import EventEncoder
+
+    pytest.importorskip("crewai.mcp")
+
+    flow = _MCPEmittingFlow()
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=flow,
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    types = [p["type"] for p in payloads]
+
+    assert types[0] == "RUN_STARTED"
+    assert types[-1] == "RUN_FINISHED"
+    assert types.count("RUN_STARTED") == 1
+    assert types.count("RUN_FINISHED") == 1
+    for expected in (
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+    ):
+        assert expected in types, (expected, types)
+    customs = [p for p in payloads if p["type"] == "CUSTOM"]
+    assert any(c.get("name") == "mcp_connection_started" for c in customs)


### PR DESCRIPTION
## What

Lane 2 (Parity) of the CrewAI refresh. Surfaces CrewAI's first-class MCP events (core since 1.4.0) as AG-UI protocol events.

- **MCP tool executions** map to `TOOL_CALL_START` / `ARGS` / `END` / `RESULT`. A failed execution also emits a `CUSTOM` `mcp_tool_execution_failed` marker so a client can distinguish a failure from a success.
- **MCP lifecycle events** (connect started/completed/failed, config-fetch failure, tool-exec started) map to `CUSTOM` events.

## How

A single stateless translator (`mcp.translate_mcp_event`) is shared by both bridge transports:

- **StreamFrame path (crewai >= 1.6):** the frame sink is widened to park MCP events by *type* (crewai emits them with the agent/crew as `source`, not the flow), and `StreamFrameTranslator` maps them. The sink is context-scoped, so only this run's MCP events reach it (no cross-run leakage).
- **Legacy bus-listener path (crewai 1.4-1.5):** MCP listeners resolve the run via `flow_context` (crewai copies contextvars into its `ThreadPoolExecutor` handler threads) and enqueue thread-safely via `_enqueue`, and only when a per-run queue exists, so there is no wasted translation or double emission on the StreamFrame path.

Capability detection is runtime-only: probe `crewai.mcp.MCPServerStdio`, the clean 1.4.0 signal (`Agent.mcps` exists from 1.0.0 as `list[str]` and cannot distinguish versions). Below 1.4 the bridge logs one warning and no-ops. Floor is the repo's existing `crewai>=1.0,<2`.

All MCP payload serialization routes through one bounded, cycle- and depth-guarded `_json_safe` primitive plus a top-level guard, so a pathological event degrades gracefully instead of faulting the run.

## Testing

Verified end-to-end against **real crewai 1.15.8** on both transports. Adds `tests/test_mcp.py` (translator, probe/warn-once, registration, serialization hardening, `_frames` seam, and real-crewai integration tests) plus a driver-level frame-path test in `test_streaming.py` that drives the shipped `_run_flow_frame_stream`. Full crew-ai python suite: 140 passed on crewai 1.15.8.

## Follow-up (showcase phase)

Unblocks the showcase `mcp-apps` demo: it should be reclassified off `not_supported_features` and its two skipped e2e tests re-enabled. `PARITY_NOTES.md`'s "requires upstream MCP support in CrewAI" note is obsolete as of crewai 1.4.0.

Linear: PNI-130