### PR TITLE
docs: document chat platforms as an AG-UI client surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | --- | ------- | ---------------- | ------------- |
 | [CopilotKit](https://github.com/CopilotKit/CopilotKit) | ✅ Supported | ➡️ [Getting Started](https://docs.copilotkit.ai/direct-to-llm/guides/quickstart) | 1st Party |
 | [Terminal + Agent]() | ✅ Supported | ➡️ [Getting Started](https://docs.ag-ui.com/quickstart/clients) | Community |
+| Chat platforms (Slack, Microsoft Teams) | ✅ Supported | ➡️ [Channels SDK](https://github.com/CopilotKit/channels-sdk) 🎮 [OpenTag example](https://github.com/CopilotKit/OpenTag) | 1st Party |
 | [React Native]() | 🛠️ Help Wanted | ➡️ [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/510) | Community |
 
 [View all supported integrations →](https://docs.ag-ui.com/introduction#supported-integrations)

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -56,6 +56,7 @@ that demonstrate the protocol's capabilities and versatility.
 
 | [CopilotKit](https://docs.copilotkit.ai/direct-to-llm/guides/quickstart)
 | [Terminal + Agent](https://docs.ag-ui.com/quickstart/clients)
+| [Chat platforms — Slack, Microsoft Teams](https://github.com/CopilotKit/channels-sdk)
 
 
 Join [Discord](https://discord.gg/Jd3FzfdJa8) to engage with the AG-UI community.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -308,7 +308,20 @@ AG-UI was born from CopilotKit's initial **partnership** with LangGraph and Crew
 | :----- | ------ | --------------- | ------------ |
 | [CopilotKit](https://github.com/CopilotKit/CopilotKit) | Supported | [Getting Started](https://docs.copilotkit.ai/direct-to-llm/guides/quickstart) | 1st Party |
 | [Terminal + Agent]() | Supported | [Getting Started](https://docs.ag-ui.com/quickstart/clients) | Community |
+| Chat platforms (Slack, Microsoft Teams) | Supported | [Channels SDK](https://github.com/CopilotKit/channels-sdk), [OpenTag example](https://github.com/CopilotKit/OpenTag) | 1st Party |
 | [React Native](https://reactnative.dev/) | Help Wanted | [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/510) | Community |
+
+An AG-UI client does not have to be a web application. The protocol describes an
+event stream rather than a rendering target, so a terminal, a mobile app, or a
+chat platform can each act as a client.
+
+A chat-platform client is something anyone can build against AG-UI. The
+[Channels SDK](https://github.com/CopilotKit/channels-sdk) is one implementation
+of it, and [OpenTag](https://github.com/CopilotKit/OpenTag)
+is a complete application built on it: a Python LangGraph agent served over AG-UI
+into Slack and Microsoft Teams. In that application the agent and its runtime are
+self-hosted, while platform credentials and message delivery are handled by
+CopilotKit Intelligence — a hosted service, not part of the protocol.
 
 ---
 

--- a/docs/quickstart/clients.mdx
+++ b/docs/quickstart/clients.mdx
@@ -11,6 +11,14 @@ leverage AG-UI's event-driven protocol**. This approach creates a direct
 interface between your users and AI agents, demonstrating direct access to the
 AG-UI protocol.
 
+A client does not have to be a web application. AG-UI describes an event stream
+rather than a rendering target, so anything that can consume those events and
+present them to a user is a client: a web app, the terminal client built below, a
+mobile app, or a chat platform such as Slack or Microsoft Teams. The
+[Channels SDK](https://github.com/CopilotKit/channels-sdk) is one chat-platform
+implementation, with [OpenTag](https://github.com/CopilotKit/OpenTag) as a
+worked example.
+
 ## When to use a client implementation
 
 Building your own client is useful if you want to explore/hack on the AG-UI


### PR DESCRIPTION
Closes [PNI-271](https://linear.app/copilotkit/issue/PNI-271)

Read the Clients listings today and you would conclude AG-UI targets web applications: they cover CopilotKit, a terminal client, and React Native. Nothing indicated that an AG-UI agent can serve a conversation in Slack or Microsoft Teams, even though it can. This is docs-only — no protocol, specification, or event-set changes.

## Changes

- **`docs/introduction.mdx`** — new row in the Clients table, same format as the existing entries. Two paragraphs under the table: a client need not be a web app, because the protocol describes an event stream rather than a rendering target; a chat-platform client is something anyone can build against AG-UI; the Channels SDK is one implementation; [OpenTag](https://github.com/CopilotKit/OpenTag) is the worked example.
- **`docs/quickstart/clients.mdx`** (Get Started) — two sentences making the same point where someone building a client will read it.
- **`docs/integrations.mdx`** — one line in the Clients list, existing pipe format.
- **`README.md`** — row added to the Clients table.

## Register

No superlatives, no "any channel", no product voice, and no hosted-service call to action — the links go to the MIT-licensed repositories, not to a signup or trial page. Where a hosted component is involved the text names it as such: in OpenTag the agent and its runtime are self-hosted, while platform credentials and message delivery are handled by CopilotKit Intelligence, which is called out as a hosted service and not part of the protocol.

## Notes for the reviewer

- The ticket said the README has no client category. It already does (`README.md:165`), so the row went into the existing table rather than a new section.
- Facts were checked against the two repositories rather than the ticket text. `channels-sdk`'s repo description also mentions Discord and Telegram; the docs text stays with Slack and Microsoft Teams, which is what the SDK's documented path and OpenTag support today.
- `prettier --check` flags all four files, but it flags them identically on `main`. Pre-existing drift, left alone so the change is not buried in a reformat.
- Both linked repositories return 200 unauthenticated and are MIT.

Outstanding acceptance criterion: **review for register by someone who does not work on Channels.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)