### PR TITLE
Add Claude Managed Agents to the docs integration listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | [Agno](https://github.com/agno-agi/agno) | ✅ Supported | ➡️ [Docs](https://docs.copilotkit.ai/agno/) 🎮 [Demos](https://dojo.ag-ui.com/agno/feature/tool_based_generative_ui) |
 | [LlamaIndex](https://github.com/run-llama/llama_index) | ✅ Supported | ➡️ [Docs](https://docs.copilotkit.ai/llamaindex/) 🎮 [Demos](https://dojo.ag-ui.com/llamaindex/feature/shared_state) |
 | [AG2](https://ag2.ai/) | ✅ Supported | ➡️ [Docs](https://docs.copilotkit.ai/ag2/)  🎮 [Demos](https://dojo.ag-ui.com/ag2/feature/shared_state) |
+| [Claude Managed Agents](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-managed-agents) | ✅ Supported | 🎮 [Demos](https://dojo.ag-ui.com/claude-managed-agents-typescript/feature/agentic_chat) |
 | [AWS Bedrock Agents](https://aws.amazon.com/bedrock/agents/) | 🛠️ In Progress | – |
 
 
@@ -115,7 +116,6 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | Framework | Status | AG-UI Resources |
 | ---------- | ------- | ---------------- |
 | [Claude Agent SDK](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-agent-sdk) | ✅ Supported | 🎮 [Demos](https://dojo.ag-ui.com/claude-agent-sdk-python/feature/shared_state) |
-| [Claude Managed Agents](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-managed-agents) | ✅ Supported | 🎮 [Demos](https://dojo.ag-ui.com/claude-managed-agents-typescript/feature/agentic_chat) |
 | [Langroid](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/langroid) | ✅ Supported | 🎮 [Demos](https://dojo.ag-ui.com/langroid/feature/shared_state) |
 | [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/) | 🛠️ In Progress | – |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | 🛠️ In Progress | – |

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -23,6 +23,7 @@ that demonstrate the protocol's capabilities and versatility.
 - **[CrewAI](https://crewai.com)** - Streamline workflows across industries with
   powerful AI agents.
 - **[AG2](https://ag2.ai)** - The Open-Source AgentOS
+- **[Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview)** - Anthropic's hosted agent sessions, bridged to AG-UI in TypeScript, Python, and .NET
 
 ## Infrastructure / Deployment
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -261,13 +261,13 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | [Agno](https://github.com/agno-agi/agno) | Supported | [Docs](https://docs.copilotkit.ai/agno/), [Demos](https://dojo.ag-ui.com/agno/feature/tool_based_generative_ui) |
 | [LlamaIndex](https://github.com/run-llama/llama_index) | Supported | [Docs](https://docs.copilotkit.ai/llamaindex/), [Demos](https://dojo.ag-ui.com/llamaindex/feature/shared_state) |
 | [AG2](https://ag2.ai/) | Supported | [Docs](https://docs.copilotkit.ai/ag2/) [Demos](https://dojo.ag-ui.com/ag2/feature/shared_state) |
+| [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) | Supported | [Integration](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-managed-agents), [Demos](https://dojo.ag-ui.com/claude-managed-agents-typescript/feature/agentic_chat) |
 | [AWS Bedrock Agents](https://aws.amazon.com/bedrock/agents/) | In Progress | – |
 
 
 ### Agent Framework - Community
 | Framework | Status | AG-UI Resources |
 | :-------- | ------ | --------------- |
-| [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) | Supported | [Integration](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-managed-agents), [Demos](https://dojo.ag-ui.com/claude-managed-agents-typescript/feature/agentic_chat) |
 | [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/) | In Progress | – |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | In Progress | – |
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -267,6 +267,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 ### Agent Framework - Community
 | Framework | Status | AG-UI Resources |
 | :-------- | ------ | --------------- |
+| [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) | Supported | [Integration](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/claude-managed-agents), [Demos](https://dojo.ag-ui.com/claude-managed-agents-typescript/feature/agentic_chat) |
 | [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/) | In Progress | – |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | In Progress | – |
 


### PR DESCRIPTION
## What this adds

Follow-up to #2247. The Claude Managed Agents integration (TypeScript, Python, .NET) is merged and the Dojo demos are live, but the docs listings did not yet present it consistently as a first-party integration:

- `docs/introduction.mdx`: a row in the Agent Framework - 1st Party table (Supported, with links to the integration and the live demo)
- `docs/integrations.mdx`: a bullet in the Agent Frameworks list
- `README.md`: move the existing row from Community to 1st Party

All existing links are preserved.

Per CONTRIBUTING the docs flow starts with an issue — happy to file one retroactively if you prefer that trail for docs changes.

## Question: CopilotKit docs guide

@contextablemark, one question while I have you: every Supported framework in these tables links a per-framework guide on docs.copilotkit.ai, which seems to be the full docs treatment for an integration. What is the process for adding one for Claude Managed Agents? Happy to draft the guide myself if that helps — just point me at the repo and the conventions.
