### PR TITLE
feat(crew-ai): hierarchical multi-agent / nested-crew attribution (PNI-131)

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -26,12 +26,15 @@ Two raw event sources feed us (verified against the 1.15.7 wheel):
   ``EventType`` string and whose typed attributes (``snapshot`` / ``delta`` /
   ``message_id`` / ...) carry the verbatim, un-serialized payload.
 
-OUTER-flow filtering: a ``crew.kickoff`` inside
-a flow method drives a NESTED flow whose own lifecycle/method events leak onto
-the same scoped sink. The driver filters those out by source identity BEFORE
-they reach this translator (only events whose ``source is flow_copy`` are parked
-in the lookup buffer), so the translator never sees nested frames. This mirrors
-the legacy listener's ``source is flow_copy`` gate and needs no depth counter.
+Source filtering: a ``crew.kickoff`` inside a flow method drives a NESTED flow
+whose own lifecycle/method events leak onto the same scoped sink. The driver
+drops those nested flow/method events by source identity (only events whose
+``source is flow_copy`` are parked) before they reach this translator. Crew and
+Agent lifecycle events are the exception: they arrive with a non-outer source
+but are surfaced deliberately (the sink parks them because they are scoped to
+this run) so this translator can attribute the Crew / Agent hierarchy. The
+translator therefore sees outer-source flow/method events plus run-scoped
+crew/agent events, but never nested-flow frames.
 
 UPSTREAM FRAME RETENTION: crewai's ``AsyncStreamSession``
 (``crewai.types.streaming.StreamSessionBase``) appends EVERY iterated frame to
