### PR TITLE
feat(mastra): opt-in live TOOL_CALL_START for server tools

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -233,6 +233,7 @@ export function makeLocalMastraAgent(
     streamChunks?: any[];
     resumeChunks?: any[];
     emitInterruptOutcome?: boolean;
+    streamServerToolCalls?: boolean;
     observationalMemory?: boolean;
     usage?: any;
     model?: any;
@@ -243,6 +244,7 @@ export function makeLocalMastraAgent(
     agent: new FakeLocalAgent(opts) as any,
     resourceId: "resource-1",
     emitInterruptOutcome: opts.emitInterruptOutcome,
+    streamServerToolCalls: opts.streamServerToolCalls,
     observationalMemory: opts.observationalMemory,
   });
 }
@@ -252,6 +254,7 @@ export function makeRemoteMastraAgent(
     streamChunks?: any[];
     resumeChunks?: any[];
     emitInterruptOutcome?: boolean;
+    streamServerToolCalls?: boolean;
     observationalMemory?: boolean;
   } = {},
 ) {
@@ -260,6 +263,7 @@ export function makeRemoteMastraAgent(
     agent: new FakeRemoteAgent(opts) as any,
     resourceId: "resource-1",
     emitInterruptOutcome: opts.emitInterruptOutcome,
+    streamServerToolCalls: opts.streamServerToolCalls,
     observationalMemory: opts.observationalMemory,
   });
 }

