### PR TITLE
fix(dotnet): align A2UI injectA2UITool with the sibling adapter contract + wire AGUI.A2UI into CI/release

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -62,6 +62,7 @@ on:
           - sdk-py
           - sdk-py-a2ui-toolkit
           - sdk-dotnet
+          - sdk-dotnet-a2ui
           - sdk-ts
           - sdk-ts-a2ui-toolkit
           - create-ag-ui-app

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -44,6 +44,7 @@ on:
           - sdk-py
           - sdk-py-a2ui-toolkit
           - sdk-dotnet
+          - sdk-dotnet-a2ui
           - sdk-ts
           - sdk-ts-a2ui-toolkit
           - create-ag-ui-app

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -111,6 +111,7 @@ on:
           - sdk-py
           - sdk-py-a2ui-toolkit
           - sdk-dotnet
+          - sdk-dotnet-a2ui
           - sdk-ts
           - sdk-ts-a2ui-toolkit
           - create-ag-ui-app
@@ -1230,6 +1231,7 @@ jobs:
         run: |
           set -euo pipefail
           dotnet test tests/AGUI.Abstractions.UnitTests -c Release -p:SignAssembly=false
+          dotnet test tests/AGUI.A2UI.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Client.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Formatting.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Protobuf.UnitTests -c Release -p:SignAssembly=false
@@ -1246,6 +1248,7 @@ jobs:
           dotnet build src/AGUI.Protobuf/AGUI.Protobuf.csproj -c Release --no-incremental
           dotnet build src/AGUI.Client/AGUI.Client.csproj -c Release --no-incremental
           dotnet build src/AGUI.Server/AGUI.Server.csproj -c Release --no-incremental
+          dotnet build src/AGUI.A2UI/AGUI.A2UI.csproj -c Release --no-incremental
 
       - name: Pack NuGet packages
         shell: bash
@@ -1602,7 +1605,7 @@ jobs:
               NUGET_INTENDED=true
             else
               # Map the dispatch scope to its ecosystem. The explicit NuGet arm
-              # catches sdk-dotnet. The *-py glob catches the sdk-py /
+              # catches the sdk-dotnet* scopes. The *-py glob catches the sdk-py /
               # integration-*-py PyPI scopes; the explicit Python names cover
               # PyPI scopes that do NOT end in -py. Everything else is npm. This
               # only affects FAILURE paging — success arms use the real
@@ -1614,7 +1617,7 @@ jobs:
               # verify-release-scope-dropdowns.sh asserts this list maps every
               # config scope to the correct ecosystem, so it cannot drift.
               case "$SCOPE" in
-                sdk-dotnet)
+                sdk-dotnet|sdk-dotnet-a2ui)
                   NUGET_INTENDED=true ;;
                 integration-agent-spec|integration-langroid|sdk-py-a2ui-toolkit)
                   PY_INTENDED=true ;;

--- a/.github/workflows/unit-dotnet-sdk.yml
+++ b/.github/workflows/unit-dotnet-sdk.yml
@@ -62,6 +62,7 @@ jobs:
           dotnet build src/AGUI.Protobuf/AGUI.Protobuf.csproj -c Release
           dotnet build src/AGUI.Client/AGUI.Client.csproj -c Release
           dotnet build src/AGUI.Server/AGUI.Server.csproj -c Release
+          dotnet build src/AGUI.A2UI/AGUI.A2UI.csproj -c Release
 
       # Run the self-contained test projects directly rather than the whole
       # AGUI.slnx: the AGUIDojoServer sample references a sibling agent-framework
@@ -69,6 +70,7 @@ jobs:
       - name: Run unit tests
         run: |
           dotnet test tests/AGUI.Abstractions.UnitTests -c Release -p:SignAssembly=false
+          dotnet test tests/AGUI.A2UI.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Client.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Formatting.UnitTests -c Release -p:SignAssembly=false
           dotnet test tests/AGUI.Protobuf.UnitTests -c Release -p:SignAssembly=false

--- a/scripts/release/detect-dotnet-version-changes.sh
+++ b/scripts/release/detect-dotnet-version-changes.sh
@@ -25,10 +25,21 @@ if ! (cd "$REPO_ROOT" && node -e "require('semver')") 2>/dev/null; then
   exit 1
 fi
 
