### PR TITLE
feat(crewai): surface reasoning as REASONING_* across providers (PNI-128)

### DIFF
--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -97,21 +97,26 @@ today. `emit_raw_events` defaults to re-reading the environment, so pass the sam
 value your endpoint was registered with if you want the declaration to describe
 *that* endpoint.
 
-`reasoning.supported` is True **only** when all three hold: the installed crewai
-exposes `LLMThinkingChunkEvent`, the `StreamFrame` transport exists (RAW is the only
-channel carrying reasoning today), *and* the passed LLM resolves to the native Google
-Gen AI provider. Otherwise `reason` names the missing piece
-(`thinking_event_missing`, `raw_transport_unavailable`, `llm_not_provided`,
-`llm_not_resolvable`, `provider_not_native_gemini`) and `transport` is `None`.
+Reasoning surfaces as first-class `REASONING_*` events (`REASONING_START` /
+`REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END` /
+`REASONING_END`, plus `REASONING_ENCRYPTED_VALUE` for signature / redacted-thinking
+blocks), **provider-agnostic** and on **both** transports. It needs neither
+`emit_raw_events` nor the `StreamFrame` transport. Two channels feed it:
 
-Reasoning is native-Gemini-only in crewai: on the 1.15.7 wheel the sole caller of
-`BaseLLM._emit_thinking_chunk_event` is `crewai/llms/providers/gemini/completion.py`.
-Anthropic's native provider has a thinking config but never emits the event, and every
-LiteLLM-routed model (including `vertex_ai/gemini-*`) emits nothing. Passing no `llm`
-therefore reports `supported: False` rather than claiming support off the class probe
-alone. On the crew-serving path `crews.py` drives completions through
-`litellm.acompletion` directly, so the native Gemini provider never runs and reasoning
-does not surface there even when it is reported supported for the LLM you passed.
+- **litellm delta** (`copilotkit_stream`): reads `reasoning_content` /
+  `thinking_blocks` for any reasoning-capable model routed through litellm
+  (deepseek-reasoner, Anthropic extended thinking, Bedrock, xAI,
+  gemini-via-litellm, and reasoning models normalised by litellm). This is the
+  provider-agnostic path and drives the crew-serving path in `crews.py` too.
+- **native `LLMThinkingChunkEvent`** (crewai's Gemini provider, crewai >= 1.10.1):
+  an additional source on the `StreamFrame` path.
+
+`reasoning.supported` is therefore True whenever a reasoning channel is live (the
+litellm channel is effectively always live, as litellm is a direct dependency). A
+non-reasoning model simply emits nothing (graceful no-op). `requiresEmitRawEvents`
+is `False`. The `nativeGeminiProvider` / `resolvedProvider` fields are
+informational (the native event is an extra source, not a requirement), and
+`thinkingEventAvailable` reports whether the native Gemini event resolved.
 
 ## Tuning knobs
 

--- a/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_capabilities.py
@@ -257,6 +257,32 @@ except Exception:  # pragma: no cover - litellm is a declared direct dep
 
 
 # --------------------------------------------------------------------------
+# Reasoning resolution
+# --------------------------------------------------------------------------
+# Two channels carry model reasoning: the litellm streaming delta
+# (``reasoning_content`` / ``thinking_blocks`` -- provider-agnostic, always
+# available since litellm is a direct dep) and crewai's native
+# ``LLMThinkingChunkEvent`` (its Gemini provider, crewai >= 1.10.1). The event
+# lives at ``crewai.events.types.llm_events`` (1.x) / ``crewai.utilities.events.
+# llm_events`` (0.x) and is NOT re-exported at the events-package root. Resolved
+# here (before ``_detect``) so both the capability snapshot and the frame-path
+# sink gate share ONE probe.
+_LLM_EVENTS_MODULE, _ = _first_module(
+    ["crewai.events.types.llm_events", "crewai.utilities.events.llm_events"]
+)
+LLMThinkingChunkEvent = (
+    getattr(_LLM_EVENTS_MODULE, "LLMThinkingChunkEvent", None)
+    if _LLM_EVENTS_MODULE is not None
+    else None
+)
+_thinking_event_available = LLMThinkingChunkEvent is not None
+_native_reasoning_event_available = _thinking_event_available
+# Reasoning surfacing is available whenever ANY channel is live -- not gated to
+# a single provider. The litellm delta channel is effectively always live.
+_reasoning_available = _litellm_available or _thinking_event_available
+
+
+# --------------------------------------------------------------------------
 # Checkpointing resolution
 # --------------------------------------------------------------------------
 # crewai's checkpointing pieces landed in different releases, so each is
@@ -554,6 +580,11 @@ class _Capabilities:
     crew_chat_module: str | None
     crew_chat_available: bool
     litellm_available: bool
+    # Reasoning: available whenever ANY channel is live (litellm delta or the
+    # native thinking event), never gated to a single provider. Surfaced for
+    # the protocol capability table.
+    reasoning_available: bool = False
+    native_reasoning_event_available: bool = False
     stream_frame_available: bool = False
     # Checkpointing: informational; the wiring keys off the resolved
     # symbols / ``flow_supports_checkpointing`` per-flow probe, not these fields.
@@ -659,6 +690,8 @@ def _detect() -> _Capabilities:
         crew_chat_module=_CREW_CHAT_MODULE_NAME,
         crew_chat_available=_crew_chat_available,
         litellm_available=_litellm_available,
+        reasoning_available=_reasoning_available,
+        native_reasoning_event_available=_native_reasoning_event_available,
         stream_frame_available=_stream_frame_available,
         checkpoint_config_available=_checkpoint_config_available,
         checkpointing_available=_checkpointing_available,
@@ -683,29 +716,16 @@ CAPABILITIES = _detect()
 
 
 # --------------------------------------------------------------------------
-# Reasoning / thinking-chunk resolution
+# Native-Gemini resolution (informational reasoning fields)
 # --------------------------------------------------------------------------
-# crewai emits ``LLMThinkingChunkEvent`` for thinking models. The class living
-# at ``<events>.types.llm_events`` is NOT evidence that a given run will produce
-# reasoning: verified against the crewai 1.15.7 wheel, the ONLY call site of
-# ``BaseLLM._emit_thinking_chunk_event`` is
-# ``crewai/llms/providers/gemini/completion.py`` - the native Google Gen AI
-# provider. Anthropic's native provider carries a ``thinking`` config and
-# extracts thinking blocks, but never emits the event; every LiteLLM-routed model
-# (including ``vertex_ai/gemini-*``, which falls back to LiteLLM) emits nothing.
-#
-# So ``get_capabilities`` requires BOTH the class AND a resolved native-Gemini
-# LLM before it advertises reasoning. Advertising off the bare class probe would
-# claim reasoning support for every OpenAI / Anthropic / Ollama run.
-_LLM_EVENTS_MODULE, _ = _first_module(
-    ["crewai.events.types.llm_events", "crewai.utilities.events.llm_events"]
-)
-LLMThinkingChunkEvent = (
-    getattr(_LLM_EVENTS_MODULE, "LLMThinkingChunkEvent", None)
-    if _LLM_EVENTS_MODULE is not None
-    else None
-)
-_thinking_event_available = LLMThinkingChunkEvent is not None
+# The thinking-chunk event class + availability flags are resolved ONCE above
+# (before ``_detect``). Reasoning is now surfaced provider-agnostically via the
+# litellm channel and the native event, so ``get_capabilities`` no longer gates
+# reasoning on a native-Gemini LLM. The resolver below stays only to populate
+# the informational ``nativeGeminiProvider`` / ``resolvedProvider`` fields: the
+# native ``LLMThinkingChunkEvent`` (verified on the 1.15.7 wheel, emitted only by
+# ``crewai/llms/providers/gemini/completion.py``) is an EXTRA frame-path source,
+# not a requirement.
 
 # crewai's canonical name for the native Google Gen AI provider. ``LLM.__new__``
 # maps both the ``gemini/`` and ``google/`` model prefixes onto it and stamps it
@@ -825,55 +845,37 @@ def _is_native_gemini(llm: Any) -> bool:
     return _safe_hasattr(llm, "thinking_config")
 
 
-def _reasoning_capability(llm: Any, *, raw_enabled: bool = False) -> dict:
+def _reasoning_capability(llm: Any = None) -> dict:
     """Build the ``reasoning`` block of the capability declaration.
 
-    ``supported`` is True only when the thinking-chunk event class resolves, the
-    RAW transport exists (StreamFrame, crewai >= 1.6, the only channel carrying
-    reasoning today), and the passed object resolves to a native-Gemini LLM.
+    Reasoning surfaces as first-class ``REASONING_*`` events, provider-agnostic
+    and on BOTH transports: ``copilotkit_stream`` reads the litellm delta's
+    ``reasoning_content`` / ``thinking_blocks`` for any reasoning-capable model
+    (deepseek-reasoner, Anthropic extended thinking, Bedrock, xAI,
+    gemini-via-litellm, ...), and crewai's native Gemini provider additionally
+    emits ``LLMThinkingChunkEvent`` on the StreamFrame path. It needs NEITHER
+    ``emit_raw_events`` NOR the StreamFrame transport.
 
-    Caveat: on the crew-serving path ``crews.py`` calls ``litellm.acompletion``
-    directly, so crewai's native Gemini provider never runs and reasoning does not
-    surface there even when this reports it supported. When no LLM is passed we
-    report ``supported: False`` with ``reason: "llm_not_provided"`` - the honest
-    answer, since reasoning availability is a per-LLM fact and cannot be derived
-    from the installed crewai alone.
+    ``supported`` describes the bridge capability, not whether a given model will
+    actually reason: a non-reasoning model simply emits nothing (graceful
+    no-op). It is therefore True whenever a reasoning channel is live -- the
+    litellm channel is effectively always live (a direct dep).
+    ``nativeGeminiProvider`` / ``resolvedProvider`` are informational: the native
+    event is an EXTRA source, not a requirement.
     """
     resolved = _resolve_llm(llm)
-    native_gemini = _is_native_gemini(resolved)
-    # Reasoning only reaches the wire through RAW passthrough, which needs the
-    # StreamFrame transport's scoped sink. Claiming support on crewai 1.0-1.5 would
-    # contradict ``rawEvents.supported: False`` in the same declaration.
-    if not _thinking_event_available:
-        reason = "thinking_event_missing"
-    elif not CAPABILITIES.stream_frame_available:
-        reason = "raw_transport_unavailable"
-    elif resolved is None:
-        # Distinguish the two: a caller who passed something deserves to know the
-        # probe could not find an LLM inside it, not that they passed nothing.
-        reason = "llm_not_provided" if llm is None else "llm_not_resolvable"
-    elif not native_gemini:
-        reason = "provider_not_native_gemini"
-    else:
-        reason = None
     return {
-        "supported": reason is None,
+        "supported": CAPABILITIES.reasoning_available,
+        # Provider-agnostic path (always live when litellm is installed).
+        "litellmChannel": CAPABILITIES.litellm_available,
+        # crewai's native Gemini thinking event: an extra frame-path source.
         "thinkingEventAvailable": _thinking_event_available,
-        "nativeGeminiProvider": native_gemini,
+        "nativeGeminiProvider": _is_native_gemini(resolved),
         # A caller object: a raising property here would escape the whole query.
         "resolvedProvider": _safe_getattr(resolved, "provider"),
-        # Reasoning reaches the wire through RAW passthrough today (there is no
-        # dedicated CrewAI -> REASONING_* mapping yet), so a caller that wants it
-        # must ALSO enable ``emit_raw_events`` - hence the explicit flag below
-        # rather than a bare "supported: true" that would over-promise.
-        "transport": "raw" if reason is None else None,
-        # Always required for reasoning to reach the wire; ``rawEventsEnabled`` says
-        # whether this configuration actually has it on.
-        "requiresEmitRawEvents": True,
-        "rawEventsEnabled": bool(
-            raw_enabled and CAPABILITIES.stream_frame_available
-        ),
-        "reason": reason,
+        # First-class REASONING_* mapping: reasoning does NOT ride RAW passthrough.
+        "requiresEmitRawEvents": False,
+        "reason": None if CAPABILITIES.reasoning_available else "litellm_unavailable",
     }
 
 
@@ -911,10 +913,11 @@ def get_capabilities(
     llm:
         The LLM, or an object carrying one: an Agent (``.llm``), a Crew
         (``.agents[*].llm``, or ``chat_llm`` / ``manager_llm`` when set), or a Flow
-        holding either. Resolution is read-only and never calls a factory. Required for a meaningful ``reasoning`` answer: reasoning is
-        native-Gemini-only in crewai, so without an LLM to resolve we report
-        ``supported: False`` with ``reason: "llm_not_provided"`` rather than
-        advertising support off the bare event-class probe.
+        holding either. Resolution is read-only and never calls a factory.
+        Optional for ``reasoning``: reasoning is now provider-agnostic (the
+        litellm channel), so it is reported supported regardless of the LLM. An
+        LLM only enriches the informational ``nativeGeminiProvider`` /
+        ``resolvedProvider`` fields.
     emission_shape / emit_raw_events:
         The values the endpoint was configured with. Defaults (``None``) resolve
         the same way the endpoint factories resolve them, so a caller that
@@ -973,6 +976,6 @@ def get_capabilities(
             "enabled": bool(resolved_raw and CAPABILITIES.stream_frame_available),
             "default": DEFAULT_EMIT_RAW_EVENTS,
         },
-        "reasoning": _reasoning_capability(llm, raw_enabled=resolved_raw),
+        "reasoning": _reasoning_capability(llm),
         "crewChat": {"supported": CAPABILITIES.crew_chat_available},
     }

--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -98,11 +98,18 @@ from ag_ui.core.events import (
     MessagesSnapshotEvent,
     StateSnapshotEvent,
     CustomEvent,
+    ReasoningStartEvent,
+    ReasoningMessageStartEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningEndEvent,
+    ReasoningEncryptedValueEvent,
 )
 
 from .sdk import litellm_messages_to_ag_ui_messages
 from .mcp import is_mcp_event, translate_mcp_event
 from ._hitl import HITLOptions, build_agui_interrupt, build_interrupt_tail
+from ._reasoning import is_thinking_event, thinking_event_text
 from .attribution import (
     BoundaryTracker,
     FLOW_METHOD,
@@ -272,6 +279,20 @@ class StreamFrameTranslator:
         self._pending_request: dict[str, Any] | None = None
         self._paused: bool = False
         self._paused_flow_id: str | None = None
+        # Native-reasoning lifecycle (crewai's Gemini ``LLMThinkingChunkEvent``).
+        # These arrive as a stream of chunks with no explicit end signal, so the
+        # message stays open until the next non-thinking event (or finalize)
+        # flushes it. The litellm-path reasoning events are already fully-formed
+        # lifecycle events and are mapped 1:1, without this state.
+        self._reasoning_message_id: str | None = None
+        self._reasoning_open = False
+        # litellm-path reasoning is mapped 1:1, so it needs no per-event flush.
+        # These flags are consulted ONLY by ``flush_open_reasoning`` on the error
+        # path, which closes a message left half-open when a mid-run error drops
+        # its trailing END frames.
+        self._litellm_message_id: str | None = None
+        self._litellm_msg_open = False
+        self._litellm_started = False
         # A MESSAGES_SNAPSHOT is authoritative: the client drops any message
         # absent from it. The method-finish snapshot comes from state.messages,
         # which never holds backend tool calls (they exist only on the wire), so
@@ -323,7 +344,20 @@ class StreamFrameTranslator:
         ]
 
     def translate(self, event: Any) -> list[Any]:
-        """Map one raw crewai/bridge event to the AG-UI events it produces."""
+        """Map one raw crewai/bridge event to the AG-UI events it produces.
+
+        Native thinking chunks (crewai's Gemini provider) drive a stateful
+        reasoning lifecycle; any other event first flushes an open native
+        reasoning message so its ``REASONING_MESSAGE_END`` / ``REASONING_END``
+        precede whatever comes next on the wire.
+        """
+        if is_thinking_event(event):
+            return self._native_thinking_events(event)
+        prefix = self._flush_native_reasoning()
+        events = self._translate_non_thinking(event)
+        return prefix + events if prefix else events
+
+    def _translate_non_thinking(self, event: Any) -> list[Any]:
         event_type = getattr(event, "type", None)
 
         if event_type == _FLOW_STARTED:
@@ -435,6 +469,61 @@ class StreamFrameTranslator:
                 )
             ]
 
