### PR TITLE
fix(integrations): carry ToolMessage.error onto the tool-result flag in four more adapters

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -205,6 +205,11 @@ def _build_snapshot_messages(input_messages: List[Any]) -> List[Any]:
                     role="tool",
                     content=_coerce_text(msg.content),
                     tool_call_id=tool_call_id,
+                    # This is an AG-UI -> AG-UI rebuild of the client's own message, so
+                    # preserve its error/encrypted_value on the snapshot echo instead of
+                    # silently dropping the client's own fields.
+                    error=getattr(msg, "error", None),
+                    encrypted_value=getattr(msg, "encrypted_value", None),
                 )
             )
     return out
@@ -237,7 +242,10 @@ def _build_strands_history(input_messages: List[Any]) -> List[Dict[str, Any]]:
                     "toolResult": {
                         "toolUseId": getattr(msg, "tool_call_id", "") or "",
                         "content": [{"text": _coerce_text(msg.content)}],
-                        "status": "success",
+                        # Carry the AG-UI failure signal onto Bedrock's toolResult status,
+                        # so a client-reported tool failure is not asserted to the model as
+                        # a success.
+                        "status": "error" if getattr(msg, "error", None) else "success",
                     }
                 }
             )

--- a/integrations/aws-strands/python/tests/test_tool_error_status.py
+++ b/integrations/aws-strands/python/tests/test_tool_error_status.py
@@ -1,0 +1,43 @@
+from ag_ui.core import ToolMessage
+
+from ag_ui_strands.agent import _build_strands_history, _build_snapshot_messages
+
+
+def _tool_message(**overrides):
+    fields = dict(
+        id="t1",
+        role="tool",
+        content="Tool failed: invalid id",
+        tool_call_id="tc1",
+    )
+    fields.update(overrides)
+    return ToolMessage(**fields)
+
+
+class TestBedrockToolResultStatus:
+    def test_error_maps_onto_bedrock_status(self):
+        # A client-reported tool failure must reach the model as an error, not a
+        # silent success -- AG-UI's ToolMessage.error sets Bedrock's toolResult status.
+        history = _build_strands_history([_tool_message(error="invalid id")])
+        tool_result = history[0]["content"][0]["toolResult"]
+        assert tool_result["status"] == "error"
+
+    def test_defaults_to_success_without_error(self):
+        history = _build_strands_history([_tool_message(content="42")])
+        tool_result = history[0]["content"][0]["toolResult"]
+        assert tool_result["status"] == "success"
+
+
+class TestSnapshotPreservesClientFields:
+    def test_preserves_error_and_encrypted_value(self):
+        # _build_snapshot_messages rebuilds the client's own message; it must not
+        # drop the client's error / encrypted_value on the snapshot echo.
+        snapshot = _build_snapshot_messages(
+            [_tool_message(error="invalid id", encrypted_value="enc-abc")]
+        )
+        assert snapshot[0].error == "invalid id"
+        assert snapshot[0].encrypted_value == "enc-abc"
+
+    def test_leaves_error_unset_when_absent(self):
+        snapshot = _build_snapshot_messages([_tool_message(content="42")])
+        assert snapshot[0].error is None

--- a/integrations/langchain/typescript/src/__tests__/messages.test.ts
+++ b/integrations/langchain/typescript/src/__tests__/messages.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import type { Message } from "@ag-ui/client";
+import { convertAGUIMessageToLangChain } from "../messages";
+
+describe("convertAGUIMessageToLangChain — tool messages", () => {
+  it("maps a tool result with no error to status 'success'", () => {
+    const msg: Message = { id: "t1", role: "tool", content: "42", toolCallId: "tc1" };
+    const result = convertAGUIMessageToLangChain(msg) as any;
+    expect(result.tool_call_id).toBe("tc1");
+    // No error carries no failure signal, so status defaults to "success".
+    expect(result.status).toBe("success");
+  });
+
+  it("maps a tool error onto LangChain's status flag", () => {
+    // A client-reported tool failure must reach the model as an error, not a
+    // silent success — AG-UI's ToolMessage.error becomes status: "error".
+    const msg: Message = {
+      id: "t1",
+      role: "tool",
+      content: "Tool failed: invalid id",
+      toolCallId: "tc1",
+      error: "invalid id",
+    };
+    const result = convertAGUIMessageToLangChain(msg) as any;
+    expect(result.status).toBe("error");
+  });
+});

--- a/integrations/langchain/typescript/src/messages.ts
+++ b/integrations/langchain/typescript/src/messages.ts
@@ -47,6 +47,9 @@ export function convertAGUIMessageToLangChain(message: Message): BaseMessage {
     return new ToolMessage({
       content: message.content,
       tool_call_id: message.toolCallId,
+      // Carry the AG-UI failure signal onto LangChain's tool-result status, so a
+      // client-reported tool failure is not delivered to the model as a success.
+      status: message.error ? "error" : "success",
     });
   }
 

--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -516,6 +516,7 @@ describe("convertAGUIMessagesToMastra", () => {
             toolCallId: "tc-1",
             toolName: "get_weather",
             result: "72°F",
+            isError: false,
           },
         ],
       });
@@ -542,8 +543,33 @@ describe("convertAGUIMessagesToMastra", () => {
             toolCallId: "tc-orphan",
             toolName: "unknown",
             result: "some result",
+            isError: false,
           },
         ],
