### PR TITLE
docs: update .NET SDK status and getting started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangChain and Crew
 | [Rust]() | ✅ Supported | ➡️ [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/rust/crates/ag-ui-client) | Community |
 | [Ruby]() | ✅ Supported | ➡️ [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/ruby) | Community |
 | [C++]() | ✅ Supported | ➡️ [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/c%2B%2B) | Community |
-| [.NET]() | 🛠️ In Progress | ➡️ [PR](https://github.com/ag-ui-protocol/ag-ui/pull/38) | Community |
+| [.NET]() | ✅ Supported | ➡️ [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/dotnet/samples/GettingStarted) | Community |
 | [Nim]() | 🛠️ In Progress | ➡️ [PR](https://github.com/ag-ui-protocol/ag-ui/pull/29) | Community |
 | [Flowise]() | 🛠️ In Progress | ➡️ [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/367) | Community |
 | [Langflow]() | 🛠️ In Progress | ➡️ [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/366) | Community |

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -48,9 +48,9 @@ that demonstrate the protocol's capabilities and versatility.
 | [Rust](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/rust/crates/ag-ui-client)
 | [Ruby](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/ruby)
 | [C++](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/c%2B%2B)
+| [.NET](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/dotnet/samples/GettingStarted)
 
 #### (coming soon)
- | [.NET](https://github.com/ag-ui-protocol/ag-ui/pull/38)
  | [Nim](https://github.com/ag-ui-protocol/ag-ui/pull/29)
  | [Flowise](https://github.com/ag-ui-protocol/ag-ui/issues/367)
  | [Langflow](https://github.com/ag-ui-protocol/ag-ui/issues/366)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -308,7 +308,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangChain and Crew
 | [Rust]() | Supported | [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/rust/crates/ag-ui-client) | Community |
 | [Ruby]() | Supported | [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/ruby) | Community |
 | [C++]() | Supported | [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/community/c%2B%2B) | Community |
-| [.NET]() | In Progress | [PR](https://github.com/ag-ui-protocol/ag-ui/pull/38) | Community |
+| [.NET]() | Supported | [Getting Started](https://github.com/ag-ui-protocol/ag-ui/tree/main/sdks/dotnet/samples/GettingStarted) | Community |
 | [Nim]() | In Progress | [PR](https://github.com/ag-ui-protocol/ag-ui/pull/29) | Community |
 | [Flowise]() | In Progress | [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/367) | Community |
 | [Langflow]() | In Progress | [GitHub Source](https://github.com/ag-ui-protocol/ag-ui/issues/366) | Community |


### PR DESCRIPTION
## Summary

* Mark the .NET SDK as supported in the repository overview and documentation landing page.
* Replace the closed port pull request with the maintained .NET getting started samples.
* Move .NET out of the integrations page coming soon list.

## Validation

* Confirmed the target sample folder exists on `main`.
* Confirmed no references to the closed .NET port pull request remain.

Fixes #2461

cc: @javiercn @danroth27 