+        # Reasoning lifecycle from the litellm path (``sdk.copilotkit_stream``):
+        # already fully-formed lifecycle events, mapped 1:1. The open/close
+        # flags are consulted only by ``flush_open_reasoning`` on the error path.
+        if event_type == EventType.REASONING_START:
+            self._litellm_message_id = getattr(event, "message_id", None)
+            self._litellm_started = True
+            return [
+                ReasoningStartEvent(
+                    type=EventType.REASONING_START,
+                    message_id=self._litellm_message_id,
+                )
+            ]
+        if event_type == EventType.REASONING_MESSAGE_START:
+            self._litellm_msg_open = True
+            return [
+                ReasoningMessageStartEvent(
+                    type=EventType.REASONING_MESSAGE_START,
+                    message_id=getattr(event, "message_id", None),
+                    role=getattr(event, "role", None),
+                )
+            ]
+        if event_type == EventType.REASONING_MESSAGE_CONTENT:
+            return [
+                ReasoningMessageContentEvent(
+                    type=EventType.REASONING_MESSAGE_CONTENT,
+                    message_id=getattr(event, "message_id", None),
+                    delta=getattr(event, "delta", None),
+                )
+            ]
+        if event_type == EventType.REASONING_MESSAGE_END:
+            self._litellm_msg_open = False
+            return [
+                ReasoningMessageEndEvent(
+                    type=EventType.REASONING_MESSAGE_END,
+                    message_id=getattr(event, "message_id", None),
+                )
+            ]
+        if event_type == EventType.REASONING_END:
+            self._litellm_started = False
+            return [
+                ReasoningEndEvent(
+                    type=EventType.REASONING_END,
+                    message_id=getattr(event, "message_id", None),
+                )
+            ]
+        if event_type == EventType.REASONING_ENCRYPTED_VALUE:
+            return [
+                ReasoningEncryptedValueEvent(
+                    type=EventType.REASONING_ENCRYPTED_VALUE,
+                    subtype=getattr(event, "subtype", None),
+                    entity_id=getattr(event, "entity_id", None),
+                    encrypted_value=getattr(event, "encrypted_value", None),
+                )
+            ]
+
         # Backend tool execution: surface the call + result so the client can
         # render it. Only ``finished`` (crewai's terminal event, whose ``output``
         # carries the result or a terminal error string). ``started`` is dropped
@@ -463,17 +552,18 @@ class StreamFrameTranslator:
         RUN_FINISHED. The errored path terminates via RUN_ERROR instead and must
         not call this.
         """
+        # main's guard: return [] unless the run is open and not yet finished.
+        # This also prevents a trailing REASONING_* after RUN_FINISHED (the
+        # flow_finished branch already flushed reasoning via translate()).
         if not (self._run_started_emitted and not self._run_finished_emitted):
             return []
         self._run_finished_emitted = True
-        # Same drain-before-terminal discipline as the ``flow_finished`` branch:
-        # close every open boundary (deepest-first) so the client never sees a
-        # dangling STEP_STARTED. This is also what balances the step of a method
-        # an interrupt paused mid-flight, which the client requires before any
-        # terminal event.
-        events: list[Any] = [
-            step_finished_event(b) for b in self._tracker.drain_all()
-        ]
+        # Reasoning ENDs first (both channels; on a clean run the litellm channel
+        # already self-closed so this is a no-op), then STEP_FINISHED (drain
+        # boundaries deepest-first so no dangling STEP_STARTED; also balances a
+        # method an interrupt paused mid-flight), then the terminal event.
+        events: list[Any] = self.flush_open_reasoning()
+        events.extend(step_finished_event(b) for b in self._tracker.drain_all())
         interrupt = self._build_interrupt()
         if interrupt is not None:
             return events + build_interrupt_tail(
@@ -489,6 +579,92 @@ class StreamFrameTranslator:
                 run_id=self._run_id,
             )
         )
+        return events
+
+    # -- native reasoning lifecycle (crewai Gemini thinking chunks) --------
+
+    def _native_thinking_events(self, event: Any) -> list[Any]:
+        """Open (if needed) and extend the native reasoning message.
+
+        crewai streams thinking as ``chunk`` deltas with no explicit end; the
+        message opens on the first chunk and is closed lazily by
+        ``_flush_native_reasoning`` when a non-thinking event follows.
+        """
+        text = thinking_event_text(event)
+        if text is None:
+            return []
+        events: list[Any] = []
+        if not self._reasoning_open:
+            self._reasoning_message_id = uuid.uuid4().hex
+            self._reasoning_open = True
+            events.append(
+                ReasoningStartEvent(
+                    type=EventType.REASONING_START,
+                    message_id=self._reasoning_message_id,
+                )
+            )
+            events.append(
+                ReasoningMessageStartEvent(
+                    type=EventType.REASONING_MESSAGE_START,
+                    message_id=self._reasoning_message_id,
+                    role="reasoning",
+                )
+            )
+        events.append(
+            ReasoningMessageContentEvent(
+                type=EventType.REASONING_MESSAGE_CONTENT,
+                message_id=self._reasoning_message_id,
+                delta=text,
+            )
+        )
+        return events
+
+    def _flush_native_reasoning(self) -> list[Any]:
+        """Close an open native reasoning message, returning its END events."""
+        if not self._reasoning_open:
+            return []
+        message_id = self._reasoning_message_id
+        self._reasoning_open = False
+        self._reasoning_message_id = None
+        return [
+            ReasoningMessageEndEvent(
+                type=EventType.REASONING_MESSAGE_END,
+                message_id=message_id,
+            ),
+            ReasoningEndEvent(
+                type=EventType.REASONING_END,
+                message_id=message_id,
+            ),
+        ]
+
+    def flush_open_reasoning(self) -> list[Any]:
+        """Close any reasoning message still open, on either channel.
+
+        Called by the frame driver on the error/timeout path so a run that
+        errors mid-reasoning does not leave a half-open lifecycle before
+        RUN_ERROR, and by ``finalize`` before the terminal event. Closes the
+        native message (via ``_flush_native_reasoning``) and the litellm message
+        (whose trailing END frames the exited frame loop never dequeues).
+        Idempotent: each channel closes at most once, so a channel already
+        closed on the happy path is a no-op.
+        """
+        events = self._flush_native_reasoning()
+        if self._litellm_msg_open:
+            self._litellm_msg_open = False
+            events.append(
+                ReasoningMessageEndEvent(
+                    type=EventType.REASONING_MESSAGE_END,
+                    message_id=self._litellm_message_id,
+                )
+            )
+        if self._litellm_started:
+            self._litellm_started = False
+            events.append(
+                ReasoningEndEvent(
+                    type=EventType.REASONING_END,
+                    message_id=self._litellm_message_id,
+                )
+            )
         return events
 
     def note_pause_from_context(self, context: Any) -> None:
@@ -943,6 +1119,13 @@ _RECOGNIZED_EVENT_TYPES = frozenset(
         EventType.TOOL_CALL_CHUNK,
         EventType.CUSTOM,
         EventType.STATE_SNAPSHOT,
+        # Reasoning lifecycle from the litellm path (Bridged* events, mapped 1:1).
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.REASONING_ENCRYPTED_VALUE,
     }
 )
 
@@ -971,10 +1154,12 @@ def is_recognized_event(event: Any) -> bool:
     """True when the translator maps this event, so RAW must not duplicate it.
 
     Covers every mapped channel: the base lifecycle / bridge types above, plus
