### PR TITLE
fix(adk): handle None id/args on real FunctionCall objects

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
@@ -336,12 +336,22 @@ def convert_adk_event_to_ag_ui_message(event: ADKEvent) -> Optional[Message]:
                 if part.text:
                     text_parts.append(part.text)
                 elif part.function_call:
+                    # `id` and `args` are optional fields on google.genai's
+                    # FunctionCall, so the attributes always exist and simply
+                    # default to None. Test the value, not the attribute:
+                    # hasattr/getattr-with-default never fire, which left the
+                    # ToolCall id as None (a pydantic error that dropped the
+                    # whole event) and serialized absent args as "None".
+                    # Mirrors event_translator._translate_function_calls_to_tool_calls.
+                    function_call = part.function_call
+                    tool_call_id = getattr(function_call, 'id', None) or event.id
+                    args = getattr(function_call, 'args', None)
                     tool_calls.append(ToolCall(
-                        id=getattr(part.function_call, 'id', event.id),
+                        id=tool_call_id,
                         type="function",
                         function=FunctionCall(
-                            name=part.function_call.name,
-                            arguments=serialize_tool_args(part.function_call.args) if hasattr(part.function_call, 'args') else "{}"
+                            name=function_call.name,
+                            arguments=serialize_tool_args(args) if args else "{}"
                         )
                     ))
             

--- a/integrations/adk-middleware/python/tests/test_utils_converters.py
+++ b/integrations/adk-middleware/python/tests/test_utils_converters.py
@@ -872,6 +872,104 @@ class TestConvertADKEventToAGUIMessage:
         tool_call = result.tool_calls[0]
         assert tool_call.id == "assistant_5"  # Falls back to event ID
 
+    # The two MagicMock tests above delete the attribute entirely. Real
+    # google.genai FunctionCall objects always *have* `id` and `args`; the
+    # fields are simply optional and default to None. These tests use real
+    # objects so the None-valued path stays covered.
+
+    def test_convert_real_function_call_with_none_id(self):
+        """Test that a real FunctionCall with id=None falls back to the event ID."""
+        event = ADKEvent(
+            id="event-123",
+            author="model",
+            content=types.Content(
+                role="model",
+                parts=[types.Part(
+                    function_call=types.FunctionCall(
+                        name="get_weather",
+                        args={"city": "Cairo"},
+                        # id defaults to None
+                    )
+                )],
+            ),
+        )
+
+        result = convert_adk_event_to_ag_ui_message(event)
+
+        # The event must survive conversion, not be dropped by the error handler.
+        assert isinstance(result, AssistantMessage)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].id == "event-123"
+        assert json.loads(result.tool_calls[0].function.arguments) == {"city": "Cairo"}
+
+    def test_convert_real_function_call_with_none_args(self):
+        """Test that a real FunctionCall with args=None serializes to '{}'."""
+        event = ADKEvent(
+            id="event-456",
+            author="model",
+            content=types.Content(
+                role="model",
+                parts=[types.Part(
+                    function_call=types.FunctionCall(
+                        id="call-456",
+                        name="get_current_time",
+                        # args defaults to None
+                    )
+                )],
+            ),
+        )
+
+        result = convert_adk_event_to_ag_ui_message(event)
+
+        tool_call = result.tool_calls[0]
+        assert tool_call.id == "call-456"
+        assert tool_call.function.arguments == "{}"
+        assert json.loads(tool_call.function.arguments) == {}
+
+    def test_convert_real_function_call_with_none_id_and_args(self):
+        """Test that a real FunctionCall missing both id and args converts."""
+        event = ADKEvent(
+            id="event-789",
+            author="model",
+            content=types.Content(
+                role="model",
+                parts=[types.Part(
+                    function_call=types.FunctionCall(name="ping")
+                )],
+            ),
+        )
+
+        result = convert_adk_event_to_ag_ui_message(event)
+
+        tool_call = result.tool_calls[0]
+        assert tool_call.id == "event-789"
+        assert tool_call.function.name == "ping"
+        assert tool_call.function.arguments == "{}"
+
+    def test_convert_real_function_call_preserves_id_and_args(self):
+        """Test that a fully populated real FunctionCall is unchanged."""
+        event = ADKEvent(
+            id="event-999",
+            author="model",
+            content=types.Content(
+                role="model",
+                parts=[types.Part(
+                    function_call=types.FunctionCall(
+                        id="call-999",
+                        name="get_weather",
+                        args={"city": "Boston"},
+                    )
+                )],
+            ),
+        )
+
+        result = convert_adk_event_to_ag_ui_message(event)
+
+        tool_call = result.tool_calls[0]
+        assert tool_call.id == "call-999"
+        assert tool_call.function.name == "get_weather"
+        assert json.loads(tool_call.function.arguments) == {"city": "Boston"}
+
     def test_convert_event_without_content(self):
         """Test converting event without content."""
         mock_event = MagicMock()


