### PR TITLE
fix(dotnet): map reasoning and skip activity in AsChatMessages

### DIFF
--- a/sdks/dotnet/src/AGUI.Abstractions/Extensions/AGUIChatMessageExtensions.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Extensions/AGUIChatMessageExtensions.cs
@@ -31,6 +31,15 @@ public static class AGUIChatMessageExtensions
 
         foreach (var message in aguiMessages)
         {
+            // Activity messages are frontend-only and are never forwarded to the agent, so a
+            // client that sends one anyway is ignored rather than failing the run. Dropped
+            // before the tool-call bookkeeping below so the message stays fully transparent:
+            // it must not split a run of parallel tool calls that is mid-coalesce.
+            if (message is AGUIActivityMessage)
+            {
+                continue;
+            }
+
             if (message is AGUIAssistantMessage toolCallAssistant && toolCallAssistant.ToolCalls is { Count: > 0 })
             {
                 pendingToolCallContents ??= new List<AIContent>();
@@ -62,6 +71,29 @@ public static class AGUIChatMessageExtensions
                 yield return new ChatMessage(ChatRole.Assistant, pendingToolCallContents) { MessageId = pendingToolCallId };
                 pendingToolCallContents = null;
                 pendingToolCallId = null;
+            }
+
+            // Reasoning is the model's own thinking rather than its output, and the spec has
+            // clients send it back on subsequent turns. Microsoft.Extensions.AI models that as
+            // TextReasoningContent on an assistant turn; encryptedValue becomes ProtectedData,
+            // the opaque provider blob MEAI round-trips untouched, which is what keeps encrypted
+            // chain-of-thought continuous across turns (store:false / ZDR).
+            if (message is AGUIReasoningMessage reasoningMessage)
+            {
+                var reasoningContents = new List<AIContent>
+                {
+                    new TextReasoningContent(reasoningMessage.Content)
+                    {
+                        ProtectedData = reasoningMessage.EncryptedValue
+                    }
+                };
+
+                yield return new ChatMessage(ChatRole.Assistant, reasoningContents)
+                {
+                    MessageId = message.Id
+                };
+
+                continue;
             }
 
             var role = MapChatRole(message.Role);
@@ -127,7 +159,6 @@ public static class AGUIChatMessageExtensions
                     AGUIAssistantMessage assistant => assistant.Content ?? string.Empty,
                     AGUISystemMessage system => system.Content,
                     AGUIDeveloperMessage developer => developer.Content,
-                    AGUIReasoningMessage reasoning => reasoning.Content,
                     _ => string.Empty,
                 };
 
@@ -268,12 +299,23 @@ public static class AGUIChatMessageExtensions
     /// </summary>
     /// <param name="role">The AG-UI role string.</param>
     /// <returns>The corresponding <see cref="ChatRole"/>.</returns>
+    /// <remarks>
+    /// <see cref="AGUIRoles.Reasoning"/> maps to <see cref="ChatRole.Assistant"/>; the reasoning
+    /// text itself is carried as <see cref="TextReasoningContent"/> by
+    /// <see cref="AsChatMessages"/>. <see cref="AGUIRoles.Activity"/> has no chat-role
+    /// equivalent — it is frontend-only and never forwarded to the agent, so
+    /// <see cref="AsChatMessages"/> drops those messages instead of calling this method.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="role"/> has no <see cref="ChatRole"/> equivalent.
+    /// </exception>
     public static ChatRole MapChatRole(string role) =>
         string.Equals(role, AGUIRoles.System, StringComparison.OrdinalIgnoreCase) ? ChatRole.System :
         string.Equals(role, AGUIRoles.User, StringComparison.OrdinalIgnoreCase) ? ChatRole.User :
         string.Equals(role, AGUIRoles.Assistant, StringComparison.OrdinalIgnoreCase) ? ChatRole.Assistant :
         string.Equals(role, AGUIRoles.Developer, StringComparison.OrdinalIgnoreCase) ? s_developerChatRole :
         string.Equals(role, AGUIRoles.Tool, StringComparison.OrdinalIgnoreCase) ? ChatRole.Tool :
