### PR TITLE
fix(dojo): drop LangSmith tracing env metadata from golden traces

### DIFF
--- a/apps/dojo/e2e/lib/event-trace-events.test.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.test.ts
@@ -212,3 +212,34 @@ test("retains the complete SSE response when a data frame is malformed", () => {
       error.frameIndex === 1,
   );
 });
+
+test("drops LangSmith tracing env metadata, whose presence varies by environment", () => {
+  // `langgraph dev` always exports LANGSMITH_LANGGRAPH_API_VARIANT=local_dev,
+  // but it only reaches run metadata when a LangSmith key enabled tracing.
+  // A trace recorded without a key must still match one recorded with it.
+  const normalized = normalizeEventTrace([
+    {
+      type: "STATE_SNAPSHOT",
+      rawEvent: {
+        data: {
+          metadata: {
+            graph_id: "agentic_chat",
+            langgraph_step: 1,
+            LANGSMITH_LANGGRAPH_API_VARIANT: "local_dev",
+            LANGSMITH_PROJECT: "dojo",
+            LANGCHAIN_CALLBACKS_BACKGROUND: "true",
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.deepEqual(normalized, [
+    {
+      type: "STATE_SNAPSHOT",
+      rawEvent: {
+        data: { metadata: { graph_id: "agentic_chat", langgraph_step: 1 } },
+      },
+    },
+  ]);
+});

--- a/apps/dojo/e2e/lib/event-trace-events.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.ts
@@ -60,6 +60,21 @@ const ENVIRONMENT_VALUE_TOKENS = new Map([
   ["langgraph_version", "<langgraph-version>"],
   ["langgraph_api_version", "<langgraph-api-version>"],
 ]);
+
+// Metadata keys that exist only when LangSmith tracing happens to be enabled,
+// so their *presence* — not just their value — varies by environment.
+//
+// langgraph-api turns tracing on whenever it sees a LangSmith API key
+// (LANGSMITH_CONTROL_PLANE_API_KEY defaults to LANGSMITH_API_KEY, which
+// force-sets LANGSMITH_TRACING). The LangSmith client then merges every
+// LANGSMITH_*/LANGCHAIN_* env var into each run's metadata dict, and
+// langchain_core hands the tracer the *same* dict object the run config
+// streams out — so `langgraph dev`'s LANGSMITH_LANGGRAPH_API_VARIANT=local_dev
+// lands in STATE_SNAPSHOT metadata. Anyone with a LangSmith key in their
+// environment (CI or a local shell) would otherwise fail every LangGraph
+// golden trace. `revision_id` is a lowercase sibling from the same merge, but
+// it is too generic a name to drop wholesale — keep the prefix rule narrow.
+const TRACING_ENV_METADATA_PATTERN = /^(?:LANGSMITH|LANGCHAIN)_/;
 const APP_CONTEXT_PREFIX = "App Context:\n";
 
 const UUID_PATTERN =
@@ -234,6 +249,7 @@ export function normalizeEventTrace(
     return Object.fromEntries(
       Object.entries(value).flatMap(([key, child]) => {
         if (key === "timestamp" && path.length === 0) return [];
+        if (TRACING_ENV_METADATA_PATTERN.test(key)) return [];
 
         const nextPath = [...path, key];
         let normalized: unknown;


### PR DESCRIPTION
## Problem

The golden event traces from #2392 fail for anyone who has a LangSmith API key in the environment. Our own CI does not, because the dojo runs keyless against LLMock — but every consumer that supplies one sees this on the very first LangGraph test:

```
EventTraceAssertionError: Event trace mismatch: agenticChatPage.event-trace.ts#sendsAndReceivesMessage
  events: expected=33, actual=33
  event type counts: identical across 9 types
  first difference: events[2].rawEvent.data.metadata.LANGSMITH_LANGGRAPH_API_VARIANT
    expected: <missing>
    actual: "local_dev"
```

Concretely: CopilotKit's `test_e2e-dojo.yml` checks this harness out at floating `main` and injects a real `LANGSMITH_API_KEY`, so all four of its open PRs went red the moment #2392 merged. A contributor with `LANGSMITH_API_KEY` exported in their shell hits the same wall locally.

## Mechanism

1. `langgraph dev` always exports `LANGSMITH_LANGGRAPH_API_VARIANT=local_dev` (`langgraph_api/cli.py:271`) — unconditionally, everywhere.
2. `langgraph_api/config/__init__.py:518-546`: `LANGSMITH_CONTROL_PLANE_API_KEY` defaults to `LANGSMITH_API_KEY`; if set with no explicit tracing flag, langgraph-api force-sets `LANGSMITH_TRACING=true`.
3. With tracing on, `langsmith/client.py:2482` (`_insert_runtime_env`) merges **every** `LANGSMITH_*`/`LANGCHAIN_*` env var into each run's `extra["metadata"]`.
4. `langchain_core/tracers/core.py:197-203` builds the run with `extra=kwargs`, where `kwargs["metadata"]` is the **same dict object** as the run config's metadata — the one langgraph streams out. Step 3's mutation therefore lands in `STATE_SNAPSHOT`.

So the key's *presence*, not just its value, depends on the environment.

## Change

`normalizeEventTrace` already tokenizes environment-dependent metadata *values* — `langgraph_api_url`, `langgraph_version`, `langgraph_api_version`. This is the same class of noise, so it belongs in the same place; it just needs dropping rather than tokenizing, since presence varies. One line, reusing the existing drop path that `timestamp` already uses:

```ts
if (TRACING_ENV_METADATA_PATTERN.test(key)) return [];
```

The rule is deliberately narrow (`/^(?:LANGSMITH|LANGCHAIN)_/`). `revision_id` is a lowercase sibling injected by the same merge, but that name is too generic to strip wholesale — noted in the comment rather than dropped.

## Testing

- **Unit suite green** — `pnpm test:event-trace-unit` → `# tests 26 / # pass 26 / # fail 0`
- **Type check green** — `pnpm check:event-trace-types` → clean
- **Prettier clean** — `prettier --check` on both changed files → *"All matched files use Prettier code style!"*
- **Mutation-checked, so the new test is not self-fulfilling** — removing just the drop line makes exactly the new test fail and nothing else:
  ```
  not ok 6 - drops LangSmith tracing env metadata, whose presence varies by environment
  # tests 26
  # pass 25
  # fail 1
  ```
  Restoring the line returns 26/26.
- **No existing fixture depends on these keys**, so nothing needs re-recording — `grep -rlE "\b(LANGSMITH|LANGCHAIN)_[A-Z_]+" --include="*.event-trace.ts"` matches nothing across both fixture files.
- **Every step of the mechanism was read out of the installed `langgraph-api` 0.12.4, `langsmith` 0.11.0 and `langchain-core` 1.5.5 wheels**, not inferred; file/line refs cited above.

Companion cleanup on the consumer side, dropping the key the dojo never needed: CopilotKit/CopilotKit#6534.