### PR TITLE
feat(crewai): opt-in RAW passthrough and get_capabilities (PNI-136, part 1)

### DIFF
--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -50,6 +50,68 @@ add_crewai_flow_fastapi_endpoint(app, MyFlow(), "/flow")
 - **Predictive state updates** – Real-time state synchronization between backend and frontend
 - **Streaming tool calls** – Live streaming of LLM responses and tool execution to the UI
 
+## Protocol surface
+
+### RAW passthrough (opt-in, default OFF)
+
+`emit_raw_events=True` mirrors the crewai events this bridge does **not** map onto
+AG-UI `RAW` events: crewai's llm / agent / task / tool channels (including
+`llm_thinking_chunk`), nested-flow lifecycle events, and internals such as `cc_env`.
+Events the bridge already maps are never duplicated as RAW.
+
+```python
+add_crewai_flow_fastapi_endpoint(app, MyFlow(), "/flow", emit_raw_events=True)
+# or, without a code change:  AGUI_CREWAI_EMIT_RAW_EVENTS=1
+```
+
+It is off by default deliberately: LangGraph shipped RAW passthrough on and the
+payload bloat had to be walked back. RAW payloads are large and can carry prompt and
+completion text, so enabling it widens what leaves your process.
+
+Requires the `StreamFrame` transport: the installed crewai must expose it (>= 1.6)
+**and** the served flow must expose `astream`, which the driver probes per flow. On
+the legacy event-bus fallback the bridge logs one warning per process and emits no
+RAW events, because that listener never sees the unmapped events.
+
+RAW mirrors never precede `RUN_STARTED`. crewai raises some events before the flow
+opens, and a `RAW` first event makes the reference client reject the whole stream, so
+those are held and released once the run has opened. Both RAW buffers are bounded; a
+saturated buffer degrades mirroring (logged) rather than the run.
+
+### `get_capabilities()`
+
+Returns a capability declaration (the CrewAI counterpart of
+`LangGraphAgent.get_capabilities`). `crewai.__version__` appears only as
+informational metadata, never as a gate.
+
+```python
+from ag_ui_crewai import get_capabilities
+
+get_capabilities(llm=my_agent.llm, emit_raw_events=True)
+```
+
+`transport`, `rawEvents`, `reasoning` and `crewChat` come from runtime probes;
+`humanInTheLoop` and `state` are static declarations of what the bridge implements
+today. `emit_raw_events` defaults to re-reading the environment, so pass the same
+value your endpoint was registered with if you want the declaration to describe
+*that* endpoint.
+
+`reasoning.supported` is True **only** when all three hold: the installed crewai
+exposes `LLMThinkingChunkEvent`, the `StreamFrame` transport exists (RAW is the only
+channel carrying reasoning today), *and* the passed LLM resolves to the native Google
+Gen AI provider. Otherwise `reason` names the missing piece
+(`thinking_event_missing`, `raw_transport_unavailable`, `llm_not_provided`,
+`llm_not_resolvable`, `provider_not_native_gemini`) and `transport` is `None`.
+
+Reasoning is native-Gemini-only in crewai: on the 1.15.7 wheel the sole caller of
+`BaseLLM._emit_thinking_chunk_event` is `crewai/llms/providers/gemini/completion.py`.
+Anthropic's native provider has a thinking config but never emits the event, and every
+LiteLLM-routed model (including `vertex_ai/gemini-*`) emits nothing. Passing no `llm`
+therefore reports `supported: False` rather than claiming support off the class probe
+alone. On the crew-serving path `crews.py` drives completions through
+`litellm.acompletion` directly, so the native Gemini provider never runs and reasoning
+does not surface there even when it is reported supported for the LLM you passed.
+
 ## Tuning knobs
 
 The CrewAI integration exposes three environment variables for tuning

--- a/integrations/crew-ai/python/ag_ui_crewai/__init__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__init__.py
@@ -14,6 +14,8 @@ from .sdk import (
 )
 # from .enterprise import CrewEnterpriseEventListener
 
+from ._capabilities import get_capabilities
+
 # CREW_ENTERPRISE_EVENT_LISTENER = CrewEnterpriseEventListener()
 
 # The Crew chat path was undiscoverable — the four symbols below (the