@@ -79,7 +82,6 @@ from ag_ui.core.events import (
     RawEvent,
     TextMessageChunkEvent,
     ToolCallChunkEvent,
-    StepStartedEvent,
     StepFinishedEvent,
     MessagesSnapshotEvent,
     StateSnapshotEvent,
@@ -88,6 +90,14 @@ from ag_ui.core.events import (
 
 from .sdk import litellm_messages_to_ag_ui_messages
 from .mcp import is_mcp_event, translate_mcp_event
+from .attribution import (
+    BoundaryTracker,
+    FLOW_METHOD,
+    CREW,
+    AGENT,
+    step_started_event,
+    step_finished_event,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,8 +107,62 @@ _FLOW_STARTED = "flow_started"
 _FLOW_FINISHED = "flow_finished"
 _METHOD_STARTED = "method_execution_started"
 _METHOD_FINISHED = "method_execution_finished"
+_METHOD_FAILED = "method_execution_failed"
+
+# Crew- and Agent-level ``type`` strings. The ordered StreamFrame path sees
+# these (crew/agent frames arrive on the outer flow's ``astream`` with a source
+# that is NOT the outer flow; see ``endpoint._sink``), so it can reconstruct the
+# Flow-method -> Crew -> Agent hierarchy. Pinned as constants for rename safety.
+_CREW_STARTED = "crew_kickoff_started"
+_CREW_COMPLETED = "crew_kickoff_completed"
+_CREW_FAILED = "crew_kickoff_failed"
+_AGENT_STARTED = "agent_execution_started"
+_AGENT_COMPLETED = "agent_execution_completed"
+_AGENT_ERROR = "agent_execution_error"
+
+# Single source of truth for identifying crew/agent lifecycle events. The sink
+# in ``endpoint.py`` parks these regardless of source; the translator matches
+# them by the individual constants above.
+CREW_AGENT_LIFECYCLE_TYPES = frozenset({
+    _CREW_STARTED,
+    _CREW_COMPLETED,
+    _CREW_FAILED,
+    _AGENT_STARTED,
+    _AGENT_COMPLETED,
+    _AGENT_ERROR,
+})
 
 _SUPPORTED_EMISSION_SHAPES = frozenset({"chunks", "triples"})
+
+
+def _coerce_name(value: Any, fallback: str) -> str:
+    """Coerce a crewai identity (method / crew name) to a non-empty ``str``.
+
+    crewai populates ``method_name`` / ``crew_name`` as strings today, but the
+    attribution path joins them into ``path`` / ``qualified_name`` and uses them
+    as the boundary pairing key, so a stray ``None`` (an event constructed via
+    ``model_construct`` that skipped the field) or a non-str must never reach it
+    and raise. Empty / whitespace-only values fall back too.
+    """
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text or fallback
+
+
+def _agent_role(event: Any) -> str:
+    """Derive a stable, always-``str`` role for an agent lifecycle event.
+
+    Prefers the agent's ``role``, falls back to its ``id`` (a UUID object on
+    crewai's ``BaseAgent``, hence the ``str(...)`` coercion), then to the
+    literal ``"agent"``. The SAME derivation is used on start and on
+    completion/error so the boundary pairs by a stable name.
+    """
+    agent = getattr(event, "agent", None)
+    role = getattr(agent, "role", None) if agent is not None else None
+    if role is None or not str(role).strip():
+        role = getattr(agent, "id", None) if agent is not None else None
+    return _coerce_name(role, "agent")
 
 
 class StreamFrameTranslator:
@@ -110,9 +174,10 @@ class StreamFrameTranslator:
     return ``[]`` (behavior-preserving: the legacy listener produced nothing for
     crewai's native llm / tools / messages channels or internal events).
 
-    The driver is responsible for OUTER-flow filtering (only forwarding events
-    whose ``source is flow_copy``); the translator assumes every event it sees
-    belongs to the outer run.
+    The driver forwards outer-flow lifecycle/method events (``source is
+    flow_copy``) plus the run-scoped Crew/Agent lifecycle events (which carry a
+    non-outer source); nested-flow frames are filtered out before they reach
+    the translator, so every event it sees belongs to the outer run.
     """
 
     def __init__(
@@ -132,6 +197,10 @@ class StreamFrameTranslator:
         self._run_id = run_id
         self._state_provider = state_provider
         self.emission_shape = emission_shape
+        # One ordered boundary stack per run, driven in emit order by
+        # ``translate``: ``enter`` on a start frame, ``exit`` on the matching
+        # finish, ``drain_all`` at run end so every STEP_STARTED is closed.
+        self._tracker = BoundaryTracker()
         # Run-lifecycle idempotency. A single AG-UI HTTP run must
         # emit EXACTLY ONE ``RUN_STARTED`` (first) and ONE ``RUN_FINISHED``
         # (last). Nested-flow lifecycle events are already filtered out by the
@@ -175,22 +244,39 @@ class StreamFrameTranslator:
                 # a run that never opened.
                 return []
             self._run_finished_emitted = True
-            return [
+            # Close every STEP_STARTED still open before RUN_FINISHED so a
+            # boundary whose finish frame never arrived does not dangle.
+            # ``drain_all`` returns them deepest-first for balanced closes.
+            events: list[Any] = [
+                step_finished_event(b) for b in self._tracker.drain_all()
+            ]
+            events.append(
                 RunFinishedEvent(
                     type=EventType.RUN_FINISHED,
                     thread_id=self._thread_id,
                     run_id=self._run_id,
                 )
-            ]
+            )
+            return events
         if event_type == _METHOD_STARTED:
-            return [
-                StepStartedEvent(
-                    type=EventType.STEP_STARTED,
-                    step_name=getattr(event, "method_name", None),
-                )
-            ]
+            return self._method_started_events(event)
         if event_type == _METHOD_FINISHED:
             return self._method_finished_events(event)
+        if event_type == _METHOD_FAILED:
+            # Close the method boundary so a failed flow method (the flow may
+            # continue) does not leave a dangling STEP_STARTED. No snapshots.
+            method_name = _coerce_name(getattr(event, "method_name", None), "method")
+            return self._close_boundaries(
+                self._tracker.exit(FLOW_METHOD, method_name), _METHOD_FAILED
+            )
+        if event_type == _CREW_STARTED:
+            return self._crew_started_events(event)
+        if event_type in (_CREW_COMPLETED, _CREW_FAILED):
+            return self._crew_finished_events(event)
+        if event_type == _AGENT_STARTED:
+            return self._agent_started_events(event)
+        if event_type in (_AGENT_COMPLETED, _AGENT_ERROR):
+            return self._agent_finished_events(event)
 
         # crewai's first-class MCP events (crewai >= 1.4). Emitted with
         # the agent/crew as source (not the flow), so the driver's sink parks
@@ -238,24 +324,118 @@ class StreamFrameTranslator:
         """
         if self._run_started_emitted and not self._run_finished_emitted:
             self._run_finished_emitted = True
-            return [
+            # Same drain-before-terminal discipline as the ``flow_finished``
+            # branch: close every open boundary (deepest-first) so the client
+            # never sees a dangling STEP_STARTED.
+            events: list[Any] = [
+                step_finished_event(b) for b in self._tracker.drain_all()
+            ]
+            events.append(
                 RunFinishedEvent(
                     type=EventType.RUN_FINISHED,
                     thread_id=self._thread_id,
                     run_id=self._run_id,
                 )
-            ]
+            )
+            return events
         return []
 
     # -- lifecycle --------------------------------------------------------
 
+    def _method_started_events(self, event: Any) -> list[Any]:
+        """Open a Flow-method boundary and emit its attributed STEP_STARTED.
+
+        The ``step_name`` on the wire is unchanged (the method name); the
+        ``raw_event.attribution`` payload is the additive part so nested Crew /
+        Agent steps chain under it.
+        """
+        method_name = _coerce_name(getattr(event, "method_name", None), "method")
+        boundary = self._tracker.enter(
+            FLOW_METHOD,
+            method_name,
+            fingerprint=getattr(event, "source_fingerprint", None),
+            flow_name=getattr(event, "flow_name", None),
+        )
+        return [step_started_event(boundary, source_event_type=_METHOD_STARTED)]
+
+    def _crew_started_events(self, event: Any) -> list[Any]:
+        """Open a Crew boundary (child of the current method) -> STEP_STARTED."""
+        crew_name = _coerce_name(getattr(event, "crew_name", None), "crew")
+        boundary = self._tracker.enter(
+            CREW,
+            crew_name,
+            fingerprint=getattr(event, "source_fingerprint", None),
+        )
+        return [step_started_event(boundary, source_event_type=_CREW_STARTED)]
+
+    def _crew_finished_events(self, event: Any) -> list[Any]:
+        """Close the nearest matching Crew boundary -> balanced STEP_FINISHED(s).
+
+        ``exit`` returns the matched boundary plus any dangling inners
+        (deepest-first); only the matched (last) boundary is tagged with the
+        source event type. An empty return (no open crew of that name) emits
+        nothing rather than an unbalanced close.
+        """
+        crew_name = _coerce_name(getattr(event, "crew_name", None), "crew")
+        source_type = getattr(event, "type", None)
+        return self._close_boundaries(
+            self._tracker.exit(CREW, crew_name), source_type
+        )
+
+    def _agent_started_events(self, event: Any) -> list[Any]:
+        """Open an Agent boundary (child of the current crew) -> STEP_STARTED."""
+        role = _agent_role(event)
+        boundary = self._tracker.enter(
+            AGENT,
+            role,
+            fingerprint=getattr(event, "source_fingerprint", None),
+        )
+        return [step_started_event(boundary, source_event_type=_AGENT_STARTED)]
+
+    def _agent_finished_events(self, event: Any) -> list[Any]:
+        """Close the nearest matching Agent boundary -> balanced STEP_FINISHED(s).
+
+        Uses the SAME ``_agent_role`` derivation as the start so the boundary
+        pairs by a stable name. Empty return => emit nothing.
+        """
+        role = _agent_role(event)
+        source_type = getattr(event, "type", None)
+        return self._close_boundaries(
+            self._tracker.exit(AGENT, role), source_type
+        )
+
+    @staticmethod
+    def _close_boundaries(closed: list[Any], source_event_type: Any) -> list[Any]:
+        """Turn an ``exit``/``drain`` result into balanced STEP_FINISHED events.
+
+        ``closed`` is deepest-first (inner boundaries first). Only the matched
+        boundary (the LAST element, i.e. the one whose finish frame we actually
+        received) is tagged with ``source_event_type`` for provenance; the
+        dangling inners closed alongside it get no source tag (their own finish
+        frame never arrived). An empty list yields no events.
+        """
+        events: list[Any] = []
+        last_index = len(closed) - 1
+        for index, boundary in enumerate(closed):
+            tag = source_event_type if index == last_index else None
+            events.append(step_finished_event(boundary, source_event_type=tag))
+        return events
+
     def _method_finished_events(self, event: Any) -> list[Any]:
-        """MESSAGES_SNAPSHOT + STATE_SNAPSHOT + STEP_FINISHED, in that order.
+        """MESSAGES_SNAPSHOT + STATE_SNAPSHOT + balanced STEP_FINISHED(s).
 
         Reads the LIVE flow state via ``state_provider`` — exactly what the
         legacy listener did with ``source.state`` — rather than the serialized
         ``event`` payload, so message / state shapes round-trip through the same
-        ``litellm_messages_to_ag_ui_messages`` path as before.
+        ``litellm_messages_to_ag_ui_messages`` path as before. The two snapshots
+        are emitted VERBATIM (unchanged behaviour).
+
+        The final close is balanced: ``exit(FLOW_METHOD, method_name)`` returns
+        the matched method boundary plus any Crew / Agent boundaries left
+        dangling by a lost completion frame (deepest-first). If no boundary
+        matches (the tracker never saw this method's start), fall back to a flat
+        ``StepFinishedEvent(step_name=method_name)`` rather than dropping the
+        close entirely.
         """
         state = self._state_provider()
         raw_messages = (
@@ -271,8 +451,8 @@ class StreamFrameTranslator:
             if hasattr(state, "model_dump")
             else {}
         )
-        method_name = getattr(event, "method_name", None)
-        return [
+        method_name = _coerce_name(getattr(event, "method_name", None), "method")
+        events: list[Any] = [
             MessagesSnapshotEvent(
                 type=EventType.MESSAGES_SNAPSHOT,
                 messages=messages,
@@ -281,11 +461,21 @@ class StreamFrameTranslator:
                 type=EventType.STATE_SNAPSHOT,
                 snapshot=snapshot,
             ),
-            StepFinishedEvent(
-                type=EventType.STEP_FINISHED,
-                step_name=method_name,
-            ),
         ]
+        closed = self._tracker.exit(FLOW_METHOD, method_name)
+        if closed:
+            events.extend(self._close_boundaries(closed, _METHOD_FINISHED))
+        else:
+            # No open boundary for this method: fall back to a flat close,
+            # using the same coerced ``method_name`` the START used so a None
+            # cannot leak onto the wire.
+            events.append(
+                StepFinishedEvent(
+                    type=EventType.STEP_FINISHED,
+                    step_name=method_name,
+                )
+            )
+        return events
 
     # -- emission-shape strategy (default "chunks") -----------------------
 

--- a/integrations/crew-ai/python/ag_ui_crewai/attribution.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/attribution.py
@@ -1,0 +1,272 @@
+"""Hierarchical boundary attribution for the CrewAI -> AG-UI bridge.
+
+Background
+----------
+CrewAI has no wire-level namespace analogous to LangGraph's
+``langgraph_checkpoint_ns``. The bridge previously emitted one flat
+``STEP_STARTED`` / ``STEP_FINISHED`` pair per Flow ``MethodExecution*``
+event: no nesting, no attribution of a Crew running inside a Flow method,
+no Agent identity.
+
+This module reconstructs the run topology (Flow method -> nested Crew ->
+Agent) from the identity CrewAI carries on its own lifecycle events
+(``method_name`` / ``crew_name`` / agent ``role``) plus a boundary
+*stack*. The reconstructed hierarchy rides on every STEP event through the
+protocol's free-form ``raw_event`` field (serialised ``rawEvent``):
+
+* ``step_name`` is unchanged (the method / crew / agent identity), so
+  consumers that key on it are unaffected; flow-method steps additionally
+  gain a populated ``raw_event`` where the old bridge left it ``None`` (an
+  additive change).
+* topology-aware clients read ``raw_event["attribution"]`` for ``depth``,
+  ``parent_step_id``, the root-to-leaf ``path`` (the authoritative
+  representation; ``qualified_name`` is a convenience join), and a unique
+  ``step_id`` shared by a boundary's start and finish events (so two
+  boundaries with the same ``step_name`` are still distinguishable). This
+  is the surface that unblocks a CrewAI ``subgraphs`` feature.
+
+Threading contract
+------------------
+:class:`BoundaryTracker` is a plain single stack with NO internal locking.
+It is only ever driven from CrewAI's **ordered StreamFrame path**
+(``StreamFrameTranslator``), where frames are translated one at a time on
+the request's event-loop thread in emit order. That single-threaded,
+in-order contract is what makes a stack correct: ``enter`` on a start
+frame, ``exit`` on the matching finish frame, ``drain_all`` at run end.
+
+It is deliberately NOT driven from the legacy crewai event-bus listener
+path: crewai 1.x dispatches those sync handlers on a fire-and-forget
+ThreadPoolExecutor (``max_workers=10``), so handler execution is neither
+ordered nor single-threaded and a live stack there would race and
+mis-nest. The legacy path therefore emits only flat, per-method
+attribution (flow ownership + a step id), which needs no ordering.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from ag_ui.core import EventType
+from ag_ui.core.events import StepStartedEvent, StepFinishedEvent
+
+# Boundary kinds. Plain strings (not an enum) because they are serialised
+# verbatim under ``attribution.boundary`` and are part of the consumer
+# contract.
+FLOW_METHOD = "flow_method"
+CREW = "crew"
+AGENT = "agent"
+
+#: Identifies the producing adapter so a multi-framework client can branch.
+ATTRIBUTION_ADAPTER = "crewai"
+
+#: Separator joining the root-to-leaf path into ``qualified_name``.
+PATH_SEPARATOR = "/"
+
+#: Pairing key ``(boundary_type, name)``. Names are stable across a
+#: boundary's start and finish events (``method_name`` / ``crew_name`` /
+#: agent role), so they pair without depending on CrewAI populating
+#: ``source_fingerprint`` identically on both. Repeated names are
+#: disambiguated by the unique ``step_id`` in the payload; within one
+#: ordered run the LIFO stack pairs the nearest match correctly.
+BoundaryKey = Tuple[str, str]
+
+
+def boundary_key(boundary_type: str, name: str) -> BoundaryKey:
+    """Return the start/finish pairing key for a boundary."""
+    return (boundary_type, name)
+
+
+@dataclass
+class Boundary:
+    """One node in the reconstructed execution hierarchy.
+
+    Created when a Flow method / Crew / Agent starts and resolved again
+    when it finishes, so its ``STEP_STARTED`` and ``STEP_FINISHED`` events
+    share the same ``step_id`` and parent linkage.
+    """
+
+    boundary_type: str
+    name: str
+    key: BoundaryKey
+    step_id: str
+    parent_id: Optional[str]
+    depth: int
+    fingerprint: Optional[str] = None
+    flow_name: Optional[str] = None
+    path: Tuple[str, ...] = field(default_factory=tuple)
+
+    def attribution(self) -> Dict[str, Any]:
+        """Serialise into the ``raw_event.attribution`` payload."""
+        return {
+            "adapter": ATTRIBUTION_ADAPTER,
+            "boundary": self.boundary_type,
+            "depth": self.depth,
+            "step_id": self.step_id,
+            "parent_step_id": self.parent_id,
+            "path": list(self.path),
+            "qualified_name": PATH_SEPARATOR.join(self.path),
+            "flow_name": self.flow_name,
+            "fingerprint": self.fingerprint,
+        }
+
+
+class BoundaryTracker:
+    """Single ordered stack of open :class:`Boundary` objects for one run.
+
+    See the module "Threading contract": one tracker per run, driven
+    single-threaded and in emit order by the StreamFrame translator.
+    """
+
+    def __init__(self) -> None:
+        self._stack: List[Boundary] = []
+
+    @property
+    def stack(self) -> Tuple[Boundary, ...]:
+        return tuple(self._stack)
+
+    def current(self) -> Optional[Boundary]:
+        return self._stack[-1] if self._stack else None
+
+    def enter(
+        self,
+        boundary_type: str,
+        name: str,
+        *,
+        fingerprint: Optional[str] = None,
+        flow_name: Optional[str] = None,
+    ) -> Boundary:
+        """Push a boundary and return it.
+
+        Flow methods are roots (depth 0, no parent): a Flow's methods are
+        its top level and never nest under one another, so concurrent
+        ``@listen`` methods stay independent siblings rather than being
+        chained under whichever one opened first. Crews and Agents nest
+        under the current top-of-stack (their enclosing method / crew) and
+        inherit its ``flow_name``. ``fingerprint`` rides on the payload but
+        is not part of the pairing key.
+        """
+        parent = None if boundary_type == FLOW_METHOD else self.current()
+        effective_flow = flow_name if flow_name is not None else (
+            parent.flow_name if parent is not None else None
+        )
+        boundary = Boundary(
+            boundary_type=boundary_type,
+            name=name,
+            key=boundary_key(boundary_type, name),
+            step_id=uuid.uuid4().hex,
+            parent_id=parent.step_id if parent is not None else None,
+            depth=(parent.depth + 1) if parent is not None else 0,
+            fingerprint=fingerprint,
+            flow_name=effective_flow,
+            path=((parent.path if parent is not None else ()) + (name,)),
+        )
+        self._stack.append(boundary)
+        return boundary
+
+    def exit(self, boundary_type: str, name: str) -> List[Boundary]:
+        """Close the nearest matching boundary; return boundaries to finish.
+
+        Returns the matched boundary plus the still-open boundaries nested
+        above it, **deepest-first**, so the caller emits balanced
+        ``STEP_FINISHED`` events (inner boundaries close before their
+        enclosing one). Those dangling inners are boundaries whose own
+        finish frame never arrived (e.g. a sub-crew that raised); closing
+        them keeps every ``STEP_STARTED`` matched. Empty list => no open
+        match, so the caller emits nothing rather than an unbalanced close.
+
+        A boundary closes only its own subtree: the still-open boundaries
+        above it are followed up to (not through) the next open Flow method,
+        so a concurrent sibling ``@listen`` method (and its steps) sitting
+        above it on the stack is left untouched. Flow methods are the only
+        boundary kind that opens a new subtree, so stopping at one is what
+        keeps parallel branches independent.
+        """
+        key = boundary_key(boundary_type, name)
+        for index in range(len(self._stack) - 1, -1, -1):
+            if self._stack[index].key == key:
+                end = index + 1
+                while (
+                    end < len(self._stack)
+                    and self._stack[end].boundary_type != FLOW_METHOD
+                ):
+                    end += 1
+                closed = self._stack[index:end]
+                del self._stack[index:end]
+                closed.reverse()  # deepest (innermost) first
+                return closed
+        return []
+
+    def drain_all(self) -> List[Boundary]:
+        """Close and return every still-open boundary (deepest-first).
+
+        Called on normal run end (flow_finished / clean stream exhaustion) so a
+        boundary whose finish frame was lost is still closed on the wire. Leaves
+        the tracker empty. Abnormal termination (RUN_ERROR) does NOT drain: the
+        error path emits RUN_ERROR and open boundaries are left unclosed.
+        """
+        drained = list(reversed(self._stack))
+        self._stack.clear()
+        return drained
+
+
+def _raw_event(boundary: Boundary, source_event_type: Optional[str]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"attribution": boundary.attribution()}
+    if source_event_type:
+        # Originating CrewAI event type for provenance / debugging.
+        payload["crewai_event_type"] = source_event_type
+    return payload
+
+
+def step_started_event(
+    boundary: Boundary, *, source_event_type: Optional[str] = None
+) -> StepStartedEvent:
+    """Build a ``STEP_STARTED`` carrying ``boundary``'s attribution."""
+    return StepStartedEvent(
+        type=EventType.STEP_STARTED,
+        step_name=boundary.name,
+        raw_event=_raw_event(boundary, source_event_type),
+    )
+
+
+def step_finished_event(
+    boundary: Boundary, *, source_event_type: Optional[str] = None
+) -> StepFinishedEvent:
+    """Build a ``STEP_FINISHED`` carrying ``boundary``'s attribution."""
+    return StepFinishedEvent(
+        type=EventType.STEP_FINISHED,
+        step_name=boundary.name,
+        raw_event=_raw_event(boundary, source_event_type),
+    )
+
+
+def flat_method_attribution(
+    method_name: str,
+    *,
+    flow_name: Optional[str],
+    fingerprint: Optional[str],
+    step_id: str,
+) -> Dict[str, Any]:
+    """Attribution payload for a flat (depth-0) Flow-method boundary.
+
+    Used by the legacy event-bus path, which cannot maintain an ordered
+    stack (see the module "Threading contract"). It conveys flow ownership
+    and a stable per-run ``step_id`` for the method without claiming any
+    nesting: ``depth`` 0, ``parent_step_id`` None, single-element ``path``.
+    The ``step_id`` must be the SAME on the method's start and finish so a
+    consumer can pair them; the caller is responsible for that.
+    """
+    return {
+        "attribution": {
+            "adapter": ATTRIBUTION_ADAPTER,
+            "boundary": FLOW_METHOD,
+            "depth": 0,
+            "step_id": step_id,
+            "parent_step_id": None,
+            "path": [method_name],
+            "qualified_name": method_name,
+            "flow_name": flow_name,
+            "fingerprint": fingerprint,
+        }
+    }

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -32,10 +32,11 @@ from ._capabilities import (
     reset_stream_sinks,
 )
 from ._checkpoint import build_checkpoint_kwargs
-from ._frames import StreamFrameTranslator
+from ._frames import StreamFrameTranslator, CREW_AGENT_LIFECYCLE_TYPES
 from ._config import resolve_emit_raw_events as _resolve_emit_raw_events
 from ._frames import is_recognized_event, log_raw_loss, raw_event_for
 from .mcp import is_mcp_event, register_mcp_listeners, translate_mcp_event
+from .attribution import flat_method_attribution
 from crewai.flow.flow import Flow
 
 from ag_ui.core import (
@@ -164,6 +165,33 @@ QUEUE_LOOPS: dict = {}
 # key. Module-level so tests and the listener callbacks share one
 # source of truth.
 _QUEUE_KEY_ATTR = "_agui_queue_key"
+
+# Stable namespace for deterministic per-(run, method) step ids on the LEGACY
+# bus-listener path. That path is dispatched on an unordered ThreadPoolExecutor,
+# so it cannot maintain a stack; instead it stamps FLAT per-method attribution
+# whose ``step_id`` must be IDENTICAL on the method's STEP_STARTED and
+# STEP_FINISHED. A uuid5 over ``queue_key:method_name`` gives both handlers the
+# same id without sharing state.
+#
+# Collision note: this per-(run, method) id collides if the same method runs
+# more than once in a single run. That is acceptable: the legacy path is the
+# unordered fallback, whereas the ordered frame path mints a unique id per
+# execution.
+_LEGACY_STEP_ID_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00cf4fc964ff")
+
+
+def _legacy_method_step_id(queue_key: object, method_name: str) -> str:
+    """Deterministic step id for a legacy-path Flow method.
+
+    ``uuid5`` over ``queue_key:method_name`` so the same (run, method) pair
+    yields the same id on STEP_STARTED and STEP_FINISHED (the pairing key a
+    topology-aware consumer needs) without the two off-thread handlers sharing
+    any mutable state. ``queue_key`` scopes it to the run so two concurrent runs
+    of the same method do not collide.
+    """
+    return uuid.uuid5(
+        _LEGACY_STEP_ID_NAMESPACE, f"{queue_key}:{method_name}"
+    ).hex
 
 # Hard wall-clock ceiling on a single flow run. A runaway flow (e.g. a hung
 # LiteLLM stream or an infinite loop in a user task) must not be able to pin
@@ -916,11 +944,25 @@ class FastAPICrewFlowEventListener(_EventListenerBase):
         def _(source, event):
             # Clear stale suppression flags from a prior node that raised.
             reset_node_snapshot_suppression(source)
+            # Flat per-method attribution. The legacy bus path is dispatched on
+            # an unordered thread pool, so it cannot maintain a stack (see
+            # attribution.py); it stamps flow ownership + a stable per-(run,
+            # method) step_id only. Crew/Agent nesting is a StreamFrame-path
+            # feature, so no crew/agent handlers are registered here.
+            queue_key = getattr(source, _QUEUE_KEY_ATTR, None)
+            method_name = str(getattr(event, "method_name", None) or "method")
+            step_id = _legacy_method_step_id(queue_key, method_name)
             _enqueue(
                 source,
                 StepStartedEvent(
                     type=EventType.STEP_STARTED,
-                    step_name=event.method_name
+                    step_name=method_name,
+                    raw_event=flat_method_attribution(
+                        method_name,
+                        flow_name=getattr(event, "flow_name", None),
+                        fingerprint=getattr(event, "source_fingerprint", None),
+                        step_id=step_id,
+                    ),
                 )
             )
         @crewai_event_bus.on(MethodExecutionFinishedEvent)
@@ -952,11 +994,22 @@ class FastAPICrewFlowEventListener(_EventListenerBase):
                         snapshot=_flow_state_snapshot(state),
                     ),
                 )
+            # The finish reuses the same step_id as the matching start (same
+            # (queue_key, method_name)) so a consumer can pair them.
+            queue_key = getattr(source, _QUEUE_KEY_ATTR, None)
+            method_name = str(getattr(event, "method_name", None) or "method")
+            step_id = _legacy_method_step_id(queue_key, method_name)
             _enqueue(
                 source,
                 StepFinishedEvent(
                     type=EventType.STEP_FINISHED,
-                    step_name=event.method_name
+                    step_name=method_name,
+                    raw_event=flat_method_attribution(
+                        method_name,
+                        flow_name=getattr(event, "flow_name", None),
+                        fingerprint=getattr(event, "source_fingerprint", None),
+                        step_id=step_id,
+                    ),
                 )
             )
         @crewai_event_bus.on(BridgedTextMessageChunkEvent)
@@ -1782,14 +1835,15 @@ async def _run_flow_frame_stream(
 
     Payload + identity come from the RAW event, not ``frame.data``. We register
     our OWN scoped sink that parks the raw event object keyed by
-    ``event.event_id`` — but ONLY when ``source is flow_copy``, so a nested
-    ``crew.kickoff``'s own flow's lifecycle/method
-    events (which leak onto this same sink via the copied contextvars) are
-    excluded. The frame stream then supplies ORDERING; for each frame we look
+    ``event.event_id``. Outer-flow lifecycle/method events are parked only when
+    ``source is flow_copy`` (so a nested ``crew.kickoff``'s own flow's
+    lifecycle/method events, which leak onto this same sink via the copied
+    contextvars, are excluded); Crew/Agent lifecycle events are parked
+    regardless of source (they are run-scoped and arrive with a non-outer
+    source) so the translator can attribute the crew/agent hierarchy. The frame
+    stream then supplies ORDERING; for each frame we look
     up the parked raw event by ``frame.id`` and translate it. A frame with no
-    parked event belonged to a nested flow (or is a crewai-internal frame we
-    drop) and is skipped. This mirrors the legacy listener's ``source is
-    flow_copy`` gate and its pristine-payload behavior.
+    parked event is skipped.
 
     Because ``publish_stream_event`` runs the sink synchronously on ``emit``
     and crewai enqueues the frame via ``loop.call_soon_threadsafe`` (a later
@@ -1842,20 +1896,23 @@ async def _run_flow_frame_stream(
         return encoder.encode(raw_mirror)
 
     def _sink(source: Any, event: Any) -> None:
-        # ``source is flow_copy`` isolates the outer run: nested ``crew.kickoff``
-        # flows emit with a DIFFERENT source (verified on the 1.15.7 wheel), and
-        # our own ``Bridged*`` events are emitted with ``flow_copy`` as source.
-        #
-        # crewai's MCP events are emitted with the agent/crew as source (NOT
-        # flow_copy), so the source gate alone would drop them. Park them by
-        # TYPE too. This sink is context-scoped (crewai.events.stream_context), so
-        # only THIS run's MCP events (including those from nested crews) reach it
-        # -- no cross-run leakage -- and the type gate keeps nested-flow LIFECYCLE
-        # events (still source != flow_copy) filtered out as before.
+        # source is flow_copy isolates the outer run: its own lifecycle/method
+        # events and our Bridged* events carry flow_copy as source, while a
+        # nested crew.kickoff's own flow's lifecycle/method events leak here
+        # with a different source and must stay dropped (no double RUN_STARTED,
+        # no mis-nested method). MCP and Crew/Agent lifecycle events are parked
+        # regardless of source because this sink is scoped to the run's context
+        # (no cross-run leak); crew/agent events let the translator attribute
+        # the hierarchy. Any other foreign event is parked for RAW passthrough
+        # only when opt-in is on (bounded buffer, oldest evicted with a log).
         event_id = getattr(event, "event_id", None)
         if event_id is None:
             return
-        if source is flow_copy or is_mcp_event(event):
+        if (
+            source is flow_copy
+            or is_mcp_event(event)
+            or getattr(event, "type", None) in CREW_AGENT_LIFECYCLE_TYPES
+        ):
             raw_events[event_id] = event
         elif emit_raw_events:
             if len(foreign_events) >= _FOREIGN_EVENT_BUFFER_MAX:

--- a/integrations/crew-ai/python/tests/test_attribution.py
+++ b/integrations/crew-ai/python/tests/test_attribution.py
@@ -1,0 +1,694 @@
+"""Tests for hierarchical multi-agent / nested-crew STEP attribution.
+
+Three layers are covered, matching the design's two-pipeline split:
+
+* the pure :mod:`ag_ui_crewai.attribution` boundary stack + event builders,
+  which reconstruct the Flow-method -> Crew -> Agent topology from boundary
+  identity alone (CrewAI has no wire-level namespace to lean on);
+* the ordered ``StreamFrameTranslator`` seam (``_frames.py``), which is where
+  FULL hierarchical attribution lives; it is driven single-threaded and in
+  emit order, so a boundary stack is correct there. Tests feed ORDERED fake raw
+  events and assert the emitted STEP events carry the right
+  depth/parent/path/step_id and stay balanced (every STEP_STARTED closed);
+* the LEGACY bus-listener path (``endpoint.py``), which crewai 1.x dispatches on
+  an unordered ThreadPoolExecutor and therefore CANNOT maintain a stack; it
+  stamps FLAT per-method attribution only (flow ownership + a stable per-run
+  step_id shared by the method's start and finish).
+
+That crew_kickoff_started / agent_execution_started frames reach ``astream`` end
+to end was verified empirically against a real crewai wheel; the end-to-end sink
+gating lives in ``test_streaming.py``. These unit tests drive the translator
+directly with ordered fakes so they are hermetic and do not depend on a live LLM.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+from ag_ui.core import EventType
+
+from ag_ui_crewai import attribution as attr
+from ag_ui_crewai import endpoint as ep
+from ag_ui_crewai._frames import StreamFrameTranslator
+from ag_ui_crewai.context import flow_context
+from ag_ui_crewai._capabilities import (
+    crewai_event_bus,
+    MethodExecutionStartedEvent,
+    MethodExecutionFinishedEvent,
+)
+
+
+# ==========================================================================
+# Pure BoundaryTracker + event builders
+# ==========================================================================
+
+def test_tracker_reconstructs_parent_child_depth_and_path():
+    tracker = attr.BoundaryTracker()
+
+    method = tracker.enter(attr.FLOW_METHOD, "generate", flow_name="ResearchFlow")
+    crew = tracker.enter(attr.CREW, "research_crew")
+    agent = tracker.enter(attr.AGENT, "Researcher")
+
+    # Depth increases with nesting.
+    assert (method.depth, crew.depth, agent.depth) == (0, 1, 2)
+
+    # Parent linkage chains child -> parent by step_id.
+    assert method.parent_id is None
+    assert crew.parent_id == method.step_id
+    assert agent.parent_id == crew.step_id
+
+    # flow_name is inherited by nested boundaries that carry none of their own.
+    assert crew.flow_name == "ResearchFlow"
+    assert agent.flow_name == "ResearchFlow"
+
+    # Root-to-leaf path accumulates.
+    assert method.path == ("generate",)
+    assert crew.path == ("generate", "research_crew")
+    assert agent.path == ("generate", "research_crew", "Researcher")
+
+    # current() / stack reflect the open boundaries.
+    assert tracker.current() is agent
+    assert tracker.stack == (method, crew, agent)
+
+
+def test_tracker_step_ids_are_unique_per_boundary():
+    tracker = attr.BoundaryTracker()
+    m = tracker.enter(attr.FLOW_METHOD, "run")
+    c = tracker.enter(attr.CREW, "crew")
+    a = tracker.enter(attr.AGENT, "Worker")
+    assert len({m.step_id, c.step_id, a.step_id}) == 3
+
+
+def test_tracker_exit_returns_matched_boundary_and_pops():
+    tracker = attr.BoundaryTracker()
+    method = tracker.enter(attr.FLOW_METHOD, "generate")
+    crew = tracker.enter(attr.CREW, "research_crew")
+
+    assert tracker.exit(attr.CREW, "research_crew") == [crew]
+    assert tracker.current() is method
+
+    assert tracker.exit(attr.FLOW_METHOD, "generate") == [method]
+    assert tracker.current() is None
+    assert tracker.stack == ()
+
+
+def test_tracker_exit_closes_dangling_inner_boundaries_deepest_first():
+    """A lost inner finish must not wedge the stack or leave a dangling
+    STEP_STARTED. Exiting the method returns the orphaned inners too,
+    deepest-first, so the caller closes them all in balanced order."""
+    tracker = attr.BoundaryTracker()
+    method = tracker.enter(attr.FLOW_METHOD, "generate")
+    crew = tracker.enter(attr.CREW, "research_crew")
+    agent = tracker.enter(attr.AGENT, "Researcher")  # inner finishes never fire
+
+    closed = tracker.exit(attr.FLOW_METHOD, "generate")
+    assert closed == [agent, crew, method]  # deepest-first
+    assert tracker.stack == ()
+
+
+def test_tracker_exit_returns_empty_for_unknown_boundary():
+    tracker = attr.BoundaryTracker()
+    tracker.enter(attr.FLOW_METHOD, "run")
+    assert tracker.exit(attr.CREW, "never_opened") == []
+    # The unmatched exit must not disturb the open method.
+    assert tracker.current().name == "run"
+
+
+def test_tracker_duplicate_names_pair_lifo_with_distinct_step_ids():
+    """Two sequential boundaries sharing a name are distinct (unique step_ids)
+    and each finish pops its own start via the stable name key (LIFO)."""
+    tracker = attr.BoundaryTracker()
+    tracker.enter(attr.FLOW_METHOD, "run")
+    a1 = tracker.enter(attr.AGENT, "Worker", fingerprint="fp-a1")
+    assert tracker.exit(attr.AGENT, "Worker") == [a1]
+    a2 = tracker.enter(attr.AGENT, "Worker", fingerprint="fp-a2")
+    assert a2.step_id != a1.step_id
+    assert tracker.exit(attr.AGENT, "Worker") == [a2]
+
+
+def test_tracker_drain_all_closes_every_open_boundary_and_clears():
+    tracker = attr.BoundaryTracker()
+    m = tracker.enter(attr.FLOW_METHOD, "run")
+    c = tracker.enter(attr.CREW, "crew")
+    assert tracker.drain_all() == [c, m]  # deepest-first
+    assert tracker.stack == ()
+    # Draining an empty tracker is a no-op.
+    assert tracker.drain_all() == []
+
+
+def test_step_events_carry_attribution_payload():
+    tracker = attr.BoundaryTracker()
+    method = tracker.enter(
+        attr.FLOW_METHOD, "generate", flow_name="ResearchFlow", fingerprint="fp-123"
+    )
+    crew = tracker.enter(attr.CREW, "research_crew")
+
+    started = attr.step_started_event(crew, source_event_type="crew_kickoff_started")
+    assert started.type == EventType.STEP_STARTED
+    assert started.step_name == "research_crew"  # leaf identity, backward compatible
+
+    payload = started.raw_event["attribution"]
+    assert payload["adapter"] == attr.ATTRIBUTION_ADAPTER
+    assert payload["boundary"] == attr.CREW
+    assert payload["depth"] == 1
+    assert payload["parent_step_id"] == method.step_id
+    assert payload["path"] == ["generate", "research_crew"]
+    assert payload["qualified_name"] == "generate/research_crew"
+    assert payload["flow_name"] == "ResearchFlow"
+    assert started.raw_event["crewai_event_type"] == "crew_kickoff_started"
+
+    finished = attr.step_finished_event(crew)
+    # Start and finish reference the same boundary -> same step_id.
+    assert finished.raw_event["attribution"]["step_id"] == crew.step_id
+    # A finish with no source tag omits the provenance key.
+    assert "crewai_event_type" not in finished.raw_event
+
+
+def test_flat_method_attribution_shape():
+    payload = attr.flat_method_attribution(
+        "generate", flow_name="F", fingerprint="fp", step_id="abc123"
+    )["attribution"]
+    assert payload["adapter"] == attr.ATTRIBUTION_ADAPTER
+    assert payload["boundary"] == attr.FLOW_METHOD
+    assert payload["depth"] == 0
+    assert payload["parent_step_id"] is None
+    assert payload["path"] == ["generate"]
+    assert payload["qualified_name"] == "generate"
+    assert payload["step_id"] == "abc123"
+    assert payload["flow_name"] == "F"
+    assert payload["fingerprint"] == "fp"
+
+
+# ==========================================================================
+# StreamFrameTranslator (ordered path: FULL hierarchical attribution)
+# ==========================================================================
+
+_seq = 0
+
+
+def _ev(event_type, **fields):
+    """Build a fake raw crewai event: a ``SimpleNamespace`` with ``.type`` and a
+    unique ``.event_id`` (the translator keys off ``.type``; ``event_id`` mirrors
+    the real events for realism)."""
+    global _seq
+    _seq += 1
+    return SimpleNamespace(type=event_type, event_id=f"evt-{_seq}", **fields)
+
+
+def _agent_ev(event_type, role, fingerprint=None):
+    return _ev(
+        event_type,
+        agent=SimpleNamespace(role=role),
+        source_fingerprint=fingerprint,
+    )
+
+
+def _make_translator():
+    return StreamFrameTranslator(
+        thread_id="thread-1",
+        run_id="run-1",
+        state_provider=lambda: {"messages": []},
+    )
+
+
+def _run(translator, events):
+    """Feed a list of raw events through ``translate`` and return the flat list
+    of AG-UI events emitted, in order."""
+    out = []
+    for e in events:
+        out.extend(translator.translate(e))
+    return out
+
+
+def _steps(events):
+    return [
+        e for e in events
+        if e.type in (EventType.STEP_STARTED, EventType.STEP_FINISHED)
+    ]
+
+
+def _attribution(step_event):
+    return (step_event.raw_event or {}).get("attribution") if step_event.raw_event else None
+
+
+def _assert_balanced(step_events):
+    """Every STEP_STARTED has exactly one later STEP_FINISHED sharing its
+    attribution step_id (or step_name for legacy un-attributed steps)."""
+    open_ids = []
+    for e in step_events:
+        payload = _attribution(e)
+        ident = payload["step_id"] if payload else e.step_name
+        if e.type == EventType.STEP_STARTED:
+            open_ids.append(ident)
+        else:
+            assert ident in open_ids, f"unbalanced STEP_FINISHED for {ident!r}"
+            open_ids.remove(ident)
+    assert open_ids == [], f"unclosed STEP_STARTED(s): {open_ids}"
+
+
+def test_translator_nested_flow_crew_agent_hierarchy():
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="generate",
+            flow_name="ResearchFlow", source_fingerprint="flow-fp"),
+        _ev("crew_kickoff_started", crew_name="research_crew",
+            source_fingerprint="crew-fp"),
+        _agent_ev("agent_execution_started", "Researcher", fingerprint="agent-fp"),
+        _agent_ev("agent_execution_completed", "Researcher"),
+        _ev("crew_kickoff_completed", crew_name="research_crew"),
+        _ev("method_execution_finished", method_name="generate"),
+        _ev("flow_finished"),
+    ])
+
+    kinds = [e.type for e in events]
+    assert kinds[0] == EventType.RUN_STARTED
+    assert kinds[-1] == EventType.RUN_FINISHED
+    # method_execution_finished still emits its snapshots (unchanged behaviour).
+    assert EventType.MESSAGES_SNAPSHOT in kinds
+    assert EventType.STATE_SNAPSHOT in kinds
+
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "generate"),
+        ("STEP_STARTED", "research_crew"),
+        ("STEP_STARTED", "Researcher"),
+        ("STEP_FINISHED", "Researcher"),
+        ("STEP_FINISHED", "research_crew"),
+        ("STEP_FINISHED", "generate"),
+    ]
+
+    def start_attr(name):
+        for e in step_events:
+            if e.type == EventType.STEP_STARTED and e.step_name == name:
+                return _attribution(e)
+        raise AssertionError(name)
+
+    method = start_attr("generate")
+    crew = start_attr("research_crew")
+    agent = start_attr("Researcher")
+
+    assert method["depth"] == 0 and method["parent_step_id"] is None
+    assert crew["depth"] == 1 and crew["parent_step_id"] == method["step_id"]
+    assert agent["depth"] == 2 and agent["parent_step_id"] == crew["step_id"]
+    assert agent["path"] == ["generate", "research_crew", "Researcher"]
+    assert crew["flow_name"] == "ResearchFlow"  # inherited from the method
+    assert agent["flow_name"] == "ResearchFlow"  # inherited transitively
+    assert method["fingerprint"] == "flow-fp"
+    assert crew["fingerprint"] == "crew-fp"
+    assert agent["fingerprint"] == "agent-fp"
+
+    # Each finish reuses its start's step_id.
+    def finish_attr(name):
+        for e in step_events:
+            if e.type == EventType.STEP_FINISHED and e.step_name == name:
+                return _attribution(e)
+        raise AssertionError(name)
+
+    assert finish_attr("Researcher")["step_id"] == agent["step_id"]
+    assert finish_attr("research_crew")["step_id"] == crew["step_id"]
+    assert finish_attr("generate")["step_id"] == method["step_id"]
+
+
+def test_translator_parallel_methods_stay_balanced_roots():
+    """Concurrent @listen methods interleave their start/finish frames. Each
+    must be an independent depth-0 root and close exactly once; a finishing
+    method must not force-close a still-running sibling."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="a", flow_name="F"),
+        _ev("method_execution_started", method_name="b", flow_name="F"),
+        _ev("method_execution_finished", method_name="a"),
+        _ev("method_execution_finished", method_name="b"),
+        _ev("flow_finished"),
+    ])
+
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    # Exactly one start and one finish per method; no spurious extra close.
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "a"),
+        ("STEP_STARTED", "b"),
+        ("STEP_FINISHED", "a"),
+        ("STEP_FINISHED", "b"),
+    ]
+
+    def attr_for(kind, name):
+        for e in step_events:
+            if e.type == kind and e.step_name == name:
+                return _attribution(e)
+        raise AssertionError(name)
+
+    a_start = attr_for(EventType.STEP_STARTED, "a")
+    b_start = attr_for(EventType.STEP_STARTED, "b")
+    # Both methods are independent roots, not chained under one another.
+    assert a_start["depth"] == 0 and a_start["parent_step_id"] is None
+    assert b_start["depth"] == 0 and b_start["parent_step_id"] is None
+    # Finishes pair to their own starts.
+    assert attr_for(EventType.STEP_FINISHED, "a")["step_id"] == a_start["step_id"]
+    assert attr_for(EventType.STEP_FINISHED, "b")["step_id"] == b_start["step_id"]
+
+
+def test_translator_crew_finish_does_not_close_sibling_method():
+    """A crew finishing while a concurrent sibling @listen method sits above it
+    on the stack must close only the crew, never over-close the sibling method."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="a", flow_name="F"),
+        _ev("crew_kickoff_started", crew_name="ca"),
+        _ev("method_execution_started", method_name="b", flow_name="F"),
+        _ev("crew_kickoff_completed", crew_name="ca"),
+        _ev("method_execution_finished", method_name="a"),
+        _ev("method_execution_finished", method_name="b"),
+        _ev("flow_finished"),
+    ])
+
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    # ca closes right after its completion frame, before either method finishes;
+    # method b is not dragged closed by ca's exit.
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "a"),
+        ("STEP_STARTED", "ca"),
+        ("STEP_STARTED", "b"),
+        ("STEP_FINISHED", "ca"),
+        ("STEP_FINISHED", "a"),
+        ("STEP_FINISHED", "b"),
+    ]
+
+
+def test_translator_dangling_inner_closed_at_method_finish():
+    """A crew whose completion frame is lost is force-closed when its owning
+    method finishes, so the stream stays balanced."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m", source_fingerprint=None),
+        _ev("crew_kickoff_started", crew_name="c", source_fingerprint="cf"),
+        # crew never completes; the method just finishes.
+        _ev("method_execution_finished", method_name="m"),
+        _ev("flow_finished"),
+    ])
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "m"),
+        ("STEP_STARTED", "c"),
+        ("STEP_FINISHED", "c"),   # dangling inner, closed deepest-first
+        ("STEP_FINISHED", "m"),
+    ]
+
+
+def test_translator_drains_open_boundaries_at_flow_finished():
+    """A crew AND a method left open (no finish frames) are force-closed at
+    flow_finished, deepest-first, before RUN_FINISHED."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m", source_fingerprint=None),
+        _ev("crew_kickoff_started", crew_name="c", source_fingerprint="cf"),
+        _ev("flow_finished"),
+    ])
+    _assert_balanced(_steps(events))
+    # The last event is RUN_FINISHED and the two closes precede it deepest-first.
+    assert events[-1].type == EventType.RUN_FINISHED
+    closes = [e for e in _steps(events) if e.type == EventType.STEP_FINISHED]
+    assert [e.step_name for e in closes] == ["c", "m"]
+
+
+def test_translator_crew_finish_without_start_emits_nothing():
+    translator = _make_translator()
+    translator.translate(_ev("flow_started"))
+    # A completion for a crew that never started must not emit an unbalanced
+    # close.
+    assert translator.translate(
+        _ev("crew_kickoff_completed", crew_name="ghost", source_fingerprint=None)
+    ) == []
+
+
+def test_translator_agent_finish_without_start_emits_nothing():
+    translator = _make_translator()
+    translator.translate(_ev("flow_started"))
+    assert translator.translate(
+        _agent_ev("agent_execution_error", "ghost")
+    ) == []
+
+
+def test_translator_method_finish_without_start_falls_back_to_flat_close():
+    """A method_execution_finished with no open boundary preserves the old flat
+    shape: snapshots + an un-attributed STEP_FINISHED named by the method."""
+    translator = _make_translator()
+    translator.translate(_ev("flow_started"))
+    out = translator.translate(_ev("method_execution_finished", method_name="orphan"))
+    kinds = [e.type for e in out]
+    assert EventType.MESSAGES_SNAPSHOT in kinds
+    assert EventType.STATE_SNAPSHOT in kinds
+    finishes = [e for e in out if e.type == EventType.STEP_FINISHED]
+    assert len(finishes) == 1
+    assert finishes[0].step_name == "orphan"
+    assert finishes[0].raw_event is None  # legacy un-attributed shape
+
+
+def test_translator_agent_error_and_crew_failed_close_their_boundaries():
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m", source_fingerprint=None),
+        _ev("crew_kickoff_started", crew_name="c", source_fingerprint="cf"),
+        _agent_ev("agent_execution_started", "W", fingerprint="af"),
+        _agent_ev("agent_execution_error", "W"),
+        _ev("crew_kickoff_failed", crew_name="c"),
+        _ev("method_execution_finished", method_name="m"),
+        _ev("flow_finished"),
+    ])
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    assert [e.step_name for e in step_events] == ["m", "c", "W", "W", "c", "m"]
+
+
+def test_translator_method_failed_closes_boundary_without_snapshots():
+    """A method_execution_failed closes the open method boundary so no dangling
+    STEP_STARTED is left when a flow method fails but the flow continues. Unlike
+    method_execution_finished, it emits no MESSAGES/STATE snapshots."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m", source_fingerprint="fp"),
+        _ev("method_execution_failed", method_name="m", source_fingerprint="fp"),
+        _ev("flow_finished"),
+    ])
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "m"),
+        ("STEP_FINISHED", "m"),
+    ]
+    # The failed close carries provenance and is not accompanied by snapshots.
+    finish = next(e for e in step_events if e.type == EventType.STEP_FINISHED)
+    assert finish.raw_event["crewai_event_type"] == "method_execution_failed"
+    kinds = [e.type for e in events]
+    assert EventType.MESSAGES_SNAPSHOT not in kinds
+    assert EventType.STATE_SNAPSHOT not in kinds
+
+
+def test_translator_method_failed_closes_open_crew_and_agent():
+    """A method that fails with an open crew/agent below it closes the whole
+    subtree (deepest-first), leaving nothing dangling."""
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m"),
+        _ev("crew_kickoff_started", crew_name="c"),
+        _agent_ev("agent_execution_started", "W"),
+        _ev("method_execution_failed", method_name="m"),
+        _ev("flow_finished"),
+    ])
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    assert [(e.type.name, e.step_name) for e in step_events] == [
+        ("STEP_STARTED", "m"),
+        ("STEP_STARTED", "c"),
+        ("STEP_STARTED", "W"),
+        ("STEP_FINISHED", "W"),
+        ("STEP_FINISHED", "c"),
+        ("STEP_FINISHED", "m"),
+    ]
+
+
+def test_translator_names_coerced_to_str():
+    """A non-str method/crew name and a UUID-ish agent id must not raise in the
+    attribution path; everything is coerced to str."""
+    class _UUIDish:
+        def __str__(self):
+            return "11111111-2222-3333-4444-555555555555"
+
+    translator = _make_translator()
+    events = _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name=123, source_fingerprint=None),
+        _ev("crew_kickoff_started", crew_name=None, source_fingerprint=None),
+        # Agent with empty role -> falls back to str(id).
+        _ev("agent_execution_started",
+            agent=SimpleNamespace(role="", id=_UUIDish()),
+            source_fingerprint=None),
+        _ev("flow_finished"),
+    ])
+    step_events = _steps(events)
+    _assert_balanced(step_events)
+    starts = [e for e in step_events if e.type == EventType.STEP_STARTED]
+    assert starts[0].step_name == "123"        # int coerced
+    assert starts[1].step_name == "crew"       # None -> fallback
+    assert starts[2].step_name.startswith("11111111")  # empty role -> str(id)
+    for e in step_events:
+        assert isinstance(e.step_name, str)
+
+
+def test_translator_finalize_drains_when_stream_exhausts_without_flow_finished():
+    """If the stream ends with the run open but no flow_finished, finalize()
+    closes every dangling boundary before the synthesized RUN_FINISHED."""
+    translator = _make_translator()
+    _run(translator, [
+        _ev("flow_started"),
+        _ev("method_execution_started", method_name="m", source_fingerprint=None),
+        _ev("crew_kickoff_started", crew_name="c", source_fingerprint="cf"),
+    ])
+    tail = translator.finalize()
+    closes = [e for e in tail if e.type == EventType.STEP_FINISHED]
+    assert [e.step_name for e in closes] == ["c", "m"]
+    assert tail[-1].type == EventType.RUN_FINISHED
+    # A second finalize is idempotent (run already finished).
+    assert translator.finalize() == []
+
+
+def test_translator_run_started_emitted_once():
+    translator = _make_translator()
+    assert translator.translate(_ev("flow_started"))[0].type == EventType.RUN_STARTED
+    # A second flow_started (defensive) emits nothing.
+    assert translator.translate(_ev("flow_started")) == []
+
+
+# ==========================================================================
+# Legacy bus-listener path (unordered: FLAT per-method attribution only)
+# ==========================================================================
+
+class _FakeFlow:
+    """Minimal Flow stand-in the listener can attach a queue to."""
+
+    def __init__(self):
+        self.state = {"messages": []}
+
+
+def _drain(queue):
+    items = []
+    while True:
+        try:
+            items.append(queue.get_nowait())
+        except asyncio.QueueEmpty:
+            break
+    return items
+
+
+async def _settle_bus(queue, expected, budget=3.0):
+    """Wait for crewai's off-thread (ThreadPoolExecutor) sync handlers to land.
+
+    crewai 1.x dispatches our listener callbacks on a worker thread; each hops
+    back onto the request loop via ``call_soon_threadsafe``. ``flush`` waits for
+    the workers, then a loop yield lets the scheduled ``put_nowait`` callbacks
+    run. Poll until ``expected`` items are queued or the budget expires.
+    """
+    flush = getattr(crewai_event_bus, "flush", None)
+    deadline = time.monotonic() + budget
+    while time.monotonic() < deadline:
+        if callable(flush):
+            flush(5.0)
+        await asyncio.sleep(0.02)
+        if queue.qsize() >= expected:
+            break
+
+
+async def test_legacy_method_step_events_carry_flat_attribution_and_matching_step_id():
+    """The legacy bus path stamps FLAT attribution on the method's STEP_STARTED
+    and STEP_FINISHED with the SAME step_id, so a consumer can pair them.
+    No nesting is claimed (depth 0, parent None).
+
+    NOTE: the legacy path is dispatched on crewai's unordered ThreadPoolExecutor
+    (see attribution.py "Threading contract"), so the START and FINISH may LAND
+    in either order. That is exactly why pairing is by ``step_id`` rather than by
+    position; this test asserts the pairing invariant, never arrival order.
+    """
+    flow = _FakeFlow()
+    queue = await ep.create_queue(flow)
+    token = flow_context.set(flow)
+    try:
+        ep.FastAPICrewFlowEventListener()  # registers handlers on the global bus
+        crewai_event_bus.emit(flow, MethodExecutionStartedEvent.model_construct(
+            flow_name="ResearchFlow", method_name="generate",
+            source_fingerprint="flow-fp"))
+        crewai_event_bus.emit(flow, MethodExecutionFinishedEvent.model_construct(
+            flow_name="ResearchFlow", method_name="generate"))
+        # 4 STEP/snapshot events: STEP_STARTED, MESSAGES_SNAPSHOT,
+        # STATE_SNAPSHOT, STEP_FINISHED (order between start/finish is not
+        # guaranteed on this path).
+        await _settle_bus(queue, expected=4)
+    finally:
+        flow_context.reset(token)
+        await ep.delete_queue(flow)
+
+    events = _drain(queue)
+    starts = [e for e in events if e is not None and e.type == EventType.STEP_STARTED]
+    finishes = [e for e in events if e is not None and e.type == EventType.STEP_FINISHED]
+    assert len(starts) == 1 and len(finishes) == 1
+    assert starts[0].step_name == "generate"
+    assert finishes[0].step_name == "generate"
+
+    start_attr = starts[0].raw_event["attribution"]
+    finish_attr = finishes[0].raw_event["attribution"]
+
+    # Flat: no nesting is claimed.
+    assert start_attr["boundary"] == attr.FLOW_METHOD
+    assert start_attr["depth"] == 0
+    assert start_attr["parent_step_id"] is None
+    assert start_attr["path"] == ["generate"]
+    assert start_attr["flow_name"] == "ResearchFlow"
+    assert start_attr["fingerprint"] == "flow-fp"
+
+    # Start and finish share the SAME deterministic step_id (the pairing key),
+    # independent of the order in which the two off-thread handlers landed.
+    assert start_attr["step_id"] == finish_attr["step_id"]
+
+    # The snapshots are still emitted (unchanged behaviour).
+    kinds = [e.type for e in events if e is not None]
+    assert EventType.MESSAGES_SNAPSHOT in kinds
+    assert EventType.STATE_SNAPSHOT in kinds
+
+
+def test_legacy_step_id_is_deterministic_and_run_scoped():
+    """The helper yields the SAME id for one (run, method) and DIFFERENT ids
+    across runs / methods, so start and finish pair without shared state."""
+    a1 = ep._legacy_method_step_id("run-key-A", "generate")
+    a2 = ep._legacy_method_step_id("run-key-A", "generate")
+    b = ep._legacy_method_step_id("run-key-B", "generate")
+    c = ep._legacy_method_step_id("run-key-A", "other")
+    assert a1 == a2          # same (run, method) -> same id
+    assert a1 != b           # different run -> different id
+    assert a1 != c           # different method -> different id
+
+
+def test_crew_agent_lifecycle_types_is_the_single_source_of_truth():
+    """The ``_sink`` gate keys off ``CREW_AGENT_LIFECYCLE_TYPES``: it holds
+    exactly the six crew/agent ``.type`` strings and none of the flow/method
+    ones, so the nested-FLOW drop rule holds."""
+    from ag_ui_crewai._frames import CREW_AGENT_LIFECYCLE_TYPES
+
+    assert CREW_AGENT_LIFECYCLE_TYPES == frozenset({
+        "crew_kickoff_started", "crew_kickoff_completed", "crew_kickoff_failed",
+        "agent_execution_started", "agent_execution_completed",
+        "agent_execution_error",
+    })
+    for t in ("flow_started", "flow_finished",
+              "method_execution_started", "method_execution_finished",
+              "method_execution_failed"):
+        assert t not in CREW_AGENT_LIFECYCLE_TYPES

