### PR TITLE
ci(crew-ai): run the examples project's tests in the crewai-python job

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -567,8 +567,15 @@ jobs:
         id: cached-uv-dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: integrations/crew-ai/python/.venv
-          key: ${{ steps.fork-check.outputs.prefix }}venv-${{ runner.os }}-crewai-py${{ env.PYTHON_VERSION }}-uv${{ env.UV_VERSION }}-${{ hashFiles('integrations/crew-ai/python/uv.lock') }}
+          # Two venvs, because examples/ is a separate uv project with its own lock
+          # and its own resolution — see the examples steps below. Both are keyed on
+          # both lockfiles: they share a path dependency (the library is `{ path =
+          # "..", editable = true }` from examples/), so a change to either lock can
+          # change what the other venv should contain.
+          path: |
+            integrations/crew-ai/python/.venv
+            integrations/crew-ai/python/examples/.venv
+          key: ${{ steps.fork-check.outputs.prefix }}venv-${{ runner.os }}-crewai-py${{ env.PYTHON_VERSION }}-uv${{ env.UV_VERSION }}-${{ hashFiles('integrations/crew-ai/python/uv.lock', 'integrations/crew-ai/python/examples/uv.lock') }}
 
       - name: Install dependencies
         working-directory: integrations/crew-ai/python
@@ -576,6 +583,25 @@ jobs:
 
       - name: Run tests
         working-directory: integrations/crew-ai/python
+        run: uv run --locked python -m pytest tests/ -v
+
+      # The dojo moved out of the library into examples/ (#2396), and its tests moved
+      # with it. They are not demo tests: they pin the two things in the dojo that the
+      # rest of the repo depends on at runtime — the telemetry opt-out at package
+      # import, without which Ctrl-C leaves a server only SIGKILL stops, and the
+      # `0.0.0.0` bind that render.yaml and apps/dojo/scripts/run-dojo-everything.js
+      # both need to reach it in a container. The step above covers tests/ under the
+      # library only, so without these two steps nothing in CI runs them.
+      #
+      # A step in this job rather than a job of its own: it shares this job's
+      # checkout, uv install and cache, and — the reason it matters — the lockfile
+      # assertion below, which measures the whole job and so covers both locks at once.
+      - name: Install examples dependencies
+        working-directory: integrations/crew-ai/python/examples
+        run: uv sync --locked
+
+      - name: Run examples tests
+        working-directory: integrations/crew-ai/python/examples
         run: uv run --locked python -m pytest tests/ -v
 
       - name: Assert no lockfile was rewritten


### PR DESCRIPTION
## What

Adds two steps to the existing `crewai-python` job in `.github/workflows/unit-python-sdk.yml` so the CrewAI **examples** project's test suite runs in CI:

```yaml
- name: Install examples dependencies
  working-directory: integrations/crew-ai/python/examples
  run: uv sync --locked

- name: Run examples tests
  working-directory: integrations/crew-ai/python/examples
  run: uv run --locked python -m pytest tests/ -v
```

## Why

PR #2396 moved the CrewAI dojo out of the published library into `integrations/crew-ai/python/examples/`, a separate uv project, and its tests moved with it into `examples/tests/test_launcher.py`. The job's existing "Run tests" step is scoped to `integrations/crew-ai/python`, which covers the library suite only, so since that merge nothing in CI has run those 9 tests.

They are not demo tests. Two of the things they pin are load-bearing:

- **`agents/__init__.py` sets `CREWAI_DISABLE_TELEMETRY` at package import.** crewai installs a SIGINT handler that flushes spans over the network before delegating to uvicorn's, and with it active Ctrl-C leaves a dojo server that only SIGKILL stops. The opt-out has to run before crewai is imported, which is why it lives in the package `__init__` and not in `dojo.py` (importing the bridge imports crewai). Two subprocess tests cover this.
- **`dojo.py`'s `main()` hands uvicorn the import string `"agents.dojo:app"` with `host="0.0.0.0"` and `reload=True`.** `render.yaml` and `apps/dojo/scripts/run-dojo-everything.js` both run this in a container, so a loopback bind makes it unreachable. One test covers it.

## Shape of the change

A step in the existing job rather than a new job, so both suites share the checkout, the uv install, the cache, and the "Assert no lockfile was rewritten" step. That guard measures the whole job via `git status --porcelain -- '*uv.lock' '*poetry.lock'`, so it now covers both lockfiles at once; both new steps use `--locked` to keep it satisfied.

The cached-venv step gains the examples venv as a second path and keys on both lockfiles. The two projects share a path dependency (`examples/` declares the library as `{ path = "..", editable = true }`), so a change to either lock can change what the other venv should contain.

## Deliberate divergence

No other integration has a CI lane for its examples project. This one is justified because the CrewAI examples project holds runtime behaviour that a merged fix depends on, which the other examples projects do not. Called out in the commit message as well.

## Verification

- **The step fails when it should.** Mutating `host="0.0.0.0"` to `"127.0.0.1"` in `agents/dojo.py` turns the examples suite red on `test_the_server_binds_every_interface_with_reload`: `1 failed, 8 passed`, non-zero exit. Reverted.
- Clean run: `9 passed`.
- `uv sync --locked` and `uv run --locked` in `examples/` both succeed and leave every tracked lockfile unmodified (`git status --porcelain -- '*uv.lock' '*poetry.lock'` empty), which is exactly what the assertion step measures.
- `actionlint` is clean on the workflow.

## Note for reviewers

The `lockfiles` job's `uv lock --check` sweep excludes `*/examples/*`, so nothing verifies the examples lock against its own manifest. `uv sync --locked` passes today; if that lock ever drifts from its `pyproject.toml`, this new step is what reports it, as a sync failure rather than as a lockfile message. Not changed here.