### PR TITLE
fix(aws-strands): resolve frontend tool name via wire->native map on continuation

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1581,6 +1581,45 @@ class StrandsAgent:
                         if tu_id and tu_name and tu_id not in _tool_call_id_to_name:
                             _tool_call_id_to_name[tu_id] = tu_name
 
+            # The durable wire->native map recorded at emission, read back from session
+            # state. Read here because the continuation derivation below needs it. Guarded:
+            # a store failure becomes ``reconciliation_setup_error``, handled below.
+            wire_to_native: Dict[str, str] = {}
+            reconciliation_setup_error: Exception | None = None
+            if session_manager is not None:
+                try:
+                    wire_to_native = (
+                        strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+                    )
+                except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
+                    reconciliation_setup_error = e
+
+            # The durable per-``toolUseId`` call metadata map recorded at
+            # emission (see the ``current_tool_use`` handler). On a RESUME
+            # run this is the ONLY source of ``{name, args, input,
+            # strands_tool_id}`` for the interrupted tool, since Strands does
+            # not re-emit ``current_tool_use`` events for it. Guarded because
+            # test doubles / stub agents may lack ``state`` entirely; a
+            # missing store just means "no persisted meta yet".
+            persisted_tool_call_meta: Dict[str, Dict[str, Any]] = {}
+            _agent_state = getattr(strands_agent, "state", None)
+            if _agent_state is not None:
+                try:
+                    persisted_tool_call_meta = (
+                        _agent_state.get(AG_UI_TOOL_CALL_MAP_STATE_KEY) or {}
+                    )
+                except Exception as e:  # noqa: BLE001 - handled by checkpoint state
+                    if has_active_interrupt:
+                        if reconciliation_setup_error is None:
+                            reconciliation_setup_error = e
+                    else:
+                        logger.warning(
+                            "Persisted tool-call metadata is unavailable; "
+                            "continuing without historical callback metadata: %s",
+                            e,
+                            exc_info=True,
+                        )
+
             # Get the latest user message for state context builder.
             # For continuation runs (has_pending_tool_result), derive a meaningful
             # message from the frontend tool that was just executed so the agent
@@ -1597,7 +1636,21 @@ class StrandsAgent:
                 _result_parts: list[str] = []
                 for msg in reversed(input_data.messages):
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
-                        tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
+                        # ``_tool_call_id_to_name`` is keyed by the NATIVE ``tooluse_...`` id
+                        # (from assistant ``toolUse`` blocks in the input / restored history),
+                        # but a frontend tool's result arrives keyed by the fresh wire uuid
+                        # handed to the client. A wire-id lookup therefore misses on a
+                        # delta-only continuation (which omits the naming assistant message),
+                        # leaving user_message empty -> stream_async("") -> the model gets no
+                        # input and re-asks the same question. Translate through the
+                        # wire->native map first (a backend tool's ids are equal, so it is
+                        # unaffected).
+                        native_tool_call_id = wire_to_native.get(
+                            msg.tool_call_id, msg.tool_call_id
+                        )
+                        tool_name = _tool_call_id_to_name.get(
+                            msg.tool_call_id
+                        ) or _tool_call_id_to_name.get(native_tool_call_id)
                         if tool_name and tool_name in frontend_tool_names:
                             # Forward the ACTUAL result so the model can act on the
                             # human's decision (e.g. an approval resolving to
@@ -1715,44 +1768,8 @@ class StrandsAgent:
             # result when its tool name is client-declared, or (for delta-only
             # payloads that omit the assistant message) when its wire id was
             # recorded in the wire->native map when the call was emitted.
-            # The durable wire->native map recorded at emission, read back from
-            # session state (restored from the store on a fresh process).
-            wire_to_native: Dict[str, str] = {}
-            reconciliation_setup_error: Exception | None = None
-            if session_manager is not None:
-                try:
-                    wire_to_native = (
-                        strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-                    )
-                except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
-                    reconciliation_setup_error = e
-
-            # The durable per-``toolUseId`` call metadata map recorded at
-            # emission (see the ``current_tool_use`` handler). On a RESUME
-            # run this is the ONLY source of ``{name, args, input,
-            # strands_tool_id}`` for the interrupted tool, since Strands does
-            # not re-emit ``current_tool_use`` events for it. Guarded because
-            # test doubles / stub agents may lack ``state`` entirely; a
-            # missing store just means "no persisted meta yet".
-            persisted_tool_call_meta: Dict[str, Dict[str, Any]] = {}
-            _agent_state = getattr(strands_agent, "state", None)
-            if _agent_state is not None:
-                try:
-                    persisted_tool_call_meta = (
-                        _agent_state.get(AG_UI_TOOL_CALL_MAP_STATE_KEY) or {}
-                    )
-                except Exception as e:  # noqa: BLE001 - handled by checkpoint state
-                    if has_active_interrupt:
-                        if reconciliation_setup_error is None:
-                            reconciliation_setup_error = e
-                    else:
-                        logger.warning(
-                            "Persisted tool-call metadata is unavailable; "
-                            "continuing without historical callback metadata: %s",
-                            e,
-                            exc_info=True,
-                        )
-
+            # wire_to_native, persisted_tool_call_meta and reconciliation_setup_error are
+            # read above; reused here.
             # Scope to the TRAILING tool results (this continuation's just-
             # returned results). ``pending_tool_result_ids`` holds those ids;
             # without this, a multi-turn continuation re-sends already-reconciled