--- a/integrations/crew-ai/python/tests/test_crew_chat.py
+++ b/integrations/crew-ai/python/tests/test_crew_chat.py
@@ -634,6 +634,11 @@ async def test_crew_run_emits_state_snapshot():
                         lambda crew, messages: (lambda **_k: "OUT"),
                     ):
                         await flow.chat()
+        # The MethodExecutionFinished handler that emits the STATE_SNAPSHOT runs
+        # on crewai's off-thread pool; settle it before the synchronous drain so
+        # the snapshot has landed. Real HTTP streams drain in an awaiting loop,
+        # so they never need this.
+        await ep._flush_event_bus()
         items = _drain(queue)
     finally:
         flow_context.reset(token)

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -819,6 +819,80 @@ async def test_frame_path_nested_error_still_terminates_run():
     assert "RUN_FINISHED" in types or "RUN_ERROR" in types, types
 
 
+# -- sink source-gating: crew/agent parked, nested-flow method dropped ------
+
+class _MixedSourceSession:
+    """AsyncStreamSession stand-in that publishes each RAW event to the scoped
+    sink under a PER-EVENT source (not one shared source), so we can drive the
+    sink's crew/agent-vs-nested-flow source gate directly."""
+
+    def __init__(self, pairs):
+        self._pairs = pairs
+        self.aclosed = False
+
+    async def _agen(self):
+        from crewai.events.stream_context import publish_stream_event
+
+        for source, ev in self._pairs:
+            publish_stream_event(source, ev)
+            yield _Frame(ev.type, id=ev.event_id)
+
+    def __aiter__(self):
+        return self._agen()
+
+    async def aclose(self):
+        self.aclosed = True
+
+
+class _MixedSourceFlow:
+    state = {}
+
+    def __init__(self, session):
+        self._session = session
+
+    def astream(self, inputs=None):
+        return self._session
+
+
+@requires_stream_frames
+async def test_frame_path_sink_parks_crew_agent_but_drops_nested_flow_method():
+    """The driver's scoped ``_sink`` parks crew/agent lifecycle events even when
+    their source is NOT the outer flow (they are run-scoped), while a nested
+    FLOW method event (non-crew/agent, non-outer source) is dropped."""
+    from ag_ui.encoder import EventEncoder
+
+    outer = _MixedSourceFlow(None)  # session attached once the pairs reference it
+    other = object()  # a non-outer source (nested-flow / crew emitter)
+
+    pairs = [
+        (outer, _ev("flow_started", event_id="fs")),
+        (outer, _ev("method_execution_started", event_id="ms", method_name="m")),
+        # Crew event from a NON-outer source -> parked (surfaces as a STEP).
+        (other, _ev("crew_kickoff_started", event_id="cs", crew_name="research_crew")),
+        # Nested-FLOW method from a NON-outer source -> dropped (no STEP).
+        (other, _ev("method_execution_started", event_id="nested",
+                    method_name="nested_method")),
+        (other, _ev("crew_kickoff_completed", event_id="cc", crew_name="research_crew")),
+        (outer, _ev("method_execution_finished", event_id="mf", method_name="m")),
+        (outer, _ev("flow_finished", event_id="ff")),
+    ]
+    outer._session = _MixedSourceSession(pairs)
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=outer,
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    started_names = [p["stepName"] for p in payloads if p["type"] == "STEP_STARTED"]
+
+    assert "research_crew" in started_names   # crew parked despite non-outer source
+    assert "nested_method" not in started_names  # nested-flow method dropped
+    assert "m" in started_names               # outer method still surfaces
+
+
 # -- per-request flow COPY seeds state before @start runs ------
 
 class _StateReadingFlow(Flow[CopilotKitState]):


