### PR TITLE
fix(aws-strands): emit RAW for unmapped stream events and forward inner agent events (#2291, #2304)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -656,6 +656,35 @@ _RAW_INVOCATION_STATE_KEYS = frozenset(
 # forwarding them would be duplicate noise even if they were serializable.
 _RAW_TERMINAL_KEYS = frozenset({"result", "stop"})
 
+# Keys the dispatch chain in ``run`` already owns. Each of their branches is
+# *conditionally* entered — ``"data" in event and event["data"]``,
+# ``"reasoningText" in event and event.get("reasoning")``,
+# ``"current_tool_use" in event and event["current_tool_use"]`` — so a payload
+# whose guard evaluates false matches no branch and, with the RAW fallback in
+# place, falls through to it.
+#
+# That conflates two different situations the fallback must keep apart:
+#
+#   unmapped            the adapter has no branch for this event at all, so
+#                       forwarding it as RAW is the whole point of issue #2291
+#   mapped-but-declined a branch exists and deliberately withheld the payload
+#
+# Only the first is RAW-eligible. Without this set the second leaks whatever
+# the guard exists to suppress: reasoning text with ``reasoning`` off,
+# encrypted ``reasoningRedactedContent``, and the ``reasoning_signature``
+# verification token would each be republished verbatim over RAW — the exact
+# content the gate withholds — while empty ``data`` and empty
+# ``current_tool_use`` updates would add a RAW event carrying no information.
+_RAW_SUPPRESSED_KEYS = frozenset(
+    {
+        "data",
+        "reasoningText",
+        "reasoningRedactedContent",
+        "reasoning_signature",
+        "current_tool_use",
+    }
+)
+
 
 def _sanitize_raw_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Return a JSON-safe RAW payload for ``event``, or ``None`` to drop it.
@@ -3450,6 +3479,17 @@ class StrandsAgent:
                     elif isinstance(event.get("message"), dict) and event[
                         "message"
                     ].get("role") == "assistant":
+                        continue
+
+                    # A key the chain above owns, reached only because that
+                    # branch's guard declined it (see _RAW_SUPPRESSED_KEYS).
+                    # "Suppressed" must mean suppressed on every channel, so
+                    # this stays silent instead of handing the withheld payload
+                    # to the RAW fallback below.
+                    elif any(key in event for key in _RAW_SUPPRESSED_KEYS):
+                        logger.debug(
+                            f"Suppressing mapped-but-declined Strands event (thread_id={input_data.thread_id}, keys={sorted(event)})"
+                        )
                         continue
 
                     # Anything the chain above does not map gets forwarded as a

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -480,6 +480,7 @@ from ag_ui.core import (
     FunctionCall,
     Interrupt,
     MessagesSnapshotEvent,
+    RawEvent,
     ReasoningEncryptedValueEvent,
     ReasoningEndEvent,
     ReasoningMessageContentEvent,
@@ -619,6 +620,120 @@ def _coerce_text(content: Any) -> str:
 def _coerce_id(value: Any) -> str:
     """Return ``value`` if it is a non-empty string, else a fresh UUID."""
     return value if isinstance(value, str) and value else str(uuid.uuid4())
+
+
+# Separator for namespacing a sub-agent's tool call ids under the parent tool
+# call that owns them. Two agents mint toolUseIds independently, so an inner id
+# can be byte-identical to a parent one; without a namespace the inner result
+# would resolve the PARENT's tool card (and vice versa). "::" is not produced by
+# any Strands/Bedrock id generator, so the prefix is unambiguous.
+_INNER_TOOL_ID_SEP = "::"
+
+
+async def _forward_inner_agent_events(
+    inner_event: Any,
+    parent_tool_use: Dict[str, Any],
+    inner_tool_calls_seen: Dict[str, Dict[str, Any]],
+) -> AsyncIterator[Any]:
+    """Translate one agent-as-tool inner event into AG-UI tool-call events.
+
+    A Strands generator tool that wraps another ``Agent`` (the agent-as-tool
+    pattern) re-yields the inner agent's whole ``stream_async`` output; Strands
+    wraps each yield as ``tool_stream_event``. The inner agent's tool calls
+    therefore never reach the parent loop's ``current_tool_use`` /
+    ``contentBlockStop`` / tool-result branches, so without this the frontend
+    sees the sub-agent as an opaque black box (see issue #2304).
+
+    Only the tool-call lifecycle is forwarded, and only onto the wire —
+    inner calls are deliberately NOT spliced into ``MessagesSnapshotEvent``
+    history, which mirrors the parent conversation Strands actually persists.
+    """
+    if not isinstance(inner_event, dict):
+        return
+
+    parent_id = parent_tool_use.get("toolUseId") or "inner"
+
+    def _namespaced(inner_id: Any) -> str:
+        return f"{parent_id}{_INNER_TOOL_ID_SEP}{inner_id or uuid.uuid4()}"
+
+    # Inner tool call, streaming its args in.
+    tool_use = inner_event.get("current_tool_use")
+    if isinstance(tool_use, dict) and tool_use.get("name"):
+        call_id = _namespaced(tool_use.get("toolUseId"))
+        raw_input = tool_use.get("input", "")
+        raw_str = (
+            raw_input
+            if isinstance(raw_input, str)
+            else json.dumps(raw_input, default=str)
+        )
+        entry = inner_tool_calls_seen.get(call_id)
+        if entry is None:
+            entry = inner_tool_calls_seen[call_id] = {
+                "name": tool_use["name"],
+                "sent_len": 0,
+                "ended": False,
+            }
+            yield ToolCallStartEvent(
+                type=EventType.TOOL_CALL_START,
+                tool_call_id=call_id,
+                tool_call_name=tool_use["name"],
+            )
+        if len(raw_str) > entry["sent_len"]:
+            yield ToolCallArgsEvent(
+                type=EventType.TOOL_CALL_ARGS,
+                tool_call_id=call_id,
+                delta=raw_str[entry["sent_len"] :],
+            )
+            entry["sent_len"] = len(raw_str)
+        return
+
+    # Inner content block closed — close the newest still-open inner call.
+    # Mirrors the parent loop, which also closes one call per contentBlockStop.
+    model_chunk = inner_event.get("event")
+    if isinstance(model_chunk, dict) and "contentBlockStop" in model_chunk:
+        for call_id, entry in reversed(list(inner_tool_calls_seen.items())):
+            if not entry["ended"]:
+                entry["ended"] = True
+                yield ToolCallEndEvent(
+                    type=EventType.TOOL_CALL_END,
+                    tool_call_id=call_id,
+                )
+                break
+        return
+
+    # Inner tool results.
+    message = inner_event.get("message")
+    if isinstance(message, dict) and message.get("role") == "user":
+        for item in message.get("content") or []:
+            if not isinstance(item, dict) or "toolResult" not in item:
+                continue
+            tool_result = item["toolResult"]
+            if not isinstance(tool_result, dict):
+                continue
+            call_id = _namespaced(tool_result.get("toolUseId"))
+            # Only resolve calls this forwarder actually opened, so a result we
+            # never announced can't leave a dangling tool card on the frontend.
+            if call_id not in inner_tool_calls_seen:
+                continue
+            texts = [
+                block["text"]
+                for block in tool_result.get("content") or []
+                if isinstance(block, dict) and "text" in block
+            ]
+            raw_text = "".join(texts)
+            try:
+                result_data = json.loads(raw_text)
+            except (json.JSONDecodeError, TypeError):
+                result_data = raw_text
+            yield ToolCallResultEvent(
+                type=EventType.TOOL_CALL_RESULT,
+                tool_call_id=call_id,
+                message_id=str(uuid.uuid4()),
+                content=json.dumps(result_data, default=str),
+                # role intentionally omitted — same as the parent-level result
+                # path, so the frontend closes the spinner without writing the
+                # inner call into conversation history.
+            )
 
 
 def _build_snapshot_messages(input_messages: List[Any]) -> List[Any]:
@@ -1793,6 +1908,10 @@ class StrandsAgent:
             # tool-call AssistantMessage id.
             last_emitted_text_message_id: str | None = None
             tool_calls_seen = {}
+            # Tool calls made by a sub-agent running as a tool (issue #2304).
+            # Kept separate from ``tool_calls_seen`` so inner calls never take
+            # part in parent-level result lookup, snapshotting or halt logic.
+            inner_tool_calls_seen: Dict[str, Dict[str, Any]] = {}
             current_state = dict(input_data.state or {})  # Track state for final snapshot
             stop_text_streaming = False
             halt_event_stream = False
@@ -2146,8 +2265,15 @@ class StrandsAgent:
 
                     logger.debug(f"Received event: {event}")
 
-                    # Skip lifecycle events
-                    if event.get("init_event_loop") or event.get("start_event_loop"):
+                    # Skip lifecycle events. ``start`` is Strands' deprecated
+                    # alias of ``start_event_loop`` and is emitted alongside it;
+                    # listing it keeps the pair consistent so one half of a
+                    # duplicate does not surface as a RAW event.
+                    if (
+                        event.get("init_event_loop")
+                        or event.get("start_event_loop")
+                        or event.get("start")
+                    ):
                         continue
                     # ``force_stop`` means Strands caught an exception mid-cycle.
                     # It is a failed run, not assistant-authored content or a
@@ -2394,6 +2520,19 @@ class StrandsAgent:
                                     type=EventType.STATE_SNAPSHOT,
                                     snapshot=stream_data["state"],
                                 )
+                            else:
+                                # Agent-as-tool: a generator tool wrapping another
+                                # Agent re-yields that agent's own stream_async events
+                                # here. Forward the inner tool-call lifecycle so the
+                                # sub-agent isn't an opaque black box (issue #2304).
+                                # Reached only when no explicit handler claimed the
+                                # payload and it is not a state snapshot.
+                                async for inner_agui_event in _forward_inner_agent_events(
+                                    stream_data,
+                                    tool_stream.get("tool_use") or {},
+                                    inner_tool_calls_seen,
+                                ):
+                                    yield inner_agui_event
 
                     # Handle tool results from Strands for backend tool rendering
                     elif "message" in event and event["message"].get("role") == "user":
@@ -3224,6 +3363,22 @@ class StrandsAgent:
                                             f"Deferring halt after frontend tool call: tool_name={tool_name}, tool_call_id={tool_use_id}, thread_id={input_data.thread_id}"
                                         )
                                         pending_halt = True
+
+                    # Anything the chain above does not map gets forwarded
+                    # verbatim as a RAW event rather than being dropped without
+                    # a trace (issue #2291). Bedrock citation deltas arrive
+                    # here, as do provider extensions this adapter predates.
+                    # The deliberate lifecycle skips at the top of the loop
+                    # short-circuit before reaching this branch and stay silent.
+                    else:
+                        logger.debug(
+                            f"Unmapped Strands event forwarded as RAW (thread_id={input_data.thread_id}): {event}"
+                        )
+                        yield RawEvent(
+                            type=EventType.RAW,
+                            event=event,
+                            source="strands",
+                        )
 
                 # Defer hand-off (safety flush): if the stream ended without a
                 # backend tool-result message (e.g. a turn with ONLY frontend tool

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from importlib.metadata import version as distribution_version
-from typing import Any, AsyncIterator, Dict, List, Tuple
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 from strands import Agent as StrandsAgentCore
 from strands.session import SessionManager
