### PR TITLE
feat(aws-strands): forward invocation state

### DIFF
--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -131,6 +131,40 @@ agentcore deploy
 
 For the complete deployment walkthrough, see [Deploy AG-UI servers in AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html).
 
+## Request-scoped invocation state
+
+Use `invocation_state_provider` to make trusted server context available to
+Strands hooks and tools for one request. The provider may be synchronous or
+asynchronous and receives both the FastAPI `Request` and the validated
+`RunAgentInput`:
+
+```python
+from fastapi import Request
+from ag_ui.core import RunAgentInput
+from ag_ui_strands import create_strands_app
+
+async def invocation_state(
+    request: Request,
+    input_data: RunAgentInput,
+) -> dict[str, object]:
+    return {
+        "tenant_id": request.state.tenant_id,
+        "run_id": input_data.run_id,
+    }
+
+app = create_strands_app(
+    agui_agent,
+    auth=require_token,
+    invocation_state_provider=invocation_state,
+)
+```
+
+The adapter shallow-copies the returned dictionary before each invocation,
+because Strands adds its own runtime entries to that dictionary. Do not source
+trusted values from client-controlled `forwarded_props`; derive them from
+authenticated request context instead. Custom routes can pass the same state
+directly with `agent.run(input_data, invocation_state={...})`.
+
 ## Human-in-the-loop (native Strands interrupts)
 
 Tools that pause with `tool_context.interrupt(...)` are bridged to the AG-UI