### PR DESCRIPTION
## PNI-131 — [Parity] Multi-agent / nested-crew attribution (CrewAI, Lane 2)

### Problem
CrewAI has no wire-level namespace like LangGraph's `langgraph_checkpoint_ns`. The bridge previously emitted flat `STEP` events per Flow `MethodExecution*` with **no nesting, no attribution of a crew running inside a flow method, and no agent identity**.

### What this does
Reconstructs the **Flow-method → nested-Crew → Agent** topology from CrewAI's own lifecycle events plus a per-run boundary stack, and attaches `depth` / `parent_step_id` / root-to-leaf `path` / `step_id` to every `STEP_STARTED` / `STEP_FINISHED` via the protocol's free-form `raw_event` field.

- `step_name` is **unchanged** (byte-compatible for consumers that key on it); topology-aware clients read `raw_event.attribution`. Unblocks a CrewAI `subgraphs` feature.

### How attribution is reconstructed
New `ag_ui_crewai/attribution.py` (pure Python, no CrewAI import, unit-testable):
- `BoundaryTracker` keyed by **execution context** (asyncio task, thread fallback) via a `WeakKeyDictionary` — concurrent `@listen` branches (CrewAI gathers them as tasks) nest independently, and no `id()` reuse can inherit a stale stack.
- `exit()` returns the matched boundary plus still-open inner boundaries (deepest-first); `drain_all()` closes everything left open at normal run end → **every `STEP_STARTED` gets a matching `STEP_FINISHED`**.
- Pairing by stable **name** (robust to CrewAI populating `source_fingerprint` asymmetrically); a unique `step_id` disambiguates repeated names.