+# `autoPublish: false` marks a scope as SEQUENCED SEPARATELY: it is enrolled in
+# release.config.json (so it is discoverable, canary-selectable, and covered by the
+# scope-dropdown guards) but is skipped by this automatic stable sweep. Without it a
+# not-yet-on-NuGet package would be detected as NEW (404) and published on the very
+# next stable release. Flipping the flag to true (or removing it) is the reviewed,
+# git-tracked "graduation" event that enrolls the scope in the shared train.
+# Omitted => true, so every already-shipping scope keeps its current behavior.
+# NOTE: the predicate is `!= false`, NOT `(.autoPublish // true)` — jq's `//` treats
+# BOTH null and false as absent, so `false // true` evaluates to true and would
+# silently publish every scope this flag is meant to hold back.
 DOTNET_PACKAGES=$(jq -c '
   [
     .scopes | to_entries[]
     | select(any(.value.packages[]; .ecosystem == "dotnet"))
+    | select(.value.autoPublish != false)
     | .value.versionSource as $versionSource
     | .value.packages[]
     | select(.ecosystem == "dotnet")

--- a/scripts/release/detect-py-version-changes.sh
+++ b/scripts/release/detect-py-version-changes.sh
@@ -24,7 +24,11 @@ fi
 # source of truth prevents drift between the version-bumper (prepare-release.ts)
 # and the publisher (this script) — if a Python package is enrolled in the
 # config it gets both bumped and published.
-PY_PACKAGES=$(jq -c '[.scopes[].packages[] | select(.ecosystem == "python") | {dir: .path, build_system: .buildSystem}]' "$CONFIG")
+# Scopes marked `autoPublish: false` are sequenced separately: enrolled in
+# release.config.json but skipped by this automatic sweep until they graduate (see
+# detect-dotnet-version-changes.sh for the rationale). Omitted => true; the predicate is
+# `!= false` because jq's `//` treats false as absent (`false // true` == true).
+PY_PACKAGES=$(jq -c '[.scopes[] | select(.autoPublish != false) | .packages[] | select(.ecosystem == "python") | {dir: .path, build_system: .buildSystem}]' "$CONFIG")
 if [ -z "$PY_PACKAGES" ] || [ "$PY_PACKAGES" = "[]" ]; then
   echo "ERROR: release.config.json has no Python packages" >&2
   exit 1

--- a/scripts/release/detect-ts-version-changes.sh
+++ b/scripts/release/detect-ts-version-changes.sh
@@ -37,7 +37,11 @@ if ! (cd "$REPO_ROOT" && node -e "require('semver')") 2>/dev/null; then
 fi
 
 # Build allowlist: every TypeScript package name listed under any scope.
-ALLOWLIST=$(jq -r '[.scopes[].packages[] | select(.ecosystem == "typescript") | .name] | sort | unique | join("\n")' "$CONFIG")
+# Scopes marked `autoPublish: false` are sequenced separately: enrolled in
+# release.config.json but skipped by this automatic sweep until they graduate (see
+# detect-dotnet-version-changes.sh for the rationale). Omitted => true; the predicate is
+# `!= false` because jq's `//` treats false as absent (`false // true` == true).
+ALLOWLIST=$(jq -r '[.scopes[] | select(.autoPublish != false) | .packages[] | select(.ecosystem == "typescript") | .name] | sort | unique | join("\n")' "$CONFIG")
 if [ -z "$ALLOWLIST" ]; then
   echo "ERROR: release.config.json has no TypeScript packages" >&2
   exit 1

--- a/scripts/release/release.config.json
+++ b/scripts/release/release.config.json
@@ -24,6 +24,15 @@
         { "name": "AGUI.Server", "path": "sdks/dotnet/src/AGUI.Server", "ecosystem": "dotnet" }
       ]
     },
+    "sdk-dotnet-a2ui": {
+      "description": "A2UI .NET SDK package (sequenced separately from the sdk-dotnet train; versioned with the cross-language A2UI family)",
+      "sharedVersion": false,
+      "versionSource": "sdks/dotnet/src/AGUI.A2UI/AGUI.A2UI.csproj",
+      "autoPublish": false,
+      "packages": [
+        { "name": "AGUI.A2UI", "path": "sdks/dotnet/src/AGUI.A2UI", "ecosystem": "dotnet" }
+      ]
+    },
     "create-ag-ui-app": {
       "description": "create-ag-ui-app CLI (independently versioned)",
       "sharedVersion": false,

--- a/sdks/dotnet/samples/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
+++ b/sdks/dotnet/samples/AGUIClientServer/AGUIDojoServer/ChatClientAgentFactory.cs
@@ -328,7 +328,12 @@ internal static class ChatClientAgentFactory
         // still balance a mid-stream failure.
         A2UIChatClientOptions resolved = new()
         {
-            InjectA2UITool = options.InjectA2UITool,
+            // Backend opt-in — the `config` half of the siblings' `forwarded ?? config` rule
+            // (ADK `a2ui["inject_a2ui_tool"]`, AWS Strands / Mastra `a2ui.injectA2UITool`),
+            // which exists precisely for a host that does not forward the runtime flag. The
+            // dojo forwards `injectA2UITool` only for langgraph* / mastra-agent-local, so these
+            // demos opt in server-side. A client-sent `false` still wins.
+            InjectA2UITool = options.InjectA2UITool ?? true,
             ToolParams = options.ToolParams,
             StreamingToolCallArgumentExtractor = OpenAIStreamingToolArguments.Extract,
         };

--- a/sdks/dotnet/src/AGUI.A2UI/A2UIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.A2UI/A2UIChatClient.cs
@@ -9,10 +9,10 @@ namespace AGUI.A2UI;
 
 /// <summary>
 /// An <see cref="IChatClient"/> decorator that adds A2UI (agent-generated UI) surface
-/// generation. Every streamed run advertises a <c>generate_a2ui</c> tool; when the wrapped
-/// model calls it, the decorator drives a <c>render_a2ui</c> structured-output subagent
-/// through the shared validate-and-retry recovery loop and feeds the resulting A2UI
-/// operations envelope back as the tool result.
+/// generation. When injection is enabled for the run, the streamed run advertises a
+/// <c>generate_a2ui</c> tool; when the wrapped model calls it, the decorator drives a
+/// <c>render_a2ui</c> structured-output subagent through the shared validate-and-retry
+/// recovery loop and feeds the resulting A2UI operations envelope back as the tool result.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -45,6 +45,7 @@ public sealed class A2UIChatClient : DelegatingChatClient
     private readonly IChatClient _subagentChatClient;
     private readonly A2UIResolvedToolParams _parameters;
     private readonly bool? _injectOption;
+    private readonly string? _injectedRenderToolName;
     private readonly Func<ChatResponseUpdate, IEnumerable<AGUIToolCallArgumentFragment>?>? _streamingArgExtractor;
 
     /// <summary>
@@ -65,6 +66,7 @@ public sealed class A2UIChatClient : DelegatingChatClient
         this._subagentChatClient = subagentChatClient;
         this._parameters = A2UIToolDefinitions.ResolveA2UIToolParams(options?.ToolParams);
         this._injectOption = options?.InjectA2UITool;
+        this._injectedRenderToolName = options?.InjectedRenderToolName;
         this._streamingArgExtractor = options?.StreamingToolCallArgumentExtractor;
     }
 
