### PR TITLE
feat(crewai): opt-in flow checkpointing / thread persistence (PNI-134)

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
@@ -20,6 +20,7 @@ module-load time without a circular dependency (mirrors ``_env``).
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -219,6 +220,139 @@ except Exception:  # pragma: no cover - litellm is a declared direct dep
     _litellm_available = False
 
 
+# --------------------------------------------------------------------------
+# Checkpointing resolution
+# --------------------------------------------------------------------------
+# crewai's checkpointing pieces landed in different releases, so each is
+# resolved/probed independently (never gated on ``__version__``) and its
+# enabling version named in the warning text. ``from_checkpoint`` (1.13)
+# predates ``CheckpointConfig`` (1.14), so the two are probed separately: on
+# 1.13.x the kwarg exists but no config can be built, and the bridge stays on
+# the no-checkpoint path.
+CHECKPOINT_ENABLING_VERSIONS: dict[str, str] = {
+    "from_checkpoint": "1.13.0",
+    "checkpoint_config": "1.14.0",
+    "fork": "1.14.2",
+    "checkpoint_events": "1.14.3",
+    "restore_from_state_id": "1.14.5",
+}
+
+_CREWAI_MODULE, _ = _first_module(["crewai"])
+_Flow = getattr(_CREWAI_MODULE, "Flow", None) if _CREWAI_MODULE else None
+_Crew = getattr(_CREWAI_MODULE, "Crew", None) if _CREWAI_MODULE else None
+
+
+def _kwarg_in_signature(func: Any, name: str) -> bool:
+    """True when ``func`` declares a parameter ``name`` (or accepts ``**kwargs``).
+
+    Used to probe whether a crewai release grew a given keyword argument
+    without gating on the version string. A ``**kwargs`` catch-all counts as
+    "accepts it": passing an unknown kwarg through ``**kwargs`` is safe.
+    """
+    if func is None:
+        return False
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):  # pragma: no cover - C builtins etc.
+        return False
+    if name in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+# ``CheckpointConfig`` is re-exported at the crewai root (1.14+); its canonical
+# home is ``crewai.state.checkpoint_config``. Try the root first, then the
+# module, so a partial / future re-org still resolves.
+CheckpointConfig = getattr(_CREWAI_MODULE, "CheckpointConfig", None) if _CREWAI_MODULE else None
+_CKPT_STATE_MODULE, _CKPT_STATE_MODULE_NAME = _first_module(["crewai.state"])
+if CheckpointConfig is None and _CKPT_STATE_MODULE is not None:
+    CheckpointConfig = getattr(_CKPT_STATE_MODULE, "CheckpointConfig", None)
+
+# ``JsonProvider`` / ``SqliteProvider`` live on ``crewai.state`` (NOT the crewai
+# root, verified on the 1.15.7 wheel).
+JsonProvider = getattr(_CKPT_STATE_MODULE, "JsonProvider", None) if _CKPT_STATE_MODULE else None
+SqliteProvider = getattr(_CKPT_STATE_MODULE, "SqliteProvider", None) if _CKPT_STATE_MODULE else None
+
+# The Checkpoint*Event lifecycle types live at
+# ``crewai.events.types.checkpoint_events`` (not re-exported at the
+# ``crewai.events`` root on 1.15.x). Resolved for callers that surface them;
+# the persistence wiring here does not depend on them.
+_CKPT_EVENTS_MODULE, _CKPT_EVENTS_MODULE_NAME = _first_module(
+    ["crewai.events.types.checkpoint_events"]
+)
+_checkpoint_events_available = _CKPT_EVENTS_MODULE is not None and (
+    getattr(_CKPT_EVENTS_MODULE, "CheckpointCompletedEvent", None) is not None
+)
+
+# ``from_checkpoint`` / ``restore_from_state_id`` are probed on ``Flow`` (the
+# bridge only checkpoints flows; the crew endpoint wraps its crew in a
+# ``ChatWithCrewFlow``). These are the CLASS-level probes for the capability
+# table / warnings; the per-flow guard below re-probes the SPECIFIC instance so
+# test doubles that implement only ``kickoff_async(self, inputs=None)`` stay on
+# the no-checkpoint path.
+_flow_from_checkpoint_supported = _kwarg_in_signature(
+    getattr(_Flow, "kickoff_async", None), "from_checkpoint"
+)
+_flow_restore_from_state_id_supported = _kwarg_in_signature(
+    getattr(_Flow, "kickoff_async", None), "restore_from_state_id"
+)
+_checkpoint_fork_supported = callable(getattr(_Flow, "fork", None)) or callable(
+    getattr(_Crew, "fork", None)
+)
+# Checkpointing needs a config type AND at least one provider to build one. The
+# ``from_checkpoint`` kwarg alone (crewai 1.13) is inert without them.
+_checkpoint_config_available = CheckpointConfig is not None and (
+    JsonProvider is not None or SqliteProvider is not None
+)
+# The full persistence path is usable when we can both build a config and pass
+# it: i.e. the config type, a provider, and the kwarg are all present.
+_checkpointing_available = _checkpoint_config_available and _flow_from_checkpoint_supported
+
+
+def flow_supports_checkpointing(flow: Any) -> bool:
+    """Return True when THIS flow can be checkpointed via ``from_checkpoint``.
+
+    Two conditions, both required (mirrors ``flow_supports_stream_frames``):
+
+    * the installed crewai can build a ``CheckpointConfig`` and exposes the
+      ``from_checkpoint`` kwarg (crewai >= 1.14 for both), and
+    * this SPECIFIC flow object exposes a driving method (``astream`` or
+      ``kickoff_async``) whose signature actually accepts ``from_checkpoint``.
+
+    The per-flow re-probe is what keeps the cancellation test doubles in
+    ``tests/test_task_cancellation.py`` (which implement only
+    ``kickoff_async(self, inputs=None)``) on the no-checkpoint path, so their
+    27 cancellation / timeout tests are unaffected.
+    """
+    if not _checkpointing_available:
+        return False
+    for method_name in ("astream", "kickoff_async"):
+        if _kwarg_in_signature(getattr(flow, method_name, None), "from_checkpoint"):
+            return True
+    return False
+
+
+def supported_checkpoint_kwargs(method: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Filter ``kwargs`` to those the bound ``method`` actually declares.
+
+    The last line of defence at the call site: even after
+    ``flow_supports_checkpointing`` gates the build, the frame path calls
+    ``astream`` and the legacy path calls ``kickoff_async`` (different methods).
+    Filtering per-method means a flow that grew one kwarg but not the other (or
+    a test double that grew neither) degrades to a no-op instead of raising
+    ``TypeError: unexpected keyword argument``.
+    """
+    if not kwargs:
+        return {}
+    try:
+        params = inspect.signature(method).parameters
+    except (TypeError, ValueError):  # pragma: no cover - C builtins etc.
+        return {}
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return dict(kwargs)
+    return {k: v for k, v in kwargs.items() if k in params}
+
+
 @dataclass(frozen=True)
 class _Capabilities:
     """Cached, immutable snapshot of the detected crewai capabilities.
@@ -237,6 +371,15 @@ class _Capabilities:
     crew_chat_available: bool
     litellm_available: bool
     stream_frame_available: bool = False
+    # Checkpointing: informational; the wiring keys off the resolved
+    # symbols / ``flow_supports_checkpointing`` per-flow probe, not these fields.
+    checkpoint_config_available: bool = False
+    checkpointing_available: bool = False
+    flow_from_checkpoint_supported: bool = False
+    flow_restore_from_state_id_supported: bool = False
+    checkpoint_fork_supported: bool = False
+    checkpoint_events_available: bool = False
+    checkpoint_state_module: str | None = None
     missing: tuple[str, ...] = field(default_factory=tuple)
 
     def warn_on_gaps(self) -> None:
@@ -300,6 +443,13 @@ def _detect() -> _Capabilities:
         crew_chat_available=_crew_chat_available,
         litellm_available=_litellm_available,
         stream_frame_available=_stream_frame_available,
+        checkpoint_config_available=_checkpoint_config_available,
+        checkpointing_available=_checkpointing_available,
+        flow_from_checkpoint_supported=_flow_from_checkpoint_supported,
+        flow_restore_from_state_id_supported=_flow_restore_from_state_id_supported,
+        checkpoint_fork_supported=_checkpoint_fork_supported,
+        checkpoint_events_available=_checkpoint_events_available,
+        checkpoint_state_module=_CKPT_STATE_MODULE_NAME,
         missing=tuple(missing),
     )
     caps.warn_on_gaps()

