### PR TITLE
DO NOT MERGE — PNI-188 CI baseline probe (488d01c2)

### DIFF
--- a/apps/dojo/BASELINE.md
+++ b/apps/dojo/BASELINE.md
@@ -1,0 +1,14 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to satisfy the `paths:` filter on the workflow below so that it
+runs against commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`, capturing the
+repository's test health *before* any AG-UI 1.0 toolchain work begins.
+
+Unlocks:
+
+- `dojo-e2e.yml` (`apps/dojo/**`)
+
+The PR carrying this file is closed, not merged, once the runs have been
+recorded on PNI-188.

--- a/scripts/release/BASELINE.md
+++ b/scripts/release/BASELINE.md
@@ -1,0 +1,15 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to satisfy the `paths:` filter on the workflows below so that they
+run against commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`, capturing the
+repository's test health *before* any AG-UI 1.0 toolchain work begins.
+
+Unlocks the non-publishing release validation:
+
+- `test-release-scripts.yml` (`scripts/release/**`)
+- `lint-release-workflows.yml` (`scripts/release/**`)
+
+The PR carrying this file is closed, not merged, once the runs have been
+recorded on PNI-188.

--- a/sdks/dotnet/BASELINE.md
+++ b/sdks/dotnet/BASELINE.md
@@ -1,0 +1,16 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to satisfy the `paths:` filter on the workflows below so that they
+run against commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`, capturing the
+repository's test health *before* any AG-UI 1.0 toolchain work begins.
+
+Unlocks:
+
+- `unit-dotnet-sdk.yml` (`sdks/dotnet/**`) — both the `dotnet / unit + integration`
+  job and the `dotnet / cross-language (TS <-> C#)` protobuf job
+- `dojo-e2e.yml` (`sdks/dotnet/**`)
+
+The PR carrying this file is closed, not merged, once the runs have been
+recorded on PNI-188.

--- a/sdks/python/BASELINE.md
+++ b/sdks/python/BASELINE.md
@@ -1,0 +1,15 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to satisfy the `paths:` filter on the workflows below so that they
+run against commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`, capturing the
+repository's test health *before* any AG-UI 1.0 toolchain work begins.
+
+Unlocks:
+
+- `unit-python-sdk.yml` (`sdks/python/**`)
+- `dojo-e2e.yml` (`sdks/python/**`)
+
+The PR carrying this file is closed, not merged, once the runs have been
+recorded on PNI-188.

--- a/sdks/typescript/BASELINE.md
+++ b/sdks/typescript/BASELINE.md
@@ -1,0 +1,16 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to satisfy the `paths:` filter on the workflows below so that they
+run against commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`, capturing the
+repository's test health *before* any AG-UI 1.0 toolchain work begins.
+
+Unlocks:
+
+- `unit-typescript-sdk.yml` (`sdks/typescript/**`)
+- `unit-dotnet-sdk.yml` (`sdks/typescript/**`)
+- `dojo-e2e.yml` (`sdks/typescript/**`)
+
+The PR carrying this file is closed, not merged, once the runs have been
+recorded on PNI-188.


### PR DESCRIPTION
## Do not merge, do not review

This is a **throwaway measurement PR**. It will be closed, never merged.

## Why it exists

[PNI-188](https://linear.app/copilotkit/issue/PNI-188/record-the-current-ag-ui-test-baseline) asks for a one-time snapshot of repository test health taken *before* any AG-UI 1.0 work starts, so that later failures can be attributed ("did we break it, or was it already broken?"). It blocks PNI-185 (Git LFS), PNI-186 (Node 22) and PNI-187 (pin uv) — those change how the repo builds, so the untouched state has to be measured first.

## Baseline commit

`488d01c2fd9e3c3a773a95d86b519acabdcdda6a`

Verified that none of the three toolchain fixes have landed at this commit:

- **PNI-186 (Node 22)** — root `engines.node` is `>=18`; 10 workflow steps hardcode `node-version: "22"`, 2 use `node-version-file: package.json`. Not standardized.
- **PNI-187 (pin uv)** — all 12 `astral-sh/setup-uv` sites use `version: ">=0.8.0"`. Unpinned.
- **PNI-185 (Git LFS)** — `.gitattributes` declares 13 binary patterns, `git lfs ls-files` reports 2 tracked files, `lfs: true` on 5 of the checkouts.

## Why the marker files

Every matrix workflow is gated on `branches: [main]` **and** `paths:`, on both `push` and `pull_request`, and the `unit-*` workflows have no `workflow_dispatch`. A bare branch push fires nothing, and a genuine no-op PR fires nothing either. Five inert `BASELINE.md` files — one per path filter — are the least invasive way to make the matrix run at this commit. No source is touched.

| Marker | Unlocks |
| --- | --- |
| `sdks/typescript/BASELINE.md` | unit-typescript-sdk, unit-dotnet-sdk, dojo-e2e |
| `sdks/python/BASELINE.md` | unit-python-sdk |
| `sdks/dotnet/BASELINE.md` | unit-dotnet-sdk, incl. `dotnet / cross-language (TS <-> C#)` |
| `apps/dojo/BASELINE.md` | dojo-e2e |
| `scripts/release/BASELINE.md` | test-release-scripts, lint-release-workflows |

`pr-check-binaries` and pkg-pr-new fire on any PR. The documentation build has no CI workflow at all and is measured locally.

## What happens next

Results are recorded on PNI-188 (attachments, not committed to this repo). Each failure is labelled real or transient, transient only if a re-run at the same commit passes. One repair ticket per real failure. Then this PR is closed.

Longer term, adding `workflow_dispatch:` to the `unit-*` workflows would remove the need for this trick — worth doing, but it has to land on `main` first, which would move the baseline commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)