### PR TITLE
fix(client): preserve state across compacted runs

### DIFF
--- a/docs/concepts/serialization.mdx
+++ b/docs/concepts/serialization.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Serialization"
-description: "Serialize event streams for history restore, branching, and compaction in AG-UI"
+description:
+  "Serialize event streams for history restore, branching, and compaction in
+  AG-UI"
 ---
 
 # Serialization
@@ -20,10 +22,10 @@ patterns with examples.
 
 - Stream serialization – Convert the full event history to and from a portable
   representation (e.g., JSON) for storage in databases, files, or logs.
-- Event compaction – Reduce verbose streams to snapshots while preserving
-  semantics (e.g., merge content chunks, collapse deltas into snapshots).
-- Run lineage – Track branches of conversation using a `parentRunId`, forming
-  a git‑like append‑only log that enables time travel and alternative paths.
+- Event compaction – Reduce verbose streams while preserving semantics (e.g.,
+  merge text and tool-call chunks, collapse state deltas into snapshots).
+- Run lineage – Track branches of conversation using a `parentRunId`, forming a
+  git‑like append‑only log that enables time travel and alternative paths.
 
 ## Updated Event Fields
 
@@ -55,13 +57,22 @@ declare function compactEvents(events: BaseEvent[]): BaseEvent[]
 
 Common compaction rules include:
 
-- Message streams – Combine `TEXT_MESSAGE_*` sequences into a single message
-  snapshot; concatenate adjacent `TEXT_MESSAGE_CONTENT` for the same message.
-- Tool calls – Collapse tool call start/content/end into a compact record.
-- State – Merge consecutive `STATE_DELTA` events into a single final
-  `STATE_SNAPSHOT` and discard superseded updates.
-- Run input normalization – Remove from `RunStarted.input.messages` any
-  messages already present earlier in the stream.
+- Message streams – Retain `TEXT_MESSAGE_START` and `TEXT_MESSAGE_END`, and
+  concatenate the intervening `TEXT_MESSAGE_CONTENT` chunks for the same
+  `messageId` into one content event.
+- Tool calls – Retain `TOOL_CALL_START` and `TOOL_CALL_END`, and concatenate the
+  intervening `TOOL_CALL_ARGS` chunks for the same `toolCallId` into one args
+  event.
+- State – Apply `STATE_SNAPSHOT` and `STATE_DELTA` events in order using one
+  cumulative state across runs. Emit a cumulative `STATE_SNAPSHOT` at each
+  boundary that has pending state events; a later snapshot resets the
+  accumulator before subsequent deltas are applied.
+- Other events – Retain other event types, including `RAW`. The generic helper
+  does not strip `RAW`, normalize run input, or generate message snapshots.
+
+State deltas are validated JSON Patch operations. An invalid delta causes
+`compactEvents` to throw. A persistence layer evaluating compacted candidates
+can catch that exception and treat the candidate as a compaction failure.
 
 ## Branching and Time Travel
 
@@ -109,28 +120,41 @@ const compacted = compactEvents(restored);
 Before:
 
 ```ts
-[
-  { type: "TEXT_MESSAGE_START", messageId: "msg1", role: "user" },
+const before = [
+  { type: "RUN_STARTED", threadId: "thread1", runId: "run1" },
+  { type: "TEXT_MESSAGE_START", messageId: "msg1", role: "assistant" },
   { type: "TEXT_MESSAGE_CONTENT", messageId: "msg1", delta: "Hello " },
   { type: "TEXT_MESSAGE_CONTENT", messageId: "msg1", delta: "world" },
   { type: "TEXT_MESSAGE_END", messageId: "msg1" },
-  { type: "STATE_DELTA", patch: { op: "add", path: "/foo", value: 1 } },
-  { type: "STATE_DELTA", patch: { op: "replace", path: "/foo", value: 2 } },
+  { type: "STATE_SNAPSHOT", snapshot: { count: 1, stale: true } },
+  { type: "RUN_FINISHED", threadId: "thread1", runId: "run1" },
+  { type: "RUN_STARTED", threadId: "thread1", runId: "run2" },
+  { type: "RAW", event: { source: "provider" } },
+  {
+    type: "STATE_DELTA",
+    delta: [
+      { op: "replace", path: "/count", value: 2 },
+      { op: "remove", path: "/stale" },
+    ],
+  },
+  { type: "RUN_FINISHED", threadId: "thread1", runId: "run2" },
 ]
 ```
 
 After:
 
 ```ts
-[
-  {
-    type: "MESSAGES_SNAPSHOT",
-    messages: [{ id: "msg1", role: "user", content: "Hello world" }],
-  },
-  {
-    type: "STATE_SNAPSHOT",
-    state: { foo: 2 },
-  },
+const after = [
+  { type: "RUN_STARTED", threadId: "thread1", runId: "run1" },
+  { type: "TEXT_MESSAGE_START", messageId: "msg1", role: "assistant" },
+  { type: "TEXT_MESSAGE_CONTENT", messageId: "msg1", delta: "Hello world" },
+  { type: "TEXT_MESSAGE_END", messageId: "msg1" },
+  { type: "STATE_SNAPSHOT", snapshot: { count: 1, stale: true } },
+  { type: "RUN_FINISHED", threadId: "thread1", runId: "run1" },
+  { type: "RUN_STARTED", threadId: "thread1", runId: "run2" },
+  { type: "RAW", event: { source: "provider" } },
+  { type: "STATE_SNAPSHOT", snapshot: { count: 2 } },
+  { type: "RUN_FINISHED", threadId: "thread1", runId: "run2" },
 ]
 ```
 
