### PR TITLE
feat: add metadata to resume entries

### DIFF
--- a/docs/concepts/interrupts.mdx
+++ b/docs/concepts/interrupts.mdx
@@ -99,6 +99,7 @@ type RunAgentInput = {
     interruptId: string
     status: "resolved" | "cancelled"
     payload?: any
+    metadata?: Record<string, any>
   }>
 }
 ```
@@ -108,6 +109,12 @@ type RunAgentInput = {
   payload (for example, `{ approved: false }`), not as a separate status.
 - `cancelled` — the user abandoned without providing meaningful input.
   `payload` should be omitted.
+- `metadata` — optional envelope data about the response (for example a
+  signature proving the human decision was not tampered with, or routing
+  keys), as opposed to `payload`, which is the answer the agent asked for and
+  will act on. Open by key; any JSON value is allowed under a key, including
+  `null`. The object itself is either absent or an object, never `null`. The
+  `ag-ui` key is reserved for AG-UI's own use. Allowed on either status.
 
 ## Contract rules
 

--- a/docs/concepts/metadata.mdx
+++ b/docs/concepts/metadata.mdx
@@ -14,13 +14,14 @@ typed that consumers are required to carry.
 
 ## Where it lives
 
-Three places, all optional:
+Four places, all optional:
 
 | Carries `metadata` | Notes                                                                          |
 | ------------------ | ------------------------------------------------------------------------------ |
 | Every event        | Declared once on the base event, so all event types have it                    |
 | Every message      | All seven roles: developer, system, assistant, user, tool, activity, reasoning |
 | Every tool call    | A tool call is not a message — see [Tool calls](#tool-calls)                   |
+| Every resume entry | A request field, so nothing merges into it — see [Resume entries](#resume-entries) |
 
 ## Shape
 
@@ -138,6 +139,19 @@ destination, so the outcome is the same however the stream is processed.
 `TOOL_CALL_RESULT` is different: it creates a tool message, so its metadata
 merges into that message like any other message-building event.
 
+## Resume entries
+
+Each entry in `RunAgentInput.resume` — the per-interrupt response a client
+sends back after a run finished with an interrupt outcome — carries its own
+metadata. It holds envelope data about the response, such as a signature
+proving the human decision was not tampered with, or routing keys; the answer
+the agent asked for belongs in `payload`.
+
+A resume entry is a request field, not something assembled from a stream, so
+there are **no merge semantics** — nothing accumulates into it. See
+[Interrupts](/concepts/interrupts#resuming-a-run) for the full resume
+contract.
+
 ## Transports
 
 Over JSON — which is what SSE carries, and what every SDK reads and writes —
@@ -175,17 +189,18 @@ cross-language suite, which is asserted there, but do not depend on it.
   or a `bigint` will be accepted at the type level and then fail when encoded.
 </Note>
 
-**TypeScript** — `metadata?: Record<string, any>` on events, messages and tool
-calls. `mergeMetadata(existing, incoming)` is exported from `@ag-ui/core` if you
-are assembling messages yourself, along with `AGUI_METADATA_KEY` for the
-reserved key.
+**TypeScript** — `metadata?: Record<string, any>` on events, messages, tool
+calls and resume entries. `mergeMetadata(existing, incoming)` is exported from
+`@ag-ui/core` if you are assembling messages yourself, along with
+`AGUI_METADATA_KEY` for the reserved key.
 
 **Python** — `metadata: Optional[Dict[str, Any]]`. `EventEncoder` serializes
 with `exclude_none=True`, so an absent object is omitted rather than emitted as
 `null`. `Metadata` and `AGUI_METADATA_KEY` are exported from `ag_ui.core`.
 
-**.NET** — `JsonElement? Metadata` on `BaseEvent`, `AGUIMessage` and
-`AGUIToolCall`, with `AGUIMetadata.ReservedKey` for the reserved key.
+**.NET** — `JsonElement? Metadata` on `BaseEvent`, `AGUIMessage`,
+`AGUIToolCall` and `AGUIResume`, with `AGUIMetadata.ReservedKey` for the
+reserved key.
 
 It is a **wire-level field**. It round-trips faithfully through JSON and
 protobuf, so a server reading `RunAgentInput` or a client decoding the stream

--- a/docs/sdk/dotnet/abstractions/types.mdx
+++ b/docs/sdk/dotnet/abstractions/types.mdx
@@ -61,6 +61,28 @@ var input = new RunAgentInput
 | `Context` | `context` | `IList<AGUIContext>?` | Context objects provided to the agent |
 | `ForwardedProperties` | `forwardedProps` | `JsonElement` | Additional properties forwarded by the client |
 
+## AGUIResume
+
+One per-interrupt response inside `RunAgentInput.Resume`, addressing an
+interrupt from the previous run. See
+[Interrupts](/concepts/interrupts#resuming-a-run) for the full resume contract.
+
+| C# property | JSON field | Type | Description |
+| ----------- | ---------- | ---- | ----------- |
+| `InterruptId` | `interruptId` | `string` | ID of the interrupt this entry addresses |
+| `Status` | `status` | `string` | `ResumeStatus.Resolved` if the user responded, `ResumeStatus.Cancelled` if they abandoned |
+| `Payload` | `payload` | `JsonElement?` | The response itself, validated against the interrupt's `responseSchema` |
+| `Metadata` | `metadata` | `JsonElement?` | Envelope data about the response — signatures, routing keys — never the answer itself |
+
+`Metadata` follows the same conventions as metadata everywhere else in the
+protocol: open by key, any JSON value allowed under a key including `null`, the
+object itself absent or an object but never `null` on the wire, and the
+`ag-ui` key (`AGUIMetadata.ReservedKey`) reserved. A resume entry is a request
+field, so nothing merges into it; see
+[Metadata](/concepts/metadata#resume-entries). The hosting layer carries it
+onto `InterruptResponseContent.Metadata`, and `AGUIChatClient` copies it from
+`InterruptResponseContent` onto the entry it sends.
+
 ## Message Types
 
 Messages form a closed hierarchy rooted at `AGUIMessage`. The base type carries

--- a/docs/sdk/dotnet/abstractions/types.mdx
+++ b/docs/sdk/dotnet/abstractions/types.mdx
@@ -79,9 +79,12 @@ protocol: open by key, any JSON value allowed under a key including `null`, the
 object itself absent or an object but never `null` on the wire, and the
 `ag-ui` key (`AGUIMetadata.ReservedKey`) reserved. A resume entry is a request
 field, so nothing merges into it; see
-[Metadata](/concepts/metadata#resume-entries). The hosting layer carries it
-onto `InterruptResponseContent.Metadata`, and `AGUIChatClient` copies it from
-`InterruptResponseContent` onto the entry it sends.
+[Metadata](/concepts/metadata#resume-entries). For non-tool interrupts, the
+hosting layer carries it onto `InterruptResponseContent.Metadata`, and
+`AGUIChatClient` copies it from `InterruptResponseContent` onto the entry it
+sends. Tool-approval entries are translated through MEAI's own approval
+content types, which have no metadata surface — read it from the raw entry via
+`RunAgentInput.Resume` if you need it there.
 
 ## Message Types
 

--- a/docs/sdk/dotnet/client/chat-client.mdx
+++ b/docs/sdk/dotnet/client/chat-client.mdx
@@ -258,6 +258,23 @@ static ChatMessage CreateInterruptResponse(InterruptRequestContent request)
 }
 ```
 
