### PR TITLE
fix(a2a): warn when frontend tools cannot reach the A2A agent

### DIFF
--- a/integrations/a2a/typescript/README.md
+++ b/integrations/a2a/typescript/README.md
@@ -33,7 +33,9 @@ const client = new A2AClient("https://my-a2a-agent");
 
 const agent = new A2AAgent({
   a2aClient: client,
-  initialMessages: [{ id: "user-1", role: "user", content: "Plan a team offsite" } as any],
+  initialMessages: [
+    { id: "user-1", role: "user", content: "Plan a team offsite" } as any,
+  ],
 });
 
 const { result, newMessages } = await agent.runAgent();
@@ -42,6 +44,23 @@ console.log(newMessages);
 ```
 
 You can inject your own `A2AClient` instance via the `client` option, override default instructions, or force blocking mode by setting `strategy: "blocking"`.
+
+## Frontend tools are not forwarded
+
+`A2AAgent` cannot deliver frontend tools to an A2A agent. The A2A protocol has no field for client-side tool definitions — its `Message` carries `parts` plus an untyped `metadata` bag, and no server-side behaviour is specified for reading tools out of it. `RunAgentInput.tools` is therefore dropped.
+
+This is easy to misread, because nothing fails: the run succeeds and the tool is simply never called, even though the same tool works over the plain AG-UI HTTP transport. `A2AAgent` logs a warning once per instance when it receives tools, so the cause is visible.
+
+To combine frontend tools with A2A agents, use `A2AMiddlewareAgent` from `@ag-ui/a2a-middleware`. It keeps your tools on an orchestration agent — which receives them the ordinary way — and reaches A2A agents through its own `send_message_to_a2a_agent` tool:
+
+```ts
+import { A2AMiddlewareAgent } from "@ag-ui/a2a-middleware";
+
+const agent = new A2AMiddlewareAgent({
+  orchestrationAgent, // a normal AG-UI agent; your frontend tools stay here
+  agentUrls: ["http://localhost:10007"],
+});
+```
 
 ## Configuration reference
 

--- a/integrations/a2a/typescript/src/__tests__/frontend-tools-warning.test.ts
+++ b/integrations/a2a/typescript/src/__tests__/frontend-tools-warning.test.ts
@@ -1,0 +1,118 @@
+import type { Message, Tool } from "@ag-ui/client";
+import { A2AAgent } from "../agent";
+import type { MessageSendParams } from "@a2a-js/sdk";
+
+/**
+ * A2AAgent bridges AG-UI messages to an A2A server, but the A2A protocol has no
+ * field for client-side tool definitions — `Message` carries only `parts` and
+ * an untyped `metadata` bag. So `RunAgentInput.tools` cannot be forwarded, and
+ * an A2A server never learns that the frontend registered any tools.
+ *
+ * That is a silent failure today: the tool is registered correctly, the run
+ * succeeds, and the tool is simply never called. Reported as
+ * CopilotKit/CopilotKit#3242, where the ADK server logged
+ * "Initialized ClientProxyToolset with 0 tools" against the A2A path and
+ * "with 1 tools" against the plain AG-UI HTTP path.
+ *
+ * The supported way to combine frontend tools with A2A agents is
+ * A2AMiddlewareAgent, which keeps the caller's tools on an orchestration agent
+ * and reaches A2A agents through its own send_message_to_a2a_agent tool. These
+ * tests pin the warning that points people there.
+ */
+
+const createMessage = (message: Partial<Message>): Message =>
+  message as Message;
+
+const createTool = (name: string): Tool =>
+  ({
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+  }) as Tool;
+
+class StubA2AClient {
+  sendMessageStream(_params: MessageSendParams) {
+    return (async function* () {
+      yield {
+        kind: "message",
+        messageId: "resp-1",
+        role: "agent",
+        parts: [{ kind: "text", text: "ack" }],
+      };
+    })();
+  }
+
+  async sendMessage(_params: MessageSendParams) {
+    return { id: null, jsonrpc: "2.0" as const, result: {} };
+  }
+
+  isErrorResponse(_response: unknown): boolean {
+    return false;
+  }
+
+  async getAgentCard() {
+    return { name: "Stub Agent", description: "", capabilities: {} };
+  }
+}
+
+function createAgent() {
+  return new A2AAgent({
+    a2aClient: new StubA2AClient() as any,
+    initialMessages: [
+      createMessage({ id: "user-1", role: "user", content: "Hi" }),
+    ],
+  });
+}
+
+describe("A2AAgent frontend tool warning (CopilotKit#3242)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns that frontend tools are not forwarded, naming them and the alternative", async () => {
+    const agent = createAgent();
+
+    await agent.runAgent({ tools: [createTool("sayHello")] });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0]);
+    expect(message).toContain("A2AAgent");
+    // Names the dropped tool, so the warning is actionable in a busy app.
+    expect(message).toContain("sayHello");
+    // Points at the supported path rather than just reporting a limitation.
+    expect(message).toContain("A2AMiddlewareAgent");
+  });
+
+  it("stays silent when the caller registered no frontend tools", async () => {
+    const agent = createAgent();
+
+    await agent.runAgent();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when tools is an empty array", async () => {
+    const agent = createAgent();
+
+    await agent.runAgent({ tools: [] });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns only once per agent, so a long conversation is not spammed", async () => {
+    const agent = createAgent();
+    const tools = [createTool("sayHello")];
+
+    await agent.runAgent({ tools });
+    await agent.runAgent({ tools });
+    await agent.runAgent({ tools });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/integrations/a2a/typescript/src/agent.ts
+++ b/integrations/a2a/typescript/src/agent.ts
@@ -35,6 +35,7 @@ const A2A_UI_MIME_TYPE = "application/json+a2ui";
 export class A2AAgent extends AbstractAgent {
   private readonly a2aClient: A2AClient;
   private readonly messageIdMap = new Map<string, string>();
+  private warnedAboutFrontendTools = false;
 
   constructor(config: A2AAgentConfig) {
     const { a2aClient, ...rest } = config;
@@ -55,6 +56,8 @@ export class A2AAgent extends AbstractAgent {
   run(input: RunAgentInput): Observable<BaseEvent> {
     return new Observable<BaseEvent>((subscriber) => {
       const run = async () => {
+        this.warnIfFrontendToolsDropped(input);
+
         const runStarted: RunStartedEvent = {
           type: EventType.RUN_STARTED,
           threadId: input.threadId,
@@ -123,6 +126,44 @@ export class A2AAgent extends AbstractAgent {
 
       return () => {};
     });
+  }
+
+  /**
+   * Warn when the caller registered frontend tools, which this agent cannot
+   * deliver.
+   *
+   * The A2A protocol has no field for client-side tool definitions — its
+   * `Message` carries `parts` plus an untyped `metadata` bag, and nothing on the
+   * server side is specified to read tools out of it. So `input.tools` is
+   * dropped here, the run still succeeds, and the tool is simply never called.
+   * That silent outcome is hard to attribute: the tool is registered correctly
+   * and the same tool works over the plain AG-UI HTTP transport
+   * (CopilotKit/CopilotKit#3242).
+   *
+   * Use `A2AMiddlewareAgent` from `@ag-ui/a2a-middleware` to combine frontend
+   * tools with A2A agents. It keeps the caller's tools on an orchestration
+   * agent — which receives them the ordinary way — and reaches A2A agents
+   * through its own `send_message_to_a2a_agent` tool.
+   *
+   * Warns once per agent instance so a long conversation isn't spammed.
+   */
+  private warnIfFrontendToolsDropped(input: RunAgentInput): void {
+    if (this.warnedAboutFrontendTools || !input.tools?.length) {
+      return;
+    }
+
+    this.warnedAboutFrontendTools = true;
+
+    const names = input.tools.map((tool) => tool.name);
+    const shown = names.slice(0, 5).join(", ");
+    const suffix = names.length > 5 ? `, +${names.length - 5} more` : "";
+
+    console.warn(
+      `A2AAgent: ${names.length} frontend tool(s) will not be available to the A2A agent (${shown}${suffix}). ` +
+        "The A2A protocol has no field for client-side tool definitions, so A2AAgent cannot forward them and the agent will never call these tools. " +
+        "To use frontend tools with A2A agents, use A2AMiddlewareAgent from @ag-ui/a2a-middleware, which keeps your tools on the orchestration agent " +
+        "and reaches A2A agents through its send_message_to_a2a_agent tool.",
+    );
   }
 
   private prepareConversation(input: RunAgentInput): ConvertedA2AMessages {


### PR DESCRIPTION
`A2AAgent` silently drops `RunAgentInput.tools`. This makes that visible; it does not add forwarding, for reasons below.

## Why tools are dropped

The A2A protocol has no field for client-side tool definitions. `Message` carries `parts` plus an untyped `metadata` bag, and no server-side behaviour is specified for reading tools out of it — `grep -c tools` over the whole `@a2a-js/sdk@0.2.5` type surface returns `0`. `@ag-ui/a2a`'s own source has zero occurrences of `tools` across all six files, so nothing is being forgotten at a call site; there is simply nowhere to put them.

## Why this is worth a warning rather than a note in a changelog

Nothing fails. The tool is registered correctly, the run succeeds, and the tool is never called. Because the very same tool works over the plain AG-UI HTTP transport, the natural conclusion is that tool registration is broken rather than that this transport cannot carry tools.

That cost is documented in CopilotKit/CopilotKit#3242, where the ADK server logged `Initialized ClientProxyToolset with 0 tools` on the A2A path against `with 1 tools` on the HTTP path. The reporter had bisected transports before filing.

## Why not just forward them in `metadata`

There is no agreed field on the wire, and the receiving side is Google's ADK A2A executor — outside this repo. A `metadata` payload would be a forward that nothing reads: it would look like a fix, close the issue, and leave the tool still uncalled. Worse, it would make the next person's bisect harder, not easier.

The supported way to combine frontend tools with A2A agents already exists: `A2AMiddlewareAgent` keeps the caller's tools on an orchestration agent — which receives them the ordinary way — and reaches A2A agents through its own `send_message_to_a2a_agent` tool (`middlewares/a2a-middleware/src/index.ts:279`). So the useful change is to point people there at the moment they hit this.

## What changed

- `A2AAgent` warns once per instance when `input.tools` is non-empty, naming the dropped tools (capped at 5, with a `+N more` suffix) and pointing at `A2AMiddlewareAgent`. Once-per-instance so a long conversation isn't spammed.
- README gains a "Frontend tools are not forwarded" section with the `A2AMiddlewareAgent` alternative. Its config fields were checked against `A2AAgentConfig` rather than written from memory.

Deliberately **not** closing CopilotKit/CopilotKit#3242 — the underlying inability is unchanged, so that issue should stay open for a real protocol-level decision. Hence `Refs`, not `Fixes`.

## Testing

**New suite, fail-first.** Before the implementation, the two warning tests failed and the two silence tests already passed (they assert absence):

```
AssertionError: expected "warn" to be called 1 times, but got 0 times
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

