### PR TITLE
add rust to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,9 @@ docs/sdk/go @mattsp1290
 sdks/community/dart @mattsp1290
 docs/sdk/dart @mattsp1290
 
+sdks/community/rust @MikeSchirtzinger @wdoppenberg
+docs/sdk/rust @MikeSchirtzinger @wdoppenberg
+
 integrations/agent-spec @sonleoracle
 
 .github/config-allowlist.txt @AlemTuzlak @atai


### PR DESCRIPTION
`sdks/community/rust` has had no code owner since the SDK landed in #243. CONTRIBUTING.md says the team adds community SDK contributors as code owners "so you can push changes without needing core team sign-off". For Rust that step got lost after the initial merge (confirmed on #2256), and I've asked there and on Discord without a response. The visible cost: #972, #2196, and #2208 all sit at zero reviews, and the only commit to the tree since the SDK landed is CI maintenance.

This adds the same two lines go and dart have (#590):

- @wdoppenberg wrote the SDK (#243), holds the ag-ui-core and ag-ui-client names on crates.io, and has offered to share or transfer them (#972).
- Me: the split plan of record for the remaining server, middleware, and verifier work is on #972, the event-parity gap analysis is on #2208 and #2257.

If the team had different names in mind, happy to switch or add any active contributors. I just want to help get the ball rolling.

@maxkorp (merged #243 and added the dart owner in #590), @jpr5 (the July Rust CI maintenance), @mme: tagging you three as the people closest to this file and this tree.
