### PR TITLE
fix(client): make TOOL_CALL_START idempotent

### DIFF
--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { firstValueFrom } from "rxjs";
@@ -812,5 +813,210 @@ describe("defaultApplyEvents with tool calls", () => {
     expect(msg.toolCalls?.length).toBe(1);
     expect(msg.toolCalls?.[0]?.id).toBe("tc-1");
     expect(msg.toolCalls?.[0]?.function?.name).toBe("lookup");
+  });
+
+  describe("TOOL_CALL_START idempotency", () => {
+    const runInput: RunAgentInput = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    // The assistant message an interrupted run leaves behind: the tool call is
+    // already in the agent's own message list, with its arguments fully
+    // streamed, before the next run starts.
+    const carriedOverAssistant = (): AssistantMessage => ({
+      id: "msg-1",
+      role: "assistant",
+      toolCalls: [
+        {
+          id: "tc-1",
+          type: "function",
+          function: { name: "openPolicyException", arguments: '{"txId":"t-9"}' },
+        },
+      ],
+    });
+
+    it("does not append a second entry when the same TOOL_CALL_START is applied twice", async () => {
+      const events$ = new Subject<BaseEvent>();
+      const agent = createAgent([]);
+      const result$ = defaultApplyEvents(runInput, events$, agent, []);
+      const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+      // The exact same event reaching the reducer twice — a run re-sync
+      // replaying it, or one stream delivered over two transports.
+      const start = {
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-1",
+        toolCallName: "search",
+        parentMessageId: "msg-1",
+      } as ToolCallStartEvent;
+
+      events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+      events$.next(start);
+      events$.next(start);
+      events$.next({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: "tc-1",
+        delta: '{"query":"x"}',
+      } as ToolCallArgsEvent);
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tc-1" } as ToolCallEndEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events$.complete();
+
+      const stateUpdates = await stateUpdatesPromise;
+      const finalState = stateUpdates[stateUpdates.length - 1];
+
+      expect(finalState.messages?.length).toBe(1);
+      const msg = finalState.messages?.[0] as AssistantMessage;
+      expect(msg.toolCalls?.length).toBe(1);
+      expect(msg.toolCalls?.[0]?.id).toBe("tc-1");
+      // The single surviving copy carries the arguments — without the guard the
+      // deltas resolve to the first match and the second copy stays empty.
+      expect(msg.toolCalls?.[0]?.function?.arguments).toBe('{"query":"x"}');
+    });
+
+    it("does not append a second entry for a tool call the agent carries from a previous run", async () => {
+      const events$ = new Subject<BaseEvent>();
+      const agent = createAgent([carriedOverAssistant()]);
+      const result$ = defaultApplyEvents(runInput, events$, agent, []);
+      const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+      events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+      events$.next({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-1",
+        toolCallName: "openPolicyException",
+        parentMessageId: "msg-1",
+      } as ToolCallStartEvent);
+      // The result is what forces a state emission after the replayed start —
+      // the replay itself is a no-op, and it mirrors the HITL flow where the
+      // result lands once the user has responded.
+      events$.next({
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "tm-1",
+        toolCallId: "tc-1",
+        content: "approved",
+      } as ToolCallResultEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events$.complete();
+
+      const stateUpdates = await stateUpdatesPromise;
+      const finalState = stateUpdates[stateUpdates.length - 1];
+
+      expect(finalState.messages?.length).toBe(2);
+      const msg = finalState.messages?.[0] as AssistantMessage;
+      expect(msg.id).toBe("msg-1");
+      expect(msg.toolCalls?.length).toBe(1);
+      // Arguments streamed on the previous run survive — a start event carries
+      // none, so overwriting them would blank the call out.
+      expect(msg.toolCalls?.[0]?.function?.arguments).toBe('{"txId":"t-9"}');
+    });
+
+    it("does not create a stray assistant message when a replayed start names an unknown parent", async () => {
+      // The dedupe has to run before the parent message is resolved: a replay
+      // whose parentMessageId is no longer in state would otherwise create a
+      // fresh assistant message to hang the duplicate off.
+      const events$ = new Subject<BaseEvent>();
+      const agent = createAgent([carriedOverAssistant()]);
+      const result$ = defaultApplyEvents(runInput, events$, agent, []);
+      const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+      events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+      events$.next({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-1",
+        toolCallName: "openPolicyException",
+        parentMessageId: "msg-regenerated",
+      } as ToolCallStartEvent);
+      events$.next({
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: "tm-1",
+        toolCallId: "tc-1",
+        content: "approved",
+      } as ToolCallResultEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events$.complete();
+
+      const stateUpdates = await stateUpdatesPromise;
+      const finalState = stateUpdates[stateUpdates.length - 1];
+
+      expect(finalState.messages?.map((m) => m.id)).toEqual(["msg-1", "tm-1"]);
+      const assistants = finalState.messages?.filter(
+        (m) => m.role === "assistant",
+      ) as AssistantMessage[];
+      expect(assistants.length).toBe(1);
+      expect(assistants[0].toolCalls?.length).toBe(1);
+    });
+
+    it("emits no state update at all for a replayed TOOL_CALL_START", async () => {
+      // Idempotent means nothing changes — not "changes to the same value".
+      // A spurious mutation would re-render every consumer of the transcript.
+      const events$ = new Subject<BaseEvent>();
+      const agent = createAgent([carriedOverAssistant()]);
+      const result$ = defaultApplyEvents(runInput, events$, agent, []);
+      const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+      events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+      events$.next({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-1",
+        toolCallName: "openPolicyException",
+        parentMessageId: "msg-1",
+      } as ToolCallStartEvent);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      events$.complete();
+
+      expect(await stateUpdatesPromise).toEqual([]);
+    });
+
+    it("updates the existing entry in place when a start reuses an id under a different name", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const events$ = new Subject<BaseEvent>();
+        const agent = createAgent([]);
+        const result$ = defaultApplyEvents(runInput, events$, agent, []);
+        const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+        events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+        events$.next({
+          type: EventType.TOOL_CALL_START,
+          toolCallId: "tc-1",
+          toolCallName: "search",
+        } as ToolCallStartEvent);
+        events$.next({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: "tc-1",
+          delta: '{"query":"x"}',
+        } as ToolCallArgsEvent);
+        events$.next({
+          type: EventType.TOOL_CALL_START,
+          toolCallId: "tc-1",
+          toolCallName: "lookup",
+        } as ToolCallStartEvent);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        events$.complete();
+
+        const stateUpdates = await stateUpdatesPromise;
+        const finalState = stateUpdates[stateUpdates.length - 1];
+
+        expect(finalState.messages?.length).toBe(1);
+        const msg = finalState.messages?.[0] as AssistantMessage;
+        expect(msg.toolCalls?.length).toBe(1);
+        expect(msg.toolCalls?.[0]?.function?.name).toBe("lookup");
+        expect(msg.toolCalls?.[0]?.function?.arguments).toBe('{"query":"x"}');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("tc-1"));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 });

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -293,6 +293,39 @@ export const defaultApplyEvents = (
           if (mutation.stopPropagation !== true) {
             const { toolCallId, toolCallName, parentMessageId } = event as ToolCallStartEvent;
 
+            // Applying a start event must be idempotent. The same start can
+            // reach this reducer twice — a tool call already carried in
+            // `agent.messages` from an earlier run and then replayed by the
+            // backend (the HITL path does this when the run re-syncs after
+            // `respond()`), or one stream re-delivered over two transports.
+            // Appending unconditionally would leave the assistant message
+            // holding the id twice, and the second copy stays empty because
+            // TOOL_CALL_ARGS resolves to the first match. That malformed
+            // message is then what travels back to the provider on the next
+            // turn. Resolve the existing entry the same way TOOL_CALL_ARGS
+            // does, and do it before resolveOrCreateAssistantMessage so a
+            // replay can't append a stray empty assistant message either.
+            const ownerMessage = messages.find((m) =>
+              (m as AssistantMessage).toolCalls?.some((tc) => tc.id === toolCallId),
+            ) as AssistantMessage | undefined;
+            const existingToolCall = ownerMessage?.toolCalls?.find((tc) => tc.id === toolCallId);
+
+            if (existingToolCall) {
+              // Update the existing entry instead of pushing a second one, and
+              // leave `arguments` untouched — a start event carries none, so
+              // the copy already in state holds the only streamed args.
+              if (existingToolCall.function.name !== toolCallName) {
+                console.warn(
+                  `TOOL_CALL_START: tool call '${toolCallId}' already exists with name ` +
+                    `'${existingToolCall.function.name}' — updating it to '${toolCallName}'`,
+                );
+                existingToolCall.function.name = toolCallName;
+                applyMutation({ messages });
+              }
+
+              return emitUpdates();
+            }
+
             const targetMessage = resolveOrCreateAssistantMessage(
               messages,
               parentMessageId,


### PR DESCRIPTION
## Problem

`@ag-ui/client`'s `TOOL_CALL_START` handler appended to the parent assistant message's `toolCalls` with no check for an existing entry with that id:

```js
message.toolCalls ??= [];
message.toolCalls.push({ id, type: "function", function: { name, arguments: "" } });
```

Any re-application of a start event therefore corrupts message state. The same start can reach the reducer twice — a tool call already carried in `agent.messages` from an earlier run and then replayed by the backend (the HITL path does this when the run re-syncs after `respond()`), or one stream re-delivered over two transports.

The duplicate's `arguments` stay empty, because `TOOL_CALL_ARGS` deltas resolve to the first match. That malformed assistant message — the same tool call twice, one copy with no arguments — is what travels back to the provider on the next turn.

This is the upstream cause behind CopilotKit#6407, which fixed the rendering symptom (a phantom blank HITL card plus a duplicate-React-key warning) at the view layer while the agent's own `messages` array kept the duplicate.

## Change

`sdks/typescript/packages/client/src/apply/default.ts` — resolve any existing entry for `toolCallId` (the same lookup `TOOL_CALL_ARGS` uses) and update it in place instead of pushing a second one. `arguments` is left untouched: a start event carries none, so the copy already in state holds the only streamed args. A start that reuses an id under a different name warns and updates the name, matching the file's existing `console.warn` idiom for protocol anomalies.

The check runs **before** `resolveOrCreateAssistantMessage`, which also closes a second latent defect on the same path: a replay whose `parentMessageId` is no longer in state (paths 3/4 of that helper) would otherwise create a stray empty assistant message to hang the duplicate off. A replay is now a true no-op — no duplicate, no stray message, and no state emission at all.

## Tests

5 tests in a new `TOOL_CALL_START idempotency` block in `default.tool-calls.test.ts`, **verified red before green** (5 failed / 10 passed against the unfixed reducer; 15/15 after):

- the same event applied twice
- a tool call carried over in `agent.messages` from a prior run and replayed
- no stray assistant message when a replay names an unknown parent
- zero state emissions for a replay (idempotent means nothing changes, not "changes to the same value")
- in-place name update when an id is reused under a different name

## Verification

- `@ag-ui/client`: 504/504 passing, 56 files.
- All 6 TypeScript SDK projects pass. Full-repo `nx run-many -t test` passes 32/33 — the one failure is `@ag-ui/cross-language-tests`, which needs the .NET SDK (not installed locally) and is unrelated.
- Prettier clean. Zero `tsc` errors in `default.ts`.

## Scope notes

- **`TOOL_CALL_ARGS` remains non-idempotent by nature** — deltas append. The CPK-7770 evidence (the duplicate copy was empty) shows only the start event was replayed, so this covers the observed defect. Whole-stream re-delivery would surface next as doubled `arguments`, which can't be deduped without sequence numbers.
- **`TOOL_CALL_RESULT` has the same class of defect** — re-applying it pushes a duplicate tool message under the same `messageId`. Left alone: same shape, different resolution question (which copy wins).
- **Why nothing upstream caught this:** `verifyEvents` (`verify/verify.ts:148`) only rejects a `TOOL_CALL_START` for a call still *in progress*, so a start re-emitted after `TOOL_CALL_END` passes verification cleanly.
- **Root cause of the double application is still unestablished.** This makes the reducer robust regardless of mechanism; it does not identify why the event arrives twice. The dual-transport hypothesis is neither confirmed nor ruled out.
- Other SDKs don't share the defect: the Python SDK is types-only (no reducer), and the .NET client's `ToolCallBuilder` is a per-run builder that throws on an in-progress duplicate rather than accumulating into persistent message state.
- Not reproduced end-to-end against a live provider — the question of whether OpenAI-style APIs reject the malformed message is still open, and the `reskinnable-demo` repro lives in the CopilotKit repo.

Refs CPK-7772 (follow-up to CPK-7770 / CopilotKit#6407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
