### PR TITLE
fix(packaging): repair subpath type resolution for mastra and langgraph

### DIFF
--- a/integrations/langgraph/typescript/.attw.json
+++ b/integrations/langgraph/typescript/.attw.json
@@ -1,3 +1,0 @@
-{
-  "profile": "node16"
-}

--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -63,5 +63,12 @@
       "import": "./dist/middlewares/index.mjs"
     },
     "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "middlewares": [
+        "dist/middlewares/index.d.ts"
+      ]
+    }
   }
 }

--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -35,6 +35,9 @@
   },
   "typesVersions": {
     "*": {
+      "a2ui": [
+        "dist/a2ui.d.ts"
+      ],
       "copilotkit": [
         "dist/copilotkit.d.ts"
       ]


### PR DESCRIPTION
Fixes [PNI-273](https://linear.app/copilotkit/issue/PNI-273/repair-the-subpath-type-resolution-that-pnpm-run-testexports-reports).

## Problem

`pnpm run test:exports` has failed at the repository root since 2026-07-01.

Two published packages declare an `exports` subpath with no corresponding `typesVersions` entry. node10 module resolution reads `typesVersions` and never reads `exports`, so it finds no declarations for the subpath and the consumer's build fails outright:

```
error TS2307: Cannot find module '@ag-ui/mastra/a2ui' or its corresponding type
declarations. There are types at '.../dist/a2ui.d.mts', but this result could not
be resolved under your current 'moduleResolution' setting.
```

| Package | Subpath | Status before |
|---|---|---|
| `@ag-ui/mastra` | `./a2ui` | `node10: 💀 Resolution failed` — the visible failure |
| `@ag-ui/langgraph` | `./middlewares` | `node10: (ignored) 💀` — **masked** by `.attw.json` |

The langgraph case is worth reading twice. `integrations/langgraph/typescript/.attw.json` pinned `{"profile": "node16"}`, suppressing the node10 row entirely. It was the only attw config in the repo, and `daadb5f3` records adding it in the commit message: *"Also add `.attw.json` (profile `node16`) to fix an existing `test:exports` failure."* The check fired in April and was silenced rather than obeyed; the defect survived another three and a half months. Deleting it means no attw failure is silenced by configuration.

## The fix

`typesVersions` entries for both subpaths, matching the convention `@ag-ui/aws-strands` already uses for its `./server` subpath, and deletion of the suppressing `.attw.json`. Three files.

A `types` condition inside `exports` is *not* an alternative — verified: node10 does not read `exports` at all, tsdown deletes the hand-added condition on the next build, and placed first it makes ESM consumers resolve the CJS declaration (`attw` reports "Masquerading as CJS").

## Why it happened twice

All three packages with subpath exports set `exports: true` in `tsdown.config.ts`, so **tsdown regenerates `package.json`'s `exports` field on every build and never writes `typesVersions`.** One half of the contract is machine-maintained; the other is hand-typed, with nothing linking them. Adding an entry point updates one and silently not the other. Recorded here and in the commit message for whoever adds the next subpath.

## Audit

Exactly three packages in the repo declare `exports` subpaths — `@ag-ui/aws-strands` (`./server`, already correct), `@ag-ui/langgraph`, `@ag-ui/mastra`. The latter two were the only gaps. No other published package has the same shape.

On the ticket's adjacent question: `@ag-ui/watsonx` and `@ag-ui/claude-managed-agents` declare `engines.node >= 20.3.0`, and neither publint nor attw reads `engines.node`. No interaction; both pass.

## Verification

Clean install and full build on Node 22.

```
 NX   Successfully ran target test:exports for 29 projects
```

Exit 0, zero `💀`, zero `ignored` across the whole run.

```
"@ag-ui/mastra"                node10: 🟢   node16 CJS: 🟢   node16 ESM: 🟢   bundler: 🟢
"@ag-ui/mastra/a2ui"           node10: 🟢   node16 CJS: 🟢   node16 ESM: 🟢   bundler: 🟢
"@ag-ui/mastra/copilotkit"     node10: 🟢   node16 CJS: 🟢   node16 ESM: 🟢   bundler: 🟢
"@ag-ui/langgraph"             node10: 🟢   node16 CJS: 🟢   node16 ESM: 🟢   bundler: 🟢
"@ag-ui/langgraph/middlewares" node10: 🟢   node16 CJS: 🟢   node16 ESM: 🟢   bundler: 🟢
```

**Beyond attw.** attw passing proves a `.d.ts` was *found*, not that its contents are right. Both packages were `npm pack`ed into a scratch consumer project outside the repo with real transitive type deps linked, then compiled under all four resolution modes. Deliberate misuses error correctly — `TS2322`, `TS2739 missing properties from type 'StateItem'`, `TS2554` — including one naming the real LangChain generic. Stripping `typesVersions` from the packed tarball flips both imports back to `TS2307`.

**Discrimination.** Removing either new `typesVersions` entry reproduces `node10: 💀 Resolution failed` and exits 1.

## Not in this PR

CI enforcement was deliberately scoped out. `test:exports` still runs locally on pre-commit via `lefthook.yml`. Two gaps found while investigating are recorded on the ticket for whenever CI enforcement is taken up:

- `nx run-many` exits 0 when no project matches the target, so a CI step running it would pass as a no-op after a target rename.
- `@ag-ui/a2ui-middleware` and `@ag-ui/claude-agent-sdk` are published but declare no `test:exports` script, so they are silently skipped rather than reported. Both pass when run manually.

Also deliberately untouched: the two packages above lack an `exports` map entirely (dual-package hazard), and `@ag-ui/mastra` declares `@copilotkit/runtime` as a non-optional peer although only `./copilotkit` imports it. Both change published resolution semantics and need their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
