### PR TITLE
fix(agno): remove the AgnoAgent protocol version ceiling

### DIFF
--- a/integrations/agno/typescript/src/__tests__/no-content-flattening.test.ts
+++ b/integrations/agno/typescript/src/__tests__/no-content-flattening.test.ts
@@ -1,0 +1,67 @@
+/**
+ * PNI-220: AgnoAgent must not have a protocol version ceiling, and the
+ * backward-compat middlewares must stay off its path. AgnoAgent inherits
+ * maxVersion from @ag-ui/client, which sits above every compat threshold,
+ * so structured message content has to reach the wire intact instead of
+ * being flattened to a text-only string — the agentic_chat_multimodal
+ * Dojo lane depends on it.
+ */
+import { describe, it, expect } from "vitest";
+import type { InputContent, RunAgentInput } from "@ag-ui/core";
+import { AgnoAgent } from "../index";
+
+const multimodalContent: InputContent[] = [
+  { type: "text", text: "what is in this image?" },
+  {
+    type: "image",
+    source: { type: "data", value: "ZmFrZS1wbmc=", mimeType: "image/png" },
+  },
+];
+
+function sseBody(threadId: string, runId: string) {
+  return [
+    { type: "RUN_STARTED", threadId, runId },
+    { type: "RUN_FINISHED", threadId, runId },
+  ]
+    .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("");
+}
+
+function createRecordingAgent() {
+  const requests: RunAgentInput[] = [];
+  const agent = new AgnoAgent({
+    url: "http://agno.invalid/agentic_chat_multimodal/agui",
+    initialMessages: [{ id: "u1", role: "user", content: multimodalContent }],
+    fetch: async (_url, requestInit) => {
+      if (typeof requestInit.body !== "string") {
+        throw new Error("expected a JSON string request body");
+      }
+      const input = JSON.parse(requestInit.body) as RunAgentInput;
+      requests.push(input);
+      return new Response(sseBody(input.threadId, input.runId), {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+  });
+  return { agent, requests };
+}
+
+describe("AgnoAgent content flattening", () => {
+  it("sends structured message content to the server un-flattened", async () => {
+    const { agent, requests } = createRecordingAgent();
+    await agent.runAgent();
+
+    expect(requests).toHaveLength(1);
+    const [message] = requests[0]!.messages;
+    if (message?.role !== "user") {
+      throw new Error("expected the user message to reach the server");
+    }
+    expect(message.content).toEqual(multimodalContent);
+  });
+
+  it("does not pin maxVersion (no renamed equivalent either)", () => {
+    expect(
+      Object.getOwnPropertyDescriptor(AgnoAgent.prototype, "maxVersion"),
+    ).toBeUndefined();
+  });
+});

--- a/integrations/agno/typescript/src/index.ts
+++ b/integrations/agno/typescript/src/index.ts
@@ -5,8 +5,4 @@
 
 import { HttpAgent } from "@ag-ui/client";
 
-export class AgnoAgent extends HttpAgent {
-  public override get maxVersion(): string {
-    return "0.0.53";
-  }
-}
+export class AgnoAgent extends HttpAgent {}


### PR DESCRIPTION
Removes the `maxVersion` ceiling from `AgnoAgent`, with a regression test holding the compat shims off its path.

Linear: [PNI-220](https://linear.app/copilotkit/issue/PNI-220/validate-agno-on-10-and-remove-its-version-ceiling)

## Why this is safe

`AbstractAgent`'s constructor is the only consumer of `maxVersion` — it auto-inserts a backward-compat middleware when `maxVersion` is at or below that middleware's threshold (`agent.ts:115-129`):

| Threshold | What the shim does |
|---|---|
| ≤ 0.0.39 | Flattens structured message content to a plain string, strips `parentRunId` |
| ≤ 0.0.45 | Maps legacy `THINKING_*` events to `REASONING_*` |
| ≤ 0.0.47 | Converts legacy `BinaryInputContent` |

Agno's pin was `0.0.53`, already above all three, so **no middleware was being inserted**. Unpinned, `maxVersion` falls back to the `@ag-ui/client` package version (`0.0.58`), which clears the same thresholds. This is a no-op on the wire, not a behavior change.

That inertness was deliberate: `e7d7b425` raised the value from `0.0.39` to `0.0.53` precisely so the flattening shim would stop destroying multimodal input. This PR finishes that job by deleting the ceiling rather than holding a number above the thresholds.

## Supporting evidence from the paired backend

Unlike the other pinned integrations, Agno's evidence is already in-repo:

- `integrations/agno/python/examples/` requires `ag-ui-protocol>=0.1.19` and `agno[agui]>=2.6.19` — versions that handle structured content parts.
- It ships an `agentic_chat_multimodal` endpoint (Gemini 2.5 Flash, explicitly built to analyze images/audio/video/documents).
- The Dojo already wires that lane up (`apps/dojo/src/agents.ts:397-411`).

That lane only works when content reaches the server un-flattened, so the un-pinned path is what the backend is already built against.

## The regression test

`src/__tests__/no-content-flattening.test.ts` drives a real `runAgent()` through the full middleware chain against an injected `fetch`, then asserts the `text` + `image` content parts arrive in the request body intact. I confirmed it is a real test rather than a vacuous one by temporarily re-pinning `0.0.39` — both cases fail under the pin and pass without it. A second case asserts no `maxVersion` descriptor exists on the prototype, so a renamed equivalent cannot quietly replace the deleted one.

## Verification

`typecheck`, `test`, and `test:exports` all pass for `@ag-ui/agno`; the package builds and its exports are intact.

**Not done here, and needed before the ticket closes:** the before/after Dojo run against the real Agno backend. I can't reach a live backend or its credentials from this environment, so the ticket's acceptance criteria around the recorded before-run, the after-run against a real (non-mock) backend, and the prepared release record still need a human with Dojo access — noting also that PNI-220 flags Agno as one of the two pinned integrations with no shared partner channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)