+`InterruptResponseContent.Metadata` optionally carries envelope data about the
+response — a signature proving the decision was not tampered with, routing keys
+— as opposed to `Payload`, which is the answer the agent asked for. The client
+copies it onto the resume entry's `metadata`, and the hosting layer hands it
+back to the server pipeline on `InterruptResponseContent`; see
+[Metadata](/concepts/metadata#resume-entries).
+
+```csharp
+new InterruptResponseContent(request.RequestId)
+{
+    Payload = payload.RootElement.Clone(),
+    Metadata = JsonDocument.Parse(
+        """{"definitionId":"review-plan","key":"afterModel-review"}""")
+        .RootElement.Clone(),
+}
+```
+
 ## Related references
 
 - [Transport](/sdk/dotnet/client/transport)

--- a/docs/sdk/dotnet/hosting/overview.mdx
+++ b/docs/sdk/dotnet/hosting/overview.mdx
@@ -46,7 +46,7 @@ The hosting layer handles the protocol details for you:
 
 - Converts `RunAgentInput.Messages` into `ChatMessage` values
 - Translates `RunAgentInput.Resume` into MEAI approval and interrupt response
-  content
+  content, carrying each entry's payload and metadata
 - Installs client-declared tools on `ChatOptions`
 - Stores the original input under
   `ChatOptions.AdditionalProperties[AGUIConstants.RunAgentInputKey]`

--- a/docs/sdk/dotnet/hosting/overview.mdx
+++ b/docs/sdk/dotnet/hosting/overview.mdx
@@ -46,7 +46,8 @@ The hosting layer handles the protocol details for you:
 
 - Converts `RunAgentInput.Messages` into `ChatMessage` values
 - Translates `RunAgentInput.Resume` into MEAI approval and interrupt response
-  content, carrying each entry's payload and metadata
+  content, carrying payload — and, for non-tool interrupts, metadata — onto
+  `InterruptResponseContent`
 - Installs client-declared tools on `ChatOptions`
 - Stores the original input under
   `ChatOptions.AdditionalProperties[AGUIConstants.RunAgentInputKey]`

--- a/docs/sdk/js/core/types.mdx
+++ b/docs/sdk/js/core/types.mdx
@@ -30,19 +30,49 @@ type RunAgentInput = {
   tools: Tool[]
   context: Context[]
   forwardedProps: any
+  resume?: ResumeEntry[]
 }
 ```
 
-| Property         | Type                | Description                                    |
-| ---------------- | ------------------- | ---------------------------------------------- |
-| `threadId`       | `string`            | ID of the conversation thread                  |
-| `runId`          | `string`            | ID of the current run                          |
-| `parentRunId`    | `string (optional)` | ID of the run that spawned this run            |
-| `state`          | `any`               | Current state of the agent                     |
-| `messages`       | `Message[]`         | Array of messages in the conversation          |
-| `tools`          | `Tool[]`            | Client-provided tools available for this run   |
-| `context`        | `Context[]`         | Array of context objects provided to the agent |
-| `forwardedProps` | `any`               | Additional properties forwarded to the agent   |
+| Property         | Type                       | Description                                    |
+| ---------------- | -------------------------- | ---------------------------------------------- |
+| `threadId`       | `string`                   | ID of the conversation thread                  |
+| `runId`          | `string`                   | ID of the current run                          |
+| `parentRunId`    | `string (optional)`        | ID of the run that spawned this run            |
+| `state`          | `any`                      | Current state of the agent                     |
+| `messages`       | `Message[]`                | Array of messages in the conversation          |
+| `tools`          | `Tool[]`                   | Client-provided tools available for this run   |
+| `context`        | `Context[]`                | Array of context objects provided to the agent |
+| `forwardedProps` | `any`                      | Additional properties forwarded to the agent   |
+| `resume`         | `ResumeEntry[] (optional)` | Per-interrupt responses resuming a run that finished with an interrupt outcome |
+
+## ResumeEntry
+
+One per-interrupt response inside `RunAgentInput.resume`, addressing an
+interrupt from the previous run. See
+[Interrupts](/concepts/interrupts#resuming-a-run) for the full resume contract.
+
+```typescript
+type ResumeEntry = {
+  interruptId: string
+  status: "resolved" | "cancelled"
+  payload?: any
+  metadata?: Record<string, any>
+}
+```
+
+| Property      | Type                                | Description                                                                 |
+| ------------- | ----------------------------------- | --------------------------------------------------------------------------- |
+| `interruptId` | `string`                            | ID of the interrupt this entry addresses                                     |
+| `status`      | `"resolved" \| "cancelled"`         | Whether the user responded or abandoned the interrupt                        |
+| `payload`     | `any (optional)`                    | The response itself, validated against the interrupt's `responseSchema`      |
+| `metadata`    | `Record<string, any> (optional)`    | Envelope data about the response — signatures, routing keys — never the answer itself |
+
+`metadata` follows the same conventions as metadata everywhere else in the
+protocol: open by key, any JSON value allowed under a key including `null`, the
+object itself absent or an object but never `null`, and the `ag-ui` key
+reserved. A resume entry is a request field, so nothing merges into it; see
+[Metadata](/concepts/metadata#resume-entries).
 
 ## Message Types
 

--- a/docs/sdk/python/core/types.mdx
+++ b/docs/sdk/python/core/types.mdx
@@ -32,18 +32,48 @@ class RunAgentInput(ConfiguredBaseModel):
     tools: List[Tool]
     context: List[Context]
     forwarded_props: Any
+    resume: Optional[List[ResumeEntry]] = None
 ```
 
-| Property          | Type            | Description                                    |
-| ----------------- | --------------- | ---------------------------------------------- |
-| `thread_id`       | `str`           | ID of the conversation thread                  |
-| `run_id`          | `str`           | ID of the current run                          |
-| `parent_run_id`   | `Optional[str]` | (Optional) ID of the run that spawned this run |
-| `state`           | `Any`           | Current state of the agent                     |
-| `messages`        | `List[Message]` | List of messages in the conversation           |
-| `tools`           | `List[Tool]`    | Client-provided tools available for this run   |
-| `context`         | `List[Context]` | List of context objects provided to the agent  |
-| `forwarded_props` | `Any`           | Additional properties forwarded to the agent   |
+| Property          | Type                          | Description                                    |
+| ----------------- | ----------------------------- | ---------------------------------------------- |
+| `thread_id`       | `str`                         | ID of the conversation thread                  |
+| `run_id`          | `str`                         | ID of the current run                          |
+| `parent_run_id`   | `Optional[str]`               | (Optional) ID of the run that spawned this run |
+| `state`           | `Any`                         | Current state of the agent                     |
+| `messages`        | `List[Message]`               | List of messages in the conversation           |
+| `tools`           | `List[Tool]`                  | Client-provided tools available for this run   |
+| `context`         | `List[Context]`               | List of context objects provided to the agent  |
+| `forwarded_props` | `Any`                         | Additional properties forwarded to the agent   |
+| `resume`          | `Optional[List[ResumeEntry]]` | Per-interrupt responses resuming a run that finished with an interrupt outcome |
+
+## ResumeEntry
+
+`from ag_ui.core import ResumeEntry`
+
+One per-interrupt response inside `RunAgentInput.resume`, addressing an
+interrupt from the previous run. See
+[Interrupts](/concepts/interrupts#resuming-a-run) for the full resume contract.
+
+```python
+class ResumeEntry(MetadataMixin):
+    interrupt_id: str
+    status: ResumeStatus  # "resolved" | "cancelled"
+    payload: Optional[Any] = None
+```
+
+| Property       | Type                       | Description                                                                  |
+| -------------- | -------------------------- | ---------------------------------------------------------------------------- |
+| `interrupt_id` | `str`                      | ID of the interrupt this entry addresses                                      |
+| `status`       | `ResumeStatus`             | `"resolved"` if the user responded, `"cancelled"` if they abandoned           |
+| `payload`      | `Optional[Any]`            | The response itself, validated against the interrupt's `response_schema`      |
+| `metadata`     | `Optional[Dict[str, Any]]` | Envelope data about the response — signatures, routing keys — never the answer itself |
+
+`metadata` follows the same conventions as metadata everywhere else in the
+protocol: open by key, any JSON value allowed under a key including `None`, the
+object itself absent or a mapping but never `null` on the wire, and the
+`ag-ui` key reserved. A resume entry is a request field, so nothing merges into
+it; see [Metadata](/concepts/metadata#resume-entries).
 
 ## Message Types
 

--- a/sdks/dotnet/src/AGUI.Abstractions/Events/AGUIResume.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Events/AGUIResume.cs
@@ -15,4 +15,20 @@ public sealed class AGUIResume
     [JsonPropertyName("payload")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public JsonElement? Payload { get; set; }
+
+    /// <summary>
+    /// Extra information attached to this resume entry, open by key.
+    /// </summary>
+    /// <remarks>
+    /// Envelope data about the response — signatures, routing keys — as opposed
+    /// to <see cref="Payload"/>, which is the answer the agent asked for and
+    /// will act on. Any JSON value is allowed under a key, including
+    /// <c>null</c>. The object itself is absent or an object, never <c>null</c>.
+    ///
+    /// The <c>ag-ui</c> key is reserved for AG-UI's own use; see <see
+    /// cref="AGUIMetadata.ReservedKey"/>.
+    /// </remarks>
+    [JsonPropertyName("metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public JsonElement? Metadata { get; set; }
 }

--- a/sdks/dotnet/src/AGUI.Abstractions/InterruptResponseContent.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/InterruptResponseContent.cs
@@ -27,4 +27,19 @@ public sealed class InterruptResponseContent : Microsoft.Extensions.AI.InputResp
     [JsonPropertyName("payload")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public JsonElement? Payload { get; set; }
+
+    /// <summary>
+    /// Gets or sets extra information attached to the resume entry this response
+    /// becomes, open by key.
+    /// </summary>
+    /// <remarks>
+    /// Envelope data about the response — signatures, routing keys — as opposed
+    /// to <see cref="Payload"/>, which is the answer the agent asked for and
+    /// will act on. Carried to and from <see cref="AGUIResume.Metadata"/> by the
+    /// client and hosting adapters. The <c>ag-ui</c> key is reserved for AG-UI's
+    /// own use; see <see cref="AGUIMetadata.ReservedKey"/>.
+    /// </remarks>
+    [JsonPropertyName("metadata")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public JsonElement? Metadata { get; set; }
 }

--- a/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
+++ b/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
@@ -81,6 +81,8 @@ AGUI.Abstractions.AGUIResume
 AGUI.Abstractions.AGUIResume.AGUIResume() -> void
 AGUI.Abstractions.AGUIResume.InterruptId.get -> string!
 AGUI.Abstractions.AGUIResume.InterruptId.set -> void
+AGUI.Abstractions.AGUIResume.Metadata.get -> System.Text.Json.JsonElement?
+AGUI.Abstractions.AGUIResume.Metadata.set -> void
 AGUI.Abstractions.AGUIResume.Payload.get -> System.Text.Json.JsonElement?
 AGUI.Abstractions.AGUIResume.Payload.set -> void
 AGUI.Abstractions.AGUIResume.Status.get -> string!

--- a/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
+++ b/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
@@ -19,6 +19,8 @@ AGUI.Abstractions.InterruptRequestContent.ToolCallId.get -> string?
 AGUI.Abstractions.InterruptRequestContent.ToolCallId.set -> void
 AGUI.Abstractions.InterruptResponseContent
 AGUI.Abstractions.InterruptResponseContent.InterruptResponseContent(string! requestId) -> void
+AGUI.Abstractions.InterruptResponseContent.Metadata.get -> System.Text.Json.JsonElement?
+AGUI.Abstractions.InterruptResponseContent.Metadata.set -> void
 AGUI.Abstractions.InterruptResponseContent.Payload.get -> System.Text.Json.JsonElement?
 AGUI.Abstractions.InterruptResponseContent.Payload.set -> void
 static AGUI.Abstractions.AGUIChatMessageExtensions.AsChatMessages(this System.Collections.Generic.IEnumerable<AGUI.Abstractions.AGUIMessage!>! aguiMessages) -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.ChatMessage!>!

--- a/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
+++ b/sdks/dotnet/src/AGUI.Client/AGUIChatClient.cs
@@ -454,6 +454,7 @@ public sealed class AGUIChatClient : DelegatingChatClient
                             InterruptId = ir.RequestId,
                             Status = ResumeStatus.Resolved,
                             Payload = ir.Payload,
+                            Metadata = ir.Metadata,
                         });
                     }
 

--- a/sdks/dotnet/src/AGUI.Server/RunAgentInputExtensions.cs
+++ b/sdks/dotnet/src/AGUI.Server/RunAgentInputExtensions.cs
@@ -81,6 +81,7 @@ public static class RunAgentInputExtensions
                 genericResponses.Add(new InterruptResponseContent(resume.InterruptId)
                 {
                     Payload = resume.Payload,
+                    Metadata = resume.Metadata,
                 });
             }
 

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ResumeMetadataTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ResumeMetadataTest.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using AGUI.Abstractions;
+using Xunit;
+
+namespace AGUI.Abstractions.UnitTests;
+
+/// <summary>
+/// Metadata on <see cref="AGUIResume"/> follows the same conventions as the
+/// metadata object on events and messages (see <see cref="MetadataTest"/>):
+/// open by key, any JSON value including null under a key, the object itself
+/// absent or an object but never null on the wire, and an explicit null read
+/// back as absent. It is envelope data about the response — signatures,
+/// routing keys — as opposed to <see cref="AGUIResume.Payload"/>, which is the
+/// answer the agent asked for.
+/// </summary>
+public sealed class ResumeMetadataTest
+{
+    // Every JSON shape the protocol promises survives a round trip.
+    private const string ValueShapesJson = """
+        {
+          "nullValue": null,
+          "string": "afterModel-review",
+          "number": 42,
+          "float": 1.5,
+          "boolean": true,
+          "emptyArray": [],
+          "array": [1, "two", null, { "nested": true }],
+          "emptyObject": {},
+          "nested": { "signature": { "alg": "ed25519", "hash": "abc" }, "tags": ["a", "b"] }
+        }
+        """;
+
+    private static JsonElement ValueShapes() => JsonDocument.Parse(ValueShapesJson).RootElement.Clone();
+
+    [Fact]
+    public void Resume_RoundTripsEveryValueShape()
+    {
+        var resume = new AGUIResume
+        {
+            InterruptId = "int-1",
+            Status = ResumeStatus.Resolved,
+            Metadata = ValueShapes(),
+        };
+
+        var json = JsonSerializer.Serialize(resume, AGUIJsonSerializerContext.Default.AGUIResume);
+        var restored = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.AGUIResume);
+
+        Assert.NotNull(restored);
+        Assert.NotNull(restored!.Metadata);
+        Assert.Equal(
+            JsonSerializer.Serialize(ValueShapes()),
+            JsonSerializer.Serialize(restored.Metadata!.Value));
+    }
+
+    [Fact]
+    public void Resume_OmitsAbsentMetadataFromTheWire()
+    {
+        // An absent object must not become "metadata": null — AG-UI never puts a
+        // null on the wire in place of the object.
+        var resume = new AGUIResume { InterruptId = "int-1", Status = ResumeStatus.Resolved };
+
+        var json = JsonSerializer.Serialize(resume, AGUIJsonSerializerContext.Default.AGUIResume);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("metadata", out _));
+    }
+
+    [Fact]
+    public void Resume_ReadsExplicitNullAsAbsent()
+    {
+        // Producers that serialize unset optionals as null must still round-trip,
+        // matching the TypeScript and Python schemas.
+        const string json = """{"interruptId":"int-1","status":"resolved","metadata":null}""";
+
+        var restored = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.AGUIResume);
+
+        Assert.NotNull(restored);
+        Assert.Null(restored!.Metadata);
+    }
+
+    [Fact]
+    public void Resume_DistinguishesEmptyObjectFromAbsent()
+    {
+        const string json = """{"interruptId":"int-1","status":"resolved","metadata":{}}""";
+
+        var restored = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.AGUIResume);
+
+        Assert.NotNull(restored);
+        Assert.NotNull(restored!.Metadata);
+        Assert.Equal(JsonValueKind.Object, restored.Metadata!.Value.ValueKind);
+        Assert.Empty(restored.Metadata!.Value.EnumerateObject());
+    }
+
+    [Fact]
+    public void Resume_CarriesMetadataOnCancelledEntries()
+    {
+        const string json = """{"interruptId":"int-1","status":"cancelled","metadata":{"reason":"timeout"}}""";
+
+        var restored = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.AGUIResume);
+
+        Assert.NotNull(restored?.Metadata);
+        Assert.Equal("timeout", restored!.Metadata!.Value.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public void Resume_MetadataReachesTheServerThroughRunAgentInput()
+    {
+        // The shape a client posts: a server handler reads the metadata off the
+        // resume entry it was sent.
+        const string json = """
+            {
+              "threadId": "t-1",
+              "runId": "r-1",
+              "messages": [],
+              "resume": [
+                {
+                  "interruptId": "generic-1",
+                  "status": "resolved",
+                  "payload": { "approved": true },
+                  "metadata": {
+                    "ag-ui": {},
+                    "definitionId": "review-plan",
+                    "key": "afterModel-review"
+                  }
+                }
+              ]
+            }
+            """;
+
+        var input = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.RunAgentInput);
+
+        Assert.NotNull(input?.Resume);
+        var entry = Assert.Single(input!.Resume!);
+        Assert.NotNull(entry.Metadata);
+        Assert.Equal("review-plan", entry.Metadata!.Value.GetProperty("definitionId").GetString());
+        Assert.Equal("afterModel-review", entry.Metadata!.Value.GetProperty("key").GetString());
+        Assert.Equal(
+            JsonValueKind.Object,
+            entry.Metadata!.Value.GetProperty(AGUIMetadata.ReservedKey).ValueKind);
+    }
+}

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/AGUIChatClientTest.cs
@@ -278,6 +278,58 @@ public sealed class AGUIChatClientTest
         Assert.Equal("caller-interrupt", entry.InterruptId);
     }
 