+        string.Equals(role, AGUIRoles.Reasoning, StringComparison.OrdinalIgnoreCase) ? ChatRole.Assistant :
         throw new InvalidOperationException($"Unknown chat role: {role}");
 
     private static string SerializeFunctionResult(FunctionResultContent functionResult, string? fallbackText)

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/AGUIChatMessageExtensionsTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/AGUIChatMessageExtensionsTest.cs
@@ -578,4 +578,153 @@ public sealed class AGUIChatMessageExtensionsTest
         Assert.Equal(2, assistantMessages.Count);
         Assert.All(assistantMessages, m => Assert.Single(m.Contents.OfType<FunctionCallContent>()));
     }
+
+    // https://github.com/ag-ui-protocol/ag-ui/issues/2290
+    // Reasoning messages are "meant to be sent back to the agent for further processing on
+    // subsequent turns", so a conforming client re-sends them and every turn after the first
+    // must keep working.
+    [Fact]
+    public void AsChatMessages_ReasoningMessage_MapsToAssistantReasoningContent()
+    {
+        var aguiMessages = new AGUIMessage[]
+        {
+            new AGUIReasoningMessage { Id = "reason-1", Content = "Counting the objectives." }
+        };
+
+        var chatMessage = Assert.Single(aguiMessages.AsChatMessages());
+
+        Assert.Equal(ChatRole.Assistant, chatMessage.Role);
+        Assert.Equal("reason-1", chatMessage.MessageId);
+        var reasoning = Assert.IsType<TextReasoningContent>(Assert.Single(chatMessage.Contents));
+        Assert.Equal("Counting the objectives.", reasoning.Text);
+        Assert.Null(reasoning.ProtectedData);
+    }
+
+    // encryptedValue is the whole point of round-tripping reasoning (store:false / ZDR), so it
+    // must survive as ProtectedData -- MEAI's home for opaque provider blobs.
+    [Fact]
+    public void AsChatMessages_ReasoningMessageWithEncryptedValue_PreservesProtectedData()
+    {
+        var aguiMessages = new AGUIMessage[]
+        {
+            new AGUIReasoningMessage
+            {
+                Id = "reason-1",
+                Content = "Redacted summary.",
+                EncryptedValue = "gAAAAABn-opaque-blob"
+            }
+        };
+
+        var chatMessage = Assert.Single(aguiMessages.AsChatMessages());
+
+        var reasoning = Assert.IsType<TextReasoningContent>(Assert.Single(chatMessage.Contents));
+        Assert.Equal("Redacted summary.", reasoning.Text);
+        Assert.Equal("gAAAAABn-opaque-blob", reasoning.ProtectedData);
+    }
+
+    // Activity is frontend-only ("never forwarded to the agent"), so a client that sends one
+    // anyway should be ignored rather than 500.
+    [Fact]
+    public void AsChatMessages_ActivityMessage_IsSkipped()
+    {
+        var aguiMessages = new AGUIMessage[]
+        {
+            new AGUIUserMessage { Id = "m1", Content = "Hello" },
+            new AGUIActivityMessage
+            {
+                Id = "act-1",
+                ActivityType = "search",
+                Content = JsonDocument.Parse("""{"query":"objectives"}""").RootElement
+            },
+            new AGUIUserMessage { Id = "m2", Content = "Still there?" }
+        };
+
+        var chatMessages = aguiMessages.AsChatMessages().ToList();
+
+        Assert.Equal(2, chatMessages.Count);
+        Assert.Equal(new[] { "m1", "m2" }, chatMessages.Select(m => m.MessageId));
+    }
+
+    // A skipped activity message must be fully transparent: it cannot split a run of parallel
+    // tool calls that AsChatMessages is coalescing, or the reconstructed history goes invalid.
+    [Fact]
+    public void AsChatMessages_ActivityBetweenParallelToolCalls_DoesNotSplitRun()
+    {
+        var aguiMessages = new AGUIMessage[]
+        {
+            new AGUIAssistantMessage { Id = "asst-1", Content = string.Empty, ToolCalls = new List<AGUIToolCall> { new AGUIToolCall { Id = "tc_1", Type = "function", Function = new AGUIToolCallFunction { Name = "get_weather", Arguments = "{}" } } } },
+            new AGUIActivityMessage { Id = "act-1", ActivityType = "thinking", Content = JsonDocument.Parse("{}").RootElement },
+            new AGUIAssistantMessage { Id = "asst-2", Content = string.Empty, ToolCalls = new List<AGUIToolCall> { new AGUIToolCall { Id = "tc_2", Type = "function", Function = new AGUIToolCallFunction { Name = "get_user_location", Arguments = "{}" } } } },
+        };
+
+        var chatMessage = Assert.Single(aguiMessages.AsChatMessages());
+
+        Assert.Equal(ChatRole.Assistant, chatMessage.Role);
+        Assert.Equal(new[] { "tc_1", "tc_2" }, chatMessage.Contents.OfType<FunctionCallContent>().Select(c => c.CallId));
+    }
+
+    [Fact]
+    public void MapChatRole_Reasoning_MapsToAssistant()
+    {
+        Assert.Equal(ChatRole.Assistant, AGUIChatMessageExtensions.MapChatRole(AGUIRoles.Reasoning));
+    }
+
+    // The exact turn-2 payload from #2290: a conforming client echoes the reasoning message it
+    // was streamed, which used to fail the whole run with "Unknown chat role: reasoning".
+    [Fact]
+    public void RunAgentInput_WithReasoningMessage_DeserializesAndConverts()
+    {
+        var json = """
+            {
+              "threadId": "t-1",
+              "runId": "r-2",
+              "messages": [
+                { "id": "1", "role": "user",      "content": "How many objectives are listed?" },
+                { "id": "2", "role": "reasoning", "content": "**Counting objectives** ... 4 items." },
+                { "id": "3", "role": "assistant", "content": "There are 4 objectives listed." },
+                { "id": "4", "role": "user",      "content": "How many agreed actions are listed?" }
+              ],
+              "context": []
+            }
+            """;
+
+        var input = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.RunAgentInput);
+
+        Assert.NotNull(input);
+        Assert.IsType<AGUIReasoningMessage>(input.Messages[1]);
+
+        var chatMessages = input.Messages.AsChatMessages().ToList();
+
+        Assert.Equal(4, chatMessages.Count);
+        var reasoning = Assert.IsType<TextReasoningContent>(Assert.Single(chatMessages[1].Contents));
+        Assert.Equal("**Counting objectives** ... 4 items.", reasoning.Text);
+    }
+
+    // Drift guard: AGUIRoles, AGUIMessageJsonConverter and AsChatMessages are three separate
+    // lists that must agree. Anything the converter can deserialize, AsChatMessages must
+    // consume without throwing -- that gap is what #2290 was.
+    [Theory]
+    [InlineData(AGUIRoles.System, """{ "id": "m", "role": "system", "content": "be brief" }""")]
+    [InlineData(AGUIRoles.User, """{ "id": "m", "role": "user", "content": "hi" }""")]
+    [InlineData(AGUIRoles.Assistant, """{ "id": "m", "role": "assistant", "content": "hello" }""")]
+    [InlineData(AGUIRoles.Developer, """{ "id": "m", "role": "developer", "content": "note" }""")]
+    [InlineData(AGUIRoles.Tool, """{ "id": "m", "role": "tool", "toolCallId": "tc_1", "content": "done" }""")]
+    [InlineData(AGUIRoles.Activity, """{ "id": "m", "role": "activity", "activityType": "search", "content": {} }""")]
+    [InlineData(AGUIRoles.Reasoning, """{ "id": "m", "role": "reasoning", "content": "thinking" }""")]
+    public void AsChatMessages_EveryDeserializableRole_DoesNotThrow(string role, string messageJson)
+    {
+        var json = $$"""
+            { "threadId": "t", "runId": "r", "messages": [ {{messageJson}} ], "context": [] }
+            """;
+
+        var input = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.RunAgentInput);
+
+        Assert.NotNull(input);
+        Assert.Equal(role, Assert.Single(input.Messages).Role);
+
+        // Must not throw. Activity is intentionally dropped; every other role yields a message.
+        var chatMessages = input.Messages.AsChatMessages().ToList();
+
+        Assert.Equal(role == AGUIRoles.Activity ? 0 : 1, chatMessages.Count);
+    }
 }


