### PR TITLE
fix(crew-ai): StreamFrame method-finished state emission (PNI-180)

### DIFF
--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -68,6 +68,7 @@ the streaming LLM text / tool-call channel); see the wire-shape note in
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import uuid
@@ -107,7 +108,10 @@ from ag_ui.core.events import (
     ReasoningEncryptedValueEvent,
 )
 
-from .sdk import litellm_messages_to_ag_ui_messages
+from .sdk import (
+    litellm_messages_to_ag_ui_messages,
+    consume_node_exit_snapshot_suppression,
+)
 from .mcp import is_mcp_event, translate_mcp_event
 from ._hitl import HITLOptions, build_agui_interrupt, build_interrupt_tail
 from ._reasoning import is_thinking_event, thinking_event_text
@@ -410,6 +414,96 @@ class EmissionShaper:
         return [*self.flush(), event]
 
 
+def _snapshot_state(state: Any) -> dict:
+    """Deep-copied point-in-time snapshot dict from a flow's state.
+
+    Mirrors ``endpoint._flow_state_snapshot``: a later method mutating the live
+    ``flow.state`` must not corrupt an already-emitted STATE_SNAPSHOT. A plain
+    dict is deep-copied (crewai returns the LIVE ``state`` dict, not a copy);
+    ``model_dump`` already yields a fresh dict for a Pydantic ``FlowState``.
+    """
+    if isinstance(state, dict):
+        return copy.deepcopy(state)
+    if hasattr(state, "model_dump"):
+        return state.model_dump()
+    return {}
+
+
+# Attributes the driver's scoped sink stamps on a parked method event to carry
+# EMIT-TIME context: the state snapshot and the snapshot-suppression decision.
+# Underscore-prefixed to avoid clashing with crewai event fields.
+_EMIT_STATE_ATTR = "_ag_ui_emit_state_snapshot"
+_EMIT_SUPPRESS_ATTR = "_ag_ui_emit_suppress"
+# Sentinels distinguishing "not stamped" from a stamped ``{}`` / ``False``.
+_NO_EMIT_STATE = object()
+_NO_EMIT_SUPPRESS = object()
+
+
+def capture_method_emit_context(event: Any, flow: Any) -> None:
+    """Stamp EMIT-TIME state + suppression context onto a parked method event.
+
+    Called by the frame driver's scoped sink, which runs synchronously at emit
+    time on the flow's OWN timeline — the point the legacy bus listener did its
+    work. The frame driver, by contrast, translates parked events on a LATER
+    loop turn, by which time the flow has run ahead, so reading either the state
+    OR the suppression flags at translate time sees a LATER method's mutations.
+    Capturing both here, at emit time, is what matches legacy:
+
+    * method_execution_finished — stamp a deep-copied state snapshot (for the
+      MESSAGES/STATE snapshots) AND consume the per-node suppression flags,
+      stamping whether THIS method withheld its node-exit snapshot.
+    * method_execution_failed — stamp only the consumed suppression decision (a
+      failed method emits no state snapshot).
+
+    Consuming here (rather than at translate time) resets the shared flow flags
+    on the flow timeline, so two consecutive emit_state/predict_state methods
+    each capture their OWN decision instead of racing over one shared flag.
+    Every other event type no-ops. Best-effort per stamp: a failure logs at
+    DEBUG and leaves the translator's live fallback in place.
+    """
+    event_type = getattr(event, "type", None)
+    if event_type not in (_METHOD_FINISHED, _METHOD_FAILED):
+        return
+    if event_type == _METHOD_FINISHED:
+        try:
+            object.__setattr__(
+                event, _EMIT_STATE_ATTR, _snapshot_state(getattr(flow, "state", {}))
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort; live fallback
+            _LOGGER.debug(
+                "ag-ui-crewai could not capture emit-time state for a %r event "
+                "(%s); falling back to the live state at translate time",
+                event_type,
+                type(exc).__name__,
+            )
+    # Consume the flags into a local FIRST — its reset is the side effect that
+    # makes consecutive methods independent — THEN stamp. object.__setattr__ on
+    # these crewai events does not realistically fail; if it ever did, the
+    # decision is already consumed, so the live fallback would re-read the reset
+    # flags as False (one transient node-exit snapshot). Hence the failure is
+    # logged rather than silently swallowed.
+    try:
+        decision = consume_node_exit_snapshot_suppression(flow)
+    except Exception as exc:  # noqa: BLE001 - best-effort; live fallback
+        _LOGGER.debug(
+            "ag-ui-crewai could not consume emit-time suppression for a %r event "
+            "(%s); falling back to consuming at translate time",
+            event_type,
+            type(exc).__name__,
+        )
+        return
+    try:
+        object.__setattr__(event, _EMIT_SUPPRESS_ATTR, decision)
+    except Exception as exc:  # noqa: BLE001 - best-effort
+        _LOGGER.debug(
+            "ag-ui-crewai could not stamp emit-time suppression for a %r event "
+            "(%s); the consumed decision is lost and the live fallback re-reads "
+            "the (now reset) flags",
+            event_type,
+            type(exc).__name__,
+        )
+
+
 class StreamFrameTranslator:
     """Stateless-ish mapper from a RAW crewai/bridge event to AG-UI events.
 
@@ -431,6 +525,7 @@ class StreamFrameTranslator:
         thread_id: str,
         run_id: str,
         state_provider: Callable[[], Any],
+        flow_provider: Callable[[], Any] | None = None,
         emission_shape: str = "triples",
         hitl_options: HITLOptions | None = None,
         resumed: bool = False,
@@ -443,6 +538,13 @@ class StreamFrameTranslator:
         self._thread_id = thread_id
         self._run_id = run_id
         self._state_provider = state_provider
+        # Reads/resets the sdk snapshot-suppression flags stashed on the flow.
+        # Absent -> suppression inert (node-exit snapshot always emits), the
+        # translator's pre-suppression behavior.
+        self._flow_provider = flow_provider
+        # Set when the last method withheld its node-exit snapshot; the terminal
+        # flow_finished/finalize snapshot is owed only then.
+        self._last_node_suppressed = False
         self.emission_shape = emission_shape
         # The streamed text / tool-call triple lifecycle, shared with the legacy
         # driver via ``reshape`` so the shape never depends on the transport.
@@ -612,6 +714,9 @@ class StreamFrameTranslator:
             events: list[Any] = [
                 step_finished_event(b) for b in self._tracker.drain_all()
             ]
+            # Terminal STATE_SNAPSHOT (before RUN_FINISHED) delivers the
+            # authoritative flow.state a suppressed last method withheld.
+            events.extend(self._terminal_state_snapshot_events())
             events.append(
                 RunFinishedEvent(
                     type=EventType.RUN_FINISHED,
@@ -626,7 +731,18 @@ class StreamFrameTranslator:
             return self._method_finished_events(event)
         if event_type == _METHOD_FAILED:
             # Close the method boundary so a failed flow method (the flow may
-            # continue) does not leave a dangling STEP_STARTED. No snapshots.
+            # continue) does not leave a dangling STEP_STARTED. Emits no
+            # MESSAGES/STATE snapshot (a failed method has no clean state).
+            #
+            # Record the emit-time suppression decision so a node that
+            # emit_state'd then failed while the flow continues still gets its
+            # authoritative flow.state redelivered by the terminal snapshot. OR
+            # (not overwrite) so a failed node — which emits NO snapshot of its
+            # own — can only ADD an owed terminal, never clear one a prior
+            # suppressed node already owed.
+            self._last_node_suppressed = (
+                self._consume_suppress(event) or self._last_node_suppressed
+            )
             method_name = _coerce_name(getattr(event, "method_name", None), "method")
             return self._close_boundaries(
                 self._tracker.exit(FLOW_METHOD, method_name), _METHOD_FAILED
@@ -801,6 +917,11 @@ class StreamFrameTranslator:
         events: list[Any] = list(self._shaper.flush())
         events.extend(self.flush_open_reasoning())
         events.extend(step_finished_event(b) for b in self._tracker.drain_all())
+        # Terminal STATE_SNAPSHOT before the terminator (interrupt tail or
+        # RUN_FINISHED): redelivers the authoritative flow.state a suppressed
+        # last method withheld — including a method that emit_state'd then paused
+        # for async HITL without a method_execution_finished.
+        events.extend(self._terminal_state_snapshot_events())
         interrupt = self._build_interrupt()
         if interrupt is not None:
             return events + build_interrupt_tail(
@@ -1030,23 +1151,68 @@ class StreamFrameTranslator:
             events.append(step_finished_event(boundary, source_event_type=tag))
         return events
 
-    def _method_finished_events(self, event: Any) -> list[Any]:
-        """MESSAGES_SNAPSHOT + STATE_SNAPSHOT + balanced STEP_FINISHED(s).
+    def _flow(self) -> Any:
+        """The live flow copy, or ``None`` when no ``flow_provider`` was given."""
+        return self._flow_provider() if self._flow_provider is not None else None
 
-        Reads the LIVE flow state via ``state_provider`` — exactly what the
-        legacy listener did with ``source.state`` — rather than the serialized
-        ``event`` payload, so message / state shapes round-trip through the same
-        ``litellm_messages_to_ag_ui_messages`` path as before. The two snapshots
-        are emitted VERBATIM (unchanged behaviour).
+    def _consume_suppress(self, event: Any) -> bool:
+        """The emit-time node-exit snapshot-suppression decision for ``event``.
+
+        Prefers the decision the sink consumed + stamped at emit time (so it is
+        THIS method's, not a later method's, flag). Falls back to consuming the
+        live flow flags when nothing was stamped — the direct-``translate`` unit
+        tests, which set the flags synchronously right before the method event,
+        or a partial sink install.
+        """
+        stamped = getattr(event, _EMIT_SUPPRESS_ATTR, _NO_EMIT_SUPPRESS)
+        if stamped is _NO_EMIT_SUPPRESS:
+            return consume_node_exit_snapshot_suppression(self._flow())
+        return bool(stamped)
+
+    def _terminal_state_snapshot_events(self) -> list[Any]:
+        """Terminal STATE_SNAPSHOT of live ``flow.state`` when a suppressed node
+        withheld its own, else ``[]``.
+
+        Consults BOTH the per-method flag (set at method finish or fail) AND the
+        live flow flags. The latter catches the ``finalize`` path where a method
+        emitted state then paused (async HITL) and never emitted
+        ``method_execution_finished``, so its suppression is otherwise invisible.
+        Clears both so it cannot double-emit.
+        """
+        owed = consume_node_exit_snapshot_suppression(self._flow()) or self._last_node_suppressed
+        self._last_node_suppressed = False
+        if not owed:
+            return []
+        return [
+            StateSnapshotEvent(
+                type=EventType.STATE_SNAPSHOT,
+                snapshot=_snapshot_state(self._state_provider()),
+            )
+        ]
+
+    def _method_finished_events(self, event: Any) -> list[Any]:
+        """MESSAGES_SNAPSHOT + (suppressible) STATE_SNAPSHOT + STEP_FINISHED(s).
+
+        State AND the suppression decision come from the EMIT-TIME context the
+        driver's sink stamped (``capture_method_emit_context``): the frame driver
+        translates on a LATER loop turn, after the flow has run ahead, so reading
+        either from the live flow here would let a later method's mutations / flag
+        flips rewrite this method's snapshot or steal its suppression. Both fall
+        back to the live flow when nothing was stamped (direct-``translate`` unit
+        tests or a partial sink). When suppressed — a manual or predicted
+        ``copilotkit_emit_state`` already gave the client authoritative state —
+        the node-exit STATE_SNAPSHOT is withheld and the terminal one is owed.
 
         The final close is balanced: ``exit(FLOW_METHOD, method_name)`` returns
         the matched method boundary plus any Crew / Agent boundaries left
         dangling by a lost completion frame (deepest-first). If no boundary
-        matches (the tracker never saw this method's start), fall back to a flat
-        ``StepFinishedEvent(step_name=method_name)`` rather than dropping the
-        close entirely.
+        matches, fall back to a flat close (or, on a RESUMED run, open the step
+        first so the client is not sent a STEP_FINISHED it never saw started).
         """
-        state = self._state_provider()
+        stamped_state = getattr(event, _EMIT_STATE_ATTR, _NO_EMIT_STATE)
+        state = (
+            self._state_provider() if stamped_state is _NO_EMIT_STATE else stamped_state
+        )
         raw_messages = (
             getattr(state, "messages", None)
             or (state.get("messages") if isinstance(state, dict) else None)
@@ -1056,13 +1222,6 @@ class StreamFrameTranslator:
         # Backend tool calls live only on the wire; merge them in so they
         # survive this authoritative snapshot (see ``_backend_tool_messages``).
         messages = self._merge_backend_tool_messages(messages)
-        snapshot = (
-            state
-            if isinstance(state, dict)
-            else state.model_dump()
-            if hasattr(state, "model_dump")
-            else {}
-        )
         method_name = _coerce_name(getattr(event, "method_name", None), "method")
         closed = self._tracker.exit(FLOW_METHOD, method_name)
         events: list[Any] = []
@@ -1073,16 +1232,24 @@ class StreamFrameTranslator:
             events.append(
                 StepStartedEvent(type=EventType.STEP_STARTED, step_name=method_name)
             )
-        events += [
+        events.append(
             MessagesSnapshotEvent(
                 type=EventType.MESSAGES_SNAPSHOT,
                 messages=messages,
-            ),
-            StateSnapshotEvent(
-                type=EventType.STATE_SNAPSHOT,
-                snapshot=snapshot,
-            ),
-        ]
+            )
+        )
+        # Emit-time suppression decision: when suppressed, withhold the node-exit
+        # STATE_SNAPSHOT and record the terminal one is owed; else emit the
+        # (deep-copied) emit-time state.
+        suppress = self._consume_suppress(event)
+        self._last_node_suppressed = suppress
+        if not suppress:
+            events.append(
+                StateSnapshotEvent(
+                    type=EventType.STATE_SNAPSHOT,
+                    snapshot=_snapshot_state(state),
+                )
+            )
         if closed:
             events.extend(self._close_boundaries(closed, _METHOD_FINISHED))
         else:

--- a/integrations/crew-ai/python/ag_ui_crewai/_frames.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/_frames.py
@@ -439,27 +439,50 @@ _NO_EMIT_STATE = object()
 _NO_EMIT_SUPPRESS = object()
 
 
+# Warn-once latch for the emit-time state-capture failure (see
+# ``_warn_capture_state_loss``): the first loss is a WARNING because it silently
+# reverts to the stale live-state read, then DEBUG so a sustained failure does
+# not spam.
+_CAPTURE_STATE_WARNED = False
+
+
+def _warn_capture_state_loss(event_type: Any, exc_name: str) -> None:
+    """Warn (once) that emit-time state capture failed and staleness may return."""
+    global _CAPTURE_STATE_WARNED  # pylint: disable=global-statement
+    message = (
+        "ag-ui-crewai could not capture emit-time state for a %r event (%s); the "
+        "per-method STATE/MESSAGES snapshot falls back to the live flow state at "
+        "translate time, which a later method may have already mutated"
+    )
+    if _CAPTURE_STATE_WARNED:
+        _LOGGER.debug(message, event_type, exc_name)
+        return
+    _CAPTURE_STATE_WARNED = True
+    _LOGGER.warning(message, event_type, exc_name)
+
+
 def capture_method_emit_context(event: Any, flow: Any) -> None:
     """Stamp EMIT-TIME state + suppression context onto a parked method event.
 
     Called by the frame driver's scoped sink, which runs synchronously at emit
-    time on the flow's OWN timeline — the point the legacy bus listener did its
-    work. The frame driver, by contrast, translates parked events on a LATER
+    time on the flow's OWN timeline (the point the legacy bus listener did its
+    work). The frame driver, by contrast, translates parked events on a LATER
     loop turn, by which time the flow has run ahead, so reading either the state
     OR the suppression flags at translate time sees a LATER method's mutations.
     Capturing both here, at emit time, is what matches legacy:
 
-    * method_execution_finished — stamp a deep-copied state snapshot (for the
+    * method_execution_finished: stamp a deep-copied state snapshot (for the
       MESSAGES/STATE snapshots) AND consume the per-node suppression flags,
       stamping whether THIS method withheld its node-exit snapshot.
-    * method_execution_failed — stamp only the consumed suppression decision (a
+    * method_execution_failed: stamp only the consumed suppression decision (a
       failed method emits no state snapshot).
 
     Consuming here (rather than at translate time) resets the shared flow flags
     on the flow timeline, so two consecutive emit_state/predict_state methods
     each capture their OWN decision instead of racing over one shared flag.
-    Every other event type no-ops. Best-effort per stamp: a failure logs at
-    DEBUG and leaves the translator's live fallback in place.
+    Every other event type no-ops. Best-effort per stamp; the state-capture
+    failure warns once (it silently reintroduces the very staleness the capture
+    prevents), the rest log at DEBUG.
     """
     event_type = getattr(event, "type", None)
     if event_type not in (_METHOD_FINISHED, _METHOD_FAILED):
@@ -470,14 +493,9 @@ def capture_method_emit_context(event: Any, flow: Any) -> None:
                 event, _EMIT_STATE_ATTR, _snapshot_state(getattr(flow, "state", {}))
             )
         except Exception as exc:  # noqa: BLE001 - best-effort; live fallback