--- a/integrations/crew-ai/python/ag_ui_crewai/_checkpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_checkpoint.py
@@ -1,0 +1,395 @@
+"""CrewAI flow checkpointing / thread persistence for the AG-UI bridge.
+
+``build_checkpoint_kwargs(flow, input_data)`` produces the kwargs the endpoints
+splice into a flow kickoff. It is opt-in (off unless ``CREWAI_CHECKPOINT`` is
+set, so the default path is unchanged), capability-gated (returns ``{}`` unless
+the installed crewai and this specific flow both support ``from_checkpoint``),
+and per-thread (each ``thread_id`` gets its own store). A leaf module: imports
+only the stdlib, ``_env`` and ``_capabilities``.
+
+crewai has two mutually exclusive resume systems: passing ``from_checkpoint``
+and ``restore_from_state_id`` together raises ``ValueError``. This module uses
+only Checkpointing: ``from_checkpoint=CheckpointConfig(...)`` persists, and
+resume is explicit via ``CheckpointConfig(restore_from=<checkpoint path>)`` (a
+fresh kickoff with ``from_checkpoint`` alone re-runs every step). It never
+emits ``restore_from_state_id``. ``inputs["id"]`` stays as the thread linkage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from . import _capabilities as _caps
+from ._env import _parse_env_bool, _parse_env_int, _parse_env_str
+
+_LOGGER = logging.getLogger(__name__)
+
+# Env knobs (all optional; the feature is off unless CREWAI_CHECKPOINT is set).
+_ENV_ENABLED = "CREWAI_CHECKPOINT"
+_ENV_PROVIDER = "CREWAI_CHECKPOINT_PROVIDER"  # "json" (default) | "sqlite"
+_ENV_DIR = "CREWAI_CHECKPOINT_DIR"  # base location; per-thread subdir appended
+_ENV_MAX = "CREWAI_CHECKPOINT_MAX"  # int cap on retained checkpoints per thread
+_ENV_ON_EVENTS = "CREWAI_CHECKPOINT_ON_EVENTS"  # comma-separated event triggers
+
+_DEFAULT_DIR = "./.checkpoints"
+_DEFAULT_PROVIDER = "json"
+# CheckpointConfig defaults ``on_events`` to ``["task_completed"]``, a crew
+# trigger. The bridge always drives a flow (which emits
+# ``method_execution_finished``, not ``task_completed``), so the stock default
+# would write nothing; a flow-appropriate trigger is required.
+_DEFAULT_ON_EVENTS = ("method_execution_finished",)
+
+# ``thread_id`` becomes a path segment, so it is sanitised to a safe charset;
+# a value that reduces to nothing usable yields ``None`` (caller then skips
+# checkpointing rather than sharing a bucket).
+_UNSAFE_SEGMENT = re.compile(r"[^A-Za-z0-9._-]+")
+_MAX_SEGMENT_LEN = 128
+# The json provider writes under ``<location>/main/``; a checkpoint id resolves
+# to ``<location>/main/<id>.json``.
+_CHECKPOINT_BRANCH_DIR = "main"
+
+# forwarded_props keys a client may use to request restoring a checkpoint
+# (checked top-level and nested under a "crewai" key). RunAgentInput.resume is
+# deliberately not consulted (it is the AG-UI interrupt-resume list, not a
+# checkpoint reference), and "restore_from_state_id" is intentionally excluded
+# (that is the @persist kwarg name, a different system).
+_RESUME_KEYS = ("restore_from", "checkpoint_id")
+
+# Dedupe one-time warnings so they log once, not per request.
+_WARN_SEEN: set[str] = set()
+
+
+@dataclass(frozen=True)
+class _CheckpointSettings:
+    enabled: bool
+    provider: str
+    base_dir: str
+    max_checkpoints: int | None
+    on_events: tuple[str, ...]
+
+
+def resolve_checkpoint_settings() -> _CheckpointSettings:
+    """Read the checkpoint env knobs into an immutable settings snapshot.
+
+    Read per request (not cached) so tests / operators can flip
+    ``CREWAI_CHECKPOINT`` without reimporting the module; the parse is cheap.
+    """
+    enabled = _parse_env_bool(_ENV_ENABLED, default=False)
+    provider = _parse_env_str(_ENV_PROVIDER, _DEFAULT_PROVIDER).lower()
+    if provider not in ("json", "sqlite"):
+        if enabled:
+            _warn_once(
+                "provider-unknown",
+                "ag-ui-crewai: unknown CREWAI_CHECKPOINT_PROVIDER %r; using %r.",
+                provider,
+                _DEFAULT_PROVIDER,
+            )
+        provider = _DEFAULT_PROVIDER
+    raw_events = _parse_env_str(_ENV_ON_EVENTS, "")
+    on_events = (
+        tuple(e.strip() for e in raw_events.split(",") if e.strip())
+        or _DEFAULT_ON_EVENTS
+    )
+    return _CheckpointSettings(
+        enabled=enabled,
+        provider=provider,
+        base_dir=_parse_env_str(_ENV_DIR, _DEFAULT_DIR),
+        max_checkpoints=_parse_env_int(_ENV_MAX, default=None),
+        on_events=on_events,
+    )
+
+
+def _safe_thread_segment(thread_id: Any) -> str | None:
+    """Map ``thread_id`` to a safe, injective path segment, or ``None``.
+
+    Returns ``None`` for a missing / non-string id, so the caller skips
+    checkpointing rather than sharing a store (a cross-session leak). Otherwise
+    the segment is ``<sanitised>-<hash>``: the sanitised prefix stays readable
+    (unsafe chars collapse to ``_``, capped in length, never escaping the base
+    dir), and the hash of the RAW id makes the mapping injective, so distinct
+    thread_ids (e.g. ``"a/b"`` vs ``"a_b"``) never collide onto one store while
+    the same id always maps to the same segment.
+    """
+    if not isinstance(thread_id, str) or not thread_id:
+        return None
+    cleaned = _UNSAFE_SEGMENT.sub("_", thread_id).strip("._")[:_MAX_SEGMENT_LEN].strip("._")
+    digest = hashlib.sha256(thread_id.encode("utf-8")).hexdigest()[:12]
+    return f"{cleaned}-{digest}" if cleaned else digest
+
+
+def _make_provider(provider: str) -> Any | None:
+    """Instantiate the configured provider, or ``None`` if none is available.
+
+    Falls back to the OTHER installed provider (with a one-time warning) when
+    the requested one is missing, symmetrically for both ``json`` and
+    ``sqlite`` requests, so a partial install degrades rather than silently
+    disabling persistence. Constructors are invoked here but the sole caller
+    (``_build_config``) runs this inside its try/except, so a raising
+    constructor degrades instead of surfacing as a request-level 500.
+    """
+    json_cls = _caps.JsonProvider
+    sqlite_cls = _caps.SqliteProvider
+    if provider == "sqlite":
+        primary, fallback, requested = sqlite_cls, json_cls, "sqlite"
+    else:  # default / "json"
+        primary, fallback, requested = json_cls, sqlite_cls, "json"
+    if primary is not None:
+        return primary()
+    if fallback is not None:
+        _warn_once(
+            "provider-fallback",
+            "ag-ui-crewai: CREWAI_CHECKPOINT_PROVIDER=%s but that crewai "
+            "provider is unavailable; falling back to the other installed "
+            "provider.",
+            requested,
+        )
+        return fallback()
+    return None
+
+
+def _thread_location(settings: _CheckpointSettings, segment: str) -> str:
+    """Per-thread checkpoint store path under the configured base dir.
+
+    ``os.path.join`` keeps this correct across separators; ``segment`` is
+    already sanitised to a safe single component.
+    """
+    return os.path.join(settings.base_dir, segment)
+
+
+def _resolve_restore_path(location: str, raw: str) -> str | None:
+    """Resolve a client-supplied checkpoint id to a file inside this thread's store.
+
+    The id is client-controlled, so it must never escape the thread's own
+    store: absolute paths, path separators and ``..`` are rejected outright,
+    and the resolved path is confirmed to sit under ``<location>/main/`` before
+    use. Returns the path only when it exists, so a bad/stale id degrades to
+    "no restore" (a warning) rather than a traversal or a crewai
+    ``FileNotFoundError`` that would 500 the request.
+    """
+    if os.path.isabs(raw) or "/" in raw or "\\" in raw or ".." in raw:
+        return None
+    name = raw if raw.endswith(".json") else raw + ".json"
+    store = os.path.join(location, _CHECKPOINT_BRANCH_DIR)
+    candidate = os.path.join(store, name)
+    try:
+        store_real = os.path.realpath(store)
+        candidate_real = os.path.realpath(candidate)
+        # A NUL byte (realpath) or a cross-drive path on Windows (commonpath)
+        # raises ValueError on the client-controlled value; treat as no-match.
+        if os.path.commonpath([store_real, candidate_real]) != store_real:
+            return None
+        return candidate if os.path.isfile(candidate) else None
+    except ValueError:
+        return None
+
+
+def _build_config(
+    settings: _CheckpointSettings, *, thread_id: Any, restore_from: str | None = None
+) -> Any | None:
+    """Build a per-thread ``CheckpointConfig``, or ``None`` if it cannot be built.
+
+    Returns ``None`` (never raises) when: the config type is unavailable, the
+    request has no usable ``thread_id``, no provider can be instantiated, or
+    construction fails. Provider instantiation and config construction both run
+    inside the try/except so a raising crewai constructor degrades to
+    "no checkpointing for this run" instead of 500-ing the request.
+
+    ``restore_from`` (already resolved to an existing checkpoint file path) is
+    folded into the config to resume that point WITHIN the checkpointing
+    system, never as the incompatible ``restore_from_state_id`` kwarg.
+    """
+    config_cls = _caps.CheckpointConfig
+    if config_cls is None:
+        return None
+    segment = _safe_thread_segment(thread_id)
+    if segment is None:
+        _warn_once(
+            "no-thread-id",
+            "ag-ui-crewai: checkpointing is enabled but the request carries no "
+            "usable thread_id; skipping persistence for this run rather than "
+            "sharing one checkpoint store across sessions.",
+        )
+        return None
+    try:
+        provider = _make_provider(settings.provider)
+        if provider is None:
+            return None
+        # Per-thread subdir under the base dir gives each thread its own store.
+        location = _thread_location(settings, segment)
+        kwargs: dict[str, Any] = {
+            "provider": provider,
+            "location": location,
+            "on_events": list(settings.on_events),
+        }
+        if settings.max_checkpoints is not None:
+            kwargs["max_checkpoints"] = settings.max_checkpoints
+        if restore_from is not None:
+            kwargs["restore_from"] = restore_from
+        return config_cls(**kwargs)
+    except Exception as exc:  # noqa: BLE001 - never let config-building break a run
+        _warn_once(
+            "config-build",
+            "ag-ui-crewai: failed to build a CheckpointConfig (%s); continuing "
+            "without checkpointing for this run." % (exc,),
+        )
+        return None
+
+
+def _resume_reference(input_data: Any) -> str | None:
+    """Extract a client-requested checkpoint id to restore, if any.
+
+    The value is a bare checkpoint id (resolved within this thread's store by
+    ``_resolve_restore_path``), NOT a ``@persist`` state id or a path. Looks at
+    ``forwarded_props`` for one of ``_RESUME_KEYS``, both at the top level and
+    nested under a ``crewai`` key. Returns the first non-empty string found,
+    else ``None``.
+    """
+
+    def _from_mapping(mapping: Any) -> str | None:
+        if not isinstance(mapping, dict):
+            return None
+        for key in _RESUME_KEYS:
+            value = mapping.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    props = getattr(input_data, "forwarded_props", None)
+    found = _from_mapping(props)
+    if found:
+        return found
+    if isinstance(props, dict):
+        found = _from_mapping(props.get("crewai"))
+        if found:
+            return found
+    return None
+
+
+def _warn_once(key: str, message: str, *args: Any) -> None:
+    """Log a WARNING once per process, keyed by ``key``.
+
+    For deploy/config-level conditions (missing capability, provider fallback)
+    where repeating per request would be noise. Per-request, client-driven
+    failures should use ``_warn`` instead so distinct occurrences are visible.
+    """
+    if key in _WARN_SEEN:
+        return
+    _WARN_SEEN.add(key)
+    _LOGGER.warning(message, *args)
+
+
+def _warn(message: str, *args: Any) -> None:
+    """Log a per-occurrence WARNING (no dedupe) for client-driven failures."""
+    _LOGGER.warning(message, *args)
+
+
+def _warn_unsupported_once(settings: _CheckpointSettings) -> None:
+    """Warn (once) that checkpointing is enabled but will not run for this flow.
+
+    Distinguishes the two distinct causes so the operator gets a truthful
+    signal instead of always being told to upgrade crewai:
+
+    * crewai itself lacks the API (``checkpointing_available`` False): name the
+      enabling version and advise an upgrade.
+    * crewai IS capable but THIS flow object does not accept ``from_checkpoint``
+      (a custom flow or a test double): an upgrade would not help, so say so.
+    """
+    caps_ = _caps.CAPABILITIES
+    versions = _caps.CHECKPOINT_ENABLING_VERSIONS
+    if not caps_.checkpointing_available:
+        # Name the LOWEST enabling version of whichever piece is missing.
+        # ``from_checkpoint`` (1.13.0) predates ``CheckpointConfig`` (1.14.0);
+        # if the kwarg is absent that is the floor, otherwise the config type is.
+        if not caps_.flow_from_checkpoint_supported:
+            need = versions["from_checkpoint"]
+        else:
+            need = versions["checkpoint_config"]
+        _warn_once(
+            "unsupported-version",
+            "ag-ui-crewai: CREWAI_CHECKPOINT is set but the installed crewai "
+            "(%s) does not expose the checkpointing API the bridge needs; runs "
+            "will NOT be persisted. Upgrade to crewai>=%s.",
+            caps_.crewai_version,
+            need,
+        )
+    else:
+        _warn_once(
+            "unsupported-flow",
+            "ag-ui-crewai: CREWAI_CHECKPOINT is set and crewai %s supports "
+            "checkpointing, but this flow object does not accept the "
+            "from_checkpoint kwarg (e.g. a custom flow or test double); runs "
+            "will NOT be persisted for it.",
+            caps_.crewai_version,
+        )
+
+
+def build_checkpoint_kwargs(flow: Any, input_data: Any) -> dict[str, Any]:
+    """Build the checkpoint kwargs to splice into a flow kickoff/astream call.
+
+    Returns ``{}`` (i.e. "no change to the default path") unless ALL of:
+
+    * ``CREWAI_CHECKPOINT`` is truthy,
+    * the installed crewai can build a config AND drive it (capability probe),
+    * this specific ``flow`` accepts ``from_checkpoint`` (per-flow probe).
+
+    When enabled the result is always exactly ``{"from_checkpoint": config}``:
+    a per-thread ``CheckpointConfig`` that persists this thread's runs and,
+    when the client supplied a resolvable checkpoint reference, carries
+    ``restore_from`` to resume that point. The module NEVER emits
+    ``restore_from_state_id`` (the incompatible ``@persist`` kwarg, which would
+    raise ``ValueError`` alongside ``from_checkpoint``). The caller still
+    filters the returned dict against the exact method being invoked via
+    ``_capabilities.supported_checkpoint_kwargs``.
+    """
+    settings = resolve_checkpoint_settings()
+    if not settings.enabled:
+        return {}
+    if not _caps.flow_supports_checkpointing(flow):
+        _warn_unsupported_once(settings)
+        return {}
+
+    thread_id = getattr(input_data, "thread_id", None)
+
+    # Resolve a client-requested checkpoint id to a file in this thread's store,
+    # if any. Any failure degrades to plain persistence (never a crash), and is
+    # logged per-occurrence since it is driven by client input.
+    restore_from: str | None = None
+    raw_ref = _resume_reference(input_data)
+    segment = _safe_thread_segment(thread_id)
+    if raw_ref is not None and segment is not None:
+        # Restore-by-id resolves against the json provider's on-disk layout;
+        # gate on the EFFECTIVE provider (json requested AND available, i.e. no
+        # fallback away from json) so a bare id is never resolved against a
+        # different layout.
+        if settings.provider == "json" and _caps.JsonProvider is not None:
+            restore_from = _resolve_restore_path(
+                _thread_location(settings, segment), raw_ref
+            )
+            if restore_from is None:
+                _warn(
+                    "ag-ui-crewai: checkpoint restore id %r could not be "
+                    "resolved to a checkpoint in this thread's store (unknown "
+                    "or rejected); continuing without restore (persistence "
+                    "still active).",
+                    raw_ref,
+                )
+        else:
+            _warn(
+                "ag-ui-crewai: a checkpoint restore id was supplied but "
+                "restore-by-id is only supported for the json provider; "
+                "ignoring it under provider %r (persistence still active).",
+                settings.provider,
+            )
+
+    config = _build_config(settings, thread_id=thread_id, restore_from=restore_from)
+    if config is None:
+        # No usable per-thread store (no thread_id, build failure, or a
+        # capability gap slipping past the guard). Skip checkpointing entirely.
+        return {}
+
+    return {"from_checkpoint": config}

--- a/integrations/crew-ai/python/ag_ui_crewai/_env.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_env.py
@@ -54,3 +54,52 @@ def _parse_env_float(
     if value <= 0:
         return None if allow_disable else default
     return value
+
+
+# Values that read as "on" for a boolean env var. Anything else (including
+# unset) is "off": a conservative default for opt-in features.
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on", "y", "t"})
+
+
+def _parse_env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean env var with a permissive true-set.
+
+    Unset -> ``default``. Otherwise case-insensitively true for
+    ``1/true/yes/on/y/t`` and false for everything else (so a typo fails
+    safe to "off" rather than silently enabling an opt-in feature).
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in _TRUE_VALUES
+
+
+def _parse_env_str(name: str, default: str) -> str:
+    """Parse a string env var, treating unset OR empty/whitespace as unset.
+
+    An operator who exports ``CREWAI_CHECKPOINT_DIR=`` (empty) means "use the
+    default", not "checkpoint to the current directory root".
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip()
+
+
+def _parse_env_int(name: str, default: int | None) -> int | None:
+    """Parse an optional positive-int env var.
+
+    Unset / unparseable / non-positive -> ``default`` (``None`` disables the
+    associated bound). Mirrors ``_parse_env_float``'s fail-safe-to-default
+    policy so a bad value never silently changes behaviour.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return value

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -27,9 +27,11 @@ from ._capabilities import (
     BaseEventListener,
     crewai_event_bus,
     flow_supports_stream_frames,
+    supported_checkpoint_kwargs,
     add_stream_sink,
     reset_stream_sinks,
 )
+from ._checkpoint import build_checkpoint_kwargs
 from ._frames import StreamFrameTranslator
 from .mcp import is_mcp_event, register_mcp_listeners, translate_mcp_event
 from crewai.flow.flow import Flow
@@ -1219,6 +1221,7 @@ async def _run_flow_event_stream(
     input_data: RunAgentInput,
     inputs: dict,
     timeout: float | None,
+    checkpoint_kwargs: dict | None = None,
 ):
     """Drive a single flow kickoff and yield encoded AG-UI events.
 