@@ -185,4 +209,3 @@ After:
 
 - Concepts: [Events](/concepts/events), [State Management](/concepts/state)
 - SDKs: TypeScript encoder and core event types
-

--- a/docs/sdk/js/client/compaction.mdx
+++ b/docs/sdk/js/client/compaction.mdx
@@ -24,21 +24,28 @@ function compactEvents(events: BaseEvent[]): BaseEvent[]
 ## What it does
 
 - Text messages: Groups `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT*` →
-  `TEXT_MESSAGE_END` for the same `messageId`, concatenating all `delta`
-  chunks into a single `TEXT_MESSAGE_CONTENT` event.
-- Tool calls: Groups `TOOL_CALL_START` → `TOOL_CALL_ARGS*` → `TOOL_CALL_END`
-  for the same `toolCallId`, concatenating all `delta` chunks into a single
+  `TEXT_MESSAGE_END` for the same `messageId`, concatenating all `delta` chunks
+  into a single `TEXT_MESSAGE_CONTENT` event.
+- Tool calls: Groups `TOOL_CALL_START` → `TOOL_CALL_ARGS*` → `TOOL_CALL_END` for
+  the same `toolCallId`, concatenating all `delta` chunks into a single
   `TOOL_CALL_ARGS` event.
+- State: Applies `STATE_SNAPSHOT` and `STATE_DELTA` events in input order using
+  one cumulative state for the thread. At each existing state flush boundary, it
+  replaces the state events since the previous boundary with a cumulative
+  `STATE_SNAPSHOT`. A later `STATE_SNAPSHOT` replaces the accumulated state;
+  later deltas continue from it.
 - Interleaved events: Any events that occur between a start/end pair are moved
   after that sequence so the streaming block remains contiguous.
-- Pass‑through: All other events (state, custom, etc.) are preserved unchanged.
+- Pass‑through: Other event types, including `RAW`, are retained. The generic
+  helper does not remove `RAW` events; an API that wants to omit them must add
+  that behavior explicitly.
 
 ## Example
 
 Before:
 
 ```ts
-[
+const before = [
   { type: EventType.TEXT_MESSAGE_START, messageId: "m1", role: "assistant" },
   { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: "Hello" },
   { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: " " },
@@ -51,15 +58,47 @@ Before:
 After:
 
 ```ts
