### PR TITLE
fix(aws-strands): carry the client's tool failure onto the reconciled toolResult status

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -9,7 +9,7 @@ import inspect
 import json
 import logging
 import uuid
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Tuple
 
 from strands import Agent as StrandsAgentCore
 from strands.session import SessionManager
@@ -1015,7 +1015,16 @@ class StrandsAgent:
                     if isinstance(content, str)
                     else flatten_content_to_text(content)
                 )
-                frontend_results.append({"wire_id": wire_id, "text": text or ""})
+                frontend_results.append(
+                    {
+                        "wire_id": wire_id,
+                        "text": text or "",
+                        # Carry the client's failure signal alongside the text so
+                        # reconciliation can stamp the persisted toolResult status
+                        # too, not just its content.
+                        "is_error": bool(getattr(msg, "error", None)),
+                    }
+                )
 
             # Translate the client's wire tool_call_id back to the native
             # toolUseId Strands persisted (they differ for frontend tools — see
@@ -1026,7 +1035,7 @@ class StrandsAgent:
             # empty toolResult. When reconciling, void placeholders in the same
             # turn are still cleared (to "") so the literal "Forwarded to client"
             # is never fed to the model.
-            resolved_native_results: Dict[str, str] = {}
+            resolved_native_results: Dict[str, Tuple[str, bool]] = {}
             corrected_native_ids: set[str] = set()
             has_nonvoid_frontend_result = any(
                 (r["text"] or "").strip() for r in frontend_results
@@ -1112,7 +1121,7 @@ class StrandsAgent:
                 ]
                 resolved_non_void = {
                     native
-                    for native, text in resolved_native_results.items()
+                    for native, (text, _is_error) in resolved_native_results.items()
                     if (text or "").strip()
                 }
                 all_non_void_resolved = len(resolved_non_void) == len(non_void_results)

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1032,13 +1032,15 @@ class StrandsAgent:
             # when there is at least one NON-EMPTY frontend result: a void tool
             # returns nothing, and the synthetic "executed successfully with no
             # return value" continuation message conveys that better than an
-            # empty toolResult. When reconciling, void placeholders in the same
+            # empty toolResult. A failed void result is the exception: it must
+            # reconcile so its status replaces the proxy's hardcoded success.
+            # When reconciling, void placeholders in the same
             # turn are still cleared (to "") so the literal "Forwarded to client"
             # is never fed to the model.
             resolved_native_results: Dict[str, Tuple[str, bool]] = {}
             corrected_native_ids: set[str] = set()
             has_nonvoid_frontend_result = any(
-                (r["text"] or "").strip() for r in frontend_results
+                (r["text"] or "").strip() or r["is_error"] for r in frontend_results
             )
             if session_manager is not None and self.config.replay_history_into_strands:
                 resolved_native_results = resolve_native_ids(

--- a/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
@@ -11,7 +11,7 @@ persisted placeholder by native id and overwrite it with the real result.
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Tuple
 
 from .client_proxy_tool import PROXY_RESULT_PLACEHOLDER
 
@@ -24,7 +24,7 @@ AG_UI_WIRE_MAP_STATE_KEY = "__ag_ui_wire_to_native__"
 def resolve_native_ids(
     wire_to_native: Mapping[str, str],
     frontend_results: Iterable[Mapping[str, Any]],
-) -> dict[str, str]:
+) -> dict[str, Tuple[str, bool]]:
     """Map client frontend results to Strands-native ``toolUseId``s.
 
     Frontend tools are emitted under a fresh wire ``tool_call_id`` that differs
@@ -37,23 +37,29 @@ def resolve_native_ids(
 
     Args:
         wire_to_native: Map of wire ``tool_call_id`` -> native ``toolUseId``.
-        frontend_results: Items with ``wire_id`` and ``text``.
+        frontend_results: Items with ``wire_id``, ``text`` and ``is_error``.
 
     Returns:
-        Map of native ``toolUseId`` -> real result text (unresolvable dropped).
+        Map of native ``toolUseId`` -> ``(real result text, is_error)``
+        (unresolvable dropped). The flag travels with the text so the
+        reconciled ``toolResult`` can carry the client's failure signal, not
+        just its output.
     """