### PR DESCRIPTION
Fixes #2290

## Problem

`AGUI.Abstractions` is internally inconsistent about message roles across three lists:

| Piece | Handles |
| --- | --- |
| `AGUIRoles` | all 7 roles, including `activity` and `reasoning` |
| `AGUIMessageJsonConverter` | deserializes all 7 |
| `MapChatRole` | **5** — throws `InvalidOperationException` on the other two |

`AsChatMessages` calls `MapChatRole` unconditionally before any per-message-type branching, so one reasoning message anywhere in `RunAgentInput.Messages` fails the whole run — an HTTP 500 from a hosted agent endpoint.

This isn't an edge case. The spec says reasoning messages "are meant to be sent back to the agent for further processing on subsequent turns", so a conforming client that echoes them gets **a 500 on turn 2 of every thread in which the model reasoned** — and every turn after, because the offending message is now part of the client's authoritative history. The thread is permanently unusable.

## Fix

**`reasoning`** → an assistant `ChatMessage` carrying `TextReasoningContent`, which is how `Microsoft.Extensions.AI` models the same concept. `encryptedValue` maps to `ProtectedData` — MEAI's documented home for "an opaque blob of data... that should be roundtripped back to the provider... often encrypted". That is what keeps encrypted chain-of-thought continuous across turns, which is the entire point of the field (and required for `store:false` / ZDR).

