### PR TITLE
fix(dotnet): make InternalsVisibleTo work under strong-naming

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1234,12 +1234,12 @@ jobs:
         working-directory: sdks/dotnet
         run: |
           set -euo pipefail
-          dotnet test tests/AGUI.Abstractions.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Client.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Formatting.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Protobuf.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Server.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests -c Release -p:SignAssembly=false
+          dotnet test tests/AGUI.Abstractions.UnitTests -c Release
+          dotnet test tests/AGUI.Client.UnitTests -c Release
+          dotnet test tests/AGUI.Formatting.UnitTests -c Release
+          dotnet test tests/AGUI.Protobuf.UnitTests -c Release
+          dotnet test tests/AGUI.Server.UnitTests -c Release
+          dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests -c Release
 
       # The integration lives in its own solution with its own
       # Directory.Build.props, so the SDK suites above do not cover it.

--- a/.github/workflows/unit-dotnet-sdk.yml
+++ b/.github/workflows/unit-dotnet-sdk.yml
@@ -68,14 +68,14 @@ jobs:
       # checkout that is not present in CI, so a solution-wide build would fail.
       - name: Run unit tests
         run: |
-          dotnet test tests/AGUI.Abstractions.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Client.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Formatting.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Protobuf.UnitTests -c Release -p:SignAssembly=false
-          dotnet test tests/AGUI.Server.UnitTests -c Release -p:SignAssembly=false
+          dotnet test tests/AGUI.Abstractions.UnitTests -c Release
+          dotnet test tests/AGUI.Client.UnitTests -c Release
+          dotnet test tests/AGUI.Formatting.UnitTests -c Release
+          dotnet test tests/AGUI.Protobuf.UnitTests -c Release
+          dotnet test tests/AGUI.Server.UnitTests -c Release
 
       - name: Run integration tests