-    the crew/agent lifecycle, backend ToolUsage, and MCP events (matched by
-    their own predicates). Without the last three a mapped event would ALSO be
-    RAW-mirrored under ``emit_raw_events=True`` (a double emit); the deliberately
-    suppressed ``tool_usage_started`` would likewise leak as RAW.
+    the crew/agent lifecycle, backend ToolUsage, MCP events, and crewai's native
+    thinking-chunk event (all matched by their own predicates). Without these a
+    mapped event would ALSO be RAW-mirrored under ``emit_raw_events=True`` (a
+    double emit) -- notably the native ``llm_thinking_chunk``, which the sink
+    parks for TRANSLATION to REASONING_*; the deliberately suppressed
+    ``tool_usage_started`` would likewise leak as RAW.
     """
     event_type = getattr(event, "type", None)
     return (
@@ -982,6 +1167,7 @@ def is_recognized_event(event: Any) -> bool:
         or event_type in CREW_AGENT_LIFECYCLE_TYPES
         or is_backend_tool_event(event)
         or is_mcp_event(event)
+        or is_thinking_event(event)
     )
 
 

--- a/integrations/crew-ai/python/ag_ui_crewai/_reasoning.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_reasoning.py
@@ -1,0 +1,107 @@
+"""Provider-agnostic reasoning extraction for the CrewAI AG-UI bridge.
+
+Two channels carry model reasoning to the bridge and both funnel through the
+helpers here:
+
+* the litellm streaming delta (``copilotkit_stream``): ``delta.reasoning_content``
+  (a string; o1/o3, deepseek-reasoner, and most reasoning models normalised by
+  litellm) and ``delta.thinking_blocks`` (Anthropic extended thinking: ``thinking``
+  text + ``signature``, and ``redacted_thinking`` blocks carrying encrypted
+  ``data``). ``reasoning_from_delta`` projects one delta onto text + encrypted
+  blobs; ``reasoning_content`` wins as the text source per delta, since litellm
+  mirrors the same text into a thinking block for Anthropic.
+* crewai's native ``LLMThinkingChunkEvent`` (its Gemini provider, crewai
+  >= 1.10.1), whose text rides on the ``chunk`` attribute. ``is_thinking_event``
+  / ``thinking_event_text`` read it by ``type`` string so the frame translator
+  stays decoupled from importing crewai.
+
+This module is a LEAF: it imports only the stdlib, so ``sdk`` / ``_frames`` can
+import it at module-load time without a circular dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# crewai's native thinking-chunk event ``type`` discriminator (its Gemini
+# provider emits it via ``BaseLLM._emit_thinking_chunk_event``, crewai
+# >= 1.10.1). Matched by string so this stays importable without crewai.
+LLM_THINKING_CHUNK = "llm_thinking_chunk"
+
+
+def is_thinking_event(event: Any) -> bool:
+    """Return True when ``event`` is crewai's native LLM thinking-chunk event."""
+    return getattr(event, "type", None) == LLM_THINKING_CHUNK
+
+
+def thinking_event_text(event: Any) -> str | None:
+    """Return the reasoning text carried by a native thinking-chunk event.
+
+    crewai carries it on ``chunk``; return ``None`` for a chunk-less event so
+    the caller can skip opening an empty reasoning message.
+    """
+    chunk = getattr(event, "chunk", None)
+    return chunk if isinstance(chunk, str) and chunk else None
+
+
+@dataclass(frozen=True)
+class DeltaReasoning:
+    """Reasoning projected out of a single litellm streaming delta.
+
+    ``text`` is the concatenated reasoning text in this delta;
+    ``encrypted`` holds any signature / redacted-thinking blobs (Anthropic
+    extended thinking), surfaced as ``REASONING_ENCRYPTED_VALUE``.
+    """
+
+    text: str = ""
+    encrypted: tuple[str, ...] = field(default_factory=tuple)
+
+    def __bool__(self) -> bool:
+        return bool(self.text or self.encrypted)
+
+
+def reasoning_from_delta(delta: Any) -> DeltaReasoning:
+    """Project one litellm streaming ``delta`` onto its reasoning content.
+
+    Reads ``reasoning_content`` (string) and ``thinking_blocks`` (list of
+    ``{type, thinking, signature}`` / ``{type: "redacted_thinking", data}``
+    dicts). Forgiving: a missing or oddly-shaped field yields an empty result
+    rather than raising, so a provider that carries no reasoning is a no-op.
+    """
+    getter = getattr(delta, "get", None)
+    if not callable(getter):
+        return DeltaReasoning()
+
+    text_parts: list[str] = []
+    encrypted: list[str] = []
+
+    reasoning_content = getter("reasoning_content")
+    has_reasoning_content = isinstance(reasoning_content, str) and bool(reasoning_content)
+    if has_reasoning_content:
+        text_parts.append(reasoning_content)
+
+    blocks = getter("thinking_blocks")
+    if isinstance(blocks, list):
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "redacted_thinking":
+                data = block.get("data")
+                if data:
+                    encrypted.append(str(data))
+                continue
+            # litellm mirrors a thinking block's text into ``reasoning_content``
+            # for Anthropic extended thinking, so taking both would emit every
+            # token twice. Take the block text only when the delta carried no
+            # reasoning_content. The signature is always kept: it rides on a
+            # thinking block, never on reasoning_content.
+            if not has_reasoning_content:
+                thinking = block.get("thinking")
+                if isinstance(thinking, str) and thinking:
+                    text_parts.append(thinking)
+            signature = block.get("signature")
+            if signature:
+                encrypted.append(str(signature))
+
+    return DeltaReasoning(text="".join(text_parts), encrypted=tuple(encrypted))

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -48,6 +48,7 @@ from ._hitl import (
     feedback_from_resume,
     resume_requested,
 )
+from ._reasoning import is_thinking_event
 from .mcp import is_mcp_event, register_mcp_listeners, translate_mcp_event
 from .attribution import flat_method_attribution
 from crewai.flow.flow import Flow
@@ -71,6 +72,12 @@ from ag_ui.core.events import (
   MessagesSnapshotEvent,
   StateSnapshotEvent,
   CustomEvent,
+  ReasoningStartEvent,
+  ReasoningMessageStartEvent,
+  ReasoningMessageContentEvent,
+  ReasoningMessageEndEvent,
+  ReasoningEndEvent,
+  ReasoningEncryptedValueEvent,
 )
 from ag_ui.encoder import EventEncoder
 
@@ -79,7 +86,13 @@ from .events import (
   BridgedToolCallChunkEvent,
   BridgedToolCallResultEvent,
   BridgedCustomEvent,
-  BridgedStateSnapshotEvent
+  BridgedStateSnapshotEvent,
+  BridgedReasoningStartEvent,
+  BridgedReasoningMessageStartEvent,
+  BridgedReasoningMessageContentEvent,
+  BridgedReasoningMessageEndEvent,
+  BridgedReasoningEndEvent,
+  BridgedReasoningEncryptedValueEvent,
 )
 from .context import flow_context
 from .utils import camel_to_snake, dump_agui_message
@@ -1104,6 +1117,67 @@ class FastAPICrewFlowEventListener(_EventListenerBase):
                 )
             )
 
+        # Reasoning lifecycle emitted by ``sdk.copilotkit_stream`` off the
+        # litellm delta. Mapped 1:1 like the text / tool-call chunks above.
+        @crewai_event_bus.on(BridgedReasoningStartEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningStartEvent(
+                    type=EventType.REASONING_START,
+                    message_id=event.message_id,
+                )
+            )
+        @crewai_event_bus.on(BridgedReasoningMessageStartEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningMessageStartEvent(
+                    type=EventType.REASONING_MESSAGE_START,
+                    message_id=event.message_id,
+                    role=event.role,
+                )
+            )
+        @crewai_event_bus.on(BridgedReasoningMessageContentEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningMessageContentEvent(
+                    type=EventType.REASONING_MESSAGE_CONTENT,
+                    message_id=event.message_id,
+                    delta=event.delta,
+                )
+            )
+        @crewai_event_bus.on(BridgedReasoningMessageEndEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningMessageEndEvent(
+                    type=EventType.REASONING_MESSAGE_END,
+                    message_id=event.message_id,
+                )
+            )
+        @crewai_event_bus.on(BridgedReasoningEndEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningEndEvent(
+                    type=EventType.REASONING_END,
+                    message_id=event.message_id,
+                )
+            )
+        @crewai_event_bus.on(BridgedReasoningEncryptedValueEvent)
+        def _(source, event):
+            _enqueue(
+                source,
+                ReasoningEncryptedValueEvent(
+                    type=EventType.REASONING_ENCRYPTED_VALUE,
+                    subtype=event.subtype,
+                    entity_id=event.entity_id,
+                    encrypted_value=event.encrypted_value,
+                )
+            )
+
         # Surface crewai's first-class MCP events (crewai >= 1.4) on the LEGACY
         # bus-listener transport (crewai 1.4-1.5, StreamFrame absent). crewai
         # emits MCP events with the agent/crew as ``source`` (NOT the Flow), so
@@ -1921,6 +1995,20 @@ async def _run_flow_frame_stream(
         state_provider=lambda: getattr(flow_copy, "state", {}),
         hitl_options=hitl_options,
     )
+
+    def _closing_reasoning_frames():
+        """Encoded REASONING_* END events for any reasoning left open at error.
+
+        Emitted before a RUN_ERROR so a run that fails mid-reasoning does not
+        leave a half-open lifecycle on the wire. A no-op when nothing is open.
+        """
+        for reasoning_event in translator.flush_open_reasoning():
+            _stamp_correlation_ids(
+                reasoning_event,
+                thread_id=input_data.thread_id,
+                run_id=input_data.run_id,
+            )
+            yield encoder.encode(reasoning_event)
     # Raw-event lookup buffer, populated by our scoped sink below. Keyed by
     # ``event.event_id`` (== ``StreamFrame.id``). Only OUTER-flow events land
     # here (source gate), which is exactly the nested-flow filter: nested