**`activity`** → dropped. It's frontend-only and "never forwarded to the agent", so a client that sends one anyway should be ignored rather than 500. It's dropped *before* the parallel-tool-call bookkeeping so the message is fully transparent — an interleaved activity must not split a tool-call run that `AsChatMessages` is mid-coalesce (there's a test for exactly that).

**`MapChatRole`** now maps `reasoning` → `ChatRole.Assistant`, so the public helper no longer throws for a role the SDK itself defines. `activity` genuinely has no `ChatRole` equivalent, and `AsChatMessages` no longer routes it there; I documented that on the method rather than inventing a bogus mapping. Since `AGUIMessageJsonConverter` already rejects unknown role discriminators with a `JsonException`, the remaining `throw` is now unreachable from the deserialization path — it only guards programmatically-constructed messages.

Also removed the `AGUIReasoningMessage reasoning => reasoning.Content` arm from the plain-text switch: reasoning now returns before it, so it was dead code that read as if reasoning were already handled. (That phantom handler is arguably how this drifted in the first place.)

## Tests

13 new tests in `AGUIChatMessageExtensionsTest`, including the exact turn-2 `RunAgentInput` payload from the issue.

The issue asked for a guard so the three lists can't drift again — that's `AsChatMessages_EveryDeserializableRole_DoesNotThrow`, a `[Theory]` over all seven roles asserting that anything `AGUIMessageJsonConverter` deserializes, `AsChatMessages` consumes without throwing. 8 of the 13 fail on `main`.

Full .NET suite (net10.0), all green with this change:

| Project | Tests |
| --- | --- |
| `AGUI.Abstractions.UnitTests` | 198 (was 185) |
| `AGUI.Server.UnitTests` | 114 |
| `AGUI.Client.UnitTests` | 114 |
| `AGUI.Hosting.AspNetCore.IntegrationTests` | 117 |
| `AGUI.Protobuf.UnitTests` | 53 |
| `AGUI.Formatting.UnitTests` | 8 |

`AGUI.Abstractions` builds clean (0 warnings, `TreatWarningsAsErrors`) across all five TFMs: `net10.0`, `net9.0`, `net8.0`, `netstandard2.0`, `net472`. No public API surface added, so no `PublicAPI.Unshipped.txt` change.

> Aside: the non-Abstractions test projects needed `-p:SignAssembly=false` to build locally, which is #2165, not this change.

## Scope note

The outbound direction is still asymmetric: `AsAGUIMessages` never produces an `AGUIReasoningMessage`, so a `TextReasoningContent` coming back from a provider maps to a plain assistant message. That's pre-existing and outside this issue, but this change makes it more visible — happy to send a follow-up if you'd like the reverse mapping too.
