### PR TITLE
ci: drop the last two protoc install steps the pin made redundant

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -237,12 +237,6 @@ jobs:
         with:
           node-version-file: ".node-version"
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
-        with:
-          version: "25.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:

--- a/.github/workflows/unit-dotnet-sdk.yml
+++ b/.github/workflows/unit-dotnet-sdk.yml
@@ -116,12 +116,6 @@ jobs:
         with:
           node-version-file: ".node-version"
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
-        with:
-          version: "25.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
         with:


### PR DESCRIPTION
Originally opened to pin the protoc version for the committed TS bindings. **Main solved that independently while this was in flight**: #2449 (M0 repo health, merged Aug 18) added `config.protocVersion: "35.1"` to the proto package in ac9d14a4 — same value this PR proposed — and the typecheck/deterministic-build work also removed the `Install protoc` step from `unit-typescript-sdk.yml`. This PR is now only the remainder of that sweep.

## Change

Remove the two remaining `Install protoc` steps:

- `unit-dotnet-sdk.yml` (cross-language job)
- `publish-release.yml` (build job)

Their only consumer was TypeScript protobuf generation during `nx build`, and since the pin, `@protobuf-ts/protoc` fetches 35.1 itself and ignores `$PATH` — each step downloads a compiler nothing then calls. Confirmed on live CI runs while the typescript job still had the step:

```
Install protoc   Getting protoc version: v25.9
Test Build       @protobuf-ts/protoc installed protoc v35.1.
```

Leaving them would assert a protoc version (`25.x`) that no longer decides anything — the next person debugging a protobuf mismatch would chase the wrong compiler.

## Reviewer notes

- The `unit-dotnet-sdk.yml` deletion is validated by this PR's own run: the cross-language job builds the TS packages (including proto generation) with the step already gone, and passes.
- The `publish-release.yml` deletion is the one edit no PR CI exercises; its first real proof is the next release. It is the same one-line-purpose removal as the two now validated live.
- The .NET protobuf project never consumed the `$PATH` protoc — Grpc.Tools brings its own compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)