### PR TITLE
fix(langgraph): map LangChain tool status back onto AG-UI ToolMessage.error

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -251,6 +251,11 @@ def langchain_messages_to_agui(messages: List[BaseMessage]) -> List[AGUIMessage]
                 role="tool",
                 content=stringify_if_needed(resolve_message_content(message.content)),
                 tool_call_id=message.tool_call_id,
+                # A LangChain tool result signals failure only through `status`, with
+                # no error text. Restore AG-UI's `error` so the failure survives the
+                # round trip; the value is a fixed sentinel (#2305) because the
+                # original text is not recoverable from the flag alone.
+                error="error" if message.status == "error" else None,
             ))
         else:
             raise TypeError(f"Unsupported message type: {type(message)}")

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -231,6 +231,22 @@ class TestLangchainMessagesToAgui(unittest.TestCase):
         assert result[0].role == "tool"
         assert result[0].content == "result"
         assert result[0].tool_call_id == "tc1"
+        # No error status carries no failure signal, so error stays unset.
+        assert result[0].error is None
+
+    def test_tool_message_error_status_maps_to_error(self):
+        # The reverse of #2263: a LangChain tool result with status "error" must set
+        # AG-UI's error so the failure survives the round trip. The value is a fixed
+        # sentinel -- the original text is not recoverable from the flag alone (#2305).
+        msg = ToolMessage(
+            id="t1",
+            content="Tool failed: invalid id",
+            tool_call_id="tc1",
+            status="error",
+        )
+        result = langchain_messages_to_agui([msg])
+        assert result[0].role == "tool"
+        assert result[0].error == "error"
 
     def test_multimodal_human_message(self):
         msg = HumanMessage(

--- a/integrations/langgraph/typescript/src/message-conversion.test.ts
+++ b/integrations/langgraph/typescript/src/message-conversion.test.ts
@@ -179,6 +179,24 @@ describe("Message Conversion - All Types", () => {
       const result: any[] = langchainMessagesToAgui([msg]);
       expect(result[0].role).toBe("tool");
       expect(result[0].toolCallId).toBe("tc1");
+      // No status / "success" carries no failure signal, so error stays unset.
+      expect(result[0].error).toBeUndefined();
+    });
+
+    it("should map a tool message error status onto AG-UI's error field", () => {
+      // The reverse of #2263: a LangChain tool result with status "error" must set
+      // AG-UI's error so the failure survives the round trip. The value is a fixed
+      // sentinel — the original text is not recoverable from the flag alone (#2305).
+      const msg = {
+        id: "t1",
+        type: "tool",
+        content: "Tool failed: invalid id",
+        tool_call_id: "tc1",
+        status: "error",
+      } as any as LangGraphMessage;
+      const result: any[] = langchainMessagesToAgui([msg]);
+      expect(result[0].role).toBe("tool");
+      expect(result[0].error).toBe("error");
     });
 
     it("should handle generic (ChatMessage) type as assistant", () => {

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -309,6 +309,11 @@ export function langchainMessagesToAgui(messages: LangGraphMessage[]): Message[]
           role: "tool",
           content: stringifyIfNeeded(resolveMessageContent(message.content)),
           toolCallId: message.tool_call_id,
+          // A LangChain tool result signals failure only through `status`, with no
+          // error text. Restore AG-UI's `error` so the failure survives the round
+          // trip; the value is a fixed sentinel (#2305) because the original text is
+          // not recoverable from the flag alone.
+          ...(message.status === "error" ? { error: "error" } : {}),
         });
         break;
       default:


### PR DESCRIPTION
Fixes #2305.

## Problem

#2263 fixed the forward direction (AG-UI → LangChain): an incoming `ToolMessage.error` becomes `status="error"`. The reverse direction was still lossy — `langchainMessagesToAgui` / `langchain_messages_to_agui` never read `status`, so a LangChain tool result with `status="error"` came back to the client with `error` unset.

This undoes #2263's fix for any flow where the client's message list seeds the next run (a fresh thread, a stateless replay, a snapshot-then-resend): the client re-converts through the forward path with `error` unset, and silently gets `status="success"` again.

## Fix

Map `status == "error"` back onto AG-UI's `error` in both adapters:

- TypeScript — `integrations/langgraph/typescript/src/utils.ts`, the `tool` branch of `langchainMessagesToAgui`.
- Python — `integrations/langgraph/python/ag_ui_langgraph/utils.py`, the `ToolMessage` branch of `langchain_messages_to_agui`.

## The sentinel, and the honest contract

Per the standard agreed on #2306, the forward direction is flag-only, so the original error text is not recoverable here. `error` therefore carries a fixed sentinel (`"error"`) rather than a synthesized-but-plausible string, so a client can tell "the agent reported failure" apart from "the agent reported *this* failure text". The flag is durable across a round trip; the text is best-effort. There is no portable free-text slot to preserve it (Bedrock's `toolResult` has none, AI SDK's `providerOptions` is provider-namespaced).

I picked a bare `"error"` sentinel to be obviously synthetic — open to a different marker if you prefer.

## Tests

A test is added on each side, next to the existing reverse-direction tool-message tests.

- TS: `message-conversion.test.ts` — full package suite green, 268 tests.
- Python: `test_message_conversion.py` — `unittest discover tests` green, 385 tests.
