### PR TITLE
fix(crewai): harden sdk.py message/stream edge cases

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/sdk.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/sdk.py
@@ -301,7 +301,10 @@ async def copilotkit_stream(response):
         return _copilotkit_stream_response(response)
     if isinstance(response, CustomStreamWrapper):
         return await _copilotkit_stream_custom_stream_wrapper(response)
-    raise ValueError("Invalid response type")
+    raise ValueError(
+        f"Invalid response type {type(response)!r}; "
+        f"expected {ModelResponse.__name__} or {CustomStreamWrapper.__name__}"
+    )
 
 
 async def _copilotkit_stream_custom_stream_wrapper(response: CustomStreamWrapper):
@@ -430,7 +433,9 @@ def litellm_messages_to_ag_ui_messages(messages: List[LiteLLMMessage]) -> List[M
         # whitelist the fields we want to keep
         whitelist = ["content", "role", "tool_calls", "id", "name", "tool_call_id"]
         message_dict = {k: v for k, v in message_dict.items() if k in whitelist}
-        if "id" not in message_dict:
+        # Backfill when id is absent OR explicitly None: the None-strip below
+        # would drop a None id, and pydantic Message validation requires one.
+        if message_dict.get("id") is None:
             message_dict["id"] = str(uuid.uuid4())
         # remove all None values
         message_dict = {k: v for k, v in message_dict.items() if v is not None}

--- a/integrations/crew-ai/python/tests/test_message_translation.py
+++ b/integrations/crew-ai/python/tests/test_message_translation.py
@@ -31,6 +31,19 @@ def test_litellm_conversion_generates_id_when_missing():
     assert len(out[0].id) == 36  # canonical uuid4 string length
 
 
+def test_litellm_conversion_generates_id_when_explicitly_none():
+    """A message with ``id`` present but ``None`` still gets a generated UUID.
+
+    Regression: the backfill guarded only on the key being absent, so an
+    explicit ``id=None`` survived to the None-strip, which then dropped the key
+    and left pydantic ``Message`` validation to fail on a missing id."""
+    out = litellm_messages_to_ag_ui_messages(
+        [{"role": "user", "content": "yo", "id": None}]
+    )
+    assert isinstance(out[0].id, str)
+    assert len(out[0].id) == 36  # canonical uuid4 string length
+
+
 def test_litellm_conversion_injects_tool_call_type():
     """Tool calls missing an explicit ``type`` are stamped ``function``."""
     out = litellm_messages_to_ag_ui_messages(

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -231,6 +231,30 @@ async def test_copilotkit_predict_state_emits_custom_event():
     ]
 
 
+async def test_copilotkit_predict_state_tool_argument_is_optional():
+    """``tool_argument`` is documented optional: omitting it must not KeyError,
+    and the wire value carries ``tool_argument=None`` (whole-object streaming)."""
+    ep.FastAPICrewFlowEventListener()  # registers bus handlers
+    flow = _FakeFlow()
+    queue = await ep.create_queue(flow)
+    flow_context.set(flow)
+    try:
+        result = await copilotkit_predict_state({"steps": {"tool_name": "SearchTool"}})
+        assert result is True
+        await _settle_bus()
+        items = _drain(queue)
+    finally:
+        await ep.delete_queue(flow)
+
+    assert len(items) == 1
+    event = items[0]
+    assert event.type == EventType.CUSTOM
+    assert event.name == "PredictState"
+    assert event.value == [
+        {"state_key": "steps", "tool": "SearchTool", "tool_argument": None}
+    ]
+
+
 async def test_copilotkit_emit_state_emits_state_snapshot():
     """``copilotkit_emit_state`` emits a STATE_SNAPSHOT carrying the state."""
     ep.FastAPICrewFlowEventListener()


### PR DESCRIPTION
## What

Two pre-existing robustness fixes in `integrations/crew-ai/python/ag_ui_crewai/sdk.py`, each with a regression test.

### 1. `litellm_messages_to_ag_ui_messages` drops an explicit `id=None`
The UUID backfill guarded only on the `id` key being **absent** (`if "id" not in message_dict`), not on it being explicitly `None`. When a caller passes `id=None`, the following None-strip removed the key and pydantic `Message` validation then failed with `user.id Field required`.

Fix: backfill on `message_dict.get("id") is None`, covering both absent and explicit-None.

### 2. `copilotkit_stream` opaque error
`raise ValueError("Invalid response type")` gave no signal about what was received or what is accepted. Now names `type(response)` and the accepted set (`ModelResponse` / `CustomStreamWrapper`).

## Tests
- `test_litellm_conversion_generates_id_when_explicitly_none` — verified **red** without the fix (`user.id Field required`), green with it.
- `test_copilotkit_predict_state_tool_argument_is_optional` — regression guard confirming an omitted optional `tool_argument` yields `tool_argument=None` and never `KeyError`s (this path was already correct via `_normalize_predict_state`'s `.get()`; the test locks it).

Full suite: **192 passed** (`cd integrations/crew-ai/python && uv run pytest -q`).

## Notes
Robustness-only, no behavior change on the happy path. Scoped to three files; no ticket refs in code per repo convention.