### PR TITLE
fix: preserve agent-specific clone state

### DIFF
--- a/integrations/langgraph/typescript/src/__tests__/agent.test.ts
+++ b/integrations/langgraph/typescript/src/__tests__/agent.test.ts
@@ -469,6 +469,32 @@ describe("header forwarding via onRequest hook", () => {
   });
 });
 
+describe("clone run-local state isolation", () => {
+  it("creates fresh run-local state on the cloned agent", () => {
+    const agent = new LangGraphAgent({
+      graphId: "test-graph",
+      deploymentUrl: "http://localhost:8000",
+    });
+
+    (agent as any).emittedToolCallStartIds.add("tool-call-1");
+    (agent as any).eventsStreamActive = true;
+
+    const cloned = agent.clone() as LangGraphAgent;
+
+    expect(cloned).toBeInstanceOf(LangGraphAgent);
+    expect((cloned as any).emittedToolCallStartIds).toBeInstanceOf(Set);
+    expect((cloned as any).emittedToolCallStartIds).not.toBe(
+      (agent as any).emittedToolCallStartIds,
+    );
+    expect([...(cloned as any).emittedToolCallStartIds]).toEqual([]);
+    expect((cloned as any).eventsStreamActive).toBe(false);
+    expect((agent as any).emittedToolCallStartIds.has("tool-call-1")).toBe(
+      true,
+    );
+    expect((agent as any).eventsStreamActive).toBe(true);
+  });
+});
+
 // ─── Part C: forwarded-headers payload injection ─────────────────────────────
 //
 // CopilotKit Runtime writes per-request x-* headers (correlation IDs, x-aimock-context,
@@ -595,12 +621,19 @@ describe("langGraphDefaultMergeState forwards props into ag-ui state", () => {
       context: [],
       forwardedProps,
     } as any;
-    return (agent as any).langGraphDefaultMergeState({ messages: [] }, [], input);
+    return (agent as any).langGraphDefaultMergeState(
+      { messages: [] },
+      [],
+      input,
+    );
   }
 
   it("surfaces each configured forwarded prop under its ag-ui state key", () => {
     const forwarded = Object.fromEntries(
-      Object.entries(FORWARDED_PROPS_TO_AGUI).map(([fp, [, sample]]) => [fp, sample]),
+      Object.entries(FORWARDED_PROPS_TO_AGUI).map(([fp, [, sample]]) => [
+        fp,
+        sample,
+      ]),
     );
     const result = mergeWith(forwarded);
     for (const [aguiKey, sample] of Object.values(FORWARDED_PROPS_TO_AGUI)) {
@@ -642,9 +675,7 @@ describe("dispatchInterruptFinish produces correct AG-UI protocol events", () =>
       lgInterrupts: [{ value: { reason: "confirm" }, id: "int-1" }],
     });
 
-    const finished = events.find(
-      (e: any) => e.type === "RUN_FINISHED",
-    );
+    const finished = events.find((e: any) => e.type === "RUN_FINISHED");
     expect(finished).toBeDefined();
     expect(finished.outcome.type).toBe("interrupt");
     expect(finished.outcome.interrupts).toHaveLength(1);
@@ -703,9 +734,7 @@ describe("dispatchInterruptFinish produces correct AG-UI protocol events", () =>
     );
     expect(customEvents).toHaveLength(0);
 
-    const finished = events.find(
-      (e: any) => e.type === "RUN_FINISHED",
-    );
+    const finished = events.find((e: any) => e.type === "RUN_FINISHED");
     expect(finished.outcome.type).toBe("interrupt");
   });
 
@@ -721,9 +750,7 @@ describe("dispatchInterruptFinish produces correct AG-UI protocol events", () =>
       lgInterrupts: [{ value: { reason: "r" }, id: "int-1" }],
     });
 
-    const finished = events.find(
-      (e: any) => e.type === "RUN_FINISHED",
-    );
+    const finished = events.find((e: any) => e.type === "RUN_FINISHED");
     expect(finished.outcome.type).toBe("interrupt");
     expect(finished.outcome.interrupts).toHaveLength(1);
   });
