### PR TITLE
fix(adk-middleware): don't hang or re-answer history when a run has no new work

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1190,9 +1190,27 @@ class ADKAgent:
         unseen_messages = await self._get_unseen_messages(input)
 
         if not unseen_messages:
-            # No unseen messages – fall through to normal execution handling
-            async for event in self._start_new_execution(input):
-                yield event
+            # Nothing new to act on. Terminate cleanly rather than starting an execution:
+            # with no unseen message there is nothing to pass as `new_message`, and
+            # `_start_new_execution` would recover one by reverse-scanning `input.messages`
+            # for the latest user message (see `_convert_latest_message`) — re-answering a
+            # question that was already answered, and appending a duplicate user event to
+            # the session. Clients re-send their whole history on every run, so "everything
+            # already processed" is the normal steady state, not a request for a turn.
+            logger.info(
+                "No unseen messages for thread %s; emitting an empty terminal pair.",
+                input.thread_id,
+            )
+            yield RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=input.thread_id,
+                run_id=input.run_id,
+            )
+            yield RunFinishedEvent(
+                type=EventType.RUN_FINISHED,
+                thread_id=input.thread_id,
+                run_id=input.run_id,
+            )
             return
 
         index = 0
@@ -1223,6 +1241,15 @@ class ADKAgent:
                     break
 
         logger.debug(f"[RUN_LOOP] Starting message loop for thread={input.thread_id}, total_unseen={total_unseen}, starting_index={index}")
+
+        # Every path out of this loop must leave the client with a terminal event. The
+        # loop can skip every batch (orphaned tool results, assistant-only batches, a
+        # non-tool batch whose following tool batch is skipped), in which case nothing
+        # below dispatches and the generator would otherwise yield nothing at all.
+        # Tracked on the yield rather than on the call so the post-loop check means
+        # literally "this run emitted nothing", independent of whether a dispatcher
+        # can ever complete without yielding.
+        emitted_any = False
 
         while index < total_unseen:
             current = unseen_messages[index]
@@ -1304,6 +1331,7 @@ class ADKAgent:
                     trailing_messages=trailing_messages if trailing_messages else None,
                     include_message_batch=not skip_tool_message_batch,
                 ):
+                    emitted_any = True
                     yield event
                 skip_tool_message_batch = False
             else:
@@ -1370,8 +1398,33 @@ class ADKAgent:
 
                 logger.debug(f"[RUN_LOOP] Calling _start_new_execution with message_batch of {len(message_batch)} messages")
                 async for event in self._start_new_execution(input, message_batch=message_batch):
+                    emitted_any = True
                     yield event
