### PR TITLE
test(dojo): add CrewAI backend_tool_rendering e2e + aimock fixtures

### DIFF
--- a/apps/dojo/e2e/aimock-setup.ts
+++ b/apps/dojo/e2e/aimock-setup.ts
@@ -615,6 +615,69 @@ export async function setupLLMock(): Promise<void> {
     },
   });
 
+  // Backend tool rendering (backend_tool_rendering flow): a "Weather Assistant"
+  // crew agent calls the backend get_weather tool, then produces a final text
+  // summary. Both the tool-call turn and the final-answer turn hit aimock.
+  // Matched on the unique "Weather Assistant" role so they beat the crew_chat
+  // "Your personal goal is" catch-all below (first registered wins). The
+  // final-answer turn is also excluded from the generic tool-result catch-all
+  // further down so this dedicated summary wins over it.
+  const isWeatherAgentCall = (req: { messages: ChatMessage[] }) =>
+    sysIncludes(req.messages, "Weather Assistant");
+  const isWeatherAgentToolResultTurn = (req: { messages: ChatMessage[] }) =>
+    isWeatherAgentCall(req) && hasToolResult(req);
+  const weatherToolCall = (location: string, id: string) => ({
+    toolCalls: [
+      { name: "get_weather", arguments: JSON.stringify({ location }), id },
+    ],
+  });
+
+  // Tool-call turn, San Francisco.
+  mockServer.addFixture({
+    match: {
+      predicate: (req) => {
+        const lastUser = req.messages.filter((m) => m.role === "user").pop();
+        return (
+          isWeatherAgentCall(req) &&
+          !hasToolResult(req) &&
+          textOf(lastUser?.content).includes("San Francisco")
+        );
+      },
+    },
+    response: weatherToolCall("San Francisco", "call_get_weather_sf"),
+  });
+
+  // Tool-call turn, New York.
+  mockServer.addFixture({
+    match: {
+      predicate: (req) => {
+        const lastUser = req.messages.filter((m) => m.role === "user").pop();
+        return (
+          isWeatherAgentCall(req) &&
+          !hasToolResult(req) &&
+          textOf(lastUser?.content).includes("New York")
+        );
+      },
+    },
+    response: weatherToolCall("New York", "call_get_weather_ny"),
+  });
+
+  // Final-answer turn: after get_weather returns, the crew agent completes with a
+  // short weather summary. One fixture serves both cities (the card data rides
+  // the tool result); the city is echoed from the user request for a natural reply.
+  mockServer.addFixture({
+    match: { predicate: (req) => isWeatherAgentToolResultTurn(req) },
+    response: (req) => {
+      const lastUser = req.messages.filter((m) => m.role === "user").pop();
+      const city = textOf(lastUser?.content).includes("New York")
+        ? "New York"
+        : "San Francisco";
+      return {
+        content: `${city}: sunny and 20°C, 50% humidity, wind around 10, feels like 25°C.`,
+      };
+    },
+  });
+
   // Crew-internal kickoff: crew.kickoff() runs the "General Assistant" agent,
   // whose single LLM call routes here. crewai's no-tools agent requires the
   // EXACT "Thought:/Final Answer:" format or it retries — returning it means