@@ -1277,8 +1280,22 @@ async def _run_flow_event_stream(
     allow_grace = False
     try:
         try:
+            # Only pass checkpoint kwargs this flow's kickoff_async declares, so
+            # a flow that predates them is called exactly as before.
+            _ckpt = supported_checkpoint_kwargs(
+                flow_copy.kickoff_async, checkpoint_kwargs or {}  # type: ignore[attr-defined]
+            )
+            if checkpoint_kwargs and not _ckpt:
+                # Checkpointing was enabled and a config was built, but this
+                # flow's kickoff_async does not accept it: warn so the no-op is
+                # visible rather than silently persisting nothing.
+                _LOGGER.warning(
+                    "ag-ui-crewai: checkpointing is enabled but "
+                    "flow.kickoff_async does not accept from_checkpoint; "
+                    "nothing will be persisted for this run."
+                )
             kickoff_task = asyncio.create_task(
-                flow_copy.kickoff_async(inputs=inputs)  # type: ignore[attr-defined]
+                flow_copy.kickoff_async(inputs=inputs, **_ckpt)  # type: ignore[attr-defined]
             )
 
             deadline = (
@@ -1817,6 +1834,7 @@ async def _run_flow_frame_stream(
     input_data: RunAgentInput,
     inputs: dict,
     timeout: float | None,
+    checkpoint_kwargs: dict | None = None,
 ):
     """StreamFrame-path driver (CPK-7719): drive ``flow.astream`` and yield
     encoded AG-UI events.
@@ -1906,7 +1924,20 @@ async def _run_flow_frame_stream(
             sink_token = add_stream_sink(_sink) if callable(add_stream_sink) else None
             # ``astream`` returns an AsyncStreamSession; iterating it spawns
             # crewai's background kickoff task and streams ordered frames.
-            session = flow_copy.astream(inputs=inputs)  # type: ignore[attr-defined]
+            # Filter against astream's own signature so an unsupported kwarg
+            # degrades cleanly instead of raising.
+            _ckpt = supported_checkpoint_kwargs(
+                flow_copy.astream, checkpoint_kwargs or {}  # type: ignore[attr-defined]
+            )
+            if checkpoint_kwargs and not _ckpt:
+                # Checkpointing enabled but this flow's astream does not accept
+                # it: warn so the no-op is visible.
+                _LOGGER.warning(
+                    "ag-ui-crewai: checkpointing is enabled but flow.astream "
+                    "does not accept from_checkpoint; nothing will be persisted "
+                    "for this run."
+                )
+            session = flow_copy.astream(inputs=inputs, **_ckpt)  # type: ignore[attr-defined]
             aiter = session.__aiter__()
             deadline = (
                 time.monotonic() + timeout if timeout is not None else None
@@ -2098,6 +2129,7 @@ def _run_flow_stream(
     input_data: RunAgentInput,
     inputs: dict,
     timeout: float | None,
+    checkpoint_kwargs: dict | None = None,
 ):
     """Select the StreamFrame path (crewai >= 1.6 + a real ``astream`` flow) or
     the legacy bus-listener path, returning the chosen async generator.
@@ -2106,6 +2138,9 @@ def _run_flow_stream(
     ``tests/test_task_cancellation.py`` implement only ``kickoff_async`` and so
     transparently keep the legacy path (and its 27 cancellation tests). Real
     crewai 1.6+ Flows take the StreamFrame path; crewai 1.0-1.5 falls back.
+
+    ``checkpoint_kwargs`` is forwarded to whichever driver is chosen; each
+    driver filters it against the exact method it invokes.
     """
     if flow_supports_stream_frames(flow_copy):
         return _run_flow_frame_stream(
@@ -2114,6 +2149,7 @@ def _run_flow_stream(
             input_data=input_data,
             inputs=inputs,
             timeout=timeout,
+            checkpoint_kwargs=checkpoint_kwargs,
         )
     return _run_flow_event_stream(
         flow_copy=flow_copy,
@@ -2121,6 +2157,7 @@ def _run_flow_stream(
         input_data=input_data,
         inputs=inputs,
         timeout=timeout,
+        checkpoint_kwargs=checkpoint_kwargs,
     )
 
 
@@ -2153,7 +2190,11 @@ def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
             context=input_data.context,
             forwarded_props=input_data.forwarded_props,
         )
+        # Keep the thread linkage crewai has always used; checkpointing layers
+        # on top and is off unless CREWAI_CHECKPOINT is set.
         inputs["id"] = input_data.thread_id
+
+        checkpoint_kwargs = build_checkpoint_kwargs(flow_copy, input_data)
 
         timeout = _flow_timeout_seconds()
 
@@ -2164,6 +2205,7 @@ def add_crewai_flow_fastapi_endpoint(app: FastAPI, flow: Flow, path: str = "/"):
                 input_data=input_data,
                 inputs=inputs,
                 timeout=timeout,
+                checkpoint_kwargs=checkpoint_kwargs,
             ),
             media_type=encoder.get_content_type(),
         )
@@ -2224,7 +2266,10 @@ def add_crewai_crew_fastapi_endpoint(
             context=input_data.context,
             forwarded_props=input_data.forwarded_props,
         )
+        # Keep the thread linkage; layer opt-in checkpointing on top.
         inputs["id"] = input_data.thread_id
+
+        checkpoint_kwargs = build_checkpoint_kwargs(flow_copy, input_data)
 
         timeout = _flow_timeout_seconds()
 
@@ -2235,6 +2280,7 @@ def add_crewai_crew_fastapi_endpoint(
                 input_data=input_data,
                 inputs=inputs,
                 timeout=timeout,
+                checkpoint_kwargs=checkpoint_kwargs,
             ),
             media_type=encoder.get_content_type(),
         )

--- a/integrations/crew-ai/python/tests/test_checkpointing.py
+++ b/integrations/crew-ai/python/tests/test_checkpointing.py
@@ -1,0 +1,780 @@
+"""Tests for CrewAI flow checkpointing / thread persistence.
+
+Covers capability probes, per-method/per-flow kwarg gating, env parsing,
+thread-id and restore-reference sanitisation, ``build_checkpoint_kwargs``
+end-to-end (off by default; builds a per-thread config; folds a resolvable
+resume reference into ``restore_from``; never emits ``restore_from_state_id``;
+returns ``{}`` for a flow that predates the kwarg), the driver-level splice,
+and real-flow persistence/restore.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+from ag_ui.core import RunAgentInput
+from ag_ui.encoder import EventEncoder
+
+from ag_ui_crewai import _capabilities as caps
+from ag_ui_crewai import _checkpoint as ckpt
+from ag_ui_crewai import endpoint as ep
+
+# Assertions that pin crewai >= 1.14 checkpoint behaviour must SKIP (not fail)
+# on any crewai in the declared >=1.0,<2 support range below 1.14, where the
+# API is absent. The bridge itself degrades gracefully there; these tests only
+# apply where the capability exists.
+requires_checkpointing = pytest.mark.skipif(
+    not caps.CAPABILITIES.checkpointing_available,
+    reason="installed crewai does not expose the checkpointing API (needs >=1.14)",
+)
+
+# The two real-flow end-to-end tests below drive a real crewai Flow, which
+# registers crewai's process-global checkpoint listener and serialises the
+# event graph. That global-state interaction is opt-in (set
+# CREWAI_CHECKPOINT_E2E=1) so the default suite stays fully deterministic and
+# cannot perturb unrelated tests that share the crewai event bus. The wiring
+# and behaviour these prove are also covered deterministically by the unit
+# tests above.
+requires_e2e = pytest.mark.skipif(
+    not os.getenv("CREWAI_CHECKPOINT_E2E"),
+    reason="real-flow e2e; set CREWAI_CHECKPOINT_E2E=1 to run",
+)
+
+
+# -- fixtures / helpers -----------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_checkpoint_warn_dedupe():
+    """Clear the one-time warning dedupe set between tests so a warning
+    asserted (or suppressed) in one test does not leak into the next."""
+    ckpt._WARN_SEEN.clear()
+    yield
+    ckpt._WARN_SEEN.clear()
+
+
+def _make_input(*, thread_id="t-1", forwarded_props=None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r-1",
+        state={},
+        messages=[],
+        tools=[],
+        context=[],
+        forwarded_props=forwarded_props if forwarded_props is not None else {},
+    )
+
+
+class _SupportingFlow:
+    """A flow whose kickoff_async/astream accept the checkpoint kwargs."""
+
+    def __init__(self):
+        self.received = None
+
+    def __deepcopy__(self, memo):  # noqa: D401 - trivial
+        return self
+
+    async def kickoff_async(self, inputs=None, from_checkpoint=None, restore_from_state_id=None):
+        self.received = {
+            "inputs": inputs,
+            "from_checkpoint": from_checkpoint,
+            "restore_from_state_id": restore_from_state_id,
+        }
+        return None
+
+    async def astream(self, inputs=None, from_checkpoint=None, restore_from_state_id=None):
+        raise NotImplementedError
+
+
+class _LegacyFlow:
+    """A flow (like the cancellation doubles) that predates checkpointing."""
+
+    def __init__(self):
+        self.received = None
+
+    def __deepcopy__(self, memo):  # noqa: D401 - trivial
+        return self
+
+    async def kickoff_async(self, inputs=None):
+        self.received = {"inputs": inputs}
+        return None
+
+
+# -- capability probes (real crewai) ----------------------------------------
+
+
+@requires_checkpointing
+def test_capabilities_resolves_checkpoint_symbols():
+    """On crewai >= 1.14 every checkpoint piece resolves."""
+    assert caps.CheckpointConfig is not None
+    assert caps.JsonProvider is not None
+    assert caps.SqliteProvider is not None
+    c = caps.CAPABILITIES
+    assert c.checkpoint_config_available is True
+    assert c.flow_from_checkpoint_supported is True
+    assert c.flow_restore_from_state_id_supported is True
+    assert c.checkpoint_fork_supported is True
+    assert c.checkpoint_events_available is True
+    assert c.checkpointing_available is True
+
+
+def test_enabling_versions_table_is_complete():
+    keys = set(caps.CHECKPOINT_ENABLING_VERSIONS)
+    assert keys == {
+        "from_checkpoint",
+        "checkpoint_config",
+        "fork",
+        "checkpoint_events",
+        "restore_from_state_id",
+    }
+
+
+# -- signature filtering -----------------------------------------------------
+
+
+def test_kwarg_in_signature():
+    def f(inputs=None, from_checkpoint=None):
+        pass
+
+    def g(inputs=None):
+        pass
+
+    def h(inputs=None, **kwargs):
+        pass
+
+    assert caps._kwarg_in_signature(f, "from_checkpoint") is True
+    assert caps._kwarg_in_signature(g, "from_checkpoint") is False
+    assert caps._kwarg_in_signature(h, "from_checkpoint") is True  # **kwargs
+    assert caps._kwarg_in_signature(None, "from_checkpoint") is False
+
+
+def test_supported_checkpoint_kwargs_filters_per_method():
+    def accepts(inputs=None, from_checkpoint=None):
+        pass
+
+    def rejects(inputs=None):
+        pass
+
+    def var_kw(inputs=None, **kw):
+        pass
+
+    payload = {"from_checkpoint": object(), "restore_from_state_id": "x"}
+    # Only the declared kwarg survives.
+    assert caps.supported_checkpoint_kwargs(accepts, payload) == {
+        "from_checkpoint": payload["from_checkpoint"]
+    }
+    # A method that declares neither gets nothing (the cancellation-double case).
+    assert caps.supported_checkpoint_kwargs(rejects, payload) == {}
+    # A **kwargs method takes everything.
+    assert caps.supported_checkpoint_kwargs(var_kw, payload) == payload
+    # Empty in, empty out.
+    assert caps.supported_checkpoint_kwargs(accepts, {}) == {}
+
+
+@requires_checkpointing
+def test_flow_supports_checkpointing_per_flow():
+    assert caps.flow_supports_checkpointing(_SupportingFlow()) is True
+    # Legacy flow (kickoff_async(inputs) only) is NOT supported even though the
+    # installed crewai is capable, the per-flow probe is what protects the
+    # cancellation doubles.
+    assert caps.flow_supports_checkpointing(_LegacyFlow()) is False
+
+
+def test_legacy_flow_never_supported():
+    # A flow that predates the kwarg is never checkpoint-supported, on any
+    # crewai (no capability guard needed).
+    assert caps.flow_supports_checkpointing(_LegacyFlow()) is False
+
+
+# -- env parsing -------------------------------------------------------------
+
+
+def test_settings_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("CREWAI_CHECKPOINT", raising=False)
+    assert ckpt.resolve_checkpoint_settings().enabled is False
+
+
+def test_settings_reads_all_knobs(monkeypatch):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "true")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_PROVIDER", "sqlite")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", "/var/ckpt")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_MAX", "5")
+    s = ckpt.resolve_checkpoint_settings()
+    assert (s.enabled, s.provider, s.base_dir, s.max_checkpoints) == (
+        True,
+        "sqlite",
+        "/var/ckpt",
+        5,
+    )
+
+
+def test_settings_bad_values_fall_back(monkeypatch):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "nope")  # not truthy
+    monkeypatch.setenv("CREWAI_CHECKPOINT_PROVIDER", "redis")  # unknown -> json
+    monkeypatch.setenv("CREWAI_CHECKPOINT_MAX", "-3")  # non-positive -> None
+    s = ckpt.resolve_checkpoint_settings()
+    assert s.enabled is False
+    assert s.provider == "json"
+    assert s.max_checkpoints is None
+
+
+def test_settings_on_events_default_is_flow_trigger(monkeypatch):
+    # Default MUST be a flow trigger, the stock CheckpointConfig default
+    # (``task_completed``) never fires for a flow, so a flow would silently
+    # write zero checkpoints.
+    monkeypatch.delenv("CREWAI_CHECKPOINT_ON_EVENTS", raising=False)
+    assert ckpt.resolve_checkpoint_settings().on_events == ("method_execution_finished",)
+
+
+def test_settings_on_events_env_override(monkeypatch):
+    monkeypatch.setenv("CREWAI_CHECKPOINT_ON_EVENTS", "flow_finished, method_execution_finished")
+    assert ckpt.resolve_checkpoint_settings().on_events == (
+        "flow_finished",
+        "method_execution_finished",
+    )
+
+
+# -- thread-id sanitisation (security: path traversal) -----------------------
+
+
+@pytest.mark.parametrize(
+    "raw,prefix",
+    [
+        ("thread-abc_123", "thread-abc_123-"),
+        # Unsafe chars collapse to "_"; leading/trailing junk stripped.
+        ("../../etc/passwd", "etc_passwd-"),
+        ("a/b\\c", "a_b_c-"),
+    ],
+)
+def test_safe_thread_segment_readable_prefix(raw, prefix):
+    seg = ckpt._safe_thread_segment(raw)
+    assert seg is not None and seg.startswith(prefix)
+
+
+@pytest.mark.parametrize("raw", ["", None, 123])
+def test_safe_thread_segment_none_for_unusable(raw):
+    # Empty / non-string ids have no usable key -> None (caller skips).
+    assert ckpt._safe_thread_segment(raw) is None
+
+
+def test_safe_thread_segment_injective():
+    # Distinct ids that would collide after char-collapse must map to DISTINCT
+    # segments (the hash suffix guarantees it), and the same id is stable.
+    a = ckpt._safe_thread_segment("a/b")
+    b = ckpt._safe_thread_segment("a_b")
+    assert a != b
+    assert a == ckpt._safe_thread_segment("a/b")
+    # Dot-only ids are usable (hash-only segment), not dropped.
+    assert ckpt._safe_thread_segment("..") != ckpt._safe_thread_segment(".")
+
+
+def test_safe_thread_segment_no_separators_or_trailing_dot():
+    # The readable prefix never contains path separators or a trailing dot,
+    # even when the raw id's boundary would otherwise leave one.
+    seg = ckpt._safe_thread_segment("a" * 127 + "." + "b" * 20)
+    assert "/" not in seg and "\\" not in seg
+    assert seg.split("-")[0] == "a" * 127
+
+
+# -- resume-reference extraction ---------------------------------------------
+
+
+def test_resume_reference_from_forwarded_props_top_level():
+    inp = _make_input(forwarded_props={"restore_from": "cp-1"})
+    assert ckpt._resume_reference(inp) == "cp-1"
+
+
+def test_resume_reference_from_nested_crewai_key():
+    inp = _make_input(forwarded_props={"crewai": {"checkpoint_id": "cp-2"}})
+    assert ckpt._resume_reference(inp) == "cp-2"
+
+
+def test_resume_reference_ignores_blank_and_nonstring():
+    # Blank / non-string values are not treated as a resume reference.
+    assert ckpt._resume_reference(_make_input(forwarded_props={"state_id": "  "})) is None
+    assert ckpt._resume_reference(_make_input(forwarded_props={"checkpoint_id": 123})) is None
+
+
+def test_resume_reference_absent():
+    assert ckpt._resume_reference(_make_input()) is None
+
+
+def test_resolve_restore_path(tmp_path):
+    # Bare id resolves under <location>/main/<id>.json when it exists.
+    location = str(tmp_path / "t1")
+    branch = tmp_path / "t1" / "main"
+    branch.mkdir(parents=True)
+    ck = branch / "cp-abc.json"
+    ck.write_text("{}")
+    assert ckpt._resolve_restore_path(location, "cp-abc") == str(ck)
+    # .json suffix added automatically; a missing id resolves to None (no crash).
+    assert ckpt._resolve_restore_path(location, "cp-abc.json") == str(ck)
+    assert ckpt._resolve_restore_path(location, "missing") is None
+
+
+def test_resolve_restore_path_bad_input_never_raises(tmp_path):
+    # A NUL byte (realpath ValueError) or other odd input must degrade to None,
+    # never propagate a ValueError that would 500 the request.
+    location = str(tmp_path / "t1")
+    (tmp_path / "t1" / "main").mkdir(parents=True)
+    assert ckpt._resolve_restore_path(location, "foo\x00bar") is None
+    assert ckpt._resolve_restore_path(location, "\x00") is None
+
+
+def test_resolve_restore_path_rejects_traversal_and_absolute(tmp_path):
+    # Security: a client-controlled id must not escape the thread's store.
+    location = str(tmp_path / "t1")
+    branch = tmp_path / "t1" / "main"
+    branch.mkdir(parents=True)
+    # A real checkpoint in a DIFFERENT thread's store.
+    other = tmp_path / "other" / "main"
+    other.mkdir(parents=True)
+    victim = other / "secret.json"
+    victim.write_text("{}")
+    # Absolute paths, separators and ".." are all rejected outright.
+    assert ckpt._resolve_restore_path(location, str(victim)) is None
+    assert ckpt._resolve_restore_path(location, "../../other/main/secret") is None
+    assert ckpt._resolve_restore_path(location, "..") is None
+    assert ckpt._resolve_restore_path(location, "sub/cp") is None
+    assert ckpt._resolve_restore_path(location, "a\\b") is None
+
+
+# -- build_checkpoint_kwargs -------------------------------------------------
+
+
+def test_build_disabled_returns_empty(monkeypatch):
+    monkeypatch.delenv("CREWAI_CHECKPOINT", raising=False)
+    assert ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input()) == {}
+
+
+@requires_checkpointing
+def test_build_enabled_supporting_flow_builds_per_thread_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input(thread_id="abc"))
+    assert "from_checkpoint" in kwargs
+    config = kwargs["from_checkpoint"]
+    assert isinstance(config, caps.CheckpointConfig)
+    # Per-thread location under the configured base dir (injective segment).
+    import os as _os
+
+    seg = ckpt._safe_thread_segment("abc")
+    assert config.location == _os.path.join(str(tmp_path), seg)
+    assert seg.startswith("abc-")
+    # No restore id was requested.
+    assert "restore_from_state_id" not in kwargs
+
+
+@requires_checkpointing
+def test_build_never_emits_restore_from_state_id(monkeypatch, tmp_path):
+    # from_checkpoint and restore_from_state_id are mutually exclusive in crewai
+    # (combining them raises ValueError). The builder must NEVER emit the latter,
+    # even when the client supplies a resume reference.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    inp = _make_input(forwarded_props={"restore_from": "cp-9"})
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp)
+    assert set(kwargs) == {"from_checkpoint"}
+    assert "restore_from_state_id" not in kwargs
+
+
+@requires_checkpointing
+def test_build_resolvable_reference_sets_restore_from(monkeypatch, tmp_path):
+    # A resolvable checkpoint reference is folded into the config's restore_from
+    # (in the checkpointing system), not passed as a separate kwarg.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    seg = ckpt._safe_thread_segment("abc")
+    branch = tmp_path / seg / "main"
+    branch.mkdir(parents=True)
+    ck = branch / "cp-1.json"
+    ck.write_text("{}")
+    inp = _make_input(thread_id="abc", forwarded_props={"restore_from": "cp-1"})
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp)
+    assert set(kwargs) == {"from_checkpoint"}
+    assert kwargs["from_checkpoint"].restore_from == str(ck)
+
+
+@requires_checkpointing
+def test_build_unresolvable_reference_warns_and_persists(monkeypatch, tmp_path, caplog):
+    # A stale / unknown reference must NOT crash (crewai would raise
+    # FileNotFoundError): warn and continue with plain persistence.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    inp = _make_input(thread_id="abc", forwarded_props={"restore_from": "does-not-exist"})
+    with caplog.at_level("WARNING"):
+        kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp)
+    assert set(kwargs) == {"from_checkpoint"}
+    assert kwargs["from_checkpoint"].restore_from is None
+    assert any("could not be resolved to a checkpoint" in r.message for r in caplog.records)
+
+
+@requires_checkpointing
+def test_build_traversal_reference_is_not_restored(monkeypatch, tmp_path):
+    # A traversal / absolute restore reference must not resolve; persistence
+    # continues but restore_from stays None (no arbitrary-file read).
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    for ref in ("../../etc/passwd", "/etc/passwd", "foo\x00bar"):
+        inp = _make_input(thread_id="abc", forwarded_props={"restore_from": ref})
+        kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp)
+        assert set(kwargs) == {"from_checkpoint"}
+        assert kwargs["from_checkpoint"].restore_from is None
+
+
+@requires_checkpointing
+def test_build_sqlite_restore_reference_warns_and_skips(monkeypatch, tmp_path, caplog):
+    # Restore-by-id targets the json layout; under sqlite it is ignored with a
+    # warning rather than silently resolving to nothing.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_PROVIDER", "sqlite")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    inp = _make_input(thread_id="abc", forwarded_props={"restore_from": "cp-1"})
+    with caplog.at_level("WARNING"):
+        kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp)
+    assert set(kwargs) == {"from_checkpoint"}
+    assert kwargs["from_checkpoint"].restore_from is None
+    assert any("only supported for the json provider" in r.message for r in caplog.records)
+
+
+@requires_checkpointing
+def test_build_enabled_max_checkpoints(monkeypatch, tmp_path):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setenv("CREWAI_CHECKPOINT_MAX", "7")
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input())
+    assert kwargs["from_checkpoint"].max_checkpoints == 7
+
+
+def test_build_enabled_legacy_flow_returns_empty_and_warns(monkeypatch, caplog):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    with caplog.at_level("WARNING"):
+        kwargs = ckpt.build_checkpoint_kwargs(_LegacyFlow(), _make_input())
+    assert kwargs == {}
+    assert any("CREWAI_CHECKPOINT is set" in r.message for r in caplog.records)
+
+
+@requires_checkpointing
+def test_build_sqlite_provider_selected(monkeypatch, tmp_path):
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_PROVIDER", "sqlite")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input())
+    provider = kwargs["from_checkpoint"].provider
+    assert isinstance(provider, caps.SqliteProvider)
+
+
+@requires_checkpointing
+def test_build_empty_thread_id_skips_checkpointing(monkeypatch, tmp_path):
+    # An unusable thread_id must NOT collapse into a shared bucket (cross-session
+    # leak); build returns {} instead.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    assert ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input(thread_id="")) == {}
+
+
+@requires_checkpointing
+def test_build_resume_id_without_config_returns_empty(monkeypatch, tmp_path):
+    # A resume id must never be returned alone (no store to restore from): with
+    # an unusable thread_id the whole dict is empty, not {restore_from_state_id}.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    inp = _make_input(thread_id="", forwarded_props={"restore_from_state_id": "cp-1"})
+    assert ckpt.build_checkpoint_kwargs(_SupportingFlow(), inp) == {}
+
+
+@requires_checkpointing
+def test_build_provider_constructor_raising_degrades(monkeypatch, tmp_path):
+    # A raising provider constructor must degrade to {} (no persistence), never
+    # bubble a 500 out of the request handler.
+    class _BoomProvider:
+        def __init__(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setattr(caps, "JsonProvider", _BoomProvider)
+    # Must not raise.
+    assert ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input()) == {}
+
+
+@requires_checkpointing
+def test_build_json_falls_back_to_sqlite_when_json_missing(monkeypatch, tmp_path):
+    # Symmetric fallback: a "json" request with JsonProvider absent falls back
+    # to the installed SqliteProvider (mirrors the sqlite->json path).
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setattr(caps, "JsonProvider", None)
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input())
+    assert isinstance(kwargs["from_checkpoint"].provider, caps.SqliteProvider)
+
+
+@requires_checkpointing
+def test_build_sqlite_falls_back_to_json_when_sqlite_missing(monkeypatch, tmp_path, caplog):
+    # Symmetric fallback: a "sqlite" request with SqliteProvider absent falls
+    # back to json and warns once.
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_PROVIDER", "sqlite")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    monkeypatch.setattr(caps, "SqliteProvider", None)
+    with caplog.at_level("WARNING"):
+        kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input())
+    assert isinstance(kwargs["from_checkpoint"].provider, caps.JsonProvider)
+    assert any("falling back to the other" in r.message for r in caplog.records)
+
+
+@requires_checkpointing
+def test_build_omits_max_checkpoints_when_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("CREWAI_CHECKPOINT_MAX", raising=False)
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+    kwargs = ckpt.build_checkpoint_kwargs(_SupportingFlow(), _make_input())
+    assert kwargs["from_checkpoint"].max_checkpoints is None
+
+
+def test_warn_unsupported_flow_does_not_advise_crewai_upgrade(monkeypatch, caplog):
+    # When crewai IS capable but the flow lacks the kwarg, the warning must NOT
+    # tell the operator to upgrade crewai (that would not help).
+    if not caps.CAPABILITIES.checkpointing_available:
+        pytest.skip("needs a capable crewai to exercise the flow-unsupported branch")
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    with caplog.at_level("WARNING"):
+        assert ckpt.build_checkpoint_kwargs(_LegacyFlow(), _make_input()) == {}
+    msgs = " ".join(r.message for r in caplog.records)
+    assert "does not accept the from_checkpoint" in msgs
+    assert "Upgrade to crewai" not in msgs
+
+
+# -- driver-level splice -----------------------------------------------------
+
+
+async def _drain(gen):
+    out = []
+    try:
+        async for chunk in gen:
+            out.append(chunk)
+    except StopAsyncIteration:  # pragma: no cover - defensive
+        pass
+    return out
+
+
+async def test_event_stream_passes_checkpoint_kwargs_to_kickoff():
+    """The from_checkpoint config built upstream actually reaches ``kickoff_async``."""
+    flow = _SupportingFlow()
+    sentinel = object()
+    gen = ep._run_flow_event_stream(
+        flow_copy=flow,
+        encoder=EventEncoder(),
+        input_data=_make_input(),
+        inputs={"id": "t-1"},
+        timeout=5.0,
+        checkpoint_kwargs={"from_checkpoint": sentinel},
+    )
+    await asyncio.wait_for(_drain(gen), timeout=10.0)
+    assert flow.received is not None
+    assert flow.received["from_checkpoint"] is sentinel
+
+
+async def test_event_stream_filters_kwargs_for_legacy_flow():
+    """A flow that predates the kwargs is called exactly as before (no crash)."""
+    flow = _LegacyFlow()
+    gen = ep._run_flow_event_stream(
+        flow_copy=flow,
+        encoder=EventEncoder(),
+        input_data=_make_input(),
+        inputs={"id": "t-1"},
+        timeout=5.0,
+        checkpoint_kwargs={"from_checkpoint": object(), "restore_from_state_id": "cp-x"},
+    )
+    # Must not raise TypeError: unexpected keyword argument.
+    await asyncio.wait_for(_drain(gen), timeout=10.0)
+    assert flow.received == {"inputs": {"id": "t-1"}}
+
+
+async def test_event_stream_no_checkpoint_kwargs_is_unchanged():
+    """checkpoint_kwargs=None keeps the legacy call shape."""
+    flow = _LegacyFlow()
+    gen = ep._run_flow_event_stream(
+        flow_copy=flow,
+        encoder=EventEncoder(),
+        input_data=_make_input(),
+        inputs={"id": "t-1"},
+        timeout=5.0,
+    )
+    await asyncio.wait_for(_drain(gen), timeout=10.0)
+    assert flow.received == {"inputs": {"id": "t-1"}}
+
+
+class _FakeStreamSession:
+    """Minimal AsyncStreamSession stand-in: ends immediately, closes cleanly."""
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def aclose(self):
+        return None
+
+
+class _AstreamRecordingFlow:
+    """Frame-path flow double: records the kwargs astream is invoked with."""
+
+    def __init__(self):
+        self.received = None
+
+    def __deepcopy__(self, memo):  # noqa: D401 - trivial
+        return self
+
+    def astream(self, inputs=None, from_checkpoint=None, restore_from_state_id=None):
+        self.received = {
+            "inputs": inputs,
+            "from_checkpoint": from_checkpoint,
+            "restore_from_state_id": restore_from_state_id,
+        }
+        return _FakeStreamSession()
+
+
+async def test_frame_stream_passes_checkpoint_kwargs_to_astream():
+    """The StreamFrame/astream path (the default on crewai >=1.6) also splices
+    the checkpoint kwargs, not just the legacy kickoff_async path."""
+    flow = _AstreamRecordingFlow()
+    sentinel = object()
+    gen = ep._run_flow_frame_stream(
+        flow_copy=flow,
+        encoder=EventEncoder(),
+        input_data=_make_input(),
+        inputs={"id": "t-1"},
+        timeout=5.0,
+        checkpoint_kwargs={"from_checkpoint": sentinel},
+    )
+    await asyncio.wait_for(_drain(gen), timeout=10.0)
+    assert flow.received is not None
+    assert flow.received["from_checkpoint"] is sentinel
+
+
+# -- real crewai Flow persistence (end-to-end) -------------------------------
+
+
+def _isolate_checkpoint_bus(monkeypatch):
+    """Give the real-flow tests a clean, ISOLATED crewai event bus.
+
+    crewai's checkpoint listener is a process-global registered once behind a
+    module-level ``_handlers_registered`` flag, and writes checkpoints by
+    serialising the captured event graph. Foreign listeners left on the shared
+    bus by other tests carry unpicklable state (``_thread.RLock``), which makes
+    the checkpoint write raise ``TypeError: cannot pickle`` unless the bus is
+    clean.
+
+    Swap each handler container for a fresh empty one via ``monkeypatch`` (which
+    restores the ORIGINAL container, with every other test's handlers intact, on
+    teardown) rather than mutating the shared dicts in place. This gives the run
+    a clean bus without corrupting global state other tests depend on.
+    """
+    import crewai.state.checkpoint_listener as _cl
+
+    bus = caps.crewai_event_bus
+    for attr in ("_sync_handlers", "_async_handlers", "_handlers"):
+        handlers = getattr(bus, attr, None)
+        if handlers is not None:
+            monkeypatch.setattr(bus, attr, type(handlers)(), raising=False)
+    # raising=True: if crewai renames this internal, fail loudly rather than let
+    # the order-independence workaround silently become a no-op.
+    monkeypatch.setattr(_cl, "_handlers_registered", False, raising=True)
+
+
+@requires_e2e
+@requires_checkpointing
+async def test_real_flow_persists_checkpoints_with_default_settings(monkeypatch, tmp_path):
+    """A real crewai Flow driven with our default config actually writes
+    checkpoint files, the proof that ``on_events`` is a flow trigger, not the
+    stock crew default (which would silently write nothing)."""
+    from crewai.flow.flow import Flow, listen, start
+
+    _isolate_checkpoint_bus(monkeypatch)
+
+    class _RealFlow(Flow):
+        @start()
+        def step_a(self):
+            self.state["a"] = 1
+            return "a"
+
+        @listen(step_a)
+        def step_b(self, _):
+            self.state["b"] = 2
+            return "b"
+
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+
+    flow = _RealFlow()
+    kwargs = ckpt.build_checkpoint_kwargs(flow, _make_input(thread_id="thread-xyz"))
+    assert "from_checkpoint" in kwargs
+
+    await asyncio.wait_for(
+        flow.kickoff_async(inputs={"id": "thread-xyz"}, **kwargs), timeout=30.0
+    )
+
+    # Checkpoints landed under the per-thread location.
+    written = list(Path(kwargs["from_checkpoint"].location).rglob("*.json"))
+    assert written, "expected checkpoint files to be written for the flow run"
+
+
+@requires_e2e
+@requires_checkpointing
+async def test_real_flow_restore_config_accepted_without_crash(monkeypatch, tmp_path):
+    """The real resume path (persist run 1, restore run 2) is accepted by crewai
+    without raising, and the builder plumbs the checkpoint into
+    ``CheckpointConfig.restore_from`` -- never as the incompatible
+    ``restore_from_state_id`` kwarg (which, combined with ``from_checkpoint``,
+    raises ``ValueError: Cannot combine ...``). This is the end-to-end
+    crash-regression for the two-systems incompatibility.
+
+    NOTE on scope: that a restored run SKIPS already-completed steps is crewai's
+    documented behaviour and is verified against the installed wheel in a
+    standalone process. It is asserted here only at the config-plumbing level:
+    crewai's restore short-circuit is driven by a process-global checkpoint
+    listener whose registration the shared conftest event-bus fixture rewrites
+    between tests, which masks the step-skip inside the suite. Asserting the
+    skip here would be flaky, so we assert the robust, harness-stable facts:
+    the config carries restore_from and the real kickoff does not raise."""
+    from crewai.flow.flow import Flow, listen, start
+
+    _isolate_checkpoint_bus(monkeypatch)
+    monkeypatch.setenv("CREWAI_CHECKPOINT", "1")
+    monkeypatch.setenv("CREWAI_CHECKPOINT_DIR", str(tmp_path))
+
+    class _RealFlow(Flow):
+        @start()
+        def step_a(self):
+            self.state["a"] = 1
+            return "a"
+
+        @listen(step_a)
+        def step_b(self, _):
+            self.state["b"] = 2
+            return "b"
+
+    # Run 1: persist.
+    k1 = ckpt.build_checkpoint_kwargs(_RealFlow(), _make_input(thread_id="cont"))
+    await asyncio.wait_for(_RealFlow().kickoff_async(inputs={"id": "cont"}, **k1), timeout=30.0)
+    checkpoints = sorted((Path(k1["from_checkpoint"].location) / "main").glob("*.json"))
+    assert checkpoints, "run 1 must have written checkpoints"
+
+    # Run 2: build a resume config from a real checkpoint and drive the real
+    # kickoff. The builder must emit from_checkpoint ONLY (never the
+    # incompatible restore_from_state_id) with restore_from set, and the real
+    # kickoff must complete without raising the "Cannot combine" ValueError.
+    ck = checkpoints[-1]
+    # Clients pass a bare checkpoint id (never an absolute path); the builder
+    # resolves it within this thread's store.
+    inp = _make_input(thread_id="cont", forwarded_props={"restore_from": ck.stem})
+    k2 = ckpt.build_checkpoint_kwargs(_RealFlow(), inp)
+    assert set(k2) == {"from_checkpoint"}
+    assert k2["from_checkpoint"].restore_from == str(ck)
+    result = await asyncio.wait_for(
+        _RealFlow().kickoff_async(inputs={"id": "cont"}, **k2), timeout=30.0
+    )
+    assert result is not None