+    // Metadata set on an InterruptResponseContent travels onto the resume entry the
+    // client sends, alongside the payload — envelope data (signatures, routing keys)
+    // as opposed to the answer itself.
+    [Fact]
+    public async Task GetStreamingResponse_InterruptResponseMetadata_ReachesTheResumeEntry()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var history = new List<ChatMessage>
+        {
+            new(ChatRole.User,
+            [
+                new InterruptResponseContent("req-interrupt")
+                {
+                    Payload = JsonDocument.Parse("""{"approved":true}""").RootElement,
+                    Metadata = JsonDocument.Parse(
+                        """{"definitionId":"review-plan","key":"afterModel-review"}""").RootElement,
+                },
+            ]),
+        };
+
+        await DrainAsync(client.GetStreamingResponseAsync(history));
+
+        var resume = transport.LastInput!.Resume;
+        Assert.NotNull(resume);
+        var entry = Assert.Single(resume!);
+        Assert.Equal("req-interrupt", entry.InterruptId);
+        Assert.True(entry.Payload!.Value.GetProperty("approved").GetBoolean());
+        Assert.NotNull(entry.Metadata);
+        Assert.Equal("review-plan", entry.Metadata!.Value.GetProperty("definitionId").GetString());
+        Assert.Equal("afterModel-review", entry.Metadata!.Value.GetProperty("key").GetString());
+    }
+
+    // An InterruptResponseContent without metadata produces a resume entry without it.
+    [Fact]
+    public async Task GetStreamingResponse_InterruptResponseWithoutMetadata_OmitsIt()
+    {
+        var transport = new CapturingTransport();
+        using var client = new AGUIChatClient(new() { Transport = transport });
+
+        var history = new List<ChatMessage>
+        {
+            new(ChatRole.User, [new InterruptResponseContent("req-interrupt")]),
+        };
+
+        await DrainAsync(client.GetStreamingResponseAsync(history));
+
+        var entry = Assert.Single(transport.LastInput!.Resume!);
+        Assert.Null(entry.Metadata);
+    }
+
     // https://github.com/microsoft/agent-framework/issues/5587
     [Fact]
     public async Task AGUIChatClient_ToolCallResultWithPlainTextContent_DoesNotParseAsJson()

