### PR TITLE
test(adk-middleware): reset the SessionManager singleton between text-event tests

### DIFF
--- a/integrations/adk-middleware/python/tests/test_text_events.py
+++ b/integrations/adk-middleware/python/tests/test_text_events.py
@@ -6,11 +6,27 @@ import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock
 import pytest
+from ag_ui_adk.session_manager import SessionManager
 
 from ag_ui.core import RunAgentInput, UserMessage
 from ag_ui_adk import ADKAgent
 from google.adk.agents import Agent
 from google.genai import types
+
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_manager():
+    """Reset the SessionManager singleton around every test in this module.
+
+    Several tests here drive the agent on the same `test_app:mock_test` thread with the
+    same message id (`msg_1`). The singleton's processed-id map is not reset between
+    them, so a later test's only message arrives already marked as seen and its run has
+    nothing unseen to dispatch — the test then passes for the wrong reason.
+    """
+    SessionManager.reset_instance()
+    yield
+    SessionManager.reset_instance()
 
 
 async def test_message_events(llmock_server=None):


### PR DESCRIPTION
## Summary

Several tests in `tests/test_text_events.py` drive the agent on the same
`test_app:mock_test` thread with the same message id (`msg_1`), and nothing resets the
`SessionManager` singleton between them. Its processed-id map therefore leaks across tests.

They still pass — but for the wrong reason, and one of them is not exercising the code path it
claims to.

## What actually happens

`SessionManager` is a singleton and `_processed_message_ids` lives on it, keyed
`app_name:thread_id`. Instrumenting `_get_unseen_messages` while running the module:

```
test_text_message_events                              key=test_app:test_thread  incoming=['msg_1']  processed=[]
test_text_message_events_from_before_agent_callback   key=test_app:test_thread  incoming=['msg_1']  processed=['msg_1']
```

The first test marks `msg_1` processed. The second sends the same id on the same thread, so its
only message is filtered out and `unseen_messages` is empty — the run has no batch to dispatch.

It passes anyway because `_start_new_execution` recovers a message when it has none, by
reverse-scanning `input.messages` via `_convert_latest_message`. So a test whose intent is
*"a `before_agent_callback` returning content produces the right START/CONTENT/END events on a
normal single-message run"* is in fact exercising that recovery path.

Running it alone passes for the right reason; running it with its module passes for the wrong
one. That difference is invisible today, which is what makes it worth fixing.

## The fix

An autouse fixture resetting the singleton around each test in the module:

```python
@pytest.fixture(autouse=True)
def _isolate_session_manager():
    SessionManager.reset_instance()
    yield
    SessionManager.reset_instance()
```

Sixteen lines including the docstring. No production code changes, no assertions relaxed, no
test renamed — the tests now exercise what they claim to.

Chosen over giving each test a unique thread id: that would fix these particular collisions
while leaving the module able to grow new ones.

## Verification

Full `adk-middleware` suite: 923 passed, 8 skipped — unchanged.

With the fixture applied, the probe above shows `processed=[]` for every test in the module.

## Why now

Found while fixing a separate bug in `ADKAgent.run` (the no-new-work paths). Any change to how
an empty `unseen_messages` is handled turns this test red, because it is silently depending on
the recovery path rather than on its own message being dispatched. That follow-up PR is stacked
on this one so it touches only the code it is about, and so this fix stands on its own merits.
