### PR TITLE
docs(tools): document ToolMessage.error in tool result examples

### DIFF
--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -175,6 +175,23 @@ message":
 This message becomes part of the conversation history, allowing the agent to
 reference and incorporate the tool's result in subsequent responses.
 
+If the tool did not succeed, set `error` to the failure message:
+
+```typescript
+{
+  id: "result-789",
+  role: "tool",
+  content: "Deployment blocked: the production environment is locked",
+  toolCallId: "tool-123",
+  error: "the production environment is locked" // Marks this result as a failure
+}
+```
+
+`error` is how the protocol expresses a client-side tool failure. Without it, a
+tool that failed is indistinguishable from one that succeeded — whatever the
+frontend happened to put in `content` is all the agent has to go on. See
+[Messages](/concepts/messages) for the full `ToolMessage` shape.
+
 ## Human-in-the-Loop Workflows
 
 The AG-UI tool system is especially powerful for implementing human-in-the-loop

--- a/docs/sdk/kotlin/core/types.mdx
+++ b/docs/sdk/kotlin/core/types.mdx
@@ -134,8 +134,9 @@ val toolResponse = AssistantMessage(
 data class ToolMessage(
     override val id: String,
     override val content: String,
+    val toolCallId: String,
     override val name: String? = null,
-    val toolCallId: String
+    val error: String? = null
 ) : Message()
 ```
 


### PR DESCRIPTION
`ToolMessage.error` is documented on the messages concept page (`messages.mdx:153,161`) and in the JS, Python, and Ruby SDK references — but two pages omit it, and both are pages an integration author is likely to work from.

- **`concepts/tools.mdx`** — the *Tool Results* example showed only `content` + `toolCallId`. Adds a failure example alongside the existing success one, reusing the page's `confirmAction` / `tool-123` scenario, plus two sentences on why the field matters.
- **`sdk/kotlin/core/types.mdx`** — the `ToolMessage` declaration omitted `error`, which the Kotlin SDK does have (`Types.kt:265-271`, documented in its own KDoc). Also corrects the `name` / `toolCallId` order to match the source.

Not hypothetical: #2226 → #2263 fixed both LangGraph adapters dropping this field, and #2306 tracks four more first-party adapters with the same one-line omission. #2226 flagged the docs inconsistency as a likely contributing cause; this is that fix, split out so it doesn't sit in the adapter PR.

`concepts/events.mdx` was checked and deliberately left alone — `ToolCallResultEvent` has no `error` field in either SDK (`events.ts:147-153`, `events.py:181-189`), so its property table is accurate. That's a protocol asymmetry, not a docs bug.

Scoped to message shape only — no claim about how adapters map `error` onto a framework's error flag, since that isn't uniformly true until #2306's PRs land.

Docs-only.

Refs #2306, #2226
