### PR TITLE
docs(dojo): fix build command in README (--filter is not an nx flag)

### DIFF
--- a/apps/dojo/README.md
+++ b/apps/dojo/README.md
@@ -31,7 +31,7 @@ The first time you want to run, you need to build all of the dojos dependencies 
 ```
 # from the ag-ui repository root
 pnpm i
-pnpm build --filter=demo-viewer
+pnpm build --projects=demo-viewer
 ```
 
 ### Run the Demo Viewer


### PR DESCRIPTION
## Problem

The dojo README tells first-time users to run:

```bash
# from the ag-ui repository root
pnpm build --filter=demo-viewer
```

This fails on a clean clone. The root `build` script is `nx run-many -t build`; pnpm forwards `--filter=demo-viewer` to Nx, and Nx passes the unrecognized flag through to **every** build task. The three tsdown-based packages (`@ag-ui/core`, `@ag-ui/a2ui-toolkit`, `create-ag-ui-app`) then receive `tsdown --filter=demo-viewer`, and tsdown — which has its own `--filter` workspace option — dies with:

```
 ERROR  Error: No valid configuration found.
```

(`--filter` is Turborepo/pnpm syntax; the command presumably predates the Nx setup. Reported by Ian Cloete, who hit exactly this on first install.)

## Fix

Use the Nx flag:

```bash
pnpm build --projects=demo-viewer
```

Verified on a clean clone with the pinned pnpm 10.33.4:
- `pnpm build --filter=demo-viewer` → reproduces the error above (exit 130)
- `pnpm build --projects=demo-viewer` → ✅ "Successfully ran target build for project demo-viewer and 28 tasks it depends on"

## Note

`apps/dojo/scripts/run-dojo-everything.js` line 382 uses `pnpm run dev --filter=demo-viewer...` (pnpm-filter syntax with the `...` deps suffix) against the same Nx-based root scripts — likely the same stale pattern, but it's a runtime dev-watch path I haven't verified, so it's left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)