+      });
+    });
+
+    it("carries a tool error onto the AI SDK isError flag", () => {
+      // A client-reported tool failure must reach the model as an error, not a
+      // silent success. AG-UI's ToolMessage.error sets the tool-result isError flag.
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "tool",
+          content: "Tool failed: invalid id",
+          toolCallId: "tc-1",
+          error: "invalid id",
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect((result[0] as any).content[0]).toEqual({
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "unknown",
+        result: "Tool failed: invalid id",
+        isError: true,
       });
     });
   });

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -210,6 +210,9 @@ export function convertAGUIMessagesToMastra(
             toolCallId: message.toolCallId,
             toolName: toolName,
             result: message.content,
+            // Carry the AG-UI failure signal onto the AI SDK v4 tool-result flag, so a
+            // client-reported tool failure is not delivered to the model as a success.
+            isError: !!message.error,
           },
         ],
       } as CoreMessage);

--- a/integrations/vercel-ai-sdk/typescript/src/__tests__/messages.test.ts
+++ b/integrations/vercel-ai-sdk/typescript/src/__tests__/messages.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import type { Message } from "@ag-ui/client";
+import { convertMessagesToVercelAISDKMessages } from "../index";
+
+describe("convertMessagesToVercelAISDKMessages — tool results", () => {
+  it("sets isError false when the tool result has no error", () => {
+    const messages: Message[] = [
+      { id: "t1", role: "tool", content: "42", toolCallId: "tc1" },
+    ];
+    const result = convertMessagesToVercelAISDKMessages(messages);
+    expect((result[0] as any).content[0]).toEqual({
+      type: "tool-result",
+      toolCallId: "tc1",
+      toolName: "unknown",
+      result: "42",
+      isError: false,
+    });
+  });
+
+  it("carries a tool error onto the AI SDK isError flag", () => {
+    // A client-reported tool failure must reach the model as an error, not a
+    // silent success. AG-UI's ToolMessage.error sets the tool-result isError flag.
+    const messages: Message[] = [
+      {
+        id: "t1",
+        role: "tool",
+        content: "Tool failed: invalid id",
+        toolCallId: "tc1",
+        error: "invalid id",
+      },
+    ];
+    const result = convertMessagesToVercelAISDKMessages(messages);
+    expect((result[0] as any).content[0].isError).toBe(true);
+  });
+});

--- a/integrations/vercel-ai-sdk/typescript/src/index.ts
+++ b/integrations/vercel-ai-sdk/typescript/src/index.ts
@@ -276,6 +276,9 @@ export function convertMessagesToVercelAISDKMessages(
             toolCallId: message.toolCallId,
             toolName: toolName,
             result: message.content,
+            // Carry the AG-UI failure signal onto the AI SDK v4 tool-result flag, so a
+            // client-reported tool failure is not delivered to the model as a success.
+            isError: !!message.error,
           },
         ],
       });


### PR DESCRIPTION
Fixes #2306.

## Problem

The one-line omission fixed for LangGraph in #2263 is present in several other first-party adapters: AG-UI's `ToolMessage.error` is not read when an incoming tool result is converted into the target framework's tool-result shape, so a client-reported tool failure is handed to the model as a success.

## Fix

Per the standard agreed on #2306: set the framework's error flag from `bool(error)`. Flag only — the text is not folded into content, because every target here has a dedicated flag (that carve-out only applies to transports with no flag, e.g. `claude-managed-agents`).

| Adapter | Site | Change |
|---|---|---|
| `langchain/typescript` | `messages.ts` | `status: message.error ? "error" : "success"` (verbatim #2263) |
| `aws-strands/python` | `agent.py` `_build_strands_history` | Bedrock `toolResult` status was pinned to `"success"` → derive from `error` |
| `vercel-ai-sdk/typescript` | `index.ts` | `isError: !!message.error` |
| `mastra/typescript` | `utils.ts` | `isError: !!message.error` |

### AI SDK version

Both `vercel-ai-sdk` and `mastra` resolve **AI SDK v4**, whose `ToolResultPart` already carries `isError` — no version gate needed. `mastra` builds the v4 `CoreMessage` type (the `as CoreMessage` cast at `utils.ts:212` is what currently hides the missing field from `tsc`), so its behavior is pinned with a test rather than relying on a type read.

### Bonus: aws-strands snapshot echo

`_build_snapshot_messages` is an AG-UI → AG-UI rebuild of the client's own messages (it seeds `MessagesSnapshotEvent`). It dropped the client's own `error` **and** `encrypted_value` on the echo. Both are now copied through. This one has no framework mapping and no invent-the-text question — it is a plain field copy.

## Scope

Flag only, one PR for all four adapters plus the snapshot fix, matching the group decision on #2306. The `docs/concepts/tools.mdx` example is being handled separately.

## Tests

A test is added next to each adapter's conversion tests, matching #2263's shape.

- `mastra`: full package suite green, 304 tests (2 existing tool-result assertions updated for the always-present `isError`).
- `langchain/typescript`: new `messages.test.ts`, 13 tests green.
- `vercel-ai-sdk/typescript`: new `messages.test.ts`, 8 tests green.
- `aws-strands/python`: new `test_tool_error_status.py`, `pytest tests/` green — 180 passed, 2 skipped.