@@ -21,6 +23,7 @@ from .sdk import (
 # signal) were absent from the package top level. Export them alongside
 # the pre-existing flow-path surface.
 __all__ = [
+    "get_capabilities",
   "add_crewai_flow_fastapi_endpoint",
   "add_crewai_crew_fastapi_endpoint",
   "crewai_prepare_inputs",

--- a/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
@@ -25,7 +25,34 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from ag_ui.core import EventType
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def _safe_getattr(obj: Any, name: str) -> Any:
+    """``getattr`` that cannot propagate a caller's property exception.
+
+    Capability probing walks arbitrary user objects, where a raising property must
+    read as "absent" rather than failing the query.
+    """
+    try:
+        return getattr(obj, name, None)
+    except Exception:  # noqa: BLE001 - a raising property is "not present"
+        return None
+
+
+def _safe_hasattr(obj: Any, name: str) -> bool:
+    """``hasattr`` that cannot propagate a caller's property exception.
+
+    Presence, not truthiness: ``GeminiCompletion`` declares
+    ``thinking_config: Any = None``, so an "is not None" check would report the
+    native provider as absent.
+    """
+    try:
+        return hasattr(obj, name)
+    except Exception:  # noqa: BLE001 - a raising property is "not usable"
+        return False
 
 
 def _crewai_version() -> str:
@@ -391,7 +418,10 @@ class _Capabilities:
     missing: tuple[str, ...] = field(default_factory=tuple)
 
     def warn_on_gaps(self) -> None:
-        """Emit one WARNING per missing capability, naming the fix.
+        """Emit one message per missing capability, naming the fix.
+
+        WARNING for a real gap; INFO for the StreamFrame transport, whose absence
+        only downgrades the bridge to the legacy path (see the last branch).
 
         Kept idempotent-friendly (call once at import). Each message names the
         crewai version / extra that unlocks the missing capability so operators
@@ -466,3 +496,299 @@ def _detect() -> _Capabilities:
 
 # Run the probe ONCE at import time and cache the result.
 CAPABILITIES = _detect()
+
+
+# --------------------------------------------------------------------------
+# Reasoning / thinking-chunk resolution
+# --------------------------------------------------------------------------
+# crewai emits ``LLMThinkingChunkEvent`` for thinking models. The class living
+# at ``<events>.types.llm_events`` is NOT evidence that a given run will produce
+# reasoning: verified against the crewai 1.15.7 wheel, the ONLY call site of
+# ``BaseLLM._emit_thinking_chunk_event`` is
+# ``crewai/llms/providers/gemini/completion.py`` - the native Google Gen AI
+# provider. Anthropic's native provider carries a ``thinking`` config and
+# extracts thinking blocks, but never emits the event; every LiteLLM-routed model
+# (including ``vertex_ai/gemini-*``, which falls back to LiteLLM) emits nothing.
+#
+# So ``get_capabilities`` requires BOTH the class AND a resolved native-Gemini
+# LLM before it advertises reasoning. Advertising off the bare class probe would
+# claim reasoning support for every OpenAI / Anthropic / Ollama run.
+_LLM_EVENTS_MODULE, _ = _first_module(
+    ["crewai.events.types.llm_events", "crewai.utilities.events.llm_events"]
+)
+LLMThinkingChunkEvent = (
+    getattr(_LLM_EVENTS_MODULE, "LLMThinkingChunkEvent", None)
+    if _LLM_EVENTS_MODULE is not None
+    else None
+)
+_thinking_event_available = LLMThinkingChunkEvent is not None
+
+# crewai's canonical name for the native Google Gen AI provider. ``LLM.__new__``
+# maps both the ``gemini/`` and ``google/`` model prefixes onto it and stamps it
+# on the constructed instance as ``.provider``.
+# crewai stamps EITHER name on a native Google Gen AI completion: ``gemini/...``
+# resolves to "gemini" and ``google/...`` keeps "google" (verified on 1.15.7 - a
+# ``provider="google"`` LLM is a real GeminiCompletion), so both must count.
+_NATIVE_GEMINI_PROVIDERS = frozenset({"gemini", "google"})
+
+
+# Depth cap for ``_resolve_llm``: an object graph with a cycle (an Agent whose
+# ``.llm`` points back at itself, or a wrapper pair that references each other)
+# would otherwise recurse until RecursionError inside a capability QUERY.
+
+_LLM_RESOLVE_MAX_DEPTH = 8
+
+
+def _resolve_llm(
+    candidate: Any, _depth: int = 0, _path: frozenset[int] = frozenset()
+) -> Any:
+    """Best-effort unwrap of an object into the crewai LLM instance it holds.
+
+    Accepts an LLM directly, or anything carrying one on a conventional attribute:
+    an Agent's ``.llm``, a Crew's ``.agents[*].llm`` / ``.chat_llm`` /
+    ``.manager_llm``, a Flow / ``ChatWithCrewFlow`` holding either. Returns ``None``
+    when no LLM can be found - the caller reports "not resolvable" rather than
+    guessing. Read-only: a callable (a ``@CrewBase`` ``crew`` factory) is never
+    invoked, and a property that raises is treated as absent.
+
+    A native-Gemini LLM WINS over any other candidate, because reasoning support is
+    the one capability that turns on it. The search is otherwise first-match.
+
+    Cycle safety tracks the ancestor PATH, not a shared visited set: a shared set is
+    never unwound, so a node reached down a dead-end branch would stay poisoned for
+    every other branch.
+    """
+    if candidate is None or _depth > _LLM_RESOLVE_MAX_DEPTH:
+        return None
+    marker = id(candidate)
+    if marker in _path:
+        return None
+    _path = _path | {marker}
+
+    if callable(candidate) and not _safe_hasattr(candidate, "provider"):
+        # A ``@CrewBase``'s ``crew`` is a factory method; calling it would execute
+        # user code inside a capability query.
+        return None
+    # A crewai 1.x LLM declares ``provider`` (native classes and the LiteLLM
+    # fallback alike), so that is the strongest "this IS the LLM" signal. Older 0.x
+    # LLMs may not, which is why the ``model`` fallback below still exists.
+    if _safe_hasattr(candidate, "provider"):
+        return candidate
+
+    # Otherwise unwrap before falling back to the weaker ``model`` signal: an
+    # Agent / Crew / Flow can itself carry a ``model`` attribute, and returning the
+    # wrapper would report "not native Gemini" for an LLM we never looked at.
+    fallback = None
+    agents = _safe_getattr(candidate, "agents")
+    candidates: list[Any] = []
+    if isinstance(agents, (list, tuple)):
+        # ``agents`` first: a Crew keeps its LLMs there, and ``chat_llm`` /
+        # ``manager_llm`` are None on a plain Crew.
+        candidates.extend(agents)
+    for attr in ("llm", "chat_llm", "manager_llm", "crew"):
+        nested = _safe_getattr(candidate, attr)
+        if nested is not None and nested is not candidate:
+            candidates.append(nested)
+    for nested in candidates:
+        resolved = _resolve_llm(nested, _depth + 1, _path)
+        if resolved is None:
+            continue
+        if _is_native_gemini(resolved):
+            # Search EVERY branch for a native-Gemini LLM before settling: an
+            # earlier revision returned the first agent's LLM without ever looking
+            # at chat_llm / manager_llm.
+            return resolved
+        if fallback is None:
+            fallback = resolved
+    if fallback is not None:
+        return fallback
+
+    if _safe_hasattr(candidate, "model") and not any(
+        _safe_hasattr(candidate, attr)
+        for attr in ("agents", "llm", "chat_llm", "manager_llm", "crew")
+    ):
+        # ``model`` alone is the crewai 0.x LLM signal, but an Agent / Crew / Flow can
+        # carry one too; returning such a wrapper would report
+        # ``provider_not_native_gemini`` for something that is not an LLM.
+        return candidate
+    return None
+
+
+def _is_native_gemini(llm: Any) -> bool:
+    """Whether ``llm`` is crewai's NATIVE Google Gen AI completion instance.
+
+    Two structural probes, no version gate and no module-name string match:
+
+    * ``provider == "gemini"`` - stamped by ``LLM.__new__`` only when it routes
+      to a native provider class.
+    * ``hasattr(llm, "thinking_config")`` - a field declared ONLY on
+      ``crewai.llms.providers.gemini.completion.GeminiCompletion`` (verified by
+      grep across ``crewai/llms/providers/`` on the 1.15.7 wheel). The LiteLLM
+      fallback ``LLM`` and every other native provider lack it.
+
+    Both are needed: a LiteLLM-routed ``gemini/<unlisted-model>`` can still carry
+    a gemini-ish provider string but has no thinking plumbing, and a future
+    provider could grow a ``thinking_config`` without being Gemini.
+    """
+    if llm is None:
+        return False
+    provider = _safe_getattr(llm, "provider")
+    if (
+        not isinstance(provider, str)
+        or provider.strip().casefold() not in _NATIVE_GEMINI_PROVIDERS
+    ):
+        return False
+    return _safe_hasattr(llm, "thinking_config")
+
+
+def _reasoning_capability(llm: Any, *, raw_enabled: bool = False) -> dict:
+    """Build the ``reasoning`` block of the capability declaration.
+
+    ``supported`` is True only when the thinking-chunk event class resolves, the
+    RAW transport exists (StreamFrame, crewai >= 1.6, the only channel carrying
+    reasoning today), and the passed object resolves to a native-Gemini LLM.
+
+    Caveat: on the crew-serving path ``crews.py`` calls ``litellm.acompletion``
+    directly, so crewai's native Gemini provider never runs and reasoning does not
+    surface there even when this reports it supported. When no LLM is passed we
+    report ``supported: False`` with ``reason: "llm_not_provided"`` - the honest
+    answer, since reasoning availability is a per-LLM fact and cannot be derived
+    from the installed crewai alone.
+    """
+    resolved = _resolve_llm(llm)
+    native_gemini = _is_native_gemini(resolved)
+    # Reasoning only reaches the wire through RAW passthrough, which needs the
+    # StreamFrame transport's scoped sink. Claiming support on crewai 1.0-1.5 would
+    # contradict ``rawEvents.supported: False`` in the same declaration.
+    if not _thinking_event_available:
+        reason = "thinking_event_missing"
+    elif not CAPABILITIES.stream_frame_available:
+        reason = "raw_transport_unavailable"
+    elif resolved is None:
+        # Distinguish the two: a caller who passed something deserves to know the
+        # probe could not find an LLM inside it, not that they passed nothing.
+        reason = "llm_not_provided" if llm is None else "llm_not_resolvable"
+    elif not native_gemini:
+        reason = "provider_not_native_gemini"
+    else:
+        reason = None
+    return {
+        "supported": reason is None,
+        "thinkingEventAvailable": _thinking_event_available,
+        "nativeGeminiProvider": native_gemini,
+        # A caller object: a raising property here would escape the whole query.
+        "resolvedProvider": _safe_getattr(resolved, "provider"),
+        # Reasoning reaches the wire through RAW passthrough today (there is no
+        # dedicated CrewAI -> REASONING_* mapping yet), so a caller that wants it
+        # must ALSO enable ``emit_raw_events`` - hence the explicit flag below
+        # rather than a bare "supported: true" that would over-promise.
+        "transport": "raw" if reason is None else None,
+        # Always required for reasoning to reach the wire; ``rawEventsEnabled`` says
+        # whether this configuration actually has it on.
+        "requiresEmitRawEvents": True,
+        "rawEventsEnabled": bool(
+            raw_enabled and CAPABILITIES.stream_frame_available
+        ),
+        "reason": reason,
+    }
+
+
+def get_capabilities(
+    *,
+    llm: Any = None,
+    emit_raw_events: bool | None = None,
+) -> dict:
+    """Return the CrewAI bridge's capability declaration.
+
+    Mirrors the shape of ``ag_ui_langgraph.LangGraphAgent.get_capabilities``
+    (``identity`` / ``humanInTheLoop`` / ``state`` / ``transport``) and adds the
+    CrewAI-specific blocks the parity lane needs: the resolved wire shape, RAW
+    passthrough, and reasoning.
+
+    No field is derived from ``crewai.__version__`` - the version string appears
+    only as informational ``crewaiVersion`` metadata (same rule as the rest of this
+    module). Within that, ``transport`` / ``rawEvents`` / ``reasoning`` / ``crewChat``
+    come from runtime probes, while ``humanInTheLoop`` and ``state`` are static
+    declarations of what the bridge implements today.
+
+    ``emission_shape`` / ``emit_raw_events`` default to re-reading the environment,
+    so a declaration fetched without arguments can disagree with an endpoint that
+    was registered with explicit ones. Pass the same values the endpoint was
+    registered with to describe THAT endpoint.
+
+    Raises
+    ------
+    ValueError
+        If ``emission_shape`` names an unknown shape, or ``emit_raw_events`` is not
+        a bool. Both are caller mistakes rather than environment conditions.
+
+    Parameters
+    ----------
+    llm:
+        The LLM, or an object carrying one: an Agent (``.llm``), a Crew
+        (``.agents[*].llm``, or ``chat_llm`` / ``manager_llm`` when set), or a Flow
+        holding either. Resolution is read-only and never calls a factory. Required for a meaningful ``reasoning`` answer: reasoning is
+        native-Gemini-only in crewai, so without an LLM to resolve we report
+        ``supported: False`` with ``reason: "llm_not_provided"`` rather than
+        advertising support off the bare event-class probe.
+    emission_shape / emit_raw_events:
+        The values the endpoint was configured with. Defaults (``None``) resolve
+        the same way the endpoint factories resolve them, so a caller that
+        configured nothing sees what the endpoint will actually emit.
+    """
+    # ``_config`` is a leaf (``_env`` + stdlib only), imported locally purely to
+    # keep this module's "crewai / litellm / stdlib only" property for every path
+    # that never calls ``get_capabilities``.
+    from ._config import DEFAULT_EMIT_RAW_EVENTS, resolve_emit_raw_events
+
+    resolved_raw = resolve_emit_raw_events(emit_raw_events)
+    return {
+        "identity": {"type": "crewai", "crewaiVersion": CAPABILITIES.crewai_version},
+        "humanInTheLoop": {
+            # True because the shipped ``human_in_the_loop`` example round-trips a
+            # frontend tool call. What is missing is the interrupt mechanism
+            # (crewai's ``@human_feedback`` / flow-level pause), below.
+            "supported": True,
+            "mechanism": "frontend-tool-calls",
+            "interrupts": False,
+            "approveWithEdits": False,
+        },
+        "state": {
+            # STATE_SNAPSHOT on every method finish plus progressive snapshots via
+            # ``copilotkit_emit_state``; no JSON-Patch deltas, and no server-side
+            # persistence across runs.
+            "snapshots": True,
+            "deltas": False,
+            "persistentState": False,
+        },
+        "transport": {
+            "streaming": True,
+            # crewai >= 1.6 ordered StreamFrame envelopes, else the legacy
+            # event-bus-listener fallback.
+            "streamFrames": CAPABILITIES.stream_frame_available,
+        },
+        "wireShape": {
+            # This build streams LLM text / tool calls as CHUNK events. MCP tool
+            # executions are the exception: their name, args and result arrive
+            # together, so they already emit canonical TOOL_CALL_* triples.
+            "emissionShape": "chunks",
+            "textMessages": [EventType.TEXT_MESSAGE_CHUNK.value],
+            "toolCalls": [EventType.TOOL_CALL_CHUNK.value],
+            "mcpToolCalls": [
+                EventType.TOOL_CALL_START.value,
+                EventType.TOOL_CALL_ARGS.value,
+                EventType.TOOL_CALL_END.value,
+                EventType.TOOL_CALL_RESULT.value,
+            ],
+        },
+        "rawEvents": {
+            # RAW needs the StreamFrame transport's scoped sink. This is the
+            # process-level probe; the driver also probes each flow for ``astream``,
+            # so a flow without it takes the legacy path and emits no RAW.
+            "supported": CAPABILITIES.stream_frame_available,
+            "enabled": bool(resolved_raw and CAPABILITIES.stream_frame_available),
+            "default": DEFAULT_EMIT_RAW_EVENTS,
+        },
+        "reasoning": _reasoning_capability(llm, raw_enabled=resolved_raw),
+        "crewChat": {"supported": CAPABILITIES.crew_chat_available},
+    }

--- a/integrations/crew-ai/python/ag_ui_crewai/_config.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_config.py
@@ -1,0 +1,78 @@
+"""Protocol-surface configuration for ag_ui_crewai.
+
+A LEAF over ``_env`` + the stdlib, so ``_capabilities`` can report the resolved
+configuration without importing the streaming stack (``_frames`` pulls in ``sdk``
+and therefore litellm).
+
+Resolution order for every option: an explicit argument on the endpoint factory
+wins over the environment variable, which wins over the shipped default. The two
+paths deliberately differ on a BAD value: an unrecognised env value falls back to
+the default (a typo in a deployment variable must not take the service down),
+while a wrong-typed argument raises at registration time (a mistake in code should
+fail loudly, once, at startup rather than per request).
+"""
+
+import logging
+import os
+
+from ._env import _FALSE_VALUES, _TRUE_VALUES, _parse_env_bool
+
+_LOGGER = logging.getLogger(__name__)
+
+# RAW passthrough ships OFF: the payloads are large and carry prompt / completion
+# text, so enabling it widens what leaves the process. Named so the capability
+# declaration reports the shipped default rather than hardcoding it.
+DEFAULT_EMIT_RAW_EVENTS = False
+
+EMIT_RAW_EVENTS_ENV_VAR = "AGUI_CREWAI_EMIT_RAW_EVENTS"
+
+# Vocabulary ``_parse_env_bool`` accepts, so the "was this value used?" check stays
+# in step with the parser instead of duplicating its token list.
+_BOOL_TOKENS = _TRUE_VALUES | _FALSE_VALUES
+
+_ENV_WARN_SEEN: set[tuple[str, str]] = set()
+
+
+def _warn_if_env_value_ignored(name: str, raw: str | None, used: bool) -> None:
+    """WARN once per (var, value) when a SET env var was silently ignored.
+
+    Falling back on a typo is the right behaviour; falling back SILENTLY made the
+    typo undiagnosable, because the operator sees default behaviour and no
+    explanation. ``used`` is decided by the CALLER, which knows its own vocabulary.
+    """
+    if raw is None or used:
+        return
+    if raw.strip() == "":
+        # ``_env`` treats an empty value as unset, so falling back is specified
+        # behaviour rather than an ignored typo.
+        return
+    key = (name, raw)
+    if key in _ENV_WARN_SEEN:
+        return
+    _ENV_WARN_SEEN.add(key)
+    _LOGGER.warning(
+        "ag-ui-crewai ignored %s=%r (unrecognised value) and is using the default "
+        "instead",
+        name,
+        raw,
+    )
+
+
+def resolve_emit_raw_events(emit_raw_events: bool | None) -> bool:
+    """Resolve RAW passthrough: explicit argument > env var > shipped default."""
+    if emit_raw_events is not None:
+        # Validate rather than trusting truthiness: config plumbing commonly hands
+        # over the STRING "false", which is truthy, and silently enabling RAW
+        # passthrough leaks prompt / completion text.
+        if not isinstance(emit_raw_events, bool):
+            raise ValueError(
+                f"emit_raw_events must be a bool, got "
+                f"{type(emit_raw_events).__name__} ({emit_raw_events!r}). Use the "
+                f"{EMIT_RAW_EVENTS_ENV_VAR} env var for string values."
+            )
+        return emit_raw_events
+    raw = os.environ.get(EMIT_RAW_EVENTS_ENV_VAR)
+    resolved = _parse_env_bool(EMIT_RAW_EVENTS_ENV_VAR, DEFAULT_EMIT_RAW_EVENTS)
+    used = raw is not None and raw.strip().casefold() in _BOOL_TOKENS
+    _warn_if_env_value_ignored(EMIT_RAW_EVENTS_ENV_VAR, raw, used)
+    return resolved

--- a/integrations/crew-ai/python/ag_ui_crewai/_env.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_env.py
@@ -57,6 +57,11 @@ def _parse_env_float(
 # unset) is "off": a conservative default for opt-in features.
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on", "y", "t"})
 
+# The mirror set. Not used by the parser (anything outside ``_TRUE_VALUES`` is
+# already false); it exists so a caller can tell an explicit "off" from an
+# unrecognised value and report the latter as a probable typo.
+_FALSE_VALUES = frozenset({"0", "false", "no", "off", "n", "f"})
+
 
 def _parse_env_bool(name: str, default: bool = False) -> bool:
     """Parse a boolean env var with a permissive true-set.

--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -66,6 +66,7 @@ the streaming LLM text / tool-call channel); see the wire-shape note in
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -75,6 +76,7 @@ from ag_ui.core import (
     RunFinishedEvent,
 )
 from ag_ui.core.events import (
+    RawEvent,
     TextMessageChunkEvent,
     ToolCallChunkEvent,
     StepStartedEvent,
@@ -86,6 +88,8 @@ from ag_ui.core.events import (
 
 from .sdk import litellm_messages_to_ag_ui_messages
 from .mcp import is_mcp_event, translate_mcp_event
+
+_LOGGER = logging.getLogger(__name__)
 
 # crewai lifecycle-event ``type`` strings. Pinned as constants so a rename
 # upstream surfaces here rather than silently producing no wire events.
@@ -322,3 +326,96 @@ class StreamFrameTranslator:
             "the StreamFrame migration ships the behavior-preserving "
             "'chunks' shape only."
         )
+
+
+# Event types the translator recognises. Used to decide whether an event is
+# "unmapped" and therefore eligible for RAW passthrough: an event we DO map but
+# deliberately suppress must not leak out as a RAW event as well.
+_RECOGNIZED_EVENT_TYPES = frozenset(
+    {
+        _FLOW_STARTED,
+        _FLOW_FINISHED,
+        _METHOD_STARTED,
+        _METHOD_FINISHED,
+        EventType.TEXT_MESSAGE_CHUNK,
+        EventType.TOOL_CALL_CHUNK,
+        EventType.CUSTOM,
+        EventType.STATE_SNAPSHOT,
+    }
+)
+
+# Source tag on emitted RAW events, so a consumer can tell CrewAI passthrough apart
+# from other producers' raw channels.
+_RAW_SOURCE = "crewai"
+
+# One WARNING per process for the first RAW-passthrough loss, then DEBUG. An
+# operator who turned RAW on is debugging something and would never see a
+# DEBUG-only drop, but a per-event WARNING under sustained pressure is its own
+# problem.
+_RAW_LOSS_WARNED = False
+
+
+def log_raw_loss(message: str, *args: Any) -> None:
+    """Log a RAW-passthrough loss: WARNING the first time, DEBUG thereafter."""
+    global _RAW_LOSS_WARNED  # pylint: disable=global-statement
+    if _RAW_LOSS_WARNED:
+        _LOGGER.debug(message, *args)
+        return
+    _RAW_LOSS_WARNED = True
+    _LOGGER.warning(message, *args)
+
+
+def is_recognized_event(event: Any) -> bool:
+    """True when the translator maps this event, so RAW must not duplicate it."""
+    return getattr(event, "type", None) in _RECOGNIZED_EVENT_TYPES
+
+
+def raw_event_for(event: Any) -> RawEvent | None:
+    """Wrap an unmapped crewai event as an AG-UI ``RAW`` event.
+
+    Payload preference order:
+
+    1. ``model_dump(mode="json")`` - every crewai event is a Pydantic model, and
+       ``mode="json"`` resolves enums / datetimes for us.
+    2. the event's own ``__dict__``, filtered to JSON-safe scalars and containers.
+
+    A RAW passthrough must never be able to break the run, so a payload we cannot
+    build at all yields ``None`` (the caller drops the mirror) rather than raising
+    into the driver's event loop.
+    """
+    event_type = getattr(event, "type", None)
+    if event_type is None:
+        return None
+
+    payload: Any = None
+    model_dump = getattr(event, "model_dump", None)
+    if callable(model_dump):
+        try:
+            payload = model_dump(mode="json")
+        except Exception as dump_exc:  # noqa: BLE001 - falls back below
+            # Surface WHY the richer payload was unavailable; silence made a degraded
+            # RAW payload indistinguishable from a complete one.
+            _LOGGER.debug(
+                "ag-ui-crewai RAW passthrough could not model_dump a %r event (%s); "
+                "falling back to instance attributes",
+                event_type,
+                type(dump_exc).__name__,
+            )
+            payload = None
+
+    if payload is None:
+        source_dict = getattr(event, "__dict__", None)
+        if isinstance(source_dict, dict):
+            payload = {
+                key: value
+                for key, value in source_dict.items()
+                if not key.startswith("_")
+                and isinstance(value, (str, int, float, bool, type(None), list, dict))
+            }
+
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        payload = {"value": payload}
+    payload.setdefault("type", str(event_type))
+    return RawEvent(type=EventType.RAW, event=payload, source=_RAW_SOURCE)

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -33,6 +33,8 @@ from ._capabilities import (
 )
 from ._checkpoint import build_checkpoint_kwargs
 from ._frames import StreamFrameTranslator
+from ._config import resolve_emit_raw_events as _resolve_emit_raw_events
+from ._frames import is_recognized_event, log_raw_loss, raw_event_for
 from .mcp import is_mcp_event, register_mcp_listeners, translate_mcp_event
 from crewai.flow.flow import Flow
 
@@ -190,6 +192,18 @@ _CANCEL_JOIN_TIMEOUT_SECONDS = 10.0
 # ceiling that short-circuits the loop when the budget is exhausted mid-pass.
 # Kept at module scope alongside the other tuning constants so operators
 # grepping for tunables find them all in one place.
+
+# Cap on both RAW buffers in ``_run_flow_frame_stream``. At the cap the oldest entry
+# is evicted (and logged) so the buffer self-heals: crewai raises some events that
+# never produce a frame, and refusing new entries would wedge it for the whole run.
+_FOREIGN_EVENT_BUFFER_MAX = 512
+
+# One-shot guard for the "emit_raw_events on the legacy transport" warning. A module
+# global, so the latch is per-process: a process serving several endpoints warns only
+# for the first one that asks. Deliberate trade against per-request log spam, since
+# the message names a transport limitation rather than a per-endpoint defect.
+_LEGACY_RAW_WARNING_EMITTED = False
+
 _DRAIN_MAX_PASSES = 10
 _DRAIN_BUDGET_SECONDS = 0.050
 
@@ -1141,6 +1155,7 @@ async def _run_flow_event_stream(
     inputs: dict,
     timeout: float | None,
     checkpoint_kwargs: dict | None = None,
+    emit_raw_events: bool = False,
 ):
     """Drive a single flow kickoff and yield encoded AG-UI events.
 
@@ -1156,6 +1171,19 @@ async def _run_flow_event_stream(
     * on exit, cancels the kickoff task, drops the queue, and resets the
       context var — unconditionally, even if the outer scope is cancelled.
     """
+    global _LEGACY_RAW_WARNING_EMITTED  # pylint: disable=global-statement
+    if emit_raw_events and not _LEGACY_RAW_WARNING_EMITTED:
+        # This listener only receives the event types it registers, so there is
+        # nothing unmapped here to mirror. Say so rather than ignoring the flag,
+        # once per process since the condition never changes between requests.
+        _LEGACY_RAW_WARNING_EMITTED = True
+        _LOGGER.warning(
+            "ag-ui-crewai ignored emit_raw_events=True: RAW passthrough requires the "
+            "crewai StreamFrame transport (crewai >= 1.6 and a flow exposing "
+            "astream); this run is on the legacy event-bus listener, which never sees "
+            "the unmapped events"
+        )
+
     # ``create_queue`` registers an entry in the module-level ``QUEUES``
     # mapping. If ``flow_context.set`` raises between ``create_queue`` and the
     # main ``try:`` block, the registered queue is orphaned — nothing deletes
@@ -1725,6 +1753,7 @@ async def _run_flow_frame_stream(
     inputs: dict,
     timeout: float | None,
     checkpoint_kwargs: dict | None = None,
+    emit_raw_events: bool = False,
 ):
     """StreamFrame-path driver: drive ``flow.astream`` and yield encoded AG-UI
     events.
@@ -1777,6 +1806,40 @@ async def _run_flow_frame_stream(
     # here (source gate), which is exactly the nested-flow filter: nested
     # frames find nothing here and are dropped.
     raw_events: dict[str, Any] = {}
+    # Second buffer for foreign-source events, populated only when RAW is enabled.
+    # crewai emits its llm / agent / task / tool events with the EMITTER as source
+    # (``crewai_event_bus.emit(self, event=...)``), never the flow, so the outer-flow
+    # gate below drops all of them - including ``llm_thinking_chunk``. Parking them
+    # separately keeps the translation gate intact, so a foreign event can never
+    # synthesize a run lifecycle event or a state snapshot.
+    foreign_events: dict[str, Any] = {}
+    # RAW mirrors that arrived BEFORE RUN_STARTED, from either source. Released in
+    # order right after the run opens: crewai raises some events before the flow
+    # starts, and a RAW first event makes @ag-ui/client's verifyEvents throw
+    # "First event must be 'RUN_STARTED'".
+    pending_raw: list[Any] = []
+
+    def _hold_pending_raw(raw_mirror: Any) -> None:
+        """Park a RAW mirror until the run has opened, logging an overflow drop."""
+        if len(pending_raw) >= _FOREIGN_EVENT_BUFFER_MAX:
+            log_raw_loss(
+                "ag-ui-crewai RAW passthrough dropped a pre-RUN_STARTED mirror (hold "
+                "buffer full at %d) thread=%s run=%s",
+                _FOREIGN_EVENT_BUFFER_MAX,
+                input_data.thread_id,
+                input_data.run_id,
+            )
+            return
+        pending_raw.append(raw_mirror)
+
+    def _emit_raw(raw_mirror: Any) -> Any:
+        """Correlate and encode a RAW mirror for the wire."""
+        _stamp_correlation_ids(
+            raw_mirror,
+            thread_id=input_data.thread_id,
+            run_id=input_data.run_id,
+        )
+        return encoder.encode(raw_mirror)
 
     def _sink(source: Any, event: Any) -> None:
         # ``source is flow_copy`` isolates the outer run: nested ``crew.kickoff``
@@ -1789,10 +1852,32 @@ async def _run_flow_frame_stream(
         # only THIS run's MCP events (including those from nested crews) reach it
         # -- no cross-run leakage -- and the type gate keeps nested-flow LIFECYCLE
         # events (still source != flow_copy) filtered out as before.
+        event_id = getattr(event, "event_id", None)
+        if event_id is None:
+            return
         if source is flow_copy or is_mcp_event(event):
-            event_id = getattr(event, "event_id", None)
-            if event_id is not None:
-                raw_events[event_id] = event
+            raw_events[event_id] = event
+        elif emit_raw_events:
+            if len(foreign_events) >= _FOREIGN_EVENT_BUFFER_MAX:
+                evicted = next(iter(foreign_events), None)
+                if evicted is None:
+                    log_raw_loss(
+                        "ag-ui-crewai RAW passthrough is disabled by a buffer cap of "
+                        "%d thread=%s run=%s",
+                        _FOREIGN_EVENT_BUFFER_MAX,
+                        input_data.thread_id,
+                        input_data.run_id,
+                    )
+                    return
+                del foreign_events[evicted]
+                log_raw_loss(
+                    "ag-ui-crewai RAW passthrough evicted the oldest parked foreign "
+                    "event (buffer full at %d) thread=%s run=%s; its RAW mirror is lost",
+                    _FOREIGN_EVENT_BUFFER_MAX,
+                    input_data.thread_id,
+                    input_data.run_id,
+                )
+            foreign_events[event_id] = event
 
     # Predeclared before the ``try`` so the ``finally`` teardown is always safe
     # to reference even if sink registration or ``astream``/``__aiter__`` raises
@@ -1886,7 +1971,31 @@ async def _run_flow_frame_stream(
                 # the outer run's wire shape stays identical to the legacy path.
                 raw_event = raw_events.pop(frame.id, None)
                 if raw_event is None:
+                    # Not an outer-flow (or MCP) event. With RAW passthrough on, mirror
+                    # it if we parked it: crewai's llm / agent / task / tool channels
+                    # and nested-flow lifecycle events all land here.
+                    foreign_event = foreign_events.pop(frame.id, None)
+                    if foreign_event is None:
+                        continue
+                    raw_mirror = raw_event_for(foreign_event)
+                    if raw_mirror is None:
+                        continue
+                    if not translator.run_started:
+                        _hold_pending_raw(raw_mirror)
+                        continue
+                    yield _emit_raw(raw_mirror)
                     continue
+
+                if emit_raw_events and not is_recognized_event(raw_event):
+                    # An OUTER-flow event the translator does not map. Mirrored here
+                    # rather than through ``translate`` so the translator keeps one
+                    # responsibility, and gated the same way as the foreign path.
+                    raw_mirror = raw_event_for(raw_event)
+                    if raw_mirror is not None:
+                        if translator.run_started:
+                            yield _emit_raw(raw_mirror)
+                        else:
+                            _hold_pending_raw(raw_mirror)
 
                 for event in translator.translate(raw_event):
                     _stamp_correlation_ids(
@@ -1895,6 +2004,13 @@ async def _run_flow_frame_stream(
                         run_id=input_data.run_id,
                     )
                     yield encoder.encode(event)
+
+                if pending_raw and translator.run_started:
+                    # The run just opened: flush the mirrors held back so they land
+                    # AFTER RUN_STARTED, in arrival order.
+                    held, pending_raw = pending_raw, []
+                    for raw_mirror in held:
+                        yield _emit_raw(raw_mirror)
 
                 if translator.run_finished:
                     # RUN_FINISHED just emitted. Do NOT break-then-aclose(): that
@@ -2011,6 +2127,7 @@ def _run_flow_stream(
     inputs: dict,
     timeout: float | None,
     checkpoint_kwargs: dict | None = None,
+    emit_raw_events: bool = False,
 ):
     """Select the StreamFrame path (crewai >= 1.6 + a real ``astream`` flow) or
     the legacy bus-listener path, returning the chosen async generator.
@@ -2031,6 +2148,7 @@ def _run_flow_stream(
             inputs=inputs,
             timeout=timeout,
             checkpoint_kwargs=checkpoint_kwargs,
+            emit_raw_events=emit_raw_events,
         )
     return _run_flow_event_stream(
         flow_copy=flow_copy,
@@ -2039,11 +2157,25 @@ def _run_flow_stream(
         inputs=inputs,
         timeout=timeout,
         checkpoint_kwargs=checkpoint_kwargs,
+        emit_raw_events=emit_raw_events,
     )
 
 
-def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
-    """Adds a CrewAI endpoint to the FastAPI app."""
+def add_crewai_flow_fastapi_endpoint(
+    app: FastAPI,
+    flow: Flow,
+    path: str = "/",
+    *,
+    emit_raw_events: bool | None = None,
+):
+    """Adds a CrewAI endpoint to the FastAPI app.
+
+    ``emit_raw_events`` opts into RAW passthrough: the crewai events this bridge does
+    not map (its llm / agent / task / tool channels, nested-flow lifecycle, internals)
+    are mirrored onto AG-UI ``RAW`` events. Off by default. Resolved at registration,
+    so a non-bool raises here rather than per request; ``None`` reads
+    ``AGUI_CREWAI_EMIT_RAW_EVENTS``.
+    """
     global GLOBAL_EVENT_LISTENER # pylint: disable=global-statement
 
     # Set up the global event listener singleton
@@ -2063,6 +2195,10 @@ def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
     # registered as before.
     if GLOBAL_EVENT_LISTENER is None and not CAPABILITIES.stream_frame_available:
         GLOBAL_EVENT_LISTENER = FastAPICrewFlowEventListener()
+
+    # Resolved HERE, not per request: a wrong-typed argument should fail once at
+    # startup rather than on every call.
+    resolved_emit_raw_events = _resolve_emit_raw_events(emit_raw_events)
 
     @app.post(path)
     async def agentic_chat_endpoint(input_data: RunAgentInput, request: Request):
@@ -2099,13 +2235,18 @@ def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
                 inputs=inputs,
                 timeout=timeout,
                 checkpoint_kwargs=checkpoint_kwargs,
+                emit_raw_events=resolved_emit_raw_events,
             ),
             media_type=encoder.get_content_type(),
         )
 
 
 def add_crewai_crew_fastapi_endpoint(
-    app: FastAPI, crew: CrewBaseInstance, path: str = "/"
+    app: FastAPI,
+    crew: CrewBaseInstance,
+    path: str = "/",
+    *,
+    emit_raw_events: bool | None = None,
 ):
     """Adds a CrewAI crew endpoint to the FastAPI app.
 
@@ -2125,6 +2266,8 @@ def add_crewai_crew_fastapi_endpoint(
     # in ``add_crewai_flow_fastapi_endpoint``).
     if GLOBAL_EVENT_LISTENER is None and not CAPABILITIES.stream_frame_available:
         GLOBAL_EVENT_LISTENER = FastAPICrewFlowEventListener()
+
+    resolved_emit_raw_events = _resolve_emit_raw_events(emit_raw_events)
 
     _cached_flow = None
     # Dedicated per-endpoint lock so two concurrent first-requests cannot
@@ -2174,6 +2317,7 @@ def add_crewai_crew_fastapi_endpoint(
                 inputs=inputs,
                 timeout=timeout,
                 checkpoint_kwargs=checkpoint_kwargs,
+                emit_raw_events=resolved_emit_raw_events,
             ),
             media_type=encoder.get_content_type(),
         )

--- a/integrations/crew-ai/python/tests/test_capability_declaration.py
+++ b/integrations/crew-ai/python/tests/test_capability_declaration.py
@@ -1,0 +1,364 @@
+"""Capability declaration and RAW-passthrough configuration: ``get_capabilities()``,
+the native-Gemini reasoning probe, and the "explicit argument > env var > default"
+resolution behind ``emit_raw_events``. No network."""
+
+import dataclasses
+
+import pytest
+from fastapi import FastAPI
+
+from ag_ui_crewai import get_capabilities
+from ag_ui_crewai import _capabilities as caps_mod
+from ag_ui_crewai import _config as config_mod
+from ag_ui_crewai import endpoint as ep
+
+
+# -- shape of the declaration ----------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clean_protocol_env(monkeypatch):
+    """Clear the RAW env var: otherwise an exported AGUI_CREWAI_EMIT_RAW_EVENTS makes
+    these tests assert the ambient environment rather than the shipped defaults."""
+    monkeypatch.delenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, raising=False)
+
+
+def test_get_capabilities_gates_raw_events_on_the_streamframe_transport(monkeypatch):
+    """RAW passthrough needs the scoped stream sink, so ``supported`` / ``enabled``
+    track the StreamFrame transport rather than the flag alone."""
+    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
+        # Skipped up front: a mid-test skip would silently void the rawEvents
+        # assertions that precede it.
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    def _set_stream_frames(available):
+        # ``CAPABILITIES`` is a frozen dataclass, so swap the whole cached probe
+        # result rather than mutating a field.
+        monkeypatch.setattr(caps_mod, "_stream_frame_available", available)
+        monkeypatch.setattr(
+            caps_mod,
+            "CAPABILITIES",
+            dataclasses.replace(
+                caps_mod.CAPABILITIES, stream_frame_available=available
+            ),
+        )
+
+    # Available transport: the flag decides.
+    _set_stream_frames(True)
+    on = get_capabilities(emit_raw_events=True)
+    assert on["transport"]["streamFrames"] is True
+    assert on["rawEvents"]["supported"] is True
+    assert on["rawEvents"]["enabled"] is True
+    assert get_capabilities(emit_raw_events=False)["rawEvents"]["enabled"] is False
+
+    # Unavailable transport: the flag cannot turn it on, and reasoning must not
+    # advertise a RAW channel that does not exist.
+    _set_stream_frames(False)
+    off = get_capabilities(llm=_FakeNativeGemini(), emit_raw_events=True)
+    assert off["transport"]["streamFrames"] is False
+    assert off["rawEvents"]["supported"] is False
+    assert off["rawEvents"]["enabled"] is False
+    assert off["reasoning"]["supported"] is False
+    assert off["reasoning"]["reason"] == "raw_transport_unavailable"
+
+
+# -- reasoning: native-Gemini-only -----------------------------------------
+
+class _FakeNativeGemini:
+    """Structural stand-in for ``crewai.llms.providers.gemini.completion``:
+    ``provider == "gemini"`` plus the gemini-only ``thinking_config`` field."""
+
+    provider = "gemini"
+    thinking_config = None
+
+
+class _FakeOpenAI:
+    provider = "openai"
+
+
+class _FakeLiteLLMGemini:
+    """A LiteLLM-routed gemini model: carries the provider string but none of
+    the native thinking plumbing (so it never emits thinking chunks)."""
+
+    provider = "gemini"
+    model = "gemini/gemini-1.0-unlisted"
+
+
+def test_reasoning_requires_an_llm_and_does_not_claim_support_from_the_class_probe():
+    """The ``LLMThinkingChunkEvent`` class existing is NOT evidence a run will
+    produce reasoning - it is emitted only by the native Gemini provider. With no
+    LLM to resolve, report unsupported with an explicit reason."""
+    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    if not caps_mod._stream_frame_available:  # pragma: no cover
+        pytest.skip("installed crewai has no StreamFrame transport for RAW")
+
+    reasoning = get_capabilities()["reasoning"]
+
+    assert reasoning["supported"] is False
+    assert reasoning["reason"] == "llm_not_provided"
+    # The class probe is reported separately, so callers can see WHY.
+    assert reasoning["thinkingEventAvailable"] is (
+        caps_mod.LLMThinkingChunkEvent is not None
+    )
+
+
+def test_reasoning_supported_only_for_native_gemini():
+    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    if not caps_mod._stream_frame_available:  # pragma: no cover
+        pytest.skip("installed crewai has no StreamFrame transport for RAW")
+
+    supported = get_capabilities(llm=_FakeNativeGemini(), emit_raw_events=True)[
+        "reasoning"
+    ]
+    assert supported["supported"] is True
+    assert supported["rawEventsEnabled"] is True
+    assert supported["nativeGeminiProvider"] is True
+    assert supported["resolvedProvider"] == "gemini"
+    # Reasoning reaches the wire via RAW passthrough today.
+    assert supported["transport"] == "raw"
+
+    not_gemini = get_capabilities(llm=_FakeOpenAI())["reasoning"]
+    assert not_gemini["supported"] is False
+    assert not_gemini["reason"] == "provider_not_native_gemini"
+
+    litellm_routed = get_capabilities(llm=_FakeLiteLLMGemini())["reasoning"]
+    assert litellm_routed["supported"] is False
+    assert litellm_routed["reason"] == "provider_not_native_gemini"
+
+
+def test_reasoning_unsupported_when_the_thinking_event_class_is_absent(monkeypatch):
+    """On a crewai without ``LLMThinkingChunkEvent`` the answer is unsupported
+    even for a native-Gemini LLM."""
+    monkeypatch.setattr(caps_mod, "_thinking_event_available", False)
+    reasoning = caps_mod._reasoning_capability(_FakeNativeGemini())
+    assert reasoning["supported"] is False
+    assert reasoning["reason"] == "thinking_event_missing"
+
+
+def test_reasoning_resolves_the_llm_through_agent_and_crew_wrappers():
+    """Callers pass what they have - an Agent, a Crew, a Flow - so the probe
+    unwraps the conventional LLM-carrying attributes."""
+    class _Agent:
+        llm = _FakeNativeGemini()
+
+    class _Crew:
+        chat_llm = _FakeNativeGemini()
+
+    class _Flow:
+        llm = _Agent()
+
+    class _NoLLM:
+        pass
+
+    assert caps_mod._resolve_llm(_Agent()) is _Agent.llm
+    assert caps_mod._resolve_llm(_Crew()) is _Crew.chat_llm
+    assert caps_mod._is_native_gemini(caps_mod._resolve_llm(_Flow())) is True
+    assert caps_mod._resolve_llm(_NoLLM()) is None
+    assert caps_mod._resolve_llm(None) is None
+
+
+def test_native_gemini_probe_needs_both_signals():
+    """Provider string alone (LiteLLM fallback) and ``thinking_config`` alone (a
+    hypothetical future provider) are each insufficient."""
+    class _ThinkingConfigOnly:
+        provider = "anthropic"
+        thinking_config = None
+
+    assert caps_mod._is_native_gemini(_FakeLiteLLMGemini()) is False
+    assert caps_mod._is_native_gemini(_ThinkingConfigOnly()) is False
+    assert caps_mod._is_native_gemini(_FakeNativeGemini()) is True
+    assert caps_mod._is_native_gemini(None) is False
+
+
+def test_thinking_chunk_event_resolves_from_the_installed_crewai():
+    """Sanity-check the resolution itself (never version-gated): on crewai 1.x
+    the class lives at ``crewai.events.types.llm_events``."""
+    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    assert caps_mod.LLMThinkingChunkEvent.__name__ == "LLMThinkingChunkEvent"
+
+
+# -- configuration resolution ----------------------------------------------
+
+def test_emit_raw_events_defaults_off_and_needs_an_explicit_truthy_value(monkeypatch):
+    monkeypatch.delenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, raising=False)
+    assert config_mod.resolve_emit_raw_events(None) is False
+
+    for value in ("1", "true", "TRUE", "yes", "on", " On "):
+        monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, value)
+        assert config_mod.resolve_emit_raw_events(None) is True, value
+
+    for value in ("0", "false", "no", "off", "", "maybe"):
+        monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, value)
+        assert config_mod.resolve_emit_raw_events(None) is False, value
+
+    # An explicit argument wins over the env var either way.
+    monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, "1")
+    assert config_mod.resolve_emit_raw_events(False) is False
+
+
+def test_reasoning_resolves_an_llm_off_a_crews_agents():
+    """A Crew keeps its LLMs on .agents; chat_llm / manager_llm are None there, so
+    resolution has to walk the agents or the documented "pass a Crew" case lies."""
+    class _Agent:
+        llm = _FakeNativeGemini()
+
+    class _Crew:
+        agents = [_Agent()]
+        chat_llm = None
+        manager_llm = None
+
+    assert caps_mod._is_native_gemini(caps_mod._resolve_llm(_Crew())) is True
+
+
+def test_llm_resolution_never_calls_a_factory_or_raising_property():
+    """Capability probing walks caller objects: it must not execute a @CrewBase
+    crew() factory or let a raising property escape as an error."""
+    class _Raising:
+        @property
+        def llm(self):
+            raise RuntimeError("should not escape")
+
+    calls = []
+
+    class _WithFactory:
+        def crew(self):
+            calls.append(1)
+            return _FakeNativeGemini()
+
+    assert caps_mod._resolve_llm(_Raising()) is None
+    assert caps_mod._resolve_llm(_WithFactory()) is None
+    assert calls == []
+
+
+def test_llm_resolution_terminates_on_a_cycle():
+    class _Cycle:
+        pass
+
+    node = _Cycle()
+    node.llm = node
+    assert caps_mod._resolve_llm(node) is None
+
+
+def test_unresolvable_llm_is_distinguished_from_no_llm():
+    """A caller who passed SOMETHING deserves to know the probe found no LLM inside
+    it, rather than being told they passed nothing."""
+    class _NoLLMAnywhere:
+        pass
+
+    assert get_capabilities()["reasoning"]["reason"] == "llm_not_provided"
+    assert get_capabilities(llm=_NoLLMAnywhere())["reasoning"]["reason"] == (
+        "llm_not_resolvable"
+    )
+
+
+def test_native_gemini_is_recognised_under_both_provider_stamps():
+    """crewai stamps "gemini" for gemini/... models and "google" for google/...;
+    both build a real GeminiCompletion, so both must count as native."""
+    class _GoogleStamped:
+        provider = "google"
+        thinking_config = None
+
+    assert caps_mod._is_native_gemini(_GoogleStamped()) is True
+    assert caps_mod._is_native_gemini(_FakeNativeGemini()) is True
+
+
+def test_mixed_crew_prefers_the_native_gemini_agent():
+    """A crew whose first agent is OpenAI and whose second is native Gemini DOES
+    have a reasoning-capable LLM; first-match resolution reported otherwise."""
+    class _OpenAIAgent:
+        llm = _FakeLiteLLMGemini()
+
+    class _GeminiAgent:
+        llm = _FakeNativeGemini()
+
+    class _MixedCrew:
+        agents = [_OpenAIAgent(), _GeminiAgent()]
+
+    assert caps_mod._is_native_gemini(caps_mod._resolve_llm(_MixedCrew())) is True
+
+
+def test_llm_resolution_searches_every_branch_for_native_gemini():
+    """Returning the first agent's LLM meant a crew whose agents are OpenAI but whose
+    chat_llm is native Gemini reported provider_not_native_gemini."""
+    class _OpenAIAgent:
+        llm = _FakeLiteLLMGemini()
+
+    class _CrewWithGeminiChatLLM:
+        agents = [_OpenAIAgent(), _OpenAIAgent()]
+        chat_llm = _FakeNativeGemini()
+
+    resolved = caps_mod._resolve_llm(_CrewWithGeminiChatLLM())
+    assert caps_mod._is_native_gemini(resolved) is True
+
+
+def test_llm_resolution_is_not_order_dependent_across_branches():
+    """A shared visited set was never unwound, so a node reached first down a
+    dead-end branch stayed poisoned and an LLM genuinely reachable elsewhere resolved
+    to None. The ancestor-path guard cuts only real cycles."""
+    shared_dead_end = object()
+
+    class _Branchy:
+        # Same object on two branches: the first branch finds no LLM below it, the
+        # second reaches one THROUGH it.
+        def __init__(self):
+            self.agents = [shared_dead_end]
+            self.llm = _FakeNativeGemini()
+
+    assert caps_mod._is_native_gemini(caps_mod._resolve_llm(_Branchy())) is True
+
+    # A genuine ancestor cycle still terminates.
+    class _Cycle:
+        pass
+
+    a, b = _Cycle(), _Cycle()
+    a.llm, b.llm = b, a
+    assert caps_mod._resolve_llm(a) is None
+
+def test_raw_passthrough_resolution_rejects_a_non_bool_argument():
+    """Config plumbing commonly yields the STRING "false", which is truthy. Silently
+    enabling RAW passthrough would widen what leaves the process (prompt and
+    completion text), so a non-bool fails at registration instead."""
+    for bad in ("false", "true", 1, 0, object()):
+        with pytest.raises(ValueError):
+            config_mod.resolve_emit_raw_events(bad)
+
+    assert config_mod.resolve_emit_raw_events(True) is True
+    assert config_mod.resolve_emit_raw_events(False) is False
+    assert config_mod.resolve_emit_raw_events(None) is config_mod.DEFAULT_EMIT_RAW_EVENTS
+
+
+def test_raw_env_var_is_honoured_and_typos_are_reported(monkeypatch, caplog):
+    """Falling back on a typo is right; falling back SILENTLY made the typo
+    undiagnosable, because the operator sees default behaviour and no explanation."""
+    import logging
+
+    monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, "ON")
+    assert config_mod.resolve_emit_raw_events(None) is True
+
+    monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, "yes-please")
+    monkeypatch.setattr(config_mod, "_ENV_WARN_SEEN", set())
+    with caplog.at_level(logging.WARNING, logger="ag_ui_crewai._config"):
+        assert config_mod.resolve_emit_raw_events(None) is False
+    assert any("yes-please" in r.getMessage() for r in caplog.records), caplog.text
+
+    # An explicitly EMPTY value is documented as "unset", so it is not a typo.
+    monkeypatch.setenv(config_mod.EMIT_RAW_EVENTS_ENV_VAR, "")
+    monkeypatch.setattr(config_mod, "_ENV_WARN_SEEN", set())
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="ag_ui_crewai._config"):
+        assert config_mod.resolve_emit_raw_events(None) is False
+    assert not caplog.records, caplog.text
+
+
+def test_endpoint_factories_reject_a_bad_raw_flag_at_registration():
+    """Resolved once at registration, so a mistake in code fails at startup rather
+    than on every request."""
+    class _Flow:
+        def kickoff_async(self, inputs=None):  # pragma: no cover - never called
+            raise AssertionError
+
+    with pytest.raises(ValueError):
+        ep.add_crewai_flow_fastapi_endpoint(
+            FastAPI(), _Flow(), "/flow", emit_raw_events="false"
+        )

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -1165,3 +1165,195 @@ async def test_frame_path_surfaces_mcp_tool_calls():
         assert expected in types, (expected, types)
     customs = [p for p in payloads if p["type"] == "CUSTOM"]
     assert any(c.get("name") == "mcp_connection_started" for c in customs)