-            _LOGGER.debug(
-                "ag-ui-crewai could not capture emit-time state for a %r event "
-                "(%s); falling back to the live state at translate time",
-                event_type,
-                type(exc).__name__,
-            )
-    # Consume the flags into a local FIRST — its reset is the side effect that
-    # makes consecutive methods independent — THEN stamp. object.__setattr__ on
+            _warn_capture_state_loss(event_type, type(exc).__name__)
+    # Consume the flags into a local FIRST (its reset is the side effect that
+    # makes consecutive methods independent), THEN stamp. object.__setattr__ on
     # these crewai events does not realistically fail; if it ever did, the
     # decision is already consumed, so the live fallback would re-read the reset
     # flags as False (one transient node-exit snapshot). Hence the failure is
@@ -737,8 +755,8 @@ class StreamFrameTranslator:
             # Record the emit-time suppression decision so a node that
             # emit_state'd then failed while the flow continues still gets its
             # authoritative flow.state redelivered by the terminal snapshot. OR
-            # (not overwrite) so a failed node — which emits NO snapshot of its
-            # own — can only ADD an owed terminal, never clear one a prior
+            # (not overwrite) so a failed node, which emits NO snapshot of its
+            # own, can only ADD an owed terminal, never clear one a prior
             # suppressed node already owed.
             self._last_node_suppressed = (
                 self._consume_suppress(event) or self._last_node_suppressed
@@ -884,13 +902,17 @@ class StreamFrameTranslator:
         return []
 
     def close_pending(self) -> list[Any]:
-        """Close open streamed message / tool sequences before a terminal RUN_ERROR.
+        """Flush what is owed before a terminal RUN_ERROR.
 
-        Open STEPS / reasoning are left to the error path\'s own handling; this only
-        balances the streamed triples the shaper owns so a RUN_ERROR mid-message does
-        not leave an unterminated START on the wire.
+        Balances the streamed triples the shaper owns (so a RUN_ERROR mid-message
+        does not leave an unterminated START on the wire) AND redelivers the
+        terminal STATE_SNAPSHOT a suppressed method withheld. An errored run must
+        still hand the client the authoritative flow.state, not strand it on an
+        ephemeral emit_state payload; the pre-suppression path emitted the
+        node-exit snapshot from live state here, so dropping it is a regression.
+        Open STEPS / reasoning are left to the error path's own handling.
         """
-        return self._shaper.flush()
+        return [*self._shaper.flush(), *self._terminal_state_snapshot_events()]
 
     def finalize(self) -> list[Any]:
         """Belt-and-braces terminal.
@@ -919,7 +941,7 @@ class StreamFrameTranslator:
         events.extend(step_finished_event(b) for b in self._tracker.drain_all())
         # Terminal STATE_SNAPSHOT before the terminator (interrupt tail or
         # RUN_FINISHED): redelivers the authoritative flow.state a suppressed
-        # last method withheld — including a method that emit_state'd then paused
+        # last method withheld, including a method that emit_state'd then paused
         # for async HITL without a method_execution_finished.
         events.extend(self._terminal_state_snapshot_events())
         interrupt = self._build_interrupt()
@@ -1160,9 +1182,9 @@ class StreamFrameTranslator:
 
         Prefers the decision the sink consumed + stamped at emit time (so it is
         THIS method's, not a later method's, flag). Falls back to consuming the
-        live flow flags when nothing was stamped — the direct-``translate`` unit
+        live flow flags when nothing was stamped (the direct-``translate`` unit
         tests, which set the flags synchronously right before the method event,
-        or a partial sink install.
+        or a partial sink install).
         """
         stamped = getattr(event, _EMIT_SUPPRESS_ATTR, _NO_EMIT_SUPPRESS)
         if stamped is _NO_EMIT_SUPPRESS:
@@ -1199,8 +1221,8 @@ class StreamFrameTranslator:
         either from the live flow here would let a later method's mutations / flag
         flips rewrite this method's snapshot or steal its suppression. Both fall
         back to the live flow when nothing was stamped (direct-``translate`` unit
-        tests or a partial sink). When suppressed — a manual or predicted
-        ``copilotkit_emit_state`` already gave the client authoritative state —
+        tests or a partial sink). When suppressed (a manual or predicted
+        ``copilotkit_emit_state`` already gave the client authoritative state),
         the node-exit STATE_SNAPSHOT is withheld and the terminal one is owed.
 
         The final close is balanced: ``exit(FLOW_METHOD, method_name)`` returns
@@ -1210,9 +1232,8 @@ class StreamFrameTranslator:
         first so the client is not sent a STEP_FINISHED it never saw started).
         """
         stamped_state = getattr(event, _EMIT_STATE_ATTR, _NO_EMIT_STATE)
-        state = (
-            self._state_provider() if stamped_state is _NO_EMIT_STATE else stamped_state
-        )
+        stamped = stamped_state is not _NO_EMIT_STATE
+        state = stamped_state if stamped else self._state_provider()
         raw_messages = (
             getattr(state, "messages", None)
             or (state.get("messages") if isinstance(state, dict) else None)
@@ -1239,15 +1260,16 @@ class StreamFrameTranslator:
             )
         )
         # Emit-time suppression decision: when suppressed, withhold the node-exit
