### PR TITLE
fix(aws-strands): treat a recorded interrupt response as answered (PNI-328)

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -79,19 +79,91 @@ _TOOL_CALL_MAP_MAX = 512
 # tool receives this in place of a real answer and can treat it as a denial.
 INTERRUPT_CANCELLED = {"cancelled": True}
 
+# Reserved native-interrupt name prefix for interrupts this adapter's approval
+# hook raises. Anything else is a generic native interrupt.
+_TOOL_APPROVAL_NAME_PREFIX = "ag_ui:tool_call:"
+
+
+def _tool_approval_response_schema() -> dict:
+    """The response contract advertised for a tool-approval interrupt.
+
+    Single source for both the schema published on the AG-UI ``Interrupt`` and
+    the resume-payload validation, so a resume can still be checked when the
+    AG-UI bookkeeping did not survive a process restart.
+    """
+    return {
+        "type": "object",
+        "properties": {"approved": {"type": "boolean"}},
+        "required": ["approved"],
+    }
+
+
+def _is_tool_approval_interrupt(native_interrupt: Any) -> bool:
+    """True when a native Strands interrupt came from the approval hook."""
+    name = getattr(native_interrupt, "name", None)
+    return (
+        isinstance(name, str)
+        and name.startswith(_TOOL_APPROVAL_NAME_PREFIX)
+        and isinstance(getattr(native_interrupt, "reason", None), dict)
+    )
+
 
 def _wrap_resume_response(status: str, payload: Any) -> dict:
     """Package a ``ResumeEntry`` for Strands' ``interruptResponse`` shape.
 
-    Strands' resume gate is truthiness-based (i.e. ``if interrupt_.response:``),
-    so a raw falsy payload (``None``, ``False``, ``""``, ``0``, ``[]``, ``{}``)
-    re-raises the same interrupt and re-runs the tool body — an infinite approve loop.
-    Always hand Strands a truthy envelope; up to the tool implementation to properly
-    destructures it (e.g. via ``.get("cancelled")`` / ``.get("response")``).
+    Strands reads a recorded answer by its presence, and ``None`` is the
+    unanswered default, so forwarding a raw ``None`` payload re-raises the same
+    interrupt and re-runs the tool body, an infinite approve loop. Always hand
+    Strands an envelope it cannot read as absent; up to the tool implementation
+    to properly destructures it (e.g. via ``.get("cancelled")`` /
+    ``.get("response")``).
     """
     if status == "cancelled":
         return dict(INTERRUPT_CANCELLED)
     return {"response": payload}
+
+
+def _native_resume_response(entry: Any, native_interrupt: Any) -> Any:
+    """Return the answer Strands records when this entry is forwarded.
+
+    One definition, read both by the batch the run forwards and by the replay
+    comparison below, so the two cannot disagree about what was submitted.
+    """
+    if _is_tool_approval_interrupt(native_interrupt):
+        return {"approved": False} if entry.status == "cancelled" else entry.payload
+    return _wrap_resume_response(entry.status, entry.payload)
+
+
+def _replays_recorded_answers(interrupt_state: Any, resume_entries: Any) -> bool:
+    """True when this batch re-submits exactly the answers the checkpoint holds.
+
+    Strands records the submitted answers before it reruns hooks and the parked
+    tool execution, and clears the checkpoint only once that work succeeds. So a
+    hook failure, or a crash after session persistence, can restore a checkpoint
+    that is activated with every interrupt already answered. That thread has no
+    way forward: fresh input is refused because the checkpoint is active, and a
+    resume finds nothing open to address. Handing Strands the identical batch is
+    the way out, because it lets the SDK finish the parked execution. The
+    checkpoint itself must be left alone: clearing it would discard exactly that
+    parked execution. Anything short of an exact replay stays refused.
+    """
+    recorded = getattr(interrupt_state, "interrupts", {}) or {}
+    if not recorded or len(resume_entries) != len(recorded):
+        return False
+    addressed: set[str] = set()
+    for entry in resume_entries:
+        interrupt_id = getattr(entry, "interrupt_id", None)
+        native_interrupt = recorded.get(interrupt_id)
+        if native_interrupt is None or interrupt_id in addressed:
+            return False
+        addressed.add(interrupt_id)
+        if not _native_interrupt_is_answered(native_interrupt):
+            return False
+        if native_interrupt.response != _native_resume_response(
+            entry, native_interrupt
+        ):
+            return False
+    return True
 
 
 def _get_strands_session_manager(agent: Any) -> Any:
@@ -116,23 +188,14 @@ def _strands_interrupt_to_agui(strands_interrupt: Any) -> "Interrupt":
     name = getattr(strands_interrupt, "name", None) or "interrupt"
     raw_reason = getattr(strands_interrupt, "reason", None)
 
