### PR TITLE
fix(mcp-middlewares): import the MCP SSE transport lazily so eventsource stays out of the module graph

### DIFF
--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -14,7 +14,6 @@ import {
 } from "@ag-ui/client";
 import { Observable, from, switchMap } from "rxjs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { randomUUID, createHash } from "crypto";
 
@@ -100,14 +99,25 @@ export function getServerHash(config: MCPClientConfig): string {
  * headers (e.g. auth) to the underlying HTTP/SSE request. Both transports accept
  * headers via `requestInit`; previously HTTP carried no headers field at all and
  * SSE's headers were never wired through. See #1862.
+ *
+ * The SSE transport is imported lazily so that `eventsource` — which it pulls
+ * in transitively, and which only some consumers ever need — stays out of the
+ * module graph unless an SSE server is actually configured. Under Bun a static
+ * import of it breaks at load time: `eventsource`'s `bun` export condition
+ * resolves to its ESM build, so the SDK's CJS `require` gets an async module
+ * back and throws.
  */
-function buildMCPTransport(config: MCPClientConfig) {
+async function buildMCPTransport(config: MCPClientConfig) {
   const options = config.headers
     ? { requestInit: { headers: config.headers } }
     : undefined;
-  return config.type === "sse"
-    ? new SSEClientTransport(new URL(config.url), options)
-    : new StreamableHTTPClientTransport(new URL(config.url), options);
+  if (config.type === "sse") {
+    const { SSEClientTransport } = await import(
+      "@modelcontextprotocol/sdk/client/sse.js"
+    );
+    return new SSEClientTransport(new URL(config.url), options);
+  }
+  return new StreamableHTTPClientTransport(new URL(config.url), options);
 }
 
 /**
@@ -297,7 +307,7 @@ export class MCPAppsMiddleware extends Middleware {
     method: string,
     params?: Record<string, unknown>,
   ): Promise<unknown> {
-    const transport = buildMCPTransport(serverConfig);
+    const transport = await buildMCPTransport(serverConfig);
 
     const client = new Client(
       { name: "mcp-apps-middleware", version: "1.0.0" },
@@ -468,7 +478,7 @@ export class MCPAppsMiddleware extends Middleware {
     toolName: string,
     args: Record<string, unknown>,
   ): Promise<unknown> {
-    const transport = buildMCPTransport(serverConfig);
+    const transport = await buildMCPTransport(serverConfig);
 
     const client = new Client(
       { name: "mcp-apps-middleware", version: "1.0.0" },
@@ -573,7 +583,7 @@ export class MCPAppsMiddleware extends Middleware {
   private async fetchToolsFromServer(
     serverConfig: MCPClientConfig,
   ): Promise<UIToolInfo[]> {
-    const transport = buildMCPTransport(serverConfig);
+    const transport = await buildMCPTransport(serverConfig);
 
     const client = new Client(
       { name: "mcp-apps-middleware", version: "1.0.0" },

--- a/middlewares/mcp-middleware/src/index.ts
+++ b/middlewares/mcp-middleware/src/index.ts
@@ -11,8 +11,9 @@ import {
 } from "@ag-ui/client";
 import { Observable, type Subscription } from "rxjs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+// Type-only: erased at compile time, so it never enters the runtime graph.
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 /**
  * MCP Client configuration for HTTP (streamable) transport.
@@ -560,15 +561,30 @@ export class MCPMiddleware extends Middleware {
    * Caveat: for the SSE transport, `requestInit.headers` only applies to
    * the POST channel — the SSE event stream uses `eventSourceInit`. For
    * streamable HTTP (the typical case) it covers all traffic.
+   *
+   * The SSE transport is imported lazily so that `eventsource` — which it
+   * pulls in transitively, and which only some consumers ever need — stays out
+   * of the module graph unless an SSE server is actually configured. Under Bun
+   * a static import of it breaks at load time: `eventsource`'s `bun` export
+   * condition resolves to its ESM build, so the SDK's CJS `require` gets an
+   * async module back and throws.
    */
   private async connect(serverConfig: MCPClientConfig): Promise<Client> {
     const opts = serverConfig.headers
       ? { requestInit: { headers: serverConfig.headers } }
       : undefined;
-    const transport =
-      serverConfig.type === "sse"
-        ? new SSEClientTransport(new URL(serverConfig.url), opts)
-        : new StreamableHTTPClientTransport(new URL(serverConfig.url), opts);
+    let transport: Transport;
+    if (serverConfig.type === "sse") {
+      const { SSEClientTransport } = await import(
+        "@modelcontextprotocol/sdk/client/sse.js"
+      );
+      transport = new SSEClientTransport(new URL(serverConfig.url), opts);
+    } else {
+      transport = new StreamableHTTPClientTransport(
+        new URL(serverConfig.url),
+        opts,
+      );
+    }
     const client = new Client({
       name: "ag-ui-mcp-middleware",
       version: "0.0.1",


### PR DESCRIPTION
## What

Make the MCP SSE client transport a **lazy** `await import()` in both
`@ag-ui/mcp-apps-middleware` and `@ag-ui/mcp-middleware`, so that
`eventsource` no longer enters the module graph just because the middleware
was imported.

## Why

`@modelcontextprotocol/sdk/client/sse.js` pulls in `eventsource`. Both
middlewares imported it statically at the top level, unconditionally — so every
consumer paid for it, including the (typical) ones that only configure
`type: "http"` servers.

Under **Bun** this is fatal rather than merely wasteful: `eventsource`'s `bun`
export condition points at its ESM build, and Bun resolves the `bun` condition
ahead of `require`. The SDK's CJS `require("eventsource")` therefore receives an
async ESM module and throws at import time. Because it depends on load order,
the failure is intermittent.

In both middlewares the SSE construction already sits behind a
`config.type === "sse"` check inside `private async` methods, so deferring the
import is contained:

- `mcp-apps-middleware`: `buildMCPTransport` is module-private; it becomes
  `async` and its three call sites (`executeMCPRequest`, `executeToolCall`,
  `fetchToolsFromServer`) gain an `await`. All three were already `private async`.
- `mcp-middleware`: `connect()` is already `private async`; the import moves
  into the `sse` branch with no signature change. `Transport` is brought in as a
  **type-only** import, which is erased at compile time and never enters the
  runtime graph.

No `as any`, no `@ts-ignore`, no implicit `any`.

The dynamic import survives the packages' own tsdown build (`format: ["cjs","esm"]`,
`minify: true`) as a real `import()` rather than being rewritten to `require`:

```
$ grep -o 'import(`[^`]*`)' middlewares/*/dist/index.js
middlewares/mcp-middleware/dist/index.js:import(`@modelcontextprotocol/sdk/client/sse.js`)
middlewares/mcp-apps-middleware/dist/index.js:import(`@modelcontextprotocol/sdk/client/sse.js`)
```

## Red / green proof

The load-bearing claim is *"`eventsource` no longer enters the module graph when
the middleware is imported."* The probe loads one target per **fresh Bun
process** (so `require.cache` cannot leak between targets) and reports whether
any `eventsource` package file — excluding `eventsource-parser` — landed in the
graph. Resolution is anchored at the middleware package directory via
`createRequire`, so bare specifiers hit the real pnpm `node_modules` and never
Bun's auto-install cache.

Both a **positive control** (import the SDK's `client/sse.js` directly — MUST be
true) and a **negative control** (import the SDK's `client/streamableHttp.js` —
MUST be false) run on **every** invocation, so the probe cannot pass vacuously.

Probe driver (`probe.sh`), unchanged between the two runs:

```bash
BUN=/path/to/bun-1.3.14/bin/bun            # Bun 1.3.14
A=middlewares/mcp-apps-middleware
B=middlewares/mcp-middleware
$BUN probe-one.cjs "$A" "@modelcontextprotocol/sdk/client/sse.js"            # positive control
$BUN probe-one.cjs "$A" "@modelcontextprotocol/sdk/client/streamableHttp.js" # negative control
$BUN probe-one.cjs "$A" "$A/dist/index.js"                                   # subject A
$BUN probe-one.cjs "$B" "$B/dist/index.js"                                   # subject B
```

`probe-one.cjs`:

```js
const path = require("path");
const { createRequire } = require("module");
const fromDir = path.resolve(process.argv[2]);
const target = process.argv[3];
const req = createRequire(path.join(fromDir, "__probe__.cjs"));
let loadError = null;
try { req(target); } catch (e) { loadError = e.stack.split("\n").slice(0, 4).join(" | "); }
const isEventSource = (k) =>
  /(^|[\\/])eventsource([@\\/])/.test(k) && !/eventsource-parser/.test(k);
const keys = Object.keys(require.cache);
const hits = keys.filter(isEventSource);
console.log(JSON.stringify({ target, totalModules: keys.length,
  eventsourceInGraph: hits.length > 0, eventsourcePaths: hits, loadError }));
```

### RED — at `origin/main` (0880dff8), before the change

```
bun 1.3.14
--- POSITIVE CONTROL: MCP SDK client/sse.js directly (MUST be true) ---
{"target":"@modelcontextprotocol/sdk/client/sse.js","totalModules":20,"eventsourceInGraph":true,"eventsourcePaths":["node_modules/.pnpm/eventsource@3.0.7/node_modules/eventsource/dist/index.js"],"loadError":null}
--- NEGATIVE CONTROL: MCP SDK client/streamableHttp.js (MUST be false) ---
{"target":"@modelcontextprotocol/sdk/client/streamableHttp.js","totalModules":20,"eventsourceInGraph":false,"eventsourcePaths":[],"loadError":null}
--- SUBJECT A: @ag-ui/mcp-apps-middleware dist/index.js (CJS) ---
{"target":"middlewares/mcp-apps-middleware/dist/index.js","totalModules":347,"eventsourceInGraph":true,"eventsourcePaths":["node_modules/.pnpm/eventsource@3.0.7/node_modules/eventsource/dist/index.js"],"loadError":null}
--- SUBJECT B: @ag-ui/mcp-middleware dist/index.js (CJS) ---
{"target":"middlewares/mcp-middleware/dist/index.js","totalModules":493,"eventsourceInGraph":true,"eventsourcePaths":["node_modules/.pnpm/eventsource@3.0.7/node_modules/eventsource/dist/index.js"],"loadError":null}
```

### GREEN — this branch, same command, probe unchanged

```
bun 1.3.14
--- POSITIVE CONTROL: MCP SDK client/sse.js directly (MUST be true) ---
{"target":"@modelcontextprotocol/sdk/client/sse.js","totalModules":20,"eventsourceInGraph":true,"eventsourcePaths":["node_modules/.pnpm/eventsource@3.0.7/node_modules/eventsource/dist/index.js"],"loadError":null}
--- NEGATIVE CONTROL: MCP SDK client/streamableHttp.js (MUST be false) ---
{"target":"@modelcontextprotocol/sdk/client/streamableHttp.js","totalModules":20,"eventsourceInGraph":false,"eventsourcePaths":[],"loadError":null}
--- SUBJECT A: @ag-ui/mcp-apps-middleware dist/index.js (CJS) ---
{"target":"middlewares/mcp-apps-middleware/dist/index.js","totalModules":344,"eventsourceInGraph":false,"eventsourcePaths":[],"loadError":null}
--- SUBJECT B: @ag-ui/mcp-middleware dist/index.js (CJS) ---
{"target":"middlewares/mcp-middleware/dist/index.js","totalModules":490,"eventsourceInGraph":false,"eventsourcePaths":[],"loadError":null}
```

Both controls are identical across the two runs; both subjects flip
`eventsourceInGraph` from `true` to `false`. Module counts drop 347 → 344 and
493 → 490 (the three `eventsource` / `eventsource-parser` / `sse.js` modules).

## Test suites

Both existing suites cover the SSE branch (`mcp-apps-middleware.test.ts` mocks
`@modelcontextprotocol/sdk/client/sse.js` and asserts the SSE transport URL and
header wiring). They pass before and after — which proves the change is
non-regressive, not that it works; the probe above is the evidence.

| Suite | cwd | Result |
| --- | --- | --- |
| `pnpm test` (vitest 4.0.18) | `middlewares/mcp-apps-middleware` | **68 passed** / 68, 1 file |
| `pnpm test` (vitest 4.0.18) | `middlewares/mcp-middleware` | **27 passed** / 27, 1 file |

Also run from the repo root:

- `pnpm --filter @ag-ui/mcp-apps-middleware --filter @ag-ui/mcp-middleware -r build` — both packages build clean (cjs + esm + dts).
- `pnpm --filter @ag-ui/mcp-middleware typecheck` (`tsc --noEmit`) — clean.
- `npx prettier --write` on both changed files — clean.

**Pre-existing failure, not introduced here:** `pnpm --filter @ag-ui/mcp-apps-middleware typecheck`
fails with `src/index.ts: error TS2307: Cannot find module 'crypto' or its
corresponding type declarations.` Verified on unmodified `origin/main` (same
error, one line lower). Untouched by this PR.

## Follow-up (not fixed here): the published `exports` field

Published `@ag-ui/mcp-apps-middleware@0.0.3` has **no** `exports` field, which is
why `main` wins for CJS consumers and the whole CJS chain gets walked. I traced
it, and **the release tooling did not drop it — the field did not exist yet**:

- npm publish times: `0.0.1` 2025-12-05, `0.0.2` 2026-01-13, `0.0.3` 2026-01-15.
- `middlewares/mcp-apps-middleware/package.json` first appears at `945ef738`
  (2026-01-22) already carrying `"version": "0.0.3"`, with `main` + `module` and
  **no** `exports`.
- `exports` (and `exports: true` in `tsdown.config.ts`) were added later, in
  `41ea3ff8` — PR #1818, `feat(middleware): add @ag-ui/mcp-middleware`,
  2026-06-01 — i.e. months after `0.0.3` was cut.

**Would the next release repeat it? No.** Packing the current source confirms the
field ships:

```
$ pnpm pack   # middlewares/mcp-apps-middleware
version 0.0.2
exports {".": {"require": "./dist/index.js", "import": "./dist/index.mjs"}, "./package.json": "./package.json"}
```

`files: ["dist/**"]` does not strip package.json fields, and tsdown's
`exports: true` regenerates the field at build time (it only reorders the
`require`/`import` keys, which are mutually exclusive conditions — cosmetic).
So the next `@ag-ui/mcp-apps-middleware` release will carry `exports` and CJS
consumers will stop being force-routed through `main`. No change needed; flagged
here only so it is not re-diagnosed.

## Scope note

This does **not** retire the downstream `eventsource` patch. Consumers are still
on the published `0.0.3`, which has the static import baked into `dist/`. The
patch can only be dropped after a new release of both middlewares **and** a
consumer bump to it.
