### PR TITLE
M0 repo health: real typecheck gate, deterministic build, hardened CI (PNI-299…303, 306)

### DIFF
--- a/.github/workflows/typecheck-typescript.yml
+++ b/.github/workflows/typecheck-typescript.yml
@@ -1,0 +1,93 @@
+name: typecheck
+
+# Runs the repository-root `pnpm run check-types` (PNI-302). The wrapper script
+# fails when zero projects expose a `typecheck` target and prints the
+# selected-project count, so a misspelled or missing target can never produce a
+# green job. Workspace packages resolve types from each other's dist/
+# declarations, so the Nx `typecheck` target depends on `^build` and `generate`
+# (see nx.json) — the job needs no cache or pre-existing build output.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sdks/**"
+      - "integrations/**"
+      - "middlewares/**"
+      - "scripts/check-types.mjs"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "nx.json"
+      - ".node-version"
+      - ".github/workflows/typecheck-typescript.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "sdks/**"
+      - "integrations/**"
+      - "middlewares/**"
+      - "scripts/check-types.mjs"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "nx.json"
+      - ".node-version"
+      - ".github/workflows/typecheck-typescript.yml"
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect fork PR
+        id: fork-check
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && \
+                "$PR_HEAD_REPO" != "$GITHUB_REPOSITORY" ]]; then
+            echo "prefix=fork-" >> "$GITHUB_OUTPUT"
+          else
+            echo "prefix=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          # Passed via env rather than interpolated into the script: a fork's repo
+          # name is attacker-controlled text. GITHUB_EVENT_NAME and
+          # GITHUB_REPOSITORY are Actions built-ins, so nothing is expanded here.
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.33.4
+
+      - name: Setup pnpm cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.local/share/pnpm/store
+          key: ${{ steps.fork-check.outputs.prefix }}${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ steps.fork-check.outputs.prefix }}${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        run: pnpm run check-types

--- a/.github/workflows/unit-typescript-sdk.yml
+++ b/.github/workflows/unit-typescript-sdk.yml
@@ -7,6 +7,7 @@ on:
       - "sdks/typescript/**"
       - "typescript-sdk/**"
       - "integrations/**"
+      - "middlewares/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "package.json"
@@ -18,6 +19,7 @@ on:
       - "sdks/typescript/**"
       - "typescript-sdk/**"
       - "integrations/**"
+      - "middlewares/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "package.json"
@@ -40,14 +42,17 @@ jobs:
       - name: Detect fork PR
         id: fork-check
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && \
-                "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && \
+                "$PR_HEAD_REPO" != "$GITHUB_REPOSITORY" ]]; then
             echo "prefix=fork-" >> "$GITHUB_OUTPUT"
           else
             echo "prefix=" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          # Passed via env rather than interpolated into the script: a fork's repo
+          # name is attacker-controlled text. GITHUB_EVENT_NAME and
+          # GITHUB_REPOSITORY are Actions built-ins, so nothing is expanded here.
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/unit-typescript-sdk.yml
+++ b/.github/workflows/unit-typescript-sdk.yml
@@ -54,12 +54,6 @@ jobs:
         with:
           node-version-file: ".node-version"
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
-        with:
-          version: "25.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
         with:
@@ -78,6 +72,12 @@ jobs:
 
       - name: Test Build
         run: pnpm run build
+
+      # A verification build must not rewrite tracked files (PNI-303): the proto
+      # generator is pinned via config.protocVersion and tsdown's exports
+      # rewriting is committed in canonical order, so any drift here is a bug.
+      - name: Verify build leaves the worktree clean
+        run: git diff --exit-code
 
       - name: Run tests
         run: pnpm run test

--- a/integrations/a2a/typescript/package.json
+++ b/integrations/a2a/typescript/package.json
@@ -21,8 +21,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/integrations/ag2/typescript/package.json
+++ b/integrations/ag2/typescript/package.json
@@ -44,8 +44,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/agno/typescript/package.json
+++ b/integrations/agno/typescript/package.json
@@ -49,8 +49,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/community/spring-ai/typescript/package.json
+++ b/integrations/community/spring-ai/typescript/package.json
@@ -49,8 +49,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/crew-ai/typescript/package.json
+++ b/integrations/crew-ai/typescript/package.json
@@ -49,8 +49,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/langchain/typescript/tsconfig.json
+++ b/integrations/langchain/typescript/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vitest/globals"],
+    "types": ["node", "vitest/globals"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/integrations/llama-index/typescript/package.json
+++ b/integrations/llama-index/typescript/package.json
@@ -49,8 +49,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/mastra/typescript/tsconfig.json
+++ b/integrations/mastra/typescript/tsconfig.json
@@ -16,7 +16,12 @@
     "types": ["vitest/globals"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      // Dedupe @ag-ui/client type identity: @copilotkit/runtime pins its own
+      // copy (0.0.57), whose AbstractAgent is nominally different from the
+      // workspace package (private members). Point every import at the
+      // workspace build so agents typecheck against a single declaration.
+      "@ag-ui/client": ["./node_modules/@ag-ui/client/dist/index.d.ts"]
     },
     "stripInternal": true
   },

--- a/integrations/pydantic-ai/typescript/package.json
+++ b/integrations/pydantic-ai/typescript/package.json
@@ -44,8 +44,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/server-starter-all-features/typescript/package.json
+++ b/integrations/server-starter-all-features/typescript/package.json
@@ -40,8 +40,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/server-starter/typescript/package.json
+++ b/integrations/server-starter/typescript/package.json
@@ -40,8 +40,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/vercel-ai-sdk/typescript/package.json
+++ b/integrations/vercel-ai-sdk/typescript/package.json
@@ -48,8 +48,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/integrations/watsonx/typescript/package.json
+++ b/integrations/watsonx/typescript/package.json
@@ -54,8 +54,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/middlewares/a2a-middleware/package.json
+++ b/middlewares/a2a-middleware/package.json
@@ -47,8 +47,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/middlewares/a2a-middleware/src/index.ts
+++ b/middlewares/a2a-middleware/src/index.ts
@@ -105,7 +105,7 @@ export class A2AMiddlewareAgent extends AbstractAgent {
 
     return stream
       .pipe(
-        transformChunks(this.debug),
+        transformChunks(this.debugLogger),
         applyAndProcessEvents,
         tap(markTextMessageAsPending),
       )

--- a/middlewares/mcp-apps-middleware/package.json
+++ b/middlewares/mcp-apps-middleware/package.json
@@ -49,8 +49,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/middlewares/mcp-apps-middleware/tsconfig.json
+++ b/middlewares/mcp-apps-middleware/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vitest/globals"],
+    "types": ["node", "vitest/globals"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/middlewares/middleware-starter/package.json
+++ b/middlewares/middleware-starter/package.json
@@ -40,8 +40,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   }

--- a/nx.json
+++ b/nx.json
@@ -75,9 +75,14 @@
       ],
       "cache": true
     },
-    "check-types": {
+    "typecheck": {
       "dependsOn": [
-        "^check-types"
+        "^build",
+        "generate"
+      ],
+      "inputs": [
+        "default",
+        "^production"
       ],
       "cache": true
     },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "nx run-many -t start",
     "lint": "nx run-many -t lint",
     "format": "prettier --write \"**/*.{ts,tsx,md,mdx}\"",