### PR DESCRIPTION
## What

Wire CrewAI flow checkpointing / thread persistence into the AG-UI bridge (PNI-134). The bridge was stateless per request (deepcopy the flow, `inputs["id"] = thread_id` the only thread linkage). This adds **opt-in, capability-gated** persistence plus point-in-time resume, and lands the capability-detection primitive that **PNI-133 (interrupts)** and **PNI-129 (time-travel)** build on.

Off by default: with `CREWAI_CHECKPOINT` unset the request path is byte-for-byte unchanged.

## How

- **`_capabilities.py`** — resolve `CheckpointConfig` (crewai root + `crewai.state`), `JsonProvider`/`SqliteProvider` (`crewai.state`), and the `Checkpoint*Event` types (`crewai.events.types.checkpoint_events`); probe `from_checkpoint` / `restore_from_state_id` kwargs and `fork` by signature/attribute (never by version string). Adds `flow_supports_checkpointing(flow)` (per-flow guard) and `supported_checkpoint_kwargs(method, kwargs)` (per-method filter).
- **`_checkpoint.py`** (new leaf) — `build_checkpoint_kwargs(flow, input_data)` returns `{}` unless enabled AND the installed crewai + this specific flow support `from_checkpoint`. Builds a per-thread `CheckpointConfig` with a flow-appropriate `on_events` default; a client-supplied checkpoint id (via `forwarded_props`) is folded into `CheckpointConfig.restore_from`.
- **`endpoint.py`** — thread `checkpoint_kwargs` through both endpoints and both stream drivers, filtered against the exact kickoff method. `inputs["id"]` preserved.
- **`_env.py`** — reusable `_parse_env_bool` / `_parse_env_str` / `_parse_env_int`.