@@ -630,6 +630,66 @@ def _coerce_id(value: Any) -> str:
 _INNER_TOOL_ID_SEP = "::"
 
 
+# Keys Strands' event loop injects into the *payload* of any event carrying a
+# ``delta``: ``ModelStreamEvent.prepare()`` does ``self.update(invocation_state)``
+# (strands/types/_events.py), which merges the live ``Agent`` object, telemetry
+# handles and cycle bookkeeping into the event dict. None of it is model output,
+# and ``agent`` in particular carries the system prompt, the full message history
+# and the model config — it must never reach a browser. Stripped by name so the
+# RAW payload keeps only the provider's own fields.
+_RAW_INVOCATION_STATE_KEYS = frozenset(
+    {
+        "agent",
+        "event_loop_cycle_id",
+        "event_loop_cycle_trace",
+        "event_loop_cycle_span",
+        "event_loop_parent_span",
+        "event_loop_parent_cycle_id",
+        "request_state",
+    }
+)
+
+# Terminal lifecycle events that carry no payload a frontend can use.
+# ``result`` is ``AgentResultEvent`` (an ``AgentResult`` holding
+# ``EventLoopMetrics``) and ``stop`` is ``EventLoopStopEvent`` (a tuple of the
+# same). Both are the end-of-run marker already represented by RUN_FINISHED, so
+# forwarding them would be duplicate noise even if they were serializable.
+_RAW_TERMINAL_KEYS = frozenset({"result", "stop"})
+
+
+def _sanitize_raw_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return a JSON-safe RAW payload for ``event``, or ``None`` to drop it.
+
+    Sanitizing is deliberately an allow-by-serializability filter, never a
+    coercion: nothing is stringified to force it through. Coercing (e.g.
+    ``json.dumps(..., default=str)``) would ship the ``repr`` of the live
+    ``Agent`` — system prompt, conversation history, model configuration — to
+    every connected client. A payload that will not encode is dropped instead.
+    """
+    if any(key in event for key in _RAW_TERMINAL_KEYS):
+        return None
+
+    payload = {
+        key: value
+        for key, value in event.items()
+        if key not in _RAW_INVOCATION_STATE_KEYS
+    }
+    if not payload:
+        return None
+
+    try:
+        # Strict round-trip: no ``default=`` hook, so any non-JSON-native object
+        # raises here rather than being silently rendered. The decoded result is
+        # what gets forwarded, guaranteeing only plain JSON types reach the wire.
+        return json.loads(json.dumps(payload))
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "Dropping unserializable Strands event from RAW forwarding "
+            f"(keys={sorted(payload)}): {exc}"
+        )
+        return None
+
+
 async def _forward_inner_agent_events(
     inner_event: Any,
     parent_tool_use: Dict[str, Any],
@@ -672,6 +732,11 @@ async def _forward_inner_agent_events(
                 "name": tool_use["name"],
                 "sent_len": 0,
                 "ended": False,
+                # Which parent tool call owns this inner call. The dict is
+                # shared across every parent agent-as-tool call in the run, so
+                # the contentBlockStop handler below needs this to avoid
+                # closing a sibling parent's inner call.
+                "parent_id": parent_id,
             }
             yield ToolCallStartEvent(
                 type=EventType.TOOL_CALL_START,
@@ -687,11 +752,21 @@ async def _forward_inner_agent_events(
             entry["sent_len"] = len(raw_str)
         return
 
-    # Inner content block closed — close the newest still-open inner call.
-    # Mirrors the parent loop, which also closes one call per contentBlockStop.
+    # Inner content block closed — close the newest still-open inner call
+    # *belonging to this parent*. Mirrors the parent loop, which also closes one
+    # call per contentBlockStop.
+    #
+    # The scoping is load-bearing: ``inner_tool_calls_seen`` is shared across
+    # every agent-as-tool call in the run, and Strands executes a parallel tool
+    # batch concurrently, so two sub-agents interleave their streams here. An
+    # unscoped "newest still-open call" search lets parent A's stop close
+    # parent B's inner call — B's tool card resolves early and A's never gets a
+    # TOOL_CALL_END at all, leaving it spinning forever on the frontend.
     model_chunk = inner_event.get("event")
     if isinstance(model_chunk, dict) and "contentBlockStop" in model_chunk:
         for call_id, entry in reversed(list(inner_tool_calls_seen.items())):
+            if entry.get("parent_id") != parent_id:
+                continue
             if not entry["ended"]:
                 entry["ended"] = True
                 yield ToolCallEndEvent(
@@ -3364,19 +3439,41 @@ class StrandsAgent:
                                         )
                                         pending_halt = True
 
-                    # Anything the chain above does not map gets forwarded
-                    # verbatim as a RAW event rather than being dropped without
-                    # a trace (issue #2291). Bedrock citation deltas arrive
-                    # here, as do provider extensions this adapter predates.
-                    # The deliberate lifecycle skips at the top of the loop
-                    # short-circuit before reaching this branch and stay silent.
+                    # Strands' ``ModelMessageEvent`` re-announces the assistant
+                    # turn as a whole once the model finishes it. Every part of
+                    # it has already been streamed — text via
+                    # TEXT_MESSAGE_CONTENT, tool calls via TOOL_CALL_* — and the
+                    # authoritative copy reaches the client through
+                    # MessagesSnapshotEvent. Letting it fall through to RAW would
+                    # re-send the full assistant text a second time, so it is
+                    # skipped explicitly rather than by omission.
+                    elif isinstance(event.get("message"), dict) and event[
+                        "message"
+                    ].get("role") == "assistant":
+                        continue
+
+                    # Anything the chain above does not map gets forwarded as a
+                    # RAW event rather than being dropped without a trace
+                    # (issue #2291). Bedrock citation deltas arrive here, as do
+                    # provider extensions this adapter predates. The deliberate
+                    # lifecycle skips at the top of the loop short-circuit
+                    # before reaching this branch and stay silent.
+                    #
+                    # Sanitizing is mandatory, not defensive: Strands merges the
+                    # live Agent and telemetry handles into delta-bearing events,
+                    # and an unserializable payload aborts the whole SSE stream
+                    # in ``endpoint.py`` (RunErrorEvent + break), costing the
+                    # client its TEXT_MESSAGE_END, snapshots and RUN_FINISHED.
                     else:
+                        raw_payload = _sanitize_raw_event(event)
+                        if raw_payload is None:
+                            continue
                         logger.debug(
-                            f"Unmapped Strands event forwarded as RAW (thread_id={input_data.thread_id}): {event}"
+                            f"Unmapped Strands event forwarded as RAW (thread_id={input_data.thread_id}): {raw_payload}"
                         )
                         yield RawEvent(
                             type=EventType.RAW,
-                            event=event,
+                            event=raw_payload,
                             source="strands",
                         )
 

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -4,8 +4,12 @@ Covers two halves of the same structural gap in the Strands adapter:
 
 Issue #2291 — the main stream loop's ``if/elif`` chain has no terminal
 ``else``, so any event the adapter does not recognise is dropped silently.
-Bedrock citation events are one such event: Strands surfaces them as
-``{"citation": ..., "delta": ...}``, which matches no branch.
+Bedrock citation events are one such event, and Strands surfaces them in two
+different envelopes depending on version: ``{"callback": {"citation": ...,
+"delta": ...}}`` on 1.15.0-1.20.0, and ``{"citation": ..., "delta": ...}`` from
+1.21.0 onward. Neither matches a branch. The declared floor is
+``strands-agents>=1.15.0`` and the lockfile pins 1.18.0, so the tests here
+accept both shapes.
 
 The fallback that fixes it may only forward what will actually encode.
 ``ModelStreamEvent.prepare()`` merges ``invocation_state`` into any event

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -39,7 +39,7 @@ from strands import Agent as StrandsAgentCore
 from strands import tool
 from strands.models.model import Model
 
-from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.agent import StrandsAgent, _sanitize_raw_event
 from ag_ui_strands.config import StrandsAgentConfig
 
 
@@ -111,6 +111,29 @@ CITATION = {
     "sourceContent": [{"text": "revenue grew 12%"}],
     "location": {"documentChar": {"documentIndex": 0, "start": 10, "end": 26}},
 }
+
+
+def _find_citation_payload(event: Any) -> Optional[dict]:
+    """Locate the citation payload in a RAW event, whatever shape it arrives in.
+
+    Strands changed ``CitationStreamEvent``'s envelope mid-1.x: releases
+    1.15.0–1.20.0 emit ``{"callback": {"citation": ..., "delta": ...}}`` while
+    1.21.0 and later emit ``{"citation": ..., "delta": ...}``. This package
+    declares ``strands-agents>=1.15.0``, so both are in range and a test that
+    pins one of them is version-fragile rather than behavioural. Searching
+    recursively asserts what actually matters — the citation reached the wire
+    instead of being dropped — without coupling to the envelope.
+    """
+    if not isinstance(event, dict):
+        return None
+    citation = event.get("citation")
+    if isinstance(citation, dict):
+        return citation
+    for value in event.values():
+        found = _find_citation_payload(value)
+        if found is not None:
+            return found
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -239,18 +262,31 @@ async def test_bedrock_citation_event_is_emitted_as_raw():
     _assert_stream_encodes(events)
 
     raw_events = [e for e in events if e.type == EventType.RAW]
-    # Strands' ``CitationStreamEvent`` is ``{"citation": ..., "delta": ...}`` at
-    # the top level (strands/types/_events.py) — it is not wrapped in a
-    # ``callback`` key anywhere in the ``stream_async`` path.
-    citation_raws = [
-        e for e in raw_events if isinstance(e.event, dict) and "citation" in e.event
+    # ``CitationStreamEvent`` has TWO wire shapes across the range this package
+    # declares (``strands-agents>=1.15.0``), verified against every published
+    # 1.x wheel in that range:
+    #
+    #   1.15.0 – 1.20.0 : {"callback": {"citation": ..., "delta": ...}}
+    #   1.21.0 – latest : {"citation": ..., "delta": ...}
+    #
+    # The adapter is right either way — RAW forwards the provider's own payload
+    # verbatim rather than normalising a shape it does not own — so this test
+    # must accept both instead of pinning whichever one the lockfile happens to
+    # resolve. Asserting the top-level key alone made the suite fail on the
+    # locked 1.18.0 while passing locally on a newer resolution.
+    located = [
+        (e, payload)
+        for e in raw_events
+        for payload in [_find_citation_payload(e.event)]
+        if payload is not None
     ]
-    assert citation_raws, (
+    assert located, (
         "expected a RAW event carrying the Bedrock citation payload; "
         f"got RAW events: {[e.event for e in raw_events]}"
     )
-    assert citation_raws[0].source == "strands"
-    assert citation_raws[0].event["citation"] == CITATION
+    event, payload = located[0]
+    assert event.source == "strands"
+    assert payload == CITATION
 
 
 @pytest.mark.asyncio
@@ -361,6 +397,20 @@ async def test_terminal_lifecycle_events_are_not_emitted_as_raw():
     ]
     assert leaked == [], f"terminal lifecycle events leaked as RAW: {leaked}"
     assert events[-1].type == EventType.RUN_FINISHED
+
+    # The end-to-end half above cannot actually pin ``_RAW_TERMINAL_KEYS``: a
+    # real ``AgentResult`` is unserializable, so it is dropped by the strict
+    # round-trip whether or not the key exclusion exists. Delete the exclusion
+    # and the assertions above still pass. Exercise the sanitizer directly with
+    # a *plainly serializable* payload so the drop can only come from the
+    # exclusion this test is named for.
+    for terminal_key in ("result", "stop"):
+        serializable = {terminal_key: {"stop_reason": "end_turn", "metrics": {}}}
+        assert json.dumps(serializable)  # the payload itself round-trips fine
+        assert _sanitize_raw_event(serializable) is None, (
+            f"{terminal_key!r} must be excluded from RAW by name, not by "
+            "accidentally failing serialization"
+        )
 
 
 @pytest.mark.asyncio
@@ -708,3 +758,126 @@ async def test_parallel_agent_as_tool_calls_close_their_own_inner_calls():
     assert not [i for i in all_ends if i.startswith("parent_b::")], (
         f"sub-agent B opened no inner call yet closed one: {all_ends}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2291 — suppressed payloads must not re-enter through the RAW fallback
+# ---------------------------------------------------------------------------
+
+
+class _ReplayAgent:
+    """Yields a fixed event list, standing in for ``Agent.stream_async``.
+
+    The suppression gates under test key off flag values (``reasoning`` false,
+    ``current_tool_use`` empty) that Strands' own constructors never produce at
+    any version in range — ``ReasoningTextStreamEvent`` hardcodes
+    ``reasoning: True``. The gates exist precisely for the payload shapes a
+    provider or a future release could emit, so they can only be exercised by
+    feeding the dispatch chain directly. The genuinely reachable case (an empty
+    text delta) is covered below by a real ``strands.Agent``.
+    """
+
+    def __init__(self, events: list[dict]) -> None:
+        self._events = events
+        self.model = MagicMock()
+        self.system_prompt = "test"
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.record_direct_tool_call = True
+
+    async def stream_async(self, message: Any):
+        for event in self._events:
+            yield event
+
+
+def _wrap_replay(events: list[dict], thread_id: str = "t1") -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=StrandsAgentConfig()
+    )
+    agent._agents_by_thread[thread_id] = _ReplayAgent(events)
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("event", "secret"),
+    [
+        # Reasoning suppressed because the ``reasoning`` flag is off.
+        ({"reasoningText": "chain of thought", "reasoning": False}, "chain of thought"),
+        # Same, with the flag absent entirely.
+        ({"reasoningText": "chain of thought"}, "chain of thought"),
+        # Redacted reasoning is encrypted provider content; the adapter exposes
+        # it only as REASONING_ENCRYPTED_VALUE, never as a bare payload.
+        (
+            {"reasoningRedactedContent": "cipher-text", "reasoning": False},
+            "cipher-text",
+        ),
+        # The verification token is deliberately never surfaced to the UI.
+        ({"reasoning_signature": "sig-abc123", "reasoning": False}, "sig-abc123"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_suppressed_reasoning_payloads_do_not_leak_as_raw(event, secret):
+    """A mapped-but-suppressed payload must stay suppressed, not become RAW.
+
+    These branches are guarded suppression gates, e.g.
+    ``elif "reasoningText" in event and event.get("reasoning")``. When the guard
+    is false the branch is skipped — and with a terminal ``else`` added for
+    issue #2291, the event then falls all the way through, so the withheld text
+    is forwarded verbatim as RAW. The adapter would be publishing over RAW
+    exactly the content the reasoning gate exists to withhold.
+
+    The pre-existing reasoning tests miss this: they assert only that no
+    ``REASONING_*`` event fires, which stays true while the payload leaks out
+    the other door.
+    """
+    events = await _collect(_wrap_replay([event, {"data": "Visible answer."}]))
+    _assert_stream_encodes(events)
+
+    raw_events = [e.event for e in events if e.type == EventType.RAW]
+    leaked = [r for r in raw_events if secret in json.dumps(r)]
+    assert leaked == [], (
+        f"suppressed payload {secret!r} was forwarded as RAW anyway: {leaked}"
+    )
+    assert raw_events == [], f"suppressed event should be silent, got RAW: {raw_events}"
+
+    # The suppression must be surgical: ordinary output still streams.
+    assert any(e.type == EventType.TEXT_MESSAGE_CONTENT for e in events)
+
+
+@pytest.mark.asyncio
+async def test_empty_tool_use_update_is_not_emitted_as_raw():
+    """``current_tool_use`` is owned by the tool-call branch, empty or not.
+
+    Its handler is gated on the value being non-empty. An empty update carries
+    nothing a client can act on, so falling through to RAW is pure noise.
+    """
+    events = await _collect(
+        _wrap_replay([{"current_tool_use": None}, {"current_tool_use": {}}])
+    )
+    _assert_stream_encodes(events)
+
+    raw_events = [e.event for e in events if e.type == EventType.RAW]
+    assert raw_events == [], f"empty tool-use updates leaked as RAW: {raw_events}"
+
+
+@pytest.mark.asyncio
+async def test_empty_text_delta_is_not_emitted_as_raw():
+    """An empty text delta must be silent — proven against a real ``Agent``.
+
+    Unlike the gates above, this one is reachable today: on the locked
+    strands-agents 1.18.0 a real ``Agent`` streaming an empty text delta emits
+    ``TextStreamEvent`` as ``{"data": "", "delta": {"text": ""}}``. The text
+    branch is gated on ``event["data"]`` being truthy, so without this fix the
+    event falls through and every empty delta becomes a RAW event carrying no
+    information at all.
+    """
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("")]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
+
+    raw_events = [e.event for e in events if e.type == EventType.RAW]
+    assert raw_events == [], f"empty text delta leaked as RAW: {raw_events}"

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -5,7 +5,13 @@ Covers two halves of the same structural gap in the Strands adapter:
 Issue #2291 — the main stream loop's ``if/elif`` chain has no terminal
 ``else``, so any event the adapter does not recognise is dropped silently.
 Bedrock citation events are one such event: Strands surfaces them as
-``{"callback": {"citation": ..., "delta": ...}}``, which matches no branch.
+``{"citation": ..., "delta": ...}``, which matches no branch.
+
+The fallback that fixes it may only forward what will actually encode.
+``ModelStreamEvent.prepare()`` merges ``invocation_state`` into any event
+carrying a ``delta`` — including the live ``Agent`` — and ``stream_async``
+always ends with an unserializable ``AgentResultEvent``. Both must be filtered
+out, and every test here asserts the whole stream survives ``EventEncoder``.
 
 Issue #2304 — a Strands generator tool that wraps another ``Agent``
 (agent-as-tool) surfaces the inner agent's whole event stream as
@@ -21,11 +27,14 @@ loop, so the assertions hold against real framework behaviour.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import Any, AsyncIterable, Optional
 from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import EventType, RunAgentInput, UserMessage
+from ag_ui.encoder import EventEncoder
 from strands import Agent as StrandsAgentCore
 from strands import tool
 from strands.models.model import Model
@@ -138,8 +147,30 @@ def _run_input(thread_id: str = "t1") -> RunAgentInput:
     )
 
 
-async def _collect(agent: StrandsAgent) -> list:
-    return [event async for event in agent.run(_run_input())]
+async def _collect(agent: StrandsAgent, thread_id: str = "t1") -> list:
+    return [event async for event in agent.run(_run_input(thread_id))]
+
+
+def _assert_stream_encodes(events: list) -> None:
+    """Every event must survive ``EventEncoder``, exactly as the endpoint does.
+
+    ``endpoint.py`` encodes each event as it streams and, on failure, emits a
+    ``RunErrorEvent(code="ENCODING_ERROR")`` and **breaks** — so a single
+    unserializable event truncates the run: no ``TEXT_MESSAGE_END``, no final
+    snapshots, no ``RUN_FINISHED``. Collecting events in-process (as these tests
+    do) never exercises that, which is why this guard is asserted explicitly in
+    every test that can produce a RAW event.
+    """
+    encoder = EventEncoder()
+    for event in events:
+        try:
+            encoder.encode(event)
+        except Exception as exc:  # noqa: BLE001 - surfacing the real failure
+            payload = getattr(event, "event", None)
+            pytest.fail(
+                f"event of type {event.type} is not encodable and would abort "
+                f"the SSE stream: {type(exc).__name__}: {exc}\npayload={payload!r}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -205,19 +236,21 @@ async def test_bedrock_citation_event_is_emitted_as_raw():
     )
 
     events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
 
     raw_events = [e for e in events if e.type == EventType.RAW]
+    # Strands' ``CitationStreamEvent`` is ``{"citation": ..., "delta": ...}`` at
+    # the top level (strands/types/_events.py) — it is not wrapped in a
+    # ``callback`` key anywhere in the ``stream_async`` path.
     citation_raws = [
-        e
-        for e in raw_events
-        if isinstance(e.event, dict) and "citation" in (e.event.get("callback") or {})
+        e for e in raw_events if isinstance(e.event, dict) and "citation" in e.event
     ]
     assert citation_raws, (
         "expected a RAW event carrying the Bedrock citation payload; "
         f"got RAW events: {[e.event for e in raw_events]}"
     )
     assert citation_raws[0].source == "strands"
-    assert citation_raws[0].event["callback"]["citation"] == CITATION
+    assert citation_raws[0].event["citation"] == CITATION
 
 
 @pytest.mark.asyncio
@@ -229,6 +262,7 @@ async def test_lifecycle_events_are_not_emitted_as_raw():
     )
 
     events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
 
     lifecycle_keys = {"init_event_loop", "start_event_loop", "start", "complete", "force_stop"}
     leaked = [
@@ -251,11 +285,111 @@ async def test_raw_fallback_does_not_disturb_mapped_events():
 
     events = await _collect(_wrap(strands_agent))
 
+    _assert_stream_encodes(events)
+
     deltas = "".join(
         e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT
     )
     assert deltas == "Revenue grew."
     assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_raw_payloads_never_carry_invocation_state_injections():
+    """`ModelStreamEvent.prepare()` merges `invocation_state` into any event
+    holding a ``delta`` — the live ``Agent``, an OTel span, a telemetry
+    ``Trace``, a ``UUID``. None of it is model output, and the ``Agent`` alone
+    carries the system prompt, message history and model config. It must never
+    be forwarded to a client, in any form, stringified or otherwise.
+    """
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("Revenue grew.", citation=CITATION)]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
+
+    raw_events = [e for e in events if e.type == EventType.RAW]
+    assert raw_events, "expected at least one RAW event to inspect"
+
+    forbidden = {
+        "agent",
+        "event_loop_cycle_id",
+        "event_loop_cycle_trace",
+        "event_loop_cycle_span",
+        "event_loop_parent_span",
+        "event_loop_parent_cycle_id",
+        "request_state",
+    }
+    for raw in raw_events:
+        leaked = forbidden & set(raw.event)
+        assert not leaked, f"invocation_state leaked into a RAW payload: {leaked}"
+
+    # And nothing anywhere in the emitted payloads may be a stringified Agent:
+    # a `default=str` style escape hatch would pass the key check above while
+    # still shipping the system prompt and history to the browser.
+    blob = json.dumps([e.event for e in raw_events])
+    assert "You are helpful" not in blob
+    assert "strands.agent.agent.Agent" not in blob
+    assert "<strands" not in blob
+
+
+@pytest.mark.asyncio
+async def test_terminal_lifecycle_events_are_not_emitted_as_raw():
+    """`AgentResultEvent` / `EventLoopStopEvent` must not reach the wire.
+
+    ``Agent.stream_async`` yields ``{"result": AgentResult(...)}`` at the end of
+    EVERY invocation. It carries ``EventLoopMetrics.traces``, which Pydantic
+    cannot serialize — forwarding it aborted the stream before RUN_FINISHED.
+    It is also pure duplication: end-of-run is already RUN_FINISHED.
+    """
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("hi")]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
+
+    leaked = [
+        e.event
+        for e in events
+        if e.type == EventType.RAW
+        and isinstance(e.event, dict)
+        and {"result", "stop"} & set(e.event)
+    ]
+    assert leaked == [], f"terminal lifecycle events leaked as RAW: {leaked}"
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_is_not_re_emitted_as_raw():
+    """Strands' ``ModelMessageEvent`` re-announces the finished assistant turn.
+
+    Its text has already been streamed via TEXT_MESSAGE_CONTENT, so forwarding
+    it as RAW re-sends the whole assistant message a second time.
+    """
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("Revenue grew.")]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
+
+    duplicated = [
+        e.event
+        for e in events
+        if e.type == EventType.RAW
+        and isinstance(e.event, dict)
+        and isinstance(e.event.get("message"), dict)
+        and e.event["message"].get("role") == "assistant"
+    ]
+    assert duplicated == [], (
+        "the assistant message was re-emitted as RAW after already being "
+        f"streamed as TEXT_MESSAGE_CONTENT: {duplicated}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +401,7 @@ async def test_raw_fallback_does_not_disturb_mapped_events():
 async def test_inner_agent_tool_call_lifecycle_is_forwarded():
     """The sub-agent's own tool call must produce start/args/end/result."""
     events = await _collect(_wrap(_nested_agent()))