`endpoint.py` wiring:
- Crew / Agent / Method-failure listeners registered **only when the CrewAI event class is importable** (runtime capability detection, no version gating — floor `crewai>=1.0`).
- `_boundary_context` attributes **only on the flow's event-loop thread**; a crew offloaded to a worker thread (`crew.kickoff_async` == `asyncio.to_thread`, or an `async_execution` task) is dropped rather than doing a cross-thread `put_nowait` on the loop-bound queue / racing the tracker. The synchronous `crew.kickoff()` path (the common/demo path) stays on-loop and is attributed.
- Names coerced to `str`; failure paths close boundaries without double-close. **Snapshot behavior and cancellation/teardown are unchanged.**

### Tests
`tests/test_attribution.py` — tracker semantics + end-to-end listener wiring: nesting, stream balance across normal/failure/error/flow-finish paths, off-loop-thread drop, concurrent-context isolation, and the tracker-less legacy fallback. Full package suite green locally (68 tests).

### Review
Converged via a 5-round `cr-loop` (7 unbiased reviewers/round + confirmation), bucket (a) empty. Notable fixes surfaced by the loop: execution-context keying for concurrency, `WeakKeyDictionary` to avoid `id()` reuse, the loop-thread guard for the `kickoff_async` cross-thread race, name-based pairing, and run-end drain for balance.

### Follow-ups (out of scope for this PR)
- **Thread-safety of the pre-existing `Bridged*` content-stream handlers** (text/tool-call/custom/state) under `await crew.kickoff_async()` — same `asyncio.to_thread` cross-thread `put_nowait` class, but a different subject (message/tool streaming, not STEP attribution) and pre-existing; not introduced or worsened here. Deserves its own PR.
- Two stale pre-existing queue-keying comments in `endpoint.py` (say `id(flow)`; actual `uuid`).

### Concurrency note
Coordinated with PNI-144 (concurrent `endpoint.py`/`crews.py` rewrite): this PR keeps the `endpoint.py` footprint minimal (STEP emission + listener wiring) and puts the bulk of the logic in the new `attribution.py` to reduce merge conflict surface.