## Two crewai state systems (the load-bearing gotcha)

`from_checkpoint` (Checkpointing) and `restore_from_state_id` (`@persist`) are **mutually exclusive** — passing both raises `ValueError: Cannot combine ...` (verified on the 1.15.7 wheel). This module commits to Checkpointing end-to-end: it persists via `from_checkpoint` and resumes via `CheckpointConfig(restore_from=<checkpoint path>)`, and **never emits `restore_from_state_id`**. `from_checkpoint` alone persists but does not auto-resume; restore is explicit (a fresh kickoff re-runs every step).

## Capability probes (verified against crewai 1.15.7)

Each piece probed independently; warns per-piece with its enabling version:

| Piece | Enabling version |
|-------|------------------|
| `from_checkpoint=` kwarg | 1.13.0 |
| `CheckpointConfig` + `JsonProvider`/`SqliteProvider` | 1.14.0 |
| `Flow.fork` / `Crew.fork` | 1.14.2 |
| `Checkpoint*Event` | 1.14.3 |
| `restore_from_state_id=` kwarg | 1.14.5 |

`from_checkpoint` predates `CheckpointConfig`, so the two are probed separately (a 1.13.x install sees the kwarg but no config type and stays on the no-checkpoint path).

## Safety / non-regression

- Floor `crewai>=1.0,<2`, runtime capability detection only (no `__version__` gating; version strings only in warning text). `inputs["id"]` kept (never formally deprecated).
- Cancellation test doubles (`kickoff_async(self, inputs=None)` only) never receive the new kwarg: the per-flow guard returns `{}` and the per-method filter drops anything unsupported. Cancellation/teardown suite unchanged.
- **Security**: client-supplied `thread_id` and checkpoint id are sanitised; the restore id cannot escape the thread's store (absolute paths, separators and `..` rejected, `commonpath` containment check), and path ops are `ValueError`-guarded so a NUL byte / cross-drive input degrades to "no restore" instead of a 500.
- **Isolation**: the per-thread store segment is injective (`<sanitised>-<hash>`), so distinct thread_ids never collide onto one store.
- Caught that the stock `on_events=["task_completed"]` writes ZERO checkpoints for a flow (flows emit `method_execution_finished`) and set a flow-appropriate default.

