### PR TITLE
fix(client): let a new run start after RUN_ERROR in verifyEvents

### DIFF
--- a/sdks/typescript/packages/client/src/verify/__tests__/verify.multiple-runs.test.ts
+++ b/sdks/typescript/packages/client/src/verify/__tests__/verify.multiple-runs.test.ts
@@ -410,6 +410,126 @@ describe("verifyEvents multiple runs", () => {
     expect(events[1].type).toBe(EventType.RUN_ERROR);
   });
 
+  // Test: A new run may start after a previous one errored
+  it("should allow a new RUN_STARTED after RUN_ERROR", async () => {
+    const source$ = new Subject<BaseEvent>();
+
+    const promise = firstValueFrom(
+      verifyEvents(false)(source$).pipe(
+        toArray(),
+        catchError((err) => {
+          throw err;
+        }),
+      ),
+    );
+
+    // First run errors
+    source$.next({
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread-1",
+      runId: "test-run-1",
+    } as RunStartedEvent);
+    source$.next({
+      type: EventType.RUN_ERROR,
+      message: "Agent unreachable",
+    } as RunErrorEvent);
+
+    // Second run starts and succeeds
+    source$.next({
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread-1",
+      runId: "test-run-2",
+    } as RunStartedEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "msg-1",
+    } as TextMessageStartEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: "msg-1",
+    } as TextMessageEndEvent);
+    source$.next(runFinished("test-thread-1", "test-run-2"));
+
+    source$.complete();
+
+    const result = await promise;
+
+    expect(result.length).toBe(6);
+    expect(result[1].type).toBe(EventType.RUN_ERROR);
+    expect((result[2] as RunStartedEvent).runId).toBe("test-run-2");
+    expect(result[5].type).toBe(EventType.RUN_FINISHED);
+  });
+
+  // Test: Replaying a stored thread whose middle run errored
+  it("should replay a thread containing an errored run without dropping later runs", async () => {
+    const source$ = new Subject<BaseEvent>();
+
+    const promise = firstValueFrom(
+      verifyEvents(false)(source$).pipe(
+        toArray(),
+        catchError((err) => {
+          throw err;
+        }),
+      ),
+    );
+
+    // Run 1 succeeded
+    source$.next({
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread-1",
+      runId: "test-run-1",
+    } as RunStartedEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "msg-1",
+    } as TextMessageStartEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: "msg-1",
+    } as TextMessageEndEvent);
+    source$.next(runFinished("test-thread-1", "test-run-1"));
+
+    // Run 2 errored, mid-message, which is what a dropped connection looks like
+    source$.next({
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread-1",
+      runId: "test-run-2",
+    } as RunStartedEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "msg-2",
+    } as TextMessageStartEvent);
+    source$.next({
+      type: EventType.RUN_ERROR,
+      message: "Agent restarted",
+    } as RunErrorEvent);
+
+    // Run 3 succeeded, and reuses the message ID left open by the errored run
+    source$.next({
+      type: EventType.RUN_STARTED,
+      threadId: "test-thread-1",
+      runId: "test-run-3",
+    } as RunStartedEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "msg-2",
+    } as TextMessageStartEvent);
+    source$.next({
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: "msg-2",
+    } as TextMessageEndEvent);
+    source$.next(runFinished("test-thread-1", "test-run-3"));
+
+    source$.complete();
+
+    const result = await promise;
+
+    // Every event in the thread is delivered, not just those up to the failure
+    expect(result.length).toBe(11);
+    expect((result[7] as RunStartedEvent).runId).toBe("test-run-3");
+    expect(result[10].type).toBe(EventType.RUN_FINISHED);
+  });
+
   // Test: Complex scenario with mixed events across runs
   it("should handle complex scenario with multiple runs and various event types", async () => {
     const source$ = new Subject<BaseEvent>();

--- a/sdks/typescript/packages/client/src/verify/verify.ts
+++ b/sdks/typescript/packages/client/src/verify/verify.ts
@@ -39,8 +39,10 @@ export const verifyEvents =
 
         log?.event("VERIFY", "Event:", event, { type: event.type });
 
-        // Check if run has errored
-        if (runError) {
+        // Check if run has errored (but allow a new RUN_STARTED to start a new run, exactly as
+        // RUN_FINISHED does below). A stream can legitimately carry more than one run, a replay of
+        // a stored thread being the common case, and a run that errored is over rather than active.
+        if (runError && eventType !== EventType.RUN_STARTED) {
           return throwError(
             () =>
               new AGUIError(
@@ -70,8 +72,8 @@ export const verifyEvents =
             return throwError(() => new AGUIError(`First event must be 'RUN_STARTED'`));
           }
         } else if (eventType === EventType.RUN_STARTED) {
-          // Allow RUN_STARTED after RUN_FINISHED (new run), but not during an active run
-          if (runStarted && !runFinished) {
+          // Allow RUN_STARTED after RUN_FINISHED or RUN_ERROR (new run), but not during an active run
+          if (runStarted && !runFinished && !runError) {
             return throwError(
               () =>
                 new AGUIError(
@@ -79,9 +81,10 @@ export const verifyEvents =
                 ),
             );
           }
-          // If we're here, it's either the first RUN_STARTED or a new run after RUN_FINISHED
-          if (runFinished) {
-            // This is a new run after the previous one finished, reset state
+          // If we're here, it's either the first RUN_STARTED or a new run after the previous one
+          // ended, whether that end was RUN_FINISHED or RUN_ERROR
+          if (runFinished || runError) {
+            // This is a new run after the previous one ended, reset state
             resetRunState();
           }
         }


### PR DESCRIPTION
Fixes #2408.

## The asymmetry

`verifyEvents` keeps two terminal flags. `RUN_FINISHED` is recoverable: a following `RUN_STARTED` resets the verifier and begins a new run. `RUN_ERROR` is not. `resetRunState()` is only reachable through `runFinished`, and the `runError` check runs before the `RUN_STARTED` branch is ever evaluated, so once a stream carries a `RUN_ERROR` every subsequent event throws, `RUN_STARTED` included.

A live run never notices, because each run is its own stream with its own verifier instance. A stream carrying more than one run does. Replaying a stored thread pushes every run through a single verifier, so the first failed turn discards every turn after it, and `AbstractAgent.connectAgent` pipes the connect stream through `verifyEvents` unconditionally. A thread containing one failed run hydrates as empty rather than as its stored contents, with no error surfaced to the user.

Measured on `0.0.58` before this change:

| thread | messages hydrated |
| -- | -- |
| every run succeeded | 3 |
| same thread, middle run errored | 0 |

## The change

Treat `RUN_ERROR` the way `RUN_FINISHED` is already treated. It ends the run, and the next `RUN_STARTED` begins a new one and resets the verifier.

Three lines, all mirroring the existing `runFinished` handling:

* the `runError` guard admits `RUN_STARTED`
* `RUN_STARTED` during an active run is still rejected, but a run that errored no longer counts as active
* `resetRunState()` runs for `runError` as well as `runFinished`

Events after `RUN_ERROR` that are not `RUN_STARTED` are still rejected, so nothing about the single-run contract changes.

## Tests

Two added to `verify.multiple-runs.test.ts`:

* a new `RUN_STARTED` is accepted after `RUN_ERROR`
* a three-run replay whose middle run errored mid-message delivers all eleven events, and the third run may reuse the message ID the errored run left open

Both fail on `main` and pass with the change. The existing suite is untouched: 506 tests pass in `@ag-ui/client`, including the case asserting that non-`RUN_STARTED` events after `RUN_ERROR` are still rejected.
