### PR TITLE
DO NOT MERGE — PNI-188 docs baseline probe (488d01c2)

### DIFF
--- a/docs/BASELINE.md
+++ b/docs/BASELINE.md
@@ -1,0 +1,13 @@
+# CI baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only to make the `Mintlify Deployment` check evaluate against commit
+`488d01c2fd9e3c3a773a95d86b519acabdcdda6a`. On the main probe PR (#2320) that check
+reported `skipping`, because nothing under `docs/` was touched.
+
+Kept separate from #2320 so that capturing the documentation cell does not re-run the
+full ~50-job test matrix.
+
+The PR carrying this file is closed, not merged, once the run has been recorded on
+PNI-188.


### PR DESCRIPTION
## Do not merge, do not review

Companion to #2320. A **throwaway measurement PR** for [PNI-188](https://linear.app/copilotkit/issue/PNI-188/record-the-current-ag-ui-test-baseline); it will be closed, never merged.

On #2320 the `Mintlify Deployment` check reported `skipping`, because that PR touches no `docs/` path. This PR touches only `docs/`, so the check evaluates at baseline commit `488d01c2fd9e3c3a773a95d86b519acabdcdda6a`. Kept separate from #2320 so capturing one cell does not cost a re-run of the full ~50-job matrix.

## Already known about the docs surface at this commit

Found locally, reproduced at both the lockfile-pinned `mintlify@4.2.123` and latest 4.x, so neither is transient:

1. **The `docs` build script is dead.** `docs/package.json` defines `"build": "mintlify build"`, but `mintlify build` is not a command at either version — both exit `Unknown command: build`. Available commands are `dev`, `openapi-check`, `broken-links`, `rename`, `update`, `upgrade`, `migrate-mdx`, `version`.

2. **An MDX parse error aborts link checking.** `mintlify broken-links` fails at `docs/sdk/dart/client/overview.mdx:141:24` with `Unexpected character ',' (U+002C) in name`. Line 141 reads ``- `headers` (Map<String, String>?): Default headers for all requests`` — `Map<String, String>?` sits outside the backticks, so MDX parses `<String,` as a JSX tag. Because the parse aborts, there is no clean link-check result at baseline, and whether other pages have broken links is unknown until this is fixed.

Each gets its own repair ticket. Fixing them is out of scope for PNI-188, which only measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)