After:

```
✓ src/__tests__/frontend-tools-warning.test.ts (4 tests)
```

Coverage is the behaviour, not the string: warns and names the tool + the alternative; silent with no `tools`; silent with `tools: []`; warns exactly once across three `runAgent()` calls.

**Full package suite** — no regressions in the existing conversion/streaming tests:

```
✓ src/__tests__/utils.test.ts (6 tests)
✓ src/__tests__/agent.test.ts (3 tests)
✓ src/__tests__/frontend-tools-warning.test.ts (4 tests)
Test Files  3 passed (3)
      Tests  13 passed (13)
```

**Types and build:**

```
tsc -p tsconfig.json --noEmit   → clean
tsdown                          → Build complete (CJS + ESM)
prettier --check <changed files> → All matched files use Prettier code style!
```

Two notes on scope hygiene, both verified rather than assumed:

- `tsdown` reordered the `exports` keys in `package.json` as a side effect. Since key order is semantically meaningful in an exports map, that was **reverted** and is not in this PR.
- The README diff includes a 3-line reformat of the pre-existing quick-start snippet. `README.md` was already prettier-dirty on `origin/main` (confirmed by checking the stashed tree), and prettier is not CI-gated here, so this only cleans a file the PR already touches. `src/utils.ts`, `src/__tests__/agent.test.ts`, and `src/__tests__/utils.test.ts` are also prettier-dirty on main and were left alone.