-    resolved: dict[str, str] = {}
+    resolved: dict[str, Tuple[str, bool]] = {}
     for result in frontend_results:
         native = wire_to_native.get(result.get("wire_id"))
         if native is not None:
-            resolved[native] = result.get("text", "")
+            resolved[native] = (
+                result.get("text", ""),
+                bool(result.get("is_error")),
+            )
     return resolved
 
 
 def reconcile_frontend_tool_results(
     session_manager: Any,
     agent: Any,
-    pending_results: Mapping[str, str],
+    pending_results: Mapping[str, Tuple[str, bool]],
 ) -> set[str]:
     """Overwrite persisted placeholder ``toolResult`` blocks with real results.
 
@@ -64,7 +70,8 @@ def reconcile_frontend_tool_results(
         session_manager: A Strands ``RepositorySessionManager`` (exposes
             ``session_id`` and ``session_repository``).
         agent: The Strands agent (exposes ``agent_id``).
-        pending_results: Map of native ``toolUseId`` -> real result text.
+        pending_results: Map of native ``toolUseId`` -> ``(real result text,
+            is_error)``.
 
     Returns:
         The set of ``toolUseId``s whose placeholder was corrected (in the store
@@ -119,8 +126,15 @@ def has_placeholder_results(messages: Iterable[Any], only_ids: Any = None) -> bo
     return False
 
 
-def _correct_message(message: Any, pending_results: Mapping[str, str]) -> set[str]:
+def _correct_message(
+    message: Any, pending_results: Mapping[str, Tuple[str, bool]]
+) -> set[str]:
     """Rewrite matching placeholder ``toolResult`` blocks in *message* in place.