-        run: dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests -c Release -p:SignAssembly=false
+        run: dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests -c Release
 
   cross-language:
     name: dotnet / cross-language (TS <-> C#)
@@ -150,5 +150,5 @@ jobs:
 
       # Phase 2: C# AGUIChatClient drives the TypeScript fake-agent server.
       - name: Cross-language Phase 2 (C# client -> TS server)
-        run: dotnet test tests/AGUI.CrossLanguage.IntegrationTests -c Release -p:SignAssembly=false
+        run: dotnet test tests/AGUI.CrossLanguage.IntegrationTests -c Release
         working-directory: sdks/dotnet

--- a/sdks/dotnet/Directory.Build.props
+++ b/sdks/dotnet/Directory.Build.props
@@ -20,6 +20,25 @@
     <NoWarn>$(NoWarn);RS0041</NoWarn>
   </PropertyGroup>
 
+  <!-- Strong-naming applies to every project, not just the packable ones. A strong-named
+       assembly can only grant InternalsVisibleTo to another strong-named assembly, so the
+       test projects that consume internals have to be signed with the same key. Signing
+       only the packable projects is what forced `-p:SignAssembly=false` on every local
+       `dotnet test` invocation. -->
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AGUI.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <!-- Public key of AGUI.snk (`sn -tp` / AssemblyName.GetPublicKey). The .NET SDK appends
+       `PublicKey=$(PublicKey)` to every InternalsVisibleTo item that has no explicit Key
+       metadata, which is what keeps friend references valid while signing is on. Left
+       unset when signing is off (`-p:SignAssembly=false`) so the attribute is emitted
+       without a key and unsigned builds keep working. -->
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
+    <PublicKey>002400000480000014010000060200000024000052534131000800000100010003c58522a6fc234108611a833bb9351f3d9b10b03e457ef23134657b4cdcdf5bf7ea692b683930d58448129e909dfa7d45c8d55bba536f5404507c7a7fd4b776d97db0cda2bf27b2fb7480175e76b0e0f4d4670052fdb656af89fc68bffe46725d1f879add87f8ac2cb5f1c4f69cbb2b0fc61b1afee74798563dd40f636e987c14f0422cb0af0b3aec4755ddff3976a134f4461e0c2fef00a9cb0724c4bf8b60ec50eddbfaf39178bef9a6078881022e42334b19bce76095a7e4930ec619a5985e9677d86b7ea6989629bd3647f955a3b5cf21a93d922621cb1c536b2cc4e6f7c9c1d0ec7347aa5b399878e6a94c27eaededcd86d12c9730f0dd3618900d61c6</PublicKey>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsPackable)' == 'true'">
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">0.0.4</VersionPrefix>
     <Authors>AG-UI Protocol</Authors>
@@ -37,8 +56,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Deterministic>true</Deterministic>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AGUI.snk</AssemblyOriginatorKeyFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnablePackageValidation>true</EnablePackageValidation>

--- a/sdks/dotnet/src/AGUI.Client/AGUI.Client.csproj
+++ b/sdks/dotnet/src/AGUI.Client/AGUI.Client.csproj
@@ -7,7 +7,7 @@
     <PackageTags>$(PackageTags);client;http;chat;microsoft-extensions-ai;sse</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+  <ItemGroup>
     <InternalsVisibleTo Include="AGUI.Client.UnitTests" />
     <InternalsVisibleTo Include="AGUI.Hosting.AspNetCore.IntegrationTests" />
   </ItemGroup>

--- a/sdks/dotnet/src/AGUI.Formatting/AGUI.Formatting.csproj
+++ b/sdks/dotnet/src/AGUI.Formatting/AGUI.Formatting.csproj
@@ -7,7 +7,7 @@
     <PackageTags>$(PackageTags);formatting;sse;server-sent-events;streaming;transport</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+  <ItemGroup>
     <InternalsVisibleTo Include="AGUI.Formatting.UnitTests" />
   </ItemGroup>
 

--- a/sdks/dotnet/src/AGUI.Protobuf/AGUI.Protobuf.csproj
+++ b/sdks/dotnet/src/AGUI.Protobuf/AGUI.Protobuf.csproj
@@ -7,7 +7,7 @@
     <PackageTags>$(PackageTags);protobuf;binary;codec;transport;serialization</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+  <ItemGroup>
     <InternalsVisibleTo Include="AGUI.Protobuf.UnitTests" />
     <InternalsVisibleTo Include="CrossLanguage.TestServer" />
   </ItemGroup>

--- a/sdks/dotnet/src/AGUI.Server/AGUI.Server.csproj
+++ b/sdks/dotnet/src/AGUI.Server/AGUI.Server.csproj
@@ -8,7 +8,7 @@
     <PackageTags>$(PackageTags);server;adapter;streaming;chat;microsoft-extensions-ai</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+  <ItemGroup>
     <InternalsVisibleTo Include="AGUI.Server.UnitTests" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #2165

I hit this the first time I ran the .NET tests, before I'd read the issue — `dotnet test tests/AGUI.Server.UnitTests` on a clean `main` gave me a wall of `CS0122` errors pointing at test files, with nothing suggesting the real cause was assembly signing.

## Root cause

Two things combine, and the issue only named one of them:

1. **`InternalsVisibleTo` was gated off under signing.** Each ItemGroup carried `Condition="'$(SignAssembly)' != 'true'"`, so a default build emitted no friend attribute at all.
2. **The test assemblies were never signed.** `SignAssembly` / `AssemblyOriginatorKeyFile` lived inside the `'$(IsPackable)' == 'true'` PropertyGroup, so only the five product assemblies were strong-named. A strong-named assembly can only grant `InternalsVisibleTo` to *another strong-named* assembly, so just deleting the `Condition` (option 1 as literally worded) would have traded `CS0122` for `CS1726`.

## Fix — option 1, done properly

- Signing moves out of the `IsPackable` group so **every** project is signed with `AGUI.snk`, including the test projects that consume internals.
- `$(PublicKey)` is set to the public key of `AGUI.snk`. The SDK appends `PublicKey=$(PublicKey)` to any `InternalsVisibleTo` item without explicit `Key` metadata — this is the built-in behaviour the issue guessed at, in [`Microsoft.NET.GenerateAssemblyInfo.targets`](https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets):

  ```xml
  <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' != ''">%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)</_Parameter1>
  <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == '' and '$(PublicKey)' != ''">%(InternalsVisibleTo.Identity), PublicKey=$(PublicKey)</_Parameter1>
  <_Parameter1 Condition="'%(InternalsVisibleTo.Key)' == '' and '$(PublicKey)' == ''">%(InternalsVisibleTo.Identity)</_Parameter1>
  ```

  The SDK does *not* derive `$(PublicKey)` from the `.snk` on its own — it has to be set, which is what was missing.
- `$(PublicKey)` is conditioned on `'$(SignAssembly)' == 'true'`, so `-p:SignAssembly=false` still lands on the third branch above: attribute emitted with no key, everything unsigned, exactly as today. The escape hatch keeps working.
- The four `Condition="'$(SignAssembly)' != 'true'"` gates are removed.

Since the flag is no longer needed, both workflows drop it (13 call sites). That's deliberate rather than cosmetic: with the flag, **CI never built the configuration anyone actually ships or develops against** — it only ever tested the unsigned one. Now CI, local `dotnet test`, and the release build all agree.

## Verification

`dotnet test tests/<Project> -c Release` with **no flag** — the command that fails on `main`:

| Project | net8.0 | net9.0 | net10.0 |
| --- | --- | --- | --- |
| `AGUI.Abstractions.UnitTests` | 185 ✅ | 185 ✅ | 185 ✅ |
| `AGUI.Client.UnitTests` | 114 ✅ | 114 ✅ | 114 ✅ |
| `AGUI.Server.UnitTests` | 114 ✅ | 114 ✅ | 114 ✅ |
| `AGUI.Protobuf.UnitTests` | 53 ✅ | 53 ✅ | 53 ✅ |
| `AGUI.Formatting.UnitTests` | 8 ✅ | 8 ✅ | 8 ✅ |

Plus `AGUI.Hosting.AspNetCore.IntegrationTests` — 117 ✅ (net10.0).

Also checked:

- **The escape hatch still works** — `-c Release -p:SignAssembly=false` passes (the old CI command).
- **Release signing is unchanged.** After a clean rebuild, every packable assembly still carries public key token `d5950b1d09108385` on `net10.0` and `netstandard2.0`, and the newly-signed test assemblies carry the same token.
- **All five TFMs build clean** (`net10.0;net9.0;net8.0;netstandard2.0;net472`), 0 warnings under `TreatWarningsAsErrors`.
- `CrossLanguage.TestServer` (a friend of `AGUI.Protobuf`) builds unflagged. I couldn't *run* `AGUI.CrossLanguage.IntegrationTests` locally — it needs the TypeScript fake-agent server on :8092, which is a pnpm/vitest setup I didn't stand up — but that's a runtime dependency, not a compile one, and the project compiles fine without the flag.

## Note on scope

I went with option 1 rather than 2 or 3 because it's the only one that leaves a single configuration: option 2 would make Debug and Release produce differently-identified assemblies, and option 3 documents a papercut instead of removing it. If you'd rather keep `-p:SignAssembly=false` in CI so the unsigned path stays covered, I'm happy to restore those lines and keep only the `Directory.Build.props` + `.csproj` changes.