-    is_tool_approval = (
-        isinstance(name, str)
-        and name.startswith("ag_ui:tool_call:")
-        and isinstance(raw_reason, dict)
-    )
-    if is_tool_approval:
+    if _is_tool_approval_interrupt(strands_interrupt):
         tool_name = raw_reason.get("tool_name", "unknown")
         return Interrupt(
             id=s_id,
             reason="tool_call",
             message=f"Approve call to {tool_name}?",
             tool_call_id=raw_reason.get("tool_use_id"),
-            response_schema={
-                "type": "object",
-                "properties": {"approved": {"type": "boolean"}},
-                "required": ["approved"],
-            },
+            response_schema=_tool_approval_response_schema(),
             metadata={
                 "tool_name": tool_name,
                 "tool_input": raw_reason.get("tool_input", {}),
@@ -147,6 +210,31 @@ def _strands_interrupt_to_agui(strands_interrupt: Any) -> "Interrupt":
         response_schema=None,
         metadata={"reason": raw_reason} if raw_reason is not None else None,
     )
+
+
+def _native_interrupt_is_answered(interrupt: Any) -> bool:
+    """True when this interrupt already carries an answer Strands will hand back.
+
+    Presence decides, not truthiness: a legitimate answer can be ``False``,
+    ``0`` or ``""``, and Strands returns any recorded response rather than
+    re-raising for a human. ``None`` is the unanswered default.
+    """
+    return getattr(interrupt, "response", None) is not None
+
+
+def _open_native_interrupts(interrupts: Any) -> dict:
+    """Return the entries of ``interrupts`` still awaiting a human, keyed by id.
+
+    The native interrupt state is the only record of what is still in flight, and
+    every "is anything still open?" decision reads it through this one predicate,
+    so the pause this run reports and the resume the next one submits cannot
+    disagree and strand a client between them.
+    """
+    return {
+        interrupt_id: interrupt
+        for interrupt_id, interrupt in (interrupts or {}).items()
+        if not _native_interrupt_is_answered(interrupt)
+    }
 
 
 def _extract_interrupts(agent: Any, terminal_result: Any) -> list:
@@ -164,14 +252,17 @@ def _extract_interrupts(agent: Any, terminal_result: Any) -> list:
                 return list(interrupts)
     interrupt_state = getattr(agent, "_interrupt_state", None)
     if interrupt_state is not None and getattr(interrupt_state, "activated", False):
-        # Mirrors Strands' own gate (strands/types/interrupt.py: ``if interrupt_.response:``)
-        # — an interrupt with a truthy response was already answered by a prior partial
-        # resume and must not be re-reported as still pending.
-        return [
-            interrupt
-            for interrupt in getattr(interrupt_state, "interrupts", {}).values()
-            if not getattr(interrupt, "response", None)
-        ]
+        open_interrupts = _open_native_interrupts(
+            getattr(interrupt_state, "interrupts", {})
+        )
+        if not open_interrupts:
+            # The checkpoint is still activated yet every interrupt is answered,
+            # so this run reports success while the agent may remain parked.
+            logger.debug(
+                "Native interrupt state is activated but every interrupt carries "
+                "a response; reporting no pending interrupts"
+            )
+        return list(open_interrupts.values())
     return []
 
 
@@ -230,12 +321,16 @@ def _preflight_resume_entries(
             "A submitted resume must contain at least one entry"
         )
 
-    current_interrupts = getattr(interrupt_state, "interrupts", {})
-    open_interrupts = {
-        interrupt_id: interrupt
-        for interrupt_id, interrupt in current_interrupts.items()
-        if not getattr(interrupt, "response", None)
-    }
+    open_interrupts = _open_native_interrupts(
+        getattr(interrupt_state, "interrupts", {})
+    )
+    # An active checkpoint whose every interrupt is answered is a thread the SDK
+    # parked mid-resume (see _replays_recorded_answers). The interrupts an exact
+    # replay may address are the answered ones it is replaying.
+    if _replays_recorded_answers(interrupt_state, resume_entries):
+        addressable = dict(getattr(interrupt_state, "interrupts", {}) or {})
+    else:
+        addressable = open_interrupts
     seen_ids: set[str] = set()
     for entry in resume_entries:
         interrupt_id = getattr(entry, "interrupt_id", None)
@@ -248,13 +343,13 @@ def _preflight_resume_entries(
                 f"Resume contains duplicate interrupt id: {interrupt_id}"
             )
         seen_ids.add(interrupt_id)
-        interrupt = open_interrupts.get(interrupt_id)
+        interrupt = addressable.get(interrupt_id)
         if interrupt is None:
             return _interrupt_resume_error(
                 f"Resume references an interrupt that is not open: {interrupt_id}"
             )
 
-    missing_ids = set(open_interrupts) - seen_ids
+    missing_ids = set(addressable) - seen_ids
     if missing_ids:
         return RunErrorEvent(
             type=EventType.RUN_ERROR,
@@ -278,14 +373,22 @@ def _preflight_resume_entries(
                     code="INTERRUPT_EXPIRED",
                 )
 
-        if (
-            entry.status != "resolved"
-            or not ag_ui_interrupt
-            or not getattr(ag_ui_interrupt, "response_schema", None)
+        schema = (
+            getattr(ag_ui_interrupt, "response_schema", None)
+            if ag_ui_interrupt
+            else None
+        )
+        if not schema and _is_tool_approval_interrupt(
+            addressable.get(entry.interrupt_id)
         ):
+            # AG-UI bookkeeping can be lost to a restart while the native
+            # interrupt is restored. A tool approval's contract is fixed, so
+            # validate against it rather than waving the payload through.
+            schema = _tool_approval_response_schema()
+
+        if entry.status != "resolved" or not schema:
             continue
 
-        schema = ag_ui_interrupt.response_schema
         payload = entry.payload
         if schema.get("type") != "object":
             continue
@@ -887,7 +990,7 @@ class StrandsInterruptHook:
         #   - raises InterruptException (first call, no response yet) → suspends loop
         #   - returns the human response payload (resume call) → enforce decision
         response = event.interrupt(
-            f"ag_ui:tool_call:{tool_name}",
+            f"{_TOOL_APPROVAL_NAME_PREFIX}{tool_name}",
             reason={
                 "tool_name": tool_name,
                 "tool_input": event.tool_use.get("input", {}),
@@ -979,7 +1082,10 @@ class StrandsAgent:
         self._agents_by_thread: Dict[str, StrandsAgentCore] = agents_by_thread if agents_by_thread is not None else {}
         # Track proxy tool names registered per thread
         self._proxy_tool_names_by_thread: Dict[str, set] = {}
-        # Store full AG-UI Interrupt objects per thread for resume validation
+        # AG-UI interrupt metadata per thread: the answer shape advertised to
+        # the client and validated on the way back, the tool card an interrupt
+        # belongs to, and an expiry. Never consulted to decide whether anything
+        # is pending; the native interrupt state answers that on its own.
         self._pending_interrupts_by_thread: Dict[str, Dict[str, Interrupt]] = {}
         # Fingerprint of last successfully-processed resume per thread (idempotency)
         self._last_resume_fingerprint: Dict[str, str] = {}
@@ -1121,7 +1227,10 @@ class StrandsAgent:
                 return
 
         # Rule 4: reject new input against a parked checkpoint before context
-        # or tool registries can be updated by a run that will not proceed.
+        # or tool registries can be updated by a run that will not proceed. The
+        # SDK owns the checkpoint, so a checkpoint it still holds active blocks
+        # the turn and is left exactly as it stands: deactivating it here would
+        # discard the tool use and tool results parked behind it.
         if (
             not resume_submitted
             and getattr(interrupt_state, "activated", False) is True
@@ -1316,40 +1425,19 @@ class StrandsAgent:
             for entry in resume_entries:
                 ag_ui_interrupt = pending_ag_ui.get(entry.interrupt_id)
                 native_interrupt = interrupt_state.interrupts.get(entry.interrupt_id)
-                is_tool_approval = (
-                    isinstance(getattr(native_interrupt, "name", None), str)
-                    and native_interrupt.name.startswith("ag_ui:tool_call:")
-                    and isinstance(getattr(native_interrupt, "reason", None), dict)
-                )
 
-                if entry.status == "cancelled":
-                    # Track tool_call_ids for cancelled tool-bound interrupts
-                    if ag_ui_interrupt and getattr(ag_ui_interrupt, "tool_call_id", None):
-                        _resumed_tool_call_ids.add(ag_ui_interrupt.tool_call_id)
-                    # Include a denial response so Strands marks this interrupt
-                    # as responded (prevents re-raising on resume).
+                if entry.status in ("cancelled", "resolved"):
+                    # A cancelled entry still carries a response, so Strands
+                    # marks the interrupt answered and stops re-raising it.
                     interrupt_responses.append({
                         "interruptResponse": {
                             "interruptId": entry.interrupt_id,
-                            "response": (
-                                {"approved": False}
-                                if is_tool_approval
-                                else _wrap_resume_response(entry.status, entry.payload)
+                            "response": _native_resume_response(
+                                entry, native_interrupt
                             ),
                         }
                     })
-                elif entry.status == "resolved":
-                    interrupt_responses.append({
-                        "interruptResponse": {
-                            "interruptId": entry.interrupt_id,
-                            "response": (
-                                entry.payload
-                                if is_tool_approval
-                                else _wrap_resume_response(entry.status, entry.payload)
-                            ),
-                        }
-                    })
-                    # Track tool_call_ids for resumed interrupts (suppress re-emission)
+                    # Track tool_call_ids so the tool card is not re-emitted.
                     if ag_ui_interrupt and getattr(ag_ui_interrupt, "tool_call_id", None):
                         _resumed_tool_call_ids.add(ag_ui_interrupt.tool_call_id)
 

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -11,6 +11,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
+from importlib.metadata import version as distribution_version
 from typing import Any, AsyncIterator, Dict, List, Tuple
 
 from strands import Agent as StrandsAgentCore
@@ -84,6 +85,27 @@ INTERRUPT_CANCELLED = {"cancelled": True}
 _TOOL_APPROVAL_NAME_PREFIX = "ag_ui:tool_call:"
 
 
+def _strands_uses_presence_based_interrupt_responses(installed_version: str) -> bool:
+    """Return the interrupt-response contract of a Strands SDK version."""
+    try:
+        major, minor = map(int, installed_version.split(".", 2)[:2])
+    except ValueError as exc:
+        raise RuntimeError(
+            "Cannot determine interrupt response semantics for "
+            f"strands-agents version {installed_version!r}"
+        ) from exc
+    return (major, minor) >= (1, 19)
+
+
+# Strands 1.15 through 1.18 returns a recorded response only when it is truthy.
+# Version 1.19 changed that predicate to presence (``response is not None``).
+_STRANDS_USES_PRESENCE_BASED_INTERRUPT_RESPONSES = (
+    _strands_uses_presence_based_interrupt_responses(
+        distribution_version("strands-agents")
+    )
+)
+
+
 def _tool_approval_response_schema() -> dict:
     """The response contract advertised for a tool-approval interrupt.
 
@@ -111,12 +133,11 @@ def _is_tool_approval_interrupt(native_interrupt: Any) -> bool:
 def _wrap_resume_response(status: str, payload: Any) -> dict:
     """Package a ``ResumeEntry`` for Strands' ``interruptResponse`` shape.
 
-    Strands reads a recorded answer by its presence, and ``None`` is the
-    unanswered default, so forwarding a raw ``None`` payload re-raises the same
-    interrupt and re-runs the tool body, an infinite approve loop. Always hand
-    Strands an envelope it cannot read as absent; up to the tool implementation
-    to properly destructures it (e.g. via ``.get("cancelled")`` /
-    ``.get("response")``).
+    Supported Strands releases read a recorded answer either by truthiness
+    (1.15 through 1.18) or by presence (1.19+). Forwarding a raw falsy payload
+    can therefore re-raise the same interrupt and re-run the tool body on the
+    compatibility floor. Always hand Strands a truthy envelope; the tool
+    implementation unwraps it via ``.get("cancelled")`` / ``.get("response")``.
     """
     if status == "cancelled":
         return dict(INTERRUPT_CANCELLED)
@@ -215,11 +236,14 @@ def _strands_interrupt_to_agui(strands_interrupt: Any) -> "Interrupt":
 def _native_interrupt_is_answered(interrupt: Any) -> bool:
     """True when this interrupt already carries an answer Strands will hand back.
 
-    Presence decides, not truthiness: a legitimate answer can be ``False``,
-    ``0`` or ``""``, and Strands returns any recorded response rather than
-    re-raising for a human. ``None`` is the unanswered default.
+    Match the installed SDK's own ``ToolContext.interrupt`` predicate. Strands
+    1.15 through 1.18 uses truthiness; 1.19 and later uses presence, with
+    ``None`` as the unanswered default.
     """
-    return getattr(interrupt, "response", None) is not None
+    response = getattr(interrupt, "response", None)
+    if _STRANDS_USES_PRESENCE_BASED_INTERRUPT_RESPONSES:
+        return response is not None
+    return bool(response)
 
 
 def _open_native_interrupts(interrupts: Any) -> dict:
@@ -256,11 +280,12 @@ def _extract_interrupts(agent: Any, terminal_result: Any) -> list:
             getattr(interrupt_state, "interrupts", {})
         )
         if not open_interrupts:
-            # The checkpoint is still activated yet every interrupt is answered,
-            # so this run reports success while the agent may remain parked.
+            # The checkpoint is still activated yet every interrupt is answered
+            # under the installed SDK's semantics, so this run reports success
+            # while the agent may remain parked.
             logger.debug(
-                "Native interrupt state is activated but every interrupt carries "
-                "a response; reporting no pending interrupts"
+                "Native interrupt state is activated but every interrupt is "
+                "answered; reporting no pending interrupts"
             )
         return list(open_interrupts.values())
     return []

--- a/integrations/aws-strands/python/tests/interrupt_state_stub.py
+++ b/integrations/aws-strands/python/tests/interrupt_state_stub.py
@@ -31,6 +31,42 @@ class InterruptStateStub:
             self.context = context
         self.activated = True
 
+    def resume(self, prompt: Any) -> None:
+        """Record the submitted answers on their interrupts, as Strands does.
+
+        Paraphrased rather than delegated for the reason given above: the real
+        method is on a private class that moved between releases, and the oldest
+        release this package supports has no ``resume`` at all, so calling it
+        would pin the suite. ``test_stub_resume_matches_the_installed_sdk``
+        holds the paraphrase to the installed release's behaviour.
+        """
+        if not self.activated:
+            return
+        if not isinstance(prompt, list):
+            raise TypeError(
+                f"prompt_type={type(prompt)} | must resume from interrupt with "
+                "list of interruptResponse's"
+            )
+        foreign_types = [
+            content_type
+            for content in prompt
+            for content_type in content
+            if content_type != "interruptResponse"
+        ]
+        if foreign_types:
+            raise TypeError(
+                f"content_types=<{foreign_types}> | must resume from interrupt "
+                "with list of interruptResponse's"
+            )
+        for content in prompt:
+            interrupt_id = content["interruptResponse"]["interruptId"]
+            if interrupt_id not in self.interrupts:
+                raise KeyError(f"interrupt_id=<{interrupt_id}> | no interrupt found")
+            self.interrupts[interrupt_id].response = content["interruptResponse"][
+                "response"
+            ]
+        self.context["responses"] = prompt
+
     def deactivate(self) -> None:
         """Clear the pause, dropping interrupts and context as Strands does."""
         self.interrupts = {}

--- a/integrations/aws-strands/python/tests/test_interrupt.py
+++ b/integrations/aws-strands/python/tests/test_interrupt.py
@@ -11,8 +11,10 @@ AG-UI interrupt lifecycle:
 
 from __future__ import annotations
 
+import ast
 import copy
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -103,9 +105,10 @@ _UNSET = object()
 class _MockStrandsCore:
     """A minimal stand-in for ``StrandsAgentCore`` driving the stream loop.
 
-    ``stream_async`` records the prompt it was called with and yields the
-    provided terminal events. When ``interrupts`` are supplied it also flips its
-    ``_interrupt_state`` to activated, mirroring a paused native run.
+    ``stream_async`` records the prompt it was called with, applies Strands' own
+    checkpoint-resume step, and then yields whatever ``_stream_body`` produces.
+    When ``interrupts`` are supplied it also flips its ``_interrupt_state`` to
+    activated, mirroring a paused native run.
     """
 
     def __init__(self, terminal_events=None, interrupts=None, session_manager=_UNSET):
@@ -129,7 +132,20 @@ class _MockStrandsCore:
             self._interrupt_state.activate()
 
     async def stream_async(self, prompt):
+        """Record the prompt and apply Strands' own checkpoint-resume step.
+
+        Real ``stream_async`` resumes the checkpoint from the prompt before
+        anything else, so an activated checkpoint rejects a prompt that is not a
+        list of interrupt responses. Doubles supply a ``_stream_body`` instead of
+        replacing this method, so none of them can skip that step: one that skips
+        it certifies prompts production would reject.
+        """
         self.stream_prompts.append(prompt)
+        self._interrupt_state.resume(prompt)
+        async for event in self._stream_body(prompt):
+            yield event
+
+    async def _stream_body(self, prompt):
         for event in self._terminal_events:
             yield event
 
@@ -137,8 +153,7 @@ class _MockStrandsCore:
 class _PostStreamMixedCore(_MockStrandsCore):
     """Create an exact mixed checkpoint only after streaming starts."""
 
-    async def stream_async(self, prompt):
-        self.stream_prompts.append(prompt)
+    async def _stream_body(self, prompt):
         interrupt = StrandsInterrupt(id="native-interrupt", name="confirm")
         self._interrupt_state.interrupts[interrupt.id] = interrupt
         self._interrupt_state.context["tool_results"] = [
@@ -174,6 +189,72 @@ def _assert_single_run_error(events: list, code: str) -> None:
     assert len(errors) == 1
     assert errors[0].code == code
     assert not any(event.type == EventType.RUN_FINISHED for event in events)
+
+
+# ---------------------------------------------------------------------------
+# Stream-double contract
+# ---------------------------------------------------------------------------
+
+
+class TestStreamDoubleContract:
+    """Every core double drives Strands' checkpoint-resume step.
+
+    Overriding ``_stream_body`` keeps that step in place; overriding or reassigning
+    ``stream_async`` would skip a call the real one makes unconditionally.
+    """
+
+    def test_only_the_shared_core_defines_stream_async(self):
+        tree = ast.parse(Path(__file__).read_text())
+        definitions = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef)
+            and any(
+                isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and child.name == "stream_async"
+                for child in node.body
+            )
+        ]
+        reassignments = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Attribute) and target.attr == "stream_async"
+                for target in node.targets
+            )
+        ]
+        assert definitions == ["_MockStrandsCore"]
+        assert reassignments == []
+
+    @pytest.mark.asyncio
+    async def test_core_double_rejects_a_prompt_the_sdk_rejects(self):
+        core = _MockStrandsCore(
+            interrupts=[StrandsInterrupt(id="native-interrupt", name="confirm")]
+        )
+
+        with pytest.raises(TypeError):
+            async for _ in core.stream_async("what now?"):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_core_double_records_the_submitted_answer(self):
+        interrupt = StrandsInterrupt(id="native-interrupt", name="confirm")
+        core = _MockStrandsCore(interrupts=[interrupt])
+
+        async for _ in core.stream_async(
+            [
+                {
+                    "interruptResponse": {
+                        "interruptId": interrupt.id,
+                        "response": {"approved": True},
+                    }
+                }
+            ]
+        ):
+            pass
+
+        assert interrupt.response == {"approved": True}
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +354,6 @@ class TestInterruptOutcome:
         )
 
         async def _activate_during_stream(prompt):
-            core.stream_prompts.append(prompt)
             core._interrupt_state.interrupts = {
                 answered.id: answered,
                 open_interrupt.id: open_interrupt,
@@ -282,7 +362,7 @@ class TestInterruptOutcome:
             if False:
                 yield None
 
-        core.stream_async = _activate_during_stream
+        core._stream_body = _activate_during_stream
         agent = _make_base_agent()
 
         with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
@@ -428,13 +508,24 @@ def _invalid_resume_case(case: str) -> tuple[list[StrandsInterrupt], list[Resume
             ResumeEntry(interrupt_id="unknown", status="resolved", payload=True),
         ]
     if case == "answered":
+        # An answered interrupt is not open, so addressing it is refused. The
+        # submitted answer deliberately differs from the recorded one: an exact
+        # replay of the recorded answers is the one batch an all-answered
+        # checkpoint accepts, and this row is about the batches it does not.
         return [
             StrandsInterrupt(
                 id="answered",
                 name="confirm",
                 response={"response": True},
             )
-        ], [ResumeEntry(interrupt_id="answered", status="resolved", payload=True)]
+        ], [ResumeEntry(interrupt_id="answered", status="resolved", payload=False)]
+    if case == "answered-partially-addressed":
+        # Both are answered, so nothing is open, and a batch that covers only
+        # one of them is not the replay the checkpoint would accept either.
+        return [
+            StrandsInterrupt(id="first", name="confirm", response={"response": True}),
+            StrandsInterrupt(id="second", name="confirm", response={"response": True}),
+        ], [ResumeEntry(interrupt_id="first", status="resolved", payload=True)]
     raise AssertionError(f"unknown resume case: {case}")
 
 
@@ -448,6 +539,7 @@ def _invalid_resume_case(case: str) -> tuple[list[StrandsInterrupt], list[Resume
         "duplicate",
         "known-then-unknown",
         "answered",
+        "answered-partially-addressed",
     ],
 )
 @pytest.mark.asyncio
@@ -713,6 +805,45 @@ async def test_post_stream_new_mixed_checkpoint_fails_before_outcome_and_stays_r
     ]
 
 
+def _sdk_active_mixed_core(session_manager=None, answered=False) -> _MockStrandsCore:
+    """A checkpoint the SDK still holds active, parking a proxy placeholder.
+
+    ``answered`` records an answer on the interrupt, which is how a checkpoint
+    ends up active with nothing open: the SDK settles the interrupt but the tool
+    output it parked has not been appended to the conversation yet.
+    """
+    interrupt = StrandsInterrupt(id="native-interrupt", name="confirm")
+    if answered:
+        interrupt.response = {"approved": True}
+    core = _MockStrandsCore(interrupts=[interrupt], session_manager=session_manager)
+    core._interrupt_state.context["tool_use_message"] = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "native-proxy", "name": "proxy"}}],
+    }
+    core._interrupt_state.context["tool_results"] = [
+        {
+            "toolUseId": "native-proxy",
+            "status": "success",
+            "content": [{"text": PROXY_RESULT_PLACEHOLDER}],
+        }
+    ]
+    core.messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "native-proxy",
+                        "status": "success",
+                        "content": [{"text": PROXY_RESULT_PLACEHOLDER}],
+                    }
+                }
+            ],
+        }
+    ]
+    return core
+
+
 def _repository_manager() -> SimpleNamespace:
     repository = SimpleNamespace(
         list_messages=MagicMock(return_value=[]),
@@ -778,6 +909,62 @@ def _mixed_resume_input(*, include_proxy_result: bool) -> RunAgentInput:
         ],
         tools=[Tool(name="approveTool", description="approve", parameters={})],
     )
+
+
+@pytest.mark.parametrize(
+    ("session_manager", "expected_code"),
+    [
+        pytest.param(None, "INTERRUPT_SESSION_REQUIRED", id="no-session"),
+        pytest.param(
+            SimpleNamespace(session_id="session-without-repository"),
+            "INTERRUPT_SESSION_CAPABILITY_ERROR",
+            id="missing-repository-capability",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_resume_against_a_parked_proxy_placeholder_hits_the_mixed_guard(
+    session_manager, expected_code
+):
+    """The guard reads the checkpoint's parked tool results, so they must be there."""
+    core = _sdk_active_mixed_core(session_manager=session_manager)
+    agent = _make_base_agent()
+    before = _snapshot_mutable_core_state(core)
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+        events = await _collect_events(
+            agent,
+            _mixed_resume_input(include_proxy_result=True),
+        )
+
+    _assert_single_run_error(events, expected_code)
+    assert core.stream_prompts == []
+    assert _snapshot_mutable_core_state(core) == before
+
+
+@pytest.mark.asyncio
+async def test_fresh_turn_never_admits_a_checkpoint_parking_a_proxy_placeholder():
+    """The parked placeholder must not reach the model as the tool's own output.
+
+    An answered interrupt leaves the checkpoint active with nothing open. Clearing
+    it for the fresh turn also clears the tool results the mixed frontend-proxy
+    guard reads a few dozen lines later, so the guard passes on an empty
+    checkpoint and the placeholder is replayed to the model under a success
+    outcome.
+    """
+    core = _sdk_active_mixed_core(answered=True)
+    agent = _make_base_agent()
+    before = _snapshot_mutable_core_state(core)
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+        events = await _collect_events(
+            agent,
+            _make_run_input(messages=[UserMessage(id="u1", content="what now?")]),
+        )
+
+    _assert_single_run_error(events, "PENDING_INTERRUPTS")
+    assert core.stream_prompts == []
+    assert _snapshot_mutable_core_state(core) == before
 
 
 @pytest.mark.asyncio
@@ -1006,11 +1193,10 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
     core.state.set("agui_context", [])
 
     async def consume_checkpoint(prompt):
-        core.stream_prompts.append(prompt)
         core._interrupt_state.deactivate()
         yield {"complete": True}
 
-    core.stream_async = consume_checkpoint
+    core._stream_body = consume_checkpoint
     agent = _make_base_agent(StrandsAgentConfig())
     input_data = _make_run_input(
         messages=[

--- a/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_bookkeeping_persistence.py
@@ -30,6 +30,7 @@ from strands.tools.registry import ToolRegistry
 
 from ag_ui_strands.agent import StrandsAgent, _resume_fingerprint
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
+from tests.interrupt_state_stub import InterruptStateStub
 
 
 def _template_agent() -> MagicMock:
@@ -254,3 +255,208 @@ class TestPersistenceHelpersAreDefensiveAgainstMocks:
         pending, fingerprint = _load_persisted_interrupt_bookkeeping(_NoState())
         assert pending is None
         assert fingerprint is None
+
+
+class TestParkedResumeRecoveredAfterRestart:
+    """A restored checkpoint that is active with nothing open must recover.
+
+    Strands records the submitted answers onto the checkpoint before it reruns
+    the parked hooks and tool execution, and clears the checkpoint only once
+    that work succeeds. A failure in between persists a checkpoint that is
+    active with every interrupt answered, and that thread has no way forward:
+    fresh input is refused because the checkpoint is active, and a resume finds
+    nothing open to address. Replaying the exact batch is the way out, because
+    it hands Strands the answers it already holds and lets it finish the parked
+    execution. The checkpoint is never torn down here, since that would discard
+    exactly that execution.
+    """
+
+    THREAD = "parked-resume-thread"
+    INTERRUPT_ID = "v1:before_tool_call:tc-1:deploy"
+    APPROVAL = {"approved": True}
+    PARKED_OUTPUT = "Deployed to production."
+
+    def _parked_interrupt(self) -> StrandsInterrupt:
+        """The approval the tool raised, as SessionManager restores it."""
+        return StrandsInterrupt(
+            id=self.INTERRUPT_ID,
+            name="ag_ui:tool_call:deploy",
+            reason={"tool_name": "deploy", "tool_input": {}, "tool_use_id": "tc-1"},
+        )
+
+    def _submitted_batch(self, approved: bool = True) -> list:
+        return [
+            ResumeEntry(
+                interrupt_id=self.INTERRUPT_ID,
+                status="resolved",
+                payload={"approved": approved},
+            )
+        ]
+
+    def _restored_process(
+        self,
+        checkpoint: InterruptStateStub,
+        state: AgentState,
+        parked_work: Any,
+    ) -> tuple[StrandsAgent, list]:
+        """Wire an adapter onto a restored checkpoint, as a fresh process would.
+
+        ``parked_work`` stands where Strands reruns the hooks and tool execution
+        the checkpoint parked: it returns the stream events that work produces,
+        or raises. Either way the submitted answers are already recorded by
+        then, and the checkpoint is cleared only if it returns, which is the
+        order the SDK itself keeps.
+        """
+        agent = StrandsAgent(
+            _template_agent(), name="test-agent", config=StrandsAgentConfig()
+        )
+        inner = MagicMock()
+        inner.tool_registry = ToolRegistry()
+        inner.state = state
+        inner._interrupt_state = checkpoint
+        submitted: list = []
+
+        async def _stream(message: Any):
+            submitted.append(message)
+            checkpoint.resume(message)
+            for event in parked_work():
+                yield event
+            checkpoint.deactivate()
+
+        inner.stream_async = _stream
+        agent._agents_by_thread[self.THREAD] = inner
+        return agent, submitted
+
+    async def _stranded_thread(self) -> tuple[InterruptStateStub, AgentState, list]:
+        """Drive the failure that strands the thread; return what persists."""
+        checkpoint = InterruptStateStub(
+            interrupts={self.INTERRUPT_ID: self._parked_interrupt()}
+        )
+        checkpoint.activate()
+        state = AgentState()
+
+        def _hook_failure():
+            raise RuntimeError("post-approval hook failed")
+
+        agent, _ = self._restored_process(checkpoint, state, _hook_failure)
+        events = await _collect(
+            agent, _run_input(self.THREAD, resume=self._submitted_batch())
+        )
+        return checkpoint, state, events
+
+    def _parked_output(self) -> list:
+        return [{"data": self.PARKED_OUTPUT}]
+
+    async def test_a_failed_resume_persists_an_active_checkpoint_with_nothing_open(
+        self,
+    ):
+        """The premise: the answer is recorded and the checkpoint stays active."""
+        checkpoint, _, events = await self._stranded_thread()
+
+        assert checkpoint.activated is True
+        assert checkpoint.interrupts[self.INTERRUPT_ID].response == self.APPROVAL
+        assert [event.type for event in events if event.type == EventType.RUN_ERROR]
+
+    async def test_replaying_the_exact_batch_completes_the_parked_execution(self):
+        checkpoint, state, _ = await self._stranded_thread()
+
+        agent, submitted = self._restored_process(
+            checkpoint, state, self._parked_output
+        )
+        events = await _collect(
+            agent, _run_input(self.THREAD, resume=self._submitted_batch())
+        )
+
+        # The answers Strands already held were handed back to it unchanged.
+        assert submitted == [
+            [
+                {
+                    "interruptResponse": {
+                        "interruptId": self.INTERRUPT_ID,
+                        "response": self.APPROVAL,
+                    }
+                }
+            ]
+        ]
+        # The parked tool's output reached the client, so the execution ran.
+        assert [
+            event.delta
+            for event in events
+            if event.type == EventType.TEXT_MESSAGE_CONTENT
+        ] == [self.PARKED_OUTPUT]
+        assert not [
+            event for event in events if event.type == EventType.RUN_ERROR
+        ]
+        assert events[-1].type == EventType.RUN_FINISHED
+        assert events[-1].outcome.type == "success"
+        # Strands cleared its own checkpoint once the parked work succeeded.
+        assert checkpoint.activated is False
+
+    async def test_a_batch_that_does_not_replay_is_still_refused(self):
+        checkpoint, state, _ = await self._stranded_thread()
+
+        agent, submitted = self._restored_process(
+            checkpoint, state, self._parked_output
+        )
+        events = await _collect(
+            agent,
+            _run_input(self.THREAD, resume=self._submitted_batch(approved=False)),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [error.code for error in errors] == ["INTERRUPT_RESUME_ERROR"]
+        # Nothing reached Strands and the checkpoint stands exactly as restored.
+        assert submitted == []
+        assert checkpoint.activated is True
+        assert checkpoint.interrupts[self.INTERRUPT_ID].response == self.APPROVAL
+
+    async def test_an_answered_interrupt_cannot_ride_along_with_an_open_one(self):
+        """A still-open sibling means nothing is parked, so nothing is replayed.
+
+        A tool approval forwards its payload raw, so a submitted ``None`` equals
+        the unanswered default and slips past comparing answers alone. Only the
+        checkpoint's own answered/open reading separates the two.
+        """
+        open_approval = StrandsInterrupt(
+            id="v1:before_tool_call:tc-2:deploy",
+            name="ag_ui:tool_call:deploy",
+            reason={"tool_name": "deploy", "tool_input": {}, "tool_use_id": "tc-2"},
+        )
+        checkpoint, state, _ = await self._stranded_thread()
+        checkpoint.interrupts[open_approval.id] = open_approval
+        checkpoint.activate()
+
+        agent, submitted = self._restored_process(
+            checkpoint, state, self._parked_output
+        )
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD,
+                resume=self._submitted_batch()
+                + [
+                    ResumeEntry(
+                        interrupt_id=open_approval.id,
+                        status="resolved",
+                        payload=None,
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [error.code for error in errors] == ["INTERRUPT_RESUME_ERROR"]
+        assert submitted == []
+
+    async def test_fresh_input_against_the_parked_checkpoint_is_still_refused(self):
+        checkpoint, state, _ = await self._stranded_thread()
+
+        agent, submitted = self._restored_process(
+            checkpoint, state, self._parked_output
+        )
+        events = await _collect(agent, _run_input(self.THREAD))
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [error.code for error in errors] == ["PENDING_INTERRUPTS"]
+        assert submitted == []
+        assert checkpoint.activated is True

--- a/integrations/aws-strands/python/tests/test_interrupt_protocol.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_protocol.py
@@ -20,7 +20,7 @@ Covers:
 - Resume: no pending interrupt on thread yields RunErrorEvent
 - Resume: a payload is checked against the schema recorded in AG-UI bookkeeping
 - Resume: a tool approval is payload-checked without surviving AG-UI bookkeeping
-- An interrupt carrying a recorded answer, falsy included, counts as answered
+- Answered/open classification matches the installed Strands response contract
 - A checkpoint the SDK still holds active blocks a fresh turn, untouched
 - Every stream double reaches Strands through the shared checkpoint-resume step
 - That step's stand-in matches the installed SDK's own resume
@@ -32,6 +32,7 @@ import ast
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, AsyncIterator, Callable, Sequence
 from unittest.mock import MagicMock
 
@@ -44,13 +45,15 @@ from ag_ui.core import (
     UserMessage,
 )
 from strands.agent.state import AgentState
-from strands.interrupt import Interrupt as StrandsInterrupt
+from strands.interrupt import Interrupt as StrandsInterrupt, InterruptException
 from strands.tools.registry import ToolRegistry
+from strands.types.tools import ToolContext
 
 from ag_ui_strands.agent import (
     StrandsAgent,
     _native_interrupt_is_answered,
     _open_native_interrupts,
+    _strands_uses_presence_based_interrupt_responses,
 )
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands import (
@@ -111,6 +114,39 @@ def _make_generic_strands_interrupt(
         name=name,
         reason=reason or {"question": "Which environment?"},
     )
+
+
+def _make_preemptive_sdk_interrupt(
+    response: Any,
+) -> tuple[bool, StrandsInterrupt]:
+    """Exercise Strands' public preemptive-response contract.
+
+    Strands 1.15 through 1.18 re-raise an interrupt whose recorded response is
+    falsy; 1.19 and later return every response except ``None``. Build a real
+    ``ToolContext`` so compatibility assertions follow the installed SDK
+    instead of restating either implementation in this test suite.
+    """
+    interrupt_state = SimpleNamespace(interrupts={})
+    tool_context = ToolContext(
+        tool_use={
+            "toolUseId": "preemptive-response-contract",
+            "name": "contract_tool",
+            "input": {},
+        },
+        agent=SimpleNamespace(_interrupt_state=interrupt_state),
+        invocation_state={},
+    )
+
+    try:
+        returned = tool_context.interrupt("preanswered", response=response)
+    except InterruptException:
+        sdk_answered = False
+    else:
+        assert returned == response
+        sdk_answered = True
+
+    [native_interrupt] = interrupt_state.interrupts.values()
+    return sdk_answered, native_interrupt
 
 
 # ---------------------------------------------------------------------------
@@ -1197,31 +1233,47 @@ class TestResumeValidationWithoutAgUiBookkeeping:
 # ---------------------------------------------------------------------------
 
 class TestAnsweredInterruptClassification:
-    """An interrupt counts as answered once an answer is recorded on it.
+    """The adapter classifies answers exactly as the installed Strands does.
 
-    Strands records whatever answer arrives, so a legitimate "no" lands on
-    ``Interrupt.response`` as ``False`` (likewise ``0`` or ``""``), and hands
-    that answer back rather than re-raising for a human. The adapter has to
-    classify it the same way, in both the resume-validation path and the
-    pause-reporting path, or it re-asks a question the human already answered.
+    Strands changed its response predicate in 1.19: older supported releases
+    use truthiness, while newer releases use presence. The adapter must follow
+    that installed contract in both resume validation and pause reporting or it
+    can hide a question that Strands is still waiting to have answered.
     """
 
     THREAD = "answered-classification-thread"
 
-    # Answers that are falsy but genuinely recorded. ``None`` is deliberately
-    # absent: Strands' Python ``Interrupt.response`` defaults to ``None``, so
-    # ``None`` reads as "no answer recorded". (The TypeScript SDK instead keys
-    # off ``undefined``, which makes a recorded ``null`` an answer there; the two
-    # SDKs do not agree on that value.)
+    @pytest.mark.parametrize(
+        ("installed_version", "expected"),
+        [
+            ("1.15.0", False),
+            ("1.18.0", False),
+            ("1.19.0", True),
+            ("2.0.0", True),
+        ],
+    )
+    def test_response_contract_boundary(self, installed_version, expected):
+        assert (
+            _strands_uses_presence_based_interrupt_responses(installed_version)
+            is expected
+        )
+
+    # Bare falsy responses cross the SDK's 1.19 behavior boundary. ``None`` is
+    # deliberately absent because it remains the unanswered default on both
+    # sides of that boundary.
     FALSY_ANSWERS = [False, 0, "", [], {}]
     FALSY_ANSWER_IDS = ["false", "zero", "empty-string", "empty-list", "empty-dict"]
 
     @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
-    def test_a_falsy_recorded_answer_closes_the_interrupt(self, recorded_answer):
-        answered = _make_strands_interrupt("my_tool", {}, "st-falsy-predicate")
-        answered.response = recorded_answer
-        assert _native_interrupt_is_answered(answered) is True
-        assert _open_native_interrupts({answered.id: answered}) == {}
+    def test_bare_falsy_response_matches_installed_sdk(self, recorded_answer):
+        sdk_answered, native_interrupt = _make_preemptive_sdk_interrupt(
+            recorded_answer
+        )
+
+        assert _native_interrupt_is_answered(native_interrupt) is sdk_answered
+        assert _open_native_interrupts({native_interrupt.id: native_interrupt}) == (
+            {} if sdk_answered else {native_interrupt.id: native_interrupt}
+        )
 
     def test_an_unanswered_interrupt_stays_open(self):
         open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open-predicate")
@@ -1231,10 +1283,10 @@ class TestAnsweredInterruptClassification:
         }
 
     async def test_resume_addresses_only_the_open_sibling(self):
-        """A falsy-answered sibling is settled, so the resume batch is complete."""
+        """A wrapped answer is settled on every supported Strands release."""
         open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
         answered = _make_strands_interrupt("my_tool", {}, "st-answered")
-        answered.response = False
+        answered.response = {"response": False}
         interrupt_state = InterruptStateStub(
             interrupts={open_interrupt.id: open_interrupt, answered.id: answered},
         )
@@ -1287,8 +1339,8 @@ class TestAnsweredInterruptClassification:
     async def test_pause_reports_only_the_interrupts_still_open(self):
         """The pause reports exactly what the SDK still holds open.
 
-        A preemptive falsy answer settles its interrupt, so re-reporting it would
-        ask the human the same question twice.
+        A bare preemptive ``False`` remains open through Strands 1.18 and closes
+        in 1.19+, so this integration path must move with the real SDK contract.
         """
         resumed = _make_strands_interrupt("my_tool", {}, "st-resumed")
         interrupt_state = InterruptStateStub(interrupts={resumed.id: resumed})
@@ -1296,12 +1348,7 @@ class TestAnsweredInterruptClassification:
 
         # The resumed tool answers a cached decision preemptively with a "no"
         # and then pauses on a fresh question.
-        cached = StrandsInterrupt(
-            id="v1:custom:use_cached_plan",
-            name="use_cached_plan",
-            reason=None,
-            response=False,
-        )
+        sdk_answered, cached = _make_preemptive_sdk_interrupt(False)
         follow_up = StrandsInterrupt(
             id="v1:custom:need_clarification",
             name="need_clarification",
@@ -1344,10 +1391,9 @@ class TestAnsweredInterruptClassification:
         assert len(finished) == 1
         outcome = finished[0].outcome
         assert isinstance(outcome, RunFinishedInterruptOutcome)
-        assert [interrupt.id for interrupt in outcome.interrupts] == [follow_up.id]
-        assert [interrupt.reason for interrupt in outcome.interrupts] == [
-            "need_clarification"
-        ]
+        assert [interrupt.id for interrupt in outcome.interrupts] == (
+            [follow_up.id] if sdk_answered else [cached.id, follow_up.id]
+        )
 
     async def test_unanswered_interrupt_still_blocks_a_partial_resume(self):
         """The partial-resume guard keeps firing for genuinely open interrupts."""
@@ -1385,14 +1431,14 @@ class TestAnsweredInterruptClassification:
 
     @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
     async def test_resume_submits_only_the_open_interrupt_answer(self, recorded_answer):
-        """Every falsy recorded answer settles its own interrupt.
+        """The adapter's truthy envelope settles every falsy client payload.
 
         Asserts the exact ``interruptResponse`` batch reaching Strands: the open
         interrupt's answer and nothing else.
         """
         open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
         answered = _make_strands_interrupt("my_tool", {}, "st-answered")
-        answered.response = recorded_answer
+        answered.response = {"response": recorded_answer}
         interrupt_state = InterruptStateStub(
             interrupts={open_interrupt.id: open_interrupt, answered.id: answered},
         )
@@ -1439,10 +1485,10 @@ class TestAnsweredInterruptClassification:
         ]
 
     @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
-    async def test_pause_omits_a_falsy_answered_interrupt(
+    async def test_pause_omits_a_wrapped_falsy_answer(
         self, recorded_answer
     ):
-        """The pause reporter settles every falsy answer, as the SDK does."""
+        """The pause reporter settles every wrapped falsy client answer."""
         resumed = _make_strands_interrupt("my_tool", {}, "st-resumed")
         interrupt_state = InterruptStateStub(interrupts={resumed.id: resumed})
         interrupt_state.activate()
@@ -1453,7 +1499,7 @@ class TestAnsweredInterruptClassification:
             id="v1:custom:use_cached_plan",
             name="use_cached_plan",
             reason=None,
-            response=recorded_answer,
+            response={"response": recorded_answer},
         )
         follow_up = StrandsInterrupt(
             id="v1:custom:need_clarification",
@@ -1689,15 +1735,14 @@ class TestAnsweredInterruptClassification:
         }
         assert interrupt_state.context == {"tool_use_message": {"role": "assistant"}}
 
-    async def test_falsy_answered_interrupt_is_not_open_for_a_resume(self):
-        """A settled interrupt is not something a resume can address.
+    async def test_wrapped_falsy_answer_is_not_open_for_a_resume(self):
+        """An adapter-managed settled interrupt cannot be addressed again.
 
-        The SDK hands its recorded answer back rather than re-raising, so a
-        resume naming it is answering a question no longer being asked, and
-        nothing may reach Strands on its behalf.
+        The truthy response envelope works across every supported Strands
+        release, so nothing may reach Strands on this interrupt's behalf.
         """
         answered = _make_strands_interrupt("my_tool", {}, "st-falsy-resumed")
-        answered.response = False
+        answered.response = {"response": False}
         interrupt_state = InterruptStateStub(interrupts={answered.id: answered})
         interrupt_state.activate()
 

--- a/integrations/aws-strands/python/tests/test_interrupt_protocol.py
+++ b/integrations/aws-strands/python/tests/test_interrupt_protocol.py
@@ -18,12 +18,21 @@ Covers:
 - Resume: cancelled forwards a native denial through stream_async() and ends cleanly
 - Resume: unknown interrupt_id yields RunErrorEvent
 - Resume: no pending interrupt on thread yields RunErrorEvent
+- Resume: a payload is checked against the schema recorded in AG-UI bookkeeping
+- Resume: a tool approval is payload-checked without surviving AG-UI bookkeeping
+- An interrupt carrying a recorded answer, falsy included, counts as answered
+- A checkpoint the SDK still holds active blocks a fresh turn, untouched
+- Every stream double reaches Strands through the shared checkpoint-resume step
+- That step's stand-in matches the installed SDK's own resume
 """
 
 from __future__ import annotations
 
+import ast
+import logging
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Sequence
 from unittest.mock import MagicMock
 
 import pytest
@@ -34,16 +43,22 @@ from ag_ui.core import (
     Tool,
     UserMessage,
 )
+from strands.agent.state import AgentState
 from strands.interrupt import Interrupt as StrandsInterrupt
 from strands.tools.registry import ToolRegistry
 
-from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.agent import (
+    StrandsAgent,
+    _native_interrupt_is_answered,
+    _open_native_interrupts,
+)
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands import (
     ResumeEntry,
     RunFinishedInterruptOutcome,
     RunFinishedSuccessOutcome,
 )
+from tests.interrupt_state_stub import InterruptStateStub
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +96,23 @@ def _make_strands_interrupt(
     )
 
 
+def _make_generic_strands_interrupt(
+    name: str = "need_clarification",
+    reason: dict | None = None,
+    interrupt_id: str = "v1:custom:generic-1",
+) -> StrandsInterrupt:
+    """Build a native interrupt raised outside the adapter's approval hook.
+
+    Its name carries no "ag_ui:tool_call:" prefix, so no fixed response
+    contract can be inferred from it.
+    """
+    return StrandsInterrupt(
+        id=interrupt_id,
+        name=name,
+        reason=reason or {"question": "Which environment?"},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -103,6 +135,54 @@ def _make_interrupt_state(activated: bool = False, interrupts: dict | None = Non
     return state
 
 
+def _is_native_resume_prompt(message: Any) -> bool:
+    """Report whether a prompt is a batch of native interrupt responses."""
+    return isinstance(message, list) and any(
+        isinstance(item, dict) and "interruptResponse" in item for item in message
+    )
+
+
+def _install_stream(inner: Any, body: Callable[[Any], AsyncIterator[Any]]) -> None:
+    """Install a stream body behind the checkpoint-resume step.
+
+    Strands' ``stream_async`` resumes the checkpoint from the prompt before
+    anything else, so an activated checkpoint rejects a prompt that is not a
+    list of interrupt responses, and a completed resume leaves the checkpoint
+    deactivated. Drive that step here and route every double in this module
+    through it rather than assigning ``stream_async`` directly: a double that
+    skips the step certifies prompts production would reject.
+    """
+
+    async def _stream(message: Any):
+        inner._interrupt_state.resume(message)
+        if _is_native_resume_prompt(message):
+            inner._interrupt_state.deactivate()
+        async for event in body(message):
+            yield event
+
+    inner.stream_async = _stream
+
+
+def _capture_prompts(inner: Any) -> list:
+    """Record every prompt handed to the installed stream double.
+
+    Returns the list the spy appends to, so a test can assert exactly which
+    interrupt answers were submitted rather than merely that a call happened.
+    The spy wraps whatever ``_install_stream`` put in place instead of replacing
+    it, so the SDK's resume step still runs on the recorded prompt.
+    """
+    installed = inner.stream_async
+    prompts: list = []
+
+    async def _spy_stream(message: Any):
+        prompts.append(message)
+        async for event in installed(message):
+            yield event
+
+    inner.stream_async = _spy_stream
+    return prompts
+
+
 def _build_agent(
     thread_id: str,
     stream_events: list,
@@ -118,16 +198,11 @@ def _build_agent(
     # Wire interrupt state
     mock_inner._interrupt_state = interrupt_state or _make_interrupt_state()
 
-    async def _stream(_msg: Any):
-        if isinstance(_msg, list) and any(
-            isinstance(item, dict) and "interruptResponse" in item
-            for item in _msg
-        ):
-            mock_inner._interrupt_state.deactivate()
+    async def _replay(_msg: Any):
         for event in stream_events:
             yield event
 
-    mock_inner.stream_async = _stream
+    _install_stream(mock_inner, _replay)
     agent._agents_by_thread[thread_id] = mock_inner
     return agent
 
@@ -174,6 +249,182 @@ def _empty_stream() -> list:
     return [
         {"result": _FakeAgentResult(stop_reason="end_turn")},
     ]
+
+
+# ---------------------------------------------------------------------------
+# Stream-double installation
+# ---------------------------------------------------------------------------
+
+
+def _stream_async_assignment_scopes(module_path: Path) -> list[str]:
+    """Name the outermost function holding each ``.stream_async`` assignment."""
+    scopes: list[str] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.enclosing: list[str] = []
+
+        def _visit_function(self, node: Any) -> None:
+            self.enclosing.append(node.name)
+            self.generic_visit(node)
+            self.enclosing.pop()
+
+        visit_FunctionDef = _visit_function
+        visit_AsyncFunctionDef = _visit_function
+
+        def visit_Assign(self, node: ast.Assign) -> None:
+            for target in node.targets:
+                if isinstance(target, ast.Attribute) and target.attr == "stream_async":
+                    scopes.append(self.enclosing[0] if self.enclosing else "<module>")
+            self.generic_visit(node)
+
+    _Visitor().visit(ast.parse(module_path.read_text()))
+    return scopes
+
+
+class TestStreamDoubleInstallation:
+    """Every double in this module reaches Strands through the SDK's resume step.
+
+    The seam is the guard, not each caller's diligence: a test that assigns
+    ``stream_async`` itself skips the step a real ``stream_async`` performs
+    unconditionally, and then certifies prompts production would reject.
+    """
+
+    def test_every_stream_double_is_installed_through_the_seam(self):
+        assert set(_stream_async_assignment_scopes(Path(__file__))) == {
+            "_install_stream",
+            "_capture_prompts",
+        }
+
+    async def test_installed_double_rejects_a_prompt_the_sdk_rejects(self):
+        """Plain user text against an activated checkpoint raises, as in Strands."""
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
+        interrupt_state = InterruptStateStub(interrupts={open_interrupt.id: open_interrupt})
+        interrupt_state.activate()
+        thread = "stream-double-thread-reject"
+        agent = _build_agent(
+            thread, _empty_stream(), StrandsAgentConfig(), interrupt_state
+        )
+
+        with pytest.raises(TypeError):
+            async for _ in agent._agents_by_thread[thread].stream_async("what now?"):
+                pass
+
+    async def test_installed_double_records_the_submitted_answer(self):
+        """A resume prompt lands on the interrupt and clears the checkpoint."""
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
+        interrupt_state = InterruptStateStub(interrupts={open_interrupt.id: open_interrupt})
+        interrupt_state.activate()
+        thread = "stream-double-thread-record"
+        agent = _build_agent(
+            thread, _empty_stream(), StrandsAgentConfig(), interrupt_state
+        )
+
+        prompt = [
+            {
+                "interruptResponse": {
+                    "interruptId": open_interrupt.id,
+                    "response": {"approved": True},
+                }
+            }
+        ]
+        async for _ in agent._agents_by_thread[thread].stream_async(prompt):
+            pass
+
+        assert open_interrupt.response == {"approved": True}
+        assert interrupt_state.activated is False
+
+
+# ---------------------------------------------------------------------------
+# Interrupt-state stub conformance
+# ---------------------------------------------------------------------------
+
+
+def _sdk_interrupt_state_class() -> Any:
+    """Return Strands' own interrupt-state class, or ``None`` if unavailable.
+
+    The class is private and has moved between releases, and the oldest release
+    this package supports carries no ``resume`` to compare against, so a caller
+    that cannot get hold of it skips rather than failing.
+    """
+    try:
+        from strands.interrupt import _InterruptState
+    except ImportError:
+        return None
+    return _InterruptState if hasattr(_InterruptState, "resume") else None
+
+
+class TestInterruptStateStubConformance:
+    """``InterruptStateStub.resume`` paraphrases the SDK's, so hold it to it.
+
+    Every double in this module drives the stub, so a paraphrase that drifted
+    from the SDK would certify prompts Strands rejects and reject prompts it
+    accepts. This is the one place that reaches for the private class, and it
+    skips when the installed release does not expose it.
+    """
+
+    INTERRUPT_ID = "stub-conformance-interrupt"
+    RESPONSE = {"approved": True}
+
+    def _activated_pair(self) -> tuple[InterruptStateStub, Any]:
+        """Build a stub and a real checkpoint holding the same open interrupt."""
+        sdk_class = _sdk_interrupt_state_class()
+        if sdk_class is None:
+            pytest.skip("installed Strands exposes no interrupt-state resume to compare")
+        stub = InterruptStateStub(
+            interrupts={self.INTERRUPT_ID: StrandsInterrupt(self.INTERRUPT_ID, "confirm")}
+        )
+        sdk_state = sdk_class(
+            interrupts={self.INTERRUPT_ID: StrandsInterrupt(self.INTERRUPT_ID, "confirm")}
+        )
+        stub.activate()
+        sdk_state.activate()
+        return stub, sdk_state
+
+    def test_stub_records_the_answer_the_sdk_records(self):
+        stub, sdk_state = self._activated_pair()
+        prompt = [
+            {
+                "interruptResponse": {
+                    "interruptId": self.INTERRUPT_ID,
+                    "response": self.RESPONSE,
+                }
+            }
+        ]
+
+        stub.resume(prompt)
+        sdk_state.resume(prompt)
+
+        assert (
+            stub.interrupts[self.INTERRUPT_ID].response
+            == sdk_state.interrupts[self.INTERRUPT_ID].response
+            == self.RESPONSE
+        )
+
+    def test_stub_rejects_an_unknown_id_the_way_the_sdk_rejects_it(self):
+        stub, sdk_state = self._activated_pair()
+        prompt = [
+            {
+                "interruptResponse": {
+                    "interruptId": "never-raised-by-this-checkpoint",
+                    "response": self.RESPONSE,
+                }
+            }
+        ]
+
+        with pytest.raises(Exception) as sdk_rejection:
+            sdk_state.resume(prompt)
+        with pytest.raises(type(sdk_rejection.value)):
+            stub.resume(prompt)
+
+    def test_stub_rejects_a_non_resume_prompt_the_way_the_sdk_rejects_it(self):
+        """The seam's rejection assertions rest on this raising as Strands does."""
+        stub, sdk_state = self._activated_pair()
+
+        with pytest.raises(Exception) as sdk_rejection:
+            sdk_state.resume("what now?")
+        with pytest.raises(type(sdk_rejection.value)):
+            stub.resume("what now?")
 
 
 # ---------------------------------------------------------------------------
@@ -328,14 +579,13 @@ class TestResumeResolvedApproved:
             interrupts={strands_interrupt.id: strands_interrupt},
         )
 
-        received_prompts: list = []
-
-        async def _capture_stream(prompt: Any):
-            received_prompts.append(prompt)
-            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
-
-        agent = _build_agent(self.THREAD + "-y", [], self._config(), interrupt_state)
-        agent._agents_by_thread[self.THREAD + "-y"].stream_async = _capture_stream
+        agent = _build_agent(
+            self.THREAD + "-y",
+            [{"result": _FakeAgentResult(stop_reason="end_turn")}],
+            self._config(),
+            interrupt_state,
+        )
+        received_prompts = _capture_prompts(agent._agents_by_thread[self.THREAD + "-y"])
 
         resume_input = _run_input(
             self.THREAD + "-y",
@@ -361,14 +611,13 @@ class TestResumeResolvedApproved:
             interrupts={strands_interrupt.id: strands_interrupt},
         )
 
-        received_prompts: list = []
-
-        async def _capture_stream(prompt: Any):
-            received_prompts.append(prompt)
-            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
-
-        agent = _build_agent(self.THREAD + "-n", [], self._config(), interrupt_state)
-        agent._agents_by_thread[self.THREAD + "-n"].stream_async = _capture_stream
+        agent = _build_agent(
+            self.THREAD + "-n",
+            [{"result": _FakeAgentResult(stop_reason="end_turn")}],
+            self._config(),
+            interrupt_state,
+        )
+        received_prompts = _capture_prompts(agent._agents_by_thread[self.THREAD + "-n"])
 
         resume_input = _run_input(
             self.THREAD + "-n",
@@ -390,16 +639,15 @@ class TestResumeResolvedApproved:
             interrupts={strands_interrupt.id: strands_interrupt},
         )
 
-        received_prompts: list = []
-
-        async def _capture_stream(prompt: Any):
-            received_prompts.append(prompt)
-            yield {"result": _FakeAgentResult(stop_reason="end_turn")}
-
-        agent = _build_agent(self.THREAD + "-replay", [], self._config(), interrupt_state)
+        agent = _build_agent(
+            self.THREAD + "-replay",
+            [{"result": _FakeAgentResult(stop_reason="end_turn")}],
+            self._config(),
+            interrupt_state,
+        )
         inner = agent._agents_by_thread[self.THREAD + "-replay"]
         inner.session_manager = None  # Force replay_history=True
-        inner.stream_async = _capture_stream
+        received_prompts = _capture_prompts(inner)
 
         resume_input = _run_input(
             self.THREAD + "-replay",
@@ -467,15 +715,7 @@ class TestResumeCancelled:
         agent = _build_agent(self.THREAD + "-deact", [], self._config(), interrupt_state)
         mock_inner = agent._agents_by_thread[self.THREAD + "-deact"]
 
-        captured_prompts: list = []
-        original_stream_async = mock_inner.stream_async
-
-        async def _spy_stream(msg: Any):
-            captured_prompts.append(msg)
-            async for event in original_stream_async(msg):
-                yield event
-
-        mock_inner.stream_async = _spy_stream
+        captured_prompts = _capture_prompts(mock_inner)
 
         resume_input = _run_input(
             self.THREAD + "-deact",
@@ -545,7 +785,6 @@ class TestResumeUnknownInterruptId:
         assert len(errors) == 1
         assert errors[0].code == "UNKNOWN_INTERRUPT_ID"
 
-
 # ---------------------------------------------------------------------------
 # Resume: idempotency and payload type validation
 # ---------------------------------------------------------------------------
@@ -554,22 +793,31 @@ class TestResumeUnknownInterruptId:
 class TestResumeValidation:
     THREAD = "resume-validation-thread"
 
-    def _agent_with_pending_schema(self, schema: dict) -> tuple[StrandsAgent, Any]:
-        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+    def _agent_with_pending_schema(
+        self,
+        schema: dict,
+        native_interrupt: Any | None = None,
+        reason: str = "tool_call",
+        thread: str | None = None,
+    ) -> tuple[StrandsAgent, Any]:
+        thread = thread or self.THREAD
+        strands_interrupt = native_interrupt or _make_strands_interrupt(
+            "my_tool", {}, "st-1"
+        )
         interrupt_state = _make_interrupt_state(
             activated=True,
             interrupts={strands_interrupt.id: strands_interrupt},
         )
         agent = _build_agent(
-            self.THREAD,
+            thread,
             _empty_stream(),
             StrandsAgentConfig(),
             interrupt_state,
         )
-        agent._pending_interrupts_by_thread[self.THREAD] = {
+        agent._pending_interrupts_by_thread[thread] = {
             strands_interrupt.id: Interrupt(
                 id=strands_interrupt.id,
-                reason="tool_call",
+                reason=reason,
                 response_schema=schema,
             )
         }
@@ -588,17 +836,8 @@ class TestResumeValidation:
             StrandsAgentConfig(),
             interrupt_state,
         )
-        stream_calls = 0
         inner = agent._agents_by_thread[self.THREAD + "-reordered"]
-        original_stream = inner.stream_async
-
-        async def _spy_stream(message: Any):
-            nonlocal stream_calls
-            stream_calls += 1
-            async for event in original_stream(message):
-                yield event
-
-        inner.stream_async = _spy_stream
+        stream_prompts = _capture_prompts(inner)
         first_resume = [
             ResumeEntry(interrupt_id=first.id, status="resolved", payload={"approved": True}),
             ResumeEntry(interrupt_id=second.id, status="cancelled"),
@@ -607,7 +846,7 @@ class TestResumeValidation:
             agent,
             _run_input(self.THREAD + "-reordered", resume=first_resume),
         )
-        assert stream_calls == 1
+        assert len(stream_prompts) == 1
 
         # A completed native resume has no active interrupts. Simulate that
         # state before replaying the equivalent entries in reverse order.
@@ -619,9 +858,68 @@ class TestResumeValidation:
                 resume=list(reversed(first_resume)),
             ),
         )
-        assert stream_calls == 1
+        assert len(stream_prompts) == 1
         assert any(event.type == EventType.RUN_FINISHED for event in replay_events)
         assert not any(event.type == EventType.RUN_ERROR for event in replay_events)
+
+    async def test_absent_and_explicit_none_payloads_submit_the_same_answer(self):
+        """The replay short-circuit may only merge resumes this SDK merges.
+
+        Pydantic gives an omitted payload and an explicit ``None`` the same
+        ``ResumeEntry.payload``, and both reach Strands as the same
+        ``interruptResponse``, so one idempotency fingerprint covering both is
+        right here. The TypeScript adapter keys off ``undefined`` and sends
+        ``{}`` for the omitted one, which is why its fingerprint separates them.
+        """
+        submitted: list = []
+        for label, entry_kwargs in (
+            ("absent", {}),
+            ("explicit-none", {"payload": None}),
+        ):
+            generic = _make_generic_strands_interrupt()
+            thread = f"{self.THREAD}-{label}-payload"
+            interrupt_state = _make_interrupt_state(
+                activated=True,
+                interrupts={generic.id: generic},
+            )
+            agent = _build_agent(
+                thread, _empty_stream(), StrandsAgentConfig(), interrupt_state
+            )
+            inner = agent._agents_by_thread[thread]
+            prompts = _capture_prompts(inner)
+
+            events = await _collect(
+                agent,
+                _run_input(
+                    thread,
+                    resume=[
+                        ResumeEntry(
+                            interrupt_id=generic.id,
+                            status="resolved",
+                            **entry_kwargs,
+                        )
+                    ],
+                ),
+            )
+
+            assert [
+                (event.code, event.message)
+                for event in events
+                if event.type == EventType.RUN_ERROR
+            ] == []
+            submitted.append(prompts)
+
+        assert submitted[0] == submitted[1]
+        assert submitted[0] == [
+            [
+                {
+                    "interruptResponse": {
+                        "interruptId": "v1:custom:generic-1",
+                        "response": {"response": None},
+                    }
+                }
+            ]
+        ]
 
     async def test_non_boolean_approval_payload_is_rejected(self):
         schema = {
@@ -696,6 +994,747 @@ class TestResumeValidation:
             ),
         )
         assert not any(event.type == EventType.RUN_ERROR for event in edited_events)
+
+    # A generic native interrupt carries no inferable response contract, so its
+    # schema can only come from the recorded AG-UI interrupt. These cases pin
+    # that read: nothing else can supply a schema here.
+
+    def _generic_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"environment": {"type": "string"}},
+            "required": ["environment"],
+        }
+
+    async def test_generic_interrupt_payload_missing_required_key_is_rejected(self):
+        generic = _make_generic_strands_interrupt()
+        agent, _ = self._agent_with_pending_schema(
+            self._generic_schema(),
+            native_interrupt=generic,
+            reason="need_clarification",
+            thread=self.THREAD + "-generic-missing",
+        )
+
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD + "-generic-missing",
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=generic.id,
+                        status="resolved",
+                        payload={},
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [event.code for event in errors] == ["INVALID_PAYLOAD"]
+        assert "environment" in errors[0].message
+
+    async def test_generic_interrupt_payload_of_wrong_type_is_rejected(self):
+        generic = _make_generic_strands_interrupt()
+        agent, _ = self._agent_with_pending_schema(
+            self._generic_schema(),
+            native_interrupt=generic,
+            reason="need_clarification",
+            thread=self.THREAD + "-generic-type",
+        )
+
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD + "-generic-type",
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=generic.id,
+                        status="resolved",
+                        payload={"environment": 3},
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [event.code for event in errors] == ["INVALID_PAYLOAD"]
+        assert "environment" in errors[0].message
+
+    async def test_generic_interrupt_payload_matching_recorded_schema_is_valid(self):
+        generic = _make_generic_strands_interrupt()
+        thread = self.THREAD + "-generic-valid"
+        agent, _ = self._agent_with_pending_schema(
+            self._generic_schema(),
+            native_interrupt=generic,
+            reason="need_clarification",
+            thread=thread,
+        )
+        received_prompts = _capture_prompts(agent._agents_by_thread[thread])
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=generic.id,
+                        status="resolved",
+                        payload={"environment": "staging"},
+                    )
+                ],
+            ),
+        )
+
+        assert not any(event.type == EventType.RUN_ERROR for event in events)
+        assert len(received_prompts) == 1
+        response = received_prompts[0][0]["interruptResponse"]
+        assert response["interruptId"] == generic.id
+        # A generic resume travels in the truthy envelope, unlike a tool
+        # approval whose payload Strands receives raw.
+        assert response["response"] == {"response": {"environment": "staging"}}
+
+
+class TestResumeValidationWithoutAgUiBookkeeping:
+    """A tool approval is validated even when only the native state survived.
+
+    A restart can restore Strands' own interrupt state while the adapter's
+    AG-UI bookkeeping (which carries ``response_schema``) is gone. The
+    tool-approval contract is fixed, so validation must not depend on that
+    bookkeeping: without it, a falsy payload would be forwarded raw, recorded
+    as "no answer", and the same interrupt re-raised forever.
+    """
+
+    THREAD = "resume-no-bookkeeping-thread"
+
+    def _agent(self, thread: str) -> tuple[StrandsAgent, Any, list]:
+        strands_interrupt = _make_strands_interrupt("my_tool", {}, "st-1")
+        interrupt_state = _make_interrupt_state(
+            activated=True,
+            interrupts={strands_interrupt.id: strands_interrupt},
+        )
+        agent = _build_agent(
+            thread,
+            [{"result": _FakeAgentResult(stop_reason="end_turn")}],
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        received_prompts = _capture_prompts(agent._agents_by_thread[thread])
+        assert thread not in agent._pending_interrupts_by_thread
+        return agent, strands_interrupt, received_prompts
+
+    async def test_falsy_approval_payload_is_rejected(self):
+        thread = self.THREAD + "-invalid"
+        agent, strands_interrupt, received_prompts = self._agent(thread)
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=strands_interrupt.id,
+                        status="resolved",
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [event.code for event in errors] == ["INVALID_PAYLOAD"]
+        assert "expected an object" in errors[0].message
+        assert received_prompts == []
+
+    async def test_non_boolean_approval_payload_is_rejected(self):
+        thread = self.THREAD + "-non-bool"
+        agent, strands_interrupt, received_prompts = self._agent(thread)
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=strands_interrupt.id,
+                        status="resolved",
+                        payload={"approved": "true"},
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert [event.code for event in errors] == ["INVALID_PAYLOAD"]
+        assert "approved" in errors[0].message
+        assert received_prompts == []
+
+    async def test_valid_approval_payload_still_reaches_strands_unchanged(self):
+        thread = self.THREAD + "-valid"
+        agent, strands_interrupt, received_prompts = self._agent(thread)
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=strands_interrupt.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        assert not any(event.type == EventType.RUN_ERROR for event in events)
+        assert len(received_prompts) == 1
+        response = received_prompts[0][0]["interruptResponse"]
+        assert response["interruptId"] == strands_interrupt.id
+        assert response["response"] == {"approved": True}
+
+
+# ---------------------------------------------------------------------------
+# Answered-vs-open classification
+# ---------------------------------------------------------------------------
+
+class TestAnsweredInterruptClassification:
+    """An interrupt counts as answered once an answer is recorded on it.
+
+    Strands records whatever answer arrives, so a legitimate "no" lands on
+    ``Interrupt.response`` as ``False`` (likewise ``0`` or ``""``), and hands
+    that answer back rather than re-raising for a human. The adapter has to
+    classify it the same way, in both the resume-validation path and the
+    pause-reporting path, or it re-asks a question the human already answered.
+    """
+
+    THREAD = "answered-classification-thread"
+
+    # Answers that are falsy but genuinely recorded. ``None`` is deliberately
+    # absent: Strands' Python ``Interrupt.response`` defaults to ``None``, so
+    # ``None`` reads as "no answer recorded". (The TypeScript SDK instead keys
+    # off ``undefined``, which makes a recorded ``null`` an answer there; the two
+    # SDKs do not agree on that value.)
+    FALSY_ANSWERS = [False, 0, "", [], {}]
+    FALSY_ANSWER_IDS = ["false", "zero", "empty-string", "empty-list", "empty-dict"]
+
+    @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
+    def test_a_falsy_recorded_answer_closes_the_interrupt(self, recorded_answer):
+        answered = _make_strands_interrupt("my_tool", {}, "st-falsy-predicate")
+        answered.response = recorded_answer
+        assert _native_interrupt_is_answered(answered) is True
+        assert _open_native_interrupts({answered.id: answered}) == {}
+
+    def test_an_unanswered_interrupt_stays_open(self):
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open-predicate")
+        assert _native_interrupt_is_answered(open_interrupt) is False
+        assert _open_native_interrupts({open_interrupt.id: open_interrupt}) == {
+            open_interrupt.id: open_interrupt
+        }
+
+    async def test_resume_addresses_only_the_open_sibling(self):
+        """A falsy-answered sibling is settled, so the resume batch is complete."""
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
+        answered = _make_strands_interrupt("my_tool", {}, "st-answered")
+        answered.response = False
+        interrupt_state = InterruptStateStub(
+            interrupts={open_interrupt.id: open_interrupt, answered.id: answered},
+        )
+        interrupt_state.activate()
+
+        agent = _build_agent(
+            self.THREAD,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        resume_prompts = _capture_prompts(agent._agents_by_thread[self.THREAD])
+
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=open_interrupt.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        errors = [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ]
+        assert errors == []
+        # The run actually reached Strands, carrying only the open interrupt's
+        # answer. The answered sibling is not re-submitted.
+        assert resume_prompts == [
+            [
+                {
+                    "interruptResponse": {
+                        "interruptId": open_interrupt.id,
+                        "response": {"approved": True},
+                    }
+                }
+            ]
+        ]
+        finished = [event for event in events if event.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        assert isinstance(finished[0].outcome, RunFinishedSuccessOutcome)
+
+    async def test_pause_reports_only_the_interrupts_still_open(self):
+        """The pause reports exactly what the SDK still holds open.
+
+        A preemptive falsy answer settles its interrupt, so re-reporting it would
+        ask the human the same question twice.
+        """
+        resumed = _make_strands_interrupt("my_tool", {}, "st-resumed")
+        interrupt_state = InterruptStateStub(interrupts={resumed.id: resumed})
+        interrupt_state.activate()
+
+        # The resumed tool answers a cached decision preemptively with a "no"
+        # and then pauses on a fresh question.
+        cached = StrandsInterrupt(
+            id="v1:custom:use_cached_plan",
+            name="use_cached_plan",
+            reason=None,
+            response=False,
+        )
+        follow_up = StrandsInterrupt(
+            id="v1:custom:need_clarification",
+            name="need_clarification",
+            reason={"question": "Which environment?"},
+        )
+
+        agent = _build_agent(
+            self.THREAD + "-pause",
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        inner = agent._agents_by_thread[self.THREAD + "-pause"]
+
+        async def _repause(message: Any):
+            interrupt_state.interrupts[cached.id] = cached
+            interrupt_state.interrupts[follow_up.id] = follow_up
+            interrupt_state.activate()
+            # An empty ``interrupts`` on the result forces the adapter to read
+            # the pause off the live interrupt state.
+            yield {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=None)}
+
+        _install_stream(inner, _repause)
+
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD + "-pause",
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=resumed.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        finished = [event for event in events if event.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        outcome = finished[0].outcome
+        assert isinstance(outcome, RunFinishedInterruptOutcome)
+        assert [interrupt.id for interrupt in outcome.interrupts] == [follow_up.id]
+        assert [interrupt.reason for interrupt in outcome.interrupts] == [
+            "need_clarification"
+        ]
+
+    async def test_unanswered_interrupt_still_blocks_a_partial_resume(self):
+        """The partial-resume guard keeps firing for genuinely open interrupts."""
+        first = _make_strands_interrupt("my_tool", {}, "st-first")
+        second = _make_strands_interrupt("my_tool", {}, "st-second")
+        interrupt_state = InterruptStateStub(
+            interrupts={first.id: first, second.id: second},
+        )
+        interrupt_state.activate()
+
+        agent = _build_agent(
+            self.THREAD + "-partial",
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        events = await _collect(
+            agent,
+            _run_input(
+                self.THREAD + "-partial",
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=first.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert len(errors) == 1
+        assert errors[0].code == "PARTIAL_RESUME"
+        assert second.id in errors[0].message
+
+    @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
+    async def test_resume_submits_only_the_open_interrupt_answer(self, recorded_answer):
+        """Every falsy recorded answer settles its own interrupt.
+
+        Asserts the exact ``interruptResponse`` batch reaching Strands: the open
+        interrupt's answer and nothing else.
+        """
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-open")
+        answered = _make_strands_interrupt("my_tool", {}, "st-answered")
+        answered.response = recorded_answer
+        interrupt_state = InterruptStateStub(
+            interrupts={open_interrupt.id: open_interrupt, answered.id: answered},
+        )
+        interrupt_state.activate()
+
+        thread = f"{self.THREAD}-submitted-answers"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        resume_prompts = _capture_prompts(agent._agents_by_thread[thread])
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=open_interrupt.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        errors = [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ]
+        assert errors == []
+        assert resume_prompts == [
+            [
+                {
+                    "interruptResponse": {
+                        "interruptId": open_interrupt.id,
+                        "response": {"approved": True},
+                    }
+                }
+            ]
+        ]
+
+    @pytest.mark.parametrize("recorded_answer", FALSY_ANSWERS, ids=FALSY_ANSWER_IDS)
+    async def test_pause_omits_a_falsy_answered_interrupt(
+        self, recorded_answer
+    ):
+        """The pause reporter settles every falsy answer, as the SDK does."""
+        resumed = _make_strands_interrupt("my_tool", {}, "st-resumed")
+        interrupt_state = InterruptStateStub(interrupts={resumed.id: resumed})
+        interrupt_state.activate()
+
+        # The resumed tool answers a cached decision preemptively and then
+        # pauses on a fresh question.
+        cached = StrandsInterrupt(
+            id="v1:custom:use_cached_plan",
+            name="use_cached_plan",
+            reason=None,
+            response=recorded_answer,
+        )
+        follow_up = StrandsInterrupt(
+            id="v1:custom:need_clarification",
+            name="need_clarification",
+            reason={"question": "Which environment?"},
+        )
+
+        thread = f"{self.THREAD}-pause-falsy"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        inner = agent._agents_by_thread[thread]
+
+        async def _repause(message: Any):
+            interrupt_state.interrupts[cached.id] = cached
+            interrupt_state.interrupts[follow_up.id] = follow_up
+            interrupt_state.activate()
+            yield {"result": _FakeAgentResult(stop_reason="interrupt", interrupts=None)}
+
+        _install_stream(inner, _repause)
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=resumed.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        finished = [event for event in events if event.type == EventType.RUN_FINISHED]
+        assert len(finished) == 1
+        outcome = finished[0].outcome
+        assert isinstance(outcome, RunFinishedInterruptOutcome)
+        assert [interrupt.id for interrupt in outcome.interrupts] == [follow_up.id]
+
+    async def test_an_explicit_none_answer_still_counts_as_unanswered(self):
+        """``None`` is the unanswered default, so recording it changes nothing.
+
+        This is where the two SDKs diverge: TypeScript keys off ``undefined``, so
+        a recorded ``null`` is an answer there. Python keys off ``None``, so it is
+        not an answer here.
+        """
+        addressed = _make_strands_interrupt("my_tool", {}, "st-addressed")
+        explicit_none = _make_strands_interrupt("my_tool", {}, "st-explicit-none")
+        explicit_none.response = None
+        interrupt_state = InterruptStateStub(
+            interrupts={addressed.id: addressed, explicit_none.id: explicit_none},
+        )
+        interrupt_state.activate()
+
+        thread = f"{self.THREAD}-explicit-none"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=addressed.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        errors = [event for event in events if event.type == EventType.RUN_ERROR]
+        assert len(errors) == 1
+        assert errors[0].code == "PARTIAL_RESUME"
+        assert explicit_none.id in errors[0].message
+
+
+    @pytest.mark.parametrize(
+        "recorded_answer",
+        [{"approved": True}, *FALSY_ANSWERS],
+        ids=["object", *FALSY_ANSWER_IDS],
+    )
+    async def test_active_checkpoint_blocks_fresh_input_untouched(
+        self, recorded_answer
+    ):
+        """A checkpoint the SDK still holds active is not the adapter's to tidy.
+
+        Deactivating it here reads as helpful and is not: ``deactivate()`` drops
+        the parked tool-use message and the tool results collected so far, and
+        nothing has appended those to the conversation yet. The parked proxy
+        placeholder in this checkpoint would then reach the model as the tool's
+        real output, under a success outcome.
+        """
+        answered = _make_strands_interrupt("my_tool", {}, "st-answered-only")
+        answered.response = recorded_answer
+        interrupt_state = InterruptStateStub(interrupts={answered.id: answered})
+        interrupt_state.activate()
+        parked_context = {
+            "tool_use_message": {"role": "assistant", "content": [{"toolUse": {}}]},
+            "tool_results": [{"toolUseId": "st-sibling", "status": "success"}],
+        }
+        interrupt_state.context = dict(parked_context)
+
+        thread = self.THREAD + "-fresh"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        prompts = _capture_prompts(agent._agents_by_thread[thread])
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                messages=[UserMessage(id="u1", content="what now?")],
+            ),
+        )
+
+        assert [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ] == [
+            (
+                "PENDING_INTERRUPTS",
+                "Thread has pending interrupts. Include resume[] to address them.",
+            )
+        ]
+        assert not any(
+            event.type == EventType.RUN_FINISHED for event in events
+        )
+        assert prompts == []
+        assert interrupt_state.activated is True
+        assert interrupt_state.interrupts == {answered.id: answered}
+        assert interrupt_state.context == parked_context
+
+    async def test_a_record_without_a_checkpoint_does_not_block_a_fresh_turn(self):
+        """The SDK's checkpoint decides, so a leftover record decides nothing.
+
+        A completed resume leaves the adapter's own record behind, and a restart
+        restores one from persisted bookkeeping. Reading either as "something is
+        pending" strands the thread: the block tells the client to resume, and
+        the resume finds nothing open to address.
+        """
+        stale = _make_strands_interrupt("my_tool", {}, "st-already-resumed")
+        thread = self.THREAD + "-stale-record"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            InterruptStateStub(),
+        )
+        inner = agent._agents_by_thread[thread]
+        inner.state = AgentState()
+        agent._pending_interrupts_by_thread[thread] = {
+            stale.id: Interrupt(id=stale.id, reason="tool_call", tool_call_id="tc-1")
+        }
+        prompts = _capture_prompts(inner)
+
+        events = await _collect(
+            agent,
+            _run_input(thread, messages=[UserMessage(id="u1", content="what now?")]),
+        )
+
+        assert [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ] == []
+        assert [
+            type(event.outcome)
+            for event in events
+            if event.type == EventType.RUN_FINISHED
+        ] == [RunFinishedSuccessOutcome]
+        assert prompts == ["what now?"]
+
+    async def test_open_interrupt_still_blocks_fresh_input_intact(self):
+        """The block stays, and the checkpoint it blocks on stays as it is.
+
+        Deactivating here would drop the pending question on the floor: the
+        client is told to resume, and the resume it sends must still find the
+        interrupt open.
+        """
+        open_interrupt = _make_strands_interrupt("my_tool", {}, "st-still-open")
+        answered = _make_strands_interrupt("my_tool", {}, "st-already-answered")
+        answered.response = {"approved": True}
+        interrupt_state = InterruptStateStub(
+            interrupts={open_interrupt.id: open_interrupt, answered.id: answered},
+        )
+        interrupt_state.activate()
+        interrupt_state.context = {"tool_use_message": {"role": "assistant"}}
+
+        thread = self.THREAD + "-still-open"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        prompts = _capture_prompts(agent._agents_by_thread[thread])
+
+        events = await _collect(
+            agent,
+            _run_input(thread, messages=[UserMessage(id="u1", content="what now?")]),
+        )
+
+        assert [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ] == [
+            (
+                "PENDING_INTERRUPTS",
+                "Thread has pending interrupts. Include resume[] to address them.",
+            )
+        ]
+        assert prompts == []
+        assert interrupt_state.activated is True
+        assert interrupt_state.interrupts == {
+            open_interrupt.id: open_interrupt,
+            answered.id: answered,
+        }
+        assert interrupt_state.context == {"tool_use_message": {"role": "assistant"}}
+
+    async def test_falsy_answered_interrupt_is_not_open_for_a_resume(self):
+        """A settled interrupt is not something a resume can address.
+
+        The SDK hands its recorded answer back rather than re-raising, so a
+        resume naming it is answering a question no longer being asked, and
+        nothing may reach Strands on its behalf.
+        """
+        answered = _make_strands_interrupt("my_tool", {}, "st-falsy-resumed")
+        answered.response = False
+        interrupt_state = InterruptStateStub(interrupts={answered.id: answered})
+        interrupt_state.activate()
+
+        thread = self.THREAD + "-falsy-resumed"
+        agent = _build_agent(
+            thread,
+            _empty_stream(),
+            StrandsAgentConfig(),
+            interrupt_state,
+        )
+        prompts = _capture_prompts(agent._agents_by_thread[thread])
+
+        events = await _collect(
+            agent,
+            _run_input(
+                thread,
+                resume=[
+                    ResumeEntry(
+                        interrupt_id=answered.id,
+                        status="resolved",
+                        payload={"approved": True},
+                    )
+                ],
+            ),
+        )
+
+        assert [
+            (event.code, event.message)
+            for event in events
+            if event.type == EventType.RUN_ERROR
+        ] == [
+            (
+                "INTERRUPT_RESUME_ERROR",
+                f"Resume references an interrupt that is not open: {answered.id}",
+            )
+        ]
+        assert prompts == []
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/aws-strands/typescript/src/__tests__/helpers.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/helpers.ts
@@ -4,7 +4,11 @@
  */
 
 import type { Agent, AgentStreamEvent } from "@strands-agents/sdk";
-import type { BaseEvent, RunAgentInput } from "@ag-ui/core";
+import type {
+  BaseEvent,
+  Interrupt as AguiInterrupt,
+  RunAgentInput,
+} from "@ag-ui/core";
 
 import { StrandsAgent } from "../agent";
 import type { StrandsAgentConfig } from "../config";
@@ -118,6 +122,51 @@ export function scriptedStrandsAgent(
   byThread.set("thread-1", stub);
   byThread.set("default", stub);
   return sa;
+}
+
+/**
+ * Park interrupts on both stores production keeps in step: the SDK's activated
+ * checkpoint, which is what decides whether anything is open, and the adapter's
+ * own record, which carries only the AG-UI metadata the SDK has nowhere for
+ * (response schema, tool card, expiry).
+ *
+ * Seeding the record alone describes a thread whose SDK considers itself idle,
+ * which production never produces, and every gate reads the SDK.
+ *
+ * `native` overrides the parked Strands interrupts when a test needs a specific
+ * shape (a tool-approval name, or a recorded response); by default each recorded
+ * id is parked as a bare unanswered generic interrupt.
+ */
+export function parkInterrupts(
+  aguiAgent: StrandsAgent,
+  threadId: string,
+  recorded: AguiInterrupt[],
+  native?: Map<string, unknown>,
+): Map<string, AguiInterrupt> {
+  const internals = aguiAgent as unknown as {
+    _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
+    _agentsByThread: Map<string, unknown>;
+  };
+  const record = new Map(
+    recorded.map((interrupt) => [interrupt.id, interrupt]),
+  );
+  internals._pendingInterruptsByThread.set(threadId, record);
+
+  const interrupts =
+    native ??
+    new Map<string, unknown>(
+      recorded.map((interrupt) => [
+        interrupt.id,
+        { id: interrupt.id, name: "need_input" },
+      ]),
+    );
+  const strandsAgent = internals._agentsByThread.get(threadId) ?? {};
+  internals._agentsByThread.set(threadId, strandsAgent);
+  (strandsAgent as { _interruptState?: unknown })._interruptState = {
+    activated: interrupts.size > 0,
+    interrupts,
+  };
+  return record;
 }
 
 /** Iterate `agent.run()` into an array. Defaults to `minimalRunInput()`. */

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
@@ -8,26 +8,123 @@
  * "nothing in the in-memory map yet" as "nothing pending".
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { SessionManager } from "@strands-agents/sdk";
 import { EventType } from "@ag-ui/core";
+import type { BaseEvent } from "@ag-ui/core";
 
 import { StrandsAgent } from "../agent";
-import { collect, minimalRunInput, scriptedAgent } from "./helpers";
+import { collect, minimalRunInput, scriptedAgent, stream } from "./helpers";
 
 // Mock the Strands Agent constructor so tests don't need a real model
 // provider, and so we can stamp a pre-activated `_interruptState` onto the
 // instance to simulate what a real SessionManager would restore.
-let nextInterruptState:
-  | { activated: boolean; interrupts: Map<string, unknown> | Record<string, unknown> }
-  | undefined;
+type RestoredInterruptState = {
+  activated: boolean;
+  interrupts: Map<string, unknown> | Record<string, unknown>;
+  deactivate?: () => void;
+};
+let nextInterruptState: RestoredInterruptState | undefined;
 let streamCalls = 0;
+// Every argument list handed to the mocked `stream()`, so a test can assert
+// which interrupt answers were actually submitted rather than only that a call
+// happened. Reset per test by the `beforeEach` below.
+const streamArgs: unknown[] = [];
+/**
+ * Results the mocked `stream()` returns, oldest first, one per call. A call
+ * past the end of the queue gets the ordinary completed-turn result, so only
+ * tests that need a paused turn have to script one.
+ */
+const scriptedStreamResults: unknown[] = [];
+/**
+ * Events the mocked `stream()` yields, oldest first, one array per call. A call
+ * past the end of the queue yields nothing, so only tests that need the SDK to
+ * emit output have to script it.
+ */
+const scriptedStreamEvents: unknown[][] = [];
+/** The most recent `FakeSessionManager` the agent's provider handed out. */
+let lastSessionManager: FakeSessionManager | undefined;
+
+/**
+ * An interrupt as it appears both on `AgentResult.interrupts` and in the
+ * `InterruptStateData` a SessionManager restores. The SDK exports `Interrupt`
+ * as a type only, so tests describe one structurally.
+ */
+type RaisedInterrupt = {
+  id: string;
+  name: string;
+  reason?: unknown;
+  response?: unknown;
+};
+
+/** Read one entry out of either shape Strands restores `interrupts` as. */
+function readRestoredInterrupt(
+  interrupts: Map<string, unknown> | Record<string, unknown>,
+  id: string,
+): unknown {
+  return interrupts instanceof Map
+    ? interrupts.get(id)
+    : (interrupts as Record<string, unknown>)[id];
+}
+
+/** Register a newly raised interrupt into either restored shape. */
+function writeRestoredInterrupt(
+  interrupts: Map<string, unknown> | Record<string, unknown>,
+  id: string,
+  interrupt: unknown,
+): void {
+  if (interrupts instanceof Map) interrupts.set(id, interrupt);
+  else (interrupts as Record<string, unknown>)[id] = interrupt;
+}
+
+/** The `interruptResponse` payloads carried by an invocation's content blocks. */
+function invocationInterruptResponses(
+  input: unknown,
+): Array<{ interruptId: string; response: unknown }> {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter(
+      (content) =>
+        !!content &&
+        typeof content === "object" &&
+        "interruptResponse" in (content as object),
+    )
+    .map(
+      (content) =>
+        (
+          content as {
+            interruptResponse: { interruptId: string; response: unknown };
+          }
+        ).interruptResponse,
+    );
+}
+
+/**
+ * The `AgentResult` Strands returns from a turn that halted on an interrupt.
+ * `Agent._createInterruptResult()` reports the unanswered interrupts and
+ * activates the checkpoint; the mocked `stream()` below mirrors both.
+ */
+function pausedResult(interrupts: RaisedInterrupt[]) {
+  return {
+    stopReason: "interrupt" as const,
+    interrupts,
+    lastMessage: { role: "assistant", content: [] },
+  };
+}
 
 vi.mock("@strands-agents/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@strands-agents/sdk")>();
   class MockAgent {
     model = { name: "mock" };
     tools: unknown[] = [];
+    // The SDK's Agent owns its conversation history and exposes the
+    // SessionManager it was constructed with, which is what tells the adapter
+    // whether to replay AG-UI history into Strands or forward a prompt.
+    messages: unknown[] = [];
+    sessionManager: unknown;
+    // A real `StateStore`, so the interrupt bookkeeping the adapter writes here
+    // round-trips through the same deep-copy/JSON validation production uses.
+    appState = new actual.StateStore();
     toolRegistry = {
       _tools: new Map<string, unknown>(),
       add(t: unknown) {
@@ -48,22 +145,97 @@ vi.mock("@strands-agents/sdk", async (importOriginal) => {
       values() {
         return Array.from(this._tools.values());
       },
+      // The real `ToolRegistry` always exposes list(); without it every run
+      // here would take the adapter's "registry cannot be enumerated" fallback,
+      // which production never reaches.
+      list() {
+        return Array.from(this._tools.values());
+      },
     };
     // Start without an interrupt so test cases only see the configured state
     // when initialize() simulates SessionManager's InitializedEvent restore.
-    _interruptState: { activated: boolean; interrupts: Map<string, unknown> | Record<string, unknown> } = {
+    _interruptState: RestoredInterruptState = {
       activated: false,
       interrupts: {},
     };
+    constructor(config?: { sessionManager?: unknown }) {
+      this.sessionManager = config?.sessionManager;
+    }
     async initialize() {
       this._interruptState = nextInterruptState ?? {
         activated: false,
         interrupts: {},
       };
     }
-    async *stream() {
+    async *stream(input?: unknown) {
       streamCalls += 1;
-      return { stopReason: "endTurn", message: { role: "assistant", content: [] } };
+      streamArgs.push(input);
+      // Mirror the SDK: it resumes the checkpoint from the invocation input and
+      // rejects an invocation carrying no interrupt responses while the
+      // checkpoint is still activated. A double that accepts one certifies
+      // behaviour production rejects.
+      const responses = invocationInterruptResponses(input);
+      let resumed = false;
+      if (responses.length > 0) {
+        // `InterruptState.resume()` records each answer on the restored
+        // interrupt and throws for an id the checkpoint never raised.
+        if (this._interruptState.activated) {
+          for (const { interruptId, response } of responses) {
+            const interrupt = readRestoredInterrupt(
+              this._interruptState.interrupts,
+              interruptId,
+            );
+            if (!interrupt) {
+              throw new Error(
+                `interrupt_id=<${interruptId}> | no interrupt found`,
+              );
+            }
+            (interrupt as { response?: unknown }).response = response;
+          }
+          resumed = true;
+        }
+      } else if (this._interruptState.activated) {
+        throw new TypeError(
+          "Agent is in an interrupted state. Resume by invoking with interruptResponse content blocks.",
+        );
+      }
+      const result =
+        scriptedStreamResults.shift() ??
+        ({
+          stopReason: "endTurn",
+          message: { role: "assistant", content: [] },
+        } as unknown);
+      // The parked hooks and tool execution run here, after the answers are
+      // recorded and before the checkpoint is cleared. A scripted Error stands
+      // for a failure in that window, which is what leaves a persisted
+      // checkpoint activated with every interrupt already answered.
+      if (result instanceof Error) throw result;
+      if (resumed) {
+        // Strands clears its own checkpoint once the resumed work succeeds. It
+        // does so internally, so this does not go through `deactivate()`: that
+        // counter exists to prove the adapter never reaches for the checkpoint.
+        this._interruptState.activated = false;
+        this._interruptState.interrupts =
+          this._interruptState.interrupts instanceof Map ? new Map() : {};
+      }
+      for (const event of scriptedStreamEvents.shift() ?? []) yield event;
+      const paused = result as {
+        stopReason?: string;
+        interrupts?: RaisedInterrupt[];
+      };
+      if (paused.stopReason === "interrupt") {
+        // `_createInterruptResult()` reports interrupts that are already on the
+        // state, then activates it, so the next turn sees them as open.
+        for (const raised of paused.interrupts ?? []) {
+          writeRestoredInterrupt(
+            this._interruptState.interrupts,
+            raised.id,
+            raised,
+          );
+        }
+        this._interruptState.activated = true;
+      }
+      return result;
     }
   }
   return {
@@ -73,6 +245,27 @@ vi.mock("@strands-agents/sdk", async (importOriginal) => {
 });
 
 class FakeSessionManager extends SessionManager {
+  /**
+   * One entry per explicit `saveSnapshot()`, capturing the agent's `appState`
+   * as it stood at that moment. The real `saveSnapshot()` serializes a whole
+   * live Agent, which a mocked one cannot satisfy; recording the state the
+   * adapter had written by then is what the durability claim rests on.
+   */
+  readonly savedSnapshots: Array<{
+    isLatest: boolean | undefined;
+    appState: Record<string, unknown>;
+  }> = [];
+  saveSnapshot = vi.fn(async (params: { target: unknown; isLatest?: boolean }) => {
+    const appState = (
+      params.target as {
+        appState?: { getAll?: () => Record<string, unknown> };
+      }
+    ).appState;
+    this.savedSnapshots.push({
+      isLatest: params.isLatest,
+      appState: appState?.getAll?.() ?? {},
+    });
+  });
   constructor() {
     super({
       sessionId: `fake-${Math.random().toString(36).slice(2)}`,
@@ -80,7 +273,64 @@ class FakeSessionManager extends SessionManager {
         snapshot: { save: vi.fn(), load: vi.fn(), delete: vi.fn() } as never,
       },
     });
+    lastSessionManager = this;
   }
+}
+
+// The mock's captured state is module-level, so clear it before every test to
+// keep assertions independent of execution order.
+beforeEach(() => {
+  nextInterruptState = undefined;
+  streamCalls = 0;
+  streamArgs.length = 0;
+  scriptedStreamResults.length = 0;
+  scriptedStreamEvents.length = 0;
+  lastSessionManager = undefined;
+});
+
+/**
+ * The interrupt answers submitted to Strands, one entry per `stream()` call.
+ * Resume runs pass `InterruptResponseContent[]`; anything else (a plain prompt
+ * string, or `undefined` for a history replay) is passed through untouched so a
+ * mismatch is visible in the failure diff.
+ */
+function submittedInterruptAnswers(): unknown[] {
+  return streamArgs.map((args) =>
+    Array.isArray(args)
+      ? args.map(
+          (content) => (content as { interruptResponse?: unknown }).interruptResponse,
+        )
+      : args,
+  );
+}
+
+/**
+ * An activated restored checkpoint whose `deactivate()` behaves like the SDK's:
+ * it clears the recorded interrupts along with the flag. The checkpoint is the
+ * SDK's to clear, so a test asserts the adapter never reaches for this.
+ */
+function restoredCheckpoint(
+  interrupts: Map<string, unknown> | Record<string, unknown>,
+): RestoredInterruptState & { deactivateCalls: number } {
+  const state = {
+    activated: true,
+    interrupts,
+    deactivateCalls: 0,
+    deactivate: () => {
+      state.deactivateCalls += 1;
+      state.activated = false;
+      state.interrupts = interrupts instanceof Map ? new Map() : {};
+    },
+  };
+  return state;
+}
+
+function newColdAgent(): StrandsAgent {
+  return new StrandsAgent({
+    agent: scriptedAgent(),
+    name: "t",
+    config: { sessionManagerProvider: () => new FakeSessionManager() },
+  });
 }
 
 describe("Cold restart: resume validation must see session-restored interrupt state", () => {
@@ -172,7 +422,6 @@ describe("Cold restart: resume validation must see session-restored interrupt st
       activated: true,
       interrupts: { "int-1": {} },
     };
-    streamCalls = 0;
 
     const agent = new StrandsAgent({
       agent: scriptedAgent(),
@@ -197,7 +446,6 @@ describe("Cold restart: resume validation must see session-restored interrupt st
       activated: true,
       interrupts: new Map([["int-1", {}]]),
     };
-    streamCalls = 0;
 
     const agent = new StrandsAgent({
       agent: scriptedAgent(),
@@ -207,7 +455,13 @@ describe("Cold restart: resume validation must see session-restored interrupt st
 
     const events = await collect(
       agent,
-      minimalRunInput({ threadId: "cold-thread-fresh-input" }),
+      minimalRunInput({
+        threadId: "cold-thread-fresh-input",
+        // A real fresh turn carries the user's new text. Submitting none would
+        // leave the adapter forwarding its placeholder prompt, so the run would
+        // not be the one production has to reject.
+        messages: [{ id: "u1", role: "user", content: "ship it" }],
+      }),
     );
 
     expect(events.map((event) => event.type)).toEqual([
@@ -217,5 +471,731 @@ describe("Cold restart: resume validation must see session-restored interrupt st
     const err = events[1] as unknown as { code: string };
     expect(err.code).toBe("PENDING_INTERRUPTS");
     expect(streamCalls).toBe(0);
+  });
+
+  it("keeps blocking fresh input on a restored checkpoint whose every interrupt is answered", async () => {
+    // A restored checkpoint stays activated after its last answer is recorded.
+    // Clearing it here to let the turn through is the SDK's call, not the
+    // adapter's: `deactivate()` drops the tool execution parked behind the
+    // checkpoint, which nothing has appended to the conversation yet.
+    const answered = new Map<string, unknown>([
+      ["int-1", { id: "int-1", name: "approve", response: { approved: true } }],
+      ["int-2", { id: "int-2", name: "clarify", response: false }],
+    ]);
+    const checkpoint = restoredCheckpoint(answered);
+    nextInterruptState = checkpoint;
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-all-answered",
+        messages: [{ id: "u1", role: "user", content: "what now?" }],
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({
+      code: "PENDING_INTERRUPTS",
+      message: "Thread has pending interrupts. Include resume[] to address them.",
+    });
+    // Nothing reached the SDK, and the checkpoint is exactly as restored.
+    expect(streamCalls).toBe(0);
+    expect(checkpoint.deactivateCalls).toBe(0);
+    expect(checkpoint.activated).toBe(true);
+    expect(checkpoint.interrupts).toEqual(answered);
+  });
+
+  it("keeps blocking fresh input while a restored interrupt is still open, leaving it intact", async () => {
+    // Deactivating here would drop the pending question on the floor: the
+    // client is told to resume, and that resume must still find the interrupt
+    // open.
+    const open = { id: "int-2", name: "clarify" };
+    const answered = { id: "int-1", name: "approve", response: { approved: true } };
+    const checkpoint = restoredCheckpoint(
+      new Map<string, unknown>([
+        ["int-1", answered],
+        ["int-2", open],
+      ]),
+    );
+    nextInterruptState = checkpoint;
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-still-open",
+        messages: [{ id: "u1", role: "user", content: "ship it" }],
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({
+      code: "PENDING_INTERRUPTS",
+      message: "Thread has pending interrupts. Include resume[] to address them.",
+    });
+    expect(streamCalls).toBe(0);
+    expect(checkpoint.deactivateCalls).toBe(0);
+    expect(checkpoint.activated).toBe(true);
+    expect(checkpoint.interrupts).toEqual(
+      new Map<string, unknown>([
+        ["int-1", answered],
+        ["int-2", open],
+      ]),
+    );
+  });
+
+  describe("A resume that pauses again on a freshly raised interrupt", () => {
+    // The other half of cold restart: once the restored checkpoint is answered,
+    // the tool can raise a new interrupt and the turn halts again. The adapter
+    // has to report it, checkpoint it durably (an interrupt exits the native
+    // loop before Strands' own invocation-boundary save), and re-arm its own
+    // bookkeeping so the following turn is gated against the NEW interrupt.
+    const THREAD = "cold-thread-repause";
+    const APPROVAL_NAME = "ag_ui:tool_call:deploy";
+
+    /** Built per test: the mocked stream records answers onto this object. */
+    const reRaisedApproval = (): RaisedInterrupt => ({
+      id: "int-2",
+      name: APPROVAL_NAME,
+      reason: {
+        tool_call: true,
+        tool_name: "deploy",
+        tool_input: {},
+        tool_use_id: "tc-2",
+      },
+    });
+
+    /**
+     * First turn: a cold thread whose restored checkpoint holds one open
+     * interrupt, resumed, with the SDK halting again on a newly raised one.
+     */
+    async function resumeThenPauseAgain(): Promise<{
+      agent: StrandsAgent;
+      events: BaseEvent[];
+    }> {
+      nextInterruptState = restoredCheckpoint(
+        new Map<string, unknown>([
+          ["int-1", { id: "int-1", name: APPROVAL_NAME }],
+        ]),
+      );
+      scriptedStreamResults.push(pausedResult([reRaisedApproval()]));
+      const agent = newColdAgent();
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: THREAD,
+          resume: [
+            { interruptId: "int-1", status: "resolved", payload: { approved: true } },
+          ],
+        }),
+      );
+      return { agent, events };
+    }
+
+    it("reports the re-raised interrupt on RUN_FINISHED", async () => {
+      const { events } = await resumeThenPauseAgain();
+
+      expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+        false,
+      );
+      expect(submittedInterruptAnswers()).toEqual([
+        [{ interruptId: "int-1", response: { approved: true } }],
+      ]);
+      expect(events[events.length - 1]).toMatchObject({
+        type: EventType.RUN_FINISHED,
+        threadId: THREAD,
+        runId: "run-1",
+        outcome: {
+          type: "interrupt",
+          interrupts: [
+            {
+              id: "int-2",
+              reason: "tool_call",
+              message: "Approve call to deploy?",
+              toolCallId: "tc-2",
+            },
+          ],
+        },
+      });
+    });
+
+    it("checkpoints the re-raised interrupt through the session manager", async () => {
+      await resumeThenPauseAgain();
+
+      // One explicit save at the interrupt boundary, and the state it captured
+      // must already name the new interrupt, or a restart resumes a thread
+      // whose only record of the open question is gone.
+      expect(
+        lastSessionManager!.savedSnapshots.map((snapshot) => snapshot.isLatest),
+      ).toEqual([true]);
+      expect(
+        lastSessionManager!.savedSnapshots[0]!.appState[
+          "ag_ui_interrupt_bookkeeping"
+        ],
+      ).toMatchObject({
+        pendingInterrupts: {
+          "int-2": { id: "int-2", reason: "tool_call", toolCallId: "tc-2" },
+        },
+      });
+    });
+
+    it("forwards an answer for the re-raised interrupt on the next turn", async () => {
+      const { agent } = await resumeThenPauseAgain();
+
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: THREAD,
+          runId: "run-2",
+          resume: [
+            { interruptId: "int-2", status: "resolved", payload: { approved: false } },
+          ],
+        }),
+      );
+
+      expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+        false,
+      );
+      expect(submittedInterruptAnswers()).toEqual([
+        [{ interruptId: "int-1", response: { approved: true } }],
+        [{ interruptId: "int-2", response: { approved: false } }],
+      ]);
+    });
+
+    // Each row is a next turn the re-armed bookkeeping has to refuse, and the
+    // reason it refuses: the gate is closed again, the new interrupt's response
+    // contract is enforced, and the answered one is no longer outstanding.
+    const refusedNextTurns: Array<{
+      turn: string;
+      code: string;
+      input: Partial<Parameters<typeof minimalRunInput>[0]>;
+    }> = [
+      {
+        turn: "fresh input",
+        code: "PENDING_INTERRUPTS",
+        input: { messages: [{ id: "u2", role: "user", content: "ship it" }] },
+      },
+      {
+        turn: "an answer violating the re-raised interrupt's response schema",
+        code: "INVALID_PAYLOAD",
+        input: {
+          resume: [
+            { interruptId: "int-2", status: "resolved", payload: { approved: "yes" } },
+          ],
+        },
+      },
+      {
+        // A different payload, so this is a new request rather than a replay of
+        // the resume that closed "int-1".
+        turn: "an answer for the interrupt the previous turn closed",
+        code: "UNKNOWN_INTERRUPT_ID",
+        input: {
+          resume: [
+            { interruptId: "int-1", status: "resolved", payload: { approved: false } },
+          ],
+        },
+      },
+    ];
+
+    it.each(refusedNextTurns)("refuses $turn with $code", async ({ code, input }) => {
+      const { agent } = await resumeThenPauseAgain();
+      const streamCallsSoFar = streamCalls;
+
+      const events = await collect(
+        agent,
+        minimalRunInput({ threadId: THREAD, runId: "run-2", ...input }),
+      );
+
+      expect(events.map((event) => event.type)).toEqual([
+        EventType.RUN_STARTED,
+        EventType.RUN_ERROR,
+      ]);
+      expect(events[1]).toMatchObject({ code });
+      expect(streamCalls).toBe(streamCallsSoFar);
+    });
+  });
+
+  describe("tool-approval payload validation without AG-UI bookkeeping", () => {
+    // A tool approval's response contract is fixed ({ approved: boolean }), so
+    // it holds even when the adapter bookkeeping carrying `responseSchema` was
+    // lost to the restart. Waving the payload through here would forward a
+    // falsy answer raw, Strands would record it as "no answer", and the same
+    // interrupt would re-raise forever.
+    const toolApproval = (id: string) => ({
+      id,
+      name: "ag_ui:tool_call:my_tool",
+      reason: { tool_call: true, tool_name: "my_tool", tool_input: {} },
+    });
+
+    const coldAgent = (id: string) => {
+      nextInterruptState = {
+        activated: true,
+        interrupts: new Map<string, unknown>([[id, toolApproval(id)]]),
+      };
+      return new StrandsAgent({
+        agent: scriptedAgent(),
+        name: "t",
+        config: { sessionManagerProvider: () => new FakeSessionManager() },
+      });
+    };
+
+    it("rejects a missing approval payload", async () => {
+      const agent = coldAgent("int-approve");
+
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: "cold-thread-approval-missing-payload",
+          resume: [{ interruptId: "int-approve", status: "resolved" }],
+        }),
+      );
+
+      const errors = events.filter(
+        (event) => event.type === EventType.RUN_ERROR,
+      ) as unknown as { code: string; message: string }[];
+      expect(errors.map((error) => error.code)).toEqual(["INVALID_PAYLOAD"]);
+      expect(errors[0]!.message).toContain("expected an object");
+      expect(streamCalls).toBe(0);
+    });
+
+    it("rejects a non-boolean approval payload", async () => {
+      const agent = coldAgent("int-approve");
+
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: "cold-thread-approval-non-boolean",
+          resume: [
+            {
+              interruptId: "int-approve",
+              status: "resolved",
+              payload: { approved: "true" },
+            },
+          ],
+        }),
+      );
+
+      const errors = events.filter(
+        (event) => event.type === EventType.RUN_ERROR,
+      ) as unknown as { code: string; message: string }[];
+      expect(errors.map((error) => error.code)).toEqual(["INVALID_PAYLOAD"]);
+      expect(errors[0]!.message).toContain("approved");
+      expect(streamCalls).toBe(0);
+    });
+
+    it("still forwards a valid approval payload to Strands unchanged", async () => {
+      const agent = coldAgent("int-approve");
+
+      const events = await collect(
+        agent,
+        minimalRunInput({
+          threadId: "cold-thread-approval-valid",
+          resume: [
+            {
+              interruptId: "int-approve",
+              status: "resolved",
+              payload: { approved: true },
+            },
+          ],
+        }),
+      );
+
+      expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+        false,
+      );
+      expect(streamCalls).toBe(1);
+      expect(submittedInterruptAnswers()).toEqual([
+        [{ interruptId: "int-approve", response: { approved: true } }],
+      ]);
+    });
+  });
+});
+
+// Both shapes Strands' restored `_interruptState.interrupts` can take: the
+// current SDK serializes a Record, older mocks used a Map.
+const interruptShapes = [
+  {
+    shape: "Map-shaped",
+    build: (entries: Array<[string, unknown]>) =>
+      new Map<string, unknown>(entries) as Map<string, unknown>,
+  },
+  {
+    shape: "record-shaped",
+    build: (entries: Array<[string, unknown]>) =>
+      Object.fromEntries(entries) as Record<string, unknown>,
+  },
+];
+
+// A response that was recorded, however falsy, is an answer. The Strands TS SDK
+// decides with `interrupt.response === undefined` (`InterruptState
+// .getUnansweredInterrupts`, `interruptFromAgent`), so a recorded `null` counts
+// as answered here even though Python's `None` does not.
+const answeredResponses: Array<{ answer: string; response: unknown }> = [
+  { answer: "false", response: false },
+  { answer: "zero", response: 0 },
+  { answer: "an empty string", response: "" },
+  { answer: "null", response: null },
+];
+
+// Two ways a restored interrupt can carry no response at all. Both stay open.
+const unansweredShapes: Array<{
+  absence: string;
+  fields: Record<string, unknown>;
+}> = [
+  { absence: "no response property", fields: {} },
+  { absence: "an explicitly undefined response", fields: { response: undefined } },
+];
+
+describe.each(interruptShapes)(
+  "Answered-vs-open classification of $shape restored interrupt state",
+  ({ build }) => {
+    it.each(answeredResponses)(
+      "submits only the open interrupt's answer when a sibling was answered with $answer",
+      async ({ response }) => {
+        nextInterruptState = {
+          activated: true,
+          interrupts: build([
+            ["int-answered", { id: "int-answered", name: "approve", response }],
+            ["int-open", { id: "int-open", name: "clarify" }],
+          ]),
+        };
+
+        const events = await collect(
+          newColdAgent(),
+          minimalRunInput({
+            threadId: "cold-thread-answered-sibling",
+            resume: [
+              {
+                interruptId: "int-open",
+                status: "resolved",
+                payload: { environment: "prod" },
+              },
+            ],
+          }),
+        );
+
+        expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+          false,
+        );
+        // The answered sibling is neither demanded nor re-submitted.
+        expect(submittedInterruptAnswers()).toEqual([
+          [{ interruptId: "int-open", response: { environment: "prod" } }],
+        ]);
+      },
+    );
+
+    it.each(unansweredShapes)(
+      "still demands a restored interrupt that carries $absence",
+      async ({ fields }) => {
+        nextInterruptState = {
+          activated: true,
+          interrupts: build([
+            ["int-addressed", { id: "int-addressed", name: "approve" }],
+            ["int-unanswered", { id: "int-unanswered", name: "clarify", ...fields }],
+          ]),
+        };
+
+        const events = await collect(
+          newColdAgent(),
+          minimalRunInput({
+            threadId: "cold-thread-unanswered-sibling",
+            resume: [
+              { interruptId: "int-addressed", status: "resolved", payload: {} },
+            ],
+          }),
+        );
+
+        const err = events.find(
+          (event) => event.type === EventType.RUN_ERROR,
+        ) as unknown as { code: string; message: string } | undefined;
+        expect(err).toBeDefined();
+        expect(err!.code).toBe("PARTIAL_RESUME");
+        expect(err!.message).toContain("int-unanswered");
+        expect(submittedInterruptAnswers()).toEqual([]);
+      },
+    );
+  },
+);
+
+/**
+ * Both SDKs record the submitted answers onto the checkpoint before they rerun
+ * the parked hooks and tool execution, and clear the checkpoint only once that
+ * work succeeds. A failure in between, or a crash after session persistence,
+ * restores a checkpoint that is activated with every interrupt already
+ * answered. That thread has no way forward: fresh input is refused because the
+ * checkpoint is active (covered above), and a resume finds nothing open to
+ * address. Replaying the exact batch is the way out, because it hands Strands
+ * the answers it already holds and lets it finish the parked execution. The
+ * checkpoint is never torn down here, since that would discard exactly that
+ * execution.
+ */
+describe("A resume the SDK parked after recording its answers", () => {
+  const APPROVAL_NAME = "ag_ui:tool_call:deploy";
+  const INTERRUPT_ID = "int-1";
+  const PARKED_OUTPUT = "Deployed to production.";
+
+  const submittedBatch = (approved = true) => [
+    {
+      interruptId: INTERRUPT_ID,
+      status: "resolved" as const,
+      payload: { approved },
+    },
+  ];
+
+  const parkedApproval = () => ({
+    id: INTERRUPT_ID,
+    name: APPROVAL_NAME,
+    reason: { tool_name: "deploy", tool_input: {}, tool_use_id: "tc-1" },
+  });
+
+  /** The checkpoint as it stands once the resumed work has failed. */
+  function strandedCheckpoint(): ReturnType<typeof restoredCheckpoint> {
+    return restoredCheckpoint(
+      new Map<string, unknown>([
+        [INTERRUPT_ID, { ...parkedApproval(), response: { approved: true } }],
+      ]),
+    );
+  }
+
+  /** The text the parked tool streams once its execution finally runs. */
+  function scriptParkedOutput(): void {
+    scriptedStreamEvents.push([stream.textDelta(PARKED_OUTPUT)]);
+  }
+
+  function emittedText(events: BaseEvent[]): string[] {
+    return events
+      .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((event) => (event as unknown as { delta: string }).delta);
+  }
+
+  it("leaves the answer recorded and the checkpoint active when the resumed work fails", async () => {
+    const checkpoint = restoredCheckpoint(
+      new Map<string, unknown>([[INTERRUPT_ID, parkedApproval()]]),
+    );
+    nextInterruptState = checkpoint;
+    scriptedStreamResults.push(new Error("post-approval hook failed"));
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-premise",
+        resume: submittedBatch(),
+      }),
+    );
+
+    expect(events[events.length - 1]).toMatchObject({
+      type: EventType.RUN_ERROR,
+    });
+    expect(checkpoint.activated).toBe(true);
+    expect(
+      readRestoredInterrupt(checkpoint.interrupts, INTERRUPT_ID),
+    ).toMatchObject({ response: { approved: true } });
+    expect(checkpoint.deactivateCalls).toBe(0);
+  });
+
+  it("completes the parked execution when the exact batch is replayed after a restart", async () => {
+    // A fresh process: nothing cached for the thread, and SessionManager
+    // restores the checkpoint the failed attempt left behind.
+    const checkpoint = strandedCheckpoint();
+    nextInterruptState = checkpoint;
+    scriptParkedOutput();
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-replay",
+        resume: submittedBatch(),
+      }),
+    );
+
+    // Strands got back the answer it already held, unchanged.
+    expect(submittedInterruptAnswers()).toEqual([
+      [{ interruptId: INTERRUPT_ID, response: { approved: true } }],
+    ]);
+    // The parked tool's output reached the client, so its execution ran.
+    expect(emittedText(events)).toEqual([PARKED_OUTPUT]);
+    expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+      false,
+    );
+    // The terminal finish carries no outcome, which is what separates a run
+    // Strands actually completed from the fingerprint shortcut's synthetic
+    // success outcome and from the interrupt variant of a run still parked.
+    expect(events[events.length - 1]).toEqual({
+      type: EventType.RUN_FINISHED,
+      threadId: "cold-thread-parked-replay",
+      runId: "run-1",
+    });
+    // The SDK cleared its own checkpoint once the parked work succeeded, and
+    // the adapter never reached for it.
+    expect(checkpoint.activated).toBe(false);
+    expect(checkpoint.deactivateCalls).toBe(0);
+  });
+
+  it("reaches Strands on a replay the idempotency fingerprint already knows", async () => {
+    // The fingerprint shortcut answers a resume the thread already completed.
+    // A parked resume has not completed, so answering it from the cache would
+    // report success while the checkpoint never advances.
+    const THREAD = "cold-thread-parked-fingerprint";
+    const agent = newColdAgent();
+
+    // Turn one completes the resume, which is what caches its fingerprint.
+    nextInterruptState = restoredCheckpoint(
+      new Map<string, unknown>([[INTERRUPT_ID, parkedApproval()]]),
+    );
+    await collect(
+      agent,
+      minimalRunInput({ threadId: THREAD, resume: submittedBatch() }),
+    );
+
+    // The SDK restores a checkpoint snapshotted before it was cleared: active,
+    // with the same answer already recorded.
+    const checkpoint = strandedCheckpoint();
+    (
+      (
+        agent as unknown as { _agentsByThread: Map<string, unknown> }
+      )._agentsByThread.get(THREAD) as { _interruptState: unknown }
+    )._interruptState = checkpoint;
+    scriptParkedOutput();
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: THREAD,
+        runId: "run-2",
+        resume: submittedBatch(),
+      }),
+    );
+
+    expect(submittedInterruptAnswers()).toEqual([
+      [{ interruptId: INTERRUPT_ID, response: { approved: true } }],
+      [{ interruptId: INTERRUPT_ID, response: { approved: true } }],
+    ]);
+    expect(emittedText(events)).toEqual([PARKED_OUTPUT]);
+    // No outcome, so this finish came from Strands rather than the shortcut.
+    expect(events[events.length - 1]).toEqual({
+      type: EventType.RUN_FINISHED,
+      threadId: THREAD,
+      runId: "run-2",
+    });
+    expect(checkpoint.activated).toBe(false);
+  });
+
+  it("still refuses a batch that replays only some of the recorded answers", async () => {
+    const checkpoint = restoredCheckpoint(
+      new Map<string, unknown>([
+        [INTERRUPT_ID, { ...parkedApproval(), response: { approved: true } }],
+        [
+          "int-2",
+          { id: "int-2", name: APPROVAL_NAME, response: { approved: true } },
+        ],
+      ]),
+    );
+    nextInterruptState = checkpoint;
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-partial",
+        resume: submittedBatch(),
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({ code: "UNKNOWN_INTERRUPT_ID" });
+    expect(submittedInterruptAnswers()).toEqual([]);
+    expect(checkpoint.activated).toBe(true);
+  });
+
+  it("still refuses a batch that repeats one id instead of covering both", async () => {
+    const checkpoint = restoredCheckpoint(
+      new Map<string, unknown>([
+        [INTERRUPT_ID, { ...parkedApproval(), response: { approved: true } }],
+        [
+          "int-2",
+          { id: "int-2", name: APPROVAL_NAME, response: { approved: true } },
+        ],
+      ]),
+    );
+    nextInterruptState = checkpoint;
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-duplicate",
+        resume: [...submittedBatch(), ...submittedBatch()],
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({ code: "UNKNOWN_INTERRUPT_ID" });
+    expect(submittedInterruptAnswers()).toEqual([]);
+    expect(checkpoint.activated).toBe(true);
+  });
+
+  it("does not treat an inactive checkpoint holding answers as a parked resume", async () => {
+    // Only a checkpoint the SDK still holds active has a parked execution to
+    // finish. An inactive one has already completed, so the resume is the
+    // ordinary stale replay and must not reach Strands again.
+    nextInterruptState = {
+      activated: false,
+      interrupts: new Map<string, unknown>([
+        [INTERRUPT_ID, { ...parkedApproval(), response: { approved: true } }],
+      ]),
+    };
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-inactive",
+        resume: submittedBatch(),
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({
+      code: "UNKNOWN_INTERRUPT_ID",
+      message: "No pending interrupts for this thread.",
+    });
+    expect(submittedInterruptAnswers()).toEqual([]);
+  });
+
+  it("still refuses a batch that does not replay the recorded answers", async () => {
+    const checkpoint = strandedCheckpoint();
+    nextInterruptState = checkpoint;
+
+    const events = await collect(
+      newColdAgent(),
+      minimalRunInput({
+        threadId: "cold-thread-parked-mismatch",
+        resume: submittedBatch(false),
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(events[1]).toMatchObject({ code: "UNKNOWN_INTERRUPT_ID" });
+    // Nothing reached the SDK and the checkpoint stands exactly as restored.
+    expect(submittedInterruptAnswers()).toEqual([]);
+    expect(checkpoint.activated).toBe(true);
+    expect(
+      readRestoredInterrupt(checkpoint.interrupts, INTERRUPT_ID),
+    ).toMatchObject({ response: { approved: true } });
+    expect(checkpoint.deactivateCalls).toBe(0);
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -6,17 +6,30 @@
  * (rather than falling into the UNKNOWN_INTERRUPT_ID gate).
  */
 import { describe, it, expect, vi } from "vitest";
-import { EventType, type BaseEvent, type RunAgentInput, type Interrupt as AguiInterrupt } from "@ag-ui/core";
+import {
+  EventType,
+  type BaseEvent,
+  type RunAgentInput,
+  type ResumeEntry,
+  type Interrupt as AguiInterrupt,
+} from "@ag-ui/core";
 import {
   AgentResult as StrandsAgentResult,
   InterruptResponseContent,
   Message as StrandsMessage,
   TextBlock,
   type Interrupt as StrandsInterrupt,
+  type InterruptResponse,
 } from "@strands-agents/sdk";
 
 import { StrandsAgent } from "../agent";
-import { collect, minimalRunInput, scriptedAgent } from "./helpers";
+import {
+  collect,
+  minimalRunInput,
+  parkInterrupts,
+  scriptedAgent,
+  stream,
+} from "./helpers";
 
 function makeAgentResultStream(
   result: StrandsAgentResult,
@@ -111,6 +124,43 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     });
   });
 
+  it("logs a debug trace when a paused result carries no interrupts", async () => {
+    // The run finishes as a success with nothing to resume, so the only trace
+    // an operator can get that the checkpoint may still be parked is this log.
+    const debug = vi.fn();
+    const stubAgent = scriptedAgent([], {
+      stream: makeAgentResultStream(buildAgentResult([])) as never,
+    });
+    const sa = new StrandsAgent({
+      agent: stubAgent,
+      name: "t",
+      config: { logger: { debug, warn: vi.fn(), error: vi.fn() } },
+    });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+
+    const events = await collect(sa);
+
+    // Control flow is unchanged: still a plain success finish, no extra event.
+    const finished = events.at(-1) as BaseEvent & { outcome?: { type: string } };
+    expect(finished.type).toBe(EventType.RUN_FINISHED);
+    expect(finished.outcome).toBeUndefined();
+    expect(events.map((e) => e.type)).not.toContain(EventType.RUN_ERROR);
+
+    const traced = debug.mock.calls.map(([message]) => String(message));
+    expect(
+      traced.some(
+        (message) =>
+          message.includes("[@ag-ui/aws-strands]") &&
+          /stopped for an interrupt with an empty interrupts list/.test(
+            message,
+          ) &&
+          message.includes("reporting no pending interrupts"),
+      ),
+    ).toBe(true);
+  });
+
   it("accepts a matching resume[] and forwards InterruptResponseContent to Strands", async () => {
     let capturedArgs: unknown = null;
     const stubAgent = scriptedAgent([], {
@@ -133,12 +183,9 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     (
       sa as unknown as { _agentsByThread: Map<string, unknown> }
     )._agentsByThread.set("thread-1", stubAgent);
-    // Seed a pending interrupt on the thread so the gate accepts the resume.
-    (
-      sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread.set("thread-1", new Map([["int-7", { id: "int-7", reason: "tool_call" }]]));
+    // Park the interrupt on the SDK's checkpoint, with the adapter's metadata
+    // record beside it, so the gate accepts the resume.
+    parkInterrupts(sa, "thread-1", [{ id: "int-7", reason: "tool_call" }]);
     const input: RunAgentInput = minimalRunInput({
       resume: [
         {
@@ -172,12 +219,8 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
   it("still emits UNKNOWN_INTERRUPT when resume[] references an unknown id", async () => {
     const stubAgent = scriptedAgent([]);
     const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    // One pending interrupt, but the resume references a different id.
-    (
-      sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread.set("thread-1", new Map([["known", { id: "known", reason: "tool_call" }]]));
+    // One open interrupt, but the resume references a different id.
+    parkInterrupts(sa, "thread-1", [{ id: "known", reason: "tool_call" }]);
 
     const events = await collect(
       sa,
@@ -218,11 +261,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     (
       sa as unknown as { _agentsByThread: Map<string, unknown> }
     )._agentsByThread.set("thread-1", stubAgent);
-    (
-      sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread.set("thread-1", new Map([["ic", { id: "ic", reason: "tool_call" }]]));
+    parkInterrupts(sa, "thread-1", [{ id: "ic", reason: "tool_call" }]);
 
     await collect(
       sa,
@@ -240,5 +279,161 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     const [first] = capturedArgs as InterruptResponseContent[];
     expect(first.interruptResponse.interruptId).toBe("ic");
     expect(first.interruptResponse.response).toEqual({ status: "cancelled" });
+  });
+});
+
+/**
+ * Resume one generic interrupt and return the single `InterruptResponse` the
+ * adapter handed to Strands. Generic on purpose: no `responseSchema` means the
+ * payload gate never runs, so whatever the client sent reaches the SDK as-is.
+ */
+async function forwardedResumeResponse(
+  entry: ResumeEntry,
+): Promise<InterruptResponse> {
+  let capturedArgs: unknown = null;
+  const stubAgent = scriptedAgent([], {
+    stream: ((args: unknown) => {
+      capturedArgs = args;
+      return (async function* () {
+        return new StrandsAgentResult({
+          stopReason: "endTurn",
+          lastMessage: StrandsMessage.fromMessageData({
+            role: "assistant",
+            content: [new TextBlock("done").toJSON()],
+          }),
+          invocationState: {},
+        });
+      })();
+    }) as never,
+  });
+  const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
+  (
+    sa as unknown as { _agentsByThread: Map<string, unknown> }
+  )._agentsByThread.set("thread-1", stubAgent);
+  parkInterrupts(sa, "thread-1", [
+    { id: entry.interruptId, reason: "need_input" },
+  ]);
+
+  const events = await collect(sa, minimalRunInput({ resume: [entry] }));
+  expect(events.map((e) => e.type)).not.toContain(EventType.RUN_ERROR);
+  expect(Array.isArray(capturedArgs)).toBe(true);
+  const [first] = capturedArgs as InterruptResponseContent[];
+  return first.interruptResponse;
+}
+
+describe("Resume responses recorded on the native interrupt", () => {
+  // Strands reads `response === undefined` as "still awaiting a human"
+  // (InterruptState.getUnansweredInterrupts, and the gate in
+  // interruptFromAgent that re-throws InterruptError). Handing it an
+  // undefined response re-raises the same interrupt on every resume, and a
+  // generic interrupt publishes no responseSchema, so nothing upstream
+  // rejects an empty payload first.
+  it("records a defined response when a resolved entry carries no payload", async () => {
+    const response = await forwardedResumeResponse({
+      interruptId: "int-absent",
+      status: "resolved",
+    });
+
+    expect(response.response).not.toBeUndefined();
+    expect(response.response).toStrictEqual({});
+  });
+
+  it("records a defined response when a resolved payload is explicitly undefined", async () => {
+    const response = await forwardedResumeResponse({
+      interruptId: "int-undef",
+      status: "resolved",
+      payload: undefined,
+    });
+
+    expect(response.response).not.toBeUndefined();
+    expect(response.response).toStrictEqual({});
+  });
+
+  // The substitution above must not become a blanket rewrite: a payload that
+  // is present is what the tool destructures, falsy values included.
+  it.each([
+    ["an object", { approved: true }],
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+    ["null", null],
+    ["an empty array", []],
+    ["an empty object", {}],
+    ["a string", "approved"],
+  ])("forwards a present payload unchanged: %s", async (_label, payload) => {
+    const response = await forwardedResumeResponse({
+      interruptId: "int-present",
+      status: "resolved",
+      payload,
+    });
+
+    expect(response.response).toStrictEqual(payload);
+  });
+
+  // The replay short-circuit answers from a fingerprint, so the fingerprint has
+  // to separate whatever this converter separates. Reading an absent payload
+  // and an explicit null as one resume answers the second with a success the
+  // SDK never produced.
+  it("does not read an explicit null payload as a replay of an absent one", async () => {
+    const forwarded: InterruptResponse[] = [];
+    const stubAgent = scriptedAgent([], {
+      stream: ((args: unknown) => {
+        for (const content of args as InterruptResponseContent[]) {
+          forwarded.push(content.interruptResponse);
+        }
+        return (async function* () {
+          yield stream.textDelta("resumed");
+          return new StrandsAgentResult({
+            stopReason: "endTurn",
+            lastMessage: StrandsMessage.fromMessageData({
+              role: "assistant",
+              content: [new TextBlock("resumed").toJSON()],
+            }),
+            invocationState: {},
+          });
+        })();
+      }) as never,
+    });
+    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
+    (
+      sa as unknown as { _agentsByThread: Map<string, unknown> }
+    )._agentsByThread.set("thread-1", stubAgent);
+    const recordOpenInterrupt = () =>
+      parkInterrupts(sa, "thread-1", [
+        { id: "int-null", reason: "need_input" },
+      ]);
+
+    recordOpenInterrupt();
+    await collect(
+      sa,
+      minimalRunInput({
+        runId: "r1",
+        resume: [{ interruptId: "int-null", status: "resolved" }],
+      }),
+    );
+
+    // The tool asks its question again, so the same id is open again and the
+    // client answers it with something else this time.
+    recordOpenInterrupt();
+    const second = await collect(
+      sa,
+      minimalRunInput({
+        runId: "r2",
+        resume: [
+          { interruptId: "int-null", status: "resolved", payload: null },
+        ],
+      }),
+    );
+
+    expect(forwarded.map((response) => response.response)).toStrictEqual([
+      {},
+      null,
+    ]);
+    expect(second.some((e) => e.type === EventType.RUN_ERROR)).toBe(false);
+    expect(
+      second
+        .filter((e) => e.type === EventType.TEXT_MESSAGE_CONTENT)
+        .map((e) => (e as unknown as { delta: string }).delta),
+    ).toStrictEqual(["resumed"]);
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-rule-gate.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { EventType, type BaseEvent, type RunAgentInput, type Interrupt as AguiInterrupt } from "@ag-ui/core";
+import { EventType, type BaseEvent, type RunAgentInput } from "@ag-ui/core";
 
 import { StrandsAgent } from "../agent";
-import { collect, minimalRunInput, scriptedAgent } from "./helpers";
+import {
+  collect,
+  minimalRunInput,
+  parkInterrupts,
+  scriptedAgent,
+} from "./helpers";
 
 /**
  * Interrupt-rule gate lives in `StrandsAgent.run()` above `_runRaw` so any
@@ -34,19 +39,16 @@ class NeverRanAgent extends StrandsAgent {
   }
 }
 
-/** Helper to set pending interrupts on the agent (new Map<string, Map<string, AguiInterrupt>> format). */
+/**
+ * Open `ids` on the thread: parked on the SDK's checkpoint, which decides what
+ * is still open, with the adapter's AG-UI metadata record beside them.
+ */
 function setPending(agent: StrandsAgent, threadId: string, ids: string[]) {
-  const pending = (
-    agent as unknown as {
-      _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-    }
-  )._pendingInterruptsByThread;
-  const map = new Map<string, AguiInterrupt>();
-  for (const id of ids) {
-    map.set(id, { id, reason: "tool_call" });
-  }
-  pending.set(threadId, map);
-  return pending;
+  return parkInterrupts(
+    agent,
+    threadId,
+    ids.map((id) => ({ id, reason: "tool_call" })),
+  );
 }
 
 describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
@@ -134,6 +136,118 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     expect(err.code).toBe("PENDING_INTERRUPTS");
   });
 
+  it("Rule 4: admits fresh input when the SDK holds no checkpoint", async () => {
+    const agent = new NeverRanAgent();
+    // A record that exists and holds nothing is what a completed resume leaves
+    // behind, and what a restart restores from persisted bookkeeping whose
+    // `pendingInterrupts` is `{}`. The SDK is the one that decides, and it has
+    // nothing parked.
+    setPending(agent, "t", []);
+
+    // Blocking the fresh turn would strand the thread: the resume such a block
+    // demands finds nothing to address.
+    const refusedResume = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [{ interruptId: "gone-1", status: "resolved", payload: {} }],
+      }),
+    );
+    expect(refusedResume.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect((refusedResume[1] as unknown as { code: string }).code).toBe(
+      "UNKNOWN_INTERRUPT_ID",
+    );
+
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "t", runId: "r2" }),
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(agent.rawCalled).toBe(1);
+  });
+
+  it("Rule 4: admits fresh input over a record the SDK has no checkpoint for", async () => {
+    const agent = new NeverRanAgent();
+    // Python pops its record on resume success only, so a resume that errors
+    // mid-stream leaves a populated record beside an idle checkpoint. Reading
+    // the record as "something is pending" strands the thread: the block tells
+    // the client to resume, and the resume finds nothing open to address.
+    parkInterrupts(
+      agent,
+      "t",
+      [{ id: "gone-1", reason: "tool_call" }],
+      new Map(),
+    );
+
+    const refusedResume = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [{ interruptId: "gone-1", status: "resolved", payload: {} }],
+      }),
+    );
+    expect(refusedResume.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    expect(refusedResume[1]).toMatchObject({
+      code: "UNKNOWN_INTERRUPT_ID",
+      message: "No pending interrupts for this thread.",
+    });
+
+    const events = await collect(
+      agent,
+      minimalRunInput({ threadId: "t", runId: "r2" }),
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(agent.rawCalled).toBe(1);
+  });
+
+  it("Rule 2: validates the submitted ids against the SDK, not the record", async () => {
+    const agent = new NeverRanAgent();
+    // The record and the checkpoint name different interrupts. Only the SDK can
+    // say which question is still being asked.
+    parkInterrupts(
+      agent,
+      "t",
+      [{ id: "recorded-only", reason: "tool_call" }],
+      new Map<string, unknown>([
+        ["sdk-open", { id: "sdk-open", name: "need_input" }],
+      ]),
+    );
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [
+          { interruptId: "recorded-only", status: "resolved", payload: {} },
+        ],
+      }),
+    );
+
+    expect(agent.rawCalled).toBe(0);
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string; message: string };
+    expect(err.code).toBe("UNKNOWN_INTERRUPT_ID");
+    expect(err.message).toContain("recorded-only");
+  });
+
   it("Rule 3: rejects partial resume that doesn't cover all interrupts", async () => {
     const agent = new NeverRanAgent();
     setPending(agent, "t", ["int-1", "int-2", "int-3"]);
@@ -218,14 +332,9 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
 
   it("Rule 7: rejects expired interrupt", async () => {
     const agent = new NeverRanAgent();
-    const pending = (
-      agent as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread;
-    const map = new Map<string, AguiInterrupt>();
-    map.set("exp-1", { id: "exp-1", reason: "tool_call", expiresAt: "2020-01-01T00:00:00Z" });
-    pending.set("t", map);
+    parkInterrupts(agent, "t", [
+      { id: "exp-1", reason: "tool_call", expiresAt: "2020-01-01T00:00:00Z" },
+    ]);
 
     const events = await collect(
       agent,
@@ -245,18 +354,17 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
 
   it("Rule 6: rejects invalid payload missing required keys", async () => {
     const agent = new NeverRanAgent();
-    const pending = (
-      agent as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread;
-    const map = new Map<string, AguiInterrupt>();
-    map.set("val-1", {
-      id: "val-1",
-      reason: "tool_call",
-      responseSchema: { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"] },
-    });
-    pending.set("t", map);
+    parkInterrupts(agent, "t", [
+      {
+        id: "val-1",
+        reason: "tool_call",
+        responseSchema: {
+          type: "object",
+          properties: { approved: { type: "boolean" } },
+          required: ["approved"],
+        },
+      },
+    ]);
 
     const events = await collect(
       agent,
@@ -277,7 +385,7 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
   it("Rule 6: rejects a non-boolean approval value", async () => {
     for (const invalidApproval of ["true", 1, null]) {
       const agent = new NeverRanAgent();
-      const pending = setPending(agent, "t", ["val-1"]).get("t")!;
+      const pending = setPending(agent, "t", ["val-1"]);
       pending.get("val-1")!.responseSchema = {
         type: "object",
         properties: { approved: { type: "boolean" } },
@@ -300,6 +408,52 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     }
   });
 
+  it("Rule 6: validates a tool approval whose record lost its schema", async () => {
+    const agent = new NeverRanAgent();
+    // A restart can restore the checkpoint while the AG-UI record comes back
+    // without the response schema it advertised. A tool approval's contract is
+    // fixed, so the SDK's own interrupt still supplies it, and a payload waved
+    // through here would be recorded as "no answer" and re-raise forever.
+    parkInterrupts(
+      agent,
+      "t",
+      [{ id: "appr-1", reason: "tool_call" }],
+      new Map<string, unknown>([
+        [
+          "appr-1",
+          {
+            id: "appr-1",
+            name: "ag_ui:tool_call:deploy",
+            reason: {
+              tool_call: true,
+              tool_name: "deploy",
+              tool_input: {},
+              tool_use_id: "tc-1",
+            },
+          },
+        ],
+      ]),
+    );
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "t",
+        runId: "r1",
+        resume: [{ interruptId: "appr-1", status: "resolved", payload: {} }],
+      }),
+    );
+
+    expect(agent.rawCalled).toBe(0);
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string; message: string };
+    expect(err.code).toBe("INVALID_PAYLOAD");
+    expect(err.message).toContain("approved");
+  });
+
   it("Rule 6: accepts explicit denial and optional approve-with-edits fields", async () => {
     const schema = {
       type: "object",
@@ -311,7 +465,7 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     };
 
     const denied = new NeverRanAgent();
-    const deniedPending = setPending(denied, "denied", ["val-1"]).get("denied")!;
+    const deniedPending = setPending(denied, "denied", ["val-1"]);
     deniedPending.get("val-1")!.responseSchema = schema;
     const deniedEvents = await collect(
       denied,
@@ -324,7 +478,7 @@ describe("StrandsAgent resume[] gate (interrupts.mdx rules 2-7)", () => {
     expect(deniedEvents.some((event) => event.type === EventType.RUN_ERROR)).toBe(false);
 
     const edited = new NeverRanAgent();
-    const editedPending = setPending(edited, "edited", ["val-2"]).get("edited")!;
+    const editedPending = setPending(edited, "edited", ["val-2"]);
     editedPending.get("val-2")!.responseSchema = schema;
     const editedEvents = await collect(
       edited,

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -209,18 +209,122 @@ function _errorMessage(e: unknown): string {
 }
 
 /**
- * Return native Strands interrupt IDs across SDK versions and test doubles.
+ * Return every native Strands interrupt on the checkpoint, keyed by ID.
  *
  * Strands' current InterruptState serializes `interrupts` as a Record, while
  * older mocks used a Map. Supporting both keeps cold-start validation aligned
- * with the state that SessionManager actually restores.
+ * with the state that SessionManager actually restores, and every reader of the
+ * restored interrupts goes through here so only one place knows both shapes.
  */
-function _nativeInterruptIds(interrupts: unknown): Set<string> {
-  if (interrupts instanceof Map) return new Set(interrupts.keys());
-  if (interrupts && typeof interrupts === "object") {
-    return new Set(Object.keys(interrupts));
+function _nativeInterruptsById(interrupts: unknown): Map<string, unknown> {
+  const entries: Iterable<[string, unknown]> =
+    interrupts instanceof Map
+      ? interrupts.entries()
+      : interrupts && typeof interrupts === "object"
+        ? Object.entries(interrupts)
+        : [];
+  return new Map(entries);
+}
+
+/**
+ * Return the native Strands interrupts still awaiting a human, keyed by ID.
+ *
+ * An interrupt carrying a recorded response was already answered, so it must
+ * not be demanded again on the next resume. This mirrors the SDK's own
+ * `response === undefined` predicate: presence decides, not truthiness, so an
+ * answer of `false`, `0` or `""` counts as answered.
+ *
+ * The native interrupt state is the only record of what is still in flight, so
+ * every "is anything still open?" decision reads it through here.
+ */
+function _openNativeInterrupts(interrupts: unknown): Map<string, unknown> {
+  const open = new Map<string, unknown>();
+  for (const [id, interrupt] of _nativeInterruptsById(interrupts)) {
+    const response = (interrupt as { response?: unknown } | null)?.response;
+    if (response === undefined) open.set(id, interrupt);
   }
-  return new Set();
+  return open;
+}
+
+/** Structural equality over the JSON-shaped answers Strands records. */
+function _sameRecordedAnswer(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    return (
+      a.length === b.length &&
+      a.every((item, index) => _sameRecordedAnswer(item, b[index]))
+    );
+  }
+  const left = a as Record<string, unknown>;
+  const right = b as Record<string, unknown>;
+  const keys = Object.keys(left);
+  return (
+    keys.length === Object.keys(right).length &&
+    keys.every(
+      (key) => key in right && _sameRecordedAnswer(left[key], right[key]),
+    )
+  );
+}
+
+/**
+ * True when `entries` re-submits exactly the answers the checkpoint already holds.
+ *
+ * Strands records the submitted answers before it reruns hooks and the parked
+ * tool execution, and clears the checkpoint only once that work succeeds. So a
+ * hook failure, or a crash after session persistence, can restore a checkpoint
+ * that is activated with every interrupt already answered. That thread has no
+ * way forward: fresh input is refused because the checkpoint is active, and a
+ * resume finds nothing open to address. Handing Strands the identical batch is
+ * the way out, because it lets the SDK finish the parked execution. The
+ * checkpoint itself must be left alone: clearing it would discard exactly that
+ * parked execution. Anything short of an exact replay stays refused.
+ */
+function _replaysRecordedAnswers(
+  interrupts: unknown,
+  entries: ResumeEntry[],
+): boolean {
+  const recorded = _nativeInterruptsById(interrupts);
+  if (recorded.size === 0 || entries.length !== recorded.size) return false;
+  const addressed = new Set<string>();
+  for (const entry of entries) {
+    const interrupt = recorded.get(entry.interruptId);
+    if (!interrupt || addressed.has(entry.interruptId)) return false;
+    addressed.add(entry.interruptId);
+    const answer = (interrupt as { response?: unknown }).response;
+    if (answer === undefined) return false;
+    if (!_sameRecordedAnswer(answer, toResumeResponse(entry))) return false;
+  }
+  return true;
+}
+
+/**
+ * Reserved native-interrupt name prefix for interrupts this adapter's
+ * `interruptOnCall` hook raises. Anything else is a generic native interrupt.
+ */
+const TOOL_APPROVAL_NAME_PREFIX = "ag_ui:tool_call:";
+
+/**
+ * The response contract advertised for a tool-approval interrupt.
+ *
+ * Single source for both the schema published on the AG-UI `Interrupt` and the
+ * resume-payload validation, so a resume can still be checked when the AG-UI
+ * bookkeeping did not survive a process restart.
+ */
+function toolApprovalResponseSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { approved: { type: "boolean" } },
+    required: ["approved"],
+  };
+}
+
+/** True when a native Strands interrupt came from the approval hook. */
+function isToolApprovalInterrupt(interrupt: unknown): boolean {
+  const name = (interrupt as { name?: unknown } | null)?.name;
+  return typeof name === "string" && name.startsWith(TOOL_APPROVAL_NAME_PREFIX);
 }
 
 /**
@@ -660,7 +764,7 @@ export class StrandsAgent {
                   return;
                 }
                 const response = event.interrupt({
-                  name: `ag_ui:tool_call:${toolName}`,
+                  name: `${TOOL_APPROVAL_NAME_PREFIX}${toolName}`,
                   reason: { tool_call: true, tool_name: toolName, tool_input: event.toolUse!.input ?? {}, tool_use_id: event.toolUse!.toolUseId },
                 });
                 if (
@@ -721,58 +825,83 @@ export class StrandsAgent {
     // interrupts. Gated above `_runRaw` so subclasses that override only
     // `_runRaw` still inherit the checks.
     if (hasResume) {
-      let pending = this._pendingInterruptsByThread.get(threadId);
-
       // Rule 5: idempotency — detect replayed resumes
       fingerprint = resumeFingerprint(inputData.resume!);
 
-      // Cold-restart fallback: if this process has nothing cached in memory
-      // for this threadId, restore the per-thread agent first (so a
-      // SessionManager-backed appState can be read), then check whether the
-      // fingerprint/pending-interrupt bookkeeping was persisted there by a
-      // prior process (see loadPersistedInterruptBookkeeping doc above).
-      // Also covers cold-restart resume validation (comment 1): the agent
-      // must be restored before deciding whether to skip validation.
-      let nativePendingIds: Set<string> | undefined;
-      if (
-        !pending &&
-        !this._lastResumeFingerprint.has(threadId) &&
-        this.config.sessionManagerProvider
-      ) {
+      // The SDK's interrupt state is the only record of what is still in
+      // flight. A cold process has nothing cached for this thread, so restore
+      // the per-thread agent first: SessionManager brings the checkpoint back
+      // with it.
+      let strandsAgent = this._agentsByThread.get(threadId);
+      if (!strandsAgent && this.config.sessionManagerProvider) {
         const restored = await this._ensureAgent(inputData, threadId);
         if ("error" in restored) {
           yield _runStarted(inputData);
           yield restored.error;
           return;
         }
-        const interruptState = (
-          restored.agent as unknown as {
-            _interruptState?: { activated?: boolean; interrupts?: unknown };
-          }
-        )._interruptState;
-        if (interruptState?.activated) {
-          nativePendingIds = _nativeInterruptIds(interruptState.interrupts);
-        }
+        strandsAgent = restored.agent;
+      }
+
+      // The AG-UI metadata and the idempotency fingerprint are this adapter's
+      // own, and a restart loses the in-process copy while SessionManager still
+      // restores the checkpoint, so read what was persisted beside it (see
+      // loadPersistedInterruptBookkeeping doc above) whenever this process holds
+      // none.
+      if (
+        strandsAgent &&
+        !this._pendingInterruptsByThread.get(threadId)?.size
+      ) {
         const { pending: persistedPending, fingerprint: persistedFingerprint } =
-          loadPersistedInterruptBookkeeping(restored.agent);
+          loadPersistedInterruptBookkeeping(strandsAgent);
         if (persistedPending) {
           this._pendingInterruptsByThread.set(threadId, persistedPending);
         }
-        if (persistedFingerprint) {
+        if (
+          persistedFingerprint &&
+          !this._lastResumeFingerprint.has(threadId)
+        ) {
           this._lastResumeFingerprint.set(threadId, persistedFingerprint);
         }
-        // Re-check the AG-UI-side map too: _ensureAgent may have raced with
-        // another call that populated it while we awaited.
-        pending = this._pendingInterruptsByThread.get(threadId);
       }
 
-      if (this._lastResumeFingerprint.get(threadId) === fingerprint) {
+      const interruptState = (
+        strandsAgent as
+          | { _interruptState?: { activated?: boolean; interrupts?: unknown } }
+          | undefined
+      )?._interruptState;
+      const checkpointActive = interruptState?.activated === true;
+      const open = checkpointActive
+        ? _openNativeInterrupts(interruptState!.interrupts)
+        : new Map<string, unknown>();
+
+      // An active checkpoint whose every interrupt is answered is a thread the
+      // SDK parked mid-resume (see _replaysRecordedAnswers). Only an exact
+      // replay gets out of it, and it has to reach Strands to do so.
+      const replayingParkedResume =
+        checkpointActive &&
+        _replaysRecordedAnswers(interruptState!.interrupts, inputData.resume!);
+
+      // Rule 5: idempotency. A replayed resume the thread already completed is
+      // answered from the fingerprint. A parked resume has not completed, so
+      // answering it here would report success while the checkpoint never
+      // advances.
+      if (
+        !replayingParkedResume &&
+        this._lastResumeFingerprint.get(threadId) === fingerprint
+      ) {
         yield _runStarted(inputData);
         yield { type: EventType.RUN_FINISHED, threadId: inputData.threadId, runId: inputData.runId, outcome: { type: "success" } };
         return;
       }
 
-      if (!pending && !nativePendingIds) {
+      // The interrupts this resume may address: normally the open ones, or the
+      // answered ones a parked resume is replaying.
+      const addressable = replayingParkedResume
+        ? _nativeInterruptsById(interruptState!.interrupts)
+        : open;
+
+      if (addressable.size === 0) {
         yield _runStarted(inputData);
         yield _runError(
           "No pending interrupts for this thread.",
@@ -781,118 +910,70 @@ export class StrandsAgent {
         return;
       }
 
-      if (!pending && nativePendingIds) {
-        // Best-effort validation against the restored native interrupt IDs
-        // only (rules 2/3) — used when persisted AG-UI bookkeeping wasn't
-        // available (e.g. no sessionManagerProvider configured) but
-        // Strands' own native interrupt state was still restored.
-        const unknown = inputData
-          .resume!.map((entry) => entry.interruptId)
-          .filter((id) => !nativePendingIds!.has(id));
-        if (unknown.length > 0) {
-          yield _runStarted(inputData);
-          yield _runError(
-            `This agent did not issue any interrupts to resume: ${unknown
-              .slice(0, 4)
-              .join(", ")}. ` +
-              "Resume entries must reference an outstanding interruptId.",
-            "UNKNOWN_INTERRUPT_ID",
-          );
-          return;
-        }
-        const resumedIds = new Set(inputData.resume!.map((e) => e.interruptId));
-        const missing = [...nativePendingIds].filter((id) => !resumedIds.has(id));
-        if (missing.length > 0) {
-          yield _runStarted(inputData);
-          yield _runError(
-            `Partial resume: missing interrupt IDs: ${missing.join(", ")}. All open interrupts must be addressed.`,
-            "PARTIAL_RESUME",
-          );
-          return;
-        }
+      // Rule 2: reject unknown interrupt IDs
+      const unknown = inputData
+        .resume!.map((entry) => entry.interruptId)
+        .filter((id) => !addressable.has(id));
+      if (unknown.length > 0) {
+        yield _runStarted(inputData);
+        yield _runError(
+          `This agent did not issue any interrupts to resume: ${unknown
+            .slice(0, 4)
+            .join(", ")}. ` +
+            "Resume entries must reference an outstanding interruptId.",
+          "UNKNOWN_INTERRUPT_ID",
+        );
+        return;
       }
 
-      if (pending) {
-        // Rule 2: reject unknown interrupt IDs
-        const unknown = inputData
-          .resume!.map((entry) => entry.interruptId)
-          .filter((id) => !pending.has(id));
-        if (unknown.length > 0) {
-          yield _runStarted(inputData);
-          yield _runError(
-            `This agent did not issue any interrupts to resume: ${unknown
-              .slice(0, 4)
-              .join(", ")}. ` +
-              "Resume entries must reference an outstanding interruptId.",
-            "UNKNOWN_INTERRUPT_ID",
-          );
-          return;
-        }
+      // Rule 3: all open interrupts must be addressed
+      const resumedIds = new Set(inputData.resume!.map((e) => e.interruptId));
+      const missing = [...addressable.keys()].filter(
+        (id) => !resumedIds.has(id),
+      );
+      if (missing.length > 0) {
+        yield _runStarted(inputData);
+        yield _runError(
+          `Partial resume: missing interrupt IDs: ${missing.join(", ")}. All open interrupts must be addressed.`,
+          "PARTIAL_RESUME",
+        );
+        return;
+      }
 
-        // Rule 3: all open interrupts must be addressed
-        const resumedIds = new Set(inputData.resume!.map((e) => e.interruptId));
-        const missing = [...pending.keys()].filter((id) => !resumedIds.has(id));
-        if (missing.length > 0) {
-          yield _runStarted(inputData);
-          yield _runError(
-            `Partial resume: missing interrupt IDs: ${missing.join(", ")}. All open interrupts must be addressed.`,
-            "PARTIAL_RESUME",
-          );
-          return;
-        }
+      // Rules 6 and 7 read what the SDK has nowhere for: the answer shape
+      // advertised to the client, and an expiry. A restart can lose that
+      // record, and a tool approval's contract is fixed, so the SDK's own
+      // interrupt supplies the schema when the record cannot.
+      const recorded = this._pendingInterruptsByThread.get(threadId);
+      for (const entry of inputData.resume!) {
+        const metadata = recorded?.get(entry.interruptId);
 
         // Rule 7: expiresAt enforcement
-        for (const entry of inputData.resume!) {
-          const interrupt = pending.get(entry.interruptId)!;
-          if (interrupt.expiresAt && new Date() > new Date(interrupt.expiresAt)) {
-            yield _runStarted(inputData);
-            yield _runError(
-              `Interrupt '${entry.interruptId}' has expired.`,
-              "INTERRUPT_EXPIRED",
-            );
-            return;
-          }
+        if (metadata?.expiresAt && new Date() > new Date(metadata.expiresAt)) {
+          yield _runStarted(inputData);
+          yield _runError(
+            `Interrupt '${entry.interruptId}' has expired.`,
+            "INTERRUPT_EXPIRED",
+          );
+          return;
+        }
 
-          // Rule 6: basic payload validation against responseSchema
-          if (entry.status === "resolved" && interrupt.responseSchema) {
-            const schema = interrupt.responseSchema as Record<string, unknown>;
-            if (schema.type === "object") {
-              if (typeof entry.payload !== "object" || entry.payload == null) {
-                yield _runStarted(inputData);
-                yield _runError(
-                  `Invalid payload for interrupt '${entry.interruptId}': expected an object.`,
-                  "INVALID_PAYLOAD",
-                );
-                return;
-              }
-              const required = schema.required as string[] | undefined;
-              if (Array.isArray(required)) {
-                const missingKeys = required.filter(
-                  (k) => !(k in (entry.payload as Record<string, unknown>)),
-                );
-                if (missingKeys.length > 0) {
-                  yield _runStarted(inputData);
-                  yield _runError(
-                    `Invalid payload for interrupt '${entry.interruptId}': missing required keys ${JSON.stringify(missingKeys)}.`,
-                    "INVALID_PAYLOAD",
-                  );
-                  return;
-                }
-              }
-              const typeError = validateObjectPayloadPropertyTypes(
-                schema,
-                entry.payload as Record<string, unknown>,
-              );
-              if (typeError) {
-                yield _runStarted(inputData);
-                yield _runError(
-                  `Invalid payload for interrupt '${entry.interruptId}': ${typeError}`,
-                  "INVALID_PAYLOAD",
-                );
-                return;
-              }
-            }
-          }
+        // Rule 6: basic payload validation against responseSchema. Skipping it
+        // for a tool approval would forward a falsy payload raw, Strands would
+        // record it as "no answer", and the same interrupt would re-raise
+        // forever.
+        if (entry.status !== "resolved") continue;
+        const schema =
+          (metadata?.responseSchema as Record<string, unknown> | undefined) ??
+          (isToolApprovalInterrupt(addressable.get(entry.interruptId))
+            ? toolApprovalResponseSchema()
+            : undefined);
+        if (!schema) continue;
+        const payloadError = validateResumePayload(entry, schema);
+        if (payloadError) {
+          yield _runStarted(inputData);
+          yield payloadError;
+          return;
         }
       }
 
@@ -901,31 +982,31 @@ export class StrandsAgent {
       // Rule 4: pending interrupts block new input without resume.
       // Per spec, clients must address all pending interrupts via resume[].
       // To abandon interrupts, send resume with all entries status: "cancelled".
-      // Check both in-memory tracking AND the Strands agent's _interruptState
-      // (which SessionManager may have restored).
-      let hasPending = this._pendingInterruptsByThread.has(threadId);
-      if (!hasPending) {
-        const cached = this._agentsByThread.get(threadId);
-        if (cached) {
-          const is = (cached as { _interruptState?: { activated: boolean } })._interruptState;
-          if (is?.activated) hasPending = true;
-        } else if (this.config.sessionManagerProvider) {
-          // A cold process has no cached agent yet, but SessionManager may
-          // restore a native pending interrupt for this thread. Restore it
-          // before deciding whether new input may proceed (Rule 4).
-          const restored = await this._ensureAgent(inputData, threadId);
-          if ("error" in restored) {
-            yield _runStarted(inputData);
-            yield restored.error;
-            return;
-          }
-          const interruptState = (
-            restored.agent as { _interruptState?: { activated?: boolean } }
-          )._interruptState;
-          hasPending = interruptState?.activated === true;
+      // The SDK owns the checkpoint, so one it still holds active blocks the
+      // turn and is left exactly as it stands: clearing it here would discard
+      // the tool execution parked behind it.
+      let interruptState: unknown;
+      const cached = this._agentsByThread.get(threadId);
+      if (cached) {
+        interruptState = (cached as { _interruptState?: unknown })
+          ._interruptState;
+      } else if (this.config.sessionManagerProvider) {
+        // A cold process has no cached agent yet, but SessionManager may
+        // restore a native pending interrupt for this thread. Restore it
+        // before deciding whether new input may proceed (Rule 4).
+        const restored = await this._ensureAgent(inputData, threadId);
+        if ("error" in restored) {
+          yield _runStarted(inputData);
+          yield restored.error;
+          return;
         }
+        interruptState = (restored.agent as { _interruptState?: unknown })
+          ._interruptState;
       }
-      if (hasPending) {
+      if (
+        (interruptState as { activated?: boolean } | null | undefined)
+          ?.activated === true
+      ) {
         yield _runStarted(inputData);
         yield _runError(
           "Thread has pending interrupts. Include resume[] to address them.",
@@ -2299,6 +2380,12 @@ export class StrandsAgent {
           };
           return;
         }
+        // The run paused with nothing to hand back, so it falls through to the
+        // success finish below while the native checkpoint may stay parked.
+        // Mirrors the Python sibling's trace for the same blind spot.
+        this._log.debug(
+          `${LOG_PREFIX} Strands stopped for an interrupt with an empty interrupts list; reporting no pending interrupts`,
+        );
       }
 
       yield {
@@ -2788,18 +2875,63 @@ function _runError(message: string, code: string): BaseEvent {
   return { type: EventType.RUN_ERROR, message, code };
 }
 
+/**
+ * Validate a resolved resume payload against an object response schema, or
+ * `null` when it satisfies the schema (or the schema is not an object schema).
+ */
+function validateResumePayload(
+  entry: ResumeEntry,
+  schema: Record<string, unknown>,
+): BaseEvent | null {
+  if (schema.type !== "object") return null;
+  if (typeof entry.payload !== "object" || entry.payload == null) {
+    return _runError(
+      `Invalid payload for interrupt '${entry.interruptId}': expected an object.`,
+      "INVALID_PAYLOAD",
+    );
+  }
+  const payload = entry.payload as Record<string, unknown>;
+  const required = schema.required as string[] | undefined;
+  if (Array.isArray(required)) {
+    const missingKeys = required.filter((k) => !(k in payload));
+    if (missingKeys.length > 0) {
+      return _runError(
+        `Invalid payload for interrupt '${entry.interruptId}': missing required keys ${JSON.stringify(missingKeys)}.`,
+        "INVALID_PAYLOAD",
+      );
+    }
+  }
+  const typeError = validateObjectPayloadPropertyTypes(schema, payload);
+  if (typeError) {
+    return _runError(
+      `Invalid payload for interrupt '${entry.interruptId}': ${typeError}`,
+      "INVALID_PAYLOAD",
+    );
+  }
+  return null;
+}
+
 /** Non-empty `resume[]` entries, or `[]` if missing. */
 function resolveResumeEntries(input: RunAgentInput): ResumeEntry[] {
   const resume = (input as { resume?: ResumeEntry[] }).resume;
   return Array.isArray(resume) && resume.length > 0 ? resume : [];
 }
 
-/** AG-UI `ResumeEntry` → Strands `InterruptResponseContent.response`. */
+/**
+ * AG-UI `ResumeEntry` → Strands `InterruptResponseContent.response`.
+ *
+ * A present payload is passed through raw, because that is what tools
+ * destructure. It just can never be `undefined`: Strands reads
+ * `response === undefined` as "still awaiting a human" and re-raises the same
+ * interrupt forever. A generic interrupt publishes no responseSchema, so an
+ * empty payload reaches here unchecked; stand in an empty object, which the
+ * SDK counts as answered and a destructuring tool can still take.
+ */
 function toResumeResponse(entry: ResumeEntry): unknown {
   if (entry.status === "cancelled") {
     return { status: "cancelled" };
   }
-  return entry.payload as unknown;
+  return entry.payload === undefined ? {} : (entry.payload as unknown);
 }
 
 // ---------------------------------------------------------------------------
@@ -2925,11 +3057,7 @@ function strandsInterruptToAgui(interrupt: StrandsInterrupt): AguiInterrupt {
   // purpose — must stay generic: preserve its native name/reason payload
   // rather than guessing tool-approval semantics out of an unrelated
   // object.
-  const isToolApproval =
-    typeof interrupt.name === "string" &&
-    interrupt.name.startsWith("ag_ui:tool_call:");
-
-  if (!isToolApproval) {
+  if (!isToolApprovalInterrupt(interrupt)) {
     const out: AguiInterrupt = {
       id: interrupt.id,
       reason: interrupt.name ?? "interrupt",
@@ -2953,11 +3081,7 @@ function strandsInterruptToAgui(interrupt: StrandsInterrupt): AguiInterrupt {
     const toolUseId = (reasonRaw as Record<string, unknown>).tool_use_id;
     if (typeof toolUseId === "string") out.toolCallId = toolUseId;
   }
-  out.responseSchema = {
-    type: "object",
-    properties: { approved: { type: "boolean" } },
-    required: ["approved"],
-  };
+  out.responseSchema = toolApprovalResponseSchema();
   const meta: Record<string, unknown> = { strandsName: interrupt.name };
   if (typeof reasonRaw === "object" && reasonRaw != null) {
     const r = reasonRaw as Record<string, unknown>;
@@ -3312,9 +3436,20 @@ function _sortKeys(val: unknown): unknown {
  */
 function resumeFingerprint(entries: ResumeEntry[]): string {
   const canonicalEntries = entries
-    .map(
-      (entry) =>
-        [entry.interruptId, entry.status, _sortKeys(entry.payload)] as const,
+    .map((entry) =>
+      // A resolved entry without a payload is not the same resume as one
+      // carrying an explicit null: `toResumeResponse` sends `{}` for the first
+      // and `null` for the second. Omit the slot rather than serializing
+      // `undefined`, which JSON would collapse into the null it must differ
+      // from. A cancelled entry's payload never reaches the SDK, so its
+      // canonical form is left alone.
+      entry.status !== "cancelled" && entry.payload === undefined
+        ? ([entry.interruptId, entry.status] as const)
+        : ([
+            entry.interruptId,
+            entry.status,
+            _sortKeys(entry.payload),
+          ] as const),
     )
     .sort((left, right) =>
       JSON.stringify(left).localeCompare(JSON.stringify(right)),


### PR DESCRIPTION
Ticket: PNI-328

## The defect

Both bridges decided which interrupts were still waiting on a human by testing the recorded response for truthiness. An interrupt answered with a legitimate falsy value, `false`, `0` or `""`, was therefore classified as still open. That both re-reported an already answered interrupt as pending and tripped the guard that rejects a resume whose entries do not cover every open interrupt.

Presence of a response now decides, matching each SDK's own predicate.

Reproduced before any code changed:

```
PARTIAL_RESUME  Partial resume: missing interrupt IDs ['v1:before_tool_call:st-answered:...']. All open interrupts must be addressed.
```

Verified after, across every falsy answer, on the declared floor and on the current Strands release: the answered interrupt drops out of the waiting set and a resume covering only the genuinely open one proceeds. Reverting the predicate to truthiness refuses that same resume, which is what makes the coverage binding rather than decorative.

### Trigger, stated precisely

The originally reported trigger, a user answering "no" to a yes/no approval, does not reach this on the tool-approval path: a denial travels as `{"approved": false}`, a truthy object, and a generic interrupt's answer is wrapped in a defined envelope on purpose. The reachable routes are answers recorded outside that envelope, namely a preemptive `interrupt(..., response=False)` and a session answered natively and later resumed through the bridge. The defect and the fix are real; the trigger is narrower than first described.

## The declared Strands floor is unchanged

An earlier revision of this branch raised it, on the grounds that Strands itself treated a falsy answer as unanswered below 1.19.0. Both halves of that reasoning were wrong, and the review was right to push back.

The adapter never hands Strands a bare falsy answer, because it wraps its own resume values, so the old range was never affected for answers arriving from a client. And the suite failures that looked like old-version incompatibility came from tests importing Strands' private interrupt-state class, whose `activate` signature moved between releases: through 1.17.0 it took a context and overwrote it, from 1.18.0 it takes none. A double that wrote a parked placeholder and then called `activate()` had its own state erased, which is why a guard appeared not to fire on those releases.

Those tests now use this repository's structural stand-in, which is the approach `main` already adopted for the same reason. The stand-in gained the resume step the stream doubles need, with a conformance test pinning that behaviour to the real implementation on whatever release is installed, guarded so it skips rather than pinning the suite.

Result: the suite passes from 1.15.0 upward, the declared floor and the example app's independent requirement both stay as `main` has them, and no control flow anywhere branches on a version string.

## One source of truth

The underlying problem was that the bridge kept its own notion of whether an interrupt was in flight alongside the SDK's, and the two drifted. Every defect found while reviewing this change was an instance of that drift.

The SDK is now the only thing asked whether an interrupt is in flight or whether a question has an answer, in both bridges, resume validation included. The adapter's per-thread record holds only what the SDK has nowhere for: the answer shape advertised to the client and validated on the way back, the link between an interrupt and its tool card, and an expiry. It is never consulted about pending-ness.

## A persisted checkpoint could strand a thread permanently

Both SDKs record the submitted answers before rerunning hooks and parked tool execution, and deactivate the checkpoint only after that work succeeds. A hook failure or a crash in between therefore leaves a restored checkpoint marked active with every interrupt already answered. Fresh input was refused because the checkpoint was active, the exact retry was refused because nothing was open, and in TypeScript the idempotency shortcut could report success without ever calling Strands.

That state is now recognised, and an exact replay of the answers Strands already recorded is forwarded so the SDK can finish the parked execution. The checkpoint is not torn down, because that would discard the parked work. A batch that does not match is still refused.

Covered end to end in both languages rather than by its end state: record the answers, fail before deactivation, persist, restart, replay the exact batch, and assert the parked tool's output reaches the client with the checkpoint ending inactive.

## The rest

- **Python** had two sibling occurrences of the truthiness test, the resume preflight and the reporter for a paused run.
- **TypeScript** has no truthiness twin, since its SDK has always keyed off presence at every supported release, confirmed by reading the packaged sources. Two related defects were fixed there instead: its native open-interrupt helper counted every restored interrupt as open regardless of a recorded response, and its resume converter could record an absent response for a resolved entry carrying no payload, re-raising the interrupt forever. A present payload, falsy values included, still passes through unchanged.
- **Approval payload validation** no longer depends on the adapter's metadata surviving a restart. The approval contract is fixed and the adapter already publishes it.
- **A paused run reporting no interrupts** now leaves a debug trace in both bridges, so a thread reported successful while possibly still parked is diagnosable.

## Transports

Transport agnostic, and it covers every transport this integration serves. The change sits in the adapter's run and resume logic, above the transport layer: the FastAPI SSE endpoint on the Python side and the HTTP and SSE endpoint on the TypeScript side both reach it through the same `run()` path, and no encoder, protocol or endpoint module is touched. There is no path that gets the fix on one transport and not the other.

## Verification

| Strands release | result |
|---|---|
| 1.15.0, the declared floor | 400 passing |
| 1.18.0, the locked release | 403 passing |
| 1.52.0, current | 407 passing, plus one pre-existing unrelated failure noted below |

TypeScript 311 passing, `tsc --noEmit` clean.

Every fix is red-green verified and mutation tested: each was broken deliberately and the suite was confirmed to notice, then restored exactly.

The test doubles were also brought up to the SDK's contract, and that was load bearing rather than cosmetic. A regression introduced midway through this work was certified green by a double that skipped a call the SDK makes unconditionally; making the doubles honest is what caught it, and that change was then removed rather than patched. The seam for installing a custom stream routes through the SDK's resume step, with a static check so a future test cannot quietly bypass it.

## Protected capabilities

All still pass, unmodified: interrupt durability across a cold restart, idempotent resume, resume payload type checking against the tool schema, the client-tool guard, and all four typed interrupt error paths including both mixed frontend-proxy ones. No runtime string that another system matches literally was reworded, verified by confirming the diff removes no line carrying any of the interrupt error codes.

One existing test case changed premise rather than being weakened, and it is worth a reviewer's eye: an atomic-preflight row previously submitted exactly the recorded answer, which is now precisely the batch the recovery path accepts. It keeps its premise by submitting a different answer, with a new sibling row for a partially covering batch, and both still return the same rejection.

## Deliberately not in this change

Testing against the current Strands release surfaced one unrelated failure: a newer agent constructor parameter is stored behind a registry rather than under its own name, so the per-thread forwarding drops it silently. Filed as PNI-347, since it concerns parameter forwarding and carries a real design decision.

Reviewing this change also surfaced roughly fifty pre-existing defects in the interrupt and history paths of both bridges, several serious on their own. Two worth naming: a persistence write that empties the pending-interrupt map after a resume that paused again, and an interrupt-expiry rejection that is unreachable in production because nothing ever populates an expiry. All catalogued for follow-up.