### PR DESCRIPTION
Fixes #2240

## Problem

`convert_adk_event_to_ag_ui_message` probes `google.genai` `FunctionCall` fields with `hasattr` / `getattr`-with-default:

```python
id=getattr(part.function_call, 'id', event.id),
arguments=serialize_tool_args(part.function_call.args) if hasattr(part.function_call, 'args') else "{}"
```

`id` and `args` are *optional fields* on a real `FunctionCall` — the attributes always exist and simply default to `None`. So neither fallback ever fires:

| Field | Actual behaviour | Consequence |
| --- | --- | --- |
| `id=None` | `getattr` returns `None`, not `event.id` | `ToolCall(id=None)` raises a pydantic `ValidationError`, which the broad `except Exception` swallows — the **entire assistant event is dropped**, text and tool call alike |
| `args=None` | `hasattr` is `True`, so `serialize_tool_args(None)` runs | Produces the literal string `"None"`, which is not valid JSON and fails `json.loads` downstream |

Both are reachable in normal operation: Gemini routinely omits `FunctionCall.id`, and a zero-argument tool yields `args=None`.

## Fix

Check the **values** rather than the attributes. This is the idiom already used by `_translate_function_calls_to_tool_calls` in `event_translator.py:1394-1398`, which handles both cases correctly — `converters.py` had just drifted from it.

## Verification

Reproduced first against real `google.genai` objects on `main`:

```
CASE 1: FunctionCall.id omitted        CASE 2: FunctionCall.args omitted
hasattr(fc, 'id') = True               hasattr(fc, 'args') = True
fc.id             = None               fc.args             = None
converted message = None       ❌      arguments repr      = 'None'   ❌
                                       json.loads FAILED   = JSONDecodeError
```

After the fix:

```
converted message = AssistantMessage(... tool_calls=[ToolCall(id='event-123', ...)])  ✅
arguments repr    = '{}'   json.loads = OK                                            ✅
```

## Tests

The two existing regression tests (`test_convert_function_call_without_id` / `..._without_args`) use `MagicMock` and `delattr` the fields, so they exercise objects where the attributes are *absent* — which is why this slipped through. They still pass unchanged; I added four tests built on real `types.FunctionCall` objects:

- `test_convert_real_function_call_with_none_id` — falls back to the event id
- `test_convert_real_function_call_with_none_args` — serializes to `"{}"`
- `test_convert_real_function_call_with_none_id_and_args` — both omitted
- `test_convert_real_function_call_preserves_id_and_args` — populated control

The first three fail on `main` and pass with this change.

Full suite, `integrations/adk-middleware/python`:

| | Passed | Errors |
| --- | --- | --- |
| `main` | 865 | 60 |
| this branch | **869** | 60 |

Exactly +4 (the new tests), no regressions. The 60 errors are identical on both runs and unrelated to this change: they are all `conftest._start_llmock()` failing to spawn the local mock-LLM server, which CI provides.

## Scope note

`event_translator.py:1000` has the same root cause in a different function:

```python
tool_call_id = getattr(func_call, 'id', str(uuid.uuid4()))
```

That default never fires either, so a `None` id would flow into `ToolCallStartEvent`. It's outside this issue's stated scope and in a much more sensitive file, so I left it alone — happy to send a follow-up PR if you'd like it fixed.