--- a/sdks/dotnet/tests/AGUI.Server.UnitTests/InterruptContentTest.cs
+++ b/sdks/dotnet/tests/AGUI.Server.UnitTests/InterruptContentTest.cs
@@ -122,6 +122,62 @@ public sealed class InterruptContentTest
         Assert.Throws<ArgumentException>("requestId", () => new InterruptResponseContent("   "));
     }
 
+    // Metadata on an incoming resume entry survives the hosting layer's translation to
+    // MEAI content, so an inner pipeline reading InterruptResponseContent sees the
+    // envelope data (signatures, routing keys) the client attached.
+    [Fact]
+    public void ResumeMetadata_SurvivesTranslationToInterruptResponseContent()
+    {
+        var input = new RunAgentInput
+        {
+            ThreadId = "t1",
+            RunId = "r1",
+            Resume =
+            [
+                new AGUIResume
+                {
+                    InterruptId = "generic-1",
+                    Status = ResumeStatus.Resolved,
+                    Payload = JsonDocument.Parse("""{"approved":true}""").RootElement,
+                    Metadata = JsonDocument.Parse(
+                        """{"definitionId":"review-plan","key":"afterModel-review"}""").RootElement,
+                },
+            ],
+        };
+
+        var context = input.ToChatRequestContext(AIJsonUtilities.DefaultOptions);
+
+        var response = Assert.Single(context.Messages
+            .SelectMany(m => m.Contents)
+            .OfType<InterruptResponseContent>());
+        Assert.Equal("generic-1", response.RequestId);
+        Assert.NotNull(response.Metadata);
+        Assert.Equal("review-plan", response.Metadata!.Value.GetProperty("definitionId").GetString());
+        Assert.Equal("afterModel-review", response.Metadata!.Value.GetProperty("key").GetString());
+    }
+
+    // A resume entry without metadata translates to content without it.
+    [Fact]
+    public void ResumeWithoutMetadata_TranslatesWithoutIt()
+    {
+        var input = new RunAgentInput
+        {
+            ThreadId = "t1",
+            RunId = "r1",
+            Resume =
+            [
+                new AGUIResume { InterruptId = "generic-1", Status = ResumeStatus.Resolved },
+            ],
+        };
+
+        var context = input.ToChatRequestContext(AIJsonUtilities.DefaultOptions);
+
+        var response = Assert.Single(context.Messages
+            .SelectMany(m => m.Contents)
+            .OfType<InterruptResponseContent>());
+        Assert.Null(response.Metadata);
+    }
+
     #endregion
 
     #region JSON Serialization