--- a/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/__init__.py
@@ -19,6 +19,7 @@ from .a2ui_tool import (
 from .client_proxy_tool import create_proxy_tool, sync_proxy_tools
 from .utils import (
     DEFAULT_URL_FETCH_POLICY,
+    InvocationStateProvider,
     UrlFetchPolicy,
     UrlFetchPolicyError,
     create_strands_app,
@@ -59,6 +60,7 @@ __all__ = [
     "UrlFetchPolicyError",
     "DEFAULT_URL_FETCH_POLICY",
     "add_strands_fastapi_endpoint",
+    "InvocationStateProvider",
     "add_ping",
     "StrandsAgentConfig",
     "ToolBehavior",
@@ -73,4 +75,3 @@ __all__ = [
     "RunFinishedInterruptOutcome",
     "RunFinishedSuccessOutcome",
 ]
-

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -368,8 +368,26 @@ class StrandsAgent:
             behavior and behavior.skip_messages_snapshot
         )
 
-    async def run(self, input_data: RunAgentInput) -> AsyncIterator[Any]:
-        """Run the Strands agent and yield AG-UI events."""
+    async def run(
+        self,
+        input_data: RunAgentInput,
+        *,
+        invocation_state: dict[str, Any] | None = None,
+    ) -> AsyncIterator[Any]:
+        """Run the Strands agent and yield AG-UI events.
+
+        Args:
+            input_data: The AG-UI run request.
+            invocation_state: Optional request-scoped state forwarded unchanged
+                to the underlying Strands invocation. The state is available to
+                hooks and tools but is not added to the model context.
+        """
+
+        stream_kwargs = (
+            {"invocation_state": invocation_state}
+            if invocation_state is not None
+            else {}
+        )
 
         # Get or create agent instance for this thread. When a
         # session_manager_provider is configured, the SessionManager handles
@@ -988,7 +1006,7 @@ class StrandsAgent:
                 # ``self.messages`` as-is. The LLM sees real tool results
                 # (including ones produced by the frontend) and emits a
                 # proper follow-up turn instead of re-calling the tool.
-                agent_stream = strands_agent.stream_async(None)
+                agent_stream = strands_agent.stream_async(None, **stream_kwargs)
             elif reconcile_session_results:
                 try:
                     corrected_native_ids = reconcile_frontend_tool_results(
@@ -1025,12 +1043,16 @@ class StrandsAgent:
                     only_ids=set(resolved_native_results),
                 )
                 agent_stream = strands_agent.stream_async(
-                    None if reconciled else user_message
+                    None if reconciled else user_message,
+                    **stream_kwargs,
                 )
             else:
                 # Legacy path: pass only the latest user message and trust
                 # Strands (via session_manager) to track history.
-                agent_stream = strands_agent.stream_async(user_message)
+                agent_stream = strands_agent.stream_async(
+                    user_message,
+                    **stream_kwargs,
+                )
 
             # Drop only the entries whose placeholder was actually corrected
             # this turn — they won't recur. Entries that were NOT corrected

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -2198,8 +2198,26 @@ class StrandsAgent:
                 self._pending_interrupts_by_thread.pop(thread_id, None)
                 self._parked_orchestrators_by_thread.pop(thread_id, None)
 
-    async def run(self, input_data: RunAgentInput) -> AsyncIterator[Any]:
-        """Run the Strands agent and yield AG-UI events."""
+    async def run(
+        self,
+        input_data: RunAgentInput,
+        *,
+        invocation_state: dict[str, Any] | None = None,
+    ) -> AsyncIterator[Any]:
+        """Run the Strands agent and yield AG-UI events.
+
+        Args:
+            input_data: The AG-UI run request.
+            invocation_state: Optional request-scoped state forwarded unchanged
+                to the underlying Strands invocation. The state is available to
+                hooks and tools but is not added to the model context.
+        """
+
+        stream_kwargs = (
+            {"invocation_state": invocation_state}
+            if invocation_state is not None
+            else {}
+        )
 
         if self._orchestrator is not None:
             # An orchestrator carries execution state on the instance and its
@@ -3367,7 +3385,7 @@ class StrandsAgent:
                 if len(remaining) != len(wire_to_native):
                     strands_agent.state.set(AG_UI_WIRE_MAP_STATE_KEY, remaining)
 
-            agent_stream = strands_agent.stream_async(resume_prompt)
+            agent_stream = strands_agent.stream_async(resume_prompt, **stream_kwargs)
             try:
                 async for event in agent_stream:
                     # Capture the terminal ``AgentResult`` (always emitted last

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -705,11 +705,16 @@ _RAW_SUPPRESSED_KEYS = frozenset(
 )
 
 
-def _sanitize_raw_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _sanitize_raw_event(
+    event: Dict[str, Any],
+    invocation_state: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Return a JSON-safe RAW payload for ``event``, or ``None`` to drop it.
 
-    Sanitizing is deliberately an allow-by-serializability filter, never a
-    coercion: nothing is stringified to force it through. Coercing (e.g.
+    Keys present in the per-run invocation state are removed because Strands
+    may merge them into otherwise public model events. Sanitizing is
+    deliberately an allow-by-serializability filter, never a coercion: nothing
+    is stringified to force it through. Coercing (e.g.
     ``json.dumps(..., default=str)``) would ship the ``repr`` of the live
     ``Agent`` — system prompt, conversation history, model configuration — to
     every connected client. A payload that will not encode is dropped instead.
@@ -721,6 +726,7 @@ def _sanitize_raw_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         key: value
         for key, value in event.items()
         if key not in _RAW_INVOCATION_STATE_KEYS
+        and (invocation_state is None or key not in invocation_state)
     }
     if not payload:
         return None
@@ -1938,7 +1944,10 @@ class StrandsAgent:
         return responses or None
 
     async def _run_orchestrator(
-        self, input_data: RunAgentInput
+        self,
+        input_data: RunAgentInput,
+        *,
+        invocation_state: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[Any]:
         """Drive a multi-agent orchestrator and translate its event stream.
 
@@ -2035,7 +2044,12 @@ class StrandsAgent:
                       else _snapshot_orchestrator_nodes(orchestrator)
                   )
 
-              stream = orchestrator.stream_async(prompt)
+              stream_kwargs = (
+                  {"invocation_state": invocation_state}
+                  if invocation_state is not None
+                  else {}
+              )
+              stream = orchestrator.stream_async(prompt, **stream_kwargs)
               try:
                   async for event in stream:
                       if not isinstance(event, dict):
@@ -2208,14 +2222,18 @@ class StrandsAgent:
 
         Args:
             input_data: The AG-UI run request.
-            invocation_state: Optional request-scoped state forwarded unchanged
-                to the underlying Strands invocation. The state is available to
-                hooks and tools but is not added to the model context.
+            invocation_state: Optional request-scoped state copied before it is
+                forwarded to the underlying Strands invocation. The state is
+                available to hooks and tools but is not added to the model
+                context.
         """
 
+        run_invocation_state = (
+            dict(invocation_state) if invocation_state is not None else None
+        )
         stream_kwargs = (
-            {"invocation_state": invocation_state}
-            if invocation_state is not None
+            {"invocation_state": run_invocation_state}
+            if run_invocation_state is not None
             else {}
         )
 
@@ -2272,7 +2290,10 @@ class StrandsAgent:
             # Close the delegate explicitly: when the consumer abandons this
             # generator, `async for` alone would leave the inner one suspended
             # until GC, so the orchestrator stream would keep running.
-            orchestrator_events = self._run_orchestrator(input_data)
+            orchestrator_events = self._run_orchestrator(
+                input_data,
+                invocation_state=run_invocation_state,
+            )
             try:
                 async for event in orchestrator_events:
                     yield event
@@ -4560,7 +4581,7 @@ class StrandsAgent:
                     # in ``endpoint.py`` (RunErrorEvent + break), costing the
                     # client its TEXT_MESSAGE_END, snapshots and RUN_FINISHED.
                     else:
-                        raw_payload = _sanitize_raw_event(event)
+                        raw_payload = _sanitize_raw_event(event, run_invocation_state)
                         if raw_payload is None:
                             continue
                         logger.debug(

--- a/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
@@ -1,6 +1,7 @@
 """FastAPI endpoint utilities for AWS Strands integration."""
 
 import asyncio
+import inspect
 import json
 from typing import Any, Callable, Optional
 
@@ -18,6 +19,21 @@ from ag_ui.core import (
 from ag_ui.encoder import AGUI_MEDIA_TYPE, EventEncoder
 
 from .agent import StrandsAgent
+from .utils import InvocationStateProvider
+
+
+async def _resolve_invocation_state(
+    provider: InvocationStateProvider,
+    request: Request,
+    input_data: RunAgentInput,
+) -> dict[str, Any] | None:
+    """Resolve trusted request state without hiding provider failures."""
+    invocation_state = provider(request, input_data)
+    if inspect.isawaitable(invocation_state):
+        invocation_state = await invocation_state
+    if invocation_state is not None and not isinstance(invocation_state, dict):
+        raise TypeError("invocation_state_provider must return a dict or None")
+    return invocation_state
 
 
 async def _require_json_content_type(request: Request) -> None:
@@ -203,12 +219,14 @@ def _encoded_or_none(encoder: EventEncoder, event) -> str | bytes | None:
     except Exception:
         return None
 
+
 def add_strands_fastapi_endpoint(
     app: FastAPI,
     agent: StrandsAgent,
     path: str,
     *,
     auth: Optional[Callable[..., Any]] = None,
+    invocation_state_provider: Optional[InvocationStateProvider] = None,
     **kwargs: Any,
 ) -> None:
     """Add a Strands agent endpoint to FastAPI app.
@@ -221,6 +239,9 @@ def add_strands_fastapi_endpoint(
             It should raise ``fastapi.HTTPException`` to reject a request. The
             endpoint is unauthenticated when this is ``None``. Authentication
             runs before the request body is parsed and validated.
+        invocation_state_provider: Optional sync or async callable receiving the
+            FastAPI request and validated AG-UI input. Its returned dictionary is
+            forwarded as trusted, request-scoped Strands invocation state.
         **kwargs: Forwarded to ``app.post`` (``tags``, ``dependencies``, ...).
             Any ``dependencies`` given here run after the ones this helper
             installs, rather than replacing them.
@@ -250,6 +271,15 @@ def add_strands_fastapi_endpoint(
     async def strands_endpoint(request: Request):
         """AWS Strands agent endpoint."""
         input_data = await _parse_run_agent_input(request)
+        invocation_state = (
+            await _resolve_invocation_state(
+                invocation_state_provider,
+                request,
+                input_data,
+            )
+            if invocation_state_provider is not None
+            else None
+        )
         # A client may send Accept as several field lines. `get` returns only
         # the first, which would hide a protobuf entry on a later one; Node
         # joins them before the Express peer ever sees the header.
@@ -264,7 +294,12 @@ def add_strands_fastapi_endpoint(
             failure: tuple[str, str] | None = None
 
             try:
-                stream = agent.run(input_data)
+                run_kwargs = (
+                    {"invocation_state": invocation_state}
+                    if invocation_state is not None
+                    else {}
+                )
+                stream = agent.run(input_data, **run_kwargs)
                 iterator = stream.__aiter__()
             except Exception as e:
                 # Headers are already committed, so a failure to even start

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -12,7 +12,7 @@ import urllib.request
 import warnings
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, TypeAlias
 from urllib.parse import quote, urlsplit, urlunsplit
 
 from ag_ui.core import (
@@ -20,10 +20,18 @@ from ag_ui.core import (
     BinaryInputContent,
     DocumentInputContent,
     ImageInputContent,
+    RunAgentInput,
     TextInputContent,
     VideoInputContent,
 )
 from ag_ui.core.types import InputContentDataSource, InputContentUrlSource
+from fastapi import Request
+
+
+InvocationStateProvider: TypeAlias = Callable[
+    [Request, RunAgentInput],
+    dict[str, Any] | None | Awaitable[dict[str, Any] | None],
+]
 
 logger = logging.getLogger(__name__)
 
@@ -750,6 +758,7 @@ def create_strands_app(
     allow_methods: Optional[List[str]] = None,
     allow_headers: Optional[List[str]] = None,
     cors_enabled: Optional[bool] = None,
+    invocation_state_provider: Optional["InvocationStateProvider"] = None,
 ) -> "Any":
     """Create a FastAPI app with a single Strands agent endpoint and optional ping endpoint.
 
@@ -790,6 +799,9 @@ def create_strands_app(
             CORS explicitly; when *origins* is empty, this uses ``["*"]`` without
             emitting the implicit-wildcard warning. ``None`` preserves the
             legacy behavior and warns when *origins* is empty.
+        invocation_state_provider: Optional sync or async callable receiving the
+            FastAPI request and validated AG-UI input. Its returned dictionary is
+            forwarded as trusted, request-scoped Strands invocation state.
     """
     from fastapi import FastAPI
     from .endpoint import add_strands_fastapi_endpoint, add_ping
@@ -820,7 +832,13 @@ def create_strands_app(
         )
 
     # Add the agent endpoint
-    add_strands_fastapi_endpoint(app, agent, path, auth=auth)
+    add_strands_fastapi_endpoint(
+        app,
+        agent,
+        path,
+        auth=auth,
+        invocation_state_provider=invocation_state_provider,
+    )
 
     # Add ping endpoint if path is provided
     if ping_path is not None:

--- a/integrations/aws-strands/python/tests/endpoint_helpers.py
+++ b/integrations/aws-strands/python/tests/endpoint_helpers.py
@@ -56,9 +56,16 @@ class FakeAgent:
     def __init__(self, events: Iterable[BaseEvent] | None = None) -> None:
         self._events = list(events) if events is not None else [run_started(), run_finished()]
         self.received: list[Any] = []
+        self.invocation_states: list[dict[str, Any] | None] = []
 
-    async def run(self, input_data: Any) -> AsyncIterator[BaseEvent]:
+    async def run(
+        self,
+        input_data: Any,
+        *,
+        invocation_state: dict[str, Any] | None = None,
+    ) -> AsyncIterator[BaseEvent]:
         self.received.append(input_data)
+        self.invocation_states.append(invocation_state)
         for event in self._events:
             yield event
 

--- a/integrations/aws-strands/python/tests/test_endpoint.py
+++ b/integrations/aws-strands/python/tests/test_endpoint.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import typing
+
 import pytest
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from ag_ui.core import EventType
+from ag_ui_strands import InvocationStateProvider
 from ag_ui_strands.endpoint import SSE_MEDIA_TYPE, add_ping, add_strands_fastapi_endpoint
+from ag_ui_strands.utils import create_strands_app
 
 from tests.endpoint_helpers import (
     valid_run_input,
@@ -133,6 +137,75 @@ def test_a_dependency_passed_here_runs_alongside_the_built_in_ones() -> None:
     assert seen == ["called"]
     # The helper's own content-type dependency survived the merge.
     assert client.post("/", content="hello").status_code == 415
+
+
+def test_request_provider_supplies_trusted_invocation_state() -> None:
+    seen: list[tuple[str, str]] = []
+
+    async def provide_invocation_state(request, input_data):
+        seen.append((request.headers["x-tenant"], input_data.thread_id))
+        return {"tenant_id": request.headers["x-tenant"]}
+
+    app = FastAPI()
+    agent = FakeAgent()
+    add_strands_fastapi_endpoint(
+        app,
+        agent,
+        "/",
+        invocation_state_provider=provide_invocation_state,
+    )
+
+    response = TestClient(app).post(
+        "/",
+        json=valid_run_input(threadId="thread-from-body"),
+        headers={"x-tenant": "tenant-from-auth"},
+    )
+
+    assert response.status_code == 200
+    assert seen == [("tenant-from-auth", "thread-from-body")]
+    assert agent.invocation_states == [{"tenant_id": "tenant-from-auth"}]
+
+
+def test_sync_request_provider_is_forwarded_by_create_strands_app() -> None:
+    agent = FakeAgent()
+
+    def provide_invocation_state(request, input_data):
+        return {"request_id": f"{request.method}:{input_data.run_id}"}
+
+    app = create_strands_app(
+        agent,
+        cors_enabled=False,
+        invocation_state_provider=provide_invocation_state,
+    )
+
+    response = TestClient(app).post("/", json=valid_run_input(runId="run-from-body"))
+
+    assert response.status_code == 200
+    assert agent.invocation_states == [{"request_id": "POST:run-from-body"}]
+
+
+def test_invalid_invocation_state_provider_result_fails_loudly() -> None:
+    app = FastAPI()
+    agent = FakeAgent()
+    add_strands_fastapi_endpoint(
+        app,
+        agent,
+        "/",
+        invocation_state_provider=lambda _request, _input: "not-a-dict",
+    )
+
+    with pytest.raises(TypeError, match="must return a dict or None"):
+        TestClient(app).post("/", json=valid_run_input())
+
+    assert agent.received == []
+
+
+def test_public_invocation_state_provider_annotation_is_resolvable() -> None:
+    provider_annotation = typing.get_type_hints(create_strands_app)[
+        "invocation_state_provider"
+    ]
+
+    assert provider_annotation == InvocationStateProvider | None
 
 
 def test_route_options_are_forwarded_to_fastapi() -> None:

--- a/integrations/aws-strands/python/tests/test_invocation_state.py
+++ b/integrations/aws-strands/python/tests/test_invocation_state.py
@@ -1,0 +1,145 @@
+"""Request-scoped state must reach the underlying Strands invocation."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ag_ui.core import (
+    RunAgentInput,
+    Tool,
+    ToolMessage,
+    UserMessage,
+)
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig
+from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+from strands import Agent
+from strands.agent.state import AgentState
+from strands.tools.registry import ToolRegistry
+
+
+def _mock_model():
+    model = MagicMock()
+    model.stateful = False
+    return model
+
+
+def _run_input(thread_id: str, *, reconcile: bool = False) -> RunAgentInput:
+    messages = (
+        [
+            ToolMessage(
+                id="tool-1",
+                role="tool",
+                content="approved",
+                tool_call_id="wire-1",
+            )
+        ]
+        if reconcile
+        else [UserMessage(id="user-1", content="hello")]
+    )
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id=f"run-{thread_id}",
+        state={},
+        messages=messages,
+        tools=(
+            [Tool(name="approve", description="Approve", parameters={})]
+            if reconcile
+            else []
+        ),
+        context=[],
+        forwarded_props={},
+    )
+
+
+class _CapturingCore:
+    instances: ClassVar[list[_CapturingCore]] = []
+
+    def __init__(self, **_kwargs):
+        self.tool_registry = ToolRegistry()
+        self.state = AgentState()
+        self.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-1"})
+        self.messages = []
+        self.calls: list[tuple[object, dict]] = []
+        type(self).instances.append(self)
+
+    async def stream_async(self, prompt, **kwargs):
+        self.calls.append((prompt, kwargs))
+        if False:
+            yield
+
+
+async def _run(
+    *,
+    invocation_state: dict | None,
+    replay_history: bool,
+) -> _CapturingCore:
+    template = Agent(model=_mock_model())
+    adapter = StrandsAgent(
+        template,
+        name="test",
+        config=StrandsAgentConfig(
+            replay_history_into_strands=replay_history,
+        ),
+    )
+    _CapturingCore.instances.clear()
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        kwargs = (
+            {"invocation_state": invocation_state}
+            if invocation_state is not None
+            else {}
+        )
+        async for _ in adapter.run(_run_input(str(replay_history)), **kwargs):
+            pass
+    return _CapturingCore.instances[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_history", [True, False])
+async def test_invocation_state_is_forwarded_unchanged(replay_history):
+    invocation_state = {"request_id": "request-1"}
+
+    core = await _run(
+        invocation_state=invocation_state,
+        replay_history=replay_history,
+    )
+
+    assert core.calls[0][1]["invocation_state"] is invocation_state
+
+
+@pytest.mark.asyncio
+async def test_omitted_invocation_state_preserves_legacy_call_shape():
+    core = await _run(invocation_state=None, replay_history=False)
+
+    assert core.calls[0][1] == {}
+
+
+@pytest.mark.asyncio
+async def test_invocation_state_is_forwarded_during_session_reconciliation():
+    invocation_state = {"request_id": "request-reconcile"}
+    template = Agent(model=_mock_model())
+    adapter = StrandsAgent(template, name="test")
+    _CapturingCore.instances.clear()
+
+    with (
+        patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore),
+        patch(
+            "ag_ui_strands.agent._get_strands_session_manager",
+            return_value=object(),
+        ),
+        patch(
+            "ag_ui_strands.agent.reconcile_frontend_tool_results",
+            return_value={"native-1"},
+        ),
+        patch("ag_ui_strands.agent.has_placeholder_results", return_value=False),
+    ):
+        async for _ in adapter.run(
+            _run_input("reconcile", reconcile=True),
+            invocation_state=invocation_state,
+        ):
+            pass
+
+    core = _CapturingCore.instances[-1]
+    assert core.calls[0][1]["invocation_state"] is invocation_state

--- a/integrations/aws-strands/python/tests/test_invocation_state.py
+++ b/integrations/aws-strands/python/tests/test_invocation_state.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 from ag_ui.core import (
+    AssistantMessage,
+    FunctionCall,
     RunAgentInput,
     Tool,
+    ToolCall,
     ToolMessage,
     UserMessage,
 )
@@ -29,6 +33,16 @@ def _mock_model():
 def _run_input(thread_id: str, *, reconcile: bool = False) -> RunAgentInput:
     messages = (
         [
+            AssistantMessage(
+                id="assistant-1",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="wire-1",
+                        function=FunctionCall(name="approve", arguments="{}"),
+                    )
+                ],
+            ),
             ToolMessage(
                 id="tool-1",
                 role="tool",
@@ -106,7 +120,12 @@ async def test_invocation_state_is_forwarded_unchanged(replay_history):
         replay_history=replay_history,
     )
 
-    assert core.calls[0][1]["invocation_state"] is invocation_state
+    forwarded = core.calls[0][1]["invocation_state"]
+    assert forwarded == invocation_state
+    assert forwarded is not invocation_state
+
+    forwarded["mutated_by_strands"] = True
+    assert invocation_state == {"request_id": "request-1"}
 
 
 @pytest.mark.asyncio
@@ -142,4 +161,12 @@ async def test_invocation_state_is_forwarded_during_session_reconciliation():
             pass
 
     core = _CapturingCore.instances[-1]
-    assert core.calls[0][1]["invocation_state"] is invocation_state
+    forwarded = core.calls[0][1]["invocation_state"]
+    assert forwarded == invocation_state
+    assert forwarded is not invocation_state
+
+
+def test_strands_stream_async_accepts_invocation_state_by_keyword_only():
+    parameter = inspect.signature(Agent.stream_async).parameters["invocation_state"]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY

--- a/integrations/aws-strands/python/tests/test_multiagent_orchestrator.py
+++ b/integrations/aws-strands/python/tests/test_multiagent_orchestrator.py
@@ -37,10 +37,12 @@ class FakeOrchestrator:
         self.events = events
         self.raises = raises
         self.prompts: list[Any] = []
+        self.invocation_states: list[dict[str, Any] | None] = []
         self.closed = False
 
     async def stream_async(self, task, invocation_state=None, **kwargs):
         self.prompts.append(task)
+        self.invocation_states.append(invocation_state)
         try:
             for event in self.events:
                 yield event
@@ -71,8 +73,18 @@ def node_stream(node_id: str, inner: dict) -> dict:
     return {"type": "multiagent_node_stream", "node_id": node_id, "event": inner}
 
 
-async def collect(agent: StrandsAgent, input_data=None) -> list:
-    return [e async for e in agent.run(input_data or FakeInput())]
+async def collect(
+    agent: StrandsAgent,
+    input_data=None,
+    *,
+    invocation_state: dict[str, Any] | None = None,
+) -> list:
+    kwargs = (
+        {"invocation_state": invocation_state}
+        if invocation_state is not None
+        else {}
+    )
+    return [e async for e in agent.run(input_data or FakeInput(), **kwargs)]
 
 
 async def _drain(stream) -> list:
@@ -121,6 +133,17 @@ async def test_orchestrator_path_chosen_when_agent_has_no_model():
     assert types[0] == EventType.RUN_STARTED
     assert types[-1] == EventType.RUN_FINISHED
     assert EventType.RUN_ERROR not in types
+
+
+@pytest.mark.asyncio
+async def test_shared_orchestrator_receives_an_isolated_invocation_state():
+    orchestrator = FakeOrchestrator([])
+    invocation_state = {"tenant_id": "tenant-1"}
+
+    await collect(make_agent(orchestrator), invocation_state=invocation_state)
+
+    assert orchestrator.invocation_states == [invocation_state]
+    assert orchestrator.invocation_states[0] is not invocation_state
 
 
 @pytest.mark.asyncio
@@ -1050,6 +1073,24 @@ async def test_a_factory_builds_a_fresh_orchestrator_per_run():
     # One at construction to validate the factory, then one per run.
     assert len(built) == 3
     assert built[1] is not built[2]
+
+
+@pytest.mark.asyncio
+async def test_factory_orchestrator_receives_invocation_state_for_its_run():
+    built = []
+
+    def build():
+        orchestrator = FakeOrchestrator([])
+        built.append(orchestrator)
+        return orchestrator
+
+    agent = StrandsAgent(build, name="multi_agent")
+    invocation_state = {"request_id": "request-1"}
+
+    await collect(agent, invocation_state=invocation_state)
+
+    assert built[1].invocation_states == [invocation_state]
+    assert built[1].invocation_states[0] is not invocation_state
 
 
 @pytest.mark.asyncio

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -174,8 +174,18 @@ def _run_input(thread_id: str = "t1") -> RunAgentInput:
     )
 
 
-async def _collect(agent: StrandsAgent, thread_id: str = "t1") -> list:
-    return [event async for event in agent.run(_run_input(thread_id))]
+async def _collect(
+    agent: StrandsAgent,
+    thread_id: str = "t1",
+    *,
+    invocation_state: dict[str, Any] | None = None,
+) -> list:
+    kwargs = (
+        {"invocation_state": invocation_state}
+        if invocation_state is not None
+        else {}
+    )
+    return [event async for event in agent.run(_run_input(thread_id), **kwargs)]
 
 
 def _assert_stream_encodes(events: list) -> None:
@@ -347,7 +357,13 @@ async def test_raw_payloads_never_carry_invocation_state_injections():
         callback_handler=None,
     )
 
-    events = await _collect(_wrap(strands_agent))
+    invocation_state = {
+        "auth_token": "server-secret",
+        "tenant_id": "tenant-42",
+    }
+    events = await _collect(
+        _wrap(strands_agent), invocation_state=invocation_state
+    )
     _assert_stream_encodes(events)
 
     raw_events = [e for e in events if e.type == EventType.RAW]
@@ -361,10 +377,19 @@ async def test_raw_payloads_never_carry_invocation_state_injections():
         "event_loop_parent_span",
         "event_loop_parent_cycle_id",
         "request_state",
+        "auth_token",
+        "tenant_id",
     }
     for raw in raw_events:
         leaked = forbidden & set(raw.event)
         assert not leaked, f"invocation_state leaked into a RAW payload: {leaked}"
+
+    # The locked SDK release does not merge custom caller keys into this
+    # particular citation envelope, while newer supported releases do. Pin the
+    # sanitizer contract directly so the protection is not version-accidental.
+    merged_payload = {"citation": CITATION, **invocation_state}
+    sanitized = _sanitize_raw_event(merged_payload, invocation_state)
+    assert sanitized == {"citation": CITATION}
 
     # And nothing anywhere in the emitted payloads may be a stringified Agent:
     # a `default=str` style escape hatch would pass the key check above while


### PR DESCRIPTION
## Summary

- add an optional keyword-only `invocation_state` argument to `StrandsAgent.run`
- shallow-copy request state before forwarding it to Strands agents, Graphs, or Swarms
- expose sync or async per-request state providers through `create_strands_app` and `add_strands_fastapi_endpoint`
- keep caller-supplied invocation-state keys out of RAW events
- preserve the legacy call shape when no invocation state is supplied

## Why

Strands tools and hooks use `invocation_state` for trusted request-scoped data. The AG-UI adapter previously dropped that channel, forcing callers to recreate agents per request or use implicit global state.

The provider receives the FastAPI `Request` and validated `RunAgentInput`, so servers can derive identity and capability context from authenticated request data rather than client-controlled AG-UI input. The adapter copies the returned dictionary because Strands mutates invocation state during a run.

## Validation

```text
uv run --locked python -m pytest tests/ -q
722 passed, 2 skipped

uv build
Built dist/ag_ui_strands-0.3.0.tar.gz
Built dist/ag_ui_strands-0.3.0-py3-none-any.whl
```

Rebased on current `main`.

Fixes #2220