+    _assert_stream_encodes(events)
 
     starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
     inner_starts = [e for e in starts if e.tool_call_name == "lookup_weather"]
@@ -304,6 +439,7 @@ async def test_inner_agent_tool_call_lifecycle_is_forwarded():
 async def test_inner_tool_call_lifecycle_is_ordered_within_the_parent_call():
     """Inner start/end must land between the parent tool's start and result."""
     events = await _collect(_wrap(_nested_agent()))
+    _assert_stream_encodes(events)
 
     def _index(predicate) -> int:
         return next(i for i, e in enumerate(events) if predicate(e))
@@ -339,6 +475,7 @@ async def test_inner_tool_call_id_cannot_collide_with_a_parent_id():
             )
         )
     )
+    _assert_stream_encodes(events)
 
     starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
     by_name = {e.tool_call_name: e.tool_call_id for e in starts}
@@ -354,3 +491,220 @@ async def test_inner_tool_call_id_cannot_collide_with_a_parent_id():
         and e.tool_call_id == by_name["lookup_weather"]
     ]
     assert len(inner_results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #2304 — two agent-as-tool calls in one parallel batch
+# ---------------------------------------------------------------------------
+
+
+class _Sequencer:
+    """Forces a specific interleaving across concurrently streaming agents.
+
+    Strands runs a parallel tool batch through ``asyncio.gather``
+    (``strands/tools/executors/concurrent.py``), so two agent-as-tool calls
+    interleave their inner streams non-deterministically. This pins one exact
+    interleaving so the regression below cannot flake either way.
+    """
+
+    def __init__(self, order: list[str]) -> None:
+        self._order = list(order)
+        self._index = 0
+        self._condition = asyncio.Condition()
+
+    async def step(self, label: str) -> None:
+        if label not in self._order:
+            return  # ungated: proceed freely
+        async with self._condition:
+            await self._condition.wait_for(
+                lambda: self._index >= len(self._order)
+                or self._order[self._index] == label
+            )
+            if self._index < len(self._order):
+                self._index += 1
+            self._condition.notify_all()
+
+
+def _gate_inner_events(agent_label: str, sequencer: _Sequencer):
+    """Wrap a sub-agent's stream, gating the events whose order drives the bug.
+
+    Gating happens where the sub-agent's events are re-yielded into the parent's
+    tool stream, because that is where Strands' concurrent executor enqueues
+    them — gating at the model instead would not pin the order the *adapter*
+    observes, since the executor's one-event-in-flight handshake reorders
+    relative to model production.
+    """
+    counters: Dict[str, int] = {}
+
+    def _label(event: Any) -> Optional[str]:
+        if not isinstance(event, dict):
+            return None
+        if isinstance(event.get("current_tool_use"), dict):
+            counters["tooluse"] = counters.get("tooluse", 0) + 1
+            return f"{agent_label}:tooluse#{counters['tooluse']}"
+        model_chunk = event.get("event")
+        if isinstance(model_chunk, dict) and "contentBlockStop" in model_chunk:
+            counters["stop"] = counters.get("stop", 0) + 1
+            return f"{agent_label}:stop#{counters['stop']}"
+        return None
+
+    async def gated(stream):
+        async for event in stream:
+            label = _label(event)
+            if label:
+                await sequencer.step(label)
+            yield event
+
+    return gated
+
+
+def _parallel_agent_as_tool_parent(sequencer: _Sequencer) -> StrandsAgentCore:
+    """A parent Agent that invokes TWO agent-as-tool tools in one batch.
+
+    Sub-agent A calls a tool of its own, streaming its arguments across two
+    deltas. Sub-agent B has no tools at all — it just answers — so the only
+    ``contentBlockStop`` it produces belongs to a *text* block. That asymmetry
+    is the point: B's text stop has no inner call of its own to close, and an
+    unscoped "newest still-open inner call" search makes it close A's instead.
+    """
+
+    @tool
+    def lookup_weather(city: str) -> str:
+        """Look up the weather for a city."""
+        return f"sunny in {city}"
+
+    # A's tool arguments arrive in two deltas, so the adapter emits a second
+    # TOOL_CALL_ARGS after B's stop lands — which is what makes the misclose
+    # observable on the wire.
+    inner_a = StrandsAgentCore(
+        model=ScriptedModel(
+            [
+                [
+                    {"messageStart": {"role": "assistant"}},
+                    {
+                        "contentBlockStart": {
+                            "start": {
+                                "toolUse": {
+                                    "toolUseId": "inner_a_1",
+                                    "name": "lookup_weather",
+                                }
+                            }
+                        }
+                    },
+                    {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"city": '}}}},
+                    {"contentBlockDelta": {"delta": {"toolUse": {"input": '"Paris"}'}}}},
+                    {"contentBlockStop": {}},
+                    {"messageStop": {"stopReason": "tool_use"}},
+                ],
+                _text_turn("Paris is sunny."),
+            ]
+        ),
+        tools=[lookup_weather],
+        callback_handler=None,
+    )
+    # B answers directly — no tools, so its only contentBlockStop is a text one.
+    inner_b = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("AMZN is up.")]),
+        callback_handler=None,
+    )
+
+    gate_a = _gate_inner_events("A", sequencer)
+    gate_b = _gate_inner_events("B", sequencer)
+
+    @tool
+    async def weather_agent(query: str):
+        """Delegate weather research to a sub-agent."""
+        async for event in gate_a(inner_a.stream_async(query)):
+            yield event
+
+    @tool
+    async def finance_agent(query: str):
+        """Delegate finance research to a sub-agent."""
+        async for event in gate_b(inner_b.stream_async(query)):
+            yield event
+
+    parent_turn = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {
+                "start": {"toolUse": {"toolUseId": "parent_a", "name": "weather_agent"}}
+            }
+        },
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"query": "weather"}'}}}},
+        {"contentBlockStop": {}},
+        {
+            "contentBlockStart": {
+                "start": {"toolUse": {"toolUseId": "parent_b", "name": "finance_agent"}}
+            }
+        },
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": '{"query": "stocks"}'}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+
+    return StrandsAgentCore(
+        model=ScriptedModel([parent_turn, _text_turn("Done.")]),
+        tools=[weather_agent, finance_agent],
+        callback_handler=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_agent_as_tool_calls_close_their_own_inner_calls():
+    """A parent's contentBlockStop must not close a *sibling* parent's call.
+
+    ``inner_tool_calls_seen`` is one dict shared by every agent-as-tool call in
+    the run, and Strands executes a parallel tool batch concurrently, so two
+    sub-agents interleave their streams. Closing "the newest still-open inner
+    call" without checking which parent the stop came from makes sub-agent B's
+    stop resolve sub-agent A's call — A's card closes while its arguments are
+    still streaming, and A's own stop then finds nothing left to close.
+    """
+    sequencer = _Sequencer(
+        [
+            "A:tooluse#1",  # A opens its inner call, first half of its args.
+            "B:stop#1",  # B's *text* block stops — it owns no inner call.
+            "A:tooluse#2",  # A streams the rest of its args.
+            "A:stop#1",  # Only now may A's inner call legitimately close.
+        ]
+    )
+
+    events = await _collect(_wrap(_parallel_agent_as_tool_parent(sequencer)))
+    _assert_stream_encodes(events)
+
+    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+    inner = [e for e in starts if e.tool_call_name == "lookup_weather"]
+    assert inner, "sub-agent A's inner tool call was never opened"
+    inner_id = inner[0].tool_call_id
+    assert inner_id.startswith("parent_a::"), (
+        f"inner call is not namespaced under its owning parent: {inner_id}"
+    )
+
+    def _indices(event_type) -> list[int]:
+        return [
+            i
+            for i, e in enumerate(events)
+            if e.type == event_type and getattr(e, "tool_call_id", None) == inner_id
+        ]
+
+    end_indices = _indices(EventType.TOOL_CALL_END)
+    args_indices = _indices(EventType.TOOL_CALL_ARGS)
+
+    assert len(end_indices) == 1, (
+        "sub-agent A's inner tool call must be closed exactly once; "
+        f"got {len(end_indices)} TOOL_CALL_END events for {inner_id}"
+    )
+    assert len(args_indices) == 2, (
+        f"expected both argument deltas for {inner_id}, got {len(args_indices)}"
+    )
+    assert end_indices[0] > args_indices[-1], (
+        "sub-agent A's inner tool call was closed by sibling sub-agent B's "
+        "contentBlockStop — TOOL_CALL_END arrived while A's arguments were "
+        f"still streaming (END at {end_indices[0]}, last ARGS at {args_indices[-1]})"
+    )
+
+    # And B, which never opened an inner call, must not have closed anything.
+    all_ends = [e.tool_call_id for e in events if e.type == EventType.TOOL_CALL_END]
+    assert not [i for i in all_ends if i.startswith("parent_b::")], (
+        f"sub-agent B opened no inner call yet closed one: {all_ends}"
+    )

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -1,0 +1,356 @@
+"""Tests for the RAW fallback and agent-as-tool inner-event forwarding.
+
+Covers two halves of the same structural gap in the Strands adapter:
+
+Issue #2291 — the main stream loop's ``if/elif`` chain has no terminal
+``else``, so any event the adapter does not recognise is dropped silently.
+Bedrock citation events are one such event: Strands surfaces them as
+``{"callback": {"citation": ..., "delta": ...}}``, which matches no branch.
+
+Issue #2304 — a Strands generator tool that wraps another ``Agent``
+(agent-as-tool) surfaces the inner agent's whole event stream as
+``tool_stream_event`` payloads. The only branch reading those handles
+``state`` snapshots and A2UI progress, so the inner agent's tool calls never
+reach the frontend.
+
+Both suites drive a REAL ``strands.Agent`` (parent and inner) over a scripted
+model provider that replays Bedrock-shaped stream chunks. Nothing here
+hand-builds the adapter's input events — they come out of Strands' own event
+loop, so the assertions hold against real framework behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterable, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import EventType, RunAgentInput, UserMessage
+from strands import Agent as StrandsAgentCore
+from strands import tool
+from strands.models.model import Model
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig
+
+
+# ---------------------------------------------------------------------------
+# Scripted model provider
+# ---------------------------------------------------------------------------
+
+
+class ScriptedModel(Model):
+    """Replays canned Bedrock-shaped stream turns, one turn per invocation."""
+
+    def __init__(self, turns: list[list[dict]]) -> None:
+        self._turns = list(turns)
+        self.calls = 0
+
+    def update_config(self, **model_config: Any) -> None:  # pragma: no cover
+        pass
+
+    def get_config(self) -> Any:  # pragma: no cover
+        return {}
+
+    def structured_output(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    async def stream(
+        self,
+        messages: Any,
+        tool_specs: Optional[list] = None,
+        system_prompt: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncIterable[dict]:
+        turn = self._turns[min(self.calls, len(self._turns) - 1)]
+        self.calls += 1
+        for event in turn:
+            yield event
+
+
+def _text_turn(text: str, citation: dict | None = None) -> list[dict]:
+    events: list[dict] = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": text}}},
+    ]
+    if citation is not None:
+        events.append({"contentBlockDelta": {"delta": {"citation": citation}}})
+    events += [
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+    ]
+    return events
+
+
+def _tool_turn(tool_use_id: str, name: str, input_json: str) -> list[dict]:
+    return [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {
+                "start": {"toolUse": {"toolUseId": tool_use_id, "name": name}}
+            }
+        },
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": input_json}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+
+
+CITATION = {
+    "title": "quarterly-report.pdf",
+    "sourceContent": [{"text": "revenue grew 12%"}],
+    "location": {"documentChar": {"documentIndex": 0, "start": 10, "end": 26}},
+}
+
+
+# ---------------------------------------------------------------------------
+# Adapter wiring
+# ---------------------------------------------------------------------------
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+def _wrap(strands_agent: StrandsAgentCore, thread_id: str = "t1") -> StrandsAgent:
+    agent = StrandsAgent(
+        _template_agent(), name="test-agent", config=StrandsAgentConfig()
+    )
+    agent._agents_by_thread[thread_id] = strands_agent
+    return agent
+
+
+def _run_input(thread_id: str = "t1") -> RunAgentInput:
+    return RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[UserMessage(id="u1", role="user", content="hello")],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
+async def _collect(agent: StrandsAgent) -> list:
+    return [event async for event in agent.run(_run_input())]
+
+
+# ---------------------------------------------------------------------------
+# Nested-agent fixture (agent-as-tool)
+# ---------------------------------------------------------------------------
+
+
+def _nested_agent(
+    parent_tool_use_id: str = "tooluse_parent_1",
+    inner_tool_use_id: str = "tooluse_inner_1",
+) -> StrandsAgentCore:
+    """A real parent Agent whose only tool wraps a real inner Agent.
+
+    The inner agent calls a real ``@tool`` of its own; Strands surfaces the
+    whole inner stream to the parent as ``tool_stream_event`` payloads.
+    """
+
+    @tool
+    def lookup_weather(city: str) -> str:
+        """Look up the weather for a city."""
+        return f"sunny in {city}"
+
+    inner = StrandsAgentCore(
+        model=ScriptedModel(
+            [
+                _tool_turn(inner_tool_use_id, "lookup_weather", '{"city": "Paris"}'),
+                _text_turn("Paris is sunny."),
+            ]
+        ),
+        tools=[lookup_weather],
+        callback_handler=None,
+    )
+
+    @tool
+    async def research_agent(query: str):
+        """Delegate research to a sub-agent."""
+        async for event in inner.stream_async(query):
+            yield event
+
+    return StrandsAgentCore(
+        model=ScriptedModel(
+            [
+                _tool_turn(parent_tool_use_id, "research_agent", '{"query": "weather"}'),
+                _text_turn("Done."),
+            ]
+        ),
+        tools=[research_agent],
+        callback_handler=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #2291 — RAW fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bedrock_citation_event_is_emitted_as_raw():
+    """A citation delta must reach the wire instead of being dropped."""
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("Revenue grew.", citation=CITATION)]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+
+    raw_events = [e for e in events if e.type == EventType.RAW]
+    citation_raws = [
+        e
+        for e in raw_events
+        if isinstance(e.event, dict) and "citation" in (e.event.get("callback") or {})
+    ]
+    assert citation_raws, (
+        "expected a RAW event carrying the Bedrock citation payload; "
+        f"got RAW events: {[e.event for e in raw_events]}"
+    )
+    assert citation_raws[0].source == "strands"
+    assert citation_raws[0].event["callback"]["citation"] == CITATION
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_events_are_not_emitted_as_raw():
+    """The deliberate plumbing skips must stay silent, not turn into RAW."""
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("hi")]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+
+    lifecycle_keys = {"init_event_loop", "start_event_loop", "start", "complete", "force_stop"}
+    leaked = [
+        e.event
+        for e in events
+        if e.type == EventType.RAW
+        and isinstance(e.event, dict)
+        and lifecycle_keys & set(e.event)
+    ]
+    assert leaked == [], f"lifecycle events leaked as RAW: {leaked}"
+
+
+@pytest.mark.asyncio
+async def test_raw_fallback_does_not_disturb_mapped_events():
+    """Text still streams normally alongside the new RAW fallback."""
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("Revenue grew.", citation=CITATION)]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+
+    deltas = "".join(
+        e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT
+    )
+    assert deltas == "Revenue grew."
+    assert events[-1].type == EventType.RUN_FINISHED
+
+
+# ---------------------------------------------------------------------------
+# Issue #2304 — agent-as-tool inner event forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inner_agent_tool_call_lifecycle_is_forwarded():
+    """The sub-agent's own tool call must produce start/args/end/result."""
+    events = await _collect(_wrap(_nested_agent()))
+
+    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+    inner_starts = [e for e in starts if e.tool_call_name == "lookup_weather"]
+    assert inner_starts, (
+        "inner sub-agent tool call was never emitted; "
+        f"only saw: {[e.tool_call_name for e in starts]}"
+    )
+
+    inner_id = inner_starts[0].tool_call_id
+
+    args = [
+        e
+        for e in events
+        if e.type == EventType.TOOL_CALL_ARGS and e.tool_call_id == inner_id
+    ]
+    assert "".join(e.delta for e in args) == '{"city": "Paris"}'
+
+    ends = [
+        e
+        for e in events
+        if e.type == EventType.TOOL_CALL_END and e.tool_call_id == inner_id
+    ]
+    assert len(ends) == 1
+
+    results = [
+        e
+        for e in events
+        if e.type == EventType.TOOL_CALL_RESULT and e.tool_call_id == inner_id
+    ]
+    assert len(results) == 1
+    assert "sunny in Paris" in results[0].content
+
+
+@pytest.mark.asyncio
+async def test_inner_tool_call_lifecycle_is_ordered_within_the_parent_call():
+    """Inner start/end must land between the parent tool's start and result."""
+    events = await _collect(_wrap(_nested_agent()))
+
+    def _index(predicate) -> int:
+        return next(i for i, e in enumerate(events) if predicate(e))
+
+    parent_start = _index(
+        lambda e: e.type == EventType.TOOL_CALL_START
+        and e.tool_call_name == "research_agent"
+    )
+    inner_start = _index(
+        lambda e: e.type == EventType.TOOL_CALL_START
+        and e.tool_call_name == "lookup_weather"
+    )
+    inner_end = _index(
+        lambda e: e.type == EventType.TOOL_CALL_END
+        and events[inner_start].tool_call_id == e.tool_call_id
+    )
+    parent_result = _index(
+        lambda e: e.type == EventType.TOOL_CALL_RESULT
+        and e.tool_call_id == "tooluse_parent_1"
+    )
+
+    assert parent_start < inner_start < inner_end < parent_result
+
+
+@pytest.mark.asyncio
+async def test_inner_tool_call_id_cannot_collide_with_a_parent_id():
+    """An inner agent reusing the parent's toolUseId must not alias it."""
+    events = await _collect(
+        _wrap(
+            _nested_agent(
+                parent_tool_use_id="tooluse_1",
+                inner_tool_use_id="tooluse_1",
+            )
+        )
+    )
+
+    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+    by_name = {e.tool_call_name: e.tool_call_id for e in starts}
+    assert by_name["research_agent"] == "tooluse_1"
+    assert by_name["lookup_weather"] != by_name["research_agent"]
+    assert "tooluse_1" in by_name["lookup_weather"]
+
+    # And the inner result must not resolve the parent's tool card.
+    inner_results = [
+        e
+        for e in events
+        if e.type == EventType.TOOL_CALL_RESULT
+        and e.tool_call_id == by_name["lookup_weather"]
+    ]
+    assert len(inner_results) == 1

--- a/integrations/aws-strands/typescript/src/__tests__/raw-content-block.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/raw-content-block.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Issue #2291 regression — the RAW fallback must not re-deliver assembled
+ * content blocks.
+ *
+ * `Agent.stream()` wraps EVERY completed content block in a `ContentBlockEvent`
+ * (`dist/src/agent/agent.js`: anything from `model.streamAggregated` that is not
+ * a `ModelStreamEvent` becomes `new ContentBlockEvent({ contentBlock })`).
+ * `unwrapStrandsEvent` then reduces that wrapper to the bare block, whose
+ * `type` is `"textBlock"`, `"reasoningBlock"`, `"citationsBlock"`, and so on.
+ * The dispatch chain maps only `"toolUseBlock"`, so before this fix every other
+ * block fell through to the RAW fallback — meaning an ordinary text turn
+ * re-delivered the entire assistant answer as a RAW event immediately after it
+ * had finished streaming as `TEXT_MESSAGE_CONTENT`.
+ *
+ * That is precisely the duplication Python's `ModelMessageEvent` skip exists to
+ * prevent, and it is a bug the RAW fallback itself introduced.
+ *
+ * Every other test in this suite hand-writes event object literals, which is
+ * exactly why this went unnoticed: a literal is only ever the shape its author
+ * already had in mind. These cases construct the REAL SDK classes and let the
+ * adapter meet the shapes the SDK actually produces.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AgentStreamEvent } from "@strands-agents/sdk";
+import {
+  ContentBlockEvent,
+  ReasoningBlock,
+  TextBlock,
+} from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { collect, scriptedStrandsAgent, stream } from "./helpers";
+
+/** Wrap a real content block exactly as `Agent.stream()` does. */
+function contentBlockEvent(contentBlock: unknown): AgentStreamEvent {
+  return new ContentBlockEvent({
+    // The adapter strips `agent`/`invocationState` by name; a stub is enough
+    // here and keeps the fixture from needing a live model.
+    agent: {} as never,
+    contentBlock: contentBlock as never,
+    invocationState: {} as never,
+  }) as unknown as AgentStreamEvent;
+}
+
+function rawPayloads(events: Array<{ type: string }>): unknown[] {
+  return events
+    .filter((e) => e.type === EventType.RAW)
+    .map((e) => (e as unknown as { event: unknown }).event);
+}
+
+describe("assembled content blocks never reach the RAW fallback", () => {
+  it("emits no RAW for a real TextBlock, and does not repeat the answer", async () => {
+    const answer = "the whole assistant answer";
+    const agent = scriptedStrandsAgent([
+      stream.textDelta(answer),
+      contentBlockEvent(new TextBlock(answer)),
+    ]);
+
+    const events = await collect(agent);
+    const raws = rawPayloads(events as Array<{ type: string }>);
+
+    expect(raws).toEqual([]);
+    // Belt and braces: the answer must appear exactly once on the wire, via
+    // the streamed text — never a second time inside a RAW payload.
+    expect(JSON.stringify(raws)).not.toContain(answer);
+  });
+
+  it("emits no RAW for a real ReasoningBlock, including its signature", async () => {
+    const agent = scriptedStrandsAgent([
+      contentBlockEvent(
+        new ReasoningBlock({ text: "chain of thought", signature: "sig" }),
+      ),
+    ]);
+
+    const events = await collect(agent);
+    const raws = rawPayloads(events as Array<{ type: string }>);
+
+    expect(raws).toEqual([]);
+    // The signature is a verification token the adapter deliberately keeps off
+    // the wire; leaking it through RAW would defeat that.
+    expect(JSON.stringify(raws)).not.toContain("sig");
+  });
+
+  it("emits no RAW for any assembled block kind the SDK may add", async () => {
+    // The fix is keyed on the `contentBlockEvent` wrapper rather than on a list
+    // of block names, so a block type this adapter has never heard of is still
+    // covered. By construction any content block is the assembled form of
+    // deltas that already streamed.
+    const agent = scriptedStrandsAgent([
+      contentBlockEvent({ type: "someFutureBlock", payload: "assembled" }),
+    ]);
+
+    const events = await collect(agent);
+
+    expect(rawPayloads(events as Array<{ type: string }>)).toEqual([]);
+  });
+
+  it("still forwards genuinely unmapped events that are not content blocks", async () => {
+    // Guard against over-correcting: the fallback must keep doing its job for
+    // events that carry information no mapped AG-UI event conveys.
+    const agent = scriptedStrandsAgent([
+      contentBlockEvent(new TextBlock("streamed already")),
+      {
+        type: "modelMetadataEvent",
+        usage: { inputTokens: 10, outputTokens: 20 },
+      } as unknown as AgentStreamEvent,
+    ]);
+
+    const events = await collect(agent);
+    const raws = rawPayloads(events as Array<{ type: string }>) as Array<{
+      type?: string;
+    }>;
+
+    expect(raws.map((r) => r?.type)).toEqual(["modelMetadataEvent"]);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
@@ -98,4 +98,104 @@ describe("RAW fallback for unmapped Strands events", () => {
     expect(deltas).toBe("hello");
     expect(rawEvents(events as Array<{ type: string }>)).toHaveLength(1);
   });
+
+  it("does not duplicate payloads that a mapped AG-UI event already carries", async () => {
+    // Each of these carries content the client has already received under a
+    // mapped event; forwarding them as RAW re-sends it. `agentResultEvent` and
+    // `modelMessageEvent` in particular would re-deliver the whole assistant
+    // message that just streamed as TEXT_MESSAGE_CONTENT.
+    const duplicated = [
+      "agentResultEvent",
+      "modelMessageEvent",
+      "toolResultEvent",
+      "messageAddedEvent",
+    ];
+
+    const agent = scriptedStrandsAgent([
+      {
+        type: "modelContentBlockDeltaEvent",
+        delta: { type: "textDelta", text: "hello" },
+      } as unknown as AgentStreamEvent,
+      ...duplicated.map(
+        (type) =>
+          ({
+            type,
+            message: { role: "assistant", content: [{ text: "hello" }] },
+            result: { stopReason: "end_turn" },
+          }) as unknown as AgentStreamEvent,
+      ),
+    ]);
+    const events = await collect(agent);
+
+    const leaked = rawEvents(events as Array<{ type: string }>)
+      .map((e) => e.event?.type)
+      .filter((type) => type !== undefined && duplicated.includes(type));
+
+    expect(leaked).toEqual([]);
+  });
+
+  it("still forwards events carrying information no mapped event conveys", async () => {
+    // The counterpart of the skip list: usage metrics and guardrail redactions
+    // have no AG-UI equivalent, so dropping them silently is the very bug
+    // issue #2291 reports. This pins the deliberate decision to forward them.
+    const agent = scriptedStrandsAgent([
+      {
+        type: "modelMetadataEvent",
+        usage: { inputTokens: 12, outputTokens: 7, totalTokens: 19 },
+        metrics: { latencyMs: 42 },
+      } as unknown as AgentStreamEvent,
+      {
+        type: "modelRedactionEvent",
+        outputRedaction: { text: "[redacted]" },
+      } as unknown as AgentStreamEvent,
+    ]);
+    const events = await collect(agent);
+
+    const kinds = rawEvents(events as Array<{ type: string }>).map(
+      (e) => e.event?.type,
+    );
+    expect(kinds).toContain("modelMetadataEvent");
+    expect(kinds).toContain("modelRedactionEvent");
+  });
+
+  it("never forwards the live agent or invocationState on a RAW payload", async () => {
+    // Strands hook events hold a live `agent` reference (system prompt, message
+    // history, model config) next to their payload. It must not reach a client.
+    const liveAgent = {
+      systemPrompt: "TOP SECRET SYSTEM PROMPT",
+      messages: [{ role: "user", content: [{ text: "private history" }] }],
+    };
+    const agent = scriptedStrandsAgent([
+      {
+        type: "modelMetadataEvent",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        agent: liveAgent,
+        invocationState: { requestState: {}, agent: liveAgent },
+      } as unknown as AgentStreamEvent,
+    ]);
+    const events = await collect(agent);
+
+    const raws = rawEvents(events as Array<{ type: string }>);
+    expect(raws).toHaveLength(1);
+
+    const serialized = JSON.stringify(raws[0].event);
+    expect(serialized).not.toContain("TOP SECRET SYSTEM PROMPT");
+    expect(serialized).not.toContain("private history");
+    expect(raws[0].event).not.toHaveProperty("agent");
+    expect(raws[0].event).not.toHaveProperty("invocationState");
+  });
+
+  it("drops an unserializable payload instead of emitting it", async () => {
+    // A payload that cannot be encoded must not reach the encoder: on the
+    // Python side the equivalent failure aborts the whole SSE stream. Dropping
+    // is the only safe outcome — coercing values to strings is what would put
+    // an agent's internals on the wire.
+    const cyclic: Record<string, unknown> = { type: "modelMetadataEvent" };
+    cyclic.self = cyclic;
+
+    const agent = scriptedStrandsAgent([cyclic as unknown as AgentStreamEvent]);
+    const events = await collect(agent);
+
+    expect(rawEvents(events as Array<{ type: string }>)).toEqual([]);
+  });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #2291 — the adapter's event dispatch has no terminal fallback, so any
+ * Strands event it does not translate is dropped with no error and no log.
+ * Provider extensions the adapter predates (Bedrock citations being the
+ * reported case) vanish before they reach the frontend.
+ *
+ * The adapter must forward anything it does not map as a RAW event carrying
+ * the original Strands payload, while the deliberate lifecycle skips stay
+ * silent.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AgentStreamEvent } from "@strands-agents/sdk";
+import { EventType } from "@ag-ui/core";
+
+import { collect, scriptedStrandsAgent } from "./helpers";
+
+const CITATION_EVENT = {
+  type: "modelCitationEvent",
+  citation: {
+    title: "quarterly-report.pdf",
+    sourceContent: [{ text: "revenue grew 12%" }],
+    location: { documentChar: { documentIndex: 0, start: 10, end: 26 } },
+  },
+} as unknown as AgentStreamEvent;
+
+function rawEvents(events: Array<{ type: string }>) {
+  return events.filter((e) => e.type === EventType.RAW) as unknown as Array<{
+    event: { type?: string };
+    source?: string;
+  }>;
+}
+
+describe("RAW fallback for unmapped Strands events", () => {
+  it("forwards an unmapped provider event as RAW with the original payload", async () => {
+    const agent = scriptedStrandsAgent([CITATION_EVENT]);
+    const events = await collect(agent);
+
+    const raws = rawEvents(events as Array<{ type: string }>);
+    const citationRaws = raws.filter(
+      (e) => e.event?.type === "modelCitationEvent",
+    );
+
+    expect(citationRaws).toHaveLength(1);
+    expect(citationRaws[0].source).toBe("strands");
+    expect(citationRaws[0].event).toEqual(CITATION_EVENT);
+  });
+
+  it("unwraps the modelStreamUpdateEvent envelope before emitting RAW", async () => {
+    // Strands v1 decorates raw model events; the RAW payload must be the inner
+    // event the adapter actually failed to map, not the wrapper.
+    const agent = scriptedStrandsAgent([
+      {
+        type: "modelStreamUpdateEvent",
+        event: CITATION_EVENT,
+      } as unknown as AgentStreamEvent,
+    ]);
+    const events = await collect(agent);
+
+    const raws = rawEvents(events as Array<{ type: string }>);
+    expect(raws.map((e) => e.event?.type)).toContain("modelCitationEvent");
+    expect(raws.map((e) => e.event?.type)).not.toContain(
+      "modelStreamUpdateEvent",
+    );
+  });
+
+  it("keeps lifecycle plumbing events silent", async () => {
+    const agent = scriptedStrandsAgent([
+      { type: "initializedEvent" } as unknown as AgentStreamEvent,
+      { type: "beforeInvocationEvent" } as unknown as AgentStreamEvent,
+      { type: "beforeModelCallEvent" } as unknown as AgentStreamEvent,
+      { type: "afterModelCallEvent" } as unknown as AgentStreamEvent,
+      { type: "modelMessageStartEvent" } as unknown as AgentStreamEvent,
+      { type: "modelMessageStopEvent" } as unknown as AgentStreamEvent,
+      { type: "afterInvocationEvent" } as unknown as AgentStreamEvent,
+    ]);
+    const events = await collect(agent);
+
+    expect(rawEvents(events as Array<{ type: string }>)).toEqual([]);
+  });
+
+  it("does not disturb events the adapter already maps", async () => {
+    const agent = scriptedStrandsAgent([
+      {
+        type: "modelContentBlockDeltaEvent",
+        delta: { type: "textDelta", text: "hello" },
+      } as unknown as AgentStreamEvent,
+      CITATION_EVENT,
+    ]);
+    const events = await collect(agent);
+
+    const deltas = (
+      events as unknown as Array<{ type: string; delta?: string }>
+    )
+      .filter((e) => e.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((e) => e.delta)
+      .join("");
+    expect(deltas).toBe("hello");
+    expect(rawEvents(events as Array<{ type: string }>)).toHaveLength(1);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/raw-fallback.test.ts
@@ -2,7 +2,9 @@
  * Issue #2291 — the adapter's event dispatch has no terminal fallback, so any
  * Strands event it does not translate is dropped with no error and no log.
  * Provider extensions the adapter predates (Bedrock citations being the
- * reported case) vanish before they reach the frontend.
+ * reported case) vanish before they reach the frontend. Citations arrive as a
+ * delta kind inside an event the adapter does handle, so the delta branch must
+ * let unrecognised kinds fall through rather than consuming them.
  *
  * The adapter must forward anything it does not map as a RAW event carrying
  * the original Strands payload, while the deliberate lifecycle skips stay
@@ -15,12 +17,23 @@ import { EventType } from "@ag-ui/core";
 
 import { collect, scriptedStrandsAgent } from "./helpers";
 
+// The shape `@strands-agents/sdk` 1.1.0 actually emits for Bedrock citations:
+// a `modelContentBlockDeltaEvent` whose delta discriminates as
+// `citationsDelta` (models/streaming.d.ts, `ContentBlockDelta`). The adapter
+// has no branch for that delta kind, so it is what the fallback must forward.
 const CITATION_EVENT = {
-  type: "modelCitationEvent",
-  citation: {
-    title: "quarterly-report.pdf",
-    sourceContent: [{ text: "revenue grew 12%" }],
-    location: { documentChar: { documentIndex: 0, start: 10, end: 26 } },
+  type: "modelContentBlockDeltaEvent",
+  delta: {
+    type: "citationsDelta",
+    citations: [
+      {
+        title: "quarterly-report.pdf",
+        source: "s3://reports/quarterly-report.pdf",
+        sourceContent: [{ text: "revenue grew 12%" }],
+        location: { documentChar: { documentIndex: 0, start: 10, end: 26 } },
+      },
+    ],
+    content: [{ text: "revenue grew 12%" }],
   },
 } as unknown as AgentStreamEvent;
 
@@ -38,7 +51,9 @@ describe("RAW fallback for unmapped Strands events", () => {
 
     const raws = rawEvents(events as Array<{ type: string }>);
     const citationRaws = raws.filter(
-      (e) => e.event?.type === "modelCitationEvent",
+      (e) =>
+        (e.event as { delta?: { type?: string } })?.delta?.type ===
+        "citationsDelta",
     );
 
     expect(citationRaws).toHaveLength(1);
@@ -58,7 +73,9 @@ describe("RAW fallback for unmapped Strands events", () => {
     const events = await collect(agent);
 
     const raws = rawEvents(events as Array<{ type: string }>);
-    expect(raws.map((e) => e.event?.type)).toContain("modelCitationEvent");
+    expect(
+      raws.map((e) => (e.event as { delta?: { type?: string } })?.delta?.type),
+    ).toContain("citationsDelta");
     expect(raws.map((e) => e.event?.type)).not.toContain(
       "modelStreamUpdateEvent",
     );

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -62,15 +62,40 @@ const LOG_PREFIX = "[@ag-ui/aws-strands]";
 const uuid = (): string => randomUUID();
 
 /**
- * Lifecycle/plumbing events the RAW fallback deliberately stays silent about.
+ * Events the RAW fallback deliberately stays silent about.
  *
- * The TS SDK surfaces hook brackets the Python `stream_async` generator never
- * emits, so these are the TS counterpart of Python's `init_event_loop` /
- * `start_event_loop` / `start` skips: they carry no payload of their own and
- * only bracket work that is already reported through mapped events. Everything
- * else falls through to a RAW event (issue #2291).
+ * Two groups, both of which would be noise rather than new information:
+ *
+ * 1. Lifecycle/plumbing brackets. The TS SDK surfaces hook brackets the Python
+ *    `stream_async` generator never emits, so these are the TS counterpart of
+ *    Python's `init_event_loop` / `start_event_loop` / `start` skips: they carry
+ *    no payload of their own and only bracket work already reported by mapped
+ *    events.
+ *
+ * 2. Payload-carrying events whose payload is *already* on the wire under a
+ *    mapped AG-UI event. Forwarding these as RAW duplicates content the client
+ *    has seen — the same class of bug as Python re-emitting `ModelMessageEvent`
+ *    after the text has already streamed:
+ *      - `agentResultEvent`  — terminal result; already `RUN_FINISHED`.
+ *      - `modelMessageEvent` — the assembled assistant message, already streamed
+ *                              as `TEXT_MESSAGE_CONTENT` / `TOOL_CALL_*`.
+ *      - `toolResultEvent`   — already mapped from `afterToolCallEvent` to
+ *                              `TOOL_CALL_RESULT`.
+ *      - `messageAddedEvent` — framework-side history bookkeeping; the client's
+ *                              history comes from `MESSAGES_SNAPSHOT`.
+ *
+ * Deliberately NOT skipped — these carry information no mapped AG-UI event
+ * conveys, which is exactly what the RAW fallback exists for (issue #2291):
+ *   - `modelMetadataEvent`  — token usage and latency metrics, which the AG-UI
+ *                             event set has no equivalent for.
+ *   - `modelRedactionEvent` — a guardrail redaction notice. Losing it silently
+ *                             would leave a client unable to tell redacted
+ *                             output from an ordinary short answer.
+ *
+ * Everything else falls through to a RAW event.
  */
 const RAW_SKIPPED_EVENT_KINDS = new Set<string>([
+  // 1. Lifecycle / plumbing brackets.
   "initializedEvent",
   "beforeInvocationEvent",
   "afterInvocationEvent",
@@ -81,7 +106,64 @@ const RAW_SKIPPED_EVENT_KINDS = new Set<string>([
   "beforeToolCallEvent",
   "modelMessageStartEvent",
   "modelMessageStopEvent",
+  // 2. Payloads already represented by a mapped AG-UI event.
+  "agentResultEvent",
+  "modelMessageEvent",
+  "toolResultEvent",
+  "messageAddedEvent",
 ]);
+
+/**
+ * Context keys Strands hangs off its events that are never model output.
+ *
+ * `agent` is a live `LocalAgent` — system prompt, full message history, model
+ * configuration — and `invocationState` transitively holds the same. Hook events
+ * define a `toJSON()` that drops both, but the model-layer events that reach the
+ * RAW fallback after unwrapping (`modelMetadataEvent` and friends) do not, so
+ * the keys are stripped by name rather than trusted to `toJSON()`.
+ *
+ * Mirrors `_RAW_INVOCATION_STATE_KEYS` in the Python adapter.
+ */
+const RAW_STRIPPED_EVENT_KEYS = new Set<string>([
+  "agent",
+  "invocationState",
+  "requestState",
+]);
+
+/**
+ * Reduce a Strands event to a JSON-safe RAW payload, or `undefined` to drop it.
+ *
+ * Two passes, both mandatory:
+ *  1. Drop the context keys above, so no agent internals reach a client.
+ *  2. Round-trip through JSON, so what we emit is plain data an in-process
+ *     consumer cannot follow back to a live object.
+ *
+ * Anything that will not serialize is dropped rather than coerced. Coercing
+ * unserializable values to strings is precisely how an agent's internals would
+ * end up on the wire, so it is never an option here.
+ */
+function sanitizeRawEvent(event: unknown): unknown | undefined {
+  if (!event || typeof event !== "object") return undefined;
+
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(event as Record<string, unknown>)) {
+    if (RAW_STRIPPED_EVENT_KEYS.has(key)) continue;
+    payload[key] = value;
+  }
+  if (Object.keys(payload).length === 0) return undefined;
+
+  try {
+    const serialized = JSON.stringify(payload);
+    if (serialized === undefined) return undefined;
+    const decoded = JSON.parse(serialized) as Record<string, unknown>;
+    // A nested `toJSON()` could reintroduce a stripped key; strip once more on
+    // the decoded, plain-data copy.
+    for (const key of RAW_STRIPPED_EVENT_KEYS) delete decoded[key];
+    return decoded;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Structural interface for a Strands multi-agent orchestrator (Graph/Swarm).
@@ -2313,13 +2395,21 @@ export class StrandsAgent {
           // (LangGraph, watsonx, a2a) already does. The lifecycle brackets in
           // `RAW_SKIPPED_EVENT_KINDS` stay silent, as they do in Python.
           if (kind && RAW_SKIPPED_EVENT_KINDS.has(kind)) continue;
+          const rawPayload = sanitizeRawEvent(event);
+          if (rawPayload === undefined) {
+            this._log.warn(
+              `${LOG_PREFIX} Dropping unserializable Strands event from RAW ` +
+                `forwarding (threadId=${inputData.threadId}, kind=${kind ?? "unknown"})`,
+            );
+            continue;
+          }
           this._log.debug(
             `${LOG_PREFIX} Unmapped Strands event forwarded as RAW ` +
               `(threadId=${inputData.threadId}, kind=${kind ?? "unknown"})`,
           );
           yield {
             type: EventType.RAW,
-            event,
+            event: rawPayload,
             source: "strands",
           } as unknown as BaseEvent;
         }

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -62,6 +62,28 @@ const LOG_PREFIX = "[@ag-ui/aws-strands]";
 const uuid = (): string => randomUUID();
 
 /**
+ * Lifecycle/plumbing events the RAW fallback deliberately stays silent about.
+ *
+ * The TS SDK surfaces hook brackets the Python `stream_async` generator never
+ * emits, so these are the TS counterpart of Python's `init_event_loop` /
+ * `start_event_loop` / `start` skips: they carry no payload of their own and
+ * only bracket work that is already reported through mapped events. Everything
+ * else falls through to a RAW event (issue #2291).
+ */
+const RAW_SKIPPED_EVENT_KINDS = new Set<string>([
+  "initializedEvent",
+  "beforeInvocationEvent",
+  "afterInvocationEvent",
+  "beforeModelCallEvent",
+  "afterModelCallEvent",
+  "beforeToolsEvent",
+  "afterToolsEvent",
+  "beforeToolCallEvent",
+  "modelMessageStartEvent",
+  "modelMessageStopEvent",
+]);
+
+/**
  * Structural interface for a Strands multi-agent orchestrator (Graph/Swarm).
  * TypeScript-only: the Python SDK currently has no orchestrator equivalent.
  */
@@ -2282,8 +2304,24 @@ export class StrandsAgent {
             };
             continue;
           }
-          // Ignore events we don't translate (BeforeInvocationEvent,
-          // ModelStreamEventHook wrappers, etc.).
+
+          // Terminal fallback: anything the dispatch above does not translate
+          // is forwarded verbatim as RAW rather than dropped without a trace
+          // (issue #2291) — provider extensions this adapter predates, Bedrock
+          // citations among them, arrive here. Mirrors the Python adapter's
+          // terminal `else`, and matches what every other streaming adapter
+          // (LangGraph, watsonx, a2a) already does. The lifecycle brackets in
+          // `RAW_SKIPPED_EVENT_KINDS` stay silent, as they do in Python.
+          if (kind && RAW_SKIPPED_EVENT_KINDS.has(kind)) continue;
+          this._log.debug(
+            `${LOG_PREFIX} Unmapped Strands event forwarded as RAW ` +
+              `(threadId=${inputData.threadId}, kind=${kind ?? "unknown"})`,
+          );
+          yield {
+            type: EventType.RAW,
+            event,
+            source: "strands",
+          } as unknown as BaseEvent;
         }
       } finally {
         // Consumer bailed (client disconnect, frontend-tool halt, error).

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -1822,7 +1822,19 @@ export class StrandsAgent {
                 }
               }
             }
-            continue;
+
+            // Only the delta kinds handled above are consumed here. Anything
+            // else falls through to the RAW fallback: Bedrock citations reach
+            // the adapter as `citationsDelta` inside this event, so an
+            // unconditional continue is what kept them off the wire.
+            const handled: ReadonlyArray<string> = [
+              "textDelta",
+              "reasoningContentDelta",
+              "toolUseInputDelta",
+            ];
+            if (handled.includes((delta as { type: string }).type)) {
+              continue;
+            }
           }
 
           // Reasoning signature (verification token) — not exposed to UI.

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -1609,6 +1609,13 @@ export class StrandsAgent {
           // (type: 'modelStreamUpdateEvent', event: ModelStreamEvent) before
           // yielding them from `agent.stream()`. Unwrap once so the dispatch
           // below operates on the inner event shape.
+          // `contentBlockEvent` is the assembled form of deltas that have
+          // already streamed, so it must never reach the RAW fallback (see
+          // `isAssembledContentBlock`). The wrapper kind has to be captured
+          // BEFORE unwrapping, because unwrapping is exactly what erases it —
+          // the bare block's own `type` is `textBlock` / `reasoningBlock` /
+          // whatever the SDK adds next.
+          const isAssembledBlock = isAssembledContentBlock(next.value);
           const event = unwrapStrandsEvent(next.value);
           const kind = getEventKind(event);
 
@@ -2395,6 +2402,18 @@ export class StrandsAgent {
           // (LangGraph, watsonx, a2a) already does. The lifecycle brackets in
           // `RAW_SKIPPED_EVENT_KINDS` stay silent, as they do in Python.
           if (kind && RAW_SKIPPED_EVENT_KINDS.has(kind)) continue;
+          // An assembled content block duplicates content already on the wire,
+          // whatever kind of block it turned out to be. Keyed on the wrapper
+          // rather than on a list of block names so a block type added by a
+          // future SDK release is covered the day it ships.
+          if (isAssembledBlock) {
+            this._log.debug(
+              `${LOG_PREFIX} Skipping assembled content block for RAW ` +
+                `forwarding; its content already streamed ` +
+                `(threadId=${inputData.threadId}, block=${kind ?? "unknown"})`,
+            );
+            continue;
+          }
           const rawPayload = sanitizeRawEvent(event);
           if (rawPayload === undefined) {
             this._log.warn(
@@ -3226,6 +3245,32 @@ function getEventKind(event: unknown): string | undefined {
     return typeof t === "string" ? t : undefined;
   }
   return undefined;
+}
+
+/**
+ * True if `event` is a `ContentBlockEvent` — an assembled content block.
+ *
+ * `Agent.stream()` yields one of these for EVERY completed content block: any
+ * value from `model.streamAggregated` that is not a `ModelStreamEvent` gets
+ * wrapped as `new ContentBlockEvent({ contentBlock })`. A content block is by
+ * construction the assembled form of deltas the adapter has *already* streamed
+ * — `textBlock` is the finished text of a turn that went out chunk by chunk as
+ * `TEXT_MESSAGE_CONTENT`, `reasoningBlock` the finished reasoning that went out
+ * as `REASONING_MESSAGE_CONTENT`.
+ *
+ * The dispatch chain translates only `toolUseBlock`, so with a terminal RAW
+ * fallback in place every other block kind would fall through and re-deliver
+ * the whole assistant message a second time, immediately after it streamed.
+ * That is the same duplication the Python adapter's explicit
+ * `ModelMessageEvent` skip prevents.
+ *
+ * Tested against the real `ContentBlockEvent` / `TextBlock` / `ReasoningBlock`
+ * classes rather than object literals — see `raw-content-block.test.ts`.
+ *
+ * Must be evaluated before `unwrapStrandsEvent`, which discards the wrapper.
+ */
+function isAssembledContentBlock(event: unknown): boolean {
+  return getEventKind(event) === "contentBlockEvent";
 }
 
 /**


### PR DESCRIPTION
Fixes #2291
Fixes #2304

## #2291 — unmapped events were dropped silently

The main stream loop's `if/elif` chain had no terminal `else`, so any event the adapter does not translate vanished with no error and no log. Bedrock citation deltas are the reported case; provider extensions this adapter predates are the general one. These now forward as RAW events.

Forwarding cannot be verbatim. Strands' `ModelStreamEvent.prepare()` merges `invocation_state` into any event carrying a `delta`, injecting the live `Agent` object, an OTel span, a telemetry `Trace` and a `UUID`. Separately, `Agent.stream_async` ends every invocation with `AgentResultEvent`, whose `EventLoopMetrics.traces` Pydantic cannot serialize. Either one aborts the whole SSE stream: `endpoint.py` catches the encode failure, emits `RunErrorEvent(code="ENCODING_ERROR")` and breaks, so the client loses its `TEXT_MESSAGE_END`, final snapshots and `RUN_FINISHED`.

So the RAW branch:
- strips the `invocation_state` injection keys (`agent`, `event_loop_cycle_id`, `event_loop_cycle_trace`, `event_loop_cycle_span`, `event_loop_parent_span`, `event_loop_parent_cycle_id`, `request_state`);
- excludes the `result` and `stop` terminators, which are already represented by `RUN_FINISHED`;
- round-trips the remainder through strict JSON and drops with a warning on failure.

Sanitization is by key denylist, never by coercion. `default=str` would ship the repr of the live `Agent` — system prompt, message history, model config — to every connected client.

Strands' `ModelMessageEvent` (`{"message": {"role": "assistant", ...}}`) is also skipped explicitly: its text has already streamed as `TEXT_MESSAGE_CONTENT`, and letting it reach RAW re-sent the whole assistant message.

The TypeScript adapter gets the same fallback. Its skip list covers the lifecycle brackets plus four payload-carrying events already represented by mapped AG-UI events (`agentResultEvent`, `modelMessageEvent`, `toolResultEvent`, `messageAddedEvent`). `modelMetadataEvent` and `modelRedactionEvent` are deliberately forwarded — usage metrics and guardrail redaction notices have no mapped AG-UI equivalent, which is exactly what the fallback exists for. TS payloads are stripped of `agent` / `invocationState` / `requestState` and JSON round-tripped for the same reason as Python.

## #2304 — agent-as-tool sub-agents were opaque

A Strands generator tool wrapping another `Agent` re-yields the inner agent's whole `stream_async` output, which Strands wraps as `tool_stream_event`. Those never reached the parent loop's tool-call branches, so the sub-agent rendered as a black box. Its tool-call lifecycle is now forwarded, with inner call ids namespaced under the owning parent so an inner id that collides with a parent id cannot resolve the wrong tool card.

The close handler is scoped per parent. `inner_tool_calls_seen` is shared across every agent-as-tool call in a run, and Strands executes a parallel tool batch concurrently, so two sub-agents interleave their streams. Closing "the newest still-open inner call" without checking which parent the stop came from lets one sub-agent's `contentBlockStop` resolve a sibling's call, closing that card while its arguments are still streaming and leaving the real one spinning.

## Tests

Python fixtures drive a real `strands.Agent` (parent and inner) over a scripted model replaying Bedrock-shaped chunks, so assertions hold against Strands' own event loop rather than hand-built dicts. Every test asserts the full stream survives `ag_ui.encoder.EventEncoder` — the guard that catches the class of bug above, kept permanently. The parallel-batch regression pins one exact interleaving across two concurrent agent-as-tool calls so it cannot flake.

Suite results on strands-agents 1.51.0 / ag-ui-protocol 0.1.19:

- **Python: 202 passed, 6 skipped, 1 failed.** The failure is `test_template_agent_propagation.py::test_template_param_round_trips[interventions]`, which is pre-existing and unrelated — it fails identically on the base commit `27e5593a` and is SDK drift around the `interventions` parameter, not a regression here.
- **TypeScript: 249 passed across 41 files**; `tsc --noEmit` clean.

## Checklist

- [x] Regression test per finding, each confirmed failing before its fix
- [x] Python suite run and reported verbatim, including the one pre-existing failure
- [x] TypeScript suite passes
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean on changed files; no unrelated formatting churn
- [x] No changes to test infrastructure or test config
- [x] No public API changes; new events are additive
