### PR TITLE
ci(python): fail the build on a stale uv.lock

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -65,7 +65,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: sdks/python
-        run: uv sync
+        # --locked fails the build if uv.lock is out of step with
+        # pyproject.toml. Release bumps used to edit pyproject alone,
+        # leaving every released package's lock a version stale (#2313,
+        # #2314); this is what stops that drifting again unnoticed.
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: sdks/python
@@ -106,7 +110,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/langgraph/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/langgraph/python
@@ -147,7 +151,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/watsonx/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/watsonx/python
@@ -188,7 +192,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/adk-middleware/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/adk-middleware/python
@@ -230,7 +234,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/adk-middleware/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Force google-adk 2.x
         working-directory: integrations/adk-middleware/python
@@ -291,7 +295,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/aws-strands/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/aws-strands/python
@@ -332,7 +336,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/langroid/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/langroid/python
@@ -373,7 +377,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/crew-ai/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/crew-ai/python
@@ -417,7 +421,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: integrations/claude-managed-agents/python
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         working-directory: integrations/claude-managed-agents/python


### PR DESCRIPTION
Third and last of the lockfile-drift set — #2313 repaired the damage, #2314 removes the cause, this stops it recurring silently.

### Why

Nothing validated Python lockfiles. Every `--frozen-lockfile` check in CI is pnpm, which is how three released packages drifted — `ag_ui_adk` five releases deep — without a single red build.

### What

Adds `--locked` to the nine existing `uv sync` steps, rather than nine new `uv lock --check` steps. `uv sync --locked` asserts the lockfile is already in step with `pyproject.toml` and exits 1 if not, so the gate rides along with a command CI already runs.

Measured on `integrations/aws-strands/python`:

| lock state | `uv sync --locked` |
| --- | --- |
| self-version knocked back one patch | **exit 1** — *"The lockfile at `uv.lock` needs to be updated, but `--locked` was provided"* |
| restored | exit 0 |

### Safe to merge as-is

Verified all eight uv-managed packages this workflow covers currently pass `uv lock --check` against `main`, so nothing goes red on landing:

`sdks/python`, `aws-strands`, `adk-middleware`, `langgraph`, `crew-ai`, `watsonx`, `langroid`, `claude-managed-agents` — all PASS.

### On sensitivity

The check is resolution-level, not byte-level. It tolerates a lock whose metadata representation is merely older than what today's uv would emit, and fails only when the lock genuinely disagrees with `pyproject.toml`. That's the right sensitivity: the version drift this exists to catch trips it, while a uv upgrade alone doesn't turn every PR red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)