@@ -1443,6 +1506,9 @@ export async function setupLLMock(): Promise<void> {
         // dedicated fixture keyed on the crew output string.
         if (hasCrewRunTool(req) && textOf(last.content) === CREW_RUN_OUTPUT)
           return false;
+        // Don't match the backend weather tool-result turn; a dedicated
+        // Weather-Assistant summary fixture answers it.
+        if (isWeatherAgentToolResultTurn(req)) return false;
         // Don't match a CrewAI A2UI turn that a2ui-crewai-fixtures.ts answers
         // itself (a surface-action click, or the closing turn over a render
         // result): a generic acknowledgment would mask the reply under test.

--- a/apps/dojo/e2e/tests/crewAITests/backendToolRenderingPage.spec.ts
+++ b/apps/dojo/e2e/tests/crewAITests/backendToolRenderingPage.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../../test-isolation-helper";
+import { awaitLLMResponseDone } from "../../utils/copilot-actions";
+
+// The weather agent runs a real crew: the model calls the backend get_weather
+// tool, the crew executes it server-side, and the bridge surfaces the call +
+// result so the client renders a weather card. The crew's own agent loop makes
+// two LLM calls (tool-call turn, then final-answer turn); both are mocked by the
+// Weather-Assistant fixtures in aimock-setup.ts.
+test("[CrewAI] Backend Tool Rendering displays weather cards", async ({
+  page,
+}) => {
+  await page.goto("/crewai/feature/backend_tool_rendering");
+
+  // Verify suggestion buttons are visible
+  await expect(
+    page.getByRole("button", { name: "Weather in San Francisco" }),
+  ).toBeVisible({
+    timeout: 5000,
+  });
+
+  // Click first suggestion and verify weather card appears
+  await page.getByRole("button", { name: "Weather in San Francisco" }).click();
+
+  // Wait for either test ID or fallback to "Current Weather" text
+  const weatherCard = page.getByTestId("weather-card");
+  const currentWeatherText = page.getByText("Current Weather");
+
+  // Try test ID first, fallback to text
+  try {
+    await expect(weatherCard.first()).toBeVisible();
+  } catch (e) {
+    // Fallback to checking for "Current Weather" text
+    await expect(currentWeatherText.first()).toBeVisible();
+  }
+
+  // Verify weather content is present (use flexible selectors)
+  const hasHumidity = await page
+    .getByText("Humidity")
+    .first()
+    .isVisible()
+    .catch(() => false);
+  const hasWind = await page
+    .getByText("Wind")
+    .first()
+    .isVisible()
+    .catch(() => false);
+  const hasCityName = await page
+    .locator("h3")
+    .filter({ hasText: /San Francisco/i })
+    .isVisible()
+    .catch(() => false);
+
+  // At least one of these should be true
+  expect(hasHumidity || hasWind || hasCityName).toBeTruthy();
+
+  // Click second suggestion
+  await page.getByRole("button", { name: "Weather in New York" }).click();
+  await awaitLLMResponseDone(page);
+
+  // Verify at least one weather-related element is still visible
+  const weatherElements = await page
+    .getByText(/Weather|Humidity|Wind|Temperature/i)
+    .count();
+  expect(weatherElements).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## What

Closes the one e2e coverage gap in the CrewAI dojo column: `backend_tool_rendering` had a working, live-verified demo but no crewAI e2e spec, because its crew agent could not be mocked cleanly.

Adds:
- `apps/dojo/e2e/tests/crewAITests/backendToolRenderingPage.spec.ts` (modeled on the langgraph-python / agno backend specs: click the weather suggestions, assert the weather card + content).
- Weather-Assistant aimock fixtures in `apps/dojo/e2e/aimock-setup.ts`.

## How the mocking works

The demo runs a `Weather Assistant` crew agent bound to a real backend `get_weather` tool. On a real LLM the crew agent uses **native function calling** and loops internally: one turn to call `get_weather`, then a second turn (with the tool result in history) to produce the final answer. Both turns route through aimock.

The existing `crew_chat` catch-all matches `sysIncludes(req.messages, "Your personal goal is")`, which is present in *every* crew agent's execution prompt (including the Weather Assistant), so it would hijack this demo. The new fixtures:
- match on the unique `"Weather Assistant"` role string,
- are registered **before** that catch-all so first-registered-wins beats it,
- drive the `get_weather` call for both San Francisco and New York, then a final weather summary,
- and the final-answer turn is excluded from the generic tool-result catch-all so its dedicated summary is served instead of the generic acknowledgment.

## Verification

- **Real LLM** (crewai 1.15.7 + gpt-5.4): the demo streams `TOOL_CALL_START/ARGS/RESULT` for `get_weather` and a final summary; weather card renders.
- **aimock harness**: new spec green, and the full `crewAITests` suite passes **36/36** with no regression to `crew_chat` (whose hijack fixture this works around).