@@ -782,7 +809,9 @@ describe("prepareStream input.resume protocol", () => {
       tools: [],
       context: [],
       forwardedProps: { command: { resume: "legacy_value" } },
-      resume: [{ interruptId: "i1", status: "resolved", payload: { new: true } }],
+      resume: [
+        { interruptId: "i1", status: "resolved", payload: { new: true } },
+      ],
     };
 
     (agent as any).client.threads.getState = vi.fn().mockResolvedValue({
@@ -798,7 +827,9 @@ describe("prepareStream input.resume protocol", () => {
     ]);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("both input.resume and forwardedProps.command.resume"),
+      expect.stringContaining(
+        "both input.resume and forwardedProps.command.resume",
+      ),
     );
 
     const payload = capturedPayload.value!;
@@ -849,7 +880,9 @@ describe("prepareStream input.resume protocol", () => {
       tools: [],
       context: [],
       forwardedProps: {},
-      resume: [{ interruptId: "i1", status: "resolved", payload: { approved: true } }],
+      resume: [
+        { interruptId: "i1", status: "resolved", payload: { approved: true } },
+      ],
     };
 
     (agent as any).client.threads.getState = vi.fn().mockResolvedValue({
@@ -925,9 +958,7 @@ describe("prepareStream input.resume protocol", () => {
       "messages-tuple",
     ]);
 
-    const finished = events.find(
-      (e: any) => e.type === "RUN_FINISHED",
-    );
+    const finished = events.find((e: any) => e.type === "RUN_FINISHED");
     expect(finished).toBeDefined();
     expect(finished.outcome.type).toBe("interrupt");
     expect(finished.outcome.interrupts).toHaveLength(1);

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -223,7 +223,8 @@ export class LangGraphAgent extends AbstractAgent {
   constructor(config: LangGraphAgentConfig) {
     super(config);
     this.config = config;
-    this.enableLegacyOnInterruptEvent = config.enableLegacyOnInterruptEvent ?? true;
+    this.enableLegacyOnInterruptEvent =
+      config.enableLegacyOnInterruptEvent ?? true;
     this.emitInterruptOutcome = config.emitInterruptOutcome ?? false;
     this.messagesInProcess = {};
     this.agentName = config.agentName;
@@ -281,6 +282,7 @@ export class LangGraphAgent extends AbstractAgent {
       client: this.client,
       enableLegacyOnInterruptEvent: this.enableLegacyOnInterruptEvent,
       emitInterruptOutcome: this.emitInterruptOutcome,
+      pendingInterrupts: structuredClone(this.pendingInterrupts ?? []),
 
       assistant: this.assistant,
       activeRun: this.activeRun ? structuredClone(this.activeRun) : undefined,
@@ -288,6 +290,8 @@ export class LangGraphAgent extends AbstractAgent {
       cancelSent: this.cancelSent,
       subgraphs: this.subgraphs ? new Set(this.subgraphs) : new Set(),
       currentSubgraph: ROOT_SUBGRAPH_NAME,
+      emittedToolCallStartIds: new Set<string>(),
+      eventsStreamActive: false,
     });
 
     // Rebuild client so onRequest captures the cloned agent's headers
@@ -702,7 +706,10 @@ export class LangGraphAgent extends AbstractAgent {
           openInterrupts: this.interruptsToAGUI(interrupts),
         }),
       };
-    } else if (effectiveCommand?.resume && typeof effectiveCommand.resume === "string") {
+    } else if (
+      effectiveCommand?.resume &&
+      typeof effectiveCommand.resume === "string"
+    ) {
       try {
         effectiveCommand.resume = JSON.parse(effectiveCommand.resume);
       } catch {
@@ -1773,7 +1780,8 @@ export class LangGraphAgent extends AbstractAgent {
       // one: the snapshot converter re-emits this same reasoning under that
       // id, and only a matching id lets the client reconcile the streamed
       // copy with the snapshot copy instead of rendering both.
-      const messageId = reasoningData.id ?? this.pendingReasoningId ?? randomUUID();
+      const messageId =
+        reasoningData.id ?? this.pendingReasoningId ?? randomUUID();
       this.pendingReasoningId = undefined;
       this.dispatchEvent({
         type: EventType.REASONING_START,
@@ -2116,8 +2124,7 @@ export class LangGraphAgent extends AbstractAgent {
    * bubbles. See #1317.
    */
   private getOrPinTextMessageId(fallbackId: string): string {
-    const messageId =
-      this.activeRun!.currentTextMessageId ?? fallbackId;
+    const messageId = this.activeRun!.currentTextMessageId ?? fallbackId;
     this.activeRun!.currentTextMessageId = messageId;
     return messageId;
   }

--- a/middlewares/a2a-middleware/src/__tests__/agent-clone.test.ts
+++ b/middlewares/a2a-middleware/src/__tests__/agent-clone.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { AbstractAgent, BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { Observable } from "rxjs";
+import { A2AMiddlewareAgent } from "../index";
+
+vi.mock("@a2a-js/sdk/client", () => {
+  class A2AClient {
+    url: string;
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    getAgentCard = vi.fn(async () => ({
+      name: this.url,
+      description: `Card for ${this.url}`,
+      skills: [],
+    }));
+  }
+
+  return { A2AClient };
+});
+
+class CloneableAgent extends AbstractAgent {
+  cloneCount = 0;
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable<BaseEvent>();
+  }
+
+  clone() {
+    this.cloneCount += 1;
+    return Object.assign(super.clone(), {
+      cloneCount: this.cloneCount,
+    });
+  }
+}
+
+describe("A2AMiddlewareAgent clone", () => {
+  it("preserves config and clones owned mutable containers", async () => {
+    const orchestrationAgent = new CloneableAgent({
+      description: "orchestrator",
+    });
+    const agent = new A2AMiddlewareAgent({
+      agentUrls: ["http://agent-a.example", "http://agent-b.example"],
+      instructions: "Route tasks to remote agents.",
+      orchestrationAgent,
+      description: "a2a middleware",
+    });
+
+    const cloned = agent.clone() as A2AMiddlewareAgent;
+
+    expect(cloned).toBeInstanceOf(A2AMiddlewareAgent);
+    expect(cloned).not.toBe(agent);
+    expect(cloned.description).toBe(agent.description);
+    expect(cloned.instructions).toBe(agent.instructions);
+    expect(cloned.agentClients).toEqual(agent.agentClients);
+    expect(cloned.agentClients).not.toBe(agent.agentClients);
+    expect(cloned.orchestrationAgent).toBeInstanceOf(CloneableAgent);
+    expect(cloned.orchestrationAgent).not.toBe(agent.orchestrationAgent);
+    expect(orchestrationAgent.cloneCount).toBe(1);
+
+    const originalCards = await agent.agentCards;
+    const clonedCards = await cloned.agentCards;
+
+    expect(cloned.agentCards).not.toBe(agent.agentCards);
+    expect(clonedCards).toEqual(originalCards);
+    expect(clonedCards).not.toBe(originalCards);
+  });
+});

--- a/middlewares/a2a-middleware/src/index.ts
+++ b/middlewares/a2a-middleware/src/index.ts
@@ -47,6 +47,17 @@ export class A2AMiddlewareAgent extends AbstractAgent {
     this.orchestrationAgent = config.orchestrationAgent;
   }
 
+  public clone() {
+    const cloned = Object.assign(super.clone(), {
+      instructions: this.instructions,
+      agentClients: [...this.agentClients],
+      agentCards: this.agentCards.then((cards) => [...cards]),
+      orchestrationAgent: this.orchestrationAgent.clone(),
+    });
+
+    return cloned;
+  }
+
   finishTextMessages(
     observer: Subscriber<{
       type: EventType;


### PR DESCRIPTION
## Summary

- Reset LangGraph run-local fields when cloning an agent.
- Preserve A2A middleware configuration and clone its orchestration agent.
- Add regression tests for both clone paths.

## Validation

- pnpm nx run @ag-ui/langgraph:test`n- pnpm nx run @ag-ui/a2a-middleware:test`n- pnpm nx run @ag-ui/langgraph:build`n- pnpm nx run @ag-ui/a2a-middleware:build`n
## Known typecheck failures

The explicit LangGraph and A2A typechecks fail on the clean base. They fail on unrelated client exports and debug configuration types. This PR does not add typecheck errors.