--- a/integrations/aws-strands/python/tests/test_frontend_tool_continuation_message.py
+++ b/integrations/aws-strands/python/tests/test_frontend_tool_continuation_message.py
@@ -1,0 +1,110 @@
+"""Regression: a frontend-tool continuation must not feed the model an empty prompt.
+
+When ``replay_history_into_strands`` is False the reconcile path is disabled, so the
+continuation runs solely off ``stream_async(user_message)``. ``user_message`` is derived by
+looking the trailing tool result's ``tool_call_id`` up in ``_tool_call_id_to_name`` — which is
+keyed by the NATIVE ``tooluse_...`` id. A frontend tool's result arrives keyed by the fresh wire
+uuid handed to the client, and on a delta-only continuation payload (no naming assistant message)
+that wire id is only resolvable through the wire->native map. Without translating the wire id
+first, the lookup misses, ``user_message`` stays "" -> ``stream_async("")`` -> the model gets no
+input and re-asks the same question.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import RunAgentInput, Tool, ToolMessage
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.config import StrandsAgentConfig
+from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+
+WIRE_ID = "wire-1"
+NATIVE_ID = "native-1"
+
+
+class _FakeState:
+    """Dict-backed stand-in for the Strands agent state (get/set)."""
+
+    def __init__(self, initial: dict):
+        self._d = dict(initial)
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def set(self, key, value):
+        self._d[key] = value
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    # No template-level session manager (avoids the spurious "will be ignored" __init__ warning).
+    mock.session_manager = None
+    mock._session_manager = None
+    return mock
+
+
+def _native_history() -> list:
+    """Restored session history: the assistant toolUse (native id + name) is here, NOT in the
+    delta-only continuation payload — so the tool name is only resolvable via wire->native."""
+    return [
+        {"role": "user", "content": [{"text": "should I proceed?"}]},
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": NATIVE_ID, "name": "ask_user", "input": {}}}],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"toolResult": {"toolUseId": NATIVE_ID, "content": [{"text": "Forwarded to client"}]}}
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_continuation_message_resolves_frontend_tool_via_wire_map():
+    thread_id = "t-continuation"
+    captured: dict = {}
+
+    async def _stream(msg=None):
+        captured["msg"] = msg
+        for _event in []:  # empty stream; we only assert on the derived prompt
+            yield _event
+
+    mock_inner = MagicMock()
+    mock_inner.tool_registry = ToolRegistry()
+    mock_inner.messages = _native_history()
+    mock_inner.state = _FakeState({AG_UI_WIRE_MAP_STATE_KEY: {WIRE_ID: NATIVE_ID}})
+    mock_inner.stream_async = _stream
+
+    agent = StrandsAgent(
+        _template_agent(),
+        name="test-agent",
+        config=StrandsAgentConfig(replay_history_into_strands=False),
+    )
+    agent._agents_by_thread[thread_id] = mock_inner
+
+    # Delta-only continuation: ONLY the frontend tool result, keyed by the wire id.
+    inp = RunAgentInput(
+        thread_id=thread_id,
+        run_id="r1",
+        state={},
+        messages=[ToolMessage(id="t1", role="tool", tool_call_id=WIRE_ID, content='{"answered": true}')],
+        tools=[Tool(name="ask_user", description="ask the human", parameters={})],
+        context=[],
+        forwarded_props={},
+    )
+
+    async for _ in agent.run(inp):
+        pass
+
+    # Without the wire->native fallback this is "" (the wire id misses in the native-keyed map).
+    assert captured.get("msg") == 'ask_user returned: {"answered": true}'


### PR DESCRIPTION
## Summary

A frontend-tool continuation run passes the model an **empty prompt** when `replay_history_into_strands=False`. The model gets no input, sees a history ending in an already-answered `toolResult`, and re-fires the same tool call every run — an infinite loop.

## The bug

The continuation-message derivation resolves the tool name from the trailing tool result's `tool_call_id`:

```python
tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
```

`_tool_call_id_to_name` is keyed by the **native** `tooluse_...` id, but a frontend tool's result arrives keyed by the **wire uuid** handed to the client. On a delta-only continuation (no assistant message in the payload), the wire-id lookup misses → `tool_name` is `None` → `user_message` stays `""` → `stream_async("")`.

This is masked when `replay_history_into_strands=True` (the reconcile path takes `stream_async(None)` and ignores `user_message`). With it disabled, the continuation runs solely off `stream_async(user_message)`, so the empty prompt breaks every resume.

## The fix

The reconcile path already translates wire→native via `resolve_native_ids`; this applies the same translation at the derivation site:

```python
native_tool_call_id = wire_to_native.get(msg.tool_call_id, msg.tool_call_id)
tool_name = _tool_call_id_to_name.get(msg.tool_call_id) or _tool_call_id_to_name.get(native_tool_call_id)
```

The `session_manager` / `wire_to_native` read moves ahead of the derivation that now needs it (same read off the already-constructed agent, conditions unchanged); the reconcile block below reuses the value. A backend tool's wire and native ids are equal, so it's absent from the map and the raw-id lookup is unchanged.

## Test

Adds a regression test (`tests/test_frontend_tool_continuation_message.py`) driving a delta-only frontend-tool continuation with `replay_history_into_strands=False`: asserts the derived prompt is `my_frontend_tool returned: {...}`, not empty.