-        # STATE_SNAPSHOT and record the terminal one is owed; else emit the
-        # (deep-copied) emit-time state.
+        # STATE_SNAPSHOT and record the terminal one is owed; else emit the state.
+        # A stamped state is already a private deep copy (isolated from later
+        # mutation); only the live-fallback read needs a fresh copy.
         suppress = self._consume_suppress(event)
         self._last_node_suppressed = suppress
         if not suppress:
             events.append(
                 StateSnapshotEvent(
                     type=EventType.STATE_SNAPSHOT,
-                    snapshot=_snapshot_state(state),
+                    snapshot=state if stamped else _snapshot_state(state),
                 )
             )
         if closed:

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -39,6 +39,7 @@ from ._frames import (
     CREW_AGENT_LIFECYCLE_TYPES,
     EmissionShaper,
     StreamFrameTranslator,
+    capture_method_emit_context,
     is_backend_tool_event,
     is_recognized_event,
     log_raw_loss,
@@ -2018,6 +2019,9 @@ async def _run_flow_frame_stream(
         thread_id=input_data.thread_id,
         run_id=input_data.run_id,
         state_provider=lambda: getattr(flow_copy, "state", {}),
+        # Lets the translator honor the sdk emit_state/predict_state suppression
+        # flags stashed on this flow (legacy-listener parity).
+        flow_provider=lambda: flow_copy,
         hitl_options=hitl_options,
         emission_shape=emission_shape,
     )
@@ -2100,6 +2104,13 @@ async def _run_flow_frame_stream(
             or is_thinking_event(event)
             or getattr(event, "type", None) in CREW_AGENT_LIFECYCLE_TYPES
         ):
+            # Capture EMIT-TIME context (this sink runs synchronously on the
+            # flow's timeline) for method finished/failed events: the state
+            # snapshot AND the consumed suppression decision. The frame driver
+            # translates later, after the flow has run ahead, so both must be
+            # captured here or a later method rewrites this method's snapshot or
+            # steals its suppression. No-ops for every other event type.
+            capture_method_emit_context(event, flow_copy)
             raw_events[event_id] = event
         elif emit_raw_events:
             if len(foreign_events) >= _FOREIGN_EVENT_BUFFER_MAX:
@@ -2558,6 +2569,7 @@ async def _run_flow_resume_stream(
         thread_id=thread_id,
         run_id=run_id,
         state_provider=lambda: getattr(resumed_flow, "state", {}),
+        flow_provider=lambda: resumed_flow,
         hitl_options=hitl_options,
         resumed=True,
     )
@@ -2568,6 +2580,10 @@ async def _run_flow_resume_stream(
         # Outer-run isolation identical to the kickoff frame driver: only this
         # flow's own events (plus MCP events, emitted with the agent as source).
         if source is resumed_flow or is_mcp_event(event):
+            # Capture EMIT-TIME state + suppression on the flow timeline before
+            # the event is queued for later translation (no-ops except for
+            # method finished/failed). See the kickoff driver for the rationale.
+            capture_method_emit_context(event, resumed_flow)
             loop.call_soon_threadsafe(queue.put_nowait, event)
 
     # Predeclared before the try so the finally teardown is always safe to

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -1000,6 +1000,12 @@ class FastAPICrewFlowEventListener(_EventListenerBase):
             _enqueue(source, None)
         @crewai_event_bus.on(MethodExecutionStartedEvent)
         def _(source, event):
+            # Same source gate every other handler has: a pooled off-thread
+            # dispatch can land for a flow whose run is not ours (or already torn
+            # down). Without it the reset below wipes suppression flags on a
+            # foreign flow, and those flags are now load-bearing.
+            if get_queue(source) is None:
+                return
             # Clear stale suppression flags from a prior node that raised.
             reset_node_snapshot_suppression(source)
             # Flat per-method attribution. The legacy bus path is dispatched on
@@ -2564,6 +2570,13 @@ async def _run_flow_resume_stream(
     # and its crew writes to memory like any other run.
     apply_thread_memory_scope(resumed_flow, thread_id)
 
+    # The method that paused for feedback emitted neither finished nor failed, so
+    # its node-exit suppression flags were never consumed. Clear them on the
+    # reloaded flow before resume_async runs (on the flow timeline, before any
+    # emit) so a stale predicted-tool / manual-emit flag cannot wrongly suppress
+    # the resumed run's first snapshot.
+    reset_node_snapshot_suppression(resumed_flow)
+
     token = flow_context.set(resumed_flow)
     translator = StreamFrameTranslator(
         thread_id=thread_id,
@@ -2707,6 +2720,8 @@ async def _run_flow_resume_stream(
                 ceiling_display,
                 ceiling_exc.args[0] if ceiling_exc.args else "",
             )
+            for _pending in translator.close_pending():
+                yield encoder.encode(_pending)
             yield encoder.encode(
                 RunErrorEvent(
                     message=(
@@ -2727,6 +2742,8 @@ async def _run_flow_resume_stream(
                 ceiling_display,
                 type(upstream_exc).__name__,
             )
+            for _pending in translator.close_pending():
+                yield encoder.encode(_pending)
             yield encoder.encode(
                 RunErrorEvent(
                     message=(
@@ -2745,6 +2762,8 @@ async def _run_flow_resume_stream(
                 run_id,
                 type(e).__name__,
             )
+            for _pending in translator.close_pending():
+                yield encoder.encode(_pending)
             yield encoder.encode(
                 RunErrorEvent(
                     message=(

--- a/integrations/crew-ai/python/tests/test_interrupts.py
+++ b/integrations/crew-ai/python/tests/test_interrupts.py
@@ -462,6 +462,42 @@ def test_translator_captures_pause_and_finalizes_interrupt():
     assert tail[0].value["id"] == "req-1"
 
 
+async def test_translator_terminal_snapshot_precedes_interrupt_tail():
+    # A method emit_states then pauses for async HITL (request + pause, no
+    # method_finished). finalize must redeliver the authoritative flow.state as a
+    # terminal STATE_SNAPSHOT BEFORE the interrupt tail (CUSTOM, RUN_FINISHED),
+    # not strand the client on the ephemeral emit payload.
+    from ag_ui_crewai.context import flow_context
+    from ag_ui_crewai.sdk import copilotkit_emit_state
+
+    class _F:
+        state = {"messages": [], "v": "authoritative"}
+
+    flow = _F()
+    tr = StreamFrameTranslator(
+        thread_id="t-1",
+        run_id="r-1",
+        state_provider=lambda: flow.state,
+        flow_provider=lambda: flow,
+    )
+    tr.translate(_flow_started())
+    tr.translate(SimpleNamespace(type="method_execution_started", method_name="propose"))
+    token = flow_context.set(flow)
+    try:
+        await copilotkit_emit_state({"v": "ephemeral"})  # sets the suppression flag
+    finally:
+        flow_context.reset(token)
+    tr.translate(_hf_requested())
+    tr.translate(_flow_paused())
+    tail = tr.finalize()
+    types = [e.type for e in tail]
+    assert EventType.STATE_SNAPSHOT in types, types
+    assert types[-2:] == [EventType.CUSTOM, EventType.RUN_FINISHED], types
+    assert types.index(EventType.STATE_SNAPSHOT) < types.index(EventType.CUSTOM), types
+    snap = next(e for e in tail if e.type == EventType.STATE_SNAPSHOT)
+    assert snap.snapshot == {"messages": [], "v": "authoritative"}
+
+
 def test_translator_no_pause_finalizes_plain_run_finished():
     tr = _translator()
     tr.translate(_flow_started())
@@ -630,6 +666,45 @@ async def test_e2e_kickoff_pause_outcome_opt_in(_isolated_cwd):
     # The reviewed method output round-trips into the interrupt metadata so the
     # client can render what the human is approving.
     assert interrupt["metadata"]["crewai"]["output"] == {"plan": ["a", "b"]}
+
+
+class _ResumeEmitFlow(Flow[_DemoState]):
+    """Pauses on ``propose``; the RESUMED ``apply`` method calls emit_state, so
+    the resume driver must honour emit-time snapshot-suppression too."""
+
+    @start()
+    @human_feedback(message="Approve?", provider=agui_feedback_provider)
+    def propose(self):
+        return {"plan": ["a"]}
+
+    @listen(propose)
+    async def apply(self, feedback):
+        from ag_ui_crewai.sdk import copilotkit_emit_state
+
+        self.state.result = "authoritative"
+        await copilotkit_emit_state({"result": "emit"})
+
+
+async def test_e2e_resume_emit_state_suppressed_on_resume_driver(_isolated_cwd):
+    # The resume driver must wire flow_provider + emit-time capture too: the
+    # resumed apply's emit_state must survive method-finish (node-exit
+    # STATE_SNAPSHOT suppressed), with the authoritative state redelivered as a
+    # terminal snapshot. Deleting the capture wiring on the resume sink regresses
+    # this (the node-exit rebuild clobbers 'emit' and no terminal is owed).
+    flow = _ResumeEmitFlow()
+    await _run_kickoff(flow, _mk_input("thr-remit"), HITLOptions())
+    resume = [ResumeEntry(interrupt_id="thr-remit", status="resolved", payload="ok")]
+    events = await _run_resume(flow, _mk_input("thr-remit", resume=resume), HITLOptions())
+    types = _types(events)
+    # apply's node-exit STATE_SNAPSHOT is suppressed: none sits between apply's
+    # (the last) MESSAGES_SNAPSHOT and the STEP_FINISHED that follows it.
+    mi = len(types) - 1 - types[::-1].index("MESSAGES_SNAPSHOT")
+    sf = types.index("STEP_FINISHED", mi)
+    assert "STATE_SNAPSHOT" not in types[mi:sf], types
+    # The authoritative state is redelivered as the terminal snapshot.
+    assert types[-2:] == ["STATE_SNAPSHOT", "RUN_FINISHED"], types
+    results = [e.get("snapshot", {}).get("result") for e in events if e.get("type") == "STATE_SNAPSHOT"]
+    assert "emit" in results and results[-1] == "authoritative", results
 
 
 async def test_e2e_resume_completes_run(_isolated_cwd):

--- a/integrations/crew-ai/python/tests/test_shared_state_streaming.py
+++ b/integrations/crew-ai/python/tests/test_shared_state_streaming.py
@@ -665,3 +665,94 @@ async def test_terminal_snapshot_serializes_pydantic_state():
     terminal = events[-3]
     assert type(terminal).__name__ == "StateSnapshotEvent"
     assert terminal.snapshot == {"messages": [], "recipe": {"title": "Soup"}}
+
+
+# --------------------------------------------------------------------------
+# StreamFrame path (crewai >= 1.6): the translator must honour the SAME
+# emit_state/predict_state suppression the legacy listener does, and owe the
+# terminal snapshot correctly across the method-failed / finalize edges.
+# Driven by feeding the translator raw lifecycle events directly (as
+# ``endpoint._run_flow_frame_stream`` does); direct-translate uses the live
+# suppression-flag fallback (the flags are set synchronously in the body here).
+# --------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+from ag_ui_crewai._frames import StreamFrameTranslator  # noqa: E402
+
+
+def _fe(type_, **attrs):  # noqa: A002 - mirror event.type
+    return SimpleNamespace(type=type_, **attrs)
+
+
+def _frame_translator(flow):
+    return StreamFrameTranslator(
+        thread_id="t-1",
+        run_id="r-1",
+        state_provider=lambda: getattr(flow, "state", {}),
+        flow_provider=lambda: flow,
+    )
+
+
+async def test_frame_method_failed_after_emit_owes_terminal_snapshot():
+    # A method emit_state's then FAILS while the flow continues to flow_finished.
+    # The failed method emits no node-exit snapshot, so the terminal snapshot is
+    # the only carrier of the authoritative flow.state — the fail path must
+    # record the owed terminal, not drop it.
+    flow = _FakeFlow(state={"messages": [], "recipe": {"title": "Pho"}})
+    tr = _frame_translator(flow)
+    tr.translate(_fe("flow_started"))
+    tr.translate(_fe("method_execution_started", method_name="chat"))
+    token = flow_context.set(flow)
+    try:
+        await copilotkit_emit_state({"recipe": "ephemeral"})
+    finally:
+        flow_context.reset(token)
+    tr.translate(_fe("method_execution_failed", method_name="chat"))
+    tail = tr.translate(_fe("flow_finished"))
+    assert _names(tail)[-2:] == ["StateSnapshotEvent", "RunFinishedEvent"]
+    snap = next(e for e in tail if type(e).__name__ == "StateSnapshotEvent")
+    assert snap.snapshot == {"messages": [], "recipe": {"title": "Pho"}}
+
+
+async def test_frame_prior_suppressed_then_later_method_fails_keeps_terminal():
+    # Node A emit_state's and finishes (owed terminal = True). Node B then FAILS
+    # without emitting. B's fail path must NOT clobber A's owed-terminal flag (it
+    # emits no snapshot of its own) — OR, not overwrite.
+    flow = _FakeFlow(state={"messages": [], "recipe": {"title": "Laksa"}})
+    tr = _frame_translator(flow)
+    tr.translate(_fe("flow_started"))
+    tr.translate(_fe("method_execution_started", method_name="a"))
+    token = flow_context.set(flow)
+    try:
+        await copilotkit_emit_state({"recipe": "ephemeral"})
+    finally:
+        flow_context.reset(token)
+    tr.translate(_fe("method_execution_finished", method_name="a"))
+    tr.translate(_fe("method_execution_started", method_name="b"))
+    tr.translate(_fe("method_execution_failed", method_name="b"))
+    tail = tr.translate(_fe("flow_finished"))
+    assert _names(tail)[-2:] == ["StateSnapshotEvent", "RunFinishedEvent"]
+    snap = next(e for e in tail if type(e).__name__ == "StateSnapshotEvent")
+    assert snap.snapshot == {"messages": [], "recipe": {"title": "Laksa"}}
+
+
+async def test_frame_finalize_redelivers_state_when_suppressed_without_finish():
+    # A method emit_state's then the stream exhausts via finalize WITHOUT a
+    # method_execution_finished (e.g. an async HITL suspend): the terminal must
+    # still redeliver the authoritative flow.state, else the client is left on
+    # the ephemeral emit payload.
+    flow = _FakeFlow(state={"messages": [], "recipe": {"title": "Ragu"}})
+    tr = _frame_translator(flow)
+    tr.translate(_fe("flow_started"))
+    tr.translate(_fe("method_execution_started", method_name="chat"))
+    token = flow_context.set(flow)
+    try:
+        await copilotkit_emit_state({"recipe": "ephemeral"})
+    finally:
+        flow_context.reset(token)
+    tail = tr.finalize()
+    names = _names(tail)
+    assert "StateSnapshotEvent" in names
+    assert names[-1] == "RunFinishedEvent"
+    snap = next(e for e in tail if type(e).__name__ == "StateSnapshotEvent")
+    assert snap.snapshot == {"messages": [], "recipe": {"title": "Ragu"}}

--- a/integrations/crew-ai/python/tests/test_shared_state_streaming.py
+++ b/integrations/crew-ai/python/tests/test_shared_state_streaming.py
@@ -693,10 +693,28 @@ def _frame_translator(flow):
     )
 
 
+async def test_frame_method_finished_after_emit_suppresses_node_exit():
+    # A method that emit_state's then finishes must have its node-exit
+    # STATE_SNAPSHOT SUPPRESSED (only MESSAGES + STEP_FINISHED), so the rebuild
+    # does not clobber the progressive emit. Direct-translate exercises the live
+    # suppression fallback (no sink stamp).
+    flow = _FakeFlow(state={"messages": [], "v": "real"})
+    tr = _frame_translator(flow)
+    tr.translate(_fe("flow_started"))
+    tr.translate(_fe("method_execution_started", method_name="chat"))
+    token = flow_context.set(flow)
+    try:
+        await copilotkit_emit_state({"v": "emit"})
+    finally:
+        flow_context.reset(token)
+    finished = tr.translate(_fe("method_execution_finished", method_name="chat"))
+    assert _names(finished) == ["MessagesSnapshotEvent", "StepFinishedEvent"]
+
+
 async def test_frame_method_failed_after_emit_owes_terminal_snapshot():
     # A method emit_state's then FAILS while the flow continues to flow_finished.
     # The failed method emits no node-exit snapshot, so the terminal snapshot is
-    # the only carrier of the authoritative flow.state — the fail path must
+    # the only carrier of the authoritative flow.state, so the fail path must
     # record the owed terminal, not drop it.
     flow = _FakeFlow(state={"messages": [], "recipe": {"title": "Pho"}})
     tr = _frame_translator(flow)
@@ -717,7 +735,7 @@ async def test_frame_method_failed_after_emit_owes_terminal_snapshot():
 async def test_frame_prior_suppressed_then_later_method_fails_keeps_terminal():
     # Node A emit_state's and finishes (owed terminal = True). Node B then FAILS
     # without emitting. B's fail path must NOT clobber A's owed-terminal flag (it
-    # emits no snapshot of its own) — OR, not overwrite.
+    # emits no snapshot of its own): OR, not overwrite.
     flow = _FakeFlow(state={"messages": [], "recipe": {"title": "Laksa"}})
     tr = _frame_translator(flow)
     tr.translate(_fe("flow_started"))

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -1287,7 +1287,7 @@ async def test_frame_path_progressive_state_snapshot_is_verbatim():
     assert snap["timestamp"] == "user-ts", snap
 
 
-# -- PNI-180: method-finished state emission (emit-time snapshot + suppression) --
+# -- method-finished state emission: emit-time snapshot + snapshot-suppression --
 
 
 class _MultiMethodMutatingState(FlowState):
@@ -1297,8 +1297,8 @@ class _MultiMethodMutatingState(FlowState):
 
 class _MultiMethodFlow(Flow[_MultiMethodMutatingState]):
     """Two methods mutating shared state: m1 appends 'one', m2 (listening on m1)
-    appends 'two'. Single-method and crew_chat flows never exercise this — which
-    is why PNI-180 defect 1 shipped with a green e2e."""
+    appends 'two'. Single-method and crew_chat flows never exercise this, which
+    is why the retroactive-rewrite defect shipped with a green e2e."""
 
     @start()
     async def m1(self):
@@ -1312,7 +1312,7 @@ class _MultiMethodFlow(Flow[_MultiMethodMutatingState]):
 
 @requires_stream_frames
 async def test_frame_path_per_method_snapshot_is_emit_time_not_retroactive():
-    """PNI-180 defect 1: a per-method STATE_SNAPSHOT must reflect state as of THAT
+    """A per-method STATE_SNAPSHOT must reflect state as of THAT
     method's finish (emit time), not a LATER method's mutation read from the live
     flow at translate time. The frame driver runs behind the flow, so pre-fix m1's
     snapshot was retroactively rewritten to ['one','two'] once m2 had appended."""
@@ -1351,8 +1351,8 @@ class _EmitThenMutateFlow(Flow[_SingleEmitStateFlow]):
 
 @requires_stream_frames
 async def test_frame_path_emit_state_suppresses_node_exit_snapshot():
-    """PNI-180 defect 2: a manual copilotkit_emit_state must survive method-finish
-    on the StreamFrame path — the node-exit STATE_SNAPSHOT is suppressed (else it
+    """A manual copilotkit_emit_state must survive method-finish
+    on the StreamFrame path: the node-exit STATE_SNAPSHOT is suppressed (else it
     clobbers the progressive emit with the rebuilt flow.state), and the
     authoritative state is redelivered as a terminal snapshot before RUN_FINISHED."""
     from ag_ui.encoder import EventEncoder
@@ -1378,7 +1378,7 @@ async def test_frame_path_emit_state_suppresses_node_exit_snapshot():
 
 
 class _TwoEmitStateFlow(Flow[_MultiMethodMutatingState]):
-    """Two sequential methods that each emit_state — the case that exercises the
+    """Two sequential methods that each emit_state: the case that exercises the
     per-method suppression DECISION (not just state content) captured at emit time."""
 
     @start()
@@ -1395,7 +1395,7 @@ class _TwoEmitStateFlow(Flow[_MultiMethodMutatingState]):
 
 @requires_stream_frames
 async def test_frame_path_two_emit_state_methods_each_suppress_node_exit():
-    """PNI-180 defect 2 (suppression half): with two consecutive emit_state
+    """Suppression half: with two consecutive emit_state
     methods, EACH method's node-exit STATE_SNAPSHOT must be suppressed so neither
     progressive emit is clobbered. Pre-fix the suppression flag was consumed at
     translate time from one shared flow flag, so m1's finish stole m2's flag and
@@ -1440,9 +1440,9 @@ class _PredictStateFlow(Flow[_SingleEmitStateFlow]):
 
 @requires_stream_frames
 async def test_frame_path_predicted_tool_suppresses_node_exit_snapshot():
-    """PNI-180 defect 2 (predicted-tool limb): a streamed predicted
+    """Predicted-tool limb: a streamed predicted
     copilotkit_predict_state tool must suppress the node-exit STATE_SNAPSHOT on
-    the StreamFrame path, exactly like copilotkit_emit_state — the authoritative
+    the StreamFrame path, exactly like copilotkit_emit_state; the authoritative
     state is redelivered as the terminal snapshot."""
     from ag_ui.encoder import EventEncoder
 
@@ -1463,6 +1463,53 @@ async def test_frame_path_predicted_tool_suppresses_node_exit_snapshot():
     assert types[-2:] == ["STATE_SNAPSHOT", "RUN_FINISHED"], types
     terminal = payloads[-2]["snapshot"]
     assert terminal.get("v") == "real", terminal
+
+
+class _EmitThenRaiseFlow(Flow[_SingleEmitStateFlow]):
+    """A method that emit_states an ephemeral value, writes the authoritative
+    value to flow.state, then raises, so the run terminates with RUN_ERROR."""
+
+    @start()
+    async def chat(self):
+        self.state.v = "authoritative"
+        await copilotkit_emit_state({"v": "emit"})
+        raise RuntimeError("boom")
+
+
+@requires_stream_frames
+async def test_frame_path_run_error_still_flushes_owed_terminal_snapshot():
+    """An errored run whose method suppressed its node-exit snapshot (via
+    emit_state) must STILL redeliver the authoritative flow.state as a terminal
+    snapshot before RUN_ERROR, not strand the client on the ephemeral emit.
+    Also exercises the method_execution_failed sink capture end-to-end."""
+    from ag_ui.encoder import EventEncoder
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=_EmitThenRaiseFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    types = [p["type"] for p in payloads]
+    assert types[-1] == "RUN_ERROR", types
+    assert types[-2] == "STATE_SNAPSHOT", types
+    vs = [p["snapshot"].get("v") for p in payloads if p["type"] == "STATE_SNAPSHOT"]
+    # Progressive emit survives; the terminal (pre-RUN_ERROR) carries flow.state.
+    assert vs == ["emit", "authoritative"], vs
+
+
+def test_snapshot_state_deep_copies_plain_dict():
+    """_snapshot_state must deep-copy a plain-dict state (crewai returns the LIVE
+    dict): mutating the source after snapshotting must not change the snapshot."""
+    from ag_ui_crewai._frames import _snapshot_state
+
+    src = {"a": [1, 2], "b": {"c": 3}}
+    snap = _snapshot_state(src)
+    src["a"].append(99)
+    src["b"]["c"] = "CHANGED"
+    assert snap == {"a": [1, 2], "b": {"c": 3}}
 
 
 class _NestedNoLeakFlow(Flow):

--- a/integrations/crew-ai/python/tests/test_streaming.py
+++ b/integrations/crew-ai/python/tests/test_streaming.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from crewai.flow.flow import Flow, start
+from crewai.flow.flow import Flow, start, listen, FlowState
 
 from ag_ui.core import EventType
 from ag_ui_crewai import endpoint as ep
@@ -1285,6 +1285,184 @@ async def test_frame_path_progressive_state_snapshot_is_verbatim():
     # User keys colliding with _FRAME_DATA_EXCLUDE are preserved verbatim.
     assert snap["type"] == "user-type", snap
     assert snap["timestamp"] == "user-ts", snap
+
+
+# -- PNI-180: method-finished state emission (emit-time snapshot + suppression) --
+
+
+class _MultiMethodMutatingState(FlowState):
+    messages: list = []
+    steps: list = []
+
+
+class _MultiMethodFlow(Flow[_MultiMethodMutatingState]):
+    """Two methods mutating shared state: m1 appends 'one', m2 (listening on m1)
+    appends 'two'. Single-method and crew_chat flows never exercise this — which
+    is why PNI-180 defect 1 shipped with a green e2e."""
+
+    @start()
+    async def m1(self):
+        self.state.steps.append("one")
+        return "go"
+
+    @listen(m1)
+    async def m2(self, _):
+        self.state.steps.append("two")
+
+
+@requires_stream_frames
+async def test_frame_path_per_method_snapshot_is_emit_time_not_retroactive():
+    """PNI-180 defect 1: a per-method STATE_SNAPSHOT must reflect state as of THAT
+    method's finish (emit time), not a LATER method's mutation read from the live
+    flow at translate time. The frame driver runs behind the flow, so pre-fix m1's
+    snapshot was retroactively rewritten to ['one','two'] once m2 had appended."""
+    from ag_ui.encoder import EventEncoder
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=_MultiMethodFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    steps_snaps = [
+        p["snapshot"].get("steps")
+        for p in payloads
+        if p["type"] == "STATE_SNAPSHOT" and isinstance(p.get("snapshot"), dict)
+    ]
+    assert steps_snaps == [["one"], ["one", "two"]], steps_snaps
+
+
+class _SingleEmitStateFlow(FlowState):
+    messages: list = []
+    v: str = ""
+
+
+class _EmitThenMutateFlow(Flow[_SingleEmitStateFlow]):
+    """One method that emit_states an ephemeral progressive value, then writes a
+    different authoritative value to flow.state before returning."""
+
+    @start()
+    async def chat(self):
+        self.state.v = "real"
+        await copilotkit_emit_state({"v": "emit"})
+
+
+@requires_stream_frames
+async def test_frame_path_emit_state_suppresses_node_exit_snapshot():
+    """PNI-180 defect 2: a manual copilotkit_emit_state must survive method-finish
+    on the StreamFrame path — the node-exit STATE_SNAPSHOT is suppressed (else it
+    clobbers the progressive emit with the rebuilt flow.state), and the
+    authoritative state is redelivered as a terminal snapshot before RUN_FINISHED."""
+    from ag_ui.encoder import EventEncoder
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=_EmitThenMutateFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    types = [p["type"] for p in payloads]
+    # Node-exit STATE_SNAPSHOT suppressed: none between MESSAGES and STEP_FINISHED.
+    mi = types.index("MESSAGES_SNAPSHOT")
+    sf = types.index("STEP_FINISHED", mi)
+    assert "STATE_SNAPSHOT" not in types[mi:sf], types
+    # Terminal snapshot after the step close, before RUN_FINISHED.
+    assert types[-2:] == ["STATE_SNAPSHOT", "RUN_FINISHED"], types
+    vs = [p["snapshot"].get("v") for p in payloads if p["type"] == "STATE_SNAPSHOT"]
+    # The progressive emit survives; the terminal carries the authoritative state.
+    assert vs == ["emit", "real"], vs
+
+
+class _TwoEmitStateFlow(Flow[_MultiMethodMutatingState]):
+    """Two sequential methods that each emit_state — the case that exercises the
+    per-method suppression DECISION (not just state content) captured at emit time."""
+
+    @start()
+    async def m1(self):
+        self.state.steps.append("a")
+        await copilotkit_emit_state({"steps": ["a-emit"]})
+        return "go"
+
+    @listen(m1)
+    async def m2(self, _):
+        self.state.steps.append("b")
+        await copilotkit_emit_state({"steps": ["b-emit"]})
+
+
+@requires_stream_frames
+async def test_frame_path_two_emit_state_methods_each_suppress_node_exit():
+    """PNI-180 defect 2 (suppression half): with two consecutive emit_state
+    methods, EACH method's node-exit STATE_SNAPSHOT must be suppressed so neither
+    progressive emit is clobbered. Pre-fix the suppression flag was consumed at
+    translate time from one shared flow flag, so m1's finish stole m2's flag and
+    m2's node-exit rebuild clobbered 'b-emit'."""
+    from ag_ui.encoder import EventEncoder
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=_TwoEmitStateFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    types = [p["type"] for p in payloads]
+    assert types == [
+        "RUN_STARTED",
+        "STEP_STARTED", "STATE_SNAPSHOT", "MESSAGES_SNAPSHOT", "STEP_FINISHED",
+        "STEP_STARTED", "STATE_SNAPSHOT", "MESSAGES_SNAPSHOT", "STEP_FINISHED",
+        "STATE_SNAPSHOT",
+        "RUN_FINISHED",
+    ], types
+    steps = [p["snapshot"].get("steps") for p in payloads if p["type"] == "STATE_SNAPSHOT"]
+    assert steps == [["a-emit"], ["b-emit"], ["a", "b"]], steps
+
+
+class _PredictStateFlow(Flow[_SingleEmitStateFlow]):
+    """Declares copilotkit_predict_state then streams the predicted tool, so the
+    node-exit snapshot is suppressed via the PREDICTED-tool limb (not emit_state)."""
+
+    @start()
+    async def chat(self):
+        from ag_ui_crewai.sdk import copilotkit_predict_state, _mark_predicted_tool_streamed
+        self.state.v = "real"
+        await copilotkit_predict_state(
+            {"v": {"tool_name": "set_v", "tool_argument": "v"}}
+        )
+        # The predicted tool actually streams (as copilotkit_stream would flag it).
+        f = flow_context.get(None)
+        _mark_predicted_tool_streamed(f, "set_v")
+
+
+@requires_stream_frames
+async def test_frame_path_predicted_tool_suppresses_node_exit_snapshot():
+    """PNI-180 defect 2 (predicted-tool limb): a streamed predicted
+    copilotkit_predict_state tool must suppress the node-exit STATE_SNAPSHOT on
+    the StreamFrame path, exactly like copilotkit_emit_state — the authoritative
+    state is redelivered as the terminal snapshot."""
+    from ag_ui.encoder import EventEncoder
+
+    encoded = await _collect(ep._run_flow_frame_stream(
+        flow_copy=_PredictStateFlow(),
+        encoder=EventEncoder(),
+        input_data=_make_run_input(),
+        inputs={},
+        timeout=30.0,
+    ))
+    payloads = _decode_sse(encoded)
+    types = [p["type"] for p in payloads]
+    # Node-exit STATE_SNAPSHOT suppressed: none between MESSAGES and STEP_FINISHED.
+    mi = types.index("MESSAGES_SNAPSHOT")
+    sf = types.index("STEP_FINISHED", mi)
+    assert "STATE_SNAPSHOT" not in types[mi:sf], types
+    # Terminal snapshot carries the authoritative state before RUN_FINISHED.
+    assert types[-2:] == ["STATE_SNAPSHOT", "RUN_FINISHED"], types
+    terminal = payloads[-2]["snapshot"]
+    assert terminal.get("v") == "real", terminal
 
 
 class _NestedNoLeakFlow(Flow):


### PR DESCRIPTION
## What

Fixes two pre-existing parity defects in the crewai>=1.6 **StreamFrame** path's method-finished state emission, both diverging from the legacy bus listener. Ref: **PNI-180**.

### Defect 1 — lazy `state_provider` (retroactive rewrite)
`_method_finished_events` read the LIVE `flow.state` at frame-**translate** time. The frame driver runs behind the flow, so a later `@start`/`@listen` method's mutation retroactively rewrote an earlier method's MESSAGES/STATE snapshot. The scoped sink now captures a deep-copied state snapshot at **emit** time (on the flow's own timeline); the translator uses it, with a live fallback for direct-translate unit tests.

### Defect 2 — snapshot-suppression not honoured on the StreamFrame path
The StreamFrame path emitted `STATE_SNAPSHOT` unconditionally, ignoring the `copilotkit_emit_state` / `copilotkit_predict_state` suppression the legacy listener honours, so the node-exit rebuild clobbered the progressive state. The sink now **consumes the suppression flags at emit time** as well (so two consecutive suppressing methods each capture their own decision instead of racing one shared flag); the node-exit `STATE_SNAPSHOT` is withheld when suppressed, and the authoritative `flow.state` is redelivered as a **terminal** snapshot at `flow_finished` / `finalize`.

### Also folded in
The deferred `MethodExecutionFailed` handling: a failed method records its emit-time suppression decision (OR, so it never clears a prior node's owed terminal), so a method that `emit_state`'d then failed while the flow continues still gets its terminal snapshot.

## Integration
Wired into **both** the kickoff and resumed-HITL frame drivers via `flow_provider` + `capture_method_emit_context`. Preserves main's backend-tool-message merge and resumed step-open, and places the terminal snapshot before the HITL interrupt tail.

## Tests
All fail against `main` before the fix, pass after: multi-method retroactive-rewrite, single- and two-method `emit_state` suppression, predicted-tool suppression, method-failed terminal ownership, and `finalize` redelivery. Full crew-ai suite green (512 passed / 2 skipped).

## Follow-up (not in this PR)
Coverage-only gaps needing HITL/resume/error harness: resume-driver e2e suppression, method-failed e2e through the sink, and HITL-interrupt + terminal ordering. The logic for each is covered by translator-level tests here.