### PR TITLE
chore(ci): stop the release publish job saving a uv cache it never writes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1072,6 +1072,23 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.PYTHON_VERSION }}
+          # The only uv command in this job is `uv publish`, which uploads
+          # already-built artifacts and never writes to the uv cache. With
+          # caching left on (setup-uv defaults to `enable-cache: auto`,
+          # `ignore-nothing-to-cache: false`), the post step tries to save a
+          # cache directory that was never created and errors:
+          #
+          #   Cache path /home/runner/work/_temp/setup-uv-cache does not exist
+          #
+          # That error fails the whole `publish` job after every package has
+          # already shipped. It only surfaces when the cache key misses, so it
+          # hid behind key hits until run 31929982725 (2026-08-16), where the
+          # release's own pyproject.toml bump changed the key. The damage is
+          # not cosmetic: `publish-dotnet` gates on this job's result, and
+          # `publish-maven` chains off that, so a release carrying both a
+          # Python package and a .NET or Java package would ship npm + PyPI
+          # and then skip the NuGet and Maven lanes.
+          enable-cache: false
 
       - name: Download Python build artifacts (stable)
         if: needs.build.outputs.mode == 'stable' && needs.build.outputs.py_count != '0'


### PR DESCRIPTION
## What happened

[Run 31929982725](https://github.com/ag-ui-protocol/ag-ui/actions/runs/31929982725) (`release / publish`, push of the #2412 release merge) went red. Everything it exists to do succeeded — `@ag-ui/langgraph@0.0.43` and `@ag-ui/mastra@1.1.2` on npm, `ag-ui-langgraph 0.0.43` on PyPI, all three tags pushed at `98e5cf2e`, `release/2026-08-16` release notes reconciled. The job then failed in **`Post Install uv`**:

```
##[error]Cache path /home/runner/work/_temp/setup-uv-cache does not exist on disk.
This likely indicates that there are no dependencies to cache.
```

## Root cause

The `publish` job's `Install uv` step (`.github/workflows/publish-release.yml:1069`) is there so `uv publish` can upload dists that the `build` job already produced. `uv publish` is the only uv command in the job, and it never writes to the uv cache. setup-uv nonetheless enables caching by default (`enable-cache: auto`, `ignore-nothing-to-cache: false`), so its post step tries to save a directory that was never created, and errors.

It only fires when the cache key misses. On [run 31843164597](https://github.com/ag-ui-protocol/ag-ui/actions/runs/31843164597) (Aug 14) the key hit and the post step logged `Cache hit occurred ... not saving cache`. This release bumped `integrations/langgraph/python/pyproject.toml`, which changed the key hash, so the save was attempted for the first time.

## Why it's worth fixing rather than ignoring

`publish-dotnet` gates on `needs.publish.result == 'success' || 'skipped'`, and `publish-maven` chains off `publish-dotnet`. A release carrying **both** a Python package and a .NET or Java package would publish npm + PyPI, fail on this empty-cache save, and then silently skip the NuGet and Maven lanes — a partial release. Run 31929982725 escaped that only because the build job found every .NET and Java package already up to date, so both counts were `0` and those jobs would have skipped anyway.

Secondary: red release runs on `main` train people to ignore the release workflow's status.

## The change

One input on the publish job's setup-uv step, plus a comment recording why.

`enable-cache: false` rather than `ignore-nothing-to-cache: true` — there is no cache to want in this job, so declining one is deterministic, where suppressing the error just hides the same empty save on every run.

The `build` job's setup-uv is deliberately untouched: it runs `uv build` and does populate the cache.

## Verification

- `scripts/release/verify-python-toolchain-pins.sh` passes (17 pin declarations, 18 setup-uv invocations) — it counts `uses:` and `version:` lines, so the added input doesn't affect it
- YAML re-parsed: `enable-cache: false` lands as a boolean on the `publish` job's step only; the `build` job's step is unchanged
- Full effect can only be confirmed by the next release that publishes a Python package

## Not addressed here

Two things noticed while diagnosing, left for separate decisions:

- The `build` job skips the pnpm cache on purpose for supply-chain hermeticity ("cached pnpm stores could be poisoned"), yet restores a uv cache. Inconsistent with the stated policy.
- `arduino/setup-protoc@v3.0.0` runs on the deprecated Node 20 runtime and annotates every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)