-[
+const after = [
   { type: EventType.TEXT_MESSAGE_START, messageId: "m1", role: "assistant" },
-  { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: "Hello world" },
+  {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId: "m1",
+    delta: "Hello world",
+  },
   { type: EventType.TEXT_MESSAGE_END, messageId: "m1" },
   { type: EventType.CUSTOM, name: "thinking" },
 ]
 ```
 
 Tool call compaction works analogously for `TOOL_CALL_ARGS` chunks.
+
+### State across runs
+
+State is cumulative across the ordered input, even when a later run contains
+only deltas:
+
+```ts
+const compacted = compactEvents([
+  { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+  { type: EventType.STATE_SNAPSHOT, snapshot: { count: 1, stale: true } },
+  { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+  { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+  {
+    type: EventType.STATE_DELTA,
+    delta: [
+      { op: "replace", path: "/count", value: 2 },
+      { op: "remove", path: "/stale" },
+    ],
+  },
+  { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+])
+
+// The emitted state snapshots are { count: 1, stale: true }, then { count: 2 }.
+```
+
+Pending state events are flushed before `RUN_STARTED`, before `RUN_FINISHED` or
+`RUN_ERROR`, and at the end of the input. A boundary with no new state events
+does not produce another state snapshot.
 
 ## When to use
 
@@ -69,8 +108,12 @@ Tool call compaction works analogously for `TOOL_CALL_ARGS` chunks.
 
 ## Notes & limitations
 
-- This utility focuses on message and tool‑call streams. It does not modify
-  state events (`STATE_SNAPSHOT`/`STATE_DELTA`) or generate message snapshots.
+- `STATE_DELTA` uses JSON Patch validation. An invalid operation throws; callers
+  evaluating candidates for persistence can treat that exception as a failed
+  compaction candidate and keep or reject the original candidate as appropriate.
+- The helper does not generate `MESSAGES_SNAPSHOT` events, normalize
+  `RUN_STARTED.input`, or strip `RAW` events.
+- State is accumulated across the full array passed to one call. If histories
+  from multiple threads are stored together, compact each thread separately.
 - For background and broader patterns (branching, normalization), see
   [Serialization](/concepts/serialization).
-

--- a/docs/superpowers/plans/2026-08-12-thread-wide-compaction.md
+++ b/docs/superpowers/plans/2026-08-12-thread-wide-compaction.md
@@ -1,0 +1,42 @@
+# Thread-wide AG-UI Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `compactEvents` preserve cumulative agent state across run boundaries and document its real behavior.
+
+**Architecture:** Keep one state accumulator for the full ordered input and emit a cumulative snapshot at each existing state flush boundary. Preserve the current event-stream API, text/tool folding, and exception behavior for invalid JSON Patch operations.
+
+**Tech Stack:** TypeScript, Vitest, `fast-json-patch`, Nx, MDX.
+
+---
+
+### Task 1: Prove cross-run state semantics
+
+**Files:**
+- Modify: `sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts`
+
+- [ ] Add fixtures where run 1 snapshots state and run 2 has only `add`, `replace`, and `remove` deltas.
+- [ ] Assert every emitted state boundary contains the cumulative thread state.
+- [ ] Add an invalid cross-run delta case and assert `compactEvents` throws.
+- [ ] Run `pnpm nx test client -- --runInBand` and confirm the new cumulative assertion fails because run 2 resets to `{}`.
+
+### Task 2: Carry state across run boundaries
+
+**Files:**
+- Modify: `sdks/typescript/packages/client/src/compact/compact.ts`
+
+- [ ] Replace run-local state initialization with one thread-wide accumulator.
+- [ ] Flush a cloned cumulative snapshot without clearing the accumulator.
+- [ ] Keep JSON Patch validation and non-mutating application semantics.
+- [ ] Run `pnpm nx test client`, `pnpm nx run client:typecheck`, and `pnpm nx run client:lint`.
+
+### Task 3: Correct public docs
+
+**Files:**
+- Modify: `docs/sdk/js/client/compaction.mdx`
+- Modify: `docs/concepts/serialization.mdx`
+
+- [ ] State that `RAW` events are not removed by the generic helper unless the API explicitly gains that behavior.
+- [ ] Explain text/tool folding and cumulative state snapshots across runs.
+- [ ] Document that invalid deltas throw and callers may treat that as a compact-candidate failure.
+- [ ] Run the repository docs checks that cover these pages.

--- a/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
+++ b/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
@@ -389,6 +389,70 @@ describe("Event Compaction", () => {
       expect(compacted[5].type).toBe(EventType.RUN_FINISHED);
     });
 
+    it("should carry cumulative state across runs with add, replace, and remove deltas", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        {
+          type: EventType.STATE_SNAPSHOT,
+          snapshot: { count: 1, label: "before", obsolete: true },
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.STATE_DELTA, delta: [{ op: "add", path: "/added", value: "run-2" }] },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "replace", path: "/label", value: "after" }],
+        },
+        { type: EventType.STATE_DELTA, delta: [{ op: "remove", path: "/obsolete" }] },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const snapshots = compactEvents(events)
+        .filter((event): event is StateSnapshotEvent => event.type === EventType.STATE_SNAPSHOT)
+        .map((event) => event.snapshot);
+
+      expect(snapshots).toEqual([
+        { count: 1, label: "before", obsolete: true },
+        { count: 1, label: "after", added: "run-2" },
+      ]);
+    });
+
+    it("should not emit another state snapshot for a later run without state events", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { count: 1 } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        { type: EventType.TEXT_MESSAGE_START, messageId: "msg1", role: "assistant" },
+        { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg1", delta: "No state change" },
+        { type: EventType.TEXT_MESSAGE_END, messageId: "msg1" },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      const snapshots = compactEvents(events).filter(
+        (event) => event.type === EventType.STATE_SNAPSHOT,
+      );
+
+      expect(snapshots).toHaveLength(1);
+      expect((snapshots[0] as StateSnapshotEvent).snapshot).toEqual({ count: 1 });
+    });
+
+    it("should throw for an invalid delta after state was established in an earlier run", () => {
+      const events = [
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+        { type: EventType.STATE_SNAPSHOT, snapshot: { existing: true } },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+        { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+        {
+          type: EventType.STATE_DELTA,
+          delta: [{ op: "replace", path: "/missing", value: "invalid" }],
+        },
+        { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+      ];
+
+      expect(() => compactEvents(events)).toThrow();
+    });
+
     it("should not emit state snapshot when no state events in run", () => {
       const events = [
         { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },

--- a/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
+++ b/sdks/typescript/packages/client/src/compact/__tests__/compact.test.ts
@@ -1,6 +1,12 @@
 import { compactEvents } from "../compact";
+import { defaultApplyEvents } from "../../apply/default";
+import { AbstractAgent } from "@/agent";
+import { AgentStateMutation } from "@/agent/subscriber";
 import {
+  BaseEvent,
   EventType,
+  Message,
+  RunAgentInput,
   TextMessageStartEvent,
   TextMessageContentEvent,
   ToolCallStartEvent,
@@ -8,6 +14,33 @@ import {
   CustomEvent,
   StateSnapshotEvent,
 } from "@ag-ui/core";
+import { firstValueFrom, of } from "rxjs";
+import { toArray } from "rxjs/operators";
+
+async function serializeDefaultReducerResult(events: BaseEvent[]): Promise<string> {
+  const input: RunAgentInput = {
+    threadId: "t1",
+    runId: "restore",
+    state: {},
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  };
+  const agent = { messages: [] } as unknown as AbstractAgent;
+  const mutations = await firstValueFrom(
+    defaultApplyEvents(input, of(...events), agent, []).pipe(toArray()),
+  );
+  const final = mutations.reduce<{ messages: Message[]; state: Record<string, unknown> }>(
+    (current, mutation: AgentStateMutation) => ({
+      messages: mutation.messages ?? current.messages,
+      state: mutation.state ?? current.state,
+    }),
+    { messages: input.messages, state: input.state },
+  );
+
+  return JSON.stringify(final);
+}
 
 describe("Event Compaction", () => {
   describe("Text Message Compaction", () => {
@@ -416,6 +449,59 @@ describe("Event Compaction", () => {
         { count: 1, label: "after", added: "run-2" },
       ]);
     });
+
+    it.each([
+      {
+        operation: "add",
+        initialState: { count: 1, label: "kept" },
+        delta: [{ op: "add", path: "/added", value: true }],
+        finalState: { count: 1, label: "kept", added: true },
+      },
+      {
+        operation: "replace",
+        initialState: { count: 1, label: "kept" },
+        delta: [{ op: "replace", path: "/count", value: 2 }],
+        finalState: { count: 2, label: "kept" },
+      },
+      {
+        operation: "remove",
+        initialState: { count: 1, obsolete: true, label: "kept" },
+        delta: [{ op: "remove", path: "/obsolete" }],
+        finalState: { count: 1, label: "kept" },
+      },
+    ])(
+      "should preserve default reducer output byte-for-byte for a cross-run $operation delta",
+      async ({ operation, initialState, delta, finalState }) => {
+        const events: BaseEvent[] = [
+          { type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" },
+          { type: EventType.STATE_SNAPSHOT, snapshot: initialState },
+          { type: EventType.TEXT_MESSAGE_START, messageId: "msg-r1", role: "assistant" },
+          { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg-r1", delta: "First " },
+          { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg-r1", delta: "run" },
+          { type: EventType.TEXT_MESSAGE_END, messageId: "msg-r1" },
+          { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" },
+          { type: EventType.RUN_STARTED, threadId: "t1", runId: "r2" },
+          { type: EventType.TEXT_MESSAGE_START, messageId: "msg-r2", role: "assistant" },
+          { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg-r2", delta: `${operation} ` },
+          { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "msg-r2", delta: "delta" },
+          { type: EventType.TEXT_MESSAGE_END, messageId: "msg-r2" },
+          { type: EventType.STATE_DELTA, delta },
+          { type: EventType.RUN_FINISHED, threadId: "t1", runId: "r2" },
+        ];
+
+        const raw = await serializeDefaultReducerResult(events);
+        const compacted = await serializeDefaultReducerResult(compactEvents(events));
+
+        expect(JSON.parse(raw)).toEqual({
+          messages: [
+            { id: "msg-r1", role: "assistant", content: "First run" },
+            { id: "msg-r2", role: "assistant", content: `${operation} delta` },
+          ],
+          state: finalState,
+        });
+        expect(compacted).toBe(raw);
+      },
+    );
 
     it("should not emit another state snapshot for a later run without state events", () => {
       const events = [

--- a/sdks/typescript/packages/client/src/compact/compact.ts
+++ b/sdks/typescript/packages/client/src/compact/compact.ts
@@ -17,8 +17,8 @@ import { structuredClone_ } from "../utils";
  * Compacts streaming events by consolidating multiple deltas into single events.
  * For text messages: multiple content deltas become one concatenated delta.
  * For tool calls: multiple args deltas become one concatenated delta.
- * For state: all STATE_SNAPSHOT and STATE_DELTA events within a run are compacted
- *   into a single STATE_SNAPSHOT representing the final state.
+ * For state: STATE_SNAPSHOT and STATE_DELTA events are applied cumulatively across
+ *   the event history and compacted into STATE_SNAPSHOT events at run boundaries.
  * Events between related streaming events are reordered to keep streaming events together.
  *
  * @param events - Array of events to compact
@@ -47,6 +47,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
 
   // State compaction: collects state events, flushed at RUN_STARTED (pre-run/inter-run), RUN_FINISHED/RUN_ERROR (in-run), and at end (trailing)
   let stateEvents: (StateSnapshotEvent | StateDeltaEvent)[] = [];
+  let state: Record<string, unknown> = {};
 
   for (const event of events) {
     // Handle text message streaming events
@@ -138,7 +139,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       pendingToolCalls.delete(toolCallId);
     } else if (event.type === EventType.RUN_STARTED) {
       // Flush any pre-run state events before starting a new run
-      flushState(stateEvents, compacted);
+      state = flushState(stateEvents, state, compacted);
       stateEvents = [];
       compacted.push(event);
     } else if (
@@ -146,7 +147,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
       event.type === EventType.RUN_ERROR
     ) {
       // Flush compacted state into output before the run boundary event
-      flushState(stateEvents, compacted);
+      state = flushState(stateEvents, state, compacted);
       stateEvents = [];
       compacted.push(event);
     } else if (
@@ -199,7 +200,7 @@ export function compactEvents(events: BaseEvent[]): BaseEvent[] {
   }
 
   // Flush any remaining state events (incomplete run or events outside runs)
-  flushState(stateEvents, compacted);
+  flushState(stateEvents, state, compacted);
 
   return compacted;
 }
@@ -284,13 +285,12 @@ function flushToolCall(
 
 function flushState(
   stateEvents: (StateSnapshotEvent | StateDeltaEvent)[],
+  state: Record<string, unknown>,
   compacted: BaseEvent[],
-): void {
+): Record<string, unknown> {
   if (stateEvents.length === 0) {
-    return;
+    return state;
   }
-
-  let state: Record<string, unknown> = {};
 
   for (const event of stateEvents) {
     if (event.type === EventType.STATE_SNAPSHOT) {
@@ -303,8 +303,9 @@ function flushState(
 
   const compactedSnapshot: StateSnapshotEvent = {
     type: EventType.STATE_SNAPSHOT,
-    snapshot: state,
+    snapshot: structuredClone_(state),
   };
 
   compacted.push(compactedSnapshot);
+  return state;
 }


### PR DESCRIPTION
## Summary

- preserve one cumulative agent-state accumulator across run boundaries in `compactEvents`
- retain existing state flush boundaries while emitting cumulative snapshots
- document actual message, tool-call, state, and `RAW` behavior
- prove raw and compact streams produce byte-identical serialized default-reducer messages/state for cross-run add, replace, and remove

## Why

Reliable Thread Restore V2 needs the canonical client compactor to preserve thread-scoped state when a later run contains deltas without a fresh snapshot. The previous run-local reset could reject a valid delta or produce the wrong state.

## Validation

- focused compaction: 31/31
- full `@ag-ui/client`: 56 files, 510/510
- client lint: passed
- changed MDX Prettier/parser check: passed
- independent spec review: passed after adding reducer-boundary equivalence fixtures
- independent code-quality review: approved

Package-wide typecheck remains red on pre-existing missing Vitest globals and unrelated test type errors; no changed production file is implicated.

## Dependency

Blocks the compact projection path in CopilotKit Intelligence V2. The Intelligence rollout remains disabled until its separate four-real-shape corpus and operational evidence gate is approved.