### PR TITLE
fix(release): stage the re-locked uv.lock in the release commit

### DIFF
--- a/scripts/release/prepare-release.test.ts
+++ b/scripts/release/prepare-release.test.ts
@@ -397,3 +397,51 @@ test(
     rmSync(root, { recursive: true, force: true });
   },
 );
+
+// Re-locking the file on disk is only half the job. The release workflow stages
+// exactly the paths named in `files` (`for f in $FILES; do git add "$f"; done`),
+// so a lock that is rewritten but not reported never reaches the release commit
+// and the `uv lock --check` gate rejects the PR. crew-ai 0.3.0 (#2366) and
+// aws-strands 0.2.5 (#2374) both had to be unblocked by hand for this reason.
+test(
+  "a Python version bump reports uv.lock among the modified files",
+  { timeout: 120_000, skip: haveUv() ? false : "uv not on PATH" },
+  async () => {
+    const root = await buildFixture();
+
+    const result = await runPrepareRelease(["--scope", "fixture-py", "--bump", "minor"], {
+      PREPARE_RELEASE_ROOT: root,
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+
+    const output = JSON.parse(result.stdout);
+    assert.deepEqual(
+      output.files,
+      ["fixture-pkg/pyproject.toml", "fixture-pkg/uv.lock"],
+      "uv.lock missing from `files` — the release workflow would not stage it",
+    );
+
+    rmSync(root, { recursive: true, force: true });
+  },
+);
+
+// A package with no uv.lock must not gain a phantom entry in `files`: the
+// workflow would `git add` a path that does not exist and abort the release.
+// (buildFixture seeds a real lock with `uv lock`, hence the same uv guard.)
+test("a Python bump with no uv.lock reports only the manifest", {
+  timeout: 120_000,
+  skip: haveUv() ? false : "uv not on PATH",
+}, async () => {
+  const root = await buildFixture();
+  rmSync(join(root, "fixture-pkg/uv.lock"), { force: true });
+
+  const result = await runPrepareRelease(["--scope", "fixture-py", "--bump", "minor"], {
+    PREPARE_RELEASE_ROOT: root,
+  });
+  assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.files, ["fixture-pkg/pyproject.toml"]);
+
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/release/prepare-release.ts
+++ b/scripts/release/prepare-release.ts
@@ -368,10 +368,25 @@ function writePyVersion(pyprojectPath: string, newVersion: string): void {
  * Packages with no uv.lock (poetry-managed, or unlocked) are skipped. A missing
  * ``uv`` is fatal rather than skipped -- silently shipping a stale lock is the
  * exact failure this exists to prevent.
+ *
+ * Returns the absolute path of the lock it rewrote, or ``null`` when there was
+ * nothing to re-lock. **The caller must report that path**: rewriting the file
+ * on disk is only half the job, because the release workflow stages exactly the
+ * paths this script names in its ``files`` output --
+ *
+ *     for f in $FILES; do git add "$f"; done
+ *
+ * -- and nothing else. A lock that is regenerated but not reported is left
+ * unstaged in the runner's working tree and discarded when the job ends, so the
+ * release PR carries the pyproject bump alone and the ``uv lock --check`` gate
+ * added alongside this function rejects it. That is not hypothetical: it is why
+ * crew-ai 0.3.0 (#2366) and aws-strands 0.2.5 (#2374) both needed a hand-pushed
+ * "sync uv.lock" commit before their release PRs could go green.
  */
-function relockPythonPackage(pyprojectPath: string): void {
+function relockPythonPackage(pyprojectPath: string): string | null {
   const pkgDir = path.dirname(pyprojectPath);
-  if (!fs.existsSync(path.join(pkgDir, "uv.lock"))) return;
+  const lockPath = path.join(pkgDir, "uv.lock");
+  if (!fs.existsSync(lockPath)) return null;
 
   try {
     // stdout belongs to this script's JSON summary -- discard uv's so the
@@ -390,6 +405,8 @@ function relockPythonPackage(pyprojectPath: string): void {
     }
     throw error;
   }
+
+  return lockPath;
 }
 
 function readDotnetVersion(propsPath: string): string {
@@ -612,7 +629,10 @@ function writeVersionFile(
     return writeMavenVersion(filePath, newVersion);
   } else {
     writePyVersion(filePath, newVersion);
-    relockPythonPackage(filePath);
+    // The re-locked uv.lock is a second modified file and must be reported, or
+    // the release workflow never stages it -- see relockPythonPackage.
+    const lockPath = relockPythonPackage(filePath);
+    if (lockPath) return [filePath, lockPath];
   }
   return [filePath];
 }


### PR DESCRIPTION
## What's broken

Every release of a uv-managed Python package needs a hand-pushed follow-up commit before its release PR can go green. Two in the last two days:

| Release | Bot commit | Manual rescue |
|---|---|---|
| crew-ai 0.3.0 (#2366) | `chore(release): bump integration-crewai-py` | `chore(release): sync crewai uv.lock to 0.3.0` — 19 min later |
| aws-strands 0.2.5 (#2374) | `chore(release): bump integration-aws-strands-py` | `chore(release): sync aws-strands uv.lock to 0.2.5` |

Both failed identically on `unit / aws-strands-python`:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
hint: To update the lockfile, run `uv lock`.
```

## Why

A uv.lock carries an entry for the package it locks — the one whose `source` is `{ editable = "." }` — so bumping `pyproject.toml` alone leaves that entry a version stale. #2314 added `relockPythonPackage()` to fix exactly this, and it works: it runs `uv lock` and the file on disk is correct.

The problem is that it stops there. `writeVersionFile` called it purely for the side effect and returned only the manifest path:

```ts
} else {
  writePyVersion(filePath, newVersion);
  relockPythonPackage(filePath);   // rewrites uv.lock on disk...
}
return [filePath];                 // ...but only reports the pyproject
```

That return value is the whole chain. It feeds `modifiedFiles` (`prepare-release.ts:683-687`), which becomes the `files` output (`:805`), which the workflow consumes verbatim:

```yaml
FILES: ${{ steps.bump.outputs.files }}
run: |
  for f in $FILES; do
    git add "$f"
  done
  git commit -m "chore(release): bump ${SCOPE} (${SUMMARY})"
```

`git add` is given exactly those paths and nothing else. The regenerated lock sits unstaged in the runner's working tree and is discarded when the job ends.

## Why it looked like a sudden regression

It isn't one — the behaviour never worked. What changed is that it became *visible*.

Before #2315, nothing verified lockfiles, so a release bumped the manifest, left the lock pinning the previous version, and published it. That silent drift is precisely what #2313 had to repair across three packages (ag_ui_adk was five releases deep). #2315 added `uv sync --locked` and `uv lock --check`, which now refuse to let a stale lock through.

So the sequence is:

1. **before 08-05** — fails silently, ships a stale lock
2. **08-05** — #2314 regenerates the lock; #2315 starts enforcing
3. **08-11** — crew-ai is the first uv-managed release to hit the gate; fixed by hand
4. **08-12** — aws-strands hits it again

The gate is working. #2314 was half a fix: it produces the right file and then drops it.

## The change

`relockPythonPackage` returns the path it rewrote (`null` when the package has no lock — poetry-managed or unlocked), and `writeVersionFile` includes it:

```ts
} else {
  writePyVersion(filePath, newVersion);
  const lockPath = relockPythonPackage(filePath);
  if (lockPath) return [filePath, lockPath];
}
return [filePath];
```

No workflow change is needed — `for f in $FILES` picks the lock up as soon as it is named.

## Tests

Two added to `prepare-release.test.ts`, both against the real `uv` on a throwaway fixture tree (via `PREPARE_RELEASE_ROOT`), no mocking:

- **reports uv.lock among the modified files** — asserts `files` is exactly `["fixture-pkg/pyproject.toml", "fixture-pkg/uv.lock"]`. Verified it fails on `main` and passes here.
- **no uv.lock reports only the manifest** — a package without a lock must not gain a phantom entry, or the workflow would `git add` a nonexistent path and abort the release.

The pre-existing test (`re-locks uv.lock's self-entry`) passes both with and without this fix — it only ever checked the file on disk, which is why the gap survived. Full suite: 8/8.

Both skip themselves when `uv` is absent; `test-release-scripts.yml` installs uv so they do not pass vacuously in CI.

## Notes for the reviewer

- **#2374 is already unblocked by hand**, so this is not required to ship 0.2.5. It stops the next release needing the same rescue.
- The lock pushed to #2374 was generated with the CI-pinned toolchain (uv 0.12.1, CPython 3.12) and its diff is the single version line. Worth knowing: an older uv (0.9.24) additionally rewrote a `typing-extensions` marker — the kind of latent flush the `relockPythonPackage` doc comment describes. Anyone regenerating a lock by hand should use the pinned version, or the diff picks up unrelated churn.