+
+    Both the text and the status are rewritten: the placeholder was written by
+    the proxy tool with a hardcoded ``"success"`` (see ``client_proxy_tool``),
+    so leaving the status alone would assert a failed frontend tool to the
+    model as a success.
 
     Returns the set of ``toolUseId``s whose block was corrected.
     """
@@ -135,7 +149,9 @@ def _correct_message(message: Any, pending_results: Mapping[str, str]) -> set[st
             continue
         tool_use_id = tool_result.get("toolUseId")
         if tool_use_id in pending_results and _is_placeholder(tool_result.get("content")):
-            tool_result["content"] = [{"text": pending_results[tool_use_id]}]
+            text, is_error = pending_results[tool_use_id]
+            tool_result["content"] = [{"text": text}]
+            tool_result["status"] = "error" if is_error else "success"
             changed.add(tool_use_id)
     return changed
 

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -628,8 +628,13 @@ class TestSessionFrontendToolReconciliation:
             {"text": '{"approved": false}'}
         ]
 
+    @pytest.mark.parametrize(
+        "content", ["tool failed: invalid id", ""], ids=["with-text", "empty"]
+    )
     @pytest.mark.asyncio
-    async def test_client_reported_failure_lands_as_an_error_status(self, tmp_path):
+    async def test_client_reported_failure_lands_as_an_error_status(
+        self, tmp_path, content
+    ):
         # The placeholder was written by the proxy tool with a hardcoded
         # "success" status. Reconciliation must overwrite the status as well as
         # the text, or the model is told a failed frontend tool succeeded.
@@ -641,7 +646,7 @@ class TestSessionFrontendToolReconciliation:
             "default",
             messages=[
                 _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", "tool failed: invalid id", error="invalid id"),
+                _payload_tool("wire-1", content, error="invalid id"),
             ],
             tools=[_frontend_tool("approve")],
             wire_map={"wire-1": "native-1"},
@@ -649,7 +654,7 @@ class TestSessionFrontendToolReconciliation:
         )
         assert instance.stream_prompts == [None]
         block = _result_content(sm, "default", 1)[0]["toolResult"]
-        assert block["content"] == [{"text": "tool failed: invalid id"}]
+        assert block["content"] == [{"text": content}]
         assert block["status"] == "error"
 
     @pytest.mark.asyncio

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -475,8 +475,14 @@ def _payload_assistant(wire_id, name, args="{}"):
     )
 
 
-def _payload_tool(wire_id, content):
-    return ToolMessage(id="t-" + wire_id, role="tool", content=content, tool_call_id=wire_id)
+def _payload_tool(wire_id, content, error=None):
+    return ToolMessage(
+        id="t-" + wire_id,
+        role="tool",
+        content=content,
+        tool_call_id=wire_id,
+        error=error,
+    )
 
 
 def _result_content(sm, agent_id, index):
@@ -621,6 +627,48 @@ class TestSessionFrontendToolReconciliation:
         assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
             {"text": '{"approved": false}'}
         ]
+
+    @pytest.mark.asyncio
+    async def test_client_reported_failure_lands_as_an_error_status(self, tmp_path):
+        # The placeholder was written by the proxy tool with a hardcoded
+        # "success" status. Reconciliation must overwrite the status as well as
+        # the text, or the model is told a failed frontend tool succeeded.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-errstatus", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_tool("wire-1", "tool failed: invalid id", error="invalid id"),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
+        )
+        assert instance.stream_prompts == [None]
+        block = _result_content(sm, "default", 1)[0]["toolResult"]
+        assert block["content"] == [{"text": "tool failed: invalid id"}]
+        assert block["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_successful_result_keeps_a_success_status(self, tmp_path):
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-okstatus", storage_dir=str(tmp_path))
+        await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_tool("wire-1", '{"approved": true}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
+        )
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["status"] == "success"
 
     @pytest.mark.asyncio
     async def test_no_wire_map_degrades_to_legacy(self, tmp_path):

--- a/integrations/aws-strands/python/tests/test_session_reconcile.py
+++ b/integrations/aws-strands/python/tests/test_session_reconcile.py
@@ -70,7 +70,7 @@ def test_reconcile_overwrites_persisted_placeholder_in_store(tmp_path):
 
     agent = SimpleNamespace(agent_id=agent_id, messages=[])
     corrected = reconcile_frontend_tool_results(
-        sm, agent, {"tu-1": '{"approved": false}'}
+        sm, agent, {"tu-1": ('{"approved": false}', False)}
     )
 
     assert corrected == {"tu-1"}
@@ -93,7 +93,9 @@ def test_reconcile_returns_set_of_corrected_tool_use_ids(tmp_path):
         messages=[{"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]}],
     )
 
-    corrected = reconcile_frontend_tool_results(sm, agent, {"tu-1": "R", "tu-absent": "X"})
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": ("R", False), "tu-absent": ("X", False)}
+    )
 
     assert corrected == {"tu-1"}
 
@@ -118,7 +120,7 @@ def test_reconcile_corrects_in_memory_agent_messages(tmp_path):
         ],
     )
 
-    reconcile_frontend_tool_results(sm, agent, {"tu-1": '{"approved": true}'})
+    reconcile_frontend_tool_results(sm, agent, {"tu-1": ('{"approved": true}', False)})
 
     in_memory = agent.messages[1]["content"][0]["toolResult"]
     assert in_memory["content"] == [{"text": '{"approved": true}'}]
@@ -154,7 +156,7 @@ def test_reconcile_handles_parallel_tool_calls_in_one_message(tmp_path):
 
     agent = SimpleNamespace(agent_id=agent_id, messages=[])
     corrected = reconcile_frontend_tool_results(
-        sm, agent, {"tu-1": "R1", "tu-2": "R2"}
+        sm, agent, {"tu-1": ("R1", False), "tu-2": ("R2", False)}
     )
 
     assert corrected == {"tu-1", "tu-2"}
@@ -171,11 +173,11 @@ def test_resolve_maps_wire_id_to_native_id():
     resolved = resolve_native_ids(
         wire_to_native={"wire-1": "native-1", "wire-2": "native-2"},
         frontend_results=[
-            {"wire_id": "wire-1", "text": "R1"},
-            {"wire_id": "wire-2", "text": "R2"},
+            {"wire_id": "wire-1", "text": "R1", "is_error": False},
+            {"wire_id": "wire-2", "text": "R2", "is_error": True},
         ],
     )
-    assert resolved == {"native-1": "R1", "native-2": "R2"}
+    assert resolved == {"native-1": ("R1", False), "native-2": ("R2", True)}
 
 
 def test_resolve_skips_results_absent_from_map():
@@ -184,11 +186,11 @@ def test_resolve_skips_results_absent_from_map():
     resolved = resolve_native_ids(
         wire_to_native={"wire-1": "native-1"},
         frontend_results=[
-            {"wire_id": "wire-1", "text": "R1"},
-            {"wire_id": "wire-unknown", "text": "R2"},
+            {"wire_id": "wire-1", "text": "R1", "is_error": False},
+            {"wire_id": "wire-unknown", "text": "R2", "is_error": False},
         ],
     )
-    assert resolved == {"native-1": "R1"}
+    assert resolved == {"native-1": ("R1", False)}
 
 
 def test_has_placeholder_results_detects_remaining_stub():
@@ -222,10 +224,131 @@ def test_reconcile_leaves_non_placeholder_results_untouched(tmp_path):
     )
 
     agent = SimpleNamespace(agent_id=agent_id, messages=[])
-    corrected = reconcile_frontend_tool_results(sm, agent, {"tu-1": "SHOULD NOT APPLY"})
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": ("SHOULD NOT APPLY", False)}
+    )
 
     assert corrected == set()
     block = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
         "content"
     ][0]["toolResult"]
     assert block["content"] == [{"text": "already the real result"}]
+
+
+def test_reconcile_stamps_error_status_on_the_persisted_result(tmp_path):
+    # The proxy wrote the placeholder with a hardcoded "success" status. A
+    # client-reported failure has to overwrite that too, or the model reads the
+    # real error text under a success flag.
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": ("boom: invalid id", True)}
+    )
+
+    assert corrected == {"tu-1"}
+    block = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
+        "content"
+    ][0]["toolResult"]
+    assert block["content"] == [{"text": "boom: invalid id"}]
+    assert block["status"] == "error"
+
+
+def test_reconcile_keeps_success_status_when_the_tool_did_not_fail(tmp_path):
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    reconcile_frontend_tool_results(sm, agent, {"tu-1": ("all good", False)})
+
+    block = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
+        "content"
+    ][0]["toolResult"]
+    assert block["status"] == "success"
+
+
+def test_reconcile_stamps_error_status_on_the_in_memory_history(tmp_path):
+    # A same-process continuation reads agent.messages, not the store.
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]},
+    )
+    agent = SimpleNamespace(
+        agent_id=agent_id,
+        messages=[{"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]}],
+    )
+
+    reconcile_frontend_tool_results(sm, agent, {"tu-1": ("boom", True)})
+
+    in_memory = agent.messages[0]["content"][0]["toolResult"]
+    assert in_memory["content"] == [{"text": "boom"}]
+    assert in_memory["status"] == "error"
+
+
+def test_reconcile_stamps_each_parallel_result_independently(tmp_path):
+    # One failed and one successful frontend tool in the same turn must not
+    # share a status.
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {
+            "role": "user",
+            "content": [
+                _tool_result_block("tu-1", PLACEHOLDER),
+                _tool_result_block("tu-2", PLACEHOLDER),
+            ],
+        },
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    reconcile_frontend_tool_results(
+        sm, agent, {"tu-1": ("ok", False), "tu-2": ("failed", True)}
+    )
+
+    blocks = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
+        "content"
+    ]
+    assert blocks[0]["toolResult"]["status"] == "success"
+    assert blocks[1]["toolResult"]["status"] == "error"
+
+
+def test_reconcile_leaves_status_alone_when_the_block_is_not_a_placeholder(tmp_path):
+    # Already-real results are never rewritten, so an unrelated error flag in
+    # pending_results must not leak onto them.
+    sm = _make_session(tmp_path)
+    agent_id = "default"
+    _seed(
+        sm,
+        agent_id,
+        0,
+        {"role": "user", "content": [_tool_result_block("tu-1", "already real")]},
+    )
+
+    agent = SimpleNamespace(agent_id=agent_id, messages=[])
+    corrected = reconcile_frontend_tool_results(sm, agent, {"tu-1": ("boom", True)})
+
+    assert corrected == set()
+    block = sm.session_repository.list_messages(sm.session_id, agent_id)[0].message[
+        "content"
+    ][0]["toolResult"]
+    assert block["status"] == "success"


### PR DESCRIPTION
Fixes #2361. Follow-up to #2317, on the branch that fix does not reach.

## The gap

`_build_strands_history` stamps `toolResult.status` from `ToolMessage.error` after #2317, but it has one production caller, inside the `replay_history` branch. When a `session_manager_provider` is configured, the run takes `reconcile_session_results` instead and the model reads the persisted history. Those `toolResult` blocks were written by `_proxy_func` with `"status": "success"` hardcoded (`client_proxy_tool.py:58`), and `_correct_message` rewrote only `content` — so on that path a failed frontend tool was still asserted to the model as a success.

There was no channel for the flag either: `pending_results` was `Mapping[str, str]`, native `toolUseId` -> text.

## The change

Widen the reconcile channel to carry the flag next to the text, as sketched on the issue:

- `agent.py:1015` — each `frontend_results` entry also carries `is_error`, read from `msg.error`.
- `session_reconcile.py` — `resolve_native_ids` returns native `toolUseId` -> `(text, is_error)`.
- `session_reconcile.py` — `_correct_message` writes `tool_result["status"]` in the same place where it rewrites `tool_result["content"]`. The status is always written, not only on failure, since the value it replaces is the proxy's placeholder rather than a real result.
- `agent.py:1119` — the `resolved_non_void` comprehension unpacks the new value shape.

`session_reconcile` is not exported from `__init__.py`, so the signature change stays inside the package. No public API moves.

## Tests

`pytest` on `integrations/aws-strands/python`: **206 passed, 2 skipped** — 199 before this branch, plus 7 new.

New cases, in `test_session_reconcile.py`:

- error flag lands as `status: "error"` on the persisted block
- no error keeps `status: "success"`
- the in-memory `agent.messages` copy is stamped too, not just the store
- two parallel results in one message get independent statuses
- a block that is not a placeholder is left alone, so an unrelated error flag cannot leak onto it

And in `test_session_manager.py`, end to end through `run()`: a client `ToolMessage` with `error` set reaches the store as `status: "error"` with the real text, and a successful one stays `"success"`.

Checked that the tests fail for the right reason: with the `tool_result["status"]` line removed, 4 of them fail and the rest of the suite stays green.

## Scope

Two things left out on purpose, both noted on the issue before I started:

1. The legacy branch (`agent.py:1138`). It has the same shape, but there the real result reaches the model as a synthetic user message, so there is no `toolResult` block to stamp. That is a different change.

2. Void results. `reconcile_session_results` is gated on `has_nonvoid_frontend_result` (`agent.py:1037`) and `ToolMessage.content` is a required `str`, so a failed tool returning `content=""` with `error` set never reaches reconciliation — it falls to the legacy path and the placeholder keeps `"success"`. Widening that gate changes when reconciliation runs at all, which is more than this issue asks for. I can fold it in here instead if you prefer one pass.