@@ -1966,12 +2054,16 @@ async def _run_flow_frame_stream(
         # events and our Bridged* events carry flow_copy as source, while a
         # nested crew.kickoff's own flow's lifecycle/method events leak here
         # with a different source and must stay dropped (no double RUN_STARTED,
-        # no mis-nested method). MCP, backend tool (ToolUsage), and Crew/Agent
-        # lifecycle events are parked regardless of source because this sink is
-        # scoped to the run's context (no cross-run leak); crew/agent events let
-        # the translator attribute the hierarchy. Any other foreign event is
-        # parked for RAW passthrough only when opt-in is on (bounded buffer,
-        # oldest evicted with a log).
+        # no mis-nested method). MCP, backend tool (ToolUsage), Crew/Agent
+        # lifecycle, and native thinking-chunk events are parked regardless of
+        # source because this sink is scoped to the run's context (no cross-run
+        # leak); crew/agent events let the translator attribute the hierarchy.
+        # crewai's native LLMThinkingChunkEvent (Gemini provider) is emitted with
+        # the LLM as source (not flow_copy): park it in raw_events so it is
+        # TRANSLATED to REASONING_* -- it therefore never also lands in
+        # foreign_events, so RAW passthrough cannot double-emit it. Any other
+        # foreign event is parked for RAW passthrough only when opt-in is on
+        # (bounded buffer, oldest evicted with a log).
         event_id = getattr(event, "event_id", None)
         if event_id is None:
             return
@@ -1979,6 +2071,7 @@ async def _run_flow_frame_stream(
             source is flow_copy
             or is_mcp_event(event)
             or is_backend_tool_event(event)
+            or is_thinking_event(event)
             or getattr(event, "type", None) in CREW_AGENT_LIFECYCLE_TYPES
         ):
             raw_events[event_id] = event
@@ -2196,6 +2289,8 @@ async def _run_flow_frame_stream(
                 f"thread={input_data.thread_id} run={input_data.run_id}: "
                 f"CrewAI flow exceeded ceiling={ceiling_display}"
             )
+            for reasoning_frame in _closing_reasoning_frames():
+                yield reasoning_frame
             yield encoder.encode(
                 RunErrorEvent(
                     message=message,
@@ -2223,6 +2318,8 @@ async def _run_flow_frame_stream(
                 f"CrewAI upstream timeout during kickoff "
                 f"(ceiling={ceiling_display} did not fire)"
             )
+            for reasoning_frame in _closing_reasoning_frames():
+                yield reasoning_frame
             yield encoder.encode(
                 RunErrorEvent(
                     message=message,
@@ -2242,6 +2339,8 @@ async def _run_flow_frame_stream(
                 f"CrewAI flow failed; see server logs"
             )
             sanitized_name = _sanitize_exception_code(type(e).__name__)
+            for reasoning_frame in _closing_reasoning_frames():
+                yield reasoning_frame
             yield encoder.encode(
                 RunErrorEvent(
                     message=message,

--- a/integrations/crew-ai/python/ag_ui_crewai/events.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/events.py
@@ -12,7 +12,13 @@ from ag_ui.core.events import (
   ToolCallResultEvent,
   TextMessageChunkEvent,
   CustomEvent,
-  StateSnapshotEvent
+  StateSnapshotEvent,
+  ReasoningStartEvent,
+  ReasoningMessageStartEvent,
+  ReasoningMessageContentEvent,
+  ReasoningMessageEndEvent,
+  ReasoningEndEvent,
+  ReasoningEncryptedValueEvent,
 )
 
 # When ``crewai``'s events package doesn't resolve, ``BaseEvent`` is ``None``.
@@ -56,10 +62,38 @@ class BridgedCustomEvent(_BridgedBase, CustomEvent):
 class BridgedStateSnapshotEvent(_BridgedBase, StateSnapshotEvent):
     """Bridged state snapshot event"""
 
+# Reasoning lifecycle, emitted by ``sdk.copilotkit_stream`` off the litellm
+# streaming delta (provider-agnostic: deepseek, Anthropic thinking, ...). Both
+# transports translate them: the legacy bus listener and the frame translator.
+class BridgedReasoningStartEvent(_BridgedBase, ReasoningStartEvent):
+    """Bridged reasoning start event"""
+
+class BridgedReasoningMessageStartEvent(_BridgedBase, ReasoningMessageStartEvent):
+    """Bridged reasoning message start event"""
+
+class BridgedReasoningMessageContentEvent(_BridgedBase, ReasoningMessageContentEvent):
+    """Bridged reasoning message content event"""
+
+class BridgedReasoningMessageEndEvent(_BridgedBase, ReasoningMessageEndEvent):
+    """Bridged reasoning message end event"""
+
+class BridgedReasoningEndEvent(_BridgedBase, ReasoningEndEvent):
+    """Bridged reasoning end event"""
+
+class BridgedReasoningEncryptedValueEvent(_BridgedBase, ReasoningEncryptedValueEvent):
+    """Bridged reasoning encrypted-value event (signature / redacted thinking)"""
+
+
 __all__ = [
     "BridgedToolCallChunkEvent",
     "BridgedToolCallResultEvent",
     "BridgedTextMessageChunkEvent",
     "BridgedCustomEvent",
     "BridgedStateSnapshotEvent",
+    "BridgedReasoningStartEvent",
+    "BridgedReasoningMessageStartEvent",
+    "BridgedReasoningMessageContentEvent",
+    "BridgedReasoningMessageEndEvent",
+    "BridgedReasoningEndEvent",
+    "BridgedReasoningEncryptedValueEvent",
 ]

--- a/integrations/crew-ai/python/ag_ui_crewai/sdk.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/sdk.py
@@ -36,8 +36,15 @@ from .events import (
   BridgedToolCallChunkEvent,
   BridgedToolCallResultEvent,
   BridgedCustomEvent,
-  BridgedStateSnapshotEvent
+  BridgedStateSnapshotEvent,
+  BridgedReasoningStartEvent,
+  BridgedReasoningMessageStartEvent,
+  BridgedReasoningMessageContentEvent,
+  BridgedReasoningMessageEndEvent,
+  BridgedReasoningEndEvent,
+  BridgedReasoningEncryptedValueEvent,
 )
+from ._reasoning import reasoning_from_delta
 from .utils import yield_control, convert_litellm_multimodal_to_agui
 
 class CopilotKitProperties(BaseModel):
@@ -320,7 +327,36 @@ async def _copilotkit_stream_custom_stream_wrapper(response: CustomStreamWrapper
     finish_reason=None
     all_tool_calls = []
 
-    async for chunk in response:
+    # Reasoning lifecycle. Reasoning tokens (delta.reasoning_content /
+    # delta.thinking_blocks) precede the answer; open a reasoning message on the
+    # first reasoning delta and close it once the model emits answer text or a
+    # tool call (or the stream ends).
+    reasoning_message_id: Optional[str] = None
+    reasoning_open = False
+
+    def _close_reasoning():
+        nonlocal reasoning_open, reasoning_message_id
+        if not reasoning_open:
+            return
+        crewai_event_bus.emit(
+            flow,
+            BridgedReasoningMessageEndEvent(
+                type=EventType.REASONING_MESSAGE_END,
+                message_id=reasoning_message_id,
+            ),
+        )
+        crewai_event_bus.emit(
+            flow,
+            BridgedReasoningEndEvent(
+                type=EventType.REASONING_END,
+                message_id=reasoning_message_id,
+            ),
+        )
+        reasoning_open = False
+        reasoning_message_id = None
+
+    try:
+      async for chunk in response:
         if message_id is None:
             message_id = chunk["id"]
 
@@ -329,10 +365,56 @@ async def _copilotkit_stream_custom_stream_wrapper(response: CustomStreamWrapper
         if not chunk["choices"]:
             continue
 
-        text_content = chunk["choices"][0]["delta"]["content"] or None
+        delta = chunk["choices"][0]["delta"]
+
+        # Stream reasoning tokens (provider-agnostic via litellm normalisation).
+        reasoning = reasoning_from_delta(delta)
+        if reasoning:
+            if not reasoning_open:
+                reasoning_message_id = str(uuid.uuid4())
+                crewai_event_bus.emit(
+                    flow,
+                    BridgedReasoningStartEvent(
+                        type=EventType.REASONING_START,
+                        message_id=reasoning_message_id,
+                    ),
+                )
+                crewai_event_bus.emit(
+                    flow,
+                    BridgedReasoningMessageStartEvent(
+                        type=EventType.REASONING_MESSAGE_START,
+                        message_id=reasoning_message_id,
+                        role="reasoning",
+                    ),
+                )
+                reasoning_open = True
+            if reasoning.text:
+                crewai_event_bus.emit(
+                    flow,
+                    BridgedReasoningMessageContentEvent(
+                        type=EventType.REASONING_MESSAGE_CONTENT,
+                        message_id=reasoning_message_id,
+                        delta=reasoning.text,
+                    ),
+                )
+            for value in reasoning.encrypted:
+                crewai_event_bus.emit(
+                    flow,
+                    BridgedReasoningEncryptedValueEvent(
+                        type=EventType.REASONING_ENCRYPTED_VALUE,
+                        subtype="message",
+                        entity_id=reasoning_message_id,
+                        encrypted_value=value,
+                    ),
+                )
+            await yield_control()
+
+        text_content = delta["content"] or None
 
         # Stream text messages
         if text_content is not None:
+            # Reasoning is done once the answer starts.
+            _close_reasoning()
             # add to the current text message
             content += text_content
             crewai_event_bus.emit(
@@ -348,10 +430,14 @@ async def _copilotkit_stream_custom_stream_wrapper(response: CustomStreamWrapper
             await yield_control()
 
         # Stream tool calls
-        tool_calls = chunk["choices"][0]["delta"]["tool_calls"] or None
+        tool_calls = delta["tool_calls"] or None
         tool_call_id = tool_calls[0].id if tool_calls is not None else None
         tool_call_arguments = tool_calls[0].function["arguments"] if tool_calls is not None else None
         tool_call_name = tool_calls[0].function["name"] if tool_calls is not None else None
+
+        if tool_calls is not None:
+            # Reasoning is done once the model calls a tool.
+            _close_reasoning()
 
         if tool_call_id is not None:
             all_tool_calls.append(
@@ -398,6 +484,11 @@ async def _copilotkit_stream_custom_stream_wrapper(response: CustomStreamWrapper
 
         if finish_reason is not None:
             break
+    finally:
+        # Close a reasoning message left open by a stream that carried only
+        # reasoning, ended before any answer text / tool call, or raised
+        # mid-reasoning.
+        _close_reasoning()
 
     tool_calls = [
         ChatCompletionMessageToolCall(

--- a/integrations/crew-ai/python/tests/test_capability_declaration.py
+++ b/integrations/crew-ai/python/tests/test_capability_declaration.py
@@ -1,6 +1,7 @@
 """Capability declaration and RAW-passthrough configuration: ``get_capabilities()``,
-the native-Gemini reasoning probe, and the "explicit argument > env var > default"
-resolution behind ``emit_raw_events``. No network."""
+the provider-agnostic reasoning capability + native-Gemini LLM resolution, and the
+"explicit argument > env var > default" resolution behind ``emit_raw_events``.
+No network."""
 
 import dataclasses
 
@@ -49,18 +50,19 @@ def test_get_capabilities_gates_raw_events_on_the_streamframe_transport(monkeypa
     assert on["rawEvents"]["enabled"] is True
     assert get_capabilities(emit_raw_events=False)["rawEvents"]["enabled"] is False
 
-    # Unavailable transport: the flag cannot turn it on, and reasoning must not
-    # advertise a RAW channel that does not exist.
+    # Unavailable transport: the flag cannot turn RAW on. Reasoning is now a
+    # first-class channel (litellm), independent of RAW / StreamFrame, so it
+    # stays supported here.
     _set_stream_frames(False)
     off = get_capabilities(llm=_FakeNativeGemini(), emit_raw_events=True)
     assert off["transport"]["streamFrames"] is False
     assert off["rawEvents"]["supported"] is False
     assert off["rawEvents"]["enabled"] is False
-    assert off["reasoning"]["supported"] is False
-    assert off["reasoning"]["reason"] == "raw_transport_unavailable"
+    assert off["reasoning"]["supported"] is True
+    assert off["reasoning"]["requiresEmitRawEvents"] is False
 
 
-# -- reasoning: native-Gemini-only -----------------------------------------
+# -- reasoning: provider-agnostic, first-class ------------------------------
 
 class _FakeNativeGemini:
     """Structural stand-in for ``crewai.llms.providers.gemini.completion``:
@@ -82,57 +84,55 @@ class _FakeLiteLLMGemini:
     model = "gemini/gemini-1.0-unlisted"
 
 
-def test_reasoning_requires_an_llm_and_does_not_claim_support_from_the_class_probe():
-    """The ``LLMThinkingChunkEvent`` class existing is NOT evidence a run will
-    produce reasoning - it is emitted only by the native Gemini provider. With no
-    LLM to resolve, report unsupported with an explicit reason."""
-    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
-        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
-    if not caps_mod._stream_frame_available:  # pragma: no cover
-        pytest.skip("installed crewai has no StreamFrame transport for RAW")
-
+def test_reasoning_supported_without_an_llm_and_provider_agnostic():
+    """Reasoning is a first-class, provider-agnostic bridge capability (the
+    litellm reasoning_content / thinking_blocks channel), NOT gated on a
+    native-Gemini LLM or the RAW transport. It is reported supported even with no
+    LLM to resolve. ``thinkingEventAvailable`` reports the extra native source."""
     reasoning = get_capabilities()["reasoning"]
 
-    assert reasoning["supported"] is False
-    assert reasoning["reason"] == "llm_not_provided"
-    # The class probe is reported separately, so callers can see WHY.
+    assert reasoning["supported"] is True
+    assert reasoning["requiresEmitRawEvents"] is False
+    assert reasoning["litellmChannel"] is True
+    assert reasoning["nativeGeminiProvider"] is False
     assert reasoning["thinkingEventAvailable"] is (
         caps_mod.LLMThinkingChunkEvent is not None
     )
 
 
-def test_reasoning_supported_only_for_native_gemini():
-    if caps_mod.LLMThinkingChunkEvent is None:  # pragma: no cover
-        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
-    if not caps_mod._stream_frame_available:  # pragma: no cover
-        pytest.skip("installed crewai has no StreamFrame transport for RAW")
+def test_reasoning_supported_across_providers():
+    """Provider-agnostic: native Gemini, OpenAI, and LiteLLM-routed models are all
+    reported supported (the litellm channel carries reasoning for any
+    reasoning-capable model). The native-Gemini fields are informational only."""
+    gemini = get_capabilities(llm=_FakeNativeGemini())["reasoning"]
+    assert gemini["supported"] is True
+    assert gemini["nativeGeminiProvider"] is True
+    assert gemini["resolvedProvider"] == "gemini"
 
-    supported = get_capabilities(llm=_FakeNativeGemini(), emit_raw_events=True)[
-        "reasoning"
-    ]
-    assert supported["supported"] is True
-    assert supported["rawEventsEnabled"] is True
-    assert supported["nativeGeminiProvider"] is True
-    assert supported["resolvedProvider"] == "gemini"
-    # Reasoning reaches the wire via RAW passthrough today.
-    assert supported["transport"] == "raw"
-
-    not_gemini = get_capabilities(llm=_FakeOpenAI())["reasoning"]
-    assert not_gemini["supported"] is False
-    assert not_gemini["reason"] == "provider_not_native_gemini"
+    openai = get_capabilities(llm=_FakeOpenAI())["reasoning"]
+    assert openai["supported"] is True
+    assert openai["nativeGeminiProvider"] is False
+    assert openai["resolvedProvider"] == "openai"
 
     litellm_routed = get_capabilities(llm=_FakeLiteLLMGemini())["reasoning"]
-    assert litellm_routed["supported"] is False
-    assert litellm_routed["reason"] == "provider_not_native_gemini"
+    assert litellm_routed["supported"] is True
+    assert litellm_routed["nativeGeminiProvider"] is False
 
 
-def test_reasoning_unsupported_when_the_thinking_event_class_is_absent(monkeypatch):
-    """On a crewai without ``LLMThinkingChunkEvent`` the answer is unsupported
-    even for a native-Gemini LLM."""
+def test_reasoning_still_supported_via_litellm_when_thinking_event_absent(monkeypatch):
+    """On a crewai without ``LLMThinkingChunkEvent`` reasoning is STILL supported
+    through the litellm channel; only the extra native Gemini source is gone. The
+    ``reasoning_available`` flag keys off the litellm channel too, so patch both."""
     monkeypatch.setattr(caps_mod, "_thinking_event_available", False)
+    monkeypatch.setattr(
+        caps_mod,
+        "CAPABILITIES",
+        dataclasses.replace(caps_mod.CAPABILITIES, reasoning_available=True),
+    )
     reasoning = caps_mod._reasoning_capability(_FakeNativeGemini())
-    assert reasoning["supported"] is False
-    assert reasoning["reason"] == "thinking_event_missing"
+    assert reasoning["supported"] is True
+    assert reasoning["thinkingEventAvailable"] is False
+    assert reasoning["reason"] is None
 
 
 def test_reasoning_resolves_the_llm_through_agent_and_crew_wrappers():
@@ -240,16 +240,18 @@ def test_llm_resolution_terminates_on_a_cycle():
     assert caps_mod._resolve_llm(node) is None
 
 
-def test_unresolvable_llm_is_distinguished_from_no_llm():
-    """A caller who passed SOMETHING deserves to know the probe found no LLM inside
-    it, rather than being told they passed nothing."""
+def test_reasoning_supported_regardless_of_llm_resolution():
+    """Reasoning no longer hinges on resolving an LLM (it is provider-agnostic via
+    the litellm channel), so passing nothing, or an object with no LLM inside it,
+    both still report supported. LLM resolution only feeds the informational
+    ``resolvedProvider`` field, which stays None when nothing resolves."""
     class _NoLLMAnywhere:
         pass
 
-    assert get_capabilities()["reasoning"]["reason"] == "llm_not_provided"
-    assert get_capabilities(llm=_NoLLMAnywhere())["reasoning"]["reason"] == (
-        "llm_not_resolvable"
-    )
+    for caps in (get_capabilities(), get_capabilities(llm=_NoLLMAnywhere())):
+        assert caps["reasoning"]["supported"] is True
+        assert caps["reasoning"]["reason"] is None
+        assert caps["reasoning"]["resolvedProvider"] is None
 
 
 def test_native_gemini_is_recognised_under_both_provider_stamps():

--- a/integrations/crew-ai/python/tests/test_reasoning.py
+++ b/integrations/crew-ai/python/tests/test_reasoning.py
@@ -1,0 +1,856 @@
+"""Reasoning surfacing: provider-agnostic REASONING_* emission across both
+channels (the litellm streaming delta via ``copilotkit_stream`` and crewai's
+native ``LLMThinkingChunkEvent``) and both transports (the legacy event-bus
+listener and the StreamFrame translator). No network.
+
+Ordering note: the crewai 1.x event bus dispatches sync handlers on a
+ThreadPoolExecutor, so bus-path tests assert the MULTISET of emitted events
+(counts + content by message id), not cross-event capture order. Exact
+lifecycle ordering is asserted against the synchronous ``StreamFrameTranslator``
+and, end-to-end, by driving a real Flow through ``_run_flow_frame_stream`` and
+decoding the SSE (the ordering there is deterministic).
+"""
+
+import json as _json
+
+import pytest
+
+from crewai.flow.flow import Flow, start
+from litellm import CustomStreamWrapper
+from litellm.types.utils import Delta
+
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+from ag_ui_crewai import endpoint as ep
+from ag_ui_crewai import _frames as frames_mod
+from ag_ui_crewai._capabilities import CAPABILITIES, LLMThinkingChunkEvent, crewai_event_bus
+from ag_ui_crewai._reasoning import (
+    DeltaReasoning,
+    is_thinking_event,
+    reasoning_from_delta,
+    thinking_event_text,
+)
+from ag_ui_crewai.context import flow_context
+from ag_ui_crewai.events import (
+    BridgedReasoningStartEvent,
+    BridgedReasoningMessageStartEvent,
+    BridgedReasoningMessageContentEvent,
+    BridgedReasoningMessageEndEvent,
+    BridgedReasoningEndEvent,
+    BridgedReasoningEncryptedValueEvent,
+)
+from ag_ui_crewai.sdk import copilotkit_stream
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def _chunk(chunk_id, *, content=None, tool_calls=None, delta=None, finish_reason=None):
+    """A LiteLLM-shaped streaming chunk. ``delta`` overrides the delta object
+    (e.g. a real ``litellm.Delta`` carrying reasoning), else a plain dict."""
+    if delta is None:
+        delta = {"content": content, "tool_calls": tool_calls}
+    return {
+        "id": chunk_id,
+        "created": 1700000000,
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_test",
+        "choices": [{"delta": delta, "finish_reason": finish_reason}],
+    }
+
+
+class _FakeStreamWrapper(CustomStreamWrapper):
+    def __init__(self, gen):  # pylint: disable=super-init-not-called
+        self._gen = gen
+
+    def __aiter__(self):
+        return self._gen
+
+
+class _FakeFlow:
+    def __init__(self, state=None):
+        self.state = state if state is not None else {}
+
+
+class _RawThinking:
+    """A minimal native thinking-chunk stand-in (``type`` + ``chunk``), for the
+    translator's string-based dispatch. A real ``LLMThinkingChunkEvent`` is
+    exercised separately."""
+
+    def __init__(self, chunk):
+        self.type = "llm_thinking_chunk"
+        self.chunk = chunk
+
+
+async def _settle_bus():
+    """Flush off-thread bus handlers then tick (mirrors test_streaming)."""
+    import asyncio
+
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flush = getattr(crewai_event_bus, "flush", None)
+    if callable(flush):
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, lambda: flush(5.0))
+        except Exception:  # noqa: BLE001
+            pass
+    await asyncio.sleep(0)
+
+
+def _drain(queue):
+    items = []
+    while not queue.empty():
+        items.append(queue.get_nowait())
+    return items
+
+
+def _translator():
+    return frames_mod.StreamFrameTranslator(
+        thread_id="t-1", run_id="r-1", state_provider=lambda: {}
+    )
+
+
+# --------------------------------------------------------------------------
+# reasoning_from_delta extraction (litellm delta, provider-agnostic)
+# --------------------------------------------------------------------------
+
+def test_reasoning_from_delta_reasoning_content_string():
+    """``delta.reasoning_content`` (o1/o3, deepseek) yields text, no encrypted."""
+    r = reasoning_from_delta(Delta(content=None, reasoning_content="because X"))
+    assert r.text == "because X"
+    assert r.encrypted == ()
+    assert bool(r) is True
+
+
+def test_reasoning_from_delta_thinking_blocks_text_and_signature():
+    """Anthropic extended thinking: ``thinking`` -> text, ``signature`` -> encrypted."""
+    r = reasoning_from_delta(
+        Delta(
+            content=None,
+            thinking_blocks=[{"type": "thinking", "thinking": "hmm", "signature": "sig1"}],
+        )
+    )
+    assert r.text == "hmm"
+    assert r.encrypted == ("sig1",)
+
+
+def test_reasoning_from_delta_redacted_thinking_is_encrypted():
+    """A ``redacted_thinking`` block surfaces its ``data`` as an encrypted value."""
+    r = reasoning_from_delta(
+        Delta(content=None, thinking_blocks=[{"type": "redacted_thinking", "data": "ENC"}])
+    )
+    assert r.text == ""
+    assert r.encrypted == ("ENC",)
+
+
+def test_reasoning_from_delta_reasoning_content_wins_over_block_text():
+    """When a delta carries reasoning_content, the thinking-block text is NOT
+    also appended (litellm mirrors it, so appending both double-emits); both
+    encrypted blobs are still kept."""
+    r = reasoning_from_delta(
+        Delta(
+            content=None,
+            reasoning_content="step1",
+            thinking_blocks=[
+                {"type": "thinking", "thinking": "step1", "signature": "sig"},
+                {"type": "redacted_thinking", "data": "ENC"},
+            ],
+        )
+    )
+    assert r.text == "step1"
+    assert r.encrypted == ("sig", "ENC")
+
+
+def test_reasoning_from_delta_anthropic_no_double_emit():
+    """Anthropic extended thinking: litellm sets reasoning_content == the
+    thinking block's text on the same delta. The text must be emitted once."""
+    r = reasoning_from_delta(
+        Delta(
+            content=None,
+            reasoning_content="Let me think",
+            thinking_blocks=[{"type": "thinking", "thinking": "Let me think"}],
+        )
+    )
+    assert r.text == "Let me think"
+
+
+def test_reasoning_from_delta_block_text_when_no_reasoning_content():
+    """A thinking block with no sibling reasoning_content contributes its text."""
+    r = reasoning_from_delta(
+        Delta(content=None, thinking_blocks=[{"type": "thinking", "thinking": "solo"}])
+    )
+    assert r.text == "solo"
+
+
+def test_reasoning_from_delta_skips_non_dict_blocks():
+    """Non-dict entries in thinking_blocks are skipped, not fatal."""
+    r = reasoning_from_delta(
+        Delta(
+            content=None,
+            thinking_blocks=["garbage", {"type": "thinking", "thinking": "ok"}],
+        )
+    )
+    assert r.text == "ok"
+
+
+def test_reasoning_from_delta_empty_and_non_dict_safe():
+    """No reasoning -> falsy result; a non-delta object degrades to empty."""
+    assert bool(reasoning_from_delta(Delta(content="answer"))) is False
+    assert reasoning_from_delta(object()) == DeltaReasoning()
+
+
+# --------------------------------------------------------------------------
+# copilotkit_stream: litellm-path lifecycle emitted as Bridged events
+# --------------------------------------------------------------------------
+
+async def test_copilotkit_stream_emits_reasoning_then_text():
+    """A reasoning delta then answer text emits the full reasoning lifecycle
+    (START / MESSAGE_START / MESSAGE_CONTENT / MESSAGE_END / END) under one id,
+    all before the answer's text chunk."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    reasoning = []
+    text_ids = []
+
+    with crewai_event_bus.scoped_handlers():
+        crewai_event_bus.on(BridgedReasoningStartEvent)(
+            lambda s, e: reasoning.append(("start", e.message_id))
+        )
+        crewai_event_bus.on(BridgedReasoningMessageStartEvent)(
+            lambda s, e: reasoning.append(("msg_start", e.message_id, e.role))
+        )
+        crewai_event_bus.on(BridgedReasoningMessageContentEvent)(
+            lambda s, e: reasoning.append(("content", e.message_id, e.delta))
+        )
+        crewai_event_bus.on(BridgedReasoningMessageEndEvent)(
+            lambda s, e: reasoning.append(("msg_end", e.message_id))
+        )
+        crewai_event_bus.on(BridgedReasoningEndEvent)(
+            lambda s, e: reasoning.append(("end", e.message_id))
+        )
+        from ag_ui_crewai.events import BridgedTextMessageChunkEvent
+
+        crewai_event_bus.on(BridgedTextMessageChunkEvent)(
+            lambda s, e: text_ids.append(e.message_id)
+        )
+
+        async def _gen():
+            yield _chunk("m1", delta=Delta(content=None, reasoning_content="thinking..."))
+            yield _chunk("m1", content="answer")
+            yield _chunk("m1", finish_reason="stop")
+
+        resp = await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    kinds = [r[0] for r in reasoning]
+    assert kinds.count("start") == 1
+    assert kinds.count("msg_start") == 1
+    assert kinds.count("msg_end") == 1
+    assert kinds.count("end") == 1
+    # One reasoning message id across the whole lifecycle, distinct from the
+    # answer's text message id.
+    rids = {r[1] for r in reasoning}
+    assert len(rids) == 1
+    rid = rids.pop()
+    assert rid != "m1"
+    contents = [r[2] for r in reasoning if r[0] == "content"]
+    assert contents == ["thinking..."]
+    roles = [r[2] for r in reasoning if r[0] == "msg_start"]
+    assert roles == ["reasoning"]
+    # The answer text still reassembles normally.
+    assert resp.choices[0].message.content == "answer"
+
+
+async def test_copilotkit_stream_reasoning_encrypted_value():
+    """A signature on a thinking block emits a REASONING_ENCRYPTED_VALUE carrying
+    it under the reasoning message id, subtype ``message``."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    starts = []
+    encrypted = []
+
+    with crewai_event_bus.scoped_handlers():
+        crewai_event_bus.on(BridgedReasoningStartEvent)(
+            lambda s, e: starts.append(e.message_id)
+        )
+        crewai_event_bus.on(BridgedReasoningEncryptedValueEvent)(
+            lambda s, e: encrypted.append((e.subtype, e.entity_id, e.encrypted_value))
+        )
+
+        async def _gen():
+            yield _chunk(
+                "m2",
+                delta=Delta(
+                    content=None,
+                    thinking_blocks=[
+                        {"type": "thinking", "thinking": "t", "signature": "SIG"}
+                    ],
+                ),
+            )
+            yield _chunk("m2", content="done")
+            yield _chunk("m2", finish_reason="stop")
+
+        await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    assert len(starts) == 1
+    assert len(encrypted) == 1
+    subtype, entity_id, value = encrypted[0]
+    assert subtype == "message"
+    assert value == "SIG"
+    assert entity_id == starts[0]
+
+
+async def test_copilotkit_stream_no_reasoning_emits_nothing():
+    """A plain text stream (no reasoning) emits no reasoning events."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    seen = []
+    with crewai_event_bus.scoped_handlers():
+        for cls in (
+            BridgedReasoningStartEvent,
+            BridgedReasoningMessageStartEvent,
+            BridgedReasoningMessageContentEvent,
+            BridgedReasoningMessageEndEvent,
+            BridgedReasoningEndEvent,
+        ):
+            crewai_event_bus.on(cls)(lambda s, e: seen.append(e.type))
+
+        async def _gen():
+            yield _chunk("m3", content="hi")
+            yield _chunk("m3", finish_reason="stop")
+
+        await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    assert seen == []
+
+
+def _capture_reasoning(bus, sink):
+    """Register handlers appending (kind, event) to ``sink`` for every Bridged
+    reasoning event. Caller owns the scoped_handlers context."""
+    bus.on(BridgedReasoningStartEvent)(lambda s, e: sink.append(("start", e)))
+    bus.on(BridgedReasoningMessageStartEvent)(lambda s, e: sink.append(("msg_start", e)))
+    bus.on(BridgedReasoningMessageContentEvent)(lambda s, e: sink.append(("content", e)))
+    bus.on(BridgedReasoningMessageEndEvent)(lambda s, e: sink.append(("msg_end", e)))
+    bus.on(BridgedReasoningEndEvent)(lambda s, e: sink.append(("end", e)))
+    bus.on(BridgedReasoningEncryptedValueEvent)(lambda s, e: sink.append(("enc", e)))
+
+
+async def test_copilotkit_stream_tool_call_closes_reasoning():
+    """Reasoning is closed before a tool call streams."""
+    from types import SimpleNamespace
+
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    events = []
+    with crewai_event_bus.scoped_handlers():
+        _capture_reasoning(crewai_event_bus, events)
+
+        async def _gen():
+            yield _chunk("mt", delta=Delta(content=None, reasoning_content="planning"))
+            yield _chunk(
+                "mt",
+                delta={
+                    "content": None,
+                    "tool_calls": [
+                        SimpleNamespace(
+                            id="c-1", function={"name": "tool", "arguments": "{}"}
+                        )
+                    ],
+                },
+            )
+            yield _chunk("mt", finish_reason="tool_calls")
+
+        await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    kinds = [k for k, _ in events]
+    assert kinds.count("start") == 1
+    assert kinds.count("msg_end") == 1
+    assert kinds.count("end") == 1
+
+
+async def test_copilotkit_stream_encrypted_only_reasoning():
+    """A redacted-thinking delta with no text still opens and closes a reasoning
+    message and emits exactly one encrypted value, no content."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    events = []
+    with crewai_event_bus.scoped_handlers():
+        _capture_reasoning(crewai_event_bus, events)
+
+        async def _gen():
+            yield _chunk(
+                "me",
+                delta=Delta(
+                    content=None,
+                    thinking_blocks=[{"type": "redacted_thinking", "data": "ENC"}],
+                ),
+            )
+            yield _chunk("me", content="answer")
+            yield _chunk("me", finish_reason="stop")
+
+        await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    kinds = [k for k, _ in events]
+    assert kinds.count("start") == 1
+    assert kinds.count("content") == 0
+    encs = [e for k, e in events if k == "enc"]
+    assert len(encs) == 1
+    assert encs[0].encrypted_value == "ENC"
+    assert kinds.count("msg_end") == 1
+    assert kinds.count("end") == 1
+
+
+async def test_copilotkit_stream_closes_reasoning_on_error():
+    """A stream that raises mid-reasoning still closes the reasoning message
+    (REASONING_MESSAGE_END + END) via the finally, so the lifecycle is not left
+    half-open."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    flow_context.set(None)
+    events = []
+    with crewai_event_bus.scoped_handlers():
+        _capture_reasoning(crewai_event_bus, events)
+
+        async def _gen():
+            yield _chunk("mx", delta=Delta(content=None, reasoning_content="mid"))
+            raise RuntimeError("stream blew up")
+
+        with pytest.raises(RuntimeError, match="stream blew up"):
+            await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        await _settle_bus()
+
+    kinds = [k for k, _ in events]
+    assert kinds.count("start") == 1
+    assert kinds.count("msg_end") == 1
+    assert kinds.count("end") == 1
+
+
+# --------------------------------------------------------------------------
+# Legacy transport: endpoint listener translates Bridged -> wire events
+# --------------------------------------------------------------------------
+
+async def test_legacy_listener_translates_reasoning_events():
+    """The bus listener maps each Bridged reasoning event to its wire event on
+    the per-flow queue."""
+    from ag_ui_crewai._capabilities import crewai_event_bus
+
+    ep.FastAPICrewFlowEventListener()  # registers bus handlers
+    flow = _FakeFlow()
+    queue = await ep.create_queue(flow)
+    flow_context.set(flow)
+    try:
+        crewai_event_bus.emit(
+            flow,
+            BridgedReasoningStartEvent(type=EventType.REASONING_START, message_id="rid"),
+        )
+        crewai_event_bus.emit(
+            flow,
+            BridgedReasoningMessageContentEvent(
+                type=EventType.REASONING_MESSAGE_CONTENT, message_id="rid", delta="why"
+            ),
+        )
+        crewai_event_bus.emit(
+            flow,
+            BridgedReasoningEncryptedValueEvent(
+                type=EventType.REASONING_ENCRYPTED_VALUE,
+                subtype="message",
+                entity_id="rid",
+                encrypted_value="SIG",
+            ),
+        )
+        await _settle_bus()
+        items = _drain(queue)
+    finally:
+        await ep.delete_queue(flow)
+
+    by_type = {e.type: e for e in items}
+    assert EventType.REASONING_START in by_type
+    assert EventType.REASONING_MESSAGE_CONTENT in by_type
+    assert EventType.REASONING_ENCRYPTED_VALUE in by_type
+    assert by_type[EventType.REASONING_MESSAGE_CONTENT].delta == "why"
+    assert by_type[EventType.REASONING_START].message_id == "rid"
+    enc = by_type[EventType.REASONING_ENCRYPTED_VALUE]
+    assert enc.encrypted_value == "SIG"
+    assert enc.entity_id == "rid"
+
+
+# --------------------------------------------------------------------------
+# Frame transport: translator maps Bridged reasoning 1:1 (deterministic order)
+# --------------------------------------------------------------------------
+
+def test_frame_translator_maps_bridged_reasoning_one_to_one():
+    """Each Bridged reasoning event translates to exactly its wire event."""
+    tr = _translator()
+    assert tr.translate(
+        BridgedReasoningStartEvent(type=EventType.REASONING_START, message_id="r")
+    )[0].type == EventType.REASONING_START
+    msg_start = tr.translate(
+        BridgedReasoningMessageStartEvent(
+            type=EventType.REASONING_MESSAGE_START, message_id="r", role="reasoning"
+        )
+    )[0]
+    assert msg_start.type == EventType.REASONING_MESSAGE_START
+    assert msg_start.role == "reasoning"
+    content = tr.translate(
+        BridgedReasoningMessageContentEvent(
+            type=EventType.REASONING_MESSAGE_CONTENT, message_id="r", delta="d"
+        )
+    )[0]
+    assert content.type == EventType.REASONING_MESSAGE_CONTENT
+    assert content.delta == "d"
+    assert tr.translate(
+        BridgedReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id="r")
+    )[0].type == EventType.REASONING_MESSAGE_END
+    assert tr.translate(
+        BridgedReasoningEndEvent(type=EventType.REASONING_END, message_id="r")
+    )[0].type == EventType.REASONING_END
+    enc = tr.translate(
+        BridgedReasoningEncryptedValueEvent(
+            type=EventType.REASONING_ENCRYPTED_VALUE,
+            subtype="message",
+            entity_id="r",
+            encrypted_value="SIG",
+        )
+    )[0]
+    assert enc.type == EventType.REASONING_ENCRYPTED_VALUE
+    assert enc.encrypted_value == "SIG"
+
+
+# --------------------------------------------------------------------------
+# Frame transport: native crewai thinking-chunk lifecycle (Gemini)
+# --------------------------------------------------------------------------
+
+def test_native_thinking_opens_lifecycle_and_streams_content():
+    """The first native thinking chunk opens START + MESSAGE_START then CONTENT;
+    a following chunk just streams CONTENT under the same id."""
+    tr = _translator()
+    first = tr.translate(_RawThinking("a"))
+    assert [e.type for e in first] == [
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+    ]
+    mid = first[0].message_id
+    assert first[1].role == "reasoning"
+    assert first[2].delta == "a"
+
+    second = tr.translate(_RawThinking("b"))
+    assert [e.type for e in second] == [EventType.REASONING_MESSAGE_CONTENT]
+    assert second[0].message_id == mid
+    assert second[0].delta == "b"
+
+
+def test_native_thinking_flushed_before_next_event():
+    """A non-thinking event closes the open reasoning message first: its
+    MESSAGE_END + END precede the next event's translation."""
+    tr = _translator()
+    tr.translate(_RawThinking("a"))
+    from ag_ui_crewai.events import BridgedTextMessageChunkEvent
+
+    out = tr.translate(
+        BridgedTextMessageChunkEvent(
+            type=EventType.TEXT_MESSAGE_CHUNK, message_id="m", role="assistant", delta="hi"
+        )
+    )
+    assert [e.type for e in out] == [
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+        EventType.TEXT_MESSAGE_CHUNK,
+    ]
+    # Closed: a later non-thinking event no longer re-flushes.
+    again = tr.translate(
+        BridgedTextMessageChunkEvent(
+            type=EventType.TEXT_MESSAGE_CHUNK, message_id="m", role="assistant", delta="!"
+        )
+    )
+    assert [e.type for e in again] == [EventType.TEXT_MESSAGE_CHUNK]
+
+
+def test_native_thinking_flushed_on_finalize():
+    """A run that ends with reasoning still open is closed by finalize()."""
+    tr = _translator()
+    # Open the run so finalize also emits RUN_FINISHED.
+    tr.translate(type("F", (), {"type": "flow_started"})())
+    tr.translate(_RawThinking("a"))
+    out = tr.finalize()
+    assert out[0].type == EventType.REASONING_MESSAGE_END
+    assert out[1].type == EventType.REASONING_END
+    assert out[-1].type == EventType.RUN_FINISHED
+
+
+def test_native_thinking_real_event_translates():
+    """A REAL crewai ``LLMThinkingChunkEvent`` drives the lifecycle (not just a
+    stand-in): proves the ``type`` / ``chunk`` contract against the installed
+    crewai."""
+    if LLMThinkingChunkEvent is None:
+        pytest.skip("crewai build without LLMThinkingChunkEvent (< 1.10.1)")
+    real = LLMThinkingChunkEvent(chunk="native reasoning", call_id="c1")
+    assert is_thinking_event(real) is True
+    assert thinking_event_text(real) == "native reasoning"
+    # The frame sink parks events by ``event_id``; a native thinking event must
+    # carry a non-None one or it could never surface on the StreamFrame path.
+    assert getattr(real, "event_id", None) is not None
+    tr = _translator()
+    out = tr.translate(real)
+    assert [e.type for e in out] == [
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+    ]
+    assert out[2].delta == "native reasoning"
+
+
+def test_native_thinking_frame_pipeline_correlation():
+    """Simulate the sink -> frame-lookup -> translate pipeline the frame driver
+    runs: a native thinking event parked by ``event_id`` is retrievable by
+    ``frame.id`` (crewai's documented ``frame.id == event.event_id`` contract)
+    and translates to the reasoning lifecycle."""
+    if LLMThinkingChunkEvent is None:
+        pytest.skip("crewai build without LLMThinkingChunkEvent (< 1.10.1)")
+    event = LLMThinkingChunkEvent(chunk="parked", call_id="c1")
+    # Sink gate: native thinking events are parked by type even though their
+    # source is the LLM (not the flow), keyed by event_id.
+    assert is_thinking_event(event) is True
+    raw_events = {}
+    raw_events[event.event_id] = event
+    # Frame driver looks the raw event up by frame.id == event_id.
+    looked_up = raw_events.pop(event.event_id, None)
+    assert looked_up is event
+    out = _translator().translate(looked_up)
+    assert [e.type for e in out] == [
+        EventType.REASONING_START,
+        EventType.REASONING_MESSAGE_START,
+        EventType.REASONING_MESSAGE_CONTENT,
+    ]
+
+
+# --------------------------------------------------------------------------
+# Frame transport: flush open reasoning on the error path
+# --------------------------------------------------------------------------
+
+def test_flush_open_reasoning_closes_native():
+    """An open native reasoning message is closed by flush_open_reasoning."""
+    tr = _translator()
+    tr.translate(_RawThinking("a"))
+    out = tr.flush_open_reasoning()
+    assert [e.type for e in out] == [
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+    ]
+    # Idempotent: a second flush is a no-op.
+    assert tr.flush_open_reasoning() == []
+
+
+def test_flush_open_reasoning_closes_litellm():
+    """An open litellm reasoning message (START+MESSAGE_START passed through, END
+    dropped by a mid-run error) is closed by flush_open_reasoning."""
+    tr = _translator()
+    tr.translate(BridgedReasoningStartEvent(type=EventType.REASONING_START, message_id="r"))
+    tr.translate(
+        BridgedReasoningMessageStartEvent(
+            type=EventType.REASONING_MESSAGE_START, message_id="r", role="reasoning"
+        )
+    )
+    tr.translate(
+        BridgedReasoningMessageContentEvent(
+            type=EventType.REASONING_MESSAGE_CONTENT, message_id="r", delta="x"
+        )
+    )
+    out = tr.flush_open_reasoning()
+    assert [e.type for e in out] == [
+        EventType.REASONING_MESSAGE_END,
+        EventType.REASONING_END,
+    ]
+    assert out[0].message_id == "r"
+
+
+def test_flush_open_reasoning_noop_after_clean_litellm_close():
+    """A litellm reasoning message closed normally leaves nothing to flush."""
+    tr = _translator()
+    tr.translate(BridgedReasoningStartEvent(type=EventType.REASONING_START, message_id="r"))
+    tr.translate(
+        BridgedReasoningMessageStartEvent(
+            type=EventType.REASONING_MESSAGE_START, message_id="r", role="reasoning"
+        )
+    )
+    tr.translate(
+        BridgedReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id="r")
+    )
+    tr.translate(BridgedReasoningEndEvent(type=EventType.REASONING_END, message_id="r"))
+    assert tr.flush_open_reasoning() == []
+
+
+# --------------------------------------------------------------------------
+# Capability surface
+# --------------------------------------------------------------------------
+
+def test_reasoning_capability_available():
+    """Reasoning is reported available (the litellm channel is always live)."""
+    assert CAPABILITIES.reasoning_available is True
+    # native_reasoning_event_available requires crewai >= 1.10.1; the pyproject
+    # floor is >= 1.0, so only assert it against whether the event resolved.
+    assert CAPABILITIES.native_reasoning_event_available is (
+        LLMThinkingChunkEvent is not None
+    )
+
+
+# --------------------------------------------------------------------------
+# End-to-end through the real StreamFrame driver (deterministic ordering).
+# These drive a real crewai Flow through ``_run_flow_frame_stream`` and decode
+# the SSE, so they catch removal of the load-bearing lines that per-event-count
+# assertions cannot: the close-before-answer ordering hooks in ``sdk.py`` and
+# the native thinking-chunk parking in the endpoint sink gate.
+# --------------------------------------------------------------------------
+
+requires_stream_frames = pytest.mark.skipif(
+    not CAPABILITIES.stream_frame_available,
+    reason="installed crewai has no StreamFrame transport",
+)
+
+
+def _decode_sse(encoded_items):
+    payloads = []
+    for chunk in encoded_items:
+        for line in chunk.splitlines():
+            if line.startswith("data:"):
+                payloads.append(_json.loads(line[len("data:"):].strip()))
+    return payloads
+
+
+async def _collect(agen):
+    return [item async for item in agen]
+
+
+def _run_input(thread_id="t-1", run_id="r-1"):
+    from ag_ui.core import RunAgentInput
+
+    return RunAgentInput(
+        thread_id=thread_id, run_id=run_id, state={}, messages=[], tools=[],
+        context=[], forwarded_props={},
+    )
+
+
+class _ReasoningThenTextFlow(Flow):
+    """A real Flow whose method drives ``copilotkit_stream`` with a litellm stream
+    that emits reasoning deltas THEN answer text, exactly as a reasoning model
+    does. Exercises the sdk state machine end-to-end through the frame driver."""
+
+    @start()
+    async def chat(self):
+        async def _gen():
+            yield _chunk("m1", delta=Delta(content=None, reasoning_content="Because "))
+            yield _chunk("m1", delta=Delta(content=None, reasoning_content="X."))
+            yield _chunk("m1", content="Answer")
+            yield _chunk("m1", finish_reason="stop")
+
+        await copilotkit_stream(_FakeStreamWrapper(_gen()))
+        return "done"
+
+
+class _NativeThinkingFlow(Flow):
+    """A real Flow emitting crewai's native ``LLMThinkingChunkEvent`` the way the
+    Gemini provider does: with the LLM (not the flow) as source."""
+
+    @start()
+    async def chat(self):
+        crewai_event_bus.emit(
+            object(),
+            event=LLMThinkingChunkEvent(chunk="pondering", call_id="c-1"),
+        )
+        return "done"
+
+
+@requires_stream_frames
+async def test_litellm_reasoning_closes_before_answer_text_e2e():
+    """The full reasoning lifecycle is emitted, and it CLOSES
+    (REASONING_MESSAGE_END + REASONING_END) BEFORE the first answer
+    TEXT_MESSAGE_CHUNK. Deleting either ``_close_reasoning()`` hook in
+    ``sdk.py`` moves the close after the text (only the finally would fire), so
+    this ordering assertion fails."""
+    payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+        flow_copy=_ReasoningThenTextFlow(),
+        encoder=EventEncoder(),
+        input_data=_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+    )))
+    types = [p["type"] for p in payloads]
+    for t in (
+        "REASONING_START", "REASONING_MESSAGE_START", "REASONING_MESSAGE_CONTENT",
+        "REASONING_MESSAGE_END", "REASONING_END", "TEXT_MESSAGE_CHUNK",
+    ):
+        assert t in types, types
+    first_text = types.index("TEXT_MESSAGE_CHUNK")
+    # Every reasoning event precedes the answer text.
+    assert types.index("REASONING_START") < first_text
+    assert types.index("REASONING_MESSAGE_END") < first_text
+    assert types.index("REASONING_END") < first_text
+    # Lifecycle is well-ordered within itself.
+    assert (
+        types.index("REASONING_START")
+        < types.index("REASONING_MESSAGE_START")
+        < types.index("REASONING_MESSAGE_CONTENT")
+        < types.index("REASONING_MESSAGE_END")
+        < types.index("REASONING_END")
+    )
+
+
+@requires_stream_frames
+async def test_native_thinking_surfaces_reasoning_e2e():
+    """A native ``LLMThinkingChunkEvent`` (LLM as source, not the flow) surfaces
+    as REASONING_* on the wire. Removing ``is_thinking_event`` from the endpoint
+    sink gate stops the event being parked, so no REASONING_* is produced and
+    this fails."""
+    if LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+        flow_copy=_NativeThinkingFlow(),
+        encoder=EventEncoder(),
+        input_data=_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+    )))
+    types = [p["type"] for p in payloads]
+    assert "REASONING_START" in types, types
+    assert "REASONING_MESSAGE_START" in types, types
+    content = next(
+        (p for p in payloads if p["type"] == "REASONING_MESSAGE_CONTENT"), None
+    )
+    assert content is not None, types
+    assert content["delta"] == "pondering"
+    # Never RAW-mirrored (recognized channel), even though RAW defaults off here.
+    assert "RAW" not in types, types
+
+
+@requires_stream_frames
+async def test_native_thinking_not_double_emitted_under_raw_passthrough():
+    """With ``emit_raw_events=True`` the native thinking chunk is TRANSLATED to
+    REASONING_* and NOT also RAW-mirrored (it is a recognized channel), so it
+    appears exactly once as reasoning and never as RAW."""
+    if LLMThinkingChunkEvent is None:  # pragma: no cover
+        pytest.skip("installed crewai does not expose LLMThinkingChunkEvent")
+    payloads = _decode_sse(await _collect(ep._run_flow_frame_stream(
+        flow_copy=_NativeThinkingFlow(),
+        encoder=EventEncoder(),
+        input_data=_run_input(),
+        inputs={"id": "t-1"},
+        timeout=30.0,
+        emit_raw_events=True,
+    )))
+    types = [p["type"] for p in payloads]
+    assert types.count("REASONING_MESSAGE_CONTENT") == 1, types
+    raw_thinking = [
+        p for p in payloads
+        if p["type"] == "RAW" and p.get("event", {}).get("type") == "llm_thinking_chunk"
+    ]
+    assert raw_thinking == [], payloads

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -1670,15 +1670,16 @@ class _ForeignSourceEmittingFlow(Flow):
 
     @start()
     async def chat(self):
-        from ag_ui_crewai._capabilities import (
-            LLMThinkingChunkEvent,
-            crewai_event_bus,
+        from ag_ui_crewai._capabilities import crewai_event_bus
+        # A genuinely FOREIGN llm event: emitted with the LLM as source (not the
+        # flow) and NOT recognized/translated by the bridge, so it is eligible for
+        # RAW passthrough. ``llm_thinking_chunk`` is deliberately NOT used here: it
+        # is now a translated channel (-> REASONING_*), covered separately.
+        from crewai.events.types.llm_events import LLMStreamChunkEvent
+        crewai_event_bus.emit(
+            object(),  # stands in for the LLM instance crewai emits with
+            event=LLMStreamChunkEvent(chunk="pondering", call_id="c-1"),
         )
-        if LLMThinkingChunkEvent is not None:
-            crewai_event_bus.emit(
-                object(),  # stands in for the LLM instance crewai emits with
-                event=LLMThinkingChunkEvent(chunk="pondering", call_id="c-1"),
-            )
         return "done"
 
 
@@ -1713,8 +1714,8 @@ async def test_raw_passthrough_mirrors_foreign_source_events_end_to_end():
     assert all(p["source"] == "crewai" for p in raws)
     assert types.index("RUN_STARTED") < types.index("RAW"), types
 
-    thinking = next(p for p in raws if p["event"]["type"] == "llm_thinking_chunk")
-    assert thinking["event"]["chunk"] == "pondering"
+    foreign = next(p for p in raws if p["event"]["type"] == "llm_stream_chunk")
+    assert foreign["event"]["chunk"] == "pondering"
 
     # Still exactly one run lifecycle: a foreign event can never synthesize one.
     assert types.count("RUN_STARTED") == 1
@@ -1844,4 +1845,7 @@ def test_mapped_events_are_never_duplicated_as_raw():
     DOES map must not also appear as RAW."""
     assert frames_mod.is_recognized_event(_ev("flow_started")) is True
     assert frames_mod.is_recognized_event(_ev("TEXT_MESSAGE_CHUNK")) is True
-    assert frames_mod.is_recognized_event(_ev("llm_thinking_chunk")) is False
+    # ``llm_thinking_chunk`` is now mapped (-> REASONING_*), so it is recognized
+    # and must never be RAW-duplicated. A genuinely unmapped llm event still is.
+    assert frames_mod.is_recognized_event(_ev("llm_thinking_chunk")) is True
+    assert frames_mod.is_recognized_event(_ev("llm_stream_chunk")) is False


### PR DESCRIPTION
## What

Surfaces model reasoning as AG-UI `REASONING_*` events from the CrewAI bridge, **provider-agnostic** and on **both transports**. Executes PNI-128 (Lane 2, Parity). Not gated to any single provider.

Emits `REASONING_START` / `REASONING_MESSAGE_START` / `REASONING_MESSAGE_CONTENT` / `REASONING_MESSAGE_END` / `REASONING_END`, plus `REASONING_ENCRYPTED_VALUE` for Anthropic signature / redacted-thinking blocks.

## Channels

- **litellm delta** (`sdk.copilotkit_stream`): now reads `delta.reasoning_content` and `delta.thinking_blocks` alongside content/tool_calls. Covers o1/o3, deepseek-reasoner, Anthropic extended thinking, and any reasoning model litellm normalizes. `reasoning_content` wins as the per-delta text source (litellm mirrors the same text into a thinking block for Anthropic, so reading both would double-emit every token). Emitted as `Bridged*` reasoning events and translated by **both** the legacy bus listener (`endpoint.py`) and the StreamFrame translator (`_frames.py`), so the litellm channel works on both transports.
- **native crewai `LLMThinkingChunkEvent`** (Gemini provider, crewai ≥ 1.10.1): resolved in `_capabilities.py` (`crewai.events.types.llm_events`, not re-exported at the events root), parked by the frame sink by type, and driven through a stateful lifecycle in the StreamFrame translator (opens on the first chunk, closes on the next non-thinking event or `finalize`). This event exists only on crewai ≥ 1.10.1, which always has the StreamFrame transport, so it is a frame-path concern by construction.

## Capability

`_capabilities.py` exposes `reasoning_available` (true whenever any channel is live; litellm is a direct dep so effectively always) and `native_reasoning_event_available`, for the protocol capability surface (PNI-136) to consume. **Coordination note for PNI-136:** its in-flight `_reasoning_capability` currently reports reasoning available only for a native-Gemini LLM; per this ticket's reversed scope, that should report available whenever a reasoning channel is live (i.e. the litellm channel), not Gemini-only.

## Error path

`copilotkit_stream` closes an open reasoning lifecycle in a `finally`; the frame driver flushes any open reasoning (both channels, idempotent) before `RUN_ERROR` so a mid-reasoning failure never ships a half-open lifecycle. Cancellation/teardown paths are unchanged.

## Capability detection

Runtime symbol resolution + probes in `_capabilities.py` (`crewai>=1.0,<2` floor), never `crewai.__version__` control flow. Graceful no-op for non-reasoning models.

## Tests

`tests/test_reasoning.py` (25 tests): litellm delta extraction (reasoning_content, thinking text/signature, redacted, Anthropic no-double-emit, non-dict blocks), the full lifecycle through `copilotkit_stream` (content, encrypted-only, tool-close, error-close, no-reasoning), the native Gemini event path + sink→frame-lookup correlation, both-transport translation, error-path flush, and the capability flags. Full suite green (262 passed, 2 skipped) against crewai 1.15.8 + litellm 1.79.

## Verification

Verified against real `litellm.Delta` shapes and a real crewai `LLMThinkingChunkEvent` (not just class-existence): the Anthropic double-emit repro (`"Let me think"` → single emit), `reasoning_content = _handle_reasoning_content(thinking_blocks)` mirroring in litellm's Anthropic handler, and `event_id`↔`frame.id` parking. Live end-to-end against a real Gemini/reasoning model needs API keys (not available in this environment).

## Follow-ups (not in this PR)

- **bucket (d)**: reconstructed `ModelResponse` omits `thinking_blocks`/signature → Anthropic multi-turn *extended-thinking-with-tools* history round-trip (separate subject: model-history fidelity, not wire emission).
- **bucket (b), parity-documented**: legacy bus transport (crewai 1.4–1.5) leaves reasoning half-open on mid-run error, matching the langgraph reference; the frame path (the common ≥1.6 transport) is guarded.
- **bucket (c), pre-existing**: `_frames` STATE_SNAPSHOT dict branch not deep-copied; `sdk` tool-delta `IndexError` edge.

Unblocks the reasoning dojo/showcase cells and eventual deletion of the showcase synth `reasoning_agent.py`.