+
+
+# --------------------------------------------------------------------------
+# RAW passthrough: opt-in, default OFF, never before RUN_STARTED
+# --------------------------------------------------------------------------
+
+class _ForeignSourceEmittingFlow(Flow):
+    """Emits a crewai llm event the way crewai itself does: with the EMITTER as
+    source, not the flow.
+
+    Every llm / agent / task / tool event on the 1.15.7 wheel is emitted this way
+    (``crewai_event_bus.emit(self, event=...)`` in ``llms/base_llm.py``), so the
+    driver's outer-flow source gate never parks them - which is why RAW passthrough
+    needs a second buffer to see them at all."""
+
+    @start()
+    async def chat(self):
+        from ag_ui_crewai._capabilities import (
+            LLMThinkingChunkEvent,
+            crewai_event_bus,
+        )
+        if LLMThinkingChunkEvent is not None:
+            crewai_event_bus.emit(
+                object(),  # stands in for the LLM instance crewai emits with
+                event=LLMThinkingChunkEvent(chunk="pondering", call_id="c-1"),
+            )
+        return "done"
+
+
+@requires_stream_frames
+async def test_raw_passthrough_mirrors_foreign_source_events_end_to_end():
+    """RAW passthrough has to reach the llm / agent / task / tool channels, which
+    crewai emits with the EMITTER as source. Gating those out (as the TRANSLATION
+    path must, so they cannot synthesize a run lifecycle) left the flag emitting
+    nothing at all, including for ``llm_thinking_chunk`` - the channel the reasoning
+    capability points at."""
+    from ag_ui.encoder import EventEncoder
+    from ag_ui_crewai._capabilities import LLMThinkingChunkEvent
+
+    if LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+
+    payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+        flow_copy=_ForeignSourceEmittingFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+        emit_raw_events=True,
+    )))
+    types = [p["type"] for p in payloads]
+
+    # The invariant RAW can break: crewai raises some events BEFORE flow_started, and
+    # @ag-ui/client's verifyEvents throws "First event must be 'RUN_STARTED'".
+    assert types[0] == "RUN_STARTED", types
+    raws = [p for p in payloads if p["type"] == "RAW"]
+    assert raws, types
+    assert all(p["source"] == "crewai" for p in raws)
+    assert types.index("RUN_STARTED") < types.index("RAW"), types
+
+    thinking = next(p for p in raws if p["event"]["type"] == "llm_thinking_chunk")
+    assert thinking["event"]["chunk"] == "pondering"
+
+    # Still exactly one run lifecycle: a foreign event can never synthesize one.
+    assert types.count("RUN_STARTED") == 1
+    assert types.count("RUN_FINISHED") == 1
+
+
+@requires_stream_frames
+async def test_foreign_source_events_are_dropped_when_raw_is_off():
+    """Default OFF means default OFF: the payload-bloat guard."""
+    from ag_ui.encoder import EventEncoder
+    from ag_ui_crewai._capabilities import LLMThinkingChunkEvent
+
+    if LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+
+    payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+        flow_copy=_ForeignSourceEmittingFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+    )))
+
+    assert "RAW" not in [p["type"] for p in payloads]
+
+
+@requires_stream_frames
+async def test_saturated_raw_buffer_degrades_without_breaking_the_run(
+    caplog, monkeypatch
+):
+    """Both RAW buffers are bounded. A saturated buffer must degrade RAW mirroring,
+    never the run - and it must say so, because silence is indistinguishable from
+    "crewai emitted nothing", the very thing RAW exists to rule out."""
+    import logging
+
+    from ag_ui.encoder import EventEncoder
+    from ag_ui_crewai._capabilities import LLMThinkingChunkEvent
+
+    if LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+
+    # Cap of 0 so EVERY event is refused: deterministic, unlike a cap of 1 that a
+    # short run may simply never reach.
+    monkeypatch.setattr(ep, "_FOREIGN_EVENT_BUFFER_MAX", 0)
+    monkeypatch.setattr(frames_mod, "_RAW_LOSS_WARNED", False)
+
+    with caplog.at_level(logging.DEBUG, logger="ag_ui_crewai._frames"):
+        payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+            flow_copy=_ForeignSourceEmittingFlow(),
+            encoder=EventEncoder(),
+            input_data=_make_run_input(),
+            inputs={"id": "t-1"},
+            timeout=30.0,
+            emit_raw_events=True,
+        )))
+
+    types = [p["type"] for p in payloads]
+    assert types[0] == "RUN_STARTED", types
+    assert types[-1] == "RUN_FINISHED", types
+    assert "RAW" not in types, types
+    assert any("RAW passthrough" in r.getMessage() for r in caplog.records), caplog.text
+
+
+async def test_legacy_transport_says_it_cannot_serve_raw(caplog, monkeypatch):
+    """The legacy bus listener only receives the event types it registers, so there
+    is nothing to mirror. Say so once per process rather than ignoring the flag."""
+    import logging
+
+    from ag_ui.core import RunFinishedEvent
+    from ag_ui.encoder import EventEncoder
+
+    monkeypatch.setattr(ep, "_LEGACY_RAW_WARNING_EMITTED", False)
+
+    class _ImmediateFlow:
+        state = {}
+
+        def __deepcopy__(self, memo):
+            return self
+
+        async def kickoff_async(self, inputs=None):
+            queue = ep.get_queue(self)
+            queue.put_nowait(RunFinishedEvent(
+                type=EventType.RUN_FINISHED, thread_id="?", run_id="?",
+            ))
+            queue.put_nowait(None)
+            return None
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_crewai.endpoint"):
+        payloads = _decode_sse(await _collect(ep._run_flow_event_stream(
+            flow_copy=_ImmediateFlow(),
+            encoder=EventEncoder(),
+            input_data=_make_run_input(),
+            inputs={"id": "t-1"},
+            timeout=30.0,
+            emit_raw_events=True,
+        )))
+
+    assert [p["type"] for p in payloads] == ["RUN_FINISHED"], payloads
+    assert any(
+        "requires the crewai StreamFrame transport" in r.getMessage()
+        for r in caplog.records
+    ), caplog.text
+
+
+def test_raw_event_builder_never_raises_and_tags_its_source():
+    """A RAW mirror must never be able to break the run, so an unusable payload
+    yields None (the driver drops the mirror) rather than raising into the loop."""
+    class _Unserializable:
+        type = "llm_call_started"
+
+        def model_dump(self, mode=None):
+            raise RuntimeError("nope")
+
+    mirror = frames_mod.raw_event_for(_Unserializable())
+    # Falls back to instance attributes; the class has none, so the payload is the
+    # type alone rather than an exception.
+    assert mirror is not None
+    assert mirror.source == "crewai"
+    assert mirror.event["type"] == "llm_call_started"
+
+    # No ``type`` at all is not mirrorable.
+    assert frames_mod.raw_event_for(SimpleNamespace()) is None
+
+
+def test_mapped_events_are_never_duplicated_as_raw():
+    """The flag adds the events that would otherwise be dropped. An event the bridge
+    DOES map must not also appear as RAW."""
+    assert frames_mod.is_recognized_event(_ev("flow_started")) is True
+    assert frames_mod.is_recognized_event(_ev("TEXT_MESSAGE_CHUNK")) is True
+    assert frames_mod.is_recognized_event(_ev("llm_thinking_chunk")) is False


