### PR TITLE
fix(client): make pnpm typecheck usable and fix the errors it hid

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
@@ -21,7 +21,7 @@ class CloneableTestAgent extends AbstractAgent {
     });
   }
 
-  protected run(_: RunAgentInput): Observable<BaseEvent> {
+  run(_: RunAgentInput): Observable<BaseEvent> {
     return EMPTY as Observable<BaseEvent>;
   }
 }

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-debug.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-debug.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { AbstractAgent } from "../agent";
 import { DebugLogger } from "@/debug-logger";
 import {
@@ -107,7 +108,7 @@ describe("Agent construction debug config", () => {
 });
 
 describe("Agent run lifecycle logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -243,7 +244,7 @@ describe("Agent run lifecycle logging", () => {
 });
 
 describe("Agent run error logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -288,7 +289,7 @@ describe("Agent run error logging", () => {
 });
 
 describe("Agent pipeline integration", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-multiple-runs.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-multiple-runs.test.ts
@@ -291,6 +291,9 @@ describe("AbstractAgent multiple runs", () => {
         messageId: "activity-1",
         activityType: "PLAN",
         content: { tasks: ["task 1"] },
+        // Schema default; apply/default.ts reads `replace ?? true`, so this
+        // spells out the behaviour the fixture already had.
+        replace: true,
       } as ActivitySnapshotEvent,
       {
         type: EventType.RUN_FINISHED,

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-result.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-result.test.ts
@@ -2,6 +2,7 @@ import { AbstractAgent } from "../agent";
 import { AgentSubscriber } from "../subscriber";
 import {
   ActivityDeltaEvent,
+  ActivityMessage,
   ActivitySnapshotEvent,
   BaseEvent,
   EventType,
@@ -370,7 +371,9 @@ describe("Agent Result", () => {
 
       const result = await agent.runAgent({ runId: "run-ops" });
 
-      const activityMessage = agent.messages.find((message) => message.id === "activity-ops");
+      const activityMessage = agent.messages.find((message) => message.id === "activity-ops") as
+        | ActivityMessage
+        | undefined;
 
       expect(activityMessage).toBeTruthy();
       expect(activityMessage?.role).toBe("activity");

--- a/sdks/typescript/packages/client/src/agent/__tests__/interrupts-lifecycle.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/interrupts-lifecycle.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { of } from "rxjs";
+import { of, type Observable } from "rxjs";
 import { AbstractAgent } from "../agent";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/core";
 import { EventType } from "@ag-ui/core";
 
 class StubAgent extends AbstractAgent {
   public received?: RunAgentInput;
-  protected run(input: RunAgentInput) {
+  run(input: RunAgentInput): Observable<BaseEvent> {
     this.received = input;
-    return of<BaseEvent>(
+    return of(
       { type: EventType.RUN_STARTED, threadId: input.threadId, runId: input.runId } as BaseEvent,
       { type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId } as BaseEvent,
     );

--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -448,7 +448,7 @@ describe("AgentSubscriber", () => {
       errorAgent.subscribe(errorHandlingSubscriber);
 
       // Mock console.error to check if it's called
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       // This should not throw because the subscriber handles the error
       await expect(errorAgent.runAgent({})).resolves.toBeDefined();
@@ -489,7 +489,7 @@ describe("AgentSubscriber", () => {
       errorAgent.subscribe(errorHandlingSubscriber);
 
       // Mock console.error to check if it's called
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       // This should throw because the subscriber doesn't stop propagation
       await expect(errorAgent.runAgent({})).rejects.toThrow("Test error");

--- a/sdks/typescript/packages/client/src/apply/__tests__/apply-debug.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/apply-debug.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import {
@@ -32,7 +33,7 @@ const createInput = (): RunAgentInput => ({
 });
 
 describe("defaultApplyEvents debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -1,7 +1,7 @@
 import { Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { firstValueFrom } from "rxjs";
-import { BaseEvent, EventType, Message, RunAgentInput } from "@ag-ui/core";
+import { ActivityMessage, BaseEvent, EventType, Message, RunAgentInput } from "@ag-ui/core";
 import { defaultApplyEvents } from "../default";
 import { AbstractAgent } from "@/agent";
 import { AgentStateMutation } from "@/agent/subscriber";
@@ -69,9 +69,10 @@ describe("defaultApplyEvents with activity events", () => {
     expect(updates.length).toBe(2);
 
     const snapshotUpdate = updates[0];
-    expect(snapshotUpdate?.messages?.[0]?.role).toBe("activity");
-    expect(snapshotUpdate?.messages?.[0]?.activityType).toBe("PLAN");
-    expect(snapshotUpdate?.messages?.[0]?.content).toEqual({ tasks: ["search"] });
+    const snapshotActivity = snapshotUpdate?.messages?.[0] as ActivityMessage | undefined;
+    expect(snapshotActivity?.role).toBe("activity");
+    expect(snapshotActivity?.activityType).toBe("PLAN");
+    expect(snapshotActivity?.content).toEqual({ tasks: ["search"] });
 
     const deltaUpdate = updates[1];
     expect(deltaUpdate?.messages?.[0]?.content).toEqual({ tasks: ["✓ search"] });
@@ -106,11 +107,12 @@ describe("defaultApplyEvents with activity events", () => {
 
     expect(updates.length).toBe(3);
     expect(updates[0]?.messages?.[0]?.content).toEqual({ operations: [] });
-    expect(updates[1]?.messages?.[0]?.content?.operations).toEqual([firstOperation]);
-    expect(updates[2]?.messages?.[0]?.content?.operations).toEqual([
-      firstOperation,
-      secondOperation,
-    ]);
+    expect((updates[1]?.messages?.[0] as ActivityMessage | undefined)?.content?.operations).toEqual(
+      [firstOperation],
+    );
+    expect((updates[2]?.messages?.[0] as ActivityMessage | undefined)?.content?.operations).toEqual(
+      [firstOperation, secondOperation],
+    );
   });
 
   it("does not replace existing activity message when replace is false", async () => {
@@ -426,7 +428,7 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       [
         { id: "m1", role: "user", content: "create a dashboard" },
         { id: "asst-1", role: "assistant", content: "I'll create that for you" },
-        { id: "tool-stream", role: "tool", content: '{"a2ui": true}' },
+        { id: "tool-stream", role: "tool", content: '{"a2ui": true}', toolCallId: "tc-1" },
         {
           id: "act-1",
           role: "activity",
@@ -438,7 +440,7 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       [
         { id: "m1", role: "user", content: "create a dashboard" },
         { id: "asst-1", role: "assistant", content: "I'll create that for you" },
-        { id: "tool-canon", role: "tool", content: '{"a2ui": true}' },
+        { id: "tool-canon", role: "tool", content: '{"a2ui": true}', toolCallId: "tc-1" },
         { id: "asst-2", role: "assistant", content: "Here's your dashboard" },
       ],
     );

--- a/sdks/typescript/packages/client/src/apply/__tests__/run-started-input.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/run-started-input.test.ts
@@ -21,7 +21,7 @@ describe("RunStartedEvent with input.messages", () => {
       this.events = events;
     }
 
-    protected run(_input: RunAgentInput): Observable<BaseEvent> {
+    run(_input: RunAgentInput): Observable<BaseEvent> {
       return of(...this.events);
     }
   }

--- a/sdks/typescript/packages/client/src/chunks/__tests__/transform-debug.test.ts
+++ b/sdks/typescript/packages/client/src/chunks/__tests__/transform-debug.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { of, concat, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { transformChunks } from "../transform";
@@ -13,7 +14,7 @@ import {
 } from "@ag-ui/core";
 
 describe("transformChunks debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
@@ -211,7 +211,7 @@ describe("BackwardCompatibility_0_0_45 (browser environment)", () => {
       const events: BaseEvent[] = [{ type: THINKING_START as EventType, title: "Processing..." }];
       const agent = new MockAgent(events);
 
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const result = await lastValueFrom(
         middleware.run(
           {

--- a/sdks/typescript/packages/client/src/middleware/__tests__/middleware-chained-integration.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/middleware-chained-integration.test.ts
@@ -2,6 +2,7 @@ import { AbstractAgent } from "@/agent";
 import { Middleware } from "@/middleware";
 import type { EventWithState } from "@/middleware/middleware";
 import {
+  AssistantMessage,
   BaseEvent,
   EventType,
   Message,
@@ -496,7 +497,7 @@ describe("Chained middleware integration (via runAgent)", () => {
         expect(mw.capturedMessages).toHaveLength(2);
 
         // First message: assistant with tool calls
-        const assistantMsg = mw.capturedMessages[0];
+        const assistantMsg = mw.capturedMessages[0] as AssistantMessage;
         expect(assistantMsg.role).toBe("assistant");
         expect(assistantMsg.toolCalls).toHaveLength(1);
         expect(assistantMsg.toolCalls![0]).toMatchObject({
@@ -527,7 +528,7 @@ describe("Chained middleware integration (via runAgent)", () => {
       for (const mw of [inner, outer]) {
         expect(mw.capturedMessages).toHaveLength(2);
 
-        const assistantMsg = mw.capturedMessages[0];
+        const assistantMsg = mw.capturedMessages[0] as AssistantMessage;
         expect(assistantMsg.role).toBe("assistant");
         expect(assistantMsg.toolCalls).toHaveLength(1);
         expect(assistantMsg.toolCalls![0]).toMatchObject({
@@ -642,7 +643,9 @@ describe("Chained middleware integration (via runAgent)", () => {
       for (const mw of [inner, outer]) {
         // msg-1 should be an assistant message with content AND tool calls
         // (TOOL_CALL_START with parentMessageId "msg-1" attaches to the existing message)
-        const msg1 = mw.capturedMessages.find((m) => m.id === "msg-1");
+        const msg1 = mw.capturedMessages.find((m) => m.id === "msg-1") as
+          | AssistantMessage
+          | undefined;
         expect(msg1).toBeDefined();
         expect(msg1!.role).toBe("assistant");
         expect(msg1!.content).toBe("Let me search");
@@ -816,14 +819,17 @@ describe("Chained middleware integration (via runAgent)", () => {
         (e) => e.event.type === EventType.TOOL_CALL_START,
       )!;
       expect(atStart.messages).toHaveLength(1);
-      expect(atStart.messages[0].toolCalls).toHaveLength(1);
-      expect(atStart.messages[0].toolCalls![0].function.arguments).toBe("");
+      const atStartMsg = atStart.messages[0] as AssistantMessage;
+      expect(atStartMsg.toolCalls).toHaveLength(1);
+      expect(atStartMsg.toolCalls![0].function.arguments).toBe("");
 
       // At TOOL_CALL_ARGS, arguments should be populated
       const atArgs = mw.capturedEventsWithState.find(
         (e) => e.event.type === EventType.TOOL_CALL_ARGS,
       )!;
-      expect(atArgs.messages[0].toolCalls![0].function.arguments).toBe('{"q":"test"}');
+      expect((atArgs.messages[0] as AssistantMessage).toolCalls![0].function.arguments).toBe(
+        '{"q":"test"}',
+      );
 
       // At TOOL_CALL_RESULT, tool message should be added
       const atResult = mw.capturedEventsWithState.find(

--- a/sdks/typescript/packages/client/src/transform/__tests__/debug.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/debug.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { take } from "rxjs/operators";
 import { parseSSEStream } from "../sse";
@@ -8,7 +9,7 @@ import { HttpEvent, HttpEventType } from "../../run/http-request";
 import { EventType } from "@ag-ui/core";
 
 describe("parseSSEStream debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -104,7 +105,7 @@ describe("parseSSEStream debug logging", () => {
 });
 
 describe("transformHttpEventStream debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/transform/__tests__/sse.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/sse.test.ts
@@ -86,7 +86,7 @@ describe("transformHttpEventStream", () => {
             resolve(events);
           }
         },
-        error: (err) => fail(err),
+        error: (err) => expect.fail(err),
       });
     });
 
@@ -192,13 +192,13 @@ describe("transformHttpEventStream", () => {
       event$.subscribe({
         next: () => {
           // This should not be called
-          fail("Should not emit events for invalid JSON");
+          expect.fail("Should not emit events for invalid JSON");
         },
         error: (err) => {
           resolve(err);
         },
         complete: () => {
-          fail("Stream should not complete successfully with invalid JSON");
+          expect.fail("Stream should not complete successfully with invalid JSON");
         },
       });
     });

--- a/sdks/typescript/packages/client/src/verify/__tests__/verify-debug.test.ts
+++ b/sdks/typescript/packages/client/src/verify/__tests__/verify-debug.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { verifyEvents } from "../verify";
@@ -14,7 +15,7 @@ import {
 } from "@ag-ui/core";
 
 describe("verifyEvents debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/verify/__tests__/verify.steps.test.ts
+++ b/sdks/typescript/packages/client/src/verify/__tests__/verify.steps.test.ts
@@ -190,7 +190,7 @@ describe("verifyEvents steps", () => {
     const subscription = verifyEvents(false)(source$).subscribe({
       next: (event) => events.push(event),
       error: (err) => {
-        fail(`Should not have errored: ${err.message}`);
+        expect.fail(`Should not have errored: ${err.message}`);
       },
     });
 

--- a/sdks/typescript/packages/client/tsconfig.json
+++ b/sdks/typescript/packages/client/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "stripInternal": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
`pnpm typecheck` in `@ag-ui/client` reports **1412 errors** on current `main`. 1360 of them are `Cannot find name 'expect' / 'describe' / 'it'`: the package's tsconfig sets `"types": ["node"]` while `include` covers the tests, so TypeScript never sees the Vitest globals. `@ag-ui/core` already sets `"types": ["vitest/globals"]` — this is the same one-line difference.

The script is therefore unusable as it stands, and that hides the other 52 errors. This PR adds the missing entry and fixes all 52. After it, `pnpm typecheck` in this package is clean.

## What the 52 were

All in tests, no production code changed.

- **27 × TS7006** — `let debugSpy: ReturnType<typeof vi.spyOn>` resolves to an untyped mock, so every `mock.calls.filter((call) => ...)` parameter was an implicit `any`. Typed as `MockInstance<typeof console.debug>` in the five `*-debug` test files.
- **13 × TS2339** — `toolCalls` / `activityType` / `content.operations` read off the `Message` union without narrowing. Narrowed with `as AssistantMessage` / `as ActivityMessage`, the idiom already used in `agent-concurrent.test.ts` and in `apply/default.ts` itself.
- **4 × TS2304 `Cannot find name 'fail'`** — `fail()` is a Jest global and does not exist in Vitest. These sit in `error` and `next` callbacks that are meant to fail the test; if one of them ever ran, the test would die with `ReferenceError: fail is not defined` instead of the intended message. Replaced with `expect.fail(...)`.
- **3 × TS2415** — `CloneableTestAgent`, `StubAgent` and `TestAgent` declare `protected run(...)`, but `AbstractAgent` declares `abstract run(...)`, which is public. Narrowing visibility in a subclass is an error; the stubs had drifted from the base class. Dropped the modifier.
- **3 × TS2554** — `vi.spyOn(...).mockImplementation()` with no argument.
- **1 × TS2352** — an `ActivitySnapshotEvent` fixture without `replace`. The schema declares `replace: z.boolean().optional().default(true)` and `apply/default.ts` reads `activityEvent.replace ?? true`, so `replace: true` spells out the behaviour the fixture already had rather than changing it.
- **1 × TS2344** — `of<BaseEvent>(a, b)` hits rxjs's tuple overload. Typed the method's return as `Observable<BaseEvent>` instead.
- **1 × TS2322** — a `role: "tool"` fixture missing the required `toolCallId`. The assertion only reads message ids, so the added field does not affect the test.

## Verification

- `pnpm typecheck`: **1412 → 0**.
- `pnpm test`: **503 passed**, 1 failed. The failure is `esm-interop.test.ts` with `ERR_UNSUPPORTED_ESM_URL_SCHEME`, which is the pre-existing Windows bug fixed by #2183 — the file is untouched here and the failure reproduces on `main`.
- Prettier: four of the touched files do not pass, but they do not pass on `main` either — the reported lines are not mine. I left them alone rather than mixing a reformat into this diff. `default.activity.test.ts` did pass before, so my lines there are formatted.

## One thing I found while doing this, out of scope here

The root `package.json` has `"check-types": "nx run-many -t check-types"`, and `nx.json` configures a `check-types` target with `dependsOn: ["^check-types"]` and caching. But no package declares a `check-types` script — all 23 that have one call it `typecheck`. So `pnpm check-types` at the root prints `No tasks were run` and checks nothing.

`CLAUDE.md` lists that same command under "Run type checking", so an agent following the repo's own instructions gets a silent pass.

Running it under the name the packages actually use, `nx run-many -t typecheck`, executes 30 projects: 26 pass and 4 fail — `@ag-ui/langchain` and `@ag-ui/mcp-apps-middleware` on `Cannot find module 'crypto'` (no `@types/node`), `@ag-ui/claude-managed-agents` on `Cannot find type definition file for 'vitest/globals'`, and `@ag-ui/a2a-middleware` on a real `TS2345` in `src/index.ts`. `@ag-ui/core`, `@ag-ui/encoder` and `@ag-ui/proto` have no target at all; `core` has one real error if you run `tsc` there by hand.

`@ag-ui/client` would have been a fifth failure before this PR, which is why I kept the two apart. I can send the wiring-up as a separate PR — scoped to renaming the targets plus those four fixes — if that is the direction you want.
