### PR TITLE
fix(crewai): remove the CrewAIAgent protocol version ceiling

### DIFF
--- a/integrations/crew-ai/typescript/src/__tests__/no-content-flattening.test.ts
+++ b/integrations/crew-ai/typescript/src/__tests__/no-content-flattening.test.ts
@@ -1,0 +1,66 @@
+/**
+ * PNI-216: the 0.0.39 content-flattening compat middleware must not be
+ * applied on CrewAI's path. CrewAIAgent inherits maxVersion from
+ * @ag-ui/client, which sits above every backward-compat threshold, so
+ * structured message content has to reach the wire intact instead of
+ * being flattened to a text-only string.
+ */
+import { describe, it, expect } from "vitest";
+import type { InputContent, RunAgentInput } from "@ag-ui/core";
+import { CrewAIAgent } from "../index";
+
+const multimodalContent: InputContent[] = [
+  { type: "text", text: "what is in this image?" },
+  {
+    type: "image",
+    source: { type: "data", value: "ZmFrZS1wbmc=", mimeType: "image/png" },
+  },
+];
+
+function sseBody(threadId: string, runId: string) {
+  return [
+    { type: "RUN_STARTED", threadId, runId },
+    { type: "RUN_FINISHED", threadId, runId },
+  ]
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("");
+}
+
+function createRecordingAgent() {
+  const requests: RunAgentInput[] = [];
+  const agent = new CrewAIAgent({
+    url: "http://crewai.invalid/agui",
+    initialMessages: [{ id: "u1", role: "user", content: multimodalContent }],
+    fetch: async (_url, requestInit) => {
+      if (typeof requestInit.body !== "string") {
+        throw new Error("expected a JSON string request body");
+      }
+      const input = JSON.parse(requestInit.body) as RunAgentInput;
+      requests.push(input);
+      return new Response(sseBody(input.threadId, input.runId), {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+  });
+  return { agent, requests };
+}
+
+describe("CrewAIAgent content flattening", () => {
+  it("sends structured message content to the server un-flattened", async () => {
+    const { agent, requests } = createRecordingAgent();
+    await agent.runAgent();
+
+    expect(requests).toHaveLength(1);
+    const [message] = requests[0]!.messages;
+    if (message?.role !== "user") {
+      throw new Error("expected the user message to reach the server");
+    }
+    expect(message.content).toEqual(multimodalContent);
+  });
+
+  it("does not pin maxVersion (no renamed equivalent either)", () => {
+    expect(
+      Object.getOwnPropertyDescriptor(CrewAIAgent.prototype, "maxVersion"),
+    ).toBeUndefined();
+  });
+});

--- a/integrations/crew-ai/typescript/src/index.ts
+++ b/integrations/crew-ai/typescript/src/index.ts
@@ -1,12 +1,3 @@
 import { HttpAgent } from "@ag-ui/client";
 
-export class CrewAIAgent extends HttpAgent {
-  // CPK-7721: raised from "0.0.39" to above 0.0.47 so NONE of the three
-  // backward-compat middlewares (BackwardCompatibility_0_0_39 / _0_0_45 /
-  // _0_0_47) auto-insert. The 0.0.39 shim in particular stripped
-  // ``parentRunId`` and FLATTENED array message content to text, destroying
-  // multimodal input client-side. "0.0.57" matches the in-repo @ag-ui/core.
-  public override get maxVersion(): string {
-    return "0.0.57";
-  }
-}
+export class CrewAIAgent extends HttpAgent {}


### PR DESCRIPTION
Removes the `maxVersion` ceiling from `CrewAIAgent` and adds the test PNI-216 asks for.

Linear: [PNI-216](https://linear.app/copilotkit/issue/PNI-216/validate-crewai-on-10-and-remove-its-version-ceiling)

## Why this is safe

`AbstractAgent`'s constructor is the only consumer of `maxVersion` — it auto-inserts a backward-compat middleware when `maxVersion` is at or below that middleware's threshold (`agent.ts:115-129`):

| Threshold | What the shim does |
|---|---|
| ≤ 0.0.39 | Flattens structured message content to a plain string, strips `parentRunId` |
| ≤ 0.0.45 | Maps legacy `THINKING_*` events to `REASONING_*` |
| ≤ 0.0.47 | Converts legacy `BinaryInputContent` |

CrewAI's pin was `0.0.57`, already above all three, so **no middleware was being inserted**. Unpinned, `maxVersion` falls back to the `@ag-ui/client` package version (`0.0.58`), which clears the same thresholds. This is a no-op on the wire, not a behavior change — the pin was inert code documenting a problem that no longer exists.

That inertness was deliberate: `15981eb3` (CPK-7721) raised the value from `0.0.39` specifically to escape the flattening shim. This PR finishes that job by deleting the ceiling instead of holding a number above the thresholds.

## The flattening proof

PNI-216 requires a test proving the 0.0.39 content-flattening translation is not applied on CrewAI's path. `src/__tests__/no-content-flattening.test.ts` drives a real `runAgent()` through the full middleware chain against an injected `fetch`, then asserts the `text` + `image` content parts arrive in the request body intact.

I confirmed it is a real test rather than a vacuous one by temporarily re-pinning `0.0.39` — both cases fail under the pin and pass without it. A second case asserts no `maxVersion` descriptor exists on the prototype, so a renamed equivalent cannot quietly come back.

## Verification

`typecheck`, `test`, and `test:exports` all pass for `@ag-ui/crewai`; the package builds and its exports are intact.

**Not done here, and needed before the ticket closes:** the before/after Dojo run against the real CrewAI backend. I can't reach a live backend or its credentials from this environment, so the ticket's acceptance criteria around the recorded before-run, the after-run against a real (non-mock) backend, and the prepared release record still need a human with Dojo access. Worth noting the risk is low given the pin was already inert — but "already inert by code reading" is not the evidence the ticket asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)