### PR DESCRIPTION
Part 1 of PNI-136, split out so the wire-shape flip lands separately. This half is independent of the emission-shape change and carries none of its risk.

## What this adds

**RAW passthrough, opt-in, default OFF.** `emit_raw_events=True` (or `AGUI_CREWAI_EMIT_RAW_EVENTS=1`) mirrors the crewai events the bridge does not map onto AG-UI `RAW` events: crewai's llm / agent / task / tool channels including `llm_thinking_chunk`, nested-flow lifecycle, and internals. Default OFF is deliberate — LangGraph shipped RAW on and the payload bloat had to be walked back (OSS-607).

**`get_capabilities()`.** A runtime capability declaration, the CrewAI counterpart of `LangGraphAgent.get_capabilities`. `crewai.__version__` is informational metadata only, never a gate.

## Two things worth reviewing closely

**crewai emits its llm events with the emitter as source, not the flow.** The driver's outer-flow source gate therefore never parks them, so a naive implementation of this flag emits *nothing at all* — including for `llm_thinking_chunk`, the exact channel the reasoning capability points at. This adds a second bounded buffer for foreign-source events while leaving the translation gate intact, so a foreign event still cannot synthesize `RUN_STARTED` / `RUN_FINISHED` or a state snapshot.

**RAW must never be the first wire event.** crewai raises some events before the flow opens, and `@ag-ui/client`'s `verifyEvents` throws `First event must be 'RUN_STARTED'`. Mirrors that arrive early are held and released in order once the run has opened.