## Env knobs

- `CREWAI_CHECKPOINT` (enable; default off)
- `CREWAI_CHECKPOINT_PROVIDER` (`json` default | `sqlite`)
- `CREWAI_CHECKPOINT_DIR` (base dir; per-thread subdir appended; default `./.checkpoints`)
- `CREWAI_CHECKPOINT_MAX` (retained checkpoints per thread)
- `CREWAI_CHECKPOINT_ON_EVENTS` (comma-separated triggers; default `method_execution_finished`)

## Tests

`tests/test_checkpointing.py`: capability probes, signature/per-flow gating, env parsing, thread-id + restore-id sanitisation (traversal / absolute / NUL-byte / injectivity), `build_checkpoint_kwargs` end-to-end (off / on / resume / legacy-flow / sqlite / provider-fallback / max), driver splice through both drivers, and real-flow persistence + restore-config on crewai 1.15.7. Full suite green (147 passed), stable across repeated runs.

Reviewed via a 6-round CR loop to convergence (crash-safety, the two-systems incompatibility, path-traversal, NUL-byte crash, and store injectivity all found and fixed).

## Notes / follow-ups

- Restore-by-id resolves against the JSON provider's on-disk layout; under sqlite it warns and skips (persistence still active).
- Client-facing surfacing of a failed restore (an AG-UI event) is left to PNI-129.
- crew-ai python has no CI job in `unit-python-sdk.yml` yet (the comment there says "no uv.lock" but one now exists); wiring that job is a separate refresh-lane task. Locally: `cd integrations/crew-ai/python && uv run --frozen python -m pytest tests/`.

Unblocks PNI-133 and PNI-129.