-    
+
+        if not emitted_any:
+            # Every batch was skipped, so there is no new work to run — but the AG-UI
+            # protocol still requires this run to terminate. Emit a bare terminal pair
+            # rather than falling through to _start_new_execution(input): that path
+            # re-answers the latest message in input.messages (via
+            # _convert_latest_message), which would turn a no-op request into a
+            # duplicate agent turn.
+            logger.info(
+                "All message batches were skipped for thread %s (%d unseen message(s)); "
+                "emitting an empty terminal pair so the run does not hang the client.",
+                input.thread_id,
+                total_unseen,
+            )
+            yield RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=input.thread_id,
+                run_id=input.run_id,
+            )
+            yield RunFinishedEvent(
+                type=EventType.RUN_FINISHED,
+                thread_id=input.thread_id,
+                run_id=input.run_id,
+            )
+
     async def _ensure_session_exists(self, app_name: str, user_id: str, thread_id: str, initial_state: dict) -> Tuple[Any, str]:
         """Ensure a session exists, creating it if necessary via session manager.
 

--- a/integrations/adk-middleware/python/tests/test_terminal_event_on_skipped_run.py
+++ b/integrations/adk-middleware/python/tests/test_terminal_event_on_skipped_run.py
@@ -1,0 +1,412 @@
+"""A run whose message batches are all skipped must still emit a terminal event.
+
+`ADKAgent.run` walks `unseen_messages` in batches and has three `continue` paths that
+dispatch nothing: an orphaned tool-result batch (no matching pending tool call), an
+assistant-only batch, and a non-tool batch whose following tool batch will be skipped.
+When *every* batch takes one of those paths the loop used to fall off the end having
+called `_start_new_execution` zero times, so the generator yielded nothing at all — no
+RUN_STARTED, no RUN_FINISHED, no RUN_ERROR. A conforming client has nothing to finalize
+on and hangs (CopilotKit surfaces this as INCOMPLETE_STREAM, "Run ended without emitting
+a terminal event").
+
+The most common way in is a client re-sending history the server no longer recognizes as
+processed — `AbstractAgent.prepareRunAgentInput` re-sends the whole list on every run, and
+`_processed_message_ids` is in-memory, so it is empty after a restart or a session-timeout
+eviction.
+
+The fix emits a bare RUN_STARTED/RUN_FINISHED pair rather than falling through to
+`_start_new_execution(input)`: that path re-answers the latest message in `input.messages`
+(see `_convert_latest_message`), which would turn a no-op request into a duplicate agent
+turn.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, List, Tuple
+
+import pytest
+import pytest_asyncio
+
+from ag_ui.core import (
+    AssistantMessage,
+    RunAgentInput,
+    Tool as AGUITool,
+    ToolMessage,
+    UserMessage,
+)
+from ag_ui_adk import ADKAgent
+from ag_ui_adk.agui_toolset import AGUIToolset
+from ag_ui_adk.session_manager import SessionManager
+
+from google.adk.agents import LlmAgent
+from google.adk.apps import App
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+
+HITL_TOOL = "ask_choice"
+
+
+class _RecordingLlm(BaseLlm):
+    """Answers with fixed text and records that it was called at all.
+
+    The point of these tests is mostly that this model is *never* reached: a run with no
+    new work must not produce an agent turn.
+    """
+
+    model: str = "recording-llm"
+    calls: int = 0
+
+    async def generate_content_async(
+        self, llm_request, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        self.calls += 1
+        yield LlmResponse(
+            content=types.Content(
+                role="model", parts=[types.Part(text="model was invoked")]
+            )
+        )
+
+
+class _CallsToolThenAnswersLlm(BaseLlm):
+    """Turn 1 calls a client-side tool (long-running, so the run pauses on it);
+    every later turn answers with text.
+
+    Needed to exercise the `_handle_tool_result_submission` dispatch path — the other
+    place the terminal-event flag is set. Without a genuinely *pending* tool call, a
+    submitted tool result is skipped rather than dispatched.
+    """
+
+    model: str = "calls-tool-llm"
+    tool_name: str = HITL_TOOL
+    calls: int = 0
+
+    async def generate_content_async(
+        self, llm_request, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        self.calls += 1
+        if self.calls == 1:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model",
+                    parts=[
+                        types.Part(
+                            function_call=types.FunctionCall(
+                                name=self.tool_name, args={}
+                            )
+                        )
+                    ],
+                ),
+                partial=False,
+                turn_complete=True,
+            )
+        else:
+            yield LlmResponse(
+                content=types.Content(
+                    role="model", parts=[types.Part(text="thanks, done")]
+                ),
+                partial=False,
+                turn_complete=True,
+            )
+
+
+def _tool(name: str) -> AGUITool:
+    return AGUITool(
+        name=name,
+        description=f"{name} tool",
+        parameters={"type": "object", "properties": {}},
+    )
+
+
+@pytest_asyncio.fixture
+async def reset_session_manager():
+    SessionManager.reset_instance()
+    yield
+    SessionManager.reset_instance()
+
+
+def _make_agent(llm: BaseLlm) -> ADKAgent:
+    return ADKAgent.from_app(
+        App(
+            name="skipped_run",
+            root_agent=LlmAgent(
+                name="SkippedRunAgent",
+                model=llm,
+                tools=[AGUIToolset()],
+                instruction="Answer the user.",
+            ),
+        ),
+        user_id="user_1",
+        session_service=InMemorySessionService(),
+    )
+
+
+async def _run(adk: ADKAgent, thread_id: str, messages, tools=None) -> Tuple[List[str], List]:
+    """Drive one AG-UI run; return (event type names, events)."""
+    events = []
+    async for event in adk.run(
+        RunAgentInput(
+            thread_id=thread_id,
+            run_id="run_1",
+            state={},
+            messages=messages,
+            tools=tools if tools is not None else [_tool("some_tool")],
+            context=[],
+            forwarded_props={},
+        )
+    ):
+        events.append(event)
+    return [type(e).__name__ for e in events], events
+
+
+_HISTORY = [
+    UserMessage(id="m1", role="user", content="build me an audience"),
+    AssistantMessage(id="m2", role="assistant", content="working on it"),
+    ToolMessage(id="m3", role="tool", content='{"ok": true}', tool_call_id="call_stale"),
+]
+
+
+async def _settled_thread_with_lost_dedupe(adk: ADKAgent, thread_id: str) -> None:
+    """Reach the state where every batch will be skipped.
+
+    Two conditions have to hold together, and neither is reachable from a bare replay:
+
+    1. **The session must already exist**, so `_get_pending_tool_call_ids` returns `[]`
+       rather than `None`. On a thread the middleware has never seen it returns `None`,
+       and `should_process_tool_batch` is left `True` — the batch dispatches and the
+       skip path is never taken.
+    2. **The in-memory dedupe map must be empty**, which is what a process restart or a
+       `session_timeout_seconds` eviction produces, and is why the client's replayed
+       history reads as entirely unseen.
+    """
+    await _run(adk, thread_id, [UserMessage(id="m0", role="user", content="hi")])
+    adk._session_manager._processed_message_ids.clear()
+
+
+@pytest.mark.asyncio
+async def test_all_batches_skipped_still_emits_a_terminal_event(reset_session_manager):
+    """The regression: this yielded zero events, so the client hung."""
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_skipped")
+
+    names, _ = await _run(adk, "thread_skipped", _HISTORY)
+
+    assert names, "run emitted no events at all — the client has nothing to finalize on"
+    assert "RunFinishedEvent" in names or "RunErrorEvent" in names, (
+        f"no terminal event in {names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skipped_run_does_not_fabricate_an_agent_turn(reset_session_manager):
+    """The reason for a bare pair rather than a fall-through to _start_new_execution.
+
+    That path calls `_convert_latest_message(input, input.messages)`, which reverse-scans
+    for the last user message — so a no-op request would re-answer the previous question:
+    a duplicate reply, a duplicate session event, and a billed model call.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_no_turn")
+    calls_before = llm.calls
+
+    names, _ = await _run(adk, "thread_no_turn", _HISTORY)
+
+    assert llm.calls == calls_before, (
+        f"the model was invoked {llm.calls - calls_before}x on a run with no new work — "
+        "the skipped-run path is re-answering history"
+    )
+    assert "TextMessageStartEvent" not in names, f"unexpected assistant turn in {names}"
+
+
+@pytest.mark.asyncio
+async def test_a_dispatchable_batch_is_unaffected(reset_session_manager):
+    """Control: a run carrying real new work still reaches the model and streams a reply."""
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+
+    names, _ = await _run(
+        adk,
+        "thread_dispatch",
+        [UserMessage(id="m1", role="user", content="hello")],
+    )
+
+    assert llm.calls == 1, f"expected exactly one model call, got {llm.calls}"
+    assert "RunFinishedEvent" in names, f"no clean terminal in {names}"
+
+
+@pytest.mark.asyncio
+async def test_synthesized_pair_is_exactly_two_correlated_events(reset_session_manager):
+    """Pins the shape and the correlation ids, not just "a terminal appeared".
+
+    Membership assertions let two bugs through: emitting the pair unconditionally, and
+    emitting it with ids the client cannot correlate to the run it asked for.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_shape")
+
+    names, events = await _run(adk, "thread_shape", _HISTORY)
+
+    assert names == ["RunStartedEvent", "RunFinishedEvent"], (
+        f"expected exactly a terminal pair, got {names}"
+    )
+    for event in events:
+        assert event.thread_id == "thread_shape", f"wrong thread_id on {type(event).__name__}"
+        assert event.run_id == "run_1", f"wrong run_id on {type(event).__name__}"
+
+
+@pytest.mark.asyncio
+async def test_pending_tool_result_dispatches_without_an_extra_pair(reset_session_manager):
+    """Covers the second place the flag is set — `_handle_tool_result_submission`.
+
+    Every other test reaches the loop's `_start_new_execution` branch, so without this
+    the tool-result branch could stop setting the flag and nothing would notice: a HITL
+    resume would gain a spurious trailing RUN_STARTED/RUN_FINISHED.
+    """
+    llm = _CallsToolThenAnswersLlm()
+    adk = _make_agent(llm)
+    tools = [_tool(HITL_TOOL)]
+
+    # Turn 1: the model calls the client tool, so the run pauses with it pending.
+    _, events = await _run(
+        adk, "thread_pending", [UserMessage(id="p1", role="user", content="ask me")], tools
+    )
+    tool_call_ids = [e.tool_call_id for e in events if type(e).__name__ == "ToolCallStartEvent"]
+    assert tool_call_ids, "fixture did not produce a pending client tool call"
+
+    # Turn 2: answer it. This must dispatch, not skip.
+    names, _ = await _run(
+        adk,
+        "thread_pending",
+        [
+            UserMessage(id="p1", role="user", content="ask me"),
+            ToolMessage(
+                id="p2", role="tool", content='{"choice": "a"}', tool_call_id=tool_call_ids[0]
+            ),
+        ],
+        tools,
+    )
+
+    assert names.count("RunStartedEvent") == 1, (
+        f"expected one run, got {names.count('RunStartedEvent')} — a spurious pair was "
+        f"appended to a dispatched turn: {names}"
+    )
+    assert llm.calls >= 2, "the tool result did not resume the agent"
+
+
+@pytest.mark.asyncio
+async def test_new_message_alongside_skipped_history_runs_once(reset_session_manager):
+    """The realistic reload-then-type flow: stale history plus genuine new work.
+
+    Some batches skip and one dispatches, so the guard must NOT fire. Asserting the
+    count rather than membership is what catches an unconditional pair.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_mixed")
+    calls_before = llm.calls
+
+    names, _ = await _run(
+        adk,
+        "thread_mixed",
+        [*_HISTORY, UserMessage(id="m4", role="user", content="make it broader")],
+    )
+
+    assert llm.calls == calls_before + 1, (
+        f"expected exactly one model call, got {llm.calls - calls_before}"
+    )
+    assert names.count("RunStartedEvent") == 1, (
+        f"a spurious terminal pair was appended to a dispatched turn: {names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_assistant_only_batch_is_skipped_and_terminated(reset_session_manager):
+    """Covers the assistant-only `continue` on its own.
+
+    In `_HISTORY` the assistant message is absorbed into the preceding user batch, so
+    that path is never taken alone there — it is a distinct branch that can regress
+    independently.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_assistant_only")
+    calls_before = llm.calls
+
+    names, _ = await _run(
+        adk,
+        "thread_assistant_only",
+        [AssistantMessage(id="a1", role="assistant", content="an earlier reply")],
+    )
+
+    assert names == ["RunStartedEvent", "RunFinishedEvent"], (
+        f"expected a terminal pair, got {names}"
+    )
+    assert llm.calls == calls_before, "an assistant-only batch must not drive a turn"
+
+
+@pytest.mark.asyncio
+async def test_no_messages_at_all_terminates_without_a_turn(reset_session_manager):
+    """An empty message list has nothing to act on."""
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+
+    names, _ = await _run(adk, "thread_empty", [])
+
+    assert names == ["RunStartedEvent", "RunFinishedEvent"], (
+        f"expected a terminal pair, got {names}"
+    )
+    assert llm.calls == 0, "an empty message list must not drive a turn"
+
+
+@pytest.mark.asyncio
+async def test_fully_processed_history_does_not_re_answer(reset_session_manager):
+    """The empty-`unseen` branch must not recover a message by scanning history.
+
+    `_start_new_execution` resolves a missing `new_message` via
+    `_convert_latest_message`, which reverse-scans `input.messages` for the last user
+    message. Reaching it with a fully-processed history re-answers a question that was
+    already answered.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    first = [UserMessage(id="q1", role="user", content="what is in my cart?")]
+    await _run(adk, "thread_answered", first)
+    calls_before = llm.calls
+
+    # Same list again: everything is now processed, so nothing is unseen.
+    names, _ = await _run(adk, "thread_answered", first)
+
+    assert llm.calls == calls_before, (
+        f"the model ran {llm.calls - calls_before}x on a fully-processed history — "
+        "the last user message is being re-answered"
+    )
+    assert names == ["RunStartedEvent", "RunFinishedEvent"], (
+        f"expected a terminal pair, got {names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_consecutive_no_work_runs_are_both_inert(reset_session_manager):
+    """The skipped run marks its messages processed, so the *second* identical request
+    reaches the empty-`unseen` branch by a different route. Both must be inert.
+
+    Before this change the first hung and the second re-answered history.
+    """
+    llm = _RecordingLlm()
+    adk = _make_agent(llm)
+    await _settled_thread_with_lost_dedupe(adk, "thread_twice")
+    calls_before = llm.calls
+
+    first, _ = await _run(adk, "thread_twice", _HISTORY)
+    second, _ = await _run(adk, "thread_twice", _HISTORY)
+
+    assert first == ["RunStartedEvent", "RunFinishedEvent"], f"run 1: {first}"
+    assert second == ["RunStartedEvent", "RunFinishedEvent"], f"run 2: {second}"
+    assert llm.calls == calls_before, (
+        f"the model ran {llm.calls - calls_before}x across two no-work runs"
+    )


### PR DESCRIPTION
This pr is stacked on #2383 which fixes incorrect tests that get triggered by this fix

## Summary

`ADKAgent.run` has two ways to reach *"there is nothing new to act on"*, and both are wrong.

- **Every batch skipped** — the generator completes having yielded **nothing**: no
  `RUN_STARTED`, no `RUN_FINISHED`, no `RUN_ERROR`. The AG-UI protocol requires a terminal
  event, so a conforming client has nothing to finalize on and hangs. CopilotKit surfaces this
  as `INCOMPLETE_STREAM` and *"Run ended without emitting a terminal event"*.
- **No unseen messages** — `_start_new_execution(input)` has no message to send, so it
  recovers one by reverse-scanning `input.messages` for the latest user message
  (`_convert_latest_message`). That **re-answers a question already answered** and appends a
  duplicate user event to the session.

They chain. The skip paths mark their messages processed, so a first no-work request hangs and
the second re-answers history.

## Reproduction

A settled thread, replayed by a client whose messages the middleware no longer recognizes as
processed, carrying **no new user message**:

```python
# 1. A thread already served, so the session exists and `pending_tool_calls` is [] not None.
await run(agent, thread_id, [UserMessage(id="m0", role="user", content="hi")])

# 2. The in-memory dedupe map is lost — a process restart, or a
#    `session_timeout_seconds` eviction.
agent._session_manager._processed_message_ids.clear()

# 3. The client re-sends its history, which `prepareRunAgentInput` does on every run.
history = [
    UserMessage(id="m1", role="user", content="build me an audience"),
    AssistantMessage(id="m2", role="assistant", content="working on it"),
    ToolMessage(id="m3", role="tool", content='{"ok": true}', tool_call_id="call_stale"),
]

first  = [e async for e in agent.run(RunAgentInput(..., messages=history))]
second = [e async for e in agent.run(RunAgentInput(..., messages=history))]

# on main: first == []                      → the client hangs
#          second re-answers "m1"           → duplicate reply + duplicate session event
```

Both conditions in step 1–2 are required. On a thread the middleware has never seen,
`_get_pending_tool_call_ids` returns `None`, `should_process_tool_batch` is left `True`, and
the batch dispatches — so a bare replay does *not* reproduce it.

Ordinary chat is unaffected: a new user message sits last with no following tool batch, so it
always dispatches. Runs carrying **no new user message** are the exposed class.

## Root cause

`run()` branches on whether there are unseen messages.

**With none** (`adk_agent.py:1192`) it called `_start_new_execution(input)`. ADK requires a
`new_message` to open an invocation, so that method falls back to `_convert_latest_message`
when it has none — recovering a message the client did not send this turn.

**With some**, it enters the per-batch loop, where three paths `continue` without dispatching:

| Line | Condition |
|---|---|
| `1282-1295` | tool-result batch with no matching pending tool call |
| `1360-1363` | batch containing only assistant messages |
| `1389-1396` | non-tool batch whose *following* tool batch will be skipped |

If every batch takes one of those, the loop exits having called `_start_new_execution` zero
times, and there was no post-loop fall-through.

Reachability comes from the dedupe state being in-memory: `_processed_message_ids`
(`session_manager.py:96`) is popped by `_untrack_session` (`:754`) once a session exceeds
`session_timeout_seconds`, and is empty after any process restart. A client re-sending its
history then presents the whole thread as unseen.

## The fix

Both paths emit a bare terminal pair and run nothing:

```python
yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=..., run_id=...)
yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=..., run_id=...)
```

For the loop, a flag tracks whether anything was emitted. It is set **on the yield**, not on
the call, so the post-loop check means literally *this run emitted nothing* and does not depend
on whether a dispatcher can complete without yielding.

Clients re-send their entire history on every run, so *"everything already processed"* is the
normal steady state rather than a request for a turn. And ADK requiring a `new_message` is the
system correctly reporting that there is no invocation to open — inventing input to satisfy
that constraint is the defect, not a workaround for it.

This also matches the remedy already used for the all-synthetic-tool-results case
(`adk_agent.py:1660-1683`), which emits the same pair for the same stated reason.

### Behavior

| Situation | Before | After |
|---|---|---|
| Any batch dispatches | normal turn | unchanged |
| Every batch skipped | **no events** — client hangs | `RUN_STARTED`/`RUN_FINISHED`, runs nothing |
| No unseen messages | **re-answers the last user message** | `RUN_STARTED`/`RUN_FINISHED`, runs nothing |

## Tests

`tests/test_terminal_event_on_skipped_run.py` — scripted `BaseLlm`, no network. Ten tests
covering both paths, the choice of remedy, correlation ids, and the chained two-run case.
Notably:

| Test | Asserts |
|---|---|
| `test_all_batches_skipped_still_emits_a_terminal_event` | fails on `main` with `assert []` |
| `test_fully_processed_history_does_not_re_answer` | the empty-`unseen` path drives no turn |
| `test_two_consecutive_no_work_runs_are_both_inert` | the chained case: both runs inert |
| `test_synthesized_pair_is_exactly_two_correlated_events` | exactly two events, carrying the run's `thread_id`/`run_id` |
| `test_pending_tool_result_dispatches_without_an_extra_pair` | the tool-result branch gains no trailing pair |
| `test_new_message_alongside_skipped_history_runs_once` | stale history + new message → one run, one model call |

Full `adk-middleware` suite: 933 passed, 8 skipped.

Checked by mutation — each of these fails the suite: dropping the loop guard so the pair is
always emitted; removing the flag from the tool-result branch; corrupting the correlation ids;
and reverting the empty-`unseen` path to `_start_new_execution`.

### Depends on the test-isolation PR

Stacked on top of the `SessionManager` isolation fix for `tests/test_text_events.py`. That is
not incidental: without it this change turns `test_text_message_events_from_before_agent_callback`
red, because that test currently reaches the empty-`unseen` branch by accident and passes only
because the fabricated message is re-injected. It is separated so this PR touches only the code
it is about, and so the test fix stands on its own merits.

## Scope & non-goals

- **The `user_message is None` fallback in `_start_new_execution` is left in place, and is
  still reachable.** Not dead code: `user_message` comes from
  `_convert_latest_message(input, message_batch)`, which only selects `role == "user"`, while
  the run loop routes `system` and `developer` messages into `message_batch` alongside user
  ones. A batch that is non-empty but contains no user-role message therefore still recovers a
  message by reverse-scanning history — the same fabrication, on a second path. Reproduced with
  `[user(already answered), system]`, which re-answers the user message; no test in the suite
  covers it (the fallback fires zero times across all 933). Fixing that needs its own tests and
  a decision about what a system-only batch should do, so it is deliberately out of scope here
  rather than overlooked.
- **Does not make the dedupe state durable.** `_processed_message_ids` remains in-memory, so a
  restart or eviction still causes a full history re-walk. This change makes the *outcome* of
  that re-walk correct.

## Alternatives considered

- **Keep `#779`'s fallback and only fix the skipped-batch path.** Rejected: it leaves the two
  branches semantically opposed — the first no-work request would terminate cleanly and the
  second re-answer history — and the duplicate turn is the more damaging of the two failures,
  since it writes to the session rather than just stalling the client.
- **Drop the fallback and let `new_message` stay `None`.** Rejected: ADK then errors, which is
  what `#779` was fixing. Terminating cleanly avoids that error without inventing a turn, so
  this supersedes that fix rather than reverting it.
- **Emit `RUN_ERROR` instead of `RUN_FINISHED`.** Rejected: nothing errored. Every message was
  already processed, which is a legitimate no-op; surfacing it as an error would put a spurious
  failure in front of the user.