## Reasoning is reported honestly

`reasoning.supported` is True only when *all three* hold: `LLMThinkingChunkEvent` exists, the `StreamFrame` transport exists (RAW is the only channel that carries reasoning today), and the passed LLM resolves to native Gemini. Reasoning is native-Gemini-only in crewai — on the 1.15.7 wheel the sole caller of `BaseLLM._emit_thinking_chunk_event` is `crewai/llms/providers/gemini/completion.py`; Anthropic's native provider has a thinking config but never emits the event, and every LiteLLM-routed model (including `vertex_ai/gemini-*`) emits nothing. A bare class probe would claim support for every other model.

Resolution walks Agent / `Crew.agents` / `chat_llm` / `manager_llm` **read-only**: it never calls a `@CrewBase` `crew()` factory, treats a raising property as absent, and cuts ancestor cycles. It prefers a native-Gemini LLM over first-match, so a mixed crew is not misreported. Both native provider stamps count (`gemini` and `google` — the latter builds a real `GeminiCompletion`).

## Configuration contract

Explicit argument > env var > shipped default, resolved at **registration** time. The two paths differ on a bad value on purpose: an unrecognised env value falls back and logs once (a typo in a deployment variable must not take a service down), while a wrong-typed argument raises. That guard is load-bearing — config plumbing commonly yields the *string* `"false"`, which is truthy, and silently enabling RAW would widen what leaves the process.

## Testing

148 → 173 tests. New coverage drives the real driver end to end (a flow emitting a genuine foreign-source `LLMThinkingChunkEvent`), asserts `RUN_STARTED` precedes any `RAW`, asserts default-OFF emits none, and checks the bounded-buffer degradation path plus the legacy-transport warning. The RAW builder is verified never to raise on an unserializable payload.

Verified against the installed crewai 1.15.7 wheel throughout.

## Not in this PR

The wire-shape decision (START/CONTENT/END triples as the default, `emission_shape` opt-out) follows in part 2. `get_capabilities()` here reports the shape this build actually emits — chunks for streamed LLM output, and the canonical `TOOL_CALL_*` triples that PNI-130's MCP path already emits.

Ticket: PNI-136
