### PR TITLE
fix(adk): escape state JSON pointer paths

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/event_translator.py
@@ -27,6 +27,7 @@ from google.adk.events import Event as ADKEvent
 
 from .config import PredictStateMapping, normalize_predict_state
 from .serialization import serialize_tool_args
+from .utils.converters import _escape_json_pointer_token
 
 import logging
 logger = logging.getLogger(__name__)
@@ -1293,7 +1294,7 @@ class EventTranslator:
         for key, value in state_delta.items():
             patches.append({
                 "op": "add",
-                "path": f"/{key}",
+                "path": f"/{_escape_json_pointer_token(key)}",
                 "value": value
             })
         

--- a/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/utils/converters.py
@@ -364,6 +364,16 @@ def convert_adk_event_to_ag_ui_message(event: ADKEvent) -> Optional[Message]:
     return None
 
 
+def _escape_json_pointer_token(value: str) -> str:
+    """Encode a single JSON Pointer token according to RFC 6901."""
+    return value.replace("~", "~0").replace("/", "~1")
+
+
+def _unescape_json_pointer_token(value: str) -> str:
+    """Decode a single JSON Pointer token according to RFC 6901."""
+    return value.replace("~1", "/").replace("~0", "~")
+
+
 def convert_state_to_json_patch(state_delta: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Convert a state delta to JSON Patch format (RFC 6902).
     
@@ -376,19 +386,20 @@ def convert_state_to_json_patch(state_delta: Dict[str, Any]) -> List[Dict[str, A
     patches = []
     
     for key, value in state_delta.items():
+        path = f"/{_escape_json_pointer_token(key)}"
+
         # Determine operation type
         if value is None:
             # Remove operation
             patches.append({
                 "op": "remove",
-                "path": f"/{key}"
+                "path": path
             })
         else:
-            # Add/replace operation
-            # We use "replace" as it works for both existing and new keys
+            # Add works for both new and existing object members.
             patches.append({
-                "op": "replace",
-                "path": f"/{key}",
+                "op": "add",
+                "path": path,
                 "value": value
             })
     
@@ -410,8 +421,9 @@ def convert_json_patch_to_state(patches: List[Dict[str, Any]]) -> Dict[str, Any]
         op = patch.get("op")
         path = patch.get("path", "")
         
-        # Extract key from path (remove leading slash)
-        key = path.lstrip("/")
+        # Remove exactly one leading slash, then decode the JSON Pointer token.
+        encoded_key = path.removeprefix("/")
+        key = _unescape_json_pointer_token(encoded_key)
         
         if op == "remove":
             state_delta[key] = None

--- a/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
+++ b/integrations/adk-middleware/python/tests/test_event_translator_comprehensive.py
@@ -954,13 +954,15 @@ class TestEventTranslatorComprehensive:
             "key-with-dashes": "value1",
             "key_with_underscores": "value2",
             "key.with.dots": "value3",
-            "key with spaces": "value4"
+            "key with spaces": "value4",
+            "user/name": "value5",
+            "config~version": "value6",
         }
 
         event = translator._create_state_delta_event(state_delta, "thread_1", "run_1")
 
         assert isinstance(event, StateDeltaEvent)
-        assert len(event.delta) == 4
+        assert len(event.delta) == 6
 
         # Check that all keys are properly escaped in paths
         patches = event.delta
@@ -969,6 +971,8 @@ class TestEventTranslatorComprehensive:
         assert "/key_with_underscores" in paths
         assert "/key.with.dots" in paths
         assert "/key with spaces" in paths
+        assert "/user~1name" in paths
+        assert "/config~0version" in paths
 
     @pytest.mark.asyncio
     async def test_force_close_streaming_message_with_open_stream(self, translator):

--- a/integrations/adk-middleware/python/tests/test_utils_converters.py
+++ b/integrations/adk-middleware/python/tests/test_utils_converters.py
@@ -945,15 +945,15 @@ class TestStateConversionFunctions:
 
         # Check each patch
         user_patch = next(p for p in patches if p["path"] == "/user_name")
-        assert user_patch["op"] == "replace"
+        assert user_patch["op"] == "add"
         assert user_patch["value"] == "John"
 
         status_patch = next(p for p in patches if p["path"] == "/status")
-        assert status_patch["op"] == "replace"
+        assert status_patch["op"] == "add"
         assert status_patch["value"] == "active"
 
         count_patch = next(p for p in patches if p["path"] == "/count")
-        assert count_patch["op"] == "replace"
+        assert count_patch["op"] == "add"
         assert count_patch["value"] == 42
 
     def test_convert_state_to_json_patch_with_none_values(self):
@@ -969,7 +969,7 @@ class TestStateConversionFunctions:
         assert len(patches) == 3
 
         keep_patch = next(p for p in patches if p["path"] == "/keep_this")
-        assert keep_patch["op"] == "replace"
+        assert keep_patch["op"] == "add"
         assert keep_patch["value"] == "value"
 
         remove_patch = next(p for p in patches if p["path"] == "/remove_this")
@@ -983,6 +983,20 @@ class TestStateConversionFunctions:
         """Test converting empty state delta."""
         patches = convert_state_to_json_patch({})
         assert patches == []
+
+    def test_convert_state_to_json_patch_escapes_json_pointer_tokens(self):
+        """Test escaping slashes and tildes in top-level state keys."""
+        patches = convert_state_to_json_patch({
+            "user/name": "Eslam",
+            "config~version": 2,
+            "obsolete/key": None,
+        })
+
+        assert patches == [
+            {"op": "add", "path": "/user~1name", "value": "Eslam"},
+            {"op": "add", "path": "/config~0version", "value": 2},
+            {"op": "remove", "path": "/obsolete~1key"},
+        ]
 
     def test_convert_json_patch_to_state_basic(self):
         """Test converting JSON patch operations to state delta."""
@@ -1032,6 +1046,26 @@ class TestStateConversionFunctions:
         state_delta = convert_json_patch_to_state([])
         assert state_delta == {}
 
+    def test_convert_json_patch_to_state_decodes_json_pointer_tokens(self):
+        """Test decoding escaped top-level state keys."""
+        patches = [
+            {"op": "add", "path": "/user~1name", "value": "Eslam"},
+            {"op": "replace", "path": "/config~0version", "value": 2},
+            {"op": "remove", "path": "/obsolete~1key"},
+        ]
+
+        assert convert_json_patch_to_state(patches) == {
+            "user/name": "Eslam",
+            "config~version": 2,
+            "obsolete/key": None,
+        }
+
+    def test_convert_json_patch_to_state_removes_one_leading_slash(self):
+        """Test that only the JSON Pointer root separator is removed."""
+        patches = [{"op": "add", "path": "//key", "value": "value"}]
+
+        assert convert_json_patch_to_state(patches) == {"/key": "value"}
+
     def test_convert_json_patch_to_state_malformed_patches(self):
         """Test converting malformed patches."""
         patches = [
@@ -1054,7 +1088,9 @@ class TestStateConversionFunctions:
             "name": "Test",
             "active": True,
             "count": 100,
-            "remove_me": None
+            "remove_me": None,
+            "user/name": "Eslam",
+            "config~version": 2,
         }
 
         patches = convert_state_to_json_patch(original_state)

--- a/integrations/adk-middleware/python/tests/test_utils_init.py
+++ b/integrations/adk-middleware/python/tests/test_utils_init.py
@@ -63,7 +63,7 @@ class TestUtilsInit:
         patches = convert_state_to_json_patch(state_delta)
 
         assert len(patches) == 1
-        assert patches[0]["op"] == "replace"
+        assert patches[0]["op"] == "add"
         assert patches[0]["path"] == "/test_key"
         assert patches[0]["value"] == "test_value"
 


### PR DESCRIPTION
## Summary

Fix ADK state delta JSON Patch generation for new keys and keys containing `/` or `~`.

- encode state keys as RFC 6901 JSON Pointer tokens in both the converter and `EventTranslator._create_state_delta_event`
- emit `add` for non-null values so patches work for both new and existing object members
- decode escaped tokens after removing exactly one leading `/`
- add regression coverage for escaped keys, round trips, and translated state deltas

Fixes #2242

## Testing

`uv run --locked pytest tests/test_utils_converters.py tests/test_event_translator_comprehensive.py -q`

Result: `130 passed`