### PR TITLE
test(dojo-e2e): fix flaky haiku ordering assertion in crewai parity

### DIFF
--- a/apps/dojo/e2e/tests/crewAIConversationalFlowsTests/featureParity.spec.ts
+++ b/apps/dojo/e2e/tests/crewAIConversationalFlowsTests/featureParity.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
 import * as path from "path";
 import { test } from "../../test-isolation-helper";
 import { A2UIPage } from "../../featurePages/A2UIPage";
@@ -15,6 +15,7 @@ import {
   sendChatMessage,
 } from "../../utils/copilot-actions";
 import { CopilotSelectors } from "../../utils/copilot-selectors";
+import { expectRenderedAfter } from "../../utils/rendering-order";
 
 const integrationId = "crewai-conversational-flows";
 const testImage = path.join(
@@ -37,34 +38,6 @@ const parityFeatures = [
   "a2ui_recovery",
   "a2ui_fixed_schema",
 ] as const;
-
-async function expectRenderedAfter(
-  earlier: Locator,
-  later: Locator,
-): Promise<void> {
-  await expect(earlier).toBeAttached();
-  await expect(later).toBeAttached();
-
-  const laterHandle = await later.elementHandle();
-  expect(laterHandle).not.toBeNull();
-  const followsInDocument = await earlier.evaluate(
-    (earlierElement, laterElement) =>
-      Boolean(
-        earlierElement.compareDocumentPosition(laterElement as Node) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
-      ),
-    laterHandle,
-  );
-  expect(followsInDocument).toBe(true);
-
-  const [earlierBox, laterBox] = await Promise.all([
-    earlier.boundingBox(),
-    later.boundingBox(),
-  ]);
-  if (earlierBox && laterBox) {
-    expect(earlierBox.y).toBeLessThan(laterBox.y);
-  }
-}
 
 test.describe("CrewAI Conversational Flows feature parity", () => {
   test.describe.configure({ mode: "serial" });
@@ -113,16 +86,8 @@ test.describe("CrewAI Conversational Flows feature parity", () => {
     await expect(reasoningIndicator).toBeVisible({ timeout: 10000 });
     await expect(answer).toBeVisible({ timeout: 10000 });
 
-    const [userBox, reasoningBox, answerBox] = await Promise.all([
-      userMessage.boundingBox(),
-      reasoningIndicator.boundingBox(),
-      answer.boundingBox(),
-    ]);
-    expect(userBox).not.toBeNull();
-    expect(reasoningBox).not.toBeNull();
-    expect(answerBox).not.toBeNull();
-    expect(userBox!.y).toBeLessThan(reasoningBox!.y);
-    expect(reasoningBox!.y).toBeLessThan(answerBox!.y);
+    await expectRenderedAfter(userMessage, reasoningIndicator);
+    await expectRenderedAfter(reasoningIndicator, answer);
   });
 
   test("multimodal turns preserve the uploaded image", async ({ page }) => {
@@ -262,10 +227,24 @@ test.describe("CrewAI Conversational Flows feature parity", () => {
     const generativeUI = new ToolBaseGenUIPage(page);
 
     await generativeUI.generateHaiku('Generate Haiku for "I will always win"');
-    await generativeUI.checkGeneratedHaiku();
+
+    // The page renders a haiku card twice: once inside the assistant message
+    // and once in the main-column carousel, which already holds a placeholder
+    // card before any turn runs. Only the in-chat one belongs to the turn being
+    // ordered, so resolve it once and use that same locator for both the
+    // readiness wait and the ordering assertion.
+    const inChatHaikuCard = CopilotSelectors.assistantMessages(page)
+      .last()
+      .getByTestId("haiku-card")
+      .last();
+    await expect(inChatHaikuCard).toBeVisible();
+    await expect(
+      inChatHaikuCard.getByTestId("haiku-japanese-line").first(),
+    ).toBeVisible();
+
     await expectRenderedAfter(
       CopilotSelectors.userMessages(page).last(),
-      generativeUI.haikuBlock.last(),
+      inChatHaikuCard,
     );
   });
 

--- a/apps/dojo/e2e/utils/rendering-order.ts
+++ b/apps/dojo/e2e/utils/rendering-order.ts
@@ -1,0 +1,49 @@
+import { expect, type Locator } from "@playwright/test";
+
+/**
+ * Assert that `later` is rendered after `earlier`: it follows `earlier` in the
+ * DOM, both have a layout box, and its box starts lower on screen.
+ *
+ * The y comparison is only meaningful for elements the caller already knows
+ * stack in one column, so scope the locators accordingly (for example to a
+ * single message) before calling this.
+ */
+export async function expectRenderedAfter(
+  earlier: Locator,
+  later: Locator,
+): Promise<void> {
+  await expect(earlier).toBeAttached();
+  await expect(later).toBeAttached();
+
+  const laterHandle = await later.elementHandle();
+  try {
+    const followsInDocument = await earlier.evaluate(
+      (earlierElement, laterElement) =>
+        Boolean(
+          earlierElement.compareDocumentPosition(laterElement as Node) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ),
+      laterHandle,
+    );
+    expect(
+      followsInDocument,
+      "later element must follow the earlier element in the DOM",
+    ).toBe(true);
+  } finally {
+    // Swallow dispose rejections: at teardown the target may already be
+    // closed, and that must not replace the assertion failure above.
+    await laterHandle?.dispose().catch(() => {});
+  }
+
+  const [earlierBox, laterBox] = await Promise.all([
+    earlier.boundingBox(),
+    later.boundingBox(),
+  ]);
+  expect(earlierBox, "earlier element must have a layout box").not.toBeNull();
+  expect(laterBox, "later element must have a layout box").not.toBeNull();
+
+  expect(
+    earlierBox!.y,
+    "earlier element must start above the later element",
+  ).toBeLessThan(laterBox!.y);
+}


### PR DESCRIPTION
## The bug

`tool-based generative UI renders its card after the user turn` in the CrewAI conversational-flows parity suite failed locally against clean `main`, and took the three a2ui tests after it down with it (the describe block is `mode: "serial"`).

It was not a missing card and not a protocol problem. The demo paints `data-testid="haiku-card"` in **two** places:

- inside the assistant message, from the `useFrontendTool` render callback
- in the main-panel carousel, which is seeded with a placeholder haiku before any turn runs

The test resolved that testid page-wide and took `.last()`. The sidebar renders before `HaikuDisplay` in the tree, so `.last()` was the **carousel** card, in a different layout column from the chat. The assertion then compared y coordinates across two independent columns:

| element | x | y |
|---|---|---|
| user message (chat) | 833 | -40 |
| haiku card (chat) | 833 | 104 |
| haiku card (carousel) | **392** | **-39.5** |

`compareDocumentPosition` passed, because the carousel genuinely does follow the user message in the DOM. The y check then came down to a 0.5px accident, which is why the test passed on some runs and failed on others.

A second defect fell out of fixing the first: `checkGeneratedHaiku()` was the readiness gate, and it also resolved page-wide. Because the carousel placeholder already carries three Japanese lines, that gate resolved almost immediately on a fresh page with no message sent, and kept resolving even when the in-chat card was removed entirely. It never gated the element under assertion.

## The fix

- Resolve the in-chat card **once** into a local and use that same locator for both the readiness wait and the ordering assertion, so the gate and the assertion cannot drift apart again.
- Move `expectRenderedAfter` into `apps/dojo/e2e/utils/rendering-order.ts` and route the reasoning test's hand-rolled y comparisons through it, so both geometric ordering sites in the file share one implementation.
- Make the helper fail loud: a null bounding box previously skipped the comparison silently via `if (earlierBox && laterBox)`; the DOM-order gate had no failure message; and the element handle was never disposed. All three addressed, with the dispose unable to mask a real assertion failure at teardown.
- Document on the helper that callers must scope locators to one column, since y ordering means nothing across columns.

## Verification

Against a local crew-ai backend plus aimock: `crewAIConversationalFlowsTests` **28/28**, run repeatedly, plus the sibling `crewAITests/toolBasedGenUIPage.spec.ts` at 2/2.

The readiness-gate fix was verified by isolating the variable rather than by the suite going green: after a real generation, deleting **only** the in-chat card and leaving the carousel in place, the old gate still resolved in 5ms while the new one times out.

`haiku-card` is the only testid in this file's blast radius that paints twice. `weather-card`, `select-steps`, `task-progress` and the a2ui surfaces each have a single render site, so no second cross-column comparison is left behind.

## Known intermittent, not introduced or fixed here

While verifying, the suite intermittently failed on a single test with the remainder skipped by serial mode. It hit four different tests across separate sessions (`v1 chat`, `multimodal`, the `agentic_chat` route test, `backend tool cards`), each time passing in isolation afterwards, and each time with the agent producing no reply at all rather than an ordering failure. It reproduces on clean `main` as well as on this branch, and appears load- or cold-start-sensitive. CI's `retries: 2` will usually mask it. Flagging it rather than leaving it to be rediscovered.

## Follow-ups this surfaced, deliberately not in scope

Review turned up a substantial pre-existing backlog in this file and its CI wiring. None of it is a regression from this change and none is fixed here:

- **Assertions that cannot fail.** `not.toContainText("Integration not found")` never matches (wrong case; that string exists only in the API route). The history-retention test is a tautology. The v1 reply regex matches the built-in v1 greeting. The HITL assertion matches aimock's generic tool-result catch-all.
- **Ordering coverage.** Every user-to-assistant ordering assertion here compares two elements from one render pass over the message array, so DOM order restates array order. They still work as weak liveness checks, and the y half can still catch a CSS-level inversion, but the order that regresses in practice is intra-message (text vs tool card inside one message) and nothing covers it.
- **CI.** Traces are configured for upload but never produced (no `trace` option, and the upload glob cannot match without an `outputDir`), so CI failures ship with no debuggable artifact. `PLAYWRIGHT_SUITE` is set by the workflow and read nowhere. The matrix omits 4 existing suite directories, so 5 spec files never run. `check-generated-files` runs `npx tsx` with no install, fetching an unpinned package.

Full triage is recorded outside the repo; happy to open issues for any of these.