--- a/sdks/python/ag_ui/core/types.py
+++ b/sdks/python/ag_ui/core/types.py
@@ -308,9 +308,13 @@ class Interrupt(ConfiguredBaseModel):
 ResumeStatus = Literal["resolved", "cancelled"]
 
 
-class ResumeEntry(ConfiguredBaseModel):
+class ResumeEntry(MetadataMixin):
     """
     A per-interrupt response in the resume array of a RunAgentInput.
+
+    ``metadata`` carries envelope data about the response — signatures, routing
+    keys — as opposed to ``payload``, which is the answer the agent asked for
+    and will act on.
     """
     interrupt_id: str
     status: ResumeStatus

--- a/sdks/python/tests/test_interrupts.py
+++ b/sdks/python/tests/test_interrupts.py
@@ -75,6 +75,102 @@ class ResumeEntryTest(unittest.TestCase):
         self.assertEqual(r.status, "cancelled")
 
 
+class ResumeEntryMetadataTest(unittest.TestCase):
+    """
+    Metadata on a resume entry follows the same conventions as everywhere else:
+    open by key, any JSON value including None under a key, the object itself
+    absent or a mapping but never null on the wire.
+    """
+
+    # Every JSON shape the protocol promises survives a round trip.
+    VALUE_SHAPES = {
+        "nullValue": None,
+        "string": "afterModel-review",
+        "number": 42,
+        "float": 1.5,
+        "boolean": True,
+        "emptyArray": [],
+        "array": [1, "two", None, {"nested": True}],
+        "emptyObject": {},
+        "nested": {"signature": {"alg": "ed25519", "hash": "abc"}, "tags": ["a", "b"]},
+    }
+
+    def test_absent_by_default(self):
+        r = ResumeEntry(interrupt_id="int-1", status="resolved")
+        self.assertIsNone(r.metadata)
+
+    def test_json_round_trip_of_every_value_shape(self):
+        r = ResumeEntry(interrupt_id="int-1", status="resolved", metadata=self.VALUE_SHAPES)
+        restored = ResumeEntry.model_validate_json(r.model_dump_json(by_alias=True))
+        self.assertEqual(restored.metadata, self.VALUE_SHAPES)
+
+    def test_empty_object_round_trips_distinct_from_absent(self):
+        r = ResumeEntry(interrupt_id="int-1", status="resolved", metadata={})
+        restored = ResumeEntry.model_validate_json(r.model_dump_json(by_alias=True))
+        self.assertEqual(restored.metadata, {})
+
+    def test_explicit_null_reads_back_as_absent(self):
+        r = ResumeEntry.model_validate(
+            {"interruptId": "int-1", "status": "resolved", "metadata": None}
+        )
+        self.assertIsNone(r.metadata)
+
+    def test_plain_model_dump_json_round_trips(self):
+        # No exclude_none here — this is the shape integrations commonly emit.
+        original = ResumeEntry(interrupt_id="int-1", status="cancelled")
+        restored = ResumeEntry.model_validate_json(original.model_dump_json(by_alias=True))
+        self.assertIsNone(restored.metadata)
+
+    def test_absent_metadata_serializes_without_the_key(self):
+        r = ResumeEntry(interrupt_id="int-1", status="resolved", payload={"approved": True})
+        dumped = r.model_dump(by_alias=True, exclude_none=True)
+        self.assertNotIn("metadata", dumped)
+
+    def test_exclude_none_preserves_null_values_under_keys(self):
+        # exclude_none must only drop the unset object itself, never recurse
+        # into metadata values — a None under a key is data.
+        r = ResumeEntry(
+            interrupt_id="int-1",
+            status="resolved",
+            metadata={"source": "ui", "nullValue": None},
+        )
+        dumped = r.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["metadata"], {"source": "ui", "nullValue": None})
+
+    def test_carried_on_cancelled_entries_too(self):
+        r = ResumeEntry(interrupt_id="int-1", status="cancelled", metadata={"reason": "timeout"})
+        self.assertEqual(r.metadata, {"reason": "timeout"})
+
+    def test_reaches_the_agent_through_run_agent_input(self):
+        i = RunAgentInput.model_validate(
+            {
+                "threadId": "t-1",
+                "runId": "r-1",
+                "state": {},
+                "messages": [],
+                "tools": [],
+                "context": [],
+                "forwardedProps": {},
+                "resume": [
+                    {
+                        "interruptId": "generic-1",
+                        "status": "resolved",
+                        "payload": {"approved": True},
+                        "metadata": {
+                            "ag-ui": {},
+                            "definitionId": "review-plan",
+                            "key": "afterModel-review",
+                        },
+                    }
+                ],
+            }
+        )
+        self.assertEqual(
+            i.resume[0].metadata,
+            {"ag-ui": {}, "definitionId": "review-plan", "key": "afterModel-review"},
+        )
+
+
 class RunAgentInputResumeTest(unittest.TestCase):
     def _base_input(self, **overrides):
         base = dict(

--- a/sdks/typescript/packages/client/src/interrupts/__tests__/helpers.test.ts
+++ b/sdks/typescript/packages/client/src/interrupts/__tests__/helpers.test.ts
@@ -83,6 +83,29 @@ describe("buildResumeArray", () => {
     expect(resume[1]).not.toHaveProperty("payload");
   });
 
+  it("carries metadata through on both statuses, and omits it when not given", () => {
+    const resume = buildResumeArray(interrupts, {
+      "int-1": {
+        status: "resolved",
+        payload: { approved: true },
+        metadata: { definitionId: "review-plan", key: "afterModel-review" },
+      },
+      "int-2": { status: "cancelled", metadata: { reason: "timeout" } },
+    });
+    expect(resume[0].metadata).toEqual({
+      definitionId: "review-plan",
+      key: "afterModel-review",
+    });
+    expect(resume[1].metadata).toEqual({ reason: "timeout" });
+
+    const bare = buildResumeArray(interrupts, {
+      "int-1": { status: "resolved" },
+      "int-2": { status: "cancelled" },
+    });
+    expect(bare[0]).not.toHaveProperty("metadata");
+    expect(bare[1]).not.toHaveProperty("metadata");
+  });
+
   it("throws when a response is missing for an open interrupt", () => {
     expect(() =>
       buildResumeArray(interrupts, {

--- a/sdks/typescript/packages/client/src/interrupts/index.ts
+++ b/sdks/typescript/packages/client/src/interrupts/index.ts
@@ -15,8 +15,6 @@ export function isInterruptExpired(interrupt: Interrupt, now: Date = new Date())
   return new Date(interrupt.expiresAt) <= now;
 }
 
-// `metadata` carries envelope data about the response (signatures, routing
-// keys) on either status — a cancellation can be signed too.
 type ResumeResponse =
   | { status: "resolved"; payload?: unknown; metadata?: Metadata }
   | { status: "cancelled"; metadata?: Metadata };

--- a/sdks/typescript/packages/client/src/interrupts/index.ts
+++ b/sdks/typescript/packages/client/src/interrupts/index.ts
@@ -1,5 +1,6 @@
 import type {
   Interrupt,
+  Metadata,
   ResumeEntry,
   RunFinishedEvent,
   RunFinishedOutcome,
@@ -14,9 +15,11 @@ export function isInterruptExpired(interrupt: Interrupt, now: Date = new Date())
   return new Date(interrupt.expiresAt) <= now;
 }
 
+// `metadata` carries envelope data about the response (signatures, routing
+// keys) on either status — a cancellation can be signed too.
 type ResumeResponse =
-  | { status: "resolved"; payload?: unknown }
-  | { status: "cancelled" };
+  | { status: "resolved"; payload?: unknown; metadata?: Metadata }
+  | { status: "cancelled"; metadata?: Metadata };
 
 export function buildResumeArray(
   interrupts: Interrupt[],
@@ -37,11 +40,9 @@ export function buildResumeArray(
 
   return interrupts.map((i) => {
     const r = responses[i.id];
-    if (r.status === "resolved") {
-      const entry: ResumeEntry = { interruptId: i.id, status: "resolved" };
-      if (r.payload !== undefined) entry.payload = r.payload;
-      return entry;
-    }
-    return { interruptId: i.id, status: "cancelled" };
+    const entry: ResumeEntry = { interruptId: i.id, status: r.status };
+    if (r.status === "resolved" && r.payload !== undefined) entry.payload = r.payload;
+    if (r.metadata !== undefined) entry.metadata = r.metadata;
+    return entry;
   });
 }

--- a/sdks/typescript/packages/core/src/__tests__/interrupts.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/interrupts.test.ts
@@ -56,6 +56,96 @@ describe("ResumeEntrySchema", () => {
   });
 });
 
+describe("ResumeEntry.metadata", () => {
+  // Every JSON shape the protocol promises survives a round trip.
+  const VALUE_SHAPES = {
+    nullValue: null,
+    string: "afterModel-review",
+    number: 42,
+    float: 1.5,
+    boolean: true,
+    emptyArray: [],
+    array: [1, "two", null, { nested: true }],
+    emptyObject: {},
+    nested: { signature: { alg: "ed25519", hash: "abc" }, tags: ["a", "b"] },
+  };
+
+  it("round-trips every JSON value shape through JSON", () => {
+    const entry = ResumeEntrySchema.parse({
+      interruptId: "int-1",
+      status: "resolved",
+      payload: { approved: true },
+      metadata: VALUE_SHAPES,
+    });
+    const restored = ResumeEntrySchema.parse(JSON.parse(JSON.stringify(entry)));
+    expect(restored.metadata).toEqual(VALUE_SHAPES);
+  });
+
+  it("round-trips an empty metadata object, distinct from absent", () => {
+    const restored = ResumeEntrySchema.parse(
+      JSON.parse(
+        JSON.stringify(
+          ResumeEntrySchema.parse({ interruptId: "int-1", status: "resolved", metadata: {} }),
+        ),
+      ),
+    );
+    expect(restored.metadata).toEqual({});
+  });
+
+  it("is optional", () => {
+    const parsed = ResumeEntrySchema.parse({ interruptId: "int-1", status: "cancelled" });
+    expect(parsed.metadata).toBeUndefined();
+  });
+
+  it("reads an explicit null as absent", () => {
+    const parsed = ResumeEntrySchema.parse({
+      interruptId: "int-1",
+      status: "resolved",
+      metadata: null,
+    });
+    expect(parsed.metadata).toBeUndefined();
+  });
+
+  it("serializes without the key when absent, rather than emitting null", () => {
+    const entry = ResumeEntrySchema.parse({ interruptId: "int-1", status: "resolved" });
+    expect(JSON.parse(JSON.stringify(entry))).not.toHaveProperty("metadata");
+  });
+
+  it("is carried on both statuses", () => {
+    const cancelled = ResumeEntrySchema.parse({
+      interruptId: "int-1",
+      status: "cancelled",
+      metadata: { reason: "timeout" },
+    });
+    expect(cancelled.metadata).toEqual({ reason: "timeout" });
+  });
+
+  it("reaches the agent through RunAgentInput.resume", () => {
+    const parsed = RunAgentInputSchema.parse({
+      threadId: "t-1",
+      runId: "r-1",
+      state: {},
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+      resume: [
+        {
+          interruptId: "generic-1",
+          status: "resolved",
+          payload: { approved: true },
+          metadata: { "ag-ui": {}, definitionId: "review-plan", key: "afterModel-review" },
+        },
+      ],
+    });
+    expect(parsed.resume?.[0].metadata).toEqual({
+      "ag-ui": {},
+      definitionId: "review-plan",
+      key: "afterModel-review",
+    });
+  });
+});
+
 describe("RunAgentInput.resume", () => {
   const baseInput = {
     threadId: "t-1",

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -217,6 +217,9 @@ export const ResumeEntrySchema = z.object({
   interruptId: z.string(),
   status: z.enum(["resolved", "cancelled"]),
   payload: z.any().optional(),
+  // Envelope data about the response — signatures, routing keys — as opposed to
+  // `payload`, which is the answer the agent asked for and will act on.
+  metadata: OptionalMetadataSchema,
 });
 
 export const RunAgentInputSchema = z.object({


### PR DESCRIPTION
## Summary

Implements [PNI-317](https://linear.app/copilotkit/issue/PNI-317/add-metadata-to-resume-entries): adds an optional, open-by-key `metadata` object to `ResumeEntry` in the TypeScript, Python and .NET SDKs, so a client can attach envelope data to a human-in-the-loop response — a signed hash proving the decision was not tampered with, routing keys like `definitionId` and `key` — without mixing it into `payload`, which is the answer the agent asked for and will act on.

The field follows the conventions established in PNI-198:

- Open by key — any JSON value allowed under a key, including `null` (a `null` *value under a key* is data and is preserved).
- The object itself is absent or an object, never `null` on the wire; an explicit `"metadata": null` is read back as absent.
- An entry without metadata serializes without the key rather than emitting `null`.
- The `ag-ui` key is reserved.
- No merge semantics — a resume entry is a request field, nothing accumulates into it.
- No protobuf work: confirmed `ResumeEntry`/`RunAgentInput` have no proto representation.

## Changes

**TypeScript** — `ResumeEntrySchema` gains `metadata: OptionalMetadataSchema` (the same null-coercing schema every event and message uses). The `buildResumeArray` client helper accepts `metadata` on both resolved and cancelled responses and passes it through.

**Python** — `ResumeEntry` now extends the `MetadataMixin` from PNI-198.

**.NET** — `AGUIResume.Metadata` (`JsonElement?`, `WhenWritingNull`), matching `BaseEvent`/`AGUIMessage`. Also plumbed through the high-level flow: `InterruptResponseContent.Metadata` travels to the resume entry in `AGUIChatClient` and back to MEAI content in `RunAgentInputExtensions`, so the field is usable without dropping to raw `RunAgentInput`. The tool-approval branch is deliberately untouched — its resume payload is synthesized from MEAI's own approval types, which AG-UI does not extend.

**Docs** — `docs/concepts/interrupts.mdx` documents the field on the resume shape; `docs/concepts/metadata.mdx` updated from three carriers to four, with a resume-entries section (envelope vs payload, no merge semantics).

## Test coverage

Each SDK asserts the acceptance criteria: absent / empty / null-valued / primitive / array / nested-object metadata survive a JSON round trip; explicit `null` reads back as absent; absent metadata serializes without the key; and the field reaches a server handler through `RunAgentInput.resume`. .NET additionally covers both adapter directions (client → resume entry, resume entry → MEAI content), including omission when unset.

Suites: TS core 193 ✅, TS client 553 ✅, Python 153 ✅, .NET Abstractions 226 / Server 129 / Client 119 ✅ (run with `-p:SignAssembly=false` as CI does).

Reviewed with Codex over two rounds; round 2 converged with no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)