@@ -93,9 +95,12 @@ public sealed class A2UIChatClient : DelegatingChatClient
         bool devWired = options?.Tools is { } tools &&
             tools.Any(t => string.Equals(t.Name, toolName, StringComparison.Ordinal));
 
+        (bool inject, string renderToolName) = ResolveInjection(
+            this._injectOption, this._injectedRenderToolName, options);
+
         // USER PREVAILS: a developer-wired generate_a2ui tool owns the behavior — do not
         // clobber it. Likewise honor a resolved opt-out. Either way, delegate untouched.
-        if (devWired || !ShouldInject(this._injectOption, options))
+        if (devWired || !inject)
         {
             await foreach (ChatResponseUpdate update in base.InnerClient
                 .GetStreamingResponseAsync(messages, options, cancellationToken)
@@ -112,7 +117,16 @@ public sealed class A2UIChatClient : DelegatingChatClient
 
         ChatOptions plannerOptions = options?.Clone() ?? new ChatOptions();
         var generateTool = new GenerateA2UIToolDeclaration(toolName, this._parameters.ToolDescription);
+
+        // Drop the A2UI middleware's injected render proxy before advertising generate_a2ui.
+        // The middleware adds `render_a2ui` to RunAgentInput.Tools in the SAME step that
+        // forwards `injectA2UITool`, and the hosting layer maps those onto ChatOptions.Tools —
+        // so whenever the flag arrives, the proxy does too. Left in place the planner would see
+        // both tools and could call the proxy directly, painting a surface that skips the
+        // subagent and the validate-and-retry loop entirely. Mirrors the sibling adapters'
+        // `dropToolNames` / `drop_tool_names` step.
         plannerOptions.Tools = (plannerOptions.Tools ?? Enumerable.Empty<AITool>())
+            .Where(t => !string.Equals(t.Name, renderToolName, StringComparison.Ordinal))
             .Append(generateTool)
             .ToList();
 
@@ -325,21 +339,70 @@ public sealed class A2UIChatClient : DelegatingChatClient
         envelopeBox.Value = ParseEnvelope(A2UIGenerationRecovery.WrapRecoveryExhaustedEnvelope(maxAttempts, attempts));
     }
 
-    // Resolves the per-run injection decision. The forwarded runtime flag wins when present
-    // (an explicit client false beats a backend opt-in); otherwise the
-    // backend option; otherwise on, because wrapping is itself the opt-in.
-    private static bool ShouldInject(bool? injectOption, ChatOptions? options)
+    // Resolves the per-run injection decision plus the name of the middleware-injected render
+    // proxy to drop. The forwarded runtime flag wins when present (an explicit client false
+    // beats a backend opt-in); otherwise the backend option; otherwise OFF, matching the
+    // sibling adapters' "no injectA2UITool, no injection" contract — wrapping alone must not
+    // advertise a tool whose surfaces nothing on the client is set up to paint.
+    //
+    // The wire flag is `boolean | string` (a string names the injected render proxy), and an
+    // empty string is falsy in the TS/Python siblings, so it reads as an opt-out here too.
+    internal static (bool Inject, string RenderToolName) ResolveInjection(
+        bool? injectOption,
+        string? injectedRenderToolName,
+        ChatOptions? options)
     {
-        if (options is not null &&
-            options.TryGetRunAgentInput(out RunAgentInput? input) &&
-            input.ForwardedProperties.ValueKind == JsonValueKind.Object &&
-            input.ForwardedProperties.TryGetProperty("injectA2UITool", out JsonElement flag) &&
-            flag.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        string fallbackName = string.IsNullOrEmpty(injectedRenderToolName)
+            ? A2UIConstants.RenderA2UIToolName
+            : injectedRenderToolName!;
+
+        if (TryReadForwardedFlag(options, out bool forwarded, out string? forwardedName))
         {
-            return flag.GetBoolean();
+            return (forwarded, forwardedName ?? fallbackName);
         }
 
-        return injectOption ?? true;
+        return (injectOption ?? false, fallbackName);
+    }
+
+    // Reads the forwarded injectA2UITool flag. Returns false when the run carries no usable
+    // flag, so the caller falls back to the backend option. A non-boolean, non-string value
+    // (null/number/array/object) is not a usable flag and is treated as absent.
+    private static bool TryReadForwardedFlag(ChatOptions? options, out bool inject, out string? renderToolName)
+    {
+        inject = false;
+        renderToolName = null;
+
+        if (options is null ||
+            !options.TryGetRunAgentInput(out RunAgentInput? input) ||
+            input.ForwardedProperties.ValueKind != JsonValueKind.Object ||
+            !input.ForwardedProperties.TryGetProperty("injectA2UITool", out JsonElement flag))
+        {
+            return false;
+        }
+
+        switch (flag.ValueKind)
+        {
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                inject = flag.GetBoolean();
+                return true;
+
+            case JsonValueKind.String:
+                string? name = flag.GetString();
+                if (string.IsNullOrEmpty(name))
+                {
+                    // "" is falsy in the siblings' `if (!flag) skip` gate — an opt-out.
+                    inject = false;
+                    return true;
+                }
+
+                inject = true;
+                renderToolName = name;
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     // Reads the A2UI state (catalog schema + forwarded context entries) from the

--- a/sdks/dotnet/src/AGUI.A2UI/A2UIChatClientOptions.cs
+++ b/sdks/dotnet/src/AGUI.A2UI/A2UIChatClientOptions.cs
@@ -11,13 +11,29 @@ namespace AGUI.A2UI;
 public sealed class A2UIChatClientOptions
 {
     /// <summary>
-    /// Gets whether to inject the <c>generate_a2ui</c> tool. <see langword="null"/> (the
-    /// default) means "auto": the per-run forwarded <c>injectA2UITool</c> flag wins when
-    /// present, otherwise injection is on because wrapping with <see cref="A2UIChatClient"/>
-    /// is itself the opt-in. An explicit value here is the backend override and is used only
-    /// when the run forwards no flag, so a client-sent <see langword="false"/> still wins.
+    /// Gets whether to inject the <c>generate_a2ui</c> tool. The per-run forwarded
+    /// <c>injectA2UITool</c> flag wins when present; this value is the backend opt-in used
+    /// only when the run forwards no flag, so a client-sent <see langword="false"/> still
+    /// wins. <see langword="null"/> (the default) means <b>off</b> — matching the sibling
+    /// adapters' "no <c>injectA2UITool</c>, no injection" contract (ADK
+    /// <c>a2ui["inject_a2ui_tool"]</c>, AWS Strands / Mastra <c>a2ui.injectA2UITool</c>).
+    /// Set <see langword="true"/> to opt in on a host that does not forward the flag.
     /// </summary>
     public bool? InjectA2UITool { get; init; }
+
+    /// <summary>
+    /// Gets the name under which the A2UI middleware injected its <c>render_a2ui</c> proxy
+    /// tool, which is dropped from the planner's tool list so the model calls
+    /// <c>generate_a2ui</c> instead of painting a surface directly (bypassing the subagent and
+    /// the validate-and-retry loop). Defaults to
+    /// <see cref="A2UIConstants.RenderA2UIToolName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only needed when the host configured the middleware with a custom name
+    /// (<c>injectA2UITool: "myName"</c>). When the run forwards that string form, the
+    /// forwarded name takes precedence over this value.
+    /// </remarks>
+    public string? InjectedRenderToolName { get; init; }
 
     /// <summary>
     /// Gets the shared toolkit parameters (tool name/description, guidelines, default surface

--- a/sdks/dotnet/src/AGUI.A2UI/AGUI.A2UI.csproj
+++ b/sdks/dotnet/src/AGUI.A2UI/AGUI.A2UI.csproj
@@ -4,6 +4,12 @@
     <TargetFrameworks>$(TargetFrameworksCore)</TargetFrameworks>
     <RootNamespace>AGUI.A2UI</RootNamespace>
     <PackageId>AGUI.A2UI</PackageId>
+    <!-- Sequenced separately from the sdk-dotnet train (release.config.json scope
+         `sdk-dotnet-a2ui`). This overrides the shared default in Directory.Build.props so
+         A2UI moves on its own cadence, pinned to the cross-language A2UI family version
+         shared by @ag-ui/a2ui-toolkit and ag-ui-a2ui-toolkit — NOT to the .NET SDK's
+         VersionPrefix, which those siblings' SDK trains (0.0.57 / 0.1.19) already diverge from. -->
+    <VersionPrefix>0.0.4</VersionPrefix>
     <Description>A2UI (agent-generated UI) toolkit and IChatClient adapter for the AG-UI protocol: injects the generate_a2ui tool, drives a render_a2ui subagent with a validate-and-retry recovery loop, and streams surfaces progressively.</Description>
     <PackageTags>$(PackageTags);a2ui;generative-ui;adapter;streaming;chat;microsoft-extensions-ai</PackageTags>
   </PropertyGroup>

--- a/sdks/dotnet/src/AGUI.A2UI/PublicAPI.Unshipped.txt
+++ b/sdks/dotnet/src/AGUI.A2UI/PublicAPI.Unshipped.txt
@@ -17,6 +17,8 @@ AGUI.A2UI.A2UIChatClientOptions
 AGUI.A2UI.A2UIChatClientOptions.A2UIChatClientOptions() -> void
 AGUI.A2UI.A2UIChatClientOptions.InjectA2UITool.get -> bool?
 AGUI.A2UI.A2UIChatClientOptions.InjectA2UITool.init -> void
+AGUI.A2UI.A2UIChatClientOptions.InjectedRenderToolName.get -> string?
+AGUI.A2UI.A2UIChatClientOptions.InjectedRenderToolName.init -> void
 AGUI.A2UI.A2UIChatClientOptions.StreamingToolCallArgumentExtractor.get -> System.Func<Microsoft.Extensions.AI.ChatResponseUpdate!, System.Collections.Generic.IEnumerable<AGUI.Server.AGUIToolCallArgumentFragment!>?>?
 AGUI.A2UI.A2UIChatClientOptions.StreamingToolCallArgumentExtractor.init -> void
 AGUI.A2UI.A2UIChatClientOptions.ToolParams.get -> AGUI.A2UI.A2UIToolParams?

--- a/sdks/dotnet/tests/AGUI.A2UI.UnitTests/A2UIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.A2UI.UnitTests/A2UIChatClientTest.cs
@@ -26,6 +26,10 @@ public sealed class A2UIChatClientTest
         var subagent = new MidStreamThrowingSubagentClient();
         var options = new A2UIChatClientOptions
         {
+            // Injection is off unless the run forwards injectA2UITool or the backend opts in
+            // (the sibling "no injectA2UITool, no injection" contract). This test drives the
+            // decorator directly with no RunAgentInput, so it opts in explicitly.
+            InjectA2UITool = true,
             StreamingToolCallArgumentExtractor = u => u.RawRepresentation as IEnumerable<AGUIToolCallArgumentFragment>,
         };
         var client = new A2UIChatClient(planner, subagent, options);

--- a/sdks/dotnet/tests/AGUI.A2UI.UnitTests/A2UIInjectionGateTest.cs
+++ b/sdks/dotnet/tests/AGUI.A2UI.UnitTests/A2UIInjectionGateTest.cs
@@ -1,0 +1,304 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AGUI.Abstractions;
+using AGUI.Server;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AGUI.A2UI.UnitTests;
+
+/// <summary>
+/// Contract tests for the <c>injectA2UITool</c> gate and the render-proxy drop, pinning parity
+/// with the sibling adapters (ADK <c>plan_a2ui_injection</c>, AWS Strands / Mastra
+/// <c>planA2UIInjection</c>):
+/// <list type="number">
+/// <item>OFF unless the run forwards <c>injectA2UITool</c> OR the backend opts in
+/// ("no <c>injectA2UITool</c>, no injection").</item>
+/// <item>Nullish precedence — a forwarded <see langword="false"/> beats a backend opt-in.</item>
+/// <item>The flag is <c>boolean | string</c>; a string names the injected render proxy, and an
+/// empty string is falsy (an opt-out).</item>
+/// <item>USER PREVAILS — a dev-wired <c>generate_a2ui</c> is never clobbered.</item>
+/// <item>The middleware-injected render proxy is DROPPED, so the planner cannot bypass the
+/// subagent + validate-and-retry loop by calling it directly.</item>
+/// </list>
+/// </summary>
+public sealed class A2UIInjectionGateTest
+{
+    private const string GenerateTool = A2UIConstants.GenerateA2UIToolName;
+    private const string RenderProxy = A2UIConstants.RenderA2UIToolName;
+
+    // ---- 1. Default is OFF (the sibling contract) -------------------------------------------
+
+    [Fact]
+    public async Task NoForwardedFlagAndNoBackendOptIn_DoesNotInjectAsync()
+    {
+        var planner = await RunAsync(options: new A2UIChatClientOptions(), forwardedJson: null);
+
+        // Wrapping alone must not advertise generate_a2ui: nothing on the client is necessarily
+        // set up to paint the resulting surfaces. Mirrors ADK/Strands `if not flag: return None`.
+        Assert.DoesNotContain(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task BackendOptIn_WithoutForwardedFlag_InjectsAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions { InjectA2UITool = true },
+            forwardedJson: null);
+
+        // The `config` half of `forwarded ?? config` — for hosts that never forward the flag.
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task BackendExplicitFalse_DoesNotInjectAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions { InjectA2UITool = false },
+            forwardedJson: null);
+
+        Assert.DoesNotContain(GenerateTool, planner.LastToolNames);
+    }
+
+    // ---- 2. Nullish precedence ---------------------------------------------------------------
+
+    [Fact]
+    public async Task ForwardedTrue_InjectsWithoutBackendOptInAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: """{"injectA2UITool":true}""");
+
+        // The client can ENABLE A2UI, not merely veto it.
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task ForwardedFalse_BeatsBackendOptInAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions { InjectA2UITool = true },
+            forwardedJson: """{"injectA2UITool":false}""");
+
+        // An explicit runtime false disables injection even when the backend opted in — the
+        // case ADK pins in test_a2ui_tool.py.
+        Assert.DoesNotContain(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task ForwardedNonBooleanNonString_TreatedAsAbsentAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions { InjectA2UITool = true },
+            forwardedJson: """{"injectA2UITool":3}""");
+
+        // A number is not a usable flag: fall through to the backend option rather than
+        // silently disabling (or enabling) on malformed input.
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+    }
+
+    // ---- 3. The string form ------------------------------------------------------------------
+
+    [Fact]
+    public async Task ForwardedEmptyString_DoesNotInjectAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: """{"injectA2UITool":""}""");
+
+        // "" is falsy in the TS/Python siblings' `if (!flag)` gate.
+        Assert.DoesNotContain(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task ForwardedStringName_InjectsAndDropsThatProxyAsync()
+    {
+        const string CustomProxy = "render_ui_custom";
+
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: $"{{\"injectA2UITool\":\"{CustomProxy}\"}}",
+            clientToolNames: [CustomProxy]);
+
+        // A string is truthy AND names the proxy the middleware injected under a custom name.
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+        Assert.DoesNotContain(CustomProxy, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task BackendInjectedRenderToolName_DropsThatProxyAsync()
+    {
+        const string CustomProxy = "paint_surface";
+
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions
+            {
+                InjectA2UITool = true,
+                InjectedRenderToolName = CustomProxy,
+            },
+            forwardedJson: null,
+            clientToolNames: [CustomProxy]);
+
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+        Assert.DoesNotContain(CustomProxy, planner.LastToolNames);
+    }
+
+    // ---- 5. The render-proxy drop ------------------------------------------------------------
+
+    [Fact]
+    public async Task ForwardedFlag_DropsInjectedRenderProxyAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: """{"injectA2UITool":true}""",
+            clientToolNames: [RenderProxy]);
+
+        // The middleware injects `render_a2ui` into RunAgentInput.Tools in the SAME step that
+        // forwards the flag, and the hosting layer maps it onto ChatOptions.Tools. Left in place
+        // the planner could call it directly and paint a surface that skipped the subagent and
+        // the validate-and-retry loop — a SILENT bypass of two of the four A2UI pillars.
+        Assert.DoesNotContain(RenderProxy, planner.LastToolNames);
+        Assert.Contains(GenerateTool, planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task Drop_PreservesUnrelatedClientToolsAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: """{"injectA2UITool":true}""",
+            clientToolNames: [RenderProxy, "get_weather", "search_flights"]);
+
+        // Only the proxy goes — the developer's own tools must survive untouched.
+        Assert.DoesNotContain(RenderProxy, planner.LastToolNames);
+        Assert.Contains("get_weather", planner.LastToolNames);
+        Assert.Contains("search_flights", planner.LastToolNames);
+    }
+
+    [Fact]
+    public async Task NoInjection_DoesNotDropTheProxyAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions(),
+            forwardedJson: """{"injectA2UITool":false}""",
+            clientToolNames: [RenderProxy]);
+
+        // Opted out: delegate untouched. Removing a client tool the adapter is not managing
+        // would break a host that drives the render proxy itself.
+        Assert.Contains(RenderProxy, planner.LastToolNames);
+        Assert.DoesNotContain(GenerateTool, planner.LastToolNames);
+    }
+
+    // ---- 4. USER PREVAILS --------------------------------------------------------------------
+
+    [Fact]
+    public async Task DevWiredGenerateTool_DelegatesUntouchedAsync()
+    {
+        var planner = await RunAsync(
+            options: new A2UIChatClientOptions { InjectA2UITool = true },
+            forwardedJson: """{"injectA2UITool":true}""",
+            clientToolNames: [GenerateTool, RenderProxy]);
+
+        // The dev owns generate_a2ui — do not double-inject, and do not mangle their tool list.
+        Assert.Equal(1, planner.LastToolNames.Count(n => n == GenerateTool));
+        Assert.Contains(RenderProxy, planner.LastToolNames);
+    }
+
+    // ---- harness -----------------------------------------------------------------------------
+
+    // Drives one streamed run through the decorator and returns the planner, which records the
+    // tool list it was actually handed. The planner emits text only (no generate_a2ui call), so
+    // the decorator's loop terminates after one round and the subagent is never invoked.
+    private static async Task<RecordingPlannerClient> RunAsync(
+        A2UIChatClientOptions options,
+        string? forwardedJson,
+        string[]? clientToolNames = null)
+    {
+        var planner = new RecordingPlannerClient();
+        var client = new A2UIChatClient(planner, new NeverCalledSubagentClient(), options);
+
+        ChatOptions chatOptions = BuildChatOptions(forwardedJson, clientToolNames);
+        await foreach (var _ in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "make a card")], chatOptions).ConfigureAwait(false))
+        {
+            // Drain.
+        }
+
+        Assert.Equal(1, planner.Calls);
+        return planner;
+    }
+
+    // Builds ChatOptions the way the AG-UI hosting layer does, so forwardedProps and the
+    // client tool list travel the real path (ToChatRequestContext stamps the RunAgentInput and
+    // maps input.Tools onto ChatOptions.Tools) rather than a test-only shortcut.
+    private static ChatOptions BuildChatOptions(string? forwardedJson, string[]? clientToolNames)
+    {
+        var input = new RunAgentInput
+        {
+            ThreadId = "thread-1",
+            RunId = "run-1",
+            Messages = [],
+            Tools = clientToolNames?.Select(name => new AGUITool
+            {
+                Name = name,
+                Description = name,
+                Parameters = JsonDocument.Parse("""{"type":"object","properties":{}}""").RootElement.Clone(),
+            }).ToList(),
+        };
+
+        if (forwardedJson is not null)
+        {
+            input.ForwardedProperties = JsonDocument.Parse(forwardedJson).RootElement.Clone();
+        }
+
+        return input.ToChatRequestContext(AIJsonUtilities.DefaultOptions).ChatOptions;
+    }
+
+    // Records the tool names it was handed, then emits text only so the planner loop ends.
+    private sealed class RecordingPlannerClient : IChatClient
+    {
+        public List<string> LastToolNames { get; private set; } = [];
+
+        public int Calls { get; private set; }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask.ConfigureAwait(false);
+            this.Calls++;
+            this.LastToolNames = (options?.Tools ?? []).Select(t => t.Name).ToList();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "Nothing to render.");
+        }
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    // The gate tests never reach generation; a call here means the decorator ran a subagent it
+    // should not have.
+    private sealed class NeverCalledSubagentClient : IChatClient
+    {
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("The render subagent must not run in a gate test.");
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## What

Review follow-ups for #2262, targeting its branch so they land with it. Two independent problems: the `injectA2UITool` contract, and the fact that `AGUI.A2UI` is invisible to CI and the release pipeline.

Everything here was verified by building and running the suites locally (.NET SDK 10 + the 8/9 runtimes) — see **Verification** for what was *not* verified.

## 1. `injectA2UITool` diverged from the sibling adapters

`injectA2UITool` is not just a boolean gate — it's half of a handshake. The middleware's `injectToolAndFlag` sets `forwardedProps.injectA2UITool` **and** appends a `render_a2ui` proxy to `input.tools` in the same inseparable step, and the type is `boolean | string` where a string names that proxy. ADK, AWS Strands and Mastra therefore all implement the same six steps.

| Step | ADK / Strands / Mastra | `A2UIChatClient` before | Now |
|---|---|---|---|
| `forwarded ?? config` precedence | ✅ | ✅ already correct | ✅ |
| USER PREVAILS on dev-wired tool | ✅ | ✅ already correct | ✅ |
| Default when nothing is set | **off** | **on** | ✅ off |
| String form names the proxy | ✅ | ignored | ✅ honored |
| Drop the injected render proxy | ✅ | **absent** | ✅ dropped |

**The proxy drop is the substantive fix.** `RunAgentInputExtensions` maps `input.Tools` onto `ChatOptions.Tools`, so whenever the flag arrives the proxy arrives with it. The planner then saw *both* `render_a2ui` and `generate_a2ui`; if the model picked the proxy, the surface still painted — via the middleware's direct-render path, with **no subagent, no validation, no validate-and-retry, no prior-surface grounding**. Two of the four A2UI pillars silently evaporate. A silent degradation is worse than a failure.

**Why this wasn't caught:** the dojo route sets `injectsA2UITool` for `langgraph*` / `mastra-agent-local` only — `ag-ui-dotnet` is deliberately excluded. So the flag is never forwarded, no proxy is ever injected, and `input.tools` is empty. #2262 cites exactly that as proof of pillar 1 ("`generate_a2ui` appears with request `tools: []`"), which confirms the one configuration in which the gap *cannot* manifest.

**On the default:** flipping it to off is the smaller change of the two, and `.UseA2UI()` being an explicit opt-in is a real distinction the siblings lack. But every sibling that does adapter-level injection defaults off *and* ships a backend opt-in documented for exactly this case ("opt in without the runtime flag… for non-CopilotKit hosts"). The concrete cost of default-on: a client can only ever *veto* A2UI, never *enable* it. LangGraph is not a counterexample — it has no adapter-level injection at all; it passes the flag into `ag-ui` state and the graph decides.

The dojo demos now opt in server-side via that same backend mechanism, so **behavior is unchanged**. `a2ui_fixed_schema` needed nothing (never wrapped).

### API shape — one call worth your review

`InjectA2UITool` stays `bool?` and gains a sibling `InjectedRenderToolName` (`string?`) rather than emulating TS's `boolean | string` union in one property. Two typed properties are more idiomatic C#, need no new public type, and give the same capability. If you'd rather mirror the siblings exactly, a small struct with implicit conversions from `bool`/`string` would do it — say the word.

## 2. `AGUI.A2UI` was invisible to CI and release

Neither workflow built the library or ran its test project, and the package was absent from `release.config.json`. **Its unit tests never ran on any PR** (#2262's CI is green partly because they don't run), and the package could never publish despite the csproj declaring `PackageId`/`Description`/`PackageTags`.

- **CI** — build `src/AGUI.A2UI`, run `tests/AGUI.A2UI.UnitTests`, in both `unit-dotnet-sdk.yml` and the `publish-release.yml` pre-publish gate.
- **Release** — enrolled in its own `sdk-dotnet-a2ui` scope, not the shared `sdk-dotnet` train, mirroring how its own siblings `sdk-ts-a2ui-toolkit` / `sdk-py-a2ui-toolkit` are already sequenced.

### `autoPublish`, and why a scope alone isn't enough

For **stable** releases the .NET detector is *not* scope-filtered: it sweeps every dotnet package in the config, and one not yet on NuGet returns 404, is marked `NEW (unpublished)`, and would publish on the very next stable run. Scope only gates prerelease/canary.

So this adds a declarative scope-level `autoPublish` flag. The scope stays enrolled — discoverable, canary-selectable, covered by the scope guards — but is skipped by the automatic sweep. Flipping it to `true` (or deleting it) is the reviewed, git-tracked graduation event.

**It scales:** honored by all three detectors (dotnet/ts/py), so it works for any future separately-sequenced library in any ecosystem. `Omitted => true`, so all 32 existing scopes are untouched — verified: TS still resolves 25 packages, Python 10.

> ⚠️ The predicate is `!= false`, **not** `(.autoPublish // true)`. jq's `//` treats `false` as absent, so `false // true` evaluates to `true` — my first attempt was a silent no-op that still published A2UI. Caught only by testing the predicate rather than trusting it; there's a comment warning off the `//` form.

### Version pinning

`AGUI.A2UI` gets its own `VersionPrefix`, pinned to the **cross-language A2UI family version** (`0.0.4`, shared by `@ag-ui/a2ui-toolkit` and `ag-ui-a2ui-toolkit`) rather than inheriting the .NET train's shared default.

| Package | Version | Train |
|---|---|---|
| `@ag-ui/core` | 0.0.57 | sdk-ts |
| `ag-ui-protocol` | 0.1.19 | sdk-py |
| `@ag-ui/a2ui-toolkit` | **0.0.4** | independent |
| `ag-ui-a2ui-toolkit` | **0.0.4** | independent |

Without its own prefix the package would publish at the train's version and thereafter move only when the train moved — *delayed, then permanently re-coupled*, which isn't separate sequencing. That the .NET train also currently reads `0.0.4` is a coincidence that masks the drift.

`0.0.4` is a judgment call and the one line to change if you disagree — `0.0.1` is the alternative if it should carry its own history.

Adding a scope trips `verify-release-scope-dropdowns.sh`, which enforces four hand-maintained projections (three scope dropdowns + the notify-job ecosystem case). All updated. I tried a `sdk-dotnet*)` glob so future scopes would auto-map, but the guard does literal pattern comparison — explicit enumeration is the intended anti-drift design.

## Tests

`A2UIInjectionGateTest` — 13 cases covering the gate matrix, precedence, the string form (including empty-string-as-falsy and malformed values), the proxy drop, and USER PREVAILS. It drives `ChatOptions` through the real `ToChatRequestContext` path so `forwardedProps` and the client tool list travel production plumbing, not a test-only shortcut.

**These pin real behavior.** Run against the pre-fix adapter, **6 of 13 fail** — exactly the default-off, empty-string and four proxy-drop cases. The other 7 pass on both, guarding the precedence that was already correct.

A2UI suite: **98 → 111**.

| Suite | net8.0 | net9.0 | net10.0 |
|---|---|---|---|
| AGUI.A2UI.UnitTests | 111 ✅ | 111 ✅ | 111 ✅ |
| AGUI.Abstractions.UnitTests | 185 ✅ | 185 ✅ | 185 ✅ |
| AGUI.Client.UnitTests | 114 ✅ | 114 ✅ | 114 ✅ |
| AGUI.Server.UnitTests | 119 ✅ | 119 ✅ | 119 ✅ |
| AGUI.Protobuf.UnitTests | 53 ✅ | 53 ✅ | 53 ✅ |
| AGUI.Formatting.UnitTests | 8 ✅ | 8 ✅ | 8 ✅ |
| Hosting.AspNetCore.IntegrationTests | — | — | 117 ✅ |

**0 failures.** All six libraries + the dojo sample build with zero warnings (`TreatWarningsAsErrors=true`, so the PublicAPI and AOT/trim analyzers are enforcing). Release guards: `verify-release-scope-dropdowns.sh` and `verify-nx-release-allowlist.sh` both pass.

## Verification gaps

- **`dotnet pack` never ran** — killed by the sandbox this was developed in. `AGUI.A2UI.0.0.4.nupkg` is *derived* from verified MSBuild properties (`PackageId=AGUI.A2UI`, `PackageVersion=0.0.4`) plus the config's `name`/`versionSource`, not confirmed against a built artifact. Worth one real pack before the first release.
- Version decoupling **was** verified empirically: bumping the train to `0.9.9` leaves `AGUI.A2UI` at `0.0.4` while `AGUI.Server`/`Abstractions` follow to `0.9.9`.
- e2e/Playwright and live-model runs were not executed.

## Not addressed (for #2262)

- Its description says three dojo demos; there are four (`a2ui_fixed_schema` was added in the last commit), and the e2e note says "three features" against four spec files.
- `CreateA2UIAdvanced`'s doc claims the per-run `injectA2UITool` flag "arrive[s] on the forwarded `RunAgentInput`" — for `ag-ui-dotnet` it never does; injection comes from the backend opt-in.
- Planner-history lossiness: only `TextContent` and `generate_a2ui` calls are accumulated into `history`, so a developer's own tool calls/results (resolved by the inner `UseFunctionInvocation`) are dropped from planner round 2 on. Harmless for the dojo demos (no server tools on those endpoints), latent for anyone combining server tools with A2UI. The pairs are balanced and could be preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