--- a/integrations/mastra/typescript/src/__tests__/tool-call-streaming.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/tool-call-streaming.test.ts
@@ -225,3 +225,181 @@ describe("incremental tool-call args (chunk processor)", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Opt-in: stream SERVER tool calls live (MastraAgentConfig.streamServerToolCalls)
+// ---------------------------------------------------------------------------
+
+const SERVER_TOOL = "deep_research";
+
+function serverToolStreamingChunks(toolCallId = "tc-s1") {
+  return [
+    {
+      type: "tool-call-input-streaming-start",
+      payload: { toolCallId, toolName: SERVER_TOOL },
+    },
+    {
+      type: "tool-call-delta",
+      payload: { argsTextDelta: '{"q":', toolCallId, toolName: SERVER_TOOL },
+    },
+    {
+      type: "tool-call-delta",
+      payload: { argsTextDelta: '"x"}', toolCallId, toolName: SERVER_TOOL },
+    },
+  ];
+}
+
+describe("streamServerToolCalls (opt-in live server-tool calls)", () => {
+  describe.each([
+    ["local", makeLocalMastraAgent],
+    ["remote", makeRemoteMastraAgent],
+  ])("%s agent path", (_label, makeAgent) => {
+    it("opens the call from the arg stream, not from the flush that follows the result", async () => {
+      // The buffered (default) path emits the whole family in one flush driven
+      // by the NEXT chunk — for a sequential server tool that is its own
+      // `tool-result`, so nothing renders while the tool runs. Taking the live
+      // path is observable in the args: one ARGS per raw JSON fragment, which
+      // only the streaming path produces (the buffered path emits a single
+      // JSON.stringify of the assembled object).
+      const agent = makeAgent({
+        streamServerToolCalls: true,
+        streamChunks: [
+          ...serverToolStreamingChunks(),
+          {
+            type: "tool-call-input-streaming-end",
+            payload: { toolCallId: "tc-s1" },
+          },
+          {
+            type: "tool-call",
+            payload: {
+              toolCallId: "tc-s1",
+              toolName: SERVER_TOOL,
+              args: { q: "x" },
+            },
+          },
+          {
+            type: "tool-result",
+            payload: { toolCallId: "tc-s1", result: { ok: true } },
+          },
+        ],
+      });
+      const events = await collectEvents(agent, input()); // server tool: absent from input().tools
+
+      const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS);
+      expect((args as any[]).map((e) => e.delta)).toEqual(['{"q":', '"x"}']);
+
+      const relevant = events
+        .filter((e) =>
+          [
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+            EventType.TOOL_CALL_RESULT,
+          ].includes(e.type),
+        )
+        .map((e) => e.type);
+      expect(relevant).toEqual([
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+      ]);
+    });
+
+    it("is off by default — the same stream buffers into one ARGS", async () => {
+      const agent = makeAgent({
+        streamChunks: [
+          ...serverToolStreamingChunks(),
+          {
+            type: "tool-call-input-streaming-end",
+            payload: { toolCallId: "tc-s1" },
+          },
+          {
+            type: "tool-call",
+            payload: {
+              toolCallId: "tc-s1",
+              toolName: SERVER_TOOL,
+              args: { q: "x" },
+            },
+          },
+          {
+            type: "tool-result",
+            payload: { toolCallId: "tc-s1", result: { ok: true } },
+          },
+        ],
+      });
+      const events = await collectEvents(agent, input());
+
+      const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS);
+      expect(args).toHaveLength(1);
+      expect(JSON.parse((args[0] as any).delta)).toEqual({ q: "x" });
+    });
+  });
+
+  it("closes a live-streamed call when the tool suspends (no orphaned START)", async () => {
+    // Suppression by clearing the buffer is not available for a call that
+    // already emitted TOOL_CALL_START, so the suspend arm closes it instead.
+    const agent = makeLocalMastraAgent({
+      streamServerToolCalls: true,
+      streamChunks: [
+        ...serverToolStreamingChunks("tc-s2"),
+        {
+          type: "tool-call-suspended",
+          payload: {
+            toolCallId: "tc-s2",
+            toolName: SERVER_TOOL,
+            suspendPayload: { reason: "needs approval" },
+            args: { q: "x" },
+          },
+        },
+      ],
+    });
+    const events = await collectEvents(agent, input());
+
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_START),
+    ).toHaveLength(1);
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_END),
+    ).toHaveLength(1);
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_RESULT),
+    ).toHaveLength(0);
+    // The interrupt itself still surfaces.
+    expect(events.filter((e) => e.type === EventType.CUSTOM)).toHaveLength(1);
+  });
+
+  it("closes a live-streamed call when the tool goes to the background", async () => {
+    const agent = makeLocalMastraAgent({
+      streamServerToolCalls: true,
+      streamChunks: [
+        ...serverToolStreamingChunks("tc-s3"),
+        {
+          type: "background-task-started",
+          payload: {
+            taskId: "task-1",
+            toolName: SERVER_TOOL,
+            toolCallId: "tc-s3",
+          },
+        },
+        { type: "finish", payload: { finishReason: "stop" } },
+      ],
+    });
+    const events = await collectEvents(agent, input());
+
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_START),
+    ).toHaveLength(1);
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_END),
+    ).toHaveLength(1);
+    expect(
+      events.filter((e) => e.type === EventType.TOOL_CALL_RESULT),
+    ).toHaveLength(0);
+    // The work continues as an activity.
+    expect(
+      events.filter((e) => e.type === EventType.ACTIVITY_SNAPSHOT),
+    ).toHaveLength(1);
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -413,6 +413,28 @@ export interface MastraAgentConfig extends AgentConfig {
    */
   emitInterruptOutcome?: boolean;
   /**
+   * Also open the tool-call family live (TOOL_CALL_START / ARGS / END as the
+   * args stream) for SERVER tools, not only for client generative-UI tools.
+   *
+   * Default **false** — today's behavior. A server tool's call is buffered in
+   * `pendingToolCall` and flushed by the NEXT chunk, which for an ordinary
+   * sequential tool is its own `tool-result`: the subscriber then receives
+   * START / ARGS / END / RESULT in one flush after the tool has already
+   * finished, so a long-running server tool paints no "running" step at all.
+   * Turn this on when your UI renders tool activity and you want that step to
+   * appear while the tool runs.
+   *
+   * The reason it is opt-in: a live-streamed call cannot be retracted. The
+   * buffer is what lets a following `tool-call-suspended` /
+   * `background-task-started` suppress the normal tool render, and a call that
+   * already emitted TOOL_CALL_START can only be CLOSED (TOOL_CALL_END), not
+   * un-emitted. Under this option those two paths therefore close the streamed
+   * call instead of suppressing it, and the consumer sees a tool call with no
+   * TOOL_CALL_RESULT (the interrupt / activity carries the outcome). If your
+   * server tools suspend or run as background tasks, leave this off.
+   */
+  streamServerToolCalls?: boolean;
+  /**
    * A2UI auto-injection config (local agents). When the runtime/middleware
    * forwards `injectA2UITool`, the bridge injects a backend-owned `generate_a2ui`
    * tool (recovery + subagent) per run so the developer wires nothing — the
@@ -573,6 +595,8 @@ export class MastraAgent extends AbstractAgent {
   public headers?: Record<string, string>;
   /** See MastraAgentConfig.emitInterruptOutcome. Default true. */
   emitInterruptOutcome: boolean;
+  /** See MastraAgentConfig.streamServerToolCalls. Default false. */
+  streamServerToolCalls: boolean;
   /** See MastraAgentConfig.a2ui — A2UI auto-injection config. */
   a2ui?: A2UIInjectConfig;
   /** See MastraAgentConfig.remoteClient. Set for remote agents only. */
@@ -607,6 +631,7 @@ export class MastraAgent extends AbstractAgent {
       untilIdle,
       tracingOptions,
       emitInterruptOutcome,
+      streamServerToolCalls,
       a2ui,
       remoteClient,
       useProcessedFinalText,
@@ -615,6 +640,7 @@ export class MastraAgent extends AbstractAgent {
     } = config;
     super(rest);
     this.emitInterruptOutcome = emitInterruptOutcome ?? true;
+    this.streamServerToolCalls = streamServerToolCalls ?? false;
     this.agent = agent;
     this.resourceId = resourceId;
     this.requestContext = requestContext ?? new RequestContext();
@@ -1467,6 +1493,14 @@ export class MastraAgent extends AbstractAgent {
     const isClientTool = (toolName?: string) =>
       !!toolName && clientToolNames.has(toolName);
 
+    // Opt-in (MastraAgentConfig.streamServerToolCalls): stream SERVER tools
+    // live too, so a long-running one paints a "running" step instead of
+    // appearing only once it has finished. The suspend / background arms below
+    // close such a call rather than suppressing it — an emitted START cannot be
+    // retracted.
+    const streamsLive = (toolName?: string) =>
+      isClientTool(toolName) || (this.streamServerToolCalls && !!toolName);
+
     // Floor / fall-back path: a final `tool-call` with no preceding client
     // delta stream is buffered here so a following tool-call-suspended /
     // background-task-started can suppress it (and reuse its args). Tool calls
@@ -1948,10 +1982,7 @@ export class MastraAgent extends AbstractAgent {
             workingMemoryToolCalls.add(chunk.payload.toolCallId);
             break;
           }
-          if (
-            chunk.payload.toolCallId &&
-            isClientTool(chunk.payload.toolName)
-          ) {
+          if (chunk.payload.toolCallId && streamsLive(chunk.payload.toolName)) {
             startStreamedToolCall(
               chunk.payload.toolCallId,
               chunk.payload.toolName,
@@ -1976,9 +2007,10 @@ export class MastraAgent extends AbstractAgent {
             }
             break;
           }
-          // Only forward deltas for a call we opened as a live (client) stream.
-          // Server-tool deltas are ignored; their args ride the final
-          // `tool-call` chunk into the buffered path.
+          // Only forward deltas for a call we opened as a live stream (client
+          // tools, plus server tools under streamServerToolCalls). Deltas for a
+          // buffered call are ignored; its args ride the final `tool-call`
+          // chunk into the buffered path.
           if (
             toolCallId &&
             streamedStarted.has(toolCallId) &&
@@ -2139,6 +2171,15 @@ export class MastraAgent extends AbstractAgent {
           // call is orphaned (never executed) so emitting TOOL_CALL_START/
           // ARGS/END without a TOOL_CALL_RESULT would violate the protocol.
           pendingToolCall = null;
+          // Under streamServerToolCalls the call may already be OPEN rather
+          // than buffered, and an emitted TOOL_CALL_START cannot be retracted —
+          // close it so the suspend does not leave a start without a terminal.
+          if (
+            chunk.payload.toolCallId &&
+            streamedStarted.has(chunk.payload.toolCallId)
+          ) {
+            endStreamedToolCall(chunk.payload.toolCallId);
+          }
           if (!chunk.payload.toolCallId || !chunk.payload.toolName) {
             callbacks.onError(
               new Error(
@@ -2219,6 +2260,13 @@ export class MastraAgent extends AbstractAgent {
               ? pendingToolCall.args
               : undefined;
           pendingToolCall = null;
+          // Under streamServerToolCalls the call may already be OPEN rather
+          // than buffered (same reasoning as tool-call-suspended above): close
+          // it, because the work continues as an activity and no
+          // TOOL_CALL_RESULT will follow.
+          if (toolCallId && streamedStarted.has(toolCallId)) {
+            endStreamedToolCall(toolCallId);
+          }
           if (taskId && toolCallId) {
             backgroundToolCalls.set(toolCallId, { taskId, toolName });
           }


### PR DESCRIPTION
Relates to #2402.

## What this does

Adds `MastraAgentConfig.streamServerToolCalls` (default `false` — exactly today's behaviour). When enabled, `tool-call-input-streaming-start` opens the tool-call family for any named tool, not only client generative-UI tools, so a long-running SERVER tool renders a "running" step while it runs.

## The problem

Live tool-call streaming is gated to CLIENT tools (`isClientTool`, `mastra.ts:1467`), so a server tool takes the buffered path: `case "tool-call"` parks the call in `pendingToolCall` and `flush()` runs only on the NEXT chunk — which, for an ordinary sequential tool, is its own `tool-result`. The subscriber then receives TOOL_CALL_START / ARGS / END / RESULT in one same-millisecond flush, after the tool has already finished.

Measured on our stack (`@ag-ui/mastra@1.1.1` + `@ag-ui/client@0.0.57` + `@assistant-ui/react-ag-ui@0.0.54`): a loopback capture of a multi-second transcription tool shows the whole family in a single flush. On a synthetic `fullStream` with a 1500 ms gap between `tool-call-input-streaming-start` and `tool-result`, pristine 1.1.1 gives a 1 ms visible window between START and RESULT; with the gate widened, 1502 ms. Those two numbers come from a timing harness in our own tree, not from the unit tests below.

## Why it is opt-in, and the open design question

The gate is load-bearing and the code says so at `mastra.ts:1459-1466`: buffering is what lets a following `tool-call-suspended` or `background-task-started` suppress the normal tool render by clearing `pendingToolCall`. An already-emitted live arg stream cannot be retracted.

This PR resolves that by **closing** such a call: under the option, both arms call `endStreamedToolCall`, so a START is never left without a terminal. The consumer sees a tool call with no `TOOL_CALL_RESULT`, and the interrupt or the activity carries the outcome — documented on the option.

The other defensible resolution is to declare the option unsupported for suspendable / background tools and refuse the combination. #2402 puts both on the table; I implemented the first because it keeps the option usable without the bridge needing to know in advance whether a tool can suspend. Happy to switch if you prefer the second.

## Tests

`src/__tests__/tool-call-streaming.test.ts` — the existing home, which already covers the buffered server-tool path:

- a server tool under the flag emits one ARGS per raw JSON fragment and the order START, ARGS, ARGS, END, RESULT (one ARGS per fragment is only producible by the live path; the buffered path emits a single `JSON.stringify` of the assembled object) — run for both the local and the remote agent paths;
- the same stream with the flag off still buffers into one ARGS (the default is unchanged);
- a live-streamed call that then suspends is closed exactly once and yields no `TOOL_CALL_RESULT`, while the interrupt still surfaces;
- a live-streamed call that then goes to the background is closed exactly once and the activity snapshot still emits.

```
pnpm vitest run                # 20 files, 315 tests passed
pnpm typecheck                 # clean
```

Run in `integrations/mastra/typescript` against `44a92a0`, with `@ag-ui/core`, `@ag-ui/client`, `@ag-ui/proto` and `@ag-ui/a2ui-toolkit` built from the workspace. I did not run the repo-wide `nx` pipeline or the dojo e2e suites locally. `prettier --check` flags `mastra.ts`, but it does so on unmodified `main` as well — none of the lines it wants to reformat are mine, so I left the file alone rather than mixing a reformat into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
