### PR TITLE
fix(crew-ai): let Ctrl-C stop the dojo server

### DIFF
--- a/apps/dojo/scripts/run-dojo-everything.js
+++ b/apps/dojo/scripts/run-dojo-everything.js
@@ -93,10 +93,11 @@ const ALL_SERVICES = {
   ],
   "crew-ai": [
     {
-      // The dojo lives inside the library package but is excluded from the
-      // published artifacts, so it has no `dev` console script (see the
-      // integration's pyproject.toml).
-      command: "uv run python -m ag_ui_crewai.dojo",
+      // The dojo lives inside the library package but is development-only, so
+      // no `dev` console script is declared for it: an entry point would ship in
+      // the published metadata and point at a module the build excludes. Run it
+      // as a module from the source checkout instead.
+      command: "uv run python -m ag_ui_crewai",
       name: "CrewAI",
       cwd: path.join(integrationsRoot, "crew-ai/python"),
       env: { PORT: 8003 },

--- a/apps/dojo/scripts/run-dojo-everything.js
+++ b/apps/dojo/scripts/run-dojo-everything.js
@@ -93,10 +93,10 @@ const ALL_SERVICES = {
   ],
   "crew-ai": [
     {
-      // No `dev` console script exists for this dojo; rationale in
-      // integrations/crew-ai/python/pyproject.toml. The target must stay the
-      // package: `-m ag_ui_crewai.dojo` exits 0 without serving, and
-      // killOthersOn "success" below would take the whole fleet down with it.
+      // No `dev` console script exists for this dojo, and the target must stay the
+      // package; rationale in integrations/crew-ai/python/pyproject.toml. Getting
+      // it wrong exits 0, which killOthersOn "success" below turns into a
+      // fleet-wide stop.
       command: "uv run python -m ag_ui_crewai",
       name: "CrewAI",
       cwd: path.join(integrationsRoot, "crew-ai/python"),

--- a/apps/dojo/scripts/run-dojo-everything.js
+++ b/apps/dojo/scripts/run-dojo-everything.js
@@ -93,10 +93,10 @@ const ALL_SERVICES = {
   ],
   "crew-ai": [
     {
-      // The dojo lives inside the library package but is development-only, so
-      // no `dev` console script is declared for it: an entry point would ship in
-      // the published metadata and point at a module the build excludes. Run it
-      // as a module from the source checkout instead.
+      // No `dev` console script exists for this dojo; rationale in
+      // integrations/crew-ai/python/pyproject.toml. The target must stay the
+      // package: `-m ag_ui_crewai.dojo` exits 0 without serving, and
+      // killOthersOn "success" below would take the whole fleet down with it.
       command: "uv run python -m ag_ui_crewai",
       name: "CrewAI",
       cwd: path.join(integrationsRoot, "crew-ai/python"),

--- a/apps/dojo/scripts/run-dojo-everything.js
+++ b/apps/dojo/scripts/run-dojo-everything.js
@@ -93,7 +93,10 @@ const ALL_SERVICES = {
   ],
   "crew-ai": [
     {
-      command: "uv run dev",
+      // The dojo lives inside the library package but is excluded from the
+      // published artifacts, so it has no `dev` console script (see the
+      // integration's pyproject.toml).
+      command: "uv run python -m ag_ui_crewai.dojo",
       name: "CrewAI",
       cwd: path.join(integrationsRoot, "crew-ai/python"),
       env: { PORT: 8003 },

--- a/integrations/crew-ai/python/.gitignore
+++ b/integrations/crew-ai/python/.gitignore
@@ -24,6 +24,9 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+# Build backends and their dependencies get fetched into the project dir often
+# enough that stray wheels here would otherwise show up as untracked.
+*.whl
 MANIFEST
 
 # PyInstaller

--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -328,8 +328,13 @@ Covers the grace window, force-cancel join, AND outer-cancel recovery
 
 ## To run the dojo examples
 
+The dojo server and its demo flows are development-only and are deliberately kept
+out of the published `ag-ui-crewai` wheel and sdist, so this workflow requires a
+checkout of the [ag-ui repository](https://github.com/ag-ui-protocol/ag-ui) and
+does not work from an installed package.
+
 ```bash
 cd integrations/crew-ai/python
 uv sync
-uv run python -m ag_ui_crewai.dojo
+uv run python -m ag_ui_crewai
 ```

--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -328,10 +328,11 @@ Covers the grace window, force-cancel join, AND outer-cancel recovery
 
 ## To run the dojo examples
 
-The dojo server and its demo flows are development-only and are deliberately kept
-out of the published `ag-ui-crewai` wheel and sdist, so this workflow requires a
-checkout of the [ag-ui repository](https://github.com/ag-ui-protocol/ag-ui) and
-does not work from an installed package.
+The dojo server, its demo flows and the `__main__.py` launcher that the command
+below runs are development-only and are all deliberately kept out of the published
+`ag-ui-crewai` wheel and sdist, so this workflow requires a checkout of the
+[ag-ui repository](https://github.com/ag-ui-protocol/ag-ui) and does not work from
+an installed package.
 
 ```bash
 cd integrations/crew-ai/python

--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -331,5 +331,5 @@ Covers the grace window, force-cancel join, AND outer-cancel recovery
 ```bash
 cd integrations/crew-ai/python
 uv sync
-uv run dev
+uv run python -m ag_ui_crewai.dojo
 ```

--- a/integrations/crew-ai/python/README.md
+++ b/integrations/crew-ai/python/README.md
@@ -339,3 +339,9 @@ cd integrations/crew-ai/python
 uv sync
 uv run python -m ag_ui_crewai
 ```
+
+The launcher defaults `CREWAI_DISABLE_TELEMETRY=true` so that Ctrl-C stops the
+server. crewai's telemetry installs a SIGINT handler that flushes queued spans to
+its OTLP endpoint before letting uvicorn shut down, and that network call from
+inside the handler wedges the reloader's worker until it is SIGKILLed. Setting the
+variable yourself overrides the default, at the cost of getting that hang back.

--- a/integrations/crew-ai/python/ag_ui_crewai/__main__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__main__.py
@@ -1,18 +1,9 @@
 """Launcher for the development-only dojo server: ``python -m ag_ui_crewai``.
 
-Owns the ``uvicorn.run`` call and deliberately never imports
-``ag_ui_crewai.dojo``: with ``reload=True`` this process is only the file-watching
-supervisor, and uvicorn hands its worker the ``"ag_ui_crewai.dojo:app"`` import
-string, so the FastAPI app and every demo flow are built exactly once, in the
-process that serves traffic. Importing the app here would build a second copy
-that nothing uses.
-
-The ``-m`` target has to be the package, never ``ag_ui_crewai.dojo``: the
-reloader spawns its worker through multiprocessing, which re-executes a module
-``-m`` target as ``__mp_main__`` but skips that re-execution when the target is a
-package ``__main__``.
-
-Excluded from the published wheel and sdist alongside ``dojo.py``.
+Hands uvicorn the ``"ag_ui_crewai.dojo:app"`` import string and does not import the
+dojo here, so the app is built once, in the reloader's worker that serves traffic.
+``tests/test_launcher.py`` pins both halves of that and the ``PORT`` read below.
+Why the ``-m`` target is the package, and why none of this ships: pyproject.toml.
 """
 
 import os
@@ -22,11 +13,12 @@ import uvicorn
 
 
 def main() -> int:
-    """Serve the dojo, returning the process exit code.
+    """Serve the dojo, returning 0; ``tests/test_launcher.py`` pins that.
 
-    Under ``reload=True`` uvicorn never exits the process itself: it swallows
-    Ctrl-C and returns once the reload supervisor stops. So a normal return is a
-    clean shutdown, and 0 is the only status there is to report.
+    Not every outcome comes back here: a startup failure such as a bound port exits
+    non-zero from inside ``uvicorn.run``, and the reloader does not check on its
+    worker, so a worker that dies at import leaves this process up with the port
+    bound and requests hanging.
     """
     port = int(os.getenv("PORT", "8000"))
     uvicorn.run(

--- a/integrations/crew-ai/python/ag_ui_crewai/__main__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__main__.py
@@ -1,0 +1,18 @@
+"""Launcher for the dojo example server: ``python -m ag_ui_crewai``.
+
+Deliberately trivial. Pointing ``-m`` straight at ``dojo`` made the process that
+actually serves traffic build the FastAPI app twice, because uvicorn's reloader
+starts its worker with multiprocessing spawn: the worker re-executes the ``-m``
+target as ``__mp_main__`` and then imports ``ag_ui_crewai.dojo:app`` separately.
+multiprocessing skips that re-execution when the ``-m`` target is a package
+``__main__``, so routing through this module leaves exactly one copy of the app
+in the worker, matching what the old ``dev`` console script did.
+
+Excluded from the published wheel and sdist alongside ``dojo.py``, which it
+imports.
+"""
+
+from .dojo import main
+
+if __name__ == "__main__":
+    main()

--- a/integrations/crew-ai/python/ag_ui_crewai/__main__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__main__.py
@@ -12,6 +12,26 @@ import sys
 import uvicorn
 
 
+def _opt_out_of_crewai_telemetry() -> None:
+    """Keep Ctrl-C working, by not collecting anonymous usage stats in the dojo.
+
+    ``import crewai`` installs a SIGINT handler that chains in front of uvicorn's
+    and, before delegating to it, force-flushes queued spans to crewai's OTLP
+    endpoint. That is a network connect with a 30s timeout run from inside the
+    handler, so the reloader's worker never reaches uvicorn's ``handle_exit``,
+    and the reloader parent meanwhile blocks in ``process.join()`` still holding
+    the listening socket: Ctrl-C leaves a server that only SIGKILL stops.
+
+    This has to happen before ``uvicorn.run`` spawns the worker, since the worker
+    inherits this environment and is where the app, and so crewai, is imported.
+    It cannot move into ``dojo.py``: ``ag_ui_crewai/__init__.py`` imports crewai,
+    so by the time any submodule body runs the handler is already installed.
+
+    ``setdefault``, because opting a dojo run back in is a developer's call.
+    """
+    os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
+
+
 def main() -> int:
     """Serve the dojo, returning 0; ``tests/test_launcher.py`` pins that.
 
@@ -20,6 +40,7 @@ def main() -> int:
     worker, so a worker that dies at import leaves this process up with the port
     bound and requests hanging.
     """
+    _opt_out_of_crewai_telemetry()
     port = int(os.getenv("PORT", "8000"))
     uvicorn.run(
         "ag_ui_crewai.dojo:app",

--- a/integrations/crew-ai/python/ag_ui_crewai/__main__.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/__main__.py
@@ -1,18 +1,42 @@
-"""Launcher for the dojo example server: ``python -m ag_ui_crewai``.
+"""Launcher for the development-only dojo server: ``python -m ag_ui_crewai``.
 
-Deliberately trivial. Pointing ``-m`` straight at ``dojo`` made the process that
-actually serves traffic build the FastAPI app twice, because uvicorn's reloader
-starts its worker with multiprocessing spawn: the worker re-executes the ``-m``
-target as ``__mp_main__`` and then imports ``ag_ui_crewai.dojo:app`` separately.
-multiprocessing skips that re-execution when the ``-m`` target is a package
-``__main__``, so routing through this module leaves exactly one copy of the app
-in the worker, matching what the old ``dev`` console script did.
+Owns the ``uvicorn.run`` call and deliberately never imports
+``ag_ui_crewai.dojo``: with ``reload=True`` this process is only the file-watching
+supervisor, and uvicorn hands its worker the ``"ag_ui_crewai.dojo:app"`` import
+string, so the FastAPI app and every demo flow are built exactly once, in the
+process that serves traffic. Importing the app here would build a second copy
+that nothing uses.
 
-Excluded from the published wheel and sdist alongside ``dojo.py``, which it
-imports.
+The ``-m`` target has to be the package, never ``ag_ui_crewai.dojo``: the
+reloader spawns its worker through multiprocessing, which re-executes a module
+``-m`` target as ``__mp_main__`` but skips that re-execution when the target is a
+package ``__main__``.
+
+Excluded from the published wheel and sdist alongside ``dojo.py``.
 """
 
-from .dojo import main
+import os
+import sys
+
+import uvicorn
+
+
+def main() -> int:
+    """Serve the dojo, returning the process exit code.
+
+    Under ``reload=True`` uvicorn never exits the process itself: it swallows
+    Ctrl-C and returns once the reload supervisor stops. So a normal return is a
+    clean shutdown, and 0 is the only status there is to report.
+    """
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(
+        "ag_ui_crewai.dojo:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/integrations/crew-ai/python/ag_ui_crewai/dojo.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/dojo.py
@@ -1,5 +1,3 @@
-import os
-import uvicorn
 from fastapi import FastAPI
 
 from .endpoint import add_crewai_flow_fastapi_endpoint, add_crewai_crew_fastapi_endpoint
@@ -124,14 +122,4 @@ for feature, flow_type in CONVERSATIONAL_FLOW_TYPES.items():
         path=f"/conversational_flows/{feature}",
         conversational=True,
         emit_interrupt_outcome=feature == "interrupt",
-    )
-
-def main():
-    """Run the uvicorn server."""
-    port = int(os.getenv("PORT", "8000"))
-    uvicorn.run(
-        "ag_ui_crewai.dojo:app",
-        host="0.0.0.0",
-        port=port,
-        reload=True
     )

--- a/integrations/crew-ai/python/ag_ui_crewai/dojo.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/dojo.py
@@ -135,3 +135,10 @@ def main():
         port=port,
         reload=True
     )
+
+
+# This module is excluded from the published wheel and sdist, so it is invoked
+# as ``python -m ag_ui_crewai.dojo`` from a source checkout rather than through
+# a console script (which would ship broken metadata).
+if __name__ == "__main__":
+    main()

--- a/integrations/crew-ai/python/ag_ui_crewai/dojo.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/dojo.py
@@ -135,10 +135,3 @@ def main():
         port=port,
         reload=True
     )
-
-
-# This module is excluded from the published wheel and sdist, so it is invoked
-# as ``python -m ag_ui_crewai.dojo`` from a source checkout rather than through
-# a console script (which would ship broken metadata).
-if __name__ == "__main__":
-    main()

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -56,6 +56,12 @@ dev = [
     "pytest-asyncio>=0.24,<0.25",
     # Dev-only; <0.29 guards against a breaking httpx 0.x minor.
     "httpx>=0.27,<0.29",
+    # tests/test_packaging.py resolves this build's own file selection with the
+    # library hatchling matches with, so pattern semantics cannot drift from the
+    # real build. >=0.12 for GitIgnoreSpec.check_file; hatchling floors at 0.10.1.
+    "pathspec>=0.12,<2",
+    # tomllib is 3.11+ and requires-python still admits 3.10.
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [build-system]
@@ -71,13 +77,14 @@ build-backend = "hatchling.build"
 # stay out of both artifacts. Nothing shipped may reference them: an entry point
 # declared in ``[project.scripts]`` survives the exclude and would install a
 # ``dev`` command that raises ModuleNotFoundError, and a shipped ``__main__.py``
-# importing the excluded ``dojo`` module would break the same way. Run the dojo
-# from a source checkout with ``uv run python -m ag_ui_crewai`` instead.
+# importing the excluded ``dojo`` module would break the same way. Both modes, and
+# this exact split, are enforced by ``tests/test_packaging.py``. Run the dojo from a
+# source checkout with ``uv run python -m ag_ui_crewai`` instead.
 #
-# That target must be the PACKAGE, not the module: ``-m ag_ui_crewai.dojo`` has
-# no ``__main__`` guard, so it builds the app and exits 0 having served nothing.
-# ``ag_ui_crewai/__main__.py`` owns the uvicorn call, which also keeps the app to
-# a single build under ``reload=True``.
+# That target must be the PACKAGE, not the module: ``-m ag_ui_crewai.dojo`` has no
+# ``__main__`` guard, so it builds the app and exits 0 having served nothing.
+# ``ag_ui_crewai/__main__.py`` owns the uvicorn call, which also keeps the app to a
+# single build under ``reload=True``.
 [tool.hatch.build]
 exclude = [
     "ag_ui_crewai/dojo.py",

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -64,14 +64,16 @@ build-backend = "hatchling.build"
 
 # Shared across wheel and sdist so the exclude list is not repeated per target.
 #
-# The dojo server and its demo flows are development-only, so they stay out of
-# both artifacts. Nothing in the published metadata may reference them: a
-# ``[project.scripts]`` entry point survives the exclude and would install a
-# ``dev`` command that raises ModuleNotFoundError. Run the dojo from a source
-# checkout with ``uv run python -m ag_ui_crewai.dojo`` instead.
+# The dojo server, its launcher and its demo flows are development-only, so they
+# stay out of both artifacts. Nothing shipped may reference them: an entry point
+# declared in ``[project.scripts]`` survives the exclude and would install a
+# ``dev`` command that raises ModuleNotFoundError, and a shipped ``__main__.py``
+# importing the excluded ``dojo`` module would break the same way. Run the dojo
+# from a source checkout with ``uv run python -m ag_ui_crewai`` instead.
 [tool.hatch.build]
 exclude = [
     "ag_ui_crewai/dojo.py",
+    "ag_ui_crewai/__main__.py",
     "ag_ui_crewai/examples/**",
 ]
 

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -50,9 +50,6 @@ dependencies = [
 # never imports it (see the note above, CPK-7721 review #6).
 tools = ["crewai-tools>=0.38.1"]
 
-[project.scripts]
-dev = "ag_ui_crewai.dojo:main"
-
 [dependency-groups]
 dev = [
     "pytest>=8.0,<9.0",
@@ -66,6 +63,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 # Shared across wheel and sdist so the exclude list is not repeated per target.
+#
+# The dojo server and its demo flows are development-only, so they stay out of
+# both artifacts. Nothing in the published metadata may reference them: a
+# ``[project.scripts]`` entry point survives the exclude and would install a
+# ``dev`` command that raises ModuleNotFoundError. Run the dojo from a source
+# checkout with ``uv run python -m ag_ui_crewai.dojo`` instead.
 [tool.hatch.build]
 exclude = [
     "ag_ui_crewai/dojo.py",

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -64,12 +64,20 @@ build-backend = "hatchling.build"
 
 # Shared across wheel and sdist so the exclude list is not repeated per target.
 #
+# CANONICAL RATIONALE for how the dojo is launched. ``render.yaml`` and
+# ``apps/dojo/scripts/run-dojo-everything.js`` point here rather than repeat it.
+#
 # The dojo server, its launcher and its demo flows are development-only, so they
 # stay out of both artifacts. Nothing shipped may reference them: an entry point
 # declared in ``[project.scripts]`` survives the exclude and would install a
 # ``dev`` command that raises ModuleNotFoundError, and a shipped ``__main__.py``
 # importing the excluded ``dojo`` module would break the same way. Run the dojo
 # from a source checkout with ``uv run python -m ag_ui_crewai`` instead.
+#
+# That target must be the PACKAGE, not the module: ``-m ag_ui_crewai.dojo`` has
+# no ``__main__`` guard, so it builds the app and exits 0 having served nothing.
+# ``ag_ui_crewai/__main__.py`` owns the uvicorn call, which also keeps the app to
+# a single build under ``reload=True``.
 [tool.hatch.build]
 exclude = [
     "ag_ui_crewai/dojo.py",
@@ -80,7 +88,9 @@ exclude = [
 [tool.hatch.build.targets.wheel]
 packages = ["ag_ui_crewai"]
 
-# Lean sdist: package + metadata only (~31 KB), matching the pre-migration Poetry sdist.
+# Lean sdist: package plus metadata only, no tests and no build output. No size
+# figure here on purpose: the previous one rotted by 5x with nothing catching it,
+# and this ``include`` list is the actual guard.
 [tool.hatch.build.targets.sdist]
 include = [
     "ag_ui_crewai",

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -56,10 +56,12 @@ dev = [
     "pytest-asyncio>=0.24,<0.25",
     # Dev-only; <0.29 guards against a breaking httpx 0.x minor.
     "httpx>=0.27,<0.29",
-    # tests/test_packaging.py resolves this build's own file selection with the
-    # library hatchling matches with, so pattern semantics cannot drift from the
-    # real build. >=0.12 for GitIgnoreSpec.check_file; hatchling floors at 0.10.1.
-    "pathspec>=0.12,<2",
+    # tests/test_packaging.py asserts against the real wheel and sdist, and builds
+    # them with `uv build --no-build-isolation` so the run needs neither network nor
+    # a warm uv cache. That takes the backend from here, which also means a hatchling
+    # upgrade arrives as a reviewable uv.lock change instead of a silent shift in
+    # what gets published. Mirrors build-system.requires below.
+    "hatchling>=1.27,<2",
     # tomllib is 3.11+ and requires-python still admits 3.10.
     "tomli>=2.0; python_version < '3.11'",
 ]
@@ -93,8 +95,12 @@ exclude = [
 packages = ["ag_ui_crewai"]
 
 # Lean sdist: package plus metadata only, no tests and no build output. No size
-# figure here on purpose: the previous one rotted by 5x with nothing catching it,
-# and this ``include`` list is the actual guard.
+# figure here on purpose; the previous one rotted by 5x with nothing catching it. The
+# guard is ``tests/test_packaging.py``, which builds the tarball and compares its
+# whole file list. Only the ``ag_ui_crewai`` entry below actually selects anything:
+# hatchling force-includes the readme, the license, ``pyproject.toml``, ``PKG-INFO``
+# and ``.gitignore`` into every sdist whatever this list says. The other three stay
+# listed as a statement of intent, and the guard catches it if that stops holding.
 [tool.hatch.build.targets.sdist]
 include = [
     "ag_ui_crewai",

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -74,17 +74,14 @@ build-backend = "hatchling.build"
 # ``apps/dojo/scripts/run-dojo-everything.js`` point here rather than repeat it.
 #
 # The dojo server, its launcher and its demo flows are development-only, so they
-# stay out of both artifacts. Nothing shipped may reference them: an entry point
-# declared in ``[project.scripts]`` survives the exclude and would install a
-# ``dev`` command that raises ModuleNotFoundError, and a shipped ``__main__.py``
-# importing the excluded ``dojo`` module would break the same way. Both modes, and
-# this exact split, are enforced by ``tests/test_packaging.py``. Run the dojo from a
-# source checkout with ``uv run python -m ag_ui_crewai`` instead.
+# stay out of both artifacts and nothing shipped may reference them: an entry point
+# declared in ``[project.scripts]`` survives the exclude and would install a ``dev``
+# command that raises ModuleNotFoundError. ``tests/test_packaging.py`` enforces the
+# split. Run the dojo from a source checkout with ``uv run python -m ag_ui_crewai``.
 #
 # That target must be the PACKAGE, not the module: ``-m ag_ui_crewai.dojo`` has no
 # ``__main__`` guard, so it builds the app and exits 0 having served nothing.
-# ``ag_ui_crewai/__main__.py`` owns the uvicorn call, which also keeps the app to a
-# single build under ``reload=True``.
+# ``ag_ui_crewai/__main__.py`` owns the uvicorn call.
 [tool.hatch.build]
 exclude = [
     "ag_ui_crewai/dojo.py",

--- a/integrations/crew-ai/python/tests/test_launcher.py
+++ b/integrations/crew-ai/python/tests/test_launcher.py
@@ -1,0 +1,89 @@
+"""Runtime contract of the ``python -m ag_ui_crewai`` dojo launcher.
+
+``render.yaml`` and ``apps/dojo/scripts/run-dojo-everything.js`` both invoke that
+command and both set ``PORT``, and the uvicorn target has to stay an import string
+for the app to be built once. Neither survives a well-meaning simplification
+unless something asserts it, so this file asserts it.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from ag_ui_crewai import __main__ as launcher
+
+
+@pytest.fixture
+def uvicorn_calls(monkeypatch):
+    """Record the launcher's ``uvicorn.run`` calls instead of serving anything."""
+    calls = []
+    monkeypatch.setattr(
+        launcher.uvicorn,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    return calls
+
+
+def _target(call):
+    """The app the launcher handed uvicorn, positional or keyword."""
+    args, kwargs = call
+    return args[0] if args else kwargs["app"]
+
+
+def test_uvicorn_gets_an_import_string_not_an_app_object(uvicorn_calls):
+    launcher.main()
+
+    target = _target(uvicorn_calls[0])
+    assert isinstance(target, str), (
+        "the target must stay an import string: an app object here is built in "
+        f"this process and again in the reloader's worker, got {target!r}"
+    )
+    assert target == "ag_ui_crewai.dojo:app"
+
+
+def test_importing_the_launcher_does_not_import_the_dojo():
+    """The other half of the single build: the string names the dojo, so this
+    process must not import it as well."""
+    probe = (
+        "import sys, ag_ui_crewai.__main__;"
+        " print('ag_ui_crewai.dojo' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "False", result.stderr
+
+
+def test_port_falls_back_to_8000(uvicorn_calls, monkeypatch):
+    monkeypatch.delenv("PORT", raising=False)
+
+    launcher.main()
+
+    assert uvicorn_calls[0][1]["port"] == 8000
+
+
+def test_port_comes_from_the_environment(uvicorn_calls, monkeypatch):
+    monkeypatch.setenv("PORT", "8003")
+
+    launcher.main()
+
+    assert uvicorn_calls[0][1]["port"] == 8003
+
+
+def test_a_non_numeric_port_fails_loudly(uvicorn_calls, monkeypatch):
+    monkeypatch.setenv("PORT", "eight-thousand")
+
+    with pytest.raises(ValueError):
+        launcher.main()
+
+    assert uvicorn_calls == []
+
+
+def test_main_returns_zero(uvicorn_calls):
+    assert launcher.main() == 0

--- a/integrations/crew-ai/python/tests/test_launcher.py
+++ b/integrations/crew-ai/python/tests/test_launcher.py
@@ -6,6 +6,7 @@ for the app to be built once. Neither survives a well-meaning simplification
 unless something asserts it, so this file asserts it.
 """
 
+import os
 import subprocess
 import sys
 
@@ -87,3 +88,33 @@ def test_a_non_numeric_port_fails_loudly(uvicorn_calls, monkeypatch):
 
 def test_main_returns_zero(uvicorn_calls):
     assert launcher.main() == 0
+
+
+def test_telemetry_is_opted_out_before_the_worker_is_spawned(uvicorn_calls, monkeypatch):
+    """Ctrl-C has to work.
+
+    crewai's telemetry chains a SIGINT handler that force-flushes spans over the
+    network, which wedges the reloader's worker mid-shutdown. The opt-out has to
+    be in the environment before ``uvicorn.run`` spawns that worker, because the
+    worker inherits this environment and imports crewai there.
+    """
+    monkeypatch.delenv("CREWAI_DISABLE_TELEMETRY", raising=False)
+    seen = []
+    monkeypatch.setattr(
+        launcher.uvicorn,
+        "run",
+        lambda *a, **k: seen.append(os.environ.get("CREWAI_DISABLE_TELEMETRY")),
+    )
+
+    launcher.main()
+
+    assert seen == ["true"]
+
+
+def test_an_explicit_telemetry_choice_is_left_alone(uvicorn_calls, monkeypatch):
+    """Opting back in is a developer's call to make, so don't overwrite it."""
+    monkeypatch.setenv("CREWAI_DISABLE_TELEMETRY", "false")
+
+    launcher.main()
+
+    assert os.environ["CREWAI_DISABLE_TELEMETRY"] == "false"

--- a/integrations/crew-ai/python/tests/test_packaging.py
+++ b/integrations/crew-ai/python/tests/test_packaging.py
@@ -1,41 +1,106 @@
-"""Packaging guard: published distribution metadata must never reference a module
-that the build strips.
+"""Packaging guard: nothing a published artifact contains may reference a module
+the build strips.
 
 The regression this locks down: ``[project.scripts] dev = "ag_ui_crewai.dojo:main"``
 coexisted with a ``[tool.hatch.build] exclude`` that removes
-``ag_ui_crewai/dojo.py`` and ``ag_ui_crewai/examples/**``, so every published wheel
-and sdist installed a ``dev`` command that raised
-``ModuleNotFoundError: No module named 'ag_ui_crewai.dojo'``. Nothing caught it:
-the whole test suite runs against an editable install, which makes the excluded
-module importable from the source tree, so the failure was invisible until a
-consumer invoked the command.
+``ag_ui_crewai/dojo.py``, so every published wheel and sdist installed a ``dev``
+command that raised ``ModuleNotFoundError: No module named 'ag_ui_crewai.dojo'``.
+Nothing caught it: the suite runs against an editable install, which makes an
+excluded module importable from the source tree, so the break was invisible until
+a consumer ran the command. The same blind spot hides the second failure mode, a
+shipped module importing an excluded one, so both are checked here.
 
-crew-ai is the integration exposed to this failure mode because its dojo lives
-inside the publishable package. An audit of every ``pyproject.toml`` under
-``integrations/``, ``middlewares/`` and ``sdks/python`` found it was the only
-library declaring a ``dev`` console script; the other twelve integrations declare
-theirs inside ``python/examples/`` projects that are never published.
+crew-ai is the integration exposed to this because its dojo lives inside the
+publishable package. Where another integration declares a ``dev`` script, it sits
+in a ``python/examples/`` project that is never published.
 
-The check is structural rather than a build: it parses ``pyproject.toml`` and
-resolves every declared entry point against the build's file-selection options,
-so it costs milliseconds and belongs in the normal unit suite. It is driven
-entirely by what the file says, so a new console script pointing at shipped code
-passes without touching this test, and one pointing at excluded code fails.
+The check is structural rather than a build, so it costs milliseconds and belongs
+in the unit suite. File selection is resolved with ``pathspec.GitIgnoreSpec``, the
+same library and spec class hatchling uses (``hatchling/builders/config.py``), so
+the pattern semantics cannot drift from the real build: a slash-less pattern
+matches at any depth, ``*`` stops at ``/``, a directory pattern takes its whole
+subtree, and ``!`` re-includes. Build options this guard does not model make it
+fail loudly instead of guessing, in either direction.
 """
 
-import fnmatch
-import tomllib
+import ast
+import os
+import re
 from pathlib import Path, PurePosixPath
 
+import pathspec
 import pytest
+
+try:  # tomllib is 3.11+, and requires-python still admits 3.10.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - depends on the interpreter
+    import tomli as tomllib
 
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
+IMPORT_NAME = "ag_ui_crewai"
 
-# Hatchling options that whitelist files: whatever a target declares, the entry
-# point's module has to survive it. ``packages`` and ``only-include`` are sugar
-# over ``include``, and all three narrow the file set the same way.
-WHITELIST_OPTIONS = ("include", "only-include", "packages")
+# Development-only code: the dojo server, the ``python -m ag_ui_crewai`` launcher
+# that runs it, and the demo flows. No artifact may ship any of it, and every
+# other module in the package must ship. Update these two lists (not the
+# assertions) when that split changes on purpose.
+DEV_ONLY_FILES = (f"{IMPORT_NAME}/dojo.py", f"{IMPORT_NAME}/__main__.py")
+DEV_ONLY_TREES = (f"{IMPORT_NAME}/examples/",)
+
+# Modules the published package exists to provide. Named so the equality check
+# below cannot pass by comparing two empty sets.
+CORE_MODULES = (
+    f"{IMPORT_NAME}/__init__.py",
+    f"{IMPORT_NAME}/endpoint.py",
+    f"{IMPORT_NAME}/sdk.py",
+    f"{IMPORT_NAME}/a2ui_tool.py",
+)
+
+# The hatchling file-selection options this guard mirrors.
+MODELED_OPTIONS = frozenset({"exclude", "include", "only-include", "packages"})
+
+# Options that cannot change which project files a published artifact contains:
+# archive naming, metadata version, editable-install layout, target version list,
+# reproducibility.
+INERT_OPTIONS = frozenset(
+    {
+        "core-metadata-version",
+        "dev-mode-dirs",
+        "dev-mode-exact",
+        "macos-max-compat",
+        "reproducible",
+        "strict-naming",
+        "versions",
+    }
+)
+
+# hatchling/builders/constants.py, plus the global excludes every target gets.
+EXCLUDED_DIRECTORIES = frozenset(
+    {
+        "__pycache__",
+        ".venv",
+        ".git",
+        ".hg",
+        ".hatch",
+        ".tox",
+        ".nox",
+        ".ruff_cache",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".pixi",
+    }
+)
+EXCLUDED_FILES = frozenset({".DS_Store", ".git"})
+GLOBAL_EXCLUDE_PATTERNS = ("*.py[cdo]", "/dist")
+
+
+class UnmodeledBuildOption(AssertionError):
+    """A build option is in play that this guard cannot resolve.
+
+    Deliberately an ``AssertionError``, so it surfaces as a test failure telling
+    the maintainer to extend the guard rather than as a verdict that happens to be
+    wrong. Silent mis-reporting is the whole thing this file guards against.
+    """
 
 
 def _load_pyproject(path=PYPROJECT):
@@ -43,27 +108,164 @@ def _load_pyproject(path=PYPROJECT):
         return tomllib.load(handle)
 
 
-def _matches(pattern, relpath):
-    """Does hatchling's glob ``pattern`` select ``relpath``?
+def _gitignore_lines(root):
+    """The ``.gitignore`` hatchling folds into every exclude spec.
 
-    Hatchling matches with gitignore syntax (via ``pathspec``), where ``*`` stops
-    at a path separator. ``fnmatch`` lets ``*`` cross separators, so the two agree
-    exactly on the pattern shapes actually in use here (a literal path, and a
-    ``dir/**`` recursive subtree) and diverge only by fnmatch being BROADER. That
-    direction is the safe one for a guard: the worst case is over-reporting, which
-    surfaces as a loud test failure a maintainer inspects, never as a silently
-    broken artifact. ``PurePath.match`` is not usable at all here -- before 3.13 it
-    treats ``**`` as a plain ``*``, so ``ag_ui_crewai/examples/**`` would fail to
-    match anything nested.
-
-    The second arm implements the gitignore rule that a pattern naming a directory
-    also selects everything beneath it, which is how ``include = ["ag_ui_crewai"]``
-    ships the whole package.
+    ``ignore-vcs`` defaults to false, so hatchling loads the nearest
+    ``.gitignore`` at or above the project root, stopping at the repo boundary
+    (``hatchling.utils.fs.locate_file``). Skipping it here would make the guard
+    narrower than the build and miss a module a stray ignore rule strips.
     """
-    pattern = pattern.strip("/")
-    return fnmatch.fnmatchcase(relpath, pattern) or fnmatch.fnmatchcase(
-        relpath, f"{pattern}/*"
+    current = root
+    while True:
+        candidate = current / ".gitignore"
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8").splitlines()
+        if (current / ".git").exists() or current == current.parent:
+            return []
+        current = current.parent
+
+
+class TargetSelection:
+    """Which files one hatchling build target ships.
+
+    Mirrors ``hatchling.builders.config.BuilderConfig``: an exclude spec built
+    from hatchling's global patterns, the local ``.gitignore`` and the declared
+    ``exclude``; an include spec from ``include`` plus one ``/<dir>/`` pattern per
+    ``packages`` entry; and ``only-include`` roots, which ``packages`` populates
+    too. Files under an only-include root are selected "explicitly", which bypasses
+    the include spec but not the exclude spec.
+    """
+
+    def __init__(self, source, options, root, plugin_name, project_name):
+        self.source = source
+        unmodeled = sorted(set(options) - MODELED_OPTIONS - INERT_OPTIONS)
+        if unmodeled:
+            named = ", ".join(repr(option) for option in unmodeled)
+            raise UnmodeledBuildOption(
+                f"{source} declares {named}, which this guard does not model, so any "
+                "verdict about the files it ships would be a guess. Model the option "
+                "in TargetSelection (see hatchling/builders/config.py) or drop it."
+            )
+
+        packages = [package.strip("/") for package in options.get("packages", [])]
+        nested = [package for package in packages if "/" in package]
+        if nested:
+            raise UnmodeledBuildOption(
+                f"{source} declares nested packages {nested!r}, which also make "
+                "hatchling rewrite distribution paths via `sources`, so a module's "
+                "shipped import path stops matching its path in the tree. Model "
+                "`sources` in TargetSelection before using a src layout."
+            )
+
+        include = list(options.get("include", []))
+        only_include = [
+            path.strip("/") for path in options.get("only-include", [])
+        ] or packages
+        if plugin_name == "wheel" and not (include or only_include):
+            only_include = _auto_detected_wheel_packages(root, project_name, source)
+
+        self.only_include = only_include
+        self._exclude_patterns = [
+            *(("a hatchling default", p) for p in GLOBAL_EXCLUDE_PATTERNS),
+            *((".gitignore", line) for line in _gitignore_lines(root)),
+            *((f"{source} exclude", p) for p in options.get("exclude", [])),
+        ]
+        self._exclude_spec = pathspec.GitIgnoreSpec.from_lines(
+            pattern for _origin, pattern in self._exclude_patterns
+        )
+        self._include_patterns = [*include, *(f"/{package}/" for package in packages)]
+        self._include_spec = (
+            pathspec.GitIgnoreSpec.from_lines(self._include_patterns)
+            if self._include_patterns
+            else None
+        )
+
+    def ships(self, relpath):
+        return self.rejection(relpath) is None
+
+    def rejection(self, relpath):
+        """Why this target does not ship ``relpath``, or ``None`` when it does."""
+        parts = PurePosixPath(relpath).parts
+        if any(part in EXCLUDED_DIRECTORIES for part in parts[:-1]):
+            return "sits in a directory hatchling always skips"
+        if parts[-1] in EXCLUDED_FILES:
+            return "is a file hatchling always skips"
+
+        explicit = bool(self.only_include)
+        if explicit and not any(
+            relpath == root or relpath.startswith(f"{root}/")
+            for root in self.only_include
+        ):
+            return f"falls outside its only-include roots {self.only_include!r}"
+
+        if self._exclude_spec.match_file(relpath):
+            return f"is stripped by {self._describe_exclusion(relpath)}"
+
+        if (
+            not explicit
+            and self._include_spec is not None
+            and not self._include_spec.match_file(relpath)
+        ):
+            return f"is not selected by its include patterns {self._include_patterns!r}"
+
+        return None
+
+    def _describe_exclusion(self, relpath):
+        """Name the pattern that stripped ``relpath``, for the failure message.
+
+        The verdict itself always comes from the combined spec above; this only
+        looks for the last pattern to claim the path so the message can quote it,
+        and stays vague when it cannot pin one down.
+        """
+        winner = None
+        for origin, pattern in self._exclude_patterns:
+            result = pathspec.GitIgnoreSpec.from_lines([pattern]).check_file(relpath)
+            if result.include is True:
+                winner = (origin, pattern)
+            elif result.include is False:
+                winner = None
+        if winner is None:
+            return "an exclude pattern"
+        origin, pattern = winner
+        return f"{origin} pattern {pattern!r}"
+
+
+def _auto_detected_wheel_packages(root, project_name, source):
+    """hatchling's wheel fallback when no file selection is declared: the directory
+    named after the project."""
+    guess = re.sub(r"[^\w\d.]+", "_", project_name)
+    if guess and (root / guess / "__init__.py").is_file():
+        return [guess]
+    raise UnmodeledBuildOption(
+        f"{source} declares no `packages`, `include` or `only-include`, and there is "
+        f"no {guess or '<project name>'}/__init__.py, so hatchling falls back to "
+        "src-layout or single-module detection, which this guard does not model. "
+        "Declare `packages` on the target instead."
     )
+
+
+def _target_selections(config, root):
+    """One ``TargetSelection`` per hatchling build target.
+
+    Target tables override the shared ``[tool.hatch.build]`` options per key. With
+    no target table declared at all, both artifacts are still built from the shared
+    options, so both are checked.
+    """
+    build = config.get("tool", {}).get("hatch", {}).get("build", {})
+    shared = {key: value for key, value in build.items() if key != "targets"}
+    project_name = config.get("project", {}).get("name", "")
+    targets = build.get("targets") or {"wheel": {}, "sdist": {}}
+    return [
+        TargetSelection(
+            f"tool.hatch.build.targets.{name}",
+            {**shared, **options},
+            root,
+            name,
+            project_name,
+        )
+        for name, options in targets.items()
+    ]
 
 
 def _declared_entry_points(config):
@@ -81,22 +283,6 @@ def _declared_entry_points(config):
             yield f"project.entry-points.{group}.{name}", name, value
 
 
-def _build_targets(config):
-    """Yield ``(source, options)`` for each hatchling build target.
-
-    Target tables override the shared ``[tool.hatch.build]`` options per key, so
-    each target is checked against its own effective file selection.
-    """
-    build = config.get("tool", {}).get("hatch", {}).get("build", {})
-    shared = {key: value for key, value in build.items() if key != "targets"}
-    targets = build.get("targets", {})
-    if not targets:
-        yield "tool.hatch.build", shared
-        return
-    for name, options in targets.items():
-        yield f"tool.hatch.build.targets.{name}", {**shared, **options}
-
-
 def _module_candidates(module):
     """The file paths a dotted module name can resolve to, module before package."""
     parts = module.split(".")
@@ -106,49 +292,97 @@ def _module_candidates(module):
     )
 
 
-def _entry_point_violations(config, package_root):
-    """Every way ``config``'s entry points fail to survive its own build config.
+def _resolve_module(module, root):
+    for candidate in _module_candidates(module):
+        if (root / candidate).is_file():
+            return candidate.as_posix()
+    return None
 
-    Returns a list of human-readable violations, empty when the invariant holds.
+
+def _python_files(root):
+    """Every ``.py`` file in the source tree, as forward-slash relative paths."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIRECTORIES]
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield Path(dirpath, filename).relative_to(root).as_posix()
+
+
+def _imported_source_files(relpath, root):
+    """Source-tree files ``relpath`` imports, parent packages included.
+
+    Imports that resolve outside the tree (third-party, stdlib) and ``from``
+    targets that name a function rather than a submodule resolve to nothing and
+    drop out.
     """
+    tree = ast.parse((root / relpath).read_text(encoding="utf-8"), filename=relpath)
+    package = PurePosixPath(relpath).parts[:-1]
+
+    dotted = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            dotted.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level > len(package):
+                continue
+            base = list(package[: len(package) - node.level + 1]) if node.level else []
+            prefix = base + (node.module.split(".") if node.module else [])
+            if prefix:
+                dotted.add(".".join(prefix))
+            dotted.update(".".join([*prefix, alias.name]) for alias in node.names)
+
+    imported = set()
+    for name in dotted:
+        parts = name.split(".")
+        for depth in range(1, len(parts) + 1):
+            resolved = _resolve_module(".".join(parts[:depth]), root)
+            if resolved is not None:
+                imported.add(resolved)
+    return imported - {relpath}
+
+
+def _entry_point_violations(config, root):
+    """Every way ``config``'s entry points fail to survive its own build config."""
     violations = []
+    selections = _target_selections(config, root)
     for source, _name, value in _declared_entry_points(config):
         module = value.split(":", 1)[0].strip()
-        candidates = _module_candidates(module)
-        resolved = next(
-            (c for c in candidates if (package_root / c).is_file()),
-            None,
-        )
+        resolved = _resolve_module(module, root)
         if resolved is None:
-            tried = ", ".join(str(c) for c in candidates)
+            tried = ", ".join(str(c) for c in _module_candidates(module))
             violations.append(
                 f"{source} = {value!r} names module {module!r}, which has no file "
                 f"in the source tree (tried {tried})"
             )
             continue
+        for selection in selections:
+            rejection = selection.rejection(resolved)
+            if rejection is not None:
+                violations.append(
+                    f"{source} = {value!r} resolves to {resolved}, which "
+                    f"{selection.source} does not ship: it {rejection}"
+                )
+    return violations
 
-        relpath = resolved.as_posix()
-        for target, options in _build_targets(config):
-            for pattern in options.get("exclude", []):
-                if _matches(pattern, relpath):
+
+def _stripped_import_violations(config, root):
+    """Every shipped module that imports a module its own target strips."""
+    violations = []
+    for selection in _target_selections(config, root):
+        for relpath in sorted(_python_files(root)):
+            if not selection.ships(relpath):
+                continue
+            for imported in sorted(_imported_source_files(relpath, root)):
+                rejection = selection.rejection(imported)
+                if rejection is not None:
                     violations.append(
-                        f"{source} = {value!r} resolves to {relpath}, which "
-                        f"{target} strips via exclude pattern {pattern!r}"
-                    )
-            for option in WHITELIST_OPTIONS:
-                patterns = options.get(option)
-                if patterns is not None and not any(
-                    _matches(p, relpath) for p in patterns
-                ):
-                    violations.append(
-                        f"{source} = {value!r} resolves to {relpath}, which "
-                        f"{target} omits: its {option} list {patterns!r} selects "
-                        "nothing on that path"
+                        f"{selection.source} ships {relpath}, which imports "
+                        f"{imported}, but that file {rejection}"
                     )
     return violations
 
 
-# -- the invariant, against the real pyproject.toml -------------------------
+# -- the invariants, against the real pyproject.toml ------------------------
 
 
 def test_declared_entry_points_survive_the_build():
@@ -167,36 +401,119 @@ def test_declared_entry_points_survive_the_build():
     )
 
 
-# -- the checker itself, so the assertion above cannot pass vacuously ------
+def test_no_shipped_module_imports_a_stripped_module():
+    """The other half of the invariant: a shipped module's imports have to ship too.
+
+    An editable install hides this completely, so a ``from .examples...`` added to
+    a runtime module would only fail on a consumer's machine.
+    """
+    violations = _stripped_import_violations(_load_pyproject(), PACKAGE_ROOT)
+
+    assert violations == [], "\n".join(
+        [
+            "modules the build ships import modules it strips, so importing the "
+            "installed package would raise ModuleNotFoundError:",
+            *(f"  - {v}" for v in violations),
+        ]
+    )
+
+
+def test_every_target_ships_the_runtime_package_and_no_dev_only_module():
+    """Pin the split in both directions.
+
+    Equality, not a one-way check: dropping a path from ``exclude`` fails here just
+    as loudly as excluding a module the package needs at runtime.
+    """
+    config = _load_pyproject()
+    modules = {
+        path
+        for path in _python_files(PACKAGE_ROOT)
+        if path.startswith(f"{IMPORT_NAME}/")
+    }
+    dev_only = {
+        path
+        for path in modules
+        if path in DEV_ONLY_FILES or path.startswith(DEV_ONLY_TREES)
+    }
+    runtime = modules - dev_only
+
+    assert set(DEV_ONLY_FILES) <= dev_only, "a dev-only module vanished from the tree"
+    assert set(CORE_MODULES) <= runtime, "a core module vanished from the tree"
+    assert len(dev_only) > len(DEV_ONLY_FILES), "the examples tree vanished"
+
+    for selection in _target_selections(config, PACKAGE_ROOT):
+        shipped = {path for path in modules if selection.ships(path)}
+
+        assert shipped == runtime, "\n".join(
+            [
+                f"{selection.source} does not ship exactly the runtime modules:",
+                *(
+                    f"  - needed at runtime but stripped: {p}"
+                    for p in sorted(runtime - shipped)
+                ),
+                *(f"  - dev-only but shipped: {p}" for p in sorted(shipped - runtime)),
+                "Fix the build config, or update DEV_ONLY_FILES / DEV_ONLY_TREES if "
+                "the split moved on purpose.",
+            ]
+        )
+
+
+def test_the_dojo_launcher_stays_in_the_source_tree():
+    """``python -m ag_ui_crewai`` is what render.yaml and the dojo runner invoke, so
+    the launcher has to exist and reach the dojo even though no artifact ships it."""
+    launcher = f"{IMPORT_NAME}/__main__.py"
+
+    assert (PACKAGE_ROOT / launcher).is_file()
+    # Either an import of the dojo module or the uvicorn import string that names it.
+    assert f"{IMPORT_NAME}/dojo.py" in _imported_source_files(
+        launcher, PACKAGE_ROOT
+    ) or f"{IMPORT_NAME}.dojo" in (PACKAGE_ROOT / launcher).read_text(encoding="utf-8")
+
+
+# -- the checker itself, so the assertions above cannot pass vacuously -----
 #
-# Synthetic configs and a temporary tree: these must keep failing the way they do
+# Synthetic configs over a temporary tree: these must keep failing the way they do
 # regardless of what the real pyproject.toml comes to declare.
 
 
 @pytest.fixture
 def fake_package(tmp_path):
-    (tmp_path / "pkg" / "examples").mkdir(parents=True)
-    for relpath in (
-        "pkg/__init__.py",
-        "pkg/shipped.py",
-        "pkg/dev_only.py",
-        "pkg/examples/__init__.py",
-        "pkg/examples/demo.py",
-    ):
-        (tmp_path / relpath).write_text("")
+    """A miniature source tree: shipped modules, a dev-only one, a demo subtree."""
+    files = {
+        "pkg/__init__.py": "from .shipped import serve\n",
+        "pkg/shipped.py": "import os\n\n\ndef serve():\n    pass\n",
+        "pkg/dev_only.py": "from .examples import demo\n",
+        "pkg/nested/__init__.py": "",
+        "pkg/nested/mod.py": "",
+        "pkg/examples/__init__.py": "",
+        "pkg/examples/demo.py": "",
+    }
+    for relpath, text in files.items():
+        path = tmp_path / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
     return tmp_path
 
 
-def _config(scripts, **build_options):
+def _config(scripts, target="wheel", **build_options):
+    """A one-target config whose whitelist ships all of ``pkg``."""
     return {
-        "project": {"scripts": scripts},
-        "tool": {"hatch": {"build": build_options}},
+        "project": {"name": "pkg", "scripts": scripts},
+        "tool": {
+            "hatch": {
+                "build": {
+                    "packages": ["pkg"],
+                    **build_options,
+                    "targets": {target: {}},
+                }
+            }
+        },
     }
 
 
 def test_checker_accepts_a_script_pointing_at_shipped_code(fake_package):
     config = _config(
-        {"serve": "pkg.shipped:main"},
+        {"serve": "pkg.shipped:serve"},
         exclude=["pkg/dev_only.py", "pkg/examples/**"],
     )
 
@@ -213,7 +530,19 @@ def test_checker_flags_a_script_excluded_by_a_literal_pattern(fake_package):
 
     assert len(violations) == 1
     assert "pkg/dev_only.py" in violations[0]
-    assert "exclude pattern 'pkg/dev_only.py'" in violations[0]
+    assert "pattern 'pkg/dev_only.py'" in violations[0]
+
+
+def test_checker_flags_a_script_excluded_by_a_pattern_without_a_slash(fake_package):
+    """The idiomatic form: gitignore patterns with no slash match at any depth, so
+    ``dev_only.py`` strips ``pkg/dev_only.py``. Hand-rolled fnmatch logic anchors
+    the pattern instead and calls this config green."""
+    config = _config({"dev": "pkg.dev_only:main"}, exclude=["dev_only.py"])
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "pattern 'dev_only.py'" in violations[0]
 
 
 def test_checker_flags_a_script_excluded_by_a_recursive_glob(fake_package):
@@ -238,13 +567,69 @@ def test_checker_flags_a_package_entry_point_excluded_as_a_directory(fake_packag
     assert "pkg/examples/__init__.py" in violations[0]
 
 
+def test_checker_honours_a_negated_exclude_pattern(fake_package):
+    """``!`` re-includes, so an exclude list can strip a directory and keep one file
+    in it. Treating ``!`` as a literal pattern would report the kept file as gone."""
+    config = _config(
+        {"demo": "pkg.examples.demo:main"},
+        exclude=["pkg/examples/**", "!pkg/examples/demo.py"],
+    )
+
+    assert _entry_point_violations(config, fake_package) == []
+
+
+def test_checker_does_not_let_a_star_cross_a_directory_separator(fake_package):
+    """``*`` stops at ``/`` in gitignore syntax, so ``pkg/*.py`` does not select a
+    nested module. A matcher where ``*`` crosses separators calls this shipped and
+    the module silently goes missing from the artifact."""
+    config = {
+        "project": {"name": "pkg", "scripts": {"serve": "pkg.nested.mod:main"}},
+        "tool": {"hatch": {"build": {"targets": {"sdist": {"include": ["pkg/*.py"]}}}}},
+    }
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "is not selected by its include patterns" in violations[0]
+
+
+def test_checker_treats_whitelist_options_as_alternatives(fake_package):
+    """hatchling ORs the whitelists: ``packages`` and ``include`` feed one spec, and
+    ``packages`` doubles as an only-include root. AND-ing them reports a shipped
+    module as omitted because the ``include`` list says nothing about it."""
+    config = {
+        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
+        "tool": {
+            "hatch": {
+                "build": {
+                    "targets": {
+                        "wheel": {"packages": ["pkg"], "include": ["README.md"]},
+                        "sdist": {"include": ["pkg", "README.md"]},
+                    }
+                }
+            }
+        },
+    }
+
+    assert _entry_point_violations(config, fake_package) == []
+
+
 def test_checker_covers_gui_scripts_and_entry_point_groups(fake_package):
     config = {
         "project": {
+            "name": "pkg",
             "gui-scripts": {"dev-gui": "pkg.dev_only:gui"},
             "entry-points": {"some.plugin.group": {"hook": "pkg.dev_only:hook"}},
         },
-        "tool": {"hatch": {"build": {"exclude": ["pkg/dev_only.py"]}}},
+        "tool": {
+            "hatch": {
+                "build": {
+                    "packages": ["pkg"],
+                    "exclude": ["pkg/dev_only.py"],
+                    "targets": {"wheel": {}},
+                }
+            }
+        },
     }
 
     sources = [v.split(" = ")[0] for v in _entry_point_violations(config, fake_package)]
@@ -265,10 +650,10 @@ def test_checker_flags_a_script_whose_module_does_not_exist(fake_package):
 
 
 def test_checker_flags_a_script_left_out_of_a_target_whitelist(fake_package):
-    """An sdist ``include`` list is the other way to drop a module: the exclude
-    list stays innocent and the file simply never gets selected."""
+    """An sdist ``include`` list is the other way to drop a module: the exclude list
+    stays innocent and the file simply never gets selected."""
     config = {
-        "project": {"scripts": {"serve": "pkg.shipped:main"}},
+        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
         "tool": {
             "hatch": {
                 "build": {
@@ -284,17 +669,18 @@ def test_checker_flags_a_script_left_out_of_a_target_whitelist(fake_package):
     violations = _entry_point_violations(config, fake_package)
 
     assert len(violations) == 1
-    assert "targets.sdist omits" in violations[0]
+    assert "targets.sdist does not ship" in violations[0]
 
 
 def test_checker_applies_shared_excludes_to_every_target(fake_package):
     """``[tool.hatch.build] exclude`` with no per-target override has to be checked
     once per target, which is how the real config strips the dojo from both."""
     config = {
-        "project": {"scripts": {"dev": "pkg.dev_only:main"}},
+        "project": {"name": "pkg", "scripts": {"dev": "pkg.dev_only:main"}},
         "tool": {
             "hatch": {
                 "build": {
+                    "packages": ["pkg"],
                     "exclude": ["pkg/dev_only.py"],
                     "targets": {"wheel": {}, "sdist": {}},
                 }
@@ -303,7 +689,7 @@ def test_checker_applies_shared_excludes_to_every_target(fake_package):
     }
 
     targets = [
-        v.split("which ")[1].split(" strips")[0]
+        v.split("which ")[1].split(" does not ship")[0]
         for v in _entry_point_violations(config, fake_package)
     ]
 
@@ -311,3 +697,86 @@ def test_checker_applies_shared_excludes_to_every_target(fake_package):
         "tool.hatch.build.targets.sdist",
         "tool.hatch.build.targets.wheel",
     ]
+
+
+def test_checker_flags_a_shipped_module_importing_a_stripped_one(fake_package):
+    config = _config({}, exclude=["pkg/dev_only.py", "pkg/examples/**"])
+    (fake_package / "pkg" / "shipped.py").write_text("from .examples import demo\n")
+
+    violations = _stripped_import_violations(config, fake_package)
+
+    stripped = "stripped by tool.hatch.build.targets.wheel exclude pattern"
+    assert [v.split("ships ")[1] for v in violations] == [
+        f"pkg/shipped.py, which imports pkg/examples/__init__.py, but that file is "
+        f"{stripped} 'pkg/examples/**'",
+        f"pkg/shipped.py, which imports pkg/examples/demo.py, but that file is "
+        f"{stripped} 'pkg/examples/**'",
+    ]
+
+
+def test_checker_ignores_a_stripped_module_importing_a_stripped_one(fake_package):
+    """``pkg/dev_only.py`` imports the demo subtree, and both are excluded, which is
+    exactly the real dojo layout: nothing shipped references either."""
+    config = _config({}, exclude=["pkg/dev_only.py", "pkg/examples/**"])
+
+    assert _stripped_import_violations(config, fake_package) == []
+
+
+def test_checker_refuses_an_unmodeled_build_option(fake_package):
+    """``force-include`` beats ``exclude``, so guessing either way is wrong."""
+    config = _config({"serve": "pkg.shipped:serve"}, **{"force-include": {"x": "y"}})
+
+    with pytest.raises(UnmodeledBuildOption, match="'force-include'"):
+        _entry_point_violations(config, fake_package)
+
+
+def test_checker_refuses_a_src_layout_package(fake_package):
+    config = {
+        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
+        "tool": {"hatch": {"build": {"targets": {"wheel": {"packages": ["src/pkg"]}}}}},
+    }
+
+    with pytest.raises(UnmodeledBuildOption, match="sources"):
+        _entry_point_violations(config, fake_package)
+
+
+def test_checker_refuses_a_wheel_it_cannot_resolve(fake_package):
+    """No whitelist and no directory named after the project: hatchling falls back
+    to detection this guard does not model, so it must not answer."""
+    config = {
+        "project": {
+            "name": "unrelated-name",
+            "scripts": {"serve": "pkg.shipped:serve"},
+        },
+        "tool": {"hatch": {"build": {"targets": {"wheel": {}}}}},
+    }
+
+    with pytest.raises(UnmodeledBuildOption, match="src-layout"):
+        _entry_point_violations(config, fake_package)
+
+
+def test_checker_resolves_a_wheel_that_declares_no_file_selection(fake_package):
+    """hatchling's own fallback when the package is named after the project."""
+    config = {
+        "project": {"name": "pkg", "scripts": {"dev": "pkg.dev_only:main"}},
+        "tool": {
+            "hatch": {"build": {"targets": {"wheel": {"exclude": ["pkg/dev_only.py"]}}}}
+        },
+    }
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "pkg/dev_only.py" in violations[0]
+
+
+def test_checker_applies_gitignore_patterns_like_the_build(fake_package):
+    """``ignore-vcs`` defaults to false, so a ``.gitignore`` rule strips a module
+    from the artifact just as an ``exclude`` entry would."""
+    (fake_package / ".gitignore").write_text("dev_only.py\n")
+    config = _config({"dev": "pkg.dev_only:main"})
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert ".gitignore pattern 'dev_only.py'" in violations[0]

--- a/integrations/crew-ai/python/tests/test_packaging.py
+++ b/integrations/crew-ai/python/tests/test_packaging.py
@@ -1,0 +1,313 @@
+"""Packaging guard: published distribution metadata must never reference a module
+that the build strips.
+
+The regression this locks down: ``[project.scripts] dev = "ag_ui_crewai.dojo:main"``
+coexisted with a ``[tool.hatch.build] exclude`` that removes
+``ag_ui_crewai/dojo.py`` and ``ag_ui_crewai/examples/**``, so every published wheel
+and sdist installed a ``dev`` command that raised
+``ModuleNotFoundError: No module named 'ag_ui_crewai.dojo'``. Nothing caught it:
+the whole test suite runs against an editable install, which makes the excluded
+module importable from the source tree, so the failure was invisible until a
+consumer invoked the command.
+
+crew-ai is the integration exposed to this failure mode because its dojo lives
+inside the publishable package. An audit of every ``pyproject.toml`` under
+``integrations/``, ``middlewares/`` and ``sdks/python`` found it was the only
+library declaring a ``dev`` console script; the other twelve integrations declare
+theirs inside ``python/examples/`` projects that are never published.
+
+The check is structural rather than a build: it parses ``pyproject.toml`` and
+resolves every declared entry point against the build's file-selection options,
+so it costs milliseconds and belongs in the normal unit suite. It is driven
+entirely by what the file says, so a new console script pointing at shipped code
+passes without touching this test, and one pointing at excluded code fails.
+"""
+
+import fnmatch
+import tomllib
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
+
+# Hatchling options that whitelist files: whatever a target declares, the entry
+# point's module has to survive it. ``packages`` and ``only-include`` are sugar
+# over ``include``, and all three narrow the file set the same way.
+WHITELIST_OPTIONS = ("include", "only-include", "packages")
+
+
+def _load_pyproject(path=PYPROJECT):
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _matches(pattern, relpath):
+    """Does hatchling's glob ``pattern`` select ``relpath``?
+
+    Hatchling matches with gitignore syntax (via ``pathspec``), where ``*`` stops
+    at a path separator. ``fnmatch`` lets ``*`` cross separators, so the two agree
+    exactly on the pattern shapes actually in use here (a literal path, and a
+    ``dir/**`` recursive subtree) and diverge only by fnmatch being BROADER. That
+    direction is the safe one for a guard: the worst case is over-reporting, which
+    surfaces as a loud test failure a maintainer inspects, never as a silently
+    broken artifact. ``PurePath.match`` is not usable at all here -- before 3.13 it
+    treats ``**`` as a plain ``*``, so ``ag_ui_crewai/examples/**`` would fail to
+    match anything nested.
+
+    The second arm implements the gitignore rule that a pattern naming a directory
+    also selects everything beneath it, which is how ``include = ["ag_ui_crewai"]``
+    ships the whole package.
+    """
+    pattern = pattern.strip("/")
+    return fnmatch.fnmatchcase(relpath, pattern) or fnmatch.fnmatchcase(
+        relpath, f"{pattern}/*"
+    )
+
+
+def _declared_entry_points(config):
+    """Yield ``(source, name, value)`` for every entry point in ``[project]``.
+
+    Covers ``scripts``, ``gui-scripts`` and every ``entry-points.*`` group, since
+    all three land in the built distribution's ``entry_points.txt``.
+    """
+    project = config.get("project", {})
+    for table in ("scripts", "gui-scripts"):
+        for name, value in project.get(table, {}).items():
+            yield f"project.{table}.{name}", name, value
+    for group, entries in project.get("entry-points", {}).items():
+        for name, value in entries.items():
+            yield f"project.entry-points.{group}.{name}", name, value
+
+
+def _build_targets(config):
+    """Yield ``(source, options)`` for each hatchling build target.
+
+    Target tables override the shared ``[tool.hatch.build]`` options per key, so
+    each target is checked against its own effective file selection.
+    """
+    build = config.get("tool", {}).get("hatch", {}).get("build", {})
+    shared = {key: value for key, value in build.items() if key != "targets"}
+    targets = build.get("targets", {})
+    if not targets:
+        yield "tool.hatch.build", shared
+        return
+    for name, options in targets.items():
+        yield f"tool.hatch.build.targets.{name}", {**shared, **options}
+
+
+def _module_candidates(module):
+    """The file paths a dotted module name can resolve to, module before package."""
+    parts = module.split(".")
+    return (
+        PurePosixPath(*parts).with_suffix(".py"),
+        PurePosixPath(*parts, "__init__.py"),
+    )
+
+
+def _entry_point_violations(config, package_root):
+    """Every way ``config``'s entry points fail to survive its own build config.
+
+    Returns a list of human-readable violations, empty when the invariant holds.
+    """
+    violations = []
+    for source, _name, value in _declared_entry_points(config):
+        module = value.split(":", 1)[0].strip()
+        candidates = _module_candidates(module)
+        resolved = next(
+            (c for c in candidates if (package_root / c).is_file()),
+            None,
+        )
+        if resolved is None:
+            tried = ", ".join(str(c) for c in candidates)
+            violations.append(
+                f"{source} = {value!r} names module {module!r}, which has no file "
+                f"in the source tree (tried {tried})"
+            )
+            continue
+
+        relpath = resolved.as_posix()
+        for target, options in _build_targets(config):
+            for pattern in options.get("exclude", []):
+                if _matches(pattern, relpath):
+                    violations.append(
+                        f"{source} = {value!r} resolves to {relpath}, which "
+                        f"{target} strips via exclude pattern {pattern!r}"
+                    )
+            for option in WHITELIST_OPTIONS:
+                patterns = options.get(option)
+                if patterns is not None and not any(
+                    _matches(p, relpath) for p in patterns
+                ):
+                    violations.append(
+                        f"{source} = {value!r} resolves to {relpath}, which "
+                        f"{target} omits: its {option} list {patterns!r} selects "
+                        "nothing on that path"
+                    )
+    return violations
+
+
+# -- the invariant, against the real pyproject.toml -------------------------
+
+
+def test_declared_entry_points_survive_the_build():
+    """No shipped entry point may point at a module the build strips or omits."""
+    violations = _entry_point_violations(_load_pyproject(), PACKAGE_ROOT)
+
+    assert violations == [], "\n".join(
+        [
+            "pyproject.toml declares entry points that the build does not ship, so "
+            "the installed command would raise ModuleNotFoundError:",
+            *(f"  - {v}" for v in violations),
+            "Either drop the entry point (dev-only code runs via "
+            "`uv run python -m <module>` from a checkout) or stop excluding the "
+            "module.",
+        ]
+    )
+
+
+# -- the checker itself, so the assertion above cannot pass vacuously ------
+#
+# Synthetic configs and a temporary tree: these must keep failing the way they do
+# regardless of what the real pyproject.toml comes to declare.
+
+
+@pytest.fixture
+def fake_package(tmp_path):
+    (tmp_path / "pkg" / "examples").mkdir(parents=True)
+    for relpath in (
+        "pkg/__init__.py",
+        "pkg/shipped.py",
+        "pkg/dev_only.py",
+        "pkg/examples/__init__.py",
+        "pkg/examples/demo.py",
+    ):
+        (tmp_path / relpath).write_text("")
+    return tmp_path
+
+
+def _config(scripts, **build_options):
+    return {
+        "project": {"scripts": scripts},
+        "tool": {"hatch": {"build": build_options}},
+    }
+
+
+def test_checker_accepts_a_script_pointing_at_shipped_code(fake_package):
+    config = _config(
+        {"serve": "pkg.shipped:main"},
+        exclude=["pkg/dev_only.py", "pkg/examples/**"],
+    )
+
+    assert _entry_point_violations(config, fake_package) == []
+
+
+def test_checker_flags_a_script_excluded_by_a_literal_pattern(fake_package):
+    config = _config(
+        {"dev": "pkg.dev_only:main"},
+        exclude=["pkg/dev_only.py", "pkg/examples/**"],
+    )
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "pkg/dev_only.py" in violations[0]
+    assert "exclude pattern 'pkg/dev_only.py'" in violations[0]
+
+
+def test_checker_flags_a_script_excluded_by_a_recursive_glob(fake_package):
+    """``dir/**`` is the shape hatchling uses for demo trees, and it has to match
+    nested modules, not just direct children."""
+    config = _config({"demo": "pkg.examples.demo:main"}, exclude=["pkg/examples/**"])
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "pkg/examples/demo.py" in violations[0]
+
+
+def test_checker_flags_a_package_entry_point_excluded_as_a_directory(fake_package):
+    """A dotted name can resolve to ``__init__.py``; excluding the directory still
+    strips it."""
+    config = _config({"demo": "pkg.examples:main"}, exclude=["pkg/examples/**"])
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "pkg/examples/__init__.py" in violations[0]
+
+
+def test_checker_covers_gui_scripts_and_entry_point_groups(fake_package):
+    config = {
+        "project": {
+            "gui-scripts": {"dev-gui": "pkg.dev_only:gui"},
+            "entry-points": {"some.plugin.group": {"hook": "pkg.dev_only:hook"}},
+        },
+        "tool": {"hatch": {"build": {"exclude": ["pkg/dev_only.py"]}}},
+    }
+
+    sources = [v.split(" = ")[0] for v in _entry_point_violations(config, fake_package)]
+
+    assert sources == [
+        "project.gui-scripts.dev-gui",
+        "project.entry-points.some.plugin.group.hook",
+    ]
+
+
+def test_checker_flags_a_script_whose_module_does_not_exist(fake_package):
+    config = _config({"ghost": "pkg.missing:main"})
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "no file in the source tree" in violations[0]
+
+
+def test_checker_flags_a_script_left_out_of_a_target_whitelist(fake_package):
+    """An sdist ``include`` list is the other way to drop a module: the exclude
+    list stays innocent and the file simply never gets selected."""
+    config = {
+        "project": {"scripts": {"serve": "pkg.shipped:main"}},
+        "tool": {
+            "hatch": {
+                "build": {
+                    "targets": {
+                        "wheel": {"packages": ["pkg"]},
+                        "sdist": {"include": ["README.md"]},
+                    }
+                }
+            }
+        },
+    }
+
+    violations = _entry_point_violations(config, fake_package)
+
+    assert len(violations) == 1
+    assert "targets.sdist omits" in violations[0]
+
+
+def test_checker_applies_shared_excludes_to_every_target(fake_package):
+    """``[tool.hatch.build] exclude`` with no per-target override has to be checked
+    once per target, which is how the real config strips the dojo from both."""
+    config = {
+        "project": {"scripts": {"dev": "pkg.dev_only:main"}},
+        "tool": {
+            "hatch": {
+                "build": {
+                    "exclude": ["pkg/dev_only.py"],
+                    "targets": {"wheel": {}, "sdist": {}},
+                }
+            }
+        },
+    }
+
+    targets = [
+        v.split("which ")[1].split(" strips")[0]
+        for v in _entry_point_violations(config, fake_package)
+    ]
+
+    assert sorted(targets) == [
+        "tool.hatch.build.targets.sdist",
+        "tool.hatch.build.targets.wheel",
+    ]

--- a/integrations/crew-ai/python/tests/test_packaging.py
+++ b/integrations/crew-ai/python/tests/test_packaging.py
@@ -1,35 +1,54 @@
-"""Packaging guard: nothing a published artifact contains may reference a module
-the build strips.
+"""Packaging guard: no published artifact may reference a module it does not contain.
 
 The regression this locks down: ``[project.scripts] dev = "ag_ui_crewai.dojo:main"``
-coexisted with a ``[tool.hatch.build] exclude`` that removes
-``ag_ui_crewai/dojo.py``, so every published wheel and sdist installed a ``dev``
-command that raised ``ModuleNotFoundError: No module named 'ag_ui_crewai.dojo'``.
-Nothing caught it: the suite runs against an editable install, which makes an
-excluded module importable from the source tree, so the break was invisible until
-a consumer ran the command. The same blind spot hides the second failure mode, a
-shipped module importing an excluded one, so both are checked here.
+coexisted with a ``[tool.hatch.build] exclude`` that removes ``ag_ui_crewai/dojo.py``,
+so every published wheel and sdist installed a ``dev`` command that raised
+``ModuleNotFoundError: No module named 'ag_ui_crewai.dojo'``. Nothing caught it: the
+suite runs against an editable install, which makes an excluded module importable
+from the source tree, so the break was invisible until a consumer ran the command.
+The same blind spot hides the second failure mode, a shipped module importing an
+excluded one, so both are checked here.
 
 crew-ai is the integration exposed to this because its dojo lives inside the
-publishable package. Where another integration declares a ``dev`` script, it sits
-in a ``python/examples/`` project that is never published.
+publishable package. Where another integration declares a ``dev`` script, it sits in
+a ``python/examples/`` project that is never published.
 
-The check is structural rather than a build, so it costs milliseconds and belongs
-in the unit suite. File selection is resolved with ``pathspec.GitIgnoreSpec``, the
-same library and spec class hatchling uses (``hatchling/builders/config.py``), so
-the pattern semantics cannot drift from the real build: a slash-less pattern
-matches at any depth, ``*`` stops at ``/``, a directory pattern takes its whole
-subtree, and ``!`` re-includes. Build options this guard does not model make it
-fail loudly instead of guessing, in either direction.
+THE ORACLE IS THE ARTIFACT, NOT A MODEL OF IT. Earlier revisions of this file
+re-implemented hatchling's file selection (its default-exclude constants, its
+``pathspec`` specs, its whitelist precedence) so the checks could run without a
+build. That model was wrong in the dangerous direction repeatedly: it called
+configurations green that ship a broken wheel, and reported ``.gitignore`` as
+stripped from an sdist that in fact contains it. So the session fixture below runs
+the real build once and every assertion reads the bytes it produced. There is
+nothing left for the guard to be incomplete about, and ``uv build`` costs under a
+second, which is noise against the rest of the suite.
+
+Two details of the build command are load-bearing. It is plain ``uv build``, which
+builds the sdist and then the wheel *from that sdist* — the same command
+``build-python-preview.yml`` and ``publish-release.yml`` run, so the wheel checked
+here is bounded by the sdist exactly as the published one is. And it is
+``--no-build-isolation``, so the backend comes from this project's own locked dev
+dependencies rather than a fresh network resolve: the guard works offline, and a
+hatchling upgrade arrives as a reviewable ``uv.lock`` change instead of a silent
+shift in what gets published.
 """
 
 import ast
+import configparser
+import importlib
 import os
 import re
+import runpy
+import shutil
+import subprocess
+import tarfile
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
-import pathspec
 import pytest
+import uvicorn
 
 try:  # tomllib is 3.11+, and requires-python still admits 3.10.
     import tomllib
@@ -37,17 +56,16 @@ except ModuleNotFoundError:  # pragma: no cover - depends on the interpreter
     import tomli as tomllib
 
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
-PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
 IMPORT_NAME = "ag_ui_crewai"
 
 # Development-only code: the dojo server, the ``python -m ag_ui_crewai`` launcher
-# that runs it, and the demo flows. No artifact may ship any of it, and every
-# other module in the package must ship. Update these two lists (not the
-# assertions) when that split changes on purpose.
+# that runs it, and the demo flows. No artifact may ship any of it, and every other
+# file in the package must ship. Update these two lists (not the assertions) when
+# that split changes on purpose.
 DEV_ONLY_FILES = (f"{IMPORT_NAME}/dojo.py", f"{IMPORT_NAME}/__main__.py")
 DEV_ONLY_TREES = (f"{IMPORT_NAME}/examples/",)
 
-# Modules the published package exists to provide. Named so the equality check
+# Modules the published package exists to provide. Named so the set-equality check
 # below cannot pass by comparing two empty sets.
 CORE_MODULES = (
     f"{IMPORT_NAME}/__init__.py",
@@ -56,727 +74,520 @@ CORE_MODULES = (
     f"{IMPORT_NAME}/a2ui_tool.py",
 )
 
-# The hatchling file-selection options this guard mirrors.
-MODELED_OPTIONS = frozenset({"exclude", "include", "only-include", "packages"})
-
-# Options that cannot change which project files a published artifact contains:
-# archive naming, metadata version, editable-install layout, target version list,
-# reproducibility.
-INERT_OPTIONS = frozenset(
-    {
-        "core-metadata-version",
-        "dev-mode-dirs",
-        "dev-mode-exact",
-        "macos-max-compat",
-        "reproducible",
-        "strict-naming",
-        "versions",
-    }
+# The sdist payload outside the package directory, as the built tarball actually
+# carries it. Every one of these is force-included by the backend rather than
+# selected by ``[tool.hatch.build.targets.sdist] include``: the readme and the
+# license because ``[project]`` names them, ``pyproject.toml`` and ``PKG-INFO``
+# because an sdist is not a build input without them, and ``.gitignore`` which
+# hatchling adds to every sdist unconditionally. Emptying the include list of all
+# but ``ag_ui_crewai`` leaves this set unchanged, which is checkable and was checked.
+# Closed set on purpose: this is what catches an sdist that quietly starts shipping
+# the test suite and the lockfile.
+SDIST_NON_PACKAGE_FILES = frozenset(
+    {"README.md", "LICENSE", "pyproject.toml", "PKG-INFO", ".gitignore"}
 )
 
-# hatchling/builders/constants.py, plus the global excludes every target gets.
-EXCLUDED_DIRECTORIES = frozenset(
-    {
-        "__pycache__",
-        ".venv",
-        ".git",
-        ".hg",
-        ".hatch",
-        ".tox",
-        ".nox",
-        ".ruff_cache",
-        ".pytest_cache",
-        ".mypy_cache",
-        ".pixi",
-    }
-)
-EXCLUDED_FILES = frozenset({".DS_Store", ".git"})
-GLOBAL_EXCLUDE_PATTERNS = ("*.py[cdo]", "/dist")
+# Byte-compilation and Finder droppings in a source checkout. They are not part of
+# the package, so they are not expected in an artifact; if a build ever started
+# shipping them the set-equality check would report them as extra files.
+DROPPING_SUFFIXES = (".pyc", ".pyo")
+DROPPING_NAMES = (".DS_Store",)
+DROPPING_DIRS = ("__pycache__",)
+
+# entry_points.txt group -> the pyproject table a maintainer would edit.
+ENTRY_POINT_TABLES = {
+    "console_scripts": "project.scripts",
+    "gui_scripts": "project.gui-scripts",
+}
 
 
-class UnmodeledBuildOption(AssertionError):
-    """A build option is in play that this guard cannot resolve.
+# -- the artifacts, built once per session ----------------------------------
 
-    Deliberately an ``AssertionError``, so it surfaces as a test failure telling
-    the maintainer to extend the guard rather than as a verdict that happens to be
-    wrong. Silent mis-reporting is the whole thing this file guards against.
+
+@dataclass(frozen=True)
+class Artifact:
+    """One built distribution, addressed by the paths a consumer sees.
+
+    ``contents`` is keyed relative to the archive's own root: for a wheel that is
+    the directory it unpacks into ``site-packages``, so ``ag_ui_crewai/sdk.py`` is
+    the installed import path; for an sdist it is the project root the backend
+    rebuilds from, with the ``<name>-<version>/`` prefix stripped.
     """
 
+    kind: str
+    filename: str
+    contents: Mapping[str, bytes]
 
-def _load_pyproject(path=PYPROJECT):
-    with path.open("rb") as handle:
-        return tomllib.load(handle)
+    def text(self, path):
+        return self.contents[path].decode("utf-8")
 
+    @property
+    def package_files(self):
+        """Files the artifact carries inside the package directory."""
+        return {
+            path for path in self.contents if path.startswith(f"{IMPORT_NAME}/")
+        }
 
-def _gitignore_lines(root):
-    """The ``.gitignore`` hatchling folds into every exclude spec.
-
-    ``ignore-vcs`` defaults to false, so hatchling loads the nearest
-    ``.gitignore`` at or above the project root, stopping at the repo boundary
-    (``hatchling.utils.fs.locate_file``). Skipping it here would make the guard
-    narrower than the build and miss a module a stray ignore rule strips.
-    """
-    current = root
-    while True:
-        candidate = current / ".gitignore"
-        if candidate.is_file():
-            return candidate.read_text(encoding="utf-8").splitlines()
-        if (current / ".git").exists() or current == current.parent:
-            return []
-        current = current.parent
-
-
-class TargetSelection:
-    """Which files one hatchling build target ships.
-
-    Mirrors ``hatchling.builders.config.BuilderConfig``: an exclude spec built
-    from hatchling's global patterns, the local ``.gitignore`` and the declared
-    ``exclude``; an include spec from ``include`` plus one ``/<dir>/`` pattern per
-    ``packages`` entry; and ``only-include`` roots, which ``packages`` populates
-    too. Files under an only-include root are selected "explicitly", which bypasses
-    the include spec but not the exclude spec.
-    """
-
-    def __init__(self, source, options, root, plugin_name, project_name):
-        self.source = source
-        unmodeled = sorted(set(options) - MODELED_OPTIONS - INERT_OPTIONS)
-        if unmodeled:
-            named = ", ".join(repr(option) for option in unmodeled)
-            raise UnmodeledBuildOption(
-                f"{source} declares {named}, which this guard does not model, so any "
-                "verdict about the files it ships would be a guess. Model the option "
-                "in TargetSelection (see hatchling/builders/config.py) or drop it."
-            )
-
-        packages = [package.strip("/") for package in options.get("packages", [])]
-        nested = [package for package in packages if "/" in package]
-        if nested:
-            raise UnmodeledBuildOption(
-                f"{source} declares nested packages {nested!r}, which also make "
-                "hatchling rewrite distribution paths via `sources`, so a module's "
-                "shipped import path stops matching its path in the tree. Model "
-                "`sources` in TargetSelection before using a src layout."
-            )
-
-        include = list(options.get("include", []))
-        only_include = [
-            path.strip("/") for path in options.get("only-include", [])
-        ] or packages
-        if plugin_name == "wheel" and not (include or only_include):
-            only_include = _auto_detected_wheel_packages(root, project_name, source)
-
-        self.only_include = only_include
-        self._exclude_patterns = [
-            *(("a hatchling default", p) for p in GLOBAL_EXCLUDE_PATTERNS),
-            *((".gitignore", line) for line in _gitignore_lines(root)),
-            *((f"{source} exclude", p) for p in options.get("exclude", [])),
-        ]
-        self._exclude_spec = pathspec.GitIgnoreSpec.from_lines(
-            pattern for _origin, pattern in self._exclude_patterns
-        )
-        self._include_patterns = [*include, *(f"/{package}/" for package in packages)]
-        self._include_spec = (
-            pathspec.GitIgnoreSpec.from_lines(self._include_patterns)
-            if self._include_patterns
-            else None
-        )
-
-    def ships(self, relpath):
-        return self.rejection(relpath) is None
-
-    def rejection(self, relpath):
-        """Why this target does not ship ``relpath``, or ``None`` when it does."""
-        parts = PurePosixPath(relpath).parts
-        if any(part in EXCLUDED_DIRECTORIES for part in parts[:-1]):
-            return "sits in a directory hatchling always skips"
-        if parts[-1] in EXCLUDED_FILES:
-            return "is a file hatchling always skips"
-
-        explicit = bool(self.only_include)
-        if explicit and not any(
-            relpath == root or relpath.startswith(f"{root}/")
-            for root in self.only_include
-        ):
-            return f"falls outside its only-include roots {self.only_include!r}"
-
-        if self._exclude_spec.match_file(relpath):
-            return f"is stripped by {self._describe_exclusion(relpath)}"
-
-        if (
-            not explicit
-            and self._include_spec is not None
-            and not self._include_spec.match_file(relpath)
-        ):
-            return f"is not selected by its include patterns {self._include_patterns!r}"
-
+    def resolve_module(self, module):
+        """The file in this artifact that ``module`` imports from, or None."""
+        for candidate in _module_candidates(module):
+            if candidate in self.contents:
+                return candidate
         return None
 
-    def _describe_exclusion(self, relpath):
-        """Name the pattern that stripped ``relpath``, for the failure message.
 
-        The verdict itself always comes from the combined spec above; this only
-        looks for the last pattern to claim the path so the message can quote it,
-        and stays vague when it cannot pin one down.
-        """
-        winner = None
-        for origin, pattern in self._exclude_patterns:
-            result = pathspec.GitIgnoreSpec.from_lines([pattern]).check_file(relpath)
-            if result.include is True:
-                winner = (origin, pattern)
-            elif result.include is False:
-                winner = None
-        if winner is None:
-            return "an exclude pattern"
-        origin, pattern = winner
-        return f"{origin} pattern {pattern!r}"
+def _read_wheel(path):
+    with zipfile.ZipFile(path) as archive:
+        return {
+            info.filename: archive.read(info)
+            for info in archive.infolist()
+            if not info.is_dir()
+        }
 
 
-def _auto_detected_wheel_packages(root, project_name, source):
-    """hatchling's wheel fallback when no file selection is declared: the directory
-    named after the project."""
-    guess = re.sub(r"[^\w\d.]+", "_", project_name)
-    if guess and (root / guess / "__init__.py").is_file():
-        return [guess]
-    raise UnmodeledBuildOption(
-        f"{source} declares no `packages`, `include` or `only-include`, and there is "
-        f"no {guess or '<project name>'}/__init__.py, so hatchling falls back to "
-        "src-layout or single-module detection, which this guard does not model. "
-        "Declare `packages` on the target instead."
-    )
-
-
-def _target_selections(config, root):
-    """One ``TargetSelection`` per hatchling build target.
-
-    Target tables override the shared ``[tool.hatch.build]`` options per key. With
-    no target table declared at all, both artifacts are still built from the shared
-    options, so both are checked.
-    """
-    build = config.get("tool", {}).get("hatch", {}).get("build", {})
-    shared = {key: value for key, value in build.items() if key != "targets"}
-    project_name = config.get("project", {}).get("name", "")
-    targets = build.get("targets") or {"wheel": {}, "sdist": {}}
-    return [
-        TargetSelection(
-            f"tool.hatch.build.targets.{name}",
-            {**shared, **options},
-            root,
-            name,
-            project_name,
+def _read_sdist(path):
+    with tarfile.open(path, "r:gz") as archive:
+        members = [member for member in archive.getmembers() if member.isfile()]
+        prefixes = {PurePosixPath(member.name).parts[0] for member in members}
+        assert len(prefixes) == 1, (
+            f"{path.name} has more than one top-level directory {sorted(prefixes)!r}; "
+            "an sdist is required to unpack into exactly one"
         )
-        for name, options in targets.items()
-    ]
+        prefix = prefixes.pop()
+        return {
+            PurePosixPath(member.name).relative_to(prefix).as_posix(): archive.extractfile(
+                member
+            ).read()
+            for member in members
+        }
 
 
-def _declared_entry_points(config):
-    """Yield ``(source, name, value)`` for every entry point in ``[project]``.
+@pytest.fixture(scope="session")
+def built_artifacts(tmp_path_factory):
+    """Build the real wheel and sdist once, into a directory outside the repo.
 
-    Covers ``scripts``, ``gui-scripts`` and every ``entry-points.*`` group, since
-    all three land in the built distribution's ``entry_points.txt``.
+    ``uv build`` builds the sdist and then the wheel *from that sdist*, so a wheel
+    reaching this fixture is also proof the sdist is a complete build input. Keep the
+    command in step with the release workflows; a wheel built straight from the tree
+    is not the artifact consumers install.
     """
-    project = config.get("project", {})
-    for table in ("scripts", "gui-scripts"):
-        for name, value in project.get(table, {}).items():
-            yield f"project.{table}.{name}", name, value
-    for group, entries in project.get("entry-points", {}).items():
-        for name, value in entries.items():
-            yield f"project.entry-points.{group}.{name}", name, value
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.fail(
+            "this guard asserts against real built artifacts and `uv` is not on PATH. "
+            "Run the suite with `uv run python -m pytest` (see the package README)."
+        )
+
+    out_dir = tmp_path_factory.mktemp("dist")
+    command = [
+        uv,
+        "build",
+        "--offline",
+        # The backend comes from this project's locked dev dependencies, so the
+        # build needs no network and no populated uv cache.
+        "--no-build-isolation",
+        "--out-dir",
+        str(out_dir),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=PACKAGE_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "\n".join(
+                [
+                    f"`{' '.join(command)}` failed with exit status "
+                    f"{result.returncode}, so there is nothing to check the "
+                    "published layout against.",
+                    "Fix the build, or run `uv sync` if hatchling is missing from the "
+                    "environment.",
+                    result.stdout,
+                    result.stderr,
+                ]
+            )
+        )
+
+    artifacts = {}
+    for kind, pattern, reader in (
+        ("wheel", "*.whl", _read_wheel),
+        ("sdist", "*.tar.gz", _read_sdist),
+    ):
+        found = sorted(out_dir.glob(pattern))
+        assert len(found) == 1, f"expected exactly one {kind}, got {found!r}"
+        artifacts[kind] = Artifact(kind, found[0].name, reader(found[0]))
+    return artifacts
+
+
+@pytest.fixture(params=["wheel", "sdist"])
+def artifact(request, built_artifacts):
+    """Each invariant below runs against both published artifacts."""
+    return built_artifacts[request.param]
+
+
+# -- shared helpers ---------------------------------------------------------
 
 
 def _module_candidates(module):
-    """The file paths a dotted module name can resolve to, module before package."""
+    """The paths a dotted module name can occupy, module before package."""
     parts = module.split(".")
     return (
-        PurePosixPath(*parts).with_suffix(".py"),
-        PurePosixPath(*parts, "__init__.py"),
+        PurePosixPath(*parts).with_suffix(".py").as_posix(),
+        PurePosixPath(*parts, "__init__.py").as_posix(),
     )
 
 
-def _resolve_module(module, root):
-    for candidate in _module_candidates(module):
-        if (root / candidate).is_file():
-            return candidate.as_posix()
-    return None
-
-
-def _python_files(root):
-    """Every ``.py`` file in the source tree, as forward-slash relative paths."""
+def _source_package_files():
+    """Every file under the package directory in the source checkout."""
+    root = PACKAGE_ROOT / IMPORT_NAME
+    found = set()
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIRECTORIES]
+        dirnames[:] = [name for name in dirnames if name not in DROPPING_DIRS]
         for filename in filenames:
-            if filename.endswith(".py"):
-                yield Path(dirpath, filename).relative_to(root).as_posix()
+            if filename.endswith(DROPPING_SUFFIXES) or filename in DROPPING_NAMES:
+                continue
+            path = Path(dirpath, filename).relative_to(PACKAGE_ROOT)
+            found.add(path.as_posix())
+    return found
 
 
-def _imported_source_files(relpath, root):
-    """Source-tree files ``relpath`` imports, parent packages included.
+def _is_dev_only(relpath):
+    return relpath in DEV_ONLY_FILES or relpath.startswith(DEV_ONLY_TREES)
 
-    Imports that resolve outside the tree (third-party, stdlib) and ``from``
-    targets that name a function rather than a submodule resolve to nothing and
-    drop out.
+
+def _entry_points(artifact):
+    """Yield ``(label, value)`` for every entry point the artifact would install.
+
+    For a wheel that is the backend's own ``entry_points.txt``, the file pip turns
+    into commands on a consumer's PATH. An sdist carries no such file, so it is read
+    from the ``pyproject.toml`` inside the sdist, which is what a wheel built from it
+    declares. Both are the artifact's own bytes; neither is the working tree's.
     """
-    tree = ast.parse((root / relpath).read_text(encoding="utf-8"), filename=relpath)
+    if artifact.kind == "wheel":
+        matches = [
+            path
+            for path in artifact.contents
+            if re.fullmatch(r"[^/]+\.dist-info/entry_points\.txt", path)
+        ]
+        if not matches:
+            return
+        parser = configparser.ConfigParser()
+        parser.optionxform = str  # entry point names are case-sensitive
+        parser.read_string(artifact.text(matches[0]))
+        for group in parser.sections():
+            table = ENTRY_POINT_TABLES.get(group, f"project.entry-points.{group}")
+            for name, value in parser.items(group):
+                yield f"{table}.{name}", value
+        return
+
+    project = tomllib.loads(artifact.text("pyproject.toml")).get("project", {})
+    for table in ("scripts", "gui-scripts"):
+        for name, value in project.get(table, {}).items():
+            yield f"project.{table}.{name}", value
+    for group, entries in project.get("entry-points", {}).items():
+        for name, value in entries.items():
+            yield f"project.entry-points.{group}.{name}", value
+
+
+def _docstring_node_ids(tree):
+    """Ids of the string constants that are docstrings rather than values.
+
+    A docstring naming a module is prose. Every other string literal can be a
+    runtime import target, which is exactly how the launcher reaches the dojo, so
+    those are scanned. Distinguishing the two is what stops this check from being
+    satisfied by a module's own documentation.
+    """
+    ids = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        if not node.body:
+            continue
+        first = node.body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                ids.add(id(first.value))
+    return ids
+
+
+_DOTTED_SELF_REFERENCE = re.compile(rf"\b{IMPORT_NAME}(?:\.[A-Za-z_]\w*)*")
+
+
+def _referenced_modules(source, relpath):
+    """Dotted module names ``relpath`` names, as absolute paths from the root.
+
+    Covers both mechanisms a module can name another by: ``import`` / ``from``
+    statements, and string literals such as the ``"ag_ui_crewai.dojo:app"`` uvicorn
+    target. An AST-only scan is blind to the second, and the second is the mechanism
+    the dojo launcher itself uses.
+    """
+    tree = ast.parse(source, filename=relpath)
     package = PurePosixPath(relpath).parts[:-1]
 
-    dotted = set()
+    names = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            dotted.update(alias.name for alias in node.names)
+            names.update(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom):
             if node.level > len(package):
                 continue
             base = list(package[: len(package) - node.level + 1]) if node.level else []
             prefix = base + (node.module.split(".") if node.module else [])
             if prefix:
-                dotted.add(".".join(prefix))
-            dotted.update(".".join([*prefix, alias.name]) for alias in node.names)
+                names.add(".".join(prefix))
+            names.update(".".join([*prefix, alias.name]) for alias in node.names)
 
-    imported = set()
-    for name in dotted:
-        parts = name.split(".")
-        for depth in range(1, len(parts) + 1):
-            resolved = _resolve_module(".".join(parts[:depth]), root)
-            if resolved is not None:
-                imported.add(resolved)
-    return imported - {relpath}
-
-
-def _entry_point_violations(config, root):
-    """Every way ``config``'s entry points fail to survive its own build config."""
-    violations = []
-    selections = _target_selections(config, root)
-    for source, _name, value in _declared_entry_points(config):
-        module = value.split(":", 1)[0].strip()
-        resolved = _resolve_module(module, root)
-        if resolved is None:
-            tried = ", ".join(str(c) for c in _module_candidates(module))
-            violations.append(
-                f"{source} = {value!r} names module {module!r}, which has no file "
-                f"in the source tree (tried {tried})"
-            )
+    docstrings = _docstring_node_ids(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
             continue
-        for selection in selections:
-            rejection = selection.rejection(resolved)
-            if rejection is not None:
-                violations.append(
-                    f"{source} = {value!r} resolves to {resolved}, which "
-                    f"{selection.source} does not ship: it {rejection}"
-                )
-    return violations
+        if id(node) in docstrings:
+            continue
+        # The pattern stops at the ":" of an import string, so
+        # "ag_ui_crewai.dojo:app" yields the module and drops the attribute.
+        names.update(_DOTTED_SELF_REFERENCE.findall(node.value))
+
+    # Importing ``a.b.c`` needs ``a`` and ``a.b`` too, so every dotted prefix is a
+    # reference in its own right. Prefixes that name nothing in the tree (a
+    # third-party root, or the attribute tail of a ``from`` import) drop out during
+    # resolution.
+    return {
+        ".".join(name.split(".")[:depth])
+        for name in names
+        for depth in range(1, name.count(".") + 2)
+    }
 
 
-def _stripped_import_violations(config, root):
-    """Every shipped module that imports a module its own target strips."""
+def _stripped_reference_violations(artifact, source_files):
+    """Every module in ``artifact`` that names a project module the artifact lacks."""
     violations = []
-    for selection in _target_selections(config, root):
-        for relpath in sorted(_python_files(root)):
-            if not selection.ships(relpath):
+    for relpath in sorted(path for path in artifact.contents if path.endswith(".py")):
+        for name in sorted(_referenced_modules(artifact.text(relpath), relpath)):
+            if artifact.resolve_module(name) is not None:
                 continue
-            for imported in sorted(_imported_source_files(relpath, root)):
-                rejection = selection.rejection(imported)
-                if rejection is not None:
-                    violations.append(
-                        f"{selection.source} ships {relpath}, which imports "
-                        f"{imported}, but that file {rejection}"
-                    )
+            in_tree = next(
+                (c for c in _module_candidates(name) if c in source_files), None
+            )
+            if in_tree is None:
+                continue  # a dependency or the stdlib, not this project's code
+            violations.append(
+                f"{relpath} references {name!r}, which is {in_tree} in the source "
+                f"tree but is not in the {artifact.kind}"
+            )
     return violations
 
 
-# -- the invariants, against the real pyproject.toml ------------------------
+# -- 1. every entry point resolves inside every artifact --------------------
 
 
-def test_declared_entry_points_survive_the_build():
-    """No shipped entry point may point at a module the build strips or omits."""
-    violations = _entry_point_violations(_load_pyproject(), PACKAGE_ROOT)
+def test_every_entry_point_resolves_in_the_artifact(artifact):
+    """No published command may point at a module the build does not ship.
 
-    assert violations == [], "\n".join(
-        [
-            "pyproject.toml declares entry points that the build does not ship, so "
-            "the installed command would raise ModuleNotFoundError:",
-            *(f"  - {v}" for v in violations),
-            "Either drop the entry point (dev-only code runs via "
-            "`uv run python -m <module>` from a checkout) or stop excluding the "
-            "module.",
-        ]
-    )
-
-
-def test_no_shipped_module_imports_a_stripped_module():
-    """The other half of the invariant: a shipped module's imports have to ship too.
-
-    An editable install hides this completely, so a ``from .examples...`` added to
-    a runtime module would only fail on a consumer's machine.
+    Entry points survive any exclude list, so an installed ``dev`` command whose
+    module was stripped raises ModuleNotFoundError on a consumer's machine.
     """
-    violations = _stripped_import_violations(_load_pyproject(), PACKAGE_ROOT)
-
-    assert violations == [], "\n".join(
-        [
-            "modules the build ships import modules it strips, so importing the "
-            "installed package would raise ModuleNotFoundError:",
-            *(f"  - {v}" for v in violations),
-        ]
-    )
-
-
-def test_every_target_ships_the_runtime_package_and_no_dev_only_module():
-    """Pin the split in both directions.
-
-    Equality, not a one-way check: dropping a path from ``exclude`` fails here just
-    as loudly as excluding a module the package needs at runtime.
-    """
-    config = _load_pyproject()
-    modules = {
-        path
-        for path in _python_files(PACKAGE_ROOT)
-        if path.startswith(f"{IMPORT_NAME}/")
-    }
-    dev_only = {
-        path
-        for path in modules
-        if path in DEV_ONLY_FILES or path.startswith(DEV_ONLY_TREES)
-    }
-    runtime = modules - dev_only
-
-    assert set(DEV_ONLY_FILES) <= dev_only, "a dev-only module vanished from the tree"
-    assert set(CORE_MODULES) <= runtime, "a core module vanished from the tree"
-    assert len(dev_only) > len(DEV_ONLY_FILES), "the examples tree vanished"
-
-    for selection in _target_selections(config, PACKAGE_ROOT):
-        shipped = {path for path in modules if selection.ships(path)}
-
-        assert shipped == runtime, "\n".join(
-            [
-                f"{selection.source} does not ship exactly the runtime modules:",
-                *(
-                    f"  - needed at runtime but stripped: {p}"
-                    for p in sorted(runtime - shipped)
-                ),
-                *(f"  - dev-only but shipped: {p}" for p in sorted(shipped - runtime)),
-                "Fix the build config, or update DEV_ONLY_FILES / DEV_ONLY_TREES if "
-                "the split moved on purpose.",
-            ]
+    violations = []
+    for label, value in _entry_points(artifact):
+        module = value.split(":", 1)[0].strip()
+        if artifact.resolve_module(module) is not None:
+            continue
+        if module.split(".")[0] != IMPORT_NAME:
+            continue  # provided by a dependency; not ours to verify
+        tried = ", ".join(_module_candidates(module))
+        violations.append(
+            f"{label} = {value!r} needs module {module!r}, which the "
+            f"{artifact.kind} does not contain (looked for {tried})"
         )
 
-
-def test_the_dojo_launcher_stays_in_the_source_tree():
-    """``python -m ag_ui_crewai`` is what render.yaml and the dojo runner invoke, so
-    the launcher has to exist and reach the dojo even though no artifact ships it."""
-    launcher = f"{IMPORT_NAME}/__main__.py"
-
-    assert (PACKAGE_ROOT / launcher).is_file()
-    # Either an import of the dojo module or the uvicorn import string that names it.
-    assert f"{IMPORT_NAME}/dojo.py" in _imported_source_files(
-        launcher, PACKAGE_ROOT
-    ) or f"{IMPORT_NAME}.dojo" in (PACKAGE_ROOT / launcher).read_text(encoding="utf-8")
-
-
-# -- the checker itself, so the assertions above cannot pass vacuously -----
-#
-# Synthetic configs over a temporary tree: these must keep failing the way they do
-# regardless of what the real pyproject.toml comes to declare.
-
-
-@pytest.fixture
-def fake_package(tmp_path):
-    """A miniature source tree: shipped modules, a dev-only one, a demo subtree."""
-    files = {
-        "pkg/__init__.py": "from .shipped import serve\n",
-        "pkg/shipped.py": "import os\n\n\ndef serve():\n    pass\n",
-        "pkg/dev_only.py": "from .examples import demo\n",
-        "pkg/nested/__init__.py": "",
-        "pkg/nested/mod.py": "",
-        "pkg/examples/__init__.py": "",
-        "pkg/examples/demo.py": "",
-    }
-    for relpath, text in files.items():
-        path = tmp_path / relpath
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text)
-    return tmp_path
-
-
-def _config(scripts, target="wheel", **build_options):
-    """A one-target config whose whitelist ships all of ``pkg``."""
-    return {
-        "project": {"name": "pkg", "scripts": scripts},
-        "tool": {
-            "hatch": {
-                "build": {
-                    "packages": ["pkg"],
-                    **build_options,
-                    "targets": {target: {}},
-                }
-            }
-        },
-    }
-
-
-def test_checker_accepts_a_script_pointing_at_shipped_code(fake_package):
-    config = _config(
-        {"serve": "pkg.shipped:serve"},
-        exclude=["pkg/dev_only.py", "pkg/examples/**"],
+    assert violations == [], "\n".join(
+        [
+            f"{artifact.filename} installs entry points whose modules it does not "
+            "contain, so running the command raises ModuleNotFoundError:",
+            *(f"  - {v}" for v in violations),
+            "Either drop the entry point (dev-only code runs via "
+            "`uv run python -m ag_ui_crewai` from a checkout) or stop excluding the "
+            "module in [tool.hatch.build].",
+        ]
     )
 
-    assert _entry_point_violations(config, fake_package) == []
+
+# -- 2. nothing shipped references anything stripped ------------------------
 
 
-def test_checker_flags_a_script_excluded_by_a_literal_pattern(fake_package):
-    config = _config(
-        {"dev": "pkg.dev_only:main"},
-        exclude=["pkg/dev_only.py", "pkg/examples/**"],
+def test_no_shipped_module_references_a_stripped_module(artifact):
+    """The other half of the invariant: what a shipped module names has to ship too.
+
+    An editable install hides this completely, so a ``from .examples import ...``
+    added to a runtime module would only fail on a consumer's machine.
+    """
+    violations = _stripped_reference_violations(artifact, _source_package_files())
+
+    assert violations == [], "\n".join(
+        [
+            f"{artifact.filename} contains modules that name modules it does not "
+            "contain, so importing the installed package raises ModuleNotFoundError:",
+            *(f"  - {v}" for v in violations),
+            "Either move the reference out of the shipped module or stop excluding "
+            "the module it names in [tool.hatch.build].",
+        ]
     )
 
-    violations = _entry_point_violations(config, fake_package)
 
-    assert len(violations) == 1
-    assert "pkg/dev_only.py" in violations[0]
-    assert "pattern 'pkg/dev_only.py'" in violations[0]
+# -- 3. the dev-only split, over complete file sets -------------------------
 
 
-def test_checker_flags_a_script_excluded_by_a_pattern_without_a_slash(fake_package):
-    """The idiomatic form: gitignore patterns with no slash match at any depth, so
-    ``dev_only.py`` strips ``pkg/dev_only.py``. Hand-rolled fnmatch logic anchors
-    the pattern instead and calls this config green."""
-    config = _config({"dev": "pkg.dev_only:main"}, exclude=["dev_only.py"])
+def test_the_source_tree_still_has_the_split_this_guard_pins():
+    """Preconditions, so the set comparisons below cannot pass by comparing nothing."""
+    source_files = _source_package_files()
+    dev_only = {path for path in source_files if _is_dev_only(path)}
 
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "pattern 'dev_only.py'" in violations[0]
-
-
-def test_checker_flags_a_script_excluded_by_a_recursive_glob(fake_package):
-    """``dir/**`` is the shape hatchling uses for demo trees, and it has to match
-    nested modules, not just direct children."""
-    config = _config({"demo": "pkg.examples.demo:main"}, exclude=["pkg/examples/**"])
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "pkg/examples/demo.py" in violations[0]
-
-
-def test_checker_flags_a_package_entry_point_excluded_as_a_directory(fake_package):
-    """A dotted name can resolve to ``__init__.py``; excluding the directory still
-    strips it."""
-    config = _config({"demo": "pkg.examples:main"}, exclude=["pkg/examples/**"])
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "pkg/examples/__init__.py" in violations[0]
-
-
-def test_checker_honours_a_negated_exclude_pattern(fake_package):
-    """``!`` re-includes, so an exclude list can strip a directory and keep one file
-    in it. Treating ``!`` as a literal pattern would report the kept file as gone."""
-    config = _config(
-        {"demo": "pkg.examples.demo:main"},
-        exclude=["pkg/examples/**", "!pkg/examples/demo.py"],
+    assert set(DEV_ONLY_FILES) <= dev_only, (
+        "a module listed in DEV_ONLY_FILES is gone from the tree; update the list or "
+        "restore the file"
+    )
+    assert set(CORE_MODULES) <= source_files - dev_only, (
+        "a module listed in CORE_MODULES is gone from the tree; update the list or "
+        "restore the file"
+    )
+    assert len(dev_only) > len(DEV_ONLY_FILES), "the examples tree is gone"
+    assert any(not path.endswith(".py") for path in dev_only), (
+        "the examples tree has no non-.py payload left, so `examples/**` staying out "
+        "of the artifacts would only be pinned for modules"
     )
 
-    assert _entry_point_violations(config, fake_package) == []
+
+def test_the_artifact_contains_exactly_the_runtime_package(artifact):
+    """Complete file sets, every extension, in both directions.
+
+    Equality rather than a one-way check: dropping ``__main__.py`` from the exclude
+    list fails here just as loudly as excluding a module the package needs at
+    runtime, and a package-data file going missing fails the same way a module does.
+    """
+    source_files = _source_package_files()
+    expected = {path for path in source_files if not _is_dev_only(path)}
+    shipped = artifact.package_files
+
+    assert shipped == expected, "\n".join(
+        [
+            f"{artifact.filename} does not contain exactly the runtime package:",
+            *(
+                f"  - needed at runtime but missing: {path}"
+                for path in sorted(expected - shipped)
+            ),
+            *(
+                f"  - dev-only but published: {path}"
+                for path in sorted(shipped - expected)
+            ),
+            "Fix [tool.hatch.build] in pyproject.toml, or update DEV_ONLY_FILES / "
+            "DEV_ONLY_TREES in this file if the split moved on purpose.",
+        ]
+    )
 
 
-def test_checker_does_not_let_a_star_cross_a_directory_separator(fake_package):
-    """``*`` stops at ``/`` in gitignore syntax, so ``pkg/*.py`` does not select a
-    nested module. A matcher where ``*`` crosses separators calls this shipped and
-    the module silently goes missing from the artifact."""
-    config = {
-        "project": {"name": "pkg", "scripts": {"serve": "pkg.nested.mod:main"}},
-        "tool": {"hatch": {"build": {"targets": {"sdist": {"include": ["pkg/*.py"]}}}}},
-    }
+def test_the_wheel_contains_nothing_but_the_package_and_its_metadata(built_artifacts):
+    """A wheel unpacks straight into site-packages, so a stray path is a stray
+    top-level install."""
+    wheel = built_artifacts["wheel"]
+    stray = sorted(
+        path
+        for path in wheel.contents
+        if path not in wheel.package_files
+        and not re.match(r"[^/]+\.dist-info/", path)
+    )
 
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "is not selected by its include patterns" in violations[0]
-
-
-def test_checker_treats_whitelist_options_as_alternatives(fake_package):
-    """hatchling ORs the whitelists: ``packages`` and ``include`` feed one spec, and
-    ``packages`` doubles as an only-include root. AND-ing them reports a shipped
-    module as omitted because the ``include`` list says nothing about it."""
-    config = {
-        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
-        "tool": {
-            "hatch": {
-                "build": {
-                    "targets": {
-                        "wheel": {"packages": ["pkg"], "include": ["README.md"]},
-                        "sdist": {"include": ["pkg", "README.md"]},
-                    }
-                }
-            }
-        },
-    }
-
-    assert _entry_point_violations(config, fake_package) == []
+    assert stray == [], "\n".join(
+        [
+            f"{wheel.filename} would install these outside {IMPORT_NAME}/ and outside "
+            "its .dist-info:",
+            *(f"  - {path}" for path in stray),
+            "Narrow the wheel's file selection in [tool.hatch.build.targets.wheel] "
+            "(including any force-include it declares).",
+        ]
+    )
 
 
-def test_checker_covers_gui_scripts_and_entry_point_groups(fake_package):
-    config = {
-        "project": {
-            "name": "pkg",
-            "gui-scripts": {"dev-gui": "pkg.dev_only:gui"},
-            "entry-points": {"some.plugin.group": {"hook": "pkg.dev_only:hook"}},
-        },
-        "tool": {
-            "hatch": {
-                "build": {
-                    "packages": ["pkg"],
-                    "exclude": ["pkg/dev_only.py"],
-                    "targets": {"wheel": {}},
-                }
-            }
-        },
-    }
+def test_the_sdist_carries_only_the_package_and_its_metadata(built_artifacts):
+    """The lean-sdist promise, read off the tarball rather than trusted.
 
-    sources = [v.split(" = ")[0] for v in _entry_point_violations(config, fake_package)]
+    A closed set: this is what catches an sdist that quietly starts shipping the test
+    suite and the lockfile because its target table stopped narrowing the build.
+    """
+    sdist = built_artifacts["sdist"]
+    payload = {path for path in sdist.contents if path not in sdist.package_files}
 
-    assert sources == [
-        "project.gui-scripts.dev-gui",
-        "project.entry-points.some.plugin.group.hook",
-    ]
-
-
-def test_checker_flags_a_script_whose_module_does_not_exist(fake_package):
-    config = _config({"ghost": "pkg.missing:main"})
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "no file in the source tree" in violations[0]
+    assert payload == SDIST_NON_PACKAGE_FILES, "\n".join(
+        [
+            f"{sdist.filename} does not carry exactly the expected metadata payload:",
+            *(
+                f"  - unexpectedly published: {path}"
+                for path in sorted(payload - SDIST_NON_PACKAGE_FILES)
+            ),
+            *(
+                f"  - expected but missing: {path}"
+                for path in sorted(SDIST_NON_PACKAGE_FILES - payload)
+            ),
+            "Fix [tool.hatch.build.targets.sdist] include, or update "
+            "SDIST_NON_PACKAGE_FILES in this file if the payload changed on purpose.",
+        ]
+    )
 
 
-def test_checker_flags_a_script_left_out_of_a_target_whitelist(fake_package):
-    """An sdist ``include`` list is the other way to drop a module: the exclude list
-    stays innocent and the file simply never gets selected."""
-    config = {
-        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
-        "tool": {
-            "hatch": {
-                "build": {
-                    "targets": {
-                        "wheel": {"packages": ["pkg"]},
-                        "sdist": {"include": ["README.md"]},
-                    }
-                }
-            }
-        },
-    }
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "targets.sdist does not ship" in violations[0]
+# -- 4. the launcher no artifact ships still serves the dojo ----------------
 
 
-def test_checker_applies_shared_excludes_to_every_target(fake_package):
-    """``[tool.hatch.build] exclude`` with no per-target override has to be checked
-    once per target, which is how the real config strips the dojo from both."""
-    config = {
-        "project": {"name": "pkg", "scripts": {"dev": "pkg.dev_only:main"}},
-        "tool": {
-            "hatch": {
-                "build": {
-                    "packages": ["pkg"],
-                    "exclude": ["pkg/dev_only.py"],
-                    "targets": {"wheel": {}, "sdist": {}},
-                }
-            }
-        },
-    }
+def test_python_dash_m_hands_uvicorn_a_resolvable_dojo_target(monkeypatch):
+    """``python -m ag_ui_crewai`` is what render.yaml and the dojo runner invoke.
 
-    targets = [
-        v.split("which ")[1].split(" does not ship")[0]
-        for v in _entry_point_violations(config, fake_package)
-    ]
+    Executed rather than read: ``runpy`` runs the launcher exactly as ``-m`` does,
+    with ``uvicorn.run`` captured, so the assertions are about the call that really
+    happens. Reading the file instead is how an earlier version of this test came to
+    be satisfied by the launcher's own docstring.
+    """
+    calls = []
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kwargs: calls.append(app))
 
-    assert sorted(targets) == [
-        "tool.hatch.build.targets.sdist",
-        "tool.hatch.build.targets.wheel",
-    ]
+    try:
+        runpy.run_module(IMPORT_NAME, run_name="__main__")
+    except SystemExit as exit_signal:
+        exit_code = exit_signal.code
+    else:
+        pytest.fail(
+            f"`python -m {IMPORT_NAME}` ran to the end of "
+            f"{IMPORT_NAME}/__main__.py without exiting, so it served nothing and "
+            'reported success. Call main() under an `if __name__ == "__main__":` '
+            "guard."
+        )
 
+    assert exit_code == 0, f"`python -m {IMPORT_NAME}` exited {exit_code!r}, not 0"
+    assert len(calls) == 1, (
+        f"`python -m {IMPORT_NAME}` made {len(calls)} uvicorn.run calls, not 1; the "
+        f"launcher has to serve the dojo, and {IMPORT_NAME}/__main__.py is the only "
+        "place that can (no artifact ships it, so nothing else covers it)"
+    )
 
-def test_checker_flags_a_shipped_module_importing_a_stripped_one(fake_package):
-    config = _config({}, exclude=["pkg/dev_only.py", "pkg/examples/**"])
-    (fake_package / "pkg" / "shipped.py").write_text("from .examples import demo\n")
+    target = calls[0]
+    assert isinstance(target, str), (
+        f"`python -m {IMPORT_NAME}` passed uvicorn a {type(target).__name__} instead "
+        "of an import string. uvicorn sys.exit(1)s on a non-string app whenever "
+        "reload or workers is set, and building the app in the reload supervisor "
+        "builds a second copy nothing serves. Pass "
+        f'"{IMPORT_NAME}.dojo:app" instead.'
+    )
 
-    violations = _stripped_import_violations(config, fake_package)
+    module_name, _, attribute = target.partition(":")
+    assert module_name == f"{IMPORT_NAME}.dojo", (
+        f"`python -m {IMPORT_NAME}` serves {module_name!r}; the launcher exists to "
+        f"serve {IMPORT_NAME}.dojo, which is the module no artifact ships"
+    )
+    assert attribute, f"uvicorn target {target!r} names no application attribute"
 
-    stripped = "stripped by tool.hatch.build.targets.wheel exclude pattern"
-    assert [v.split("ships ")[1] for v in violations] == [
-        f"pkg/shipped.py, which imports pkg/examples/__init__.py, but that file is "
-        f"{stripped} 'pkg/examples/**'",
-        f"pkg/shipped.py, which imports pkg/examples/demo.py, but that file is "
-        f"{stripped} 'pkg/examples/**'",
-    ]
-
-
-def test_checker_ignores_a_stripped_module_importing_a_stripped_one(fake_package):
-    """``pkg/dev_only.py`` imports the demo subtree, and both are excluded, which is
-    exactly the real dojo layout: nothing shipped references either."""
-    config = _config({}, exclude=["pkg/dev_only.py", "pkg/examples/**"])
-
-    assert _stripped_import_violations(config, fake_package) == []
-
-
-def test_checker_refuses_an_unmodeled_build_option(fake_package):
-    """``force-include`` beats ``exclude``, so guessing either way is wrong."""
-    config = _config({"serve": "pkg.shipped:serve"}, **{"force-include": {"x": "y"}})
-
-    with pytest.raises(UnmodeledBuildOption, match="'force-include'"):
-        _entry_point_violations(config, fake_package)
-
-
-def test_checker_refuses_a_src_layout_package(fake_package):
-    config = {
-        "project": {"name": "pkg", "scripts": {"serve": "pkg.shipped:serve"}},
-        "tool": {"hatch": {"build": {"targets": {"wheel": {"packages": ["src/pkg"]}}}}},
-    }
-
-    with pytest.raises(UnmodeledBuildOption, match="sources"):
-        _entry_point_violations(config, fake_package)
-
-
-def test_checker_refuses_a_wheel_it_cannot_resolve(fake_package):
-    """No whitelist and no directory named after the project: hatchling falls back
-    to detection this guard does not model, so it must not answer."""
-    config = {
-        "project": {
-            "name": "unrelated-name",
-            "scripts": {"serve": "pkg.shipped:serve"},
-        },
-        "tool": {"hatch": {"build": {"targets": {"wheel": {}}}}},
-    }
-
-    with pytest.raises(UnmodeledBuildOption, match="src-layout"):
-        _entry_point_violations(config, fake_package)
-
-
-def test_checker_resolves_a_wheel_that_declares_no_file_selection(fake_package):
-    """hatchling's own fallback when the package is named after the project."""
-    config = {
-        "project": {"name": "pkg", "scripts": {"dev": "pkg.dev_only:main"}},
-        "tool": {
-            "hatch": {"build": {"targets": {"wheel": {"exclude": ["pkg/dev_only.py"]}}}}
-        },
-    }
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert "pkg/dev_only.py" in violations[0]
-
-
-def test_checker_applies_gitignore_patterns_like_the_build(fake_package):
-    """``ignore-vcs`` defaults to false, so a ``.gitignore`` rule strips a module
-    from the artifact just as an ``exclude`` entry would."""
-    (fake_package / ".gitignore").write_text("dev_only.py\n")
-    config = _config({"dev": "pkg.dev_only:main"})
-
-    violations = _entry_point_violations(config, fake_package)
-
-    assert len(violations) == 1
-    assert ".gitignore pattern 'dev_only.py'" in violations[0]
+    served = importlib.import_module(module_name)
+    assert hasattr(served, attribute), (
+        f"uvicorn target {target!r} names {attribute!r}, which {module_name} does not "
+        f"define, so `python -m {IMPORT_NAME}` fails at startup"
+    )

--- a/integrations/crew-ai/python/uv.lock
+++ b/integrations/crew-ai/python/uv.lock
@@ -38,8 +38,10 @@ tools = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pathspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.metadata]
@@ -57,8 +59,10 @@ provides-extras = ["tools"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27,<0.29" },
+    { name = "pathspec", specifier = ">=0.12,<2" },
     { name = "pytest", specifier = ">=8.0,<9.0" },
     { name = "pytest-asyncio", specifier = ">=0.24,<0.25" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 
 [[package]]
@@ -2330,6 +2334,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]

--- a/integrations/crew-ai/python/uv.lock
+++ b/integrations/crew-ai/python/uv.lock
@@ -37,8 +37,8 @@ tools = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hatchling" },
     { name = "httpx" },
-    { name = "pathspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -58,8 +58,8 @@ provides-extras = ["tools"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hatchling", specifier = ">=1.27,<2" },
     { name = "httpx", specifier = ">=0.27,<0.29" },
-    { name = "pathspec", specifier = ">=0.12,<2" },
     { name = "pytest", specifier = ">=8.0,<9.0" },
     { name = "pytest-asyncio", specifier = ">=0.24,<0.25" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
@@ -1070,6 +1070,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/08/33331757185504aae48b8d9bd78cec03a76e3aecfb52e549d05a2347c0dd/hatchling-1.32.0.tar.gz", hash = "sha256:0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f", size = 57783, upload-time = "2026-08-11T05:03:44.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl", hash = "sha256:0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc", size = 78435, upload-time = "2026-08-11T05:03:42.644Z" },
 ]
 
 [[package]]
@@ -3681,6 +3698,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3690,6 +3716,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]

--- a/integrations/crew-ai/typescript/README.md
+++ b/integrations/crew-ai/typescript/README.md
@@ -40,5 +40,5 @@ const result = await agent.runAgent({
 
 ```bash
 cd integrations/crew-ai/python
-poetry install && poetry run dev
+uv sync && uv run python -m ag_ui_crewai.dojo
 ```

--- a/integrations/crew-ai/typescript/README.md
+++ b/integrations/crew-ai/typescript/README.md
@@ -38,7 +38,10 @@ const result = await agent.runAgent({
 
 ## To run the example server in the dojo
 
+The dojo server is development-only and is not shipped in the published
+`ag-ui-crewai` package, so run it from a checkout of this repository.
+
 ```bash
 cd integrations/crew-ai/python
-uv sync && uv run python -m ag_ui_crewai.dojo
+uv sync && uv run python -m ag_ui_crewai
 ```

--- a/render.yaml
+++ b/render.yaml
@@ -40,9 +40,9 @@ projects:
         sync: false
       region: virginia
       buildCommand: uv sync
-      # No `dev` console script is declared for the development-only dojo: an
-      # entry point would ship in the published metadata and point at a module
-      # the build excludes. Run it as a module from the source checkout instead.
+      # No `dev` console script exists for this dojo, and the target must stay
+      # the package (`-m ag_ui_crewai.dojo` exits 0 without serving). Rationale
+      # in integrations/crew-ai/python/pyproject.toml.
       startCommand: uv run python -m ag_ui_crewai
       autoDeployTrigger: commit
       rootDir: integrations/crew-ai/python

--- a/render.yaml
+++ b/render.yaml
@@ -40,9 +40,8 @@ projects:
         sync: false
       region: virginia
       buildCommand: uv sync
-      # No `dev` console script exists for this dojo, and the target must stay
-      # the package (`-m ag_ui_crewai.dojo` exits 0 without serving). Rationale
-      # in integrations/crew-ai/python/pyproject.toml.
+      # No `dev` console script exists for this dojo, and the target must stay the
+      # package. Rationale in integrations/crew-ai/python/pyproject.toml.
       startCommand: uv run python -m ag_ui_crewai
       autoDeployTrigger: commit
       rootDir: integrations/crew-ai/python

--- a/render.yaml
+++ b/render.yaml
@@ -40,9 +40,10 @@ projects:
         sync: false
       region: virginia
       buildCommand: uv sync
-      # No `dev` console script: the dojo module is excluded from the published
-      # artifacts, so it is run as a module from the source checkout.
-      startCommand: uv run python -m ag_ui_crewai.dojo
+      # No `dev` console script is declared for the development-only dojo: an
+      # entry point would ship in the published metadata and point at a module
+      # the build excludes. Run it as a module from the source checkout instead.
+      startCommand: uv run python -m ag_ui_crewai
       autoDeployTrigger: commit
       rootDir: integrations/crew-ai/python
     - type: web

--- a/render.yaml
+++ b/render.yaml
@@ -40,7 +40,9 @@ projects:
         sync: false
       region: virginia
       buildCommand: uv sync
-      startCommand: uv run dev
+      # No `dev` console script: the dojo module is excluded from the published
+      # artifacts, so it is run as a module from the source checkout.
+      startCommand: uv run python -m ag_ui_crewai.dojo
       autoDeployTrigger: commit
       rootDir: integrations/crew-ai/python
     - type: web


### PR DESCRIPTION
## What

`uv run python -m ag_ui_crewai` could not be stopped with Ctrl-C. The dojo kept serving after SIGINT and needed a SIGKILL to go away, leaving the port bound in the meantime.

## Why it happened

`import crewai` installs a SIGINT handler that chains in front of uvicorn's own. Before delegating to uvicorn, that handler force-flushes queued telemetry spans to crewai's OTLP endpoint, which is a blocking network connect with a 30 second timeout, run from inside the signal handler.

So the reloader's worker never reaches uvicorn's `handle_exit`, and the reloader parent meanwhile sits in `process.join()` still holding the listening socket. The port stays bound and requests keep being served until the worker is killed.

Captured mid-hang, the worker is inside the handler on a socket connect to the telemetry endpoint while the parent waits on it:

```
pid 85557 (spawn worker)  TCP *:8744 (LISTEN) + ...->167.99.24.219:4319 (ESTABLISHED)
    uv__io_poll -> PyErr_CheckSignals -> sock_connect -> internal_connect
                -> PyErr_CheckSignals -> acquire_timed
pid 85432 (reloader)      TCP *:8744 (LISTEN)   os_waitpid
```

Only the worker blocks. A process that imports crewai but builds no flows has no spans queued and exits in 0.9 seconds; the worker builds every dojo flow, so it has spans to export.

## The fix

Opt the dojo out of crewai's telemetry, which skips the handler registration entirely.

Two constraints shaped where it goes:

- It has to happen before `uvicorn.run` spawns the worker, since the worker inherits the environment and is where the app, and so crewai, is imported.
- It cannot live in `dojo.py`. `ag_ui_crewai/__init__.py` imports `.endpoint`, which imports crewai, so by the time any submodule body runs the handler is already installed. An opt-out there would be dead code.

`os.environ.setdefault` leaves an explicit choice alone, so a developer who wants telemetry on for a dojo run can still have it, hang included. The README documents the default and that trade.

Bounding the span-export timeout was the alternative and was rejected: crewai passes `timeout=30` to the exporter explicitly, so no environment variable overrides it, and any bound would still run network I/O from inside a signal handler.

Per the scope of this fix, no worker supervision was added to the launcher and `reload=True` is unchanged.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `/openapi.json` | 28 paths | 28 paths |
| Group SIGINT | still serving past 30s, needed SIGKILL | exits 130 in 0.2s, port released |
| SIGINT to launcher alone | n/a | exits 0 in 0.9s, no survivors, port released |
| `pytest` | 748 passed, 2 skipped | 750 passed, 2 skipped |

Reproduced and verified on macOS, Python 3.12.0, uvicorn 0.34.3, crewai 1.15.11.

## Tests

Two tests in `tests/test_launcher.py`, alongside the existing launcher contract tests:

- the opt-out is in the environment *before* `uvicorn.run` is called, which is the property that makes the worker inherit it
- an explicit `CREWAI_DISABLE_TELEMETRY` value is not overwritten

## Scope notes

- The dojo, its flows and the launcher are development-only and excluded from the published wheel and sdist, so this changes nothing for consumers of `ag-ui-crewai`.
- The underlying behaviour is not dojo-specific. Any uvicorn app using this bridge with `reload=True` can hit the same hang, since the cause is crewai performing network I/O in a signal handler. That library-side exposure is left open here.
- This branch also carries the preceding dojo launcher commits (`python -m ag_ui_crewai`, the single-build fix, and the packaging guards), which were not yet pushed anywhere. The Ctrl-C fix builds directly on them. Happy to split them into a base PR and stack this one on top if that reads better for review.