-    "check-types": "nx run-many -t check-types",
+    "check-types": "node ./scripts/check-types.mjs",
     "test": "nx run-many -t test",
     "test:coverage": "nx run-many -t test:coverage",
     "test:watch": "nx run-many -t test && nx watch --all -- nx run-many -t test",

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Runs the repository-wide TypeScript typecheck via Nx.
+//
+// `nx run-many` exits 0 when its target selection is empty ("No tasks were
+// run"), which is how the root command stayed green for months while pointing
+// at a target name no project had (PNI-299). This wrapper fails when zero
+// projects expose `typecheck`, and prints the selected-project count so an
+// empty selection can never pass silently.
+//
+// The command's contract is "typecheck every project". Selection flags such as
+// --projects/--exclude are rejected rather than forwarded: they could narrow
+// the run to zero tasks behind the guard's back, and re-implementing Nx's
+// argument parsing here just to keep the count honest is a losing game. For a
+// custom selection, call `pnpm nx run-many -t typecheck --projects=...`
+// directly and own its empty-selection semantics.
+
+import { spawnSync } from "node:child_process";
+
+const useShell = process.platform === "win32";
+
+// pnpm forwards the `--` separator itself (`pnpm run check-types -- --skip-nx-cache`
+// yields argv ["--", "--skip-nx-cache"]), and nx would treat everything after `--`
+// as task overrides and hand it to tsc. Strip it so forwarded flags reach nx.
+const forwarded = process.argv.slice(2).filter((arg, index) => !(arg === "--" && index === 0));
+
+// Selection-neutral flags only; anything else is refused with a pointer to nx.
+const allowedFlags = new Set(["--skip-nx-cache", "--verbose"]);
+const rejected = forwarded.filter((arg) => !allowedFlags.has(arg));
+if (rejected.length > 0) {
+  console.error(
+    `check-types: unsupported argument(s): ${rejected.join(" ")}\n` +
+      "check-types always typechecks every project. For a custom selection run\n" +
+      "  pnpm nx run-many -t typecheck --projects=<projects>\n" +
+      "directly (note: nx exits 0 when the selection is empty).",
+  );
+  process.exit(1);
+}
+
+const shown = spawnSync("nx", ["show", "projects", "--with-target", "typecheck", "--json"], {
+  encoding: "utf8",
+  shell: useShell,
+});
+
+if (shown.status !== 0) {
+  process.stderr.write(shown.stdout ?? "");
+  process.stderr.write(shown.stderr ?? "");
+  console.error("check-types: failed to list projects with a typecheck target.");
+  process.exit(shown.status ?? 1);
+}
+
+let projects;
+try {
+  projects = JSON.parse(shown.stdout);
+} catch {
+  console.error("check-types: could not parse `nx show projects` output:");
+  console.error(shown.stdout);
+  process.exit(1);
+}
+
+if (!Array.isArray(projects) || projects.length === 0) {
+  console.error(
+    "check-types: no projects expose a `typecheck` target; refusing to report success.",
+  );
+  process.exit(1);
+}
+
+console.log(`check-types: running the typecheck target for ${projects.length} projects`);
+
+const run = spawnSync("nx", ["run-many", "-t", "typecheck", ...forwarded], {
+  stdio: "inherit",
+  shell: useShell,
+});
+
+process.exit(run.status ?? 1);

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
@@ -21,7 +21,7 @@ class CloneableTestAgent extends AbstractAgent {
     });
   }
 
