### PR TITLE
chore(release): sync sdk-py lockfile

### DIFF
--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -1,10 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- regenerate `sdks/python/uv.lock` after the `ag-ui-protocol` 0.1.20 version bump
- unblock the `python` and `lockfiles` jobs on release PR #2405

`release/next` was created before #2375 merged, so the later sdk-py bump still used the old release script that re-locked `uv.lock` without staging it.

## Verification

- `uv 0.12.1 lock --check`
- `uv 0.12.1 sync --locked`
- `uv 0.12.1 run --locked python -m unittest discover tests -v` (126 tests)