### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're standardizing the way AI agents connect to user-facing applications through a lightweight, event-based protocol. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Network call has no timeout
   File: integrations/agno/python/examples/server/api/backend_tool_rendering.py
   An agent tool that makes a network request without a timeout can hang indefinitely, blocking the conversation loop and exhausting the agent's wall-clock budget.

2. [HIGH] Tool fetches a caller-controlled URL (SSRF)
   File: integrations/agno/python/examples/server/api/backend_tool_rendering.py
   This tool issues an HTTP request to a URL built from a parameter or an interpolated string rather than a fixed literal.

3. [HIGH] Pydantic AI tool fetches a caller-controlled URL (SSRF)
   File: integrations/pydantic-ai/python/examples/server/api/backend_tool_rendering.py
   This Pydantic AI tool issues an HTTP request whose URL is built from a parameter or interpolated value rather than a fixed literal.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)