-  protected run(_: RunAgentInput): Observable<BaseEvent> {
+  run(_: RunAgentInput): Observable<BaseEvent> {
     return EMPTY as Observable<BaseEvent>;
   }
 }

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-debug.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-debug.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { AbstractAgent } from "../agent";
 import { DebugLogger } from "@/debug-logger";
 import {
@@ -107,7 +107,7 @@ describe("Agent construction debug config", () => {
 });
 
 describe("Agent run lifecycle logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -243,7 +243,7 @@ describe("Agent run lifecycle logging", () => {
 });
 
 describe("Agent run error logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -288,7 +288,7 @@ describe("Agent run error logging", () => {
 });
 
 describe("Agent pipeline integration", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-multiple-runs.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-multiple-runs.test.ts
@@ -291,6 +291,7 @@ describe("AbstractAgent multiple runs", () => {
         messageId: "activity-1",
         activityType: "PLAN",
         content: { tasks: ["task 1"] },
+        replace: false,
       } as ActivitySnapshotEvent,
       {
         type: EventType.RUN_FINISHED,

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-result.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-result.test.ts
@@ -373,9 +373,11 @@ describe("Agent Result", () => {
       const activityMessage = agent.messages.find((message) => message.id === "activity-ops");
 
       expect(activityMessage).toBeTruthy();
-      expect(activityMessage?.role).toBe("activity");
-      expect(activityMessage?.activityType).toBe("PLAN");
-      expect(activityMessage?.content).toEqual({
+      if (activityMessage?.role !== "activity") {
+        throw new Error(`Expected activity message, got role ${activityMessage?.role}`);
+      }
+      expect(activityMessage.activityType).toBe("PLAN");
+      expect(activityMessage.content).toEqual({
         operations: [firstOperation, secondOperation],
       });
 

--- a/sdks/typescript/packages/client/src/agent/__tests__/interrupts-lifecycle.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/interrupts-lifecycle.test.ts
@@ -6,9 +6,9 @@ import { EventType } from "@ag-ui/core";
 
 class StubAgent extends AbstractAgent {
   public received?: RunAgentInput;
-  protected run(input: RunAgentInput) {
+  run(input: RunAgentInput) {
     this.received = input;
-    return of<BaseEvent>(
+    return of(
       { type: EventType.RUN_STARTED, threadId: input.threadId, runId: input.runId } as BaseEvent,
       { type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId } as BaseEvent,
     );

--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -448,7 +448,7 @@ describe("AgentSubscriber", () => {
       errorAgent.subscribe(errorHandlingSubscriber);
 
       // Mock console.error to check if it's called
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       // This should not throw because the subscriber handles the error
       await expect(errorAgent.runAgent({})).resolves.toBeDefined();
@@ -489,7 +489,7 @@ describe("AgentSubscriber", () => {
       errorAgent.subscribe(errorHandlingSubscriber);
 
       // Mock console.error to check if it's called
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       // This should throw because the subscriber doesn't stop propagation
       await expect(errorAgent.runAgent({})).rejects.toThrow("Test error");

--- a/sdks/typescript/packages/client/src/apply/__tests__/apply-debug.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/apply-debug.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import {
@@ -32,7 +32,7 @@ const createInput = (): RunAgentInput => ({
 });
 
 describe("defaultApplyEvents debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.activity.test.ts
@@ -35,6 +35,14 @@ async function emitAndCollect(
   return updatesPromise;
 }
 
+/** Narrow a message to the activity role, failing the test otherwise. */
+function expectActivityMessage(message: Message | undefined) {
+  if (message?.role !== "activity") {
+    throw new Error(`Expected activity message, got role ${message?.role}`);
+  }
+  return message;
+}
+
 /** Shorthand: apply a single MESSAGES_SNAPSHOT and return the resulting messages. */
 async function applySnapshot(initial: Message[], snapshotMessages: Message[]): Promise<Message[]> {
   const updates = await emitAndCollect(initial, (events$) => {
@@ -68,10 +76,10 @@ describe("defaultApplyEvents with activity events", () => {
 
     expect(updates.length).toBe(2);
 
-    const snapshotUpdate = updates[0];
-    expect(snapshotUpdate?.messages?.[0]?.role).toBe("activity");
-    expect(snapshotUpdate?.messages?.[0]?.activityType).toBe("PLAN");
-    expect(snapshotUpdate?.messages?.[0]?.content).toEqual({ tasks: ["search"] });
+    const snapshotMessage = expectActivityMessage(updates[0]?.messages?.[0]);
+    expect(snapshotMessage.role).toBe("activity");
+    expect(snapshotMessage.activityType).toBe("PLAN");
+    expect(snapshotMessage.content).toEqual({ tasks: ["search"] });
 
     const deltaUpdate = updates[1];
     expect(deltaUpdate?.messages?.[0]?.content).toEqual({ tasks: ["✓ search"] });
@@ -106,8 +114,10 @@ describe("defaultApplyEvents with activity events", () => {
 
     expect(updates.length).toBe(3);
     expect(updates[0]?.messages?.[0]?.content).toEqual({ operations: [] });
-    expect(updates[1]?.messages?.[0]?.content?.operations).toEqual([firstOperation]);
-    expect(updates[2]?.messages?.[0]?.content?.operations).toEqual([
+    expect(expectActivityMessage(updates[1]?.messages?.[0]).content.operations).toEqual([
+      firstOperation,
+    ]);
+    expect(expectActivityMessage(updates[2]?.messages?.[0]).content.operations).toEqual([
       firstOperation,
       secondOperation,
     ]);
@@ -426,7 +436,7 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       [
         { id: "m1", role: "user", content: "create a dashboard" },
         { id: "asst-1", role: "assistant", content: "I'll create that for you" },
-        { id: "tool-stream", role: "tool", content: '{"a2ui": true}' },
+        { id: "tool-stream", role: "tool", content: '{"a2ui": true}', toolCallId: "tc-stream" },
         {
           id: "act-1",
           role: "activity",
@@ -438,7 +448,7 @@ describe("MESSAGES_SNAPSHOT preserves client-only messages", () => {
       [
         { id: "m1", role: "user", content: "create a dashboard" },
         { id: "asst-1", role: "assistant", content: "I'll create that for you" },
-        { id: "tool-canon", role: "tool", content: '{"a2ui": true}' },
+        { id: "tool-canon", role: "tool", content: '{"a2ui": true}', toolCallId: "tc-canon" },
         { id: "asst-2", role: "assistant", content: "Here's your dashboard" },
       ],
     );

--- a/sdks/typescript/packages/client/src/apply/__tests__/run-started-input.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/run-started-input.test.ts
@@ -21,7 +21,7 @@ describe("RunStartedEvent with input.messages", () => {
       this.events = events;
     }
 
-    protected run(_input: RunAgentInput): Observable<BaseEvent> {
+    run(_input: RunAgentInput): Observable<BaseEvent> {
       return of(...this.events);
     }
   }

--- a/sdks/typescript/packages/client/src/chunks/__tests__/transform-debug.test.ts
+++ b/sdks/typescript/packages/client/src/chunks/__tests__/transform-debug.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { of, concat, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { transformChunks } from "../transform";
@@ -13,7 +13,7 @@ import {
 } from "@ag-ui/core";
 
 describe("transformChunks debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/backward-compatibility-0-0-45.test.ts
@@ -211,7 +211,7 @@ describe("BackwardCompatibility_0_0_45 (browser environment)", () => {
       const events: BaseEvent[] = [{ type: THINKING_START as EventType, title: "Processing..." }];
       const agent = new MockAgent(events);
 
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const result = await lastValueFrom(
         middleware.run(
           {

--- a/sdks/typescript/packages/client/src/middleware/__tests__/middleware-chained-integration.test.ts
+++ b/sdks/typescript/packages/client/src/middleware/__tests__/middleware-chained-integration.test.ts
@@ -43,6 +43,14 @@ vi.mock("@/utils", async () => {
 
 // ── Reusable helpers ─────────────────────────────────────────────────────────
 
+/** Narrow a message to the assistant role, failing the test otherwise. */
+function expectAssistantMessage(message: Message | undefined) {
+  if (message?.role !== "assistant") {
+    throw new Error(`Expected assistant message, got role ${message?.role}`);
+  }
+  return message;
+}
+
 /**
  * Uses runNextWithState and captures { messages, state } at RUN_FINISHED.
  * This is the middleware pattern that broke before the fix when chained:
@@ -496,7 +504,7 @@ describe("Chained middleware integration (via runAgent)", () => {
         expect(mw.capturedMessages).toHaveLength(2);
 
         // First message: assistant with tool calls
-        const assistantMsg = mw.capturedMessages[0];
+        const assistantMsg = expectAssistantMessage(mw.capturedMessages[0]);
         expect(assistantMsg.role).toBe("assistant");
         expect(assistantMsg.toolCalls).toHaveLength(1);
         expect(assistantMsg.toolCalls![0]).toMatchObject({
@@ -527,7 +535,7 @@ describe("Chained middleware integration (via runAgent)", () => {
       for (const mw of [inner, outer]) {
         expect(mw.capturedMessages).toHaveLength(2);
 
-        const assistantMsg = mw.capturedMessages[0];
+        const assistantMsg = expectAssistantMessage(mw.capturedMessages[0]);
         expect(assistantMsg.role).toBe("assistant");
         expect(assistantMsg.toolCalls).toHaveLength(1);
         expect(assistantMsg.toolCalls![0]).toMatchObject({
@@ -642,12 +650,12 @@ describe("Chained middleware integration (via runAgent)", () => {
       for (const mw of [inner, outer]) {
         // msg-1 should be an assistant message with content AND tool calls
         // (TOOL_CALL_START with parentMessageId "msg-1" attaches to the existing message)
-        const msg1 = mw.capturedMessages.find((m) => m.id === "msg-1");
+        const msg1 = expectAssistantMessage(mw.capturedMessages.find((m) => m.id === "msg-1"));
         expect(msg1).toBeDefined();
-        expect(msg1!.role).toBe("assistant");
-        expect(msg1!.content).toBe("Let me search");
-        expect(msg1!.toolCalls).toHaveLength(1);
-        expect(msg1!.toolCalls![0]).toMatchObject({
+        expect(msg1.role).toBe("assistant");
+        expect(msg1.content).toBe("Let me search");
+        expect(msg1.toolCalls).toHaveLength(1);
+        expect(msg1.toolCalls![0]).toMatchObject({
           id: "tc-1",
           function: { name: "search" },
         });
@@ -816,14 +824,17 @@ describe("Chained middleware integration (via runAgent)", () => {
         (e) => e.event.type === EventType.TOOL_CALL_START,
       )!;
       expect(atStart.messages).toHaveLength(1);
-      expect(atStart.messages[0].toolCalls).toHaveLength(1);
-      expect(atStart.messages[0].toolCalls![0].function.arguments).toBe("");
+      const startMsg = expectAssistantMessage(atStart.messages[0]);
+      expect(startMsg.toolCalls).toHaveLength(1);
+      expect(startMsg.toolCalls![0].function.arguments).toBe("");
 
       // At TOOL_CALL_ARGS, arguments should be populated
       const atArgs = mw.capturedEventsWithState.find(
         (e) => e.event.type === EventType.TOOL_CALL_ARGS,
       )!;
-      expect(atArgs.messages[0].toolCalls![0].function.arguments).toBe('{"q":"test"}');
+      expect(expectAssistantMessage(atArgs.messages[0]).toolCalls![0].function.arguments).toBe(
+        '{"q":"test"}',
+      );
 
       // At TOOL_CALL_RESULT, tool message should be added
       const atResult = mw.capturedEventsWithState.find(

--- a/sdks/typescript/packages/client/src/transform/__tests__/debug.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/debug.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { take } from "rxjs/operators";
 import { parseSSEStream } from "../sse";
@@ -8,7 +8,7 @@ import { HttpEvent, HttpEventType } from "../../run/http-request";
 import { EventType } from "@ag-ui/core";
 
 describe("parseSSEStream debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -104,7 +104,7 @@ describe("parseSSEStream debug logging", () => {
 });
 
 describe("transformHttpEventStream debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/transform/__tests__/sse.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/sse.test.ts
@@ -86,7 +86,7 @@ describe("transformHttpEventStream", () => {
             resolve(events);
           }
         },
-        error: (err) => fail(err),
+        error: (err) => expect.fail(String(err)),
       });
     });
 
@@ -192,13 +192,13 @@ describe("transformHttpEventStream", () => {
       event$.subscribe({
         next: () => {
           // This should not be called
-          fail("Should not emit events for invalid JSON");
+          expect.fail("Should not emit events for invalid JSON");
         },
         error: (err) => {
           resolve(err);
         },
         complete: () => {
-          fail("Stream should not complete successfully with invalid JSON");
+          expect.fail("Stream should not complete successfully with invalid JSON");
         },
       });
     });

--- a/sdks/typescript/packages/client/src/verify/__tests__/verify-debug.test.ts
+++ b/sdks/typescript/packages/client/src/verify/__tests__/verify-debug.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import { Subject, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { verifyEvents } from "../verify";
@@ -14,7 +14,7 @@ import {
 } from "@ag-ui/core";
 
 describe("verifyEvents debug logging", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: MockInstance<typeof console.debug>;
 
   beforeEach(() => {
     debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});

--- a/sdks/typescript/packages/client/src/verify/__tests__/verify.steps.test.ts
+++ b/sdks/typescript/packages/client/src/verify/__tests__/verify.steps.test.ts
@@ -190,7 +190,7 @@ describe("verifyEvents steps", () => {
     const subscription = verifyEvents(false)(source$).subscribe({
       next: (event) => events.push(event),
       error: (err) => {
-        fail(`Should not have errored: ${err.message}`);
+        expect.fail(`Should not have errored: ${err.message}`);
       },
     });
 

--- a/sdks/typescript/packages/client/tsconfig.json
+++ b/sdks/typescript/packages/client/tsconfig.json
@@ -17,7 +17,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["node"],
+    "types": ["node", "vitest/globals"],
     "stripInternal": true
   },
   "include": ["src/**/*"],

--- a/sdks/typescript/packages/core/package.json
+++ b/sdks/typescript/packages/core/package.json
@@ -18,6 +18,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "lint": "eslint \"src/**/*.ts*\"",
+    "typecheck": "tsc --noEmit",
     "clean": "git clean -fdX --exclude=\"!.env\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/sdks/typescript/packages/core/src/__tests__/backwards-compatibility.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/backwards-compatibility.test.ts
@@ -243,7 +243,11 @@ describe("Backwards Compatibility", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.messages.length).toBe(2);
-        expect(result.data.messages[1].toolCalls?.length).toBe(1);
+        const assistantMessage = result.data.messages[1];
+        expect(assistantMessage.role).toBe("assistant");
+        expect(
+          assistantMessage.role === "assistant" ? assistantMessage.toolCalls?.length : undefined,
+        ).toBe(1);
         expect(result.data.tools.length).toBe(1);
         expect(result.data.context.length).toBe(1);
       }

--- a/sdks/typescript/packages/encoder/package.json
+++ b/sdks/typescript/packages/encoder/package.json
@@ -18,6 +18,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "lint": "eslint \"src/**/*.ts*\"",
+    "typecheck": "tsc --noEmit",
     "clean": "git clean -fdX --exclude=\"!.env\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/sdks/typescript/packages/encoder/tsconfig.json
+++ b/sdks/typescript/packages/encoder/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["vitest/globals"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -21,6 +21,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "lint": "eslint \"src/**/*.ts*\"",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "clean": "git clean -fdX --exclude=\"!.env\"",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/sdks/typescript/packages/proto/package.json
+++ b/sdks/typescript/packages/proto/package.json
@@ -14,6 +14,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "config": {
+    "protocVersion": "35.1"
+  },
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",

--- a/sdks/typescript/packages/proto/tsconfig.typecheck.json
+++ b/sdks/typescript/packages/proto/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Implements the six triage-status cleanup issues from the AG-UI 1.0 **M0 — Repository health and reproducible baseline** milestone, one commit per ticket.

## PNI-303 — Make pnpm build deterministic
A clean checkout's `pnpm run build` rewrote 18 tracked files. Two root causes, both fixed:
- `@protobuf-ts/protoc` used whatever protoc was on PATH (or downloaded latest), so the generated proto headers and well-known-type comments drifted per machine. Now pinned via `config.protocVersion: "35.1"` in the proto package, which regenerates the checked-in files byte-identically. The unit workflow's PATH protoc install is removed as redundant.
- tsdown (`exports: true`) rewrote 14 integration/middleware manifests into require-first exports order on every build. That order matches the majority of already-committed packages, so it is now committed as canonical (rebuild verified stable).
The unit workflow runs `git diff --exit-code` after the build as a regression guard. Acceptance verified: install → build → `git diff --exit-code` all pass from a clean checkout.

## PNI-299 — Repair the false-green root typecheck command
`pnpm run check-types` ran `nx run-many -t check-types` while all real targets are named `typecheck`, so it exited 0 having run nothing. The script now goes through `scripts/check-types.mjs`, which counts the projects exposing `typecheck`, fails loudly when the selection is empty, prints the count, and then runs the real target. `nx.json` target defaults are renamed to `typecheck` and given the ordering a clean checkout needs (`^build` + `generate`, since workspace packages resolve types from each other's `dist` declarations). The wrapper deliberately refuses selection flags (`--projects`/`--exclude`/`-p`) instead of mirroring nx's argument parsing — an empty nx selection exits 0, and every parsing divergence found in review was a fresh false-green path; custom selections get a pointer to `nx run-many` directly.

## PNI-301 — Add typecheck targets for core, encoder and proto
The three published protocol packages had no typecheck target. Each gets `tsc --noEmit`; proto uses a dedicated `tsconfig.typecheck.json` so its package-root `__tests__` are covered without touching the build tsconfig, and encoder gains `vitest/globals` types matching core. The new coverage found one genuine bug (a core test read `toolCalls` off the `Message` union without narrowing), fixed with proper narrowing. 33 of 37 Nx projects now expose `typecheck`; `publint --strict` and `attw --pack` stay green for all three.

## PNI-300 — Make every existing typecheck target green
Fixes the four failing projects from the ticket plus `@ag-ui/mastra`, which broke after filing. No exclusions, skips, or type-unsafe casts anywhere:
- **client**: `vitest/globals` added to tsconfig types (tests rely on the shared `globals: true` base), plus genuine strict fixes across 16 test files — typed `MockInstance<typeof console.debug>` spies, public `run()` on test agents to match `AbstractAgent`, discriminated-union narrowing helpers for role-specific message props, required `mockImplementation` args, complete event/message fixtures, `expect.fail` instead of jest's `fail`.
- **a2a-middleware**: passes `this.debugLogger` to `transformChunks`, matching `AbstractAgent`'s own usage. `this.debug` is the unresolved config object and resolved to `undefined`, so pipeline debug logging was silently dead — this fix turns it on when enabled.
- **langchain / mcp-apps-middleware**: the explicit tsconfig `types` field hid the already-installed `@types/node`; added `node` so the `crypto` import resolves.
- **mastra**: `@copilotkit/runtime` pins its own `@ag-ui/client@0.0.57`, whose `AbstractAgent` is nominally incompatible with the workspace `0.0.58` (private members). A documented tsconfig `paths` entry dedupes the declaration, typecheck-only.

## PNI-306 — Harden the unit workflow's GitHub context handling
`github.event_name` / `github.repository` move out of inline `${{ }}` interpolation onto Actions built-in env vars, and the fork head repo travels through the non-reserved `PR_HEAD_REPO`, matching the lint workflow's pattern. `middlewares/**` added to triggers since the build/test commands already cover those projects. zizmor and actionlint report no findings.

## PNI-302 — Run the real TypeScript typecheck gate in CI
New `typecheck-typescript.yml`: frozen install under the repository's pinned Node (`.node-version`) and pnpm toolchain, then `pnpm run check-types`. The wrapper provides the zero-selection guard and visible project count. Triggers cover SDK/integration/middleware sources plus lockfile, workspace, nx and wrapper-script paths.

## Verification
- `pnpm install --frozen-lockfile` → `pnpm run build` → `git diff --exit-code` ✅
- `pnpm run check-types -- --skip-nx-cache`: 33/33 projects green ✅
- `pnpm run test`: 33 projects green ✅ · `pnpm run lint`: 7 projects green ✅
- zizmor + actionlint clean on both workflows ✅
- Reviewed to convergence over four adversarial review rounds (findings fixed: guard bypass via selection flags — closed structurally; pnpm's forwarded `--` separator reaching tsc).

Out of scope by design: exact Node patch pinning (PNI-280) and repository-wide Prettier policy (PNI-305) are separate open tickets.

Closes PNI-299, PNI-300, PNI-301, PNI-302, PNI-303, PNI-306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
