### PR TITLE
test(aws-strands): make the TypeScript tests check what they claim

### DIFF
--- a/integrations/aws-strands/typescript/src/__tests__/helpers.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/helpers.ts
@@ -3,11 +3,22 @@
  * the TS Strands SDK's streaming shape.
  */
 
-import type { Agent, AgentStreamEvent } from "@strands-agents/sdk";
-import type {
-  BaseEvent,
-  Interrupt as AguiInterrupt,
-  RunAgentInput,
+import {
+  Agent as StrandsAgentCore,
+  Model,
+  tool,
+  type Agent,
+  type AgentStreamEvent,
+  type Message as StrandsMessage,
+  type ModelStreamEvent,
+} from "@strands-agents/sdk";
+import { z } from "zod";
+import { expect } from "vitest";
+import {
+  EventType,
+  type BaseEvent,
+  type Interrupt as AguiInterrupt,
+  type RunAgentInput,
 } from "@ag-ui/core";
 
 import { StrandsAgent } from "../agent";
@@ -16,15 +27,17 @@ import type { StrandsAgentConfig } from "../config";
 export function minimalRunInput(
   overrides: Partial<RunAgentInput> = {},
 ): RunAgentInput {
+  // The spread comes FIRST so the defaults below actually win. It cannot be
+  // dropped: RunAgentInput carries keys this list does not enumerate (resume,
+  // parentRunId), and every resume-carrying test reaches the gate through it.
   return {
+    ...overrides,
     threadId: overrides.threadId ?? "thread-1",
     runId: overrides.runId ?? "run-1",
     state: overrides.state ?? {},
     messages: overrides.messages ?? [],
     tools: overrides.tools ?? [],
     context: overrides.context ?? [],
-    forwardedProps: overrides.forwardedProps,
-    ...overrides,
   };
 }
 
@@ -243,3 +256,396 @@ export const stream = {
       message,
     }) as unknown as AgentStreamEvent,
 };
+
+// ---------------------------------------------------------------------------
+// Real-SDK drivers
+// ---------------------------------------------------------------------------
+//
+// `scriptedAgent` above hands the adapter a hand-rolled literal, so the real
+// Strands agent loop never runs and anything the adapter relies on the SDK to
+// do (construction, tool registration, seeding, the interrupt machinery) is
+// assumed rather than exercised. The drivers below instead subclass the real
+// `Model` and let the real `Agent` run, mirroring the Python suite's
+// `_ScriptedModel`: only the network boundary is scripted.
+
+/**
+ * Ends the turn without emitting a content block, so an under-scripted run
+ * terminates without fabricating text or tool content. The SDK still records
+ * an empty assistant message for the turn, so a test that cares how many turns
+ * ran should assert on `ScriptedModel.calls`.
+ */
+const END_TURN_ONLY = [
+  { type: "modelMessageStartEvent", role: "assistant" },
+  { type: "modelMessageStopEvent", stopReason: "endTurn" },
+] as ModelStreamEvent[];
+
+/**
+ * A real `Model` whose `stream()` replays scripted, provider-shaped chunks.
+ * Because it subclasses the SDK's `Model`, the inherited `streamAggregated()`
+ * does the genuine block/message aggregation the agent loop consumes.
+ *
+ * One instance backs every per-thread agent the adapter clones, so `calls` is
+ * a single cursor over `turns` shared across threads rather than a per-thread
+ * count. A multi-thread test therefore scripts one turn per expected model
+ * call, in the order the threads will reach the model.
+ */
+export class ScriptedModel extends Model {
+  /** Number of turns the agent has driven, used to index the script. */
+  public calls = 0;
+
+  private readonly config: Record<string, unknown> = {
+    modelId: "scripted-model",
+  };
+
+  constructor(
+    private readonly turns: ModelStreamEvent[][] = [],
+    /** 1-based invocation that should fail, modelling a provider error. */
+    private readonly throwOnCall?: number,
+  ) {
+    super();
+  }
+
+  getConfig() {
+    return { ...this.config };
+  }
+
+  // Required by the abstract base. The adapter never calls it, so there is
+  // nothing here for a test to observe.
+  updateConfig(modelConfig: Record<string, unknown>) {
+    Object.assign(this.config, modelConfig);
+  }
+
+  async *stream(_messages: StrandsMessage[]): AsyncIterable<ModelStreamEvent> {
+    if (this.throwOnCall !== undefined && this.calls + 1 === this.throwOnCall) {
+      this.calls += 1;
+      throw new Error("scripted provider failure");
+    }
+    // Past the end of the script, end the turn with no content block so a run
+    // whose tool results come back terminates instead of replaying the last
+    // turn. See END_TURN_ONLY: this is silent by design, so assert on `calls`
+    // when the number of turns is part of what a test is pinning.
+    const turn = this.turns[this.calls] ?? END_TURN_ONLY;
+    this.calls += 1;
+    for (const event of turn) yield event;
+  }
+}
+
+/**
+ * Provider-shaped chunk sequences for one model turn. `stopReason` values must
+ * use the SDK's camelCase spellings: the agent loop exits on
+ * `stopReason !== "toolUse"`, so a snake_case `"tool_use"` silently ends the
+ * turn and the tool never runs.
+ */
+export const modelTurn = {
+  text: (text: string): ModelStreamEvent[] =>
+    [
+      { type: "modelMessageStartEvent", role: "assistant" },
+      { type: "modelContentBlockStartEvent" },
+      {
+        type: "modelContentBlockDeltaEvent",
+        delta: { type: "textDelta", text },
+      },
+      { type: "modelContentBlockStopEvent" },
+      { type: "modelMessageStopEvent", stopReason: "endTurn" },
+    ] as ModelStreamEvent[],
+
+  /** One assistant turn calling `calls` in parallel, ending with `toolUse`. */
+  toolUse: (
+    ...calls: { toolUseId: string; name: string; input?: unknown }[]
+  ): ModelStreamEvent[] =>
+    [
+      { type: "modelMessageStartEvent", role: "assistant" },
+      ...calls.flatMap((c) => [
+        {
+          type: "modelContentBlockStartEvent",
+          start: { type: "toolUseStart", toolUseId: c.toolUseId, name: c.name },
+        },
+        {
+          type: "modelContentBlockDeltaEvent",
+          delta: {
+            type: "toolUseInputDelta",
+            input: JSON.stringify(c.input ?? {}),
+          },
+        },
+        { type: "modelContentBlockStopEvent" },
+      ]),
+      { type: "modelMessageStopEvent", stopReason: "toolUse" },
+    ] as ModelStreamEvent[],
+
+  /** Assistant text followed, in the same turn, by tool calls. */
+  textThenToolUse: (
+    text: string,
+    ...calls: { toolUseId: string; name: string; input?: unknown }[]
+  ): ModelStreamEvent[] =>
+    [
+      { type: "modelMessageStartEvent", role: "assistant" },
+      { type: "modelContentBlockStartEvent" },
+      {
+        type: "modelContentBlockDeltaEvent",
+        delta: { type: "textDelta", text },
+      },
+      { type: "modelContentBlockStopEvent" },
+      ...calls.flatMap((c) => [
+        {
+          type: "modelContentBlockStartEvent",
+          start: { type: "toolUseStart", toolUseId: c.toolUseId, name: c.name },
+        },
+        {
+          type: "modelContentBlockDeltaEvent",
+          delta: {
+            type: "toolUseInputDelta",
+            input: JSON.stringify(c.input ?? {}),
+          },
+        },
+        { type: "modelContentBlockStopEvent" },
+      ]),
+      { type: "modelMessageStopEvent", stopReason: "toolUse" },
+    ] as ModelStreamEvent[],
+};
+
+/** A real SDK tool that records every execution, so denial is observable. */
+export function recordingTool(name: string, description = "d") {
+  const calls: unknown[] = [];
+  const instance = tool({
+    name,
+    description,
+    inputSchema: z.object({}).passthrough(),
+    callback: async (input: unknown) => {
+      calls.push(input);
+      // A JSON-serializable result: a bare string makes the adapter log a
+      // parse failure for what is a successful call.
+      return { ran: name };
+    },
+  });
+  return { tool: instance, calls };
+}
+
+/**
+ * Build a `StrandsAgent` over a real `Agent` driven by a `ScriptedModel`.
+ * Deliberately does NOT pre-seed `_agentsByThread`: the per-thread agent is
+ * constructed, tool-synced and seeded by the adapter itself, so those paths
+ * are under test rather than skipped.
+ */
+export function realStrandsAgent(
+  turns: ModelStreamEvent[][] = [],
+  options: {
+    config?: StrandsAgentConfig;
+    name?: string;
+    tools?: unknown[];
+    systemPrompt?: string;
+    /** 1-based model invocation that should fail. */
+    throwOnCall?: number;
+  } = {},
+): { agent: StrandsAgent; model: ScriptedModel; template: StrandsAgentCore } {
+  const model = new ScriptedModel(turns, options.throwOnCall);
+  const template = new StrandsAgentCore({
+    model,
+    tools: (options.tools ?? []) as never,
+    ...(options.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
+  });
+  const agent = new StrandsAgent({
+    agent: template,
+    name: options.name ?? "test",
+    config: options.config,
+  });
+  return { agent, model, template };
+}
+
+/** The real per-thread `Agent` the adapter built for `threadId`, if any. */
+export function threadAgent(
+  agent: StrandsAgent,
+  threadId = "thread-1",
+): StrandsAgentCore | undefined {
+  return (
+    agent as unknown as { _agentsByThread: Map<string, StrandsAgentCore> }
+  )._agentsByThread.get(threadId);
+}
+
+const WRAPPED = Symbol("captureStreamArgs.wrapped");
+
+/**
+ * Record the arguments the adapter passes to the real per-thread agent's
+ * `stream()`, delegating to the real implementation so behaviour is unchanged.
+ * Lets a test assert the Strands-facing wire shape without replacing the agent.
+ * Returns the full argument list of each call plus a `restore()` that unwraps.
+ */
+export function captureStreamArgs(
+  agent: StrandsAgent,
+  threadId = "thread-1",
+): { calls: unknown[][]; restore: () => void } {
+  const core = threadAgent(agent, threadId);
+  if (!core) throw new Error(`no per-thread agent for "${threadId}"`);
+  const target = core as unknown as Record<string | symbol, unknown>;
+  // Stacking wrappers would double-count every later call.
+  if (target[WRAPPED]) {
+    throw new Error(`stream() is already captured for thread "${threadId}"`);
+  }
+  const calls: unknown[][] = [];
+  const original = core.stream.bind(core) as (...a: unknown[]) => unknown;
+  const wrapper = (...args: unknown[]) => {
+    calls.push(args);
+    return original(...args);
+  };
+  target[WRAPPED] = true;
+  target.stream = wrapper;
+  return {
+    calls,
+    restore: () => {
+      // Delete rather than reassign: leaving a bound own property would keep
+      // shadowing the prototype method the agent would otherwise use.
+      delete target.stream;
+      delete target[WRAPPED];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event assertions
+// ---------------------------------------------------------------------------
+//
+// Shared so that a run which failed, or never produced the event under
+// inspection, cannot satisfy an assertion about what it produced. Each helper
+// fails loudly on an absent subject rather than holding vacuously, which is
+// the failure mode these tests exist to remove. Prefer these over reaching
+// into an event array directly.
+
+/** An assistant message as it appears in a MESSAGES_SNAPSHOT. */
+export type SnapshotMessage = {
+  id: string;
+  role: string;
+  content?: string;
+  toolCalls?: { id: string }[];
+};
+
+export type FinishedEvent = BaseEvent & {
+  outcome?: {
+    type?: string;
+    interrupts?: {
+      id: string;
+      reason?: string;
+      message?: string;
+      toolCallId?: string;
+      responseSchema?: unknown;
+      metadata?: {
+        strandsName?: string;
+        tool_name?: string;
+        tool_input?: unknown;
+        reason?: unknown;
+      };
+    }[];
+  };
+};
+
+export type ToolStartEvent = BaseEvent & {
+  toolCallId: string;
+  toolCallName: string;
+  parentMessageId?: string;
+};
+
+/** RUN_ERROR codes in emission order, empty when the run raised none. */
+export function errorCodes(events: BaseEvent[]): string[] {
+  return events
+    .filter((e) => e.type === EventType.RUN_ERROR)
+    .map((e) => {
+      const err = e as BaseEvent & { code?: string; message?: string };
+      // A code-less RUN_ERROR would otherwise render as null and read like no
+      // error at all in a failure message.
+      return err.code ?? `<no code: ${err.message ?? "unknown"}>`;
+    });
+}
+
+/** Assert the run raised no error, reporting the codes when it did. */
+export function expectNoRunError(events: BaseEvent[], label = "run"): void {
+  const codes = errorCodes(events);
+  expect(codes, `${label} emitted RUN_ERROR ${JSON.stringify(codes)}`).toEqual(
+    [],
+  );
+}
+
+/**
+ * Assert the run ran to completion: no error, and not suspended. An interrupt
+ * also emits RUN_FINISHED, so the outcome check is what separates a completed
+ * run from one parked waiting on a resume.
+ */
+export function expectCompletedRun(events: BaseEvent[], label = "run"): void {
+  expectNoRunError(events, label);
+  expect(
+    events.map((e) => e.type),
+    `${label} produced no RUN_FINISHED`,
+  ).toContain(EventType.RUN_FINISHED);
+  expect(
+    finishedOf(events).outcome?.type,
+    `${label} suspended on an interrupt instead of completing`,
+  ).not.toBe("interrupt");
+}
+
+/**
+ * The run's RUN_FINISHED, failing readably when there is none. Asserts there
+ * is exactly one: these helpers describe a single `collect()` of one run, and
+ * silently taking the first would describe the wrong run in a stream carrying
+ * several.
+ */
+export function finishedOf(events: BaseEvent[]): FinishedEvent {
+  const finished = events.filter(
+    (e) => e.type === EventType.RUN_FINISHED,
+  ) as FinishedEvent[];
+  expect(
+    finished,
+    `expected exactly one RUN_FINISHED, got ${finished.length}`,
+  ).toHaveLength(1);
+  return finished[0];
+}
+
+/** The interrupts the run reported, failing when it reported none. */
+export function interruptsOf(
+  events: BaseEvent[],
+  expected = 1,
+): NonNullable<NonNullable<FinishedEvent["outcome"]>["interrupts"]> {
+  const finished = finishedOf(events);
+  expect(finished.outcome?.type, "run did not finish with an interrupt").toBe(
+    "interrupt",
+  );
+  const interrupts = finished.outcome?.interrupts ?? [];
+  expect(
+    interrupts,
+    `expected ${expected} open interrupt(s), got ${JSON.stringify(
+      interrupts.map((i) => i.id),
+    )}`,
+  ).toHaveLength(expected);
+  return interrupts;
+}
+
+/** The id of the run's single interrupt. */
+export function soleInterruptId(events: BaseEvent[]): string {
+  return interruptsOf(events)[0].id;
+}
+
+/** TOOL_CALL_START events, asserting how many the run should have produced. */
+export function toolStartsOf(
+  events: BaseEvent[],
+  expected?: number,
+): ToolStartEvent[] {
+  const starts = events.filter(
+    (e) => e.type === EventType.TOOL_CALL_START,
+  ) as ToolStartEvent[];
+  if (expected !== undefined) {
+    expect(
+      starts,
+      `expected ${expected} TOOL_CALL_START event(s), got ${starts.length}`,
+    ).toHaveLength(expected);
+  } else {
+    expect(starts.length, "no TOOL_CALL_START emitted").toBeGreaterThan(0);
+  }
+  return starts;
+}
+
+/** Every MESSAGES_SNAPSHOT the run emitted, asserting at least one. */
+export function snapshotsOf(
+  events: BaseEvent[],
+): { messages: SnapshotMessage[] }[] {
+  const snapshots = events.filter(
+    (e) => e.type === EventType.MESSAGES_SNAPSHOT,
+  ) as unknown as { messages: SnapshotMessage[] }[];
+  expect(snapshots.length, "no MESSAGES_SNAPSHOT emitted").toBeGreaterThan(0);
+  return snapshots;
+}

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-atomicity.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-atomicity.test.ts
@@ -1,0 +1,426 @@
+/**
+ * A rejected resume must be atomic and must leave the checkpoint retryable.
+ *
+ * Atomic: the gate rejects before anything is mutated, so the model is never
+ * invoked and the run's client tools are never registered on the per-thread
+ * agent. Retryable: the interrupts stay open, so a later complete and valid
+ * batch still resumes the run rather than the rejection burning the checkpoint.
+ *
+ * Driven through the real Strands SDK: the interrupts are raised by the real
+ * interrupt machinery, so what is under test is the adapter's real gate over
+ * real checkpoint state.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventType } from "@ag-ui/core";
+import {
+  collect,
+  errorCodes,
+  finishedOf,
+  interruptsOf,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+  recordingTool,
+  threadAgent,
+} from "./helpers";
+
+const TOOL_A = "confirm_a";
+const TOOL_B = "confirm_b";
+/** Registering this would prove the gate mutated state before rejecting. */
+const MUST_NOT_REGISTER = [
+  { name: "must_not_register", description: "d", parameters: {} },
+] as never;
+
+/** An agent parked on two open approval interrupts from one assistant turn. */
+async function parkedOnTwoInterrupts() {
+  const a = recordingTool(TOOL_A);
+  const b = recordingTool(TOOL_B);
+  const { agent, model } = realStrandsAgent(
+    [
+      modelTurn.toolUse(
+        { toolUseId: "tu-a", name: TOOL_A, input: {} },
+        { toolUseId: "tu-b", name: TOOL_B, input: {} },
+      ),
+      modelTurn.text("done"),
+    ],
+    {
+      tools: [a.tool, b.tool],
+      config: {
+        toolBehaviors: {
+          [TOOL_A]: { interruptOnCall: true },
+          [TOOL_B]: { interruptOnCall: true },
+        },
+      },
+    },
+  );
+  const first = await collect(
+    agent,
+    minimalRunInput({
+      messages: [{ id: "u1", role: "user", content: "go" } as never],
+    }),
+  );
+  const interrupts = interruptsOf(first, 2);
+  // Resolve ids by tool name: position is not part of the contract, and a
+  // silent reordering would otherwise swap which tool each answer applies to.
+  const idFor = (toolName: string) => {
+    const match = interrupts.find((i) => i.metadata?.tool_name === toolName);
+    expect(match, `no open interrupt for ${toolName}`).toBeDefined();
+    return match!.id;
+  };
+  return { agent, model, idFor, aCalls: a.calls, bCalls: b.calls };
+}
+
+/** Names of tools registered on the real per-thread agent. */
+function registeredToolNames(
+  agent: ReturnType<typeof realStrandsAgent>["agent"],
+) {
+  const registry = threadAgent(agent)!.toolRegistry as unknown as {
+    list: () => { name: string }[];
+  };
+  return registry.list().map((t) => t.name);
+}
+
+function resumeRun(
+  entries: unknown[],
+  runId: string,
+  options: { carryCanaryTool?: boolean } = {},
+) {
+  const carryCanaryTool = options.carryCanaryTool ?? true;
+  return minimalRunInput({
+    runId,
+    messages: [{ id: "u1", role: "user", content: "go" } as never],
+    // Only a run the gate is expected to reject carries the canary tool. An
+    // accepted run legitimately registers it, which would contradict the
+    // constant's own name. This flag selects the tool list; the rejection
+    // itself is asserted by each caller.
+    tools: carryCanaryTool ? MUST_NOT_REGISTER : ([] as never),
+    resume: entries as never,
+  });
+}
+
+describe("a rejected resume is atomic", () => {
+  it("rejects an unknown interrupt id without invoking the model", async () => {
+    const { agent, model, idFor } = await parkedOnTwoInterrupts();
+    const callsBefore = model.calls;
+
+    const events = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+          {
+            interruptId: "no-such-id",
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+
+    expect(errorCodes(events)).toEqual(["UNKNOWN_INTERRUPT_ID"]);
+    expect(model.calls, "model was invoked by a rejected resume").toBe(
+      callsBefore,
+    );
+    expect(registeredToolNames(agent)).not.toContain("must_not_register");
+  });
+
+  it("does not register the rejected run's tools", async () => {
+    const { agent, idFor } = await parkedOnTwoInterrupts();
+
+    const events = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+
+    // Pin why the run was rejected: without this the assertion below would
+    // also pass for a run that failed for some unrelated reason.
+    expect(errorCodes(events)).toEqual(["PARTIAL_RESUME"]);
+    const registered = registeredToolNames(agent);
+    // The positive half matters: not.toContain also holds against a registry
+    // that was emptied, which would not be the gate behaving correctly.
+    expect(registered).toEqual(expect.arrayContaining([TOOL_A, TOOL_B]));
+    expect(registered).not.toContain("must_not_register");
+  });
+
+  it("rejects a partial batch without invoking the model", async () => {
+    const { agent, model, idFor } = await parkedOnTwoInterrupts();
+    const callsBefore = model.calls;
+
+    const events = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+
+    expect(errorCodes(events)).toEqual(["PARTIAL_RESUME"]);
+    expect(model.calls).toBe(callsBefore);
+  });
+
+  it("rejects an invalid payload without running the approved tool", async () => {
+    const { agent, model, idFor, aCalls, bCalls } =
+      await parkedOnTwoInterrupts();
+    const callsBefore = model.calls;
+
+    const events = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: "yes" },
+          },
+          {
+            interruptId: idFor(TOOL_B),
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+
+    expect(errorCodes(events)).toEqual(["INVALID_PAYLOAD"]);
+    expect(model.calls).toBe(callsBefore);
+    expect(registeredToolNames(agent)).not.toContain("must_not_register");
+    // The valid sibling entry must not take effect just because it was valid.
+    expect(aCalls).toEqual([]);
+    expect(bCalls).toEqual([]);
+  });
+
+  it("blocks a new turn that ignores the open interrupts", async () => {
+    const { agent, model } = await parkedOnTwoInterrupts();
+    const callsBefore = model.calls;
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [
+          { id: "u2", role: "user", content: "something else" } as never,
+        ],
+        tools: MUST_NOT_REGISTER,
+      }),
+    );
+
+    expect(errorCodes(events)).toEqual(["PENDING_INTERRUPTS"]);
+    expect(model.calls).toBe(callsBefore);
+    const registered = registeredToolNames(agent);
+    expect(registered).toEqual(expect.arrayContaining([TOOL_A, TOOL_B]));
+    expect(registered).not.toContain("must_not_register");
+  });
+});
+
+describe("a failed resume leaves no replayable fingerprint", () => {
+  it("does not store the resume fingerprint for a run that failed", async () => {
+    // Narrow on purpose. This pins the fingerprint invariant only: a resume
+    // that passes validation and then fails inside the run must not leave a
+    // fingerprint behind, because a stored one makes the next identical
+    // request look like a replay and answer it with a bare success.
+    //
+    // FINDING, pinned rather than fixed: the retry is not replayed, but it
+    // cannot make progress either. The failed resume already applied the
+    // answers and ran both tools, so the interrupts are gone and the retry is
+    // rejected with UNKNOWN_INTERRUPT_ID. A client whose resumed run dies
+    // mid-flight therefore has no way to retry that batch, and the work the
+    // tools did is not reflected in any completed run. Asserted as observed so
+    // that making this path genuinely retryable shows up here as a failure.
+    const a = recordingTool(TOOL_A);
+    const b = recordingTool(TOOL_B);
+    const { agent } = realStrandsAgent(
+      [
+        modelTurn.toolUse(
+          { toolUseId: "tu-a", name: TOOL_A, input: {} },
+          { toolUseId: "tu-b", name: TOOL_B, input: {} },
+        ),
+        modelTurn.text("done"),
+      ],
+      {
+        tools: [a.tool, b.tool],
+        throwOnCall: 2,
+        config: {
+          toolBehaviors: {
+            [TOOL_A]: { interruptOnCall: true },
+            [TOOL_B]: { interruptOnCall: true },
+          },
+        },
+      },
+    );
+    const first = await collect(
+      agent,
+      minimalRunInput({
+        messages: [{ id: "u1", role: "user", content: "go" } as never],
+      }),
+    );
+    const batch = interruptsOf(first, 2).map((i) => ({
+      interruptId: i.id,
+      status: "resolved",
+      payload: { approved: true },
+    }));
+
+    const failed = await collect(agent, resumeRun(batch, "run-2"));
+    expect(errorCodes(failed), "the resumed run did not fail").toEqual([
+      "STRANDS_ERROR",
+    ]);
+    // The answers were applied before the failure, which is why the batch
+    // cannot be replayed afterwards.
+    expect(a.calls).toHaveLength(1);
+    expect(b.calls).toHaveLength(1);
+
+    const retried = await collect(agent, resumeRun(batch, "run-3"));
+    // The invariant under test: not answered with a synthetic success.
+    const replayedAsSuccess =
+      errorCodes(retried).length === 0 &&
+      retried.some(
+        (e) =>
+          e.type === EventType.RUN_FINISHED &&
+          (e as { outcome?: { type?: string } }).outcome?.type === "success",
+      );
+    expect(
+      replayedAsSuccess,
+      "an identical retry after a failed run was replayed as a bare success",
+    ).toBe(false);
+    // The observed outcome, pinned as the finding above.
+    expect(errorCodes(retried)).toEqual(["UNKNOWN_INTERRUPT_ID"]);
+  });
+});
+
+describe("a rejected resume stays retryable", () => {
+  it("still accepts a corrected batch after an invalid payload", async () => {
+    const { agent, idFor, aCalls, bCalls } = await parkedOnTwoInterrupts();
+
+    const rejected = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: "yes" },
+          },
+          {
+            interruptId: idFor(TOOL_B),
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+    const accepted = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+          {
+            interruptId: idFor(TOOL_B),
+            status: "resolved",
+            payload: { approved: false },
+          },
+        ],
+        "run-3",
+        { carryCanaryTool: false },
+      ),
+    );
+
+    expect(errorCodes(rejected)).toEqual(["INVALID_PAYLOAD"]);
+    expect(errorCodes(accepted)).toEqual([]);
+    expect(
+      aCalls,
+      "approved tool did not run on the corrected retry",
+    ).toHaveLength(1);
+    expect(bCalls, "denied tool ran anyway").toEqual([]);
+  });
+
+  it("accepts a complete valid batch after a rejection", async () => {
+    const { agent, idFor, aCalls, bCalls } = await parkedOnTwoInterrupts();
+
+    const rejected = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+          {
+            interruptId: "no-such-id",
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-2",
+      ),
+    );
+    const partial = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ],
+        "run-3",
+      ),
+    );
+    const accepted = await collect(
+      agent,
+      resumeRun(
+        [
+          {
+            interruptId: idFor(TOOL_A),
+            status: "resolved",
+            payload: { approved: true },
+          },
+          {
+            interruptId: idFor(TOOL_B),
+            status: "resolved",
+            payload: { approved: false },
+          },
+        ],
+        "run-4",
+        { carryCanaryTool: false },
+      ),
+    );
+
+    expect(errorCodes(rejected)).toEqual(["UNKNOWN_INTERRUPT_ID"]);
+    expect(errorCodes(partial)).toEqual(["PARTIAL_RESUME"]);
+    expect(errorCodes(accepted)).toEqual([]);
+    // The retry is what finally decides each tool, per its own answer.
+    expect(
+      aCalls,
+      "approved tool did not run on the accepted retry",
+    ).toHaveLength(1);
+    expect(bCalls, "denied tool ran anyway").toEqual([]);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-generic.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-generic.test.ts
@@ -2,172 +2,196 @@
  * Generic (non-tool-approval) native interrupts must stay generic.
  *
  * Interrupts NOT raised by the adapter's own interruptOnCall hook (which
- * always uses the "ag_ui:tool_call:" name prefix) — e.g. a user's own tool
- * or hook calling `event.interrupt()` directly for a generic
- * human-in-the-loop request — must be preserved as generic AG-UI
- * interrupts, not misclassified as tool-call approvals with fabricated
- * schema/metadata.
+ * always uses the "ag_ui:tool_call:" name prefix), e.g. a user's own tool
+ * calling `context.interrupt()` directly for a generic human-in-the-loop
+ * request, must be preserved as generic AG-UI interrupts, not misclassified
+ * as tool-call approvals with fabricated schema/metadata.
+ *
+ * The interrupts here are raised by a real tool running inside the real
+ * Strands agent loop, so the classification is exercised against interrupts
+ * the SDK actually produced.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { EventType, type BaseEvent } from "@ag-ui/core";
+import { tool, type ToolContext } from "@strands-agents/sdk";
+import { z } from "zod";
+
 import {
-  AgentResult as StrandsAgentResult,
-  Message as StrandsMessage,
-  TextBlock,
-  type Interrupt as StrandsInterrupt,
-} from "@strands-agents/sdk";
+  collect,
+  expectNoRunError,
+  finishedOf,
+  interruptsOf,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+} from "./helpers";
+import type { StrandsAgentConfig } from "../config";
 
-import { StrandsAgent } from "../agent";
-import { collect } from "./helpers";
+const QUESTION = { question: "Which environment?" };
 
-function makeAgentResultStream(result: StrandsAgentResult) {
-  return async function* () {
-    return result;
-  };
-}
+/** Bodies that ran only after a resume delivered a response, by tool name. */
+const resumedBodies: string[] = [];
+/** Resume responses the SDK handed back to the interrupted tool. */
+const resumedResponses: unknown[] = [];
 
-function buildAgentResult(interrupts: StrandsInterrupt[]): StrandsAgentResult {
-  return new StrandsAgentResult({
-    stopReason: "interrupt",
-    lastMessage: StrandsMessage.fromMessageData({
-      role: "assistant",
-      content: [new TextBlock("awaiting input").toJSON()],
-    }),
-    invocationState: {},
-    interrupts,
+beforeEach(() => {
+  resumedBodies.length = 0;
+  resumedResponses.length = 0;
+});
+
+/** A user's own tool raising a generic HITL interrupt, not an approval. */
+function clarifyingTool(name: string) {
+  return tool({
+    name,
+    description: "Asks the operator which environment to use",
+    inputSchema: z.object({}).passthrough(),
+    callback: async (_input: unknown, context?: ToolContext) => {
+      // `interrupt()` itself is synchronous and throws to suspend the run, so
+      // nothing below it runs until a resume supplies a response.
+      resumedResponses.push(
+        context!.interrupt({ name: "need_clarification", reason: QUESTION }),
+      );
+      resumedBodies.push(name);
+      return { clarified: true };
+    },
   });
 }
 
-function genericStrandsInterrupt(
-  id: string,
-  name: string,
-  reason: unknown,
-): StrandsInterrupt {
-  return { id, name, reason } as unknown as StrandsInterrupt;
+/** A tool that raises no interrupt of its own. */
+function plainTool(name: string) {
+  return tool({
+    name,
+    description: "Does the thing",
+    inputSchema: z.object({}).passthrough(),
+    callback: async () => ({ done: true }),
+  });
 }
+
+async function runWith(
+  toolName: string,
+  config?: StrandsAgentConfig,
+  toolFactory: (name: string) => ReturnType<typeof tool> = clarifyingTool,
+) {
+  const { agent } = realStrandsAgent(
+    [
+      modelTurn.toolUse({ toolUseId: "tu-1", name: toolName, input: {} }),
+      modelTurn.text("done"),
+    ],
+    { tools: [toolFactory(toolName)], config },
+  );
+  const events = await collect(
+    agent,
+    minimalRunInput({
+      messages: [{ id: "u1", role: "user", content: "deploy" } as never],
+    }),
+  );
+  expectNoRunError(events);
+  return { events, agent };
+}
+
+type Finished = BaseEvent & {
+  outcome?: {
+    type: string;
+    interrupts?: {
+      id: string;
+      reason: string;
+      responseSchema?: unknown;
+      toolCallId?: string;
+      metadata?: { reason?: unknown; strandsName?: string };
+    }[];
+  };
+};
+
+const firstInterrupt = (events: BaseEvent[]) =>
+  interruptsOf(events)[0] as NonNullable<
+    NonNullable<Finished["outcome"]>["interrupts"]
+  >[number];
 
 describe("Generic native interrupts (not raised by the adapter's own hook)", () => {
   it("preserves the native name as reason instead of fabricating tool_call", async () => {
-    const interrupts = [
-      genericStrandsInterrupt("int-1", "need_clarification", {
-        question: "Which environment?",
-      }),
-    ];
-    const stubAgent = {
-      model: { name: "stub-model", modelId: "stub-model" },
-      tools: [],
-      toolRegistry: { list: () => [] },
-      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
-    };
-    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
-
-    const events = await collect(sa);
-    const finished = events.at(-1) as BaseEvent & {
-      outcome?: { type: string; interrupts?: unknown[] };
-    };
-    expect(finished.type).toBe(EventType.RUN_FINISHED);
-    const first = finished.outcome?.interrupts?.[0] as {
-      id: string;
-      reason: string;
-    };
-    expect(first.id).toBe("int-1");
-    expect(first.reason).toBe("need_clarification");
+    const interrupt = firstInterrupt((await runWith("ask_operator")).events);
+    expect(interrupt.id).toBeTruthy();
+    expect(interrupt.reason).toBe("need_clarification");
   });
 
   it("does not fabricate a tool-approval responseSchema or toolCallId", async () => {
-    const interrupts = [
-      genericStrandsInterrupt("int-2", "need_clarification", {
-        question: "Which environment?",
-      }),
-    ];
-    const stubAgent = {
-      model: { name: "stub-model", modelId: "stub-model" },
-      tools: [],
-      toolRegistry: { list: () => [] },
-      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
-    };
-    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
-
-    const events = await collect(sa);
-    const finished = events.at(-1) as BaseEvent & {
-      outcome?: { type: string; interrupts?: unknown[] };
-    };
-    const first = finished.outcome?.interrupts?.[0] as {
-      responseSchema?: unknown;
-      toolCallId?: string;
-    };
-    expect(first.responseSchema).toBeUndefined();
-    expect(first.toolCallId).toBeUndefined();
+    const interrupt = firstInterrupt((await runWith("ask_operator")).events);
+    // An absence check cannot fail if the field is renamed, so responseSchema
+    // is paired with the tool-approval test below, which asserts it IS
+    // populated there. toolCallId has no such pair in this file.
+    expect(interrupt.reason).toBe("need_clarification");
+    expect(interrupt.responseSchema).toBeUndefined();
+    expect(interrupt.toolCallId).toBeUndefined();
   });
 
   it("preserves the native reason payload in metadata", async () => {
-    const interrupts = [
-      genericStrandsInterrupt("int-3", "need_clarification", {
-        question: "Which environment?",
-      }),
-    ];
-    const stubAgent = {
-      model: { name: "stub-model", modelId: "stub-model" },
-      tools: [],
-      toolRegistry: { list: () => [] },
-      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
-    };
-    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
+    const interrupt = firstInterrupt((await runWith("ask_operator")).events);
+    expect(interrupt.metadata?.reason).toEqual(QUESTION);
+  });
 
-    const events = await collect(sa);
-    const finished = events.at(-1) as BaseEvent & {
-      outcome?: { type: string; interrupts?: unknown[] };
-    };
-    const first = finished.outcome?.interrupts?.[0] as {
-      metadata?: { reason?: unknown };
-    };
-    expect(first.metadata?.reason).toEqual({ question: "Which environment?" });
+  it("records the generic interrupt as pending so it can be resumed", async () => {
+    const { agent, events } = await runWith("ask_operator");
+    const interrupt = firstInterrupt(events);
+    const pending = (
+      agent as unknown as {
+        _pendingInterruptsByThread: Map<string, Map<string, unknown>>;
+      }
+    )._pendingInterruptsByThread.get("thread-1");
+    expect(
+      pending,
+      "generic interrupt was reported but not recorded",
+    ).toBeDefined();
+    expect(pending!.has(interrupt.id)).toBe(true);
+  });
+
+  it("resumes a generic interrupt and runs the rest of the tool", async () => {
+    const { events, agent } = await runWith("ask_operator");
+    const interrupt = firstInterrupt(events);
+
+    const resumed = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "deploy" } as never],
+        resume: [
+          {
+            interruptId: interrupt.id,
+            status: "resolved",
+            payload: { environment: "staging" },
+          },
+        ] as never,
+      }),
+    );
+
+    // A generic interrupt has no responseSchema, so this also covers the
+    // resume path where the payload gate has nothing to validate against.
+    expectNoRunError(resumed, "generic resume");
+    // A resume that was ignored would re-raise the interrupt and still finish
+    // without error, so the interrupt-free finish is the load-bearing half.
+    expect(
+      finishedOf(resumed).outcome?.type,
+      "the resume was ignored and the interrupt was raised again",
+    ).not.toBe("interrupt");
+    // And the tool body past the interrupt actually ran, with the payload the
+    // client sent. Without this the round trip passes on a dropped payload.
+    expect(resumedBodies).toEqual(["ask_operator"]);
+    expect(resumedResponses).toEqual([{ environment: "staging" }]);
   });
 
   it("still classifies an ag_ui:tool_call:-named interrupt as a tool-call approval", async () => {
-    // Sanity check: the ag_ui:tool_call: naming convention still produces
-    // the tool-approval shape, unaffected by the generic path above.
-    const interrupts = [
-      {
-        id: "int-4",
-        name: "ag_ui:tool_call:confirm_delete",
-        reason: {
-          tool_call: true,
-          tool_name: "confirm_delete",
-          tool_input: {},
-          tool_use_id: "int-4",
-        },
-      } as unknown as StrandsInterrupt,
-    ];
-    const stubAgent = {
-      model: { name: "stub-model", modelId: "stub-model" },
-      tools: [],
-      toolRegistry: { list: () => [] },
-      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
-    };
-    const sa = new StrandsAgent({ agent: stubAgent as never, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
-
-    const events = await collect(sa);
-    const finished = events.at(-1) as BaseEvent & {
-      outcome?: { type: string; interrupts?: unknown[] };
-    };
-    const first = finished.outcome?.interrupts?.[0] as {
-      reason: string;
-      responseSchema?: unknown;
-    };
-    expect(first.reason).toBe("tool_call");
-    expect(first.responseSchema).toBeDefined();
+    // Sanity check: the adapter's own naming convention still produces the
+    // tool-approval shape, unaffected by the generic path above. Uses a plain
+    // tool so the approval hook is the only interrupt source in the run.
+    const { events } = await runWith(
+      "confirm_delete",
+      { toolBehaviors: { confirm_delete: { interruptOnCall: true } } },
+      plainTool,
+    );
+    const interrupt = firstInterrupt(events);
+    expect(interrupt.reason).toBe("tool_call");
+    expect(interrupt.responseSchema).toBeDefined();
+    expect(interrupt.metadata?.strandsName).toBe(
+      "ag_ui:tool_call:confirm_delete",
+    );
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -5,13 +5,13 @@
  * on the thread so the follow-up `resume[]` request is recognised as known
  * (rather than falling into the UNKNOWN_INTERRUPT_ID gate).
  */
+
 import { describe, it, expect, vi } from "vitest";
 import {
   EventType,
   type BaseEvent,
-  type RunAgentInput,
-  type ResumeEntry,
   type Interrupt as AguiInterrupt,
+  type ResumeEntry,
 } from "@ag-ui/core";
 import {
   AgentResult as StrandsAgentResult,
@@ -24,13 +24,28 @@ import {
 
 import { StrandsAgent } from "../agent";
 import {
+  captureStreamArgs,
   collect,
+  expectNoRunError,
+  finishedOf,
   minimalRunInput,
+  modelTurn,
   parkInterrupts,
+  realStrandsAgent,
+  recordingTool,
   scriptedAgent,
+  soleInterruptId,
   stream,
+  threadAgent,
 } from "./helpers";
 
+const TOOL = "confirm_delete";
+
+/**
+ * Wrap a pre-built `AgentResult` as an agent stream. Retained for the tests
+ * that pin adapter handling of a specific result shape, where constructing the
+ * shape directly is the point.
+ */
 function makeAgentResultStream(
   result: StrandsAgentResult,
   events: unknown[] = [],
@@ -39,18 +54,6 @@ function makeAgentResultStream(
     for (const e of events) yield e;
     return result;
   };
-}
-
-function strandsInterrupt(id: string, toolName: string): StrandsInterrupt {
-  // Mirrors the shape the adapter's own interruptOnCall hook produces:
-  // name prefixed with "ag_ui:tool_call:" and a structured reason object.
-  // The concrete class is internal; the adapter only reads .id / .name /
-  // .reason, so a plain object that matches the interface is sufficient.
-  return {
-    id,
-    name: `ag_ui:tool_call:${toolName}`,
-    reason: { tool_call: true, tool_name: toolName, tool_input: {}, tool_use_id: id },
-  } as unknown as StrandsInterrupt;
 }
 
 function buildAgentResult(interrupts: StrandsInterrupt[]): StrandsAgentResult {
@@ -65,63 +68,184 @@ function buildAgentResult(interrupts: StrandsInterrupt[]): StrandsAgentResult {
   });
 }
 
+function approvalAgent(options: { sessionManager?: unknown } = {}) {
+  const { tool, calls } = recordingTool(TOOL);
+  const built = realStrandsAgent(
+    [
+      modelTurn.toolUse({
+        toolUseId: "tu-1",
+        name: TOOL,
+        input: { target: "db" },
+      }),
+      modelTurn.text("done"),
+    ],
+    {
+      tools: [tool],
+      config: {
+        toolBehaviors: { [TOOL]: { interruptOnCall: true } },
+        ...(options.sessionManager
+          ? { sessionManagerProvider: () => options.sessionManager as never }
+          : {}),
+      },
+    },
+  );
+  return { ...built, calls };
+}
+
+const userTurn = () =>
+  minimalRunInput({
+    messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+  });
+
+function pendingFor(agent: StrandsAgent, threadId = "thread-1") {
+  return (
+    agent as unknown as {
+      _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
+    }
+  )._pendingInterruptsByThread.get(threadId);
+}
+
+
 describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
   it("emits RUN_FINISHED with outcome.interrupt when Strands stops for interrupt", async () => {
-    const interrupts = [strandsInterrupt("int-1", "confirm_delete")];
-    const stubAgent = scriptedAgent([], {
-      stream: makeAgentResultStream(buildAgentResult(interrupts)) as never,
-    });
-    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
+    const { agent } = approvalAgent();
+    const events = await collect(agent, userTurn());
 
-    const events = await collect(sa);
-    const finished = events.at(-1) as BaseEvent & {
-      outcome?: { type: string; interrupts?: unknown[] };
-    };
-    expect(finished.type).toBe(EventType.RUN_FINISHED);
+    const finished = finishedOf(events);
     expect(finished.outcome?.type).toBe("interrupt");
     expect(finished.outcome?.interrupts).toHaveLength(1);
-    const first = finished.outcome?.interrupts?.[0] as {
-      id: string;
-      reason: string;
-      message?: string;
-      metadata?: { strandsName?: string };
-    };
-    expect(first.id).toBe("int-1");
-    expect(first.reason).toBe("tool_call");
-    expect(first.message).toBe("Approve call to confirm_delete?");
-    expect(first.metadata?.strandsName).toBe("ag_ui:tool_call:confirm_delete");
 
-    // The interrupt is now pending on the thread.
-    const pending = (
-      sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread.get("thread-1");
-    expect(pending?.has("int-1")).toBe(true);
+    const first = finished.outcome!.interrupts![0];
+    expect(first.reason).toBe("tool_call");
+    expect(first.message).toBe(`Approve call to ${TOOL}?`);
+    expect(first.metadata?.strandsName).toBe(`ag_ui:tool_call:${TOOL}`);
+
+    // The adapter recorded the interrupt as pending under the id it reported.
+    expect(pendingFor(agent)?.has(first.id)).toBe(true);
   });
 
   it("checkpoints an interrupt before returning it to a resumable client", async () => {
-    const saveSnapshot = vi.fn().mockResolvedValue(undefined);
-    const stubAgent = scriptedAgent([], {
-      stream: makeAgentResultStream(
-        buildAgentResult([strandsInterrupt("int-1", "confirm_delete")]),
-      ) as never,
-      sessionManager: { saveSnapshot } as never,
-    });
-    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
+    const saveSnapshot = vi.fn();
+    const sessionManager = { initAgent: vi.fn(), saveSnapshot };
+    const { agent } = approvalAgent({ sessionManager });
 
-    await collect(sa);
-
-    expect(saveSnapshot).toHaveBeenCalledWith({
-      target: stubAgent,
-      isLatest: true,
+    // Record when the checkpoint lands relative to the events the client sees.
+    const seenAtSave: string[] = [];
+    const events: BaseEvent[] = [];
+    saveSnapshot.mockImplementation(async () => {
+      seenAtSave.push(...events.map((e) => e.type));
     });
+    for await (const e of agent.run(userTurn())) events.push(e);
+
+    expect(saveSnapshot).toHaveBeenCalledTimes(1);
+    // Identity, not deep equality: a structurally similar agent is not the
+    // agent whose interrupt state has to survive the restart.
+    expect(saveSnapshot.mock.calls[0][0].target).toBe(threadAgent(agent));
+    expect(saveSnapshot.mock.calls[0][0].isLatest).toBe(true);
+    // "before returning it": the run was already under way when the checkpoint
+    // fired, and no RUN_FINISHED had been yielded yet. The positive half
+    // matters: not.toContain alone holds on an empty array.
+    expect(seenAtSave).toContain(EventType.RUN_STARTED);
+    expect(seenAtSave).not.toContain(EventType.RUN_FINISHED);
+    expect(events.map((e) => e.type)).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("accepts a matching resume[] and forwards InterruptResponseContent to Strands", async () => {
+    const { agent, calls } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const id = soleInterruptId(first);
+
+    // Not restored: each test builds its own agent, so the wrapper cannot
+    // outlive the assertions it was installed for.
+    const { calls: streamArgs } = captureStreamArgs(agent);
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+        resume: [
+          { interruptId: id, status: "resolved", payload: { approved: true } },
+        ] as never,
+      }),
+    );
+
+    expect(events.map((e) => e.type)).toContain(EventType.RUN_FINISHED);
+    expect(events.map((e) => e.type)).not.toContain(EventType.RUN_ERROR);
+
+    // Strands received InterruptResponseContent[] as its invoke args.
+    expect(streamArgs).toHaveLength(1);
+    const [forwarded] = streamArgs[0][0] as InterruptResponseContent[];
+    expect(forwarded).toBeInstanceOf(InterruptResponseContent);
+    expect(forwarded.interruptResponse.interruptId).toBe(id);
+    expect(forwarded.interruptResponse.response).toEqual({ approved: true });
+
+    // The approval actually took effect, and the pending set was cleared.
+    expect(calls).toHaveLength(1);
+    expect(pendingFor(agent)).toBeUndefined();
+  });
+
+  it("still emits UNKNOWN_INTERRUPT_ID when resume[] references an unknown id", async () => {
+    const { agent } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const known = soleInterruptId(first);
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+        resume: [
+          { interruptId: "unknown-id", status: "resolved" },
+          {
+            interruptId: known,
+            status: "resolved",
+            payload: { approved: true },
+          },
+        ] as never,
+      }),
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.RUN_ERROR,
+    ]);
+    const err = events[1] as unknown as { code: string; message: string };
+    expect(err.code).toBe("UNKNOWN_INTERRUPT_ID");
+    expect(err.message).toContain("unknown-id");
+  });
+
+  it("forwards a cancelled resume as native InterruptResponseContent through Strands", async () => {
+    const { agent, calls } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const id = soleInterruptId(first);
+
+    const { calls: streamArgs } = captureStreamArgs(agent);
+    const second = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+        resume: [{ interruptId: id, status: "cancelled" }] as never,
+      }),
+    );
+    expectNoRunError(second, "cancelled resume");
+
+    // All-cancelled resumes must still be forwarded to Strands as native
+    // InterruptResponseContent, not short-circuited with a synthetic
+    // RUN_FINISHED that bypasses stream()/native cleanup/hooks/session
+    // persistence.
+    expect(streamArgs).toHaveLength(1);
+    const [forwarded] = streamArgs[0][0] as InterruptResponseContent[];
+    expect(forwarded).toBeInstanceOf(InterruptResponseContent);
+    expect(forwarded.interruptResponse.interruptId).toBe(id);
+    expect(forwarded.interruptResponse.response).toEqual({
+      status: "cancelled",
+    });
+    expect(calls, "cancelled resume executed the tool").toEqual([]);
+    expect(
+      pendingFor(agent),
+      "cancelled resume left the interrupt pending",
+    ).toBeUndefined();
   });
 
   it("logs a debug trace when a paused result carries no interrupts", async () => {
@@ -159,126 +283,6 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
           message.includes("reporting no pending interrupts"),
       ),
     ).toBe(true);
-  });
-
-  it("accepts a matching resume[] and forwards InterruptResponseContent to Strands", async () => {
-    let capturedArgs: unknown = null;
-    const stubAgent = scriptedAgent([], {
-      stream: ((args: unknown) => {
-        capturedArgs = args;
-        // After resume, Strands completes normally.
-        return (async function* () {
-          return new StrandsAgentResult({
-            stopReason: "endTurn",
-            lastMessage: StrandsMessage.fromMessageData({
-              role: "assistant",
-              content: [new TextBlock("done").toJSON()],
-            }),
-            invocationState: {},
-          });
-        })();
-      }) as never,
-    });
-    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
-    // Park the interrupt on the SDK's checkpoint, with the adapter's metadata
-    // record beside it, so the gate accepts the resume.
-    parkInterrupts(sa, "thread-1", [{ id: "int-7", reason: "tool_call" }]);
-    const input: RunAgentInput = minimalRunInput({
-      resume: [
-        {
-          interruptId: "int-7",
-          status: "resolved",
-          payload: { approved: true },
-        },
-      ],
-    });
-    const events = await collect(sa, input);
-
-    expect(events.map((e) => e.type)).toContain(EventType.RUN_FINISHED);
-    expect(events.map((e) => e.type)).not.toContain(EventType.RUN_ERROR);
-
-    // Strands received InterruptResponseContent[] as its invoke args.
-    expect(Array.isArray(capturedArgs)).toBe(true);
-    const [first] = capturedArgs as InterruptResponseContent[];
-    expect(first).toBeInstanceOf(InterruptResponseContent);
-    expect(first.interruptResponse.interruptId).toBe("int-7");
-    expect(first.interruptResponse.response).toEqual({ approved: true });
-
-    // The pending set was cleared once resume was accepted.
-    const cleared = (
-      sa as unknown as {
-        _pendingInterruptsByThread: Map<string, Map<string, AguiInterrupt>>;
-      }
-    )._pendingInterruptsByThread.get("thread-1");
-    expect(cleared).toBeUndefined();
-  });
-
-  it("still emits UNKNOWN_INTERRUPT when resume[] references an unknown id", async () => {
-    const stubAgent = scriptedAgent([]);
-    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    // One open interrupt, but the resume references a different id.
-    parkInterrupts(sa, "thread-1", [{ id: "known", reason: "tool_call" }]);
-
-    const events = await collect(
-      sa,
-      minimalRunInput({
-        resume: [
-          { interruptId: "unknown-id", status: "resolved" },
-          { interruptId: "known", status: "resolved", payload: { approved: true } },
-        ],
-      }),
-    );
-    expect(events.map((e) => e.type)).toEqual([
-      EventType.RUN_STARTED,
-      EventType.RUN_ERROR,
-    ]);
-    const err = events[1] as unknown as { code: string; message: string };
-    expect(err.code).toBe("UNKNOWN_INTERRUPT_ID");
-    expect(err.message).toContain("unknown-id");
-  });
-
-  it("forwards a cancelled resume as native InterruptResponseContent through Strands", async () => {
-    let capturedArgs: unknown = null;
-    const stubAgent = scriptedAgent([], {
-      stream: ((args: unknown) => {
-        capturedArgs = args;
-        return (async function* () {
-          return new StrandsAgentResult({
-            stopReason: "endTurn",
-            lastMessage: StrandsMessage.fromMessageData({
-              role: "assistant",
-              content: [new TextBlock("ok").toJSON()],
-            }),
-            invocationState: {},
-          });
-        })();
-      }) as never,
-    });
-    const sa = new StrandsAgent({ agent: stubAgent, name: "t" });
-    (
-      sa as unknown as { _agentsByThread: Map<string, unknown> }
-    )._agentsByThread.set("thread-1", stubAgent);
-    parkInterrupts(sa, "thread-1", [{ id: "ic", reason: "tool_call" }]);
-
-    await collect(
-      sa,
-      minimalRunInput({
-        resume: [{ interruptId: "ic", status: "cancelled" }],
-      }),
-    );
-
-    // All-cancelled resumes must still be forwarded to Strands as native
-    // InterruptResponseContent — not short-circuited with a synthetic
-    // RUN_FINISHED that bypasses stream()/native cleanup/hooks/session
-    // persistence.
-    expect(capturedArgs).not.toBeNull();
-    expect(Array.isArray(capturedArgs)).toBe(true);
-    const [first] = capturedArgs as InterruptResponseContent[];
-    expect(first.interruptResponse.interruptId).toBe("ic");
-    expect(first.interruptResponse.response).toEqual({ status: "cancelled" });
   });
 });
 

--- a/integrations/aws-strands/typescript/src/__tests__/seed-concurrency.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/seed-concurrency.test.ts
@@ -2,33 +2,65 @@
  * Seed building for one thread with slow multimodal URL fetches must not
  * serialize cold-cache inits for OTHER threads behind the global
  * _threadInitLock.
+ *
+ * The property is an ordering one, so it is asserted as ordering: thread A is
+ * held open inside its seed fetch by a latch, and thread B must run to
+ * completion before that latch is released.
+ *
+ * The release timer is the discriminator, so this is a time bound rather than
+ * a pure ordering check. It sits orders of magnitude above B's observed cost
+ * (single-digit ms) to keep the margin wide, and under vitest's default 5000ms
+ * timeout so a serialised B fails on the assertion below rather than aborting
+ * as a bare timeout. A machine that cannot run B inside it reports the
+ * serialisation message misleadingly.
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { StrandsAgent } from "../agent";
-import { minimalRunInput, scriptedAgent } from "./helpers";
+import { describe, it, expect, afterEach } from "vitest";
+import type { BaseEvent } from "@ag-ui/core";
+import {
+  expectCompletedRun,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+} from "./helpers";
 
-// Each cold-init needs a fresh stub (first run on the thread returns quickly).
-const fastStub = (): import("@strands-agents/sdk").Agent => scriptedAgent();
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 describe("seed build is outside _threadInitLock", () => {
+  const origFetch = globalThis.fetch;
   afterEach(() => {
-    vi.restoreAllMocks();
+    globalThis.fetch = origFetch;
   });
 
   it("concurrent cold-inits on different threads don't serialise on a slow seed", async () => {
-    // Spy on global fetch; make all fetches slow (200ms) so the seed helper's
-    // URL resolution for thread A blocks only A, not B.
-    const origFetch = globalThis.fetch;
+    const firstFetch = deferred();
+    const release = deferred();
+
+    // A's seed fetch parks until the test releases it, so A provably holds
+    // whatever it is going to hold for as long as the test needs.
     globalThis.fetch = (async (): Promise<Response> => {
-      await new Promise((r) => setTimeout(r, 200));
-      // Return an empty PNG body so the content converter drops it harmlessly.
+      firstFetch.resolve();
+      await release.promise;
+      // No Content-Type on the response, so the converter logs "No MIME type
+      // provided" and drops the block harmlessly. The body is incidental.
       return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer, {
         status: 200,
       }) as Response;
     }) as typeof fetch;
 
-    const agent = new StrandsAgent({ agent: fastStub(), name: "s" });
+    // One script cursor is shared across both threads, so the turns are
+    // consumed in whatever order the threads reach the model. Nothing here
+    // depends on which thread got which, so both turns are identical.
+    const { agent, model } = realStrandsAgent([
+      modelTurn.text("ok"),
+      modelTurn.text("ok"),
+    ]);
 
     const inputA = minimalRunInput({
       threadId: "a",
@@ -49,34 +81,73 @@ describe("seed build is outside _threadInitLock", () => {
         { id: "u-a2", role: "user", content: "hi" } as never,
       ],
     });
-    const inputB = minimalRunInput({ threadId: "b" });
+    const inputB = minimalRunInput({
+      threadId: "b",
+      messages: [{ id: "u-b1", role: "user", content: "hi" } as never],
+    });
 
-    const t0 = Date.now();
-    // Launch A first (it will start fetching the slow URL for its seed).
-    const a = agent.run(inputA);
-    const aFirst = a.next();
-    // Give A a tick to start but NOT enough time to finish the fetch.
-    await new Promise((r) => setTimeout(r, 30));
-    // Now B starts. B has no seed to fetch, should complete promptly even
-    // while A is still blocked.
-    const bStart = Date.now();
-    const b = agent.run(inputB);
-    const bFirst = await b.next();
-    const bDur = Date.now() - bStart;
-    expect(bFirst.done).toBe(false); // got an event
-    // B's first event arrived well under A's 200ms seed-fetch delay →
-    // confirms B is not serialised behind A's lock.
-    expect(bDur).toBeLessThan(150);
-    // Now finish A (drain both).
-    await aFirst;
-    for await (const _ of a) {
-      void _;
+    const eventsA: BaseEvent[] = [];
+    const eventsB: BaseEvent[] = [];
+    const order: string[] = [];
+
+    // Drain A in the background. `run()` is a lazy generator: pulling a single
+    // event only parks it on RUN_STARTED, which is emitted before the agent is
+    // built, so A has to be actively consumed to reach the seed fetch at all.
+    let aFinished = false;
+    const drainedA = (async () => {
+      for await (const e of agent.run(inputA)) eventsA.push(e);
+      aFinished = true;
+    })();
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      // A is now inside the seed fetch and cannot proceed until released.
+      // If A fails before fetching, surface that instead of hanging here.
+      await Promise.race([
+        firstFetch.promise,
+        drainedA.then(() => {
+          throw new Error(
+            `thread A finished without fetching its remote image; events: ${eventsA
+              .map((e) => e.type)
+              .join(", ")}`,
+          );
+        }),
+      ]);
+
+      const drainedB = (async () => {
+        for await (const e of agent.run(inputB)) eventsB.push(e);
+        order.push("b-finished");
+      })();
+
+      // Watchdog only: releases A so a serialised B reports the assertion
+      // below rather than hanging. B costs single-digit ms in practice.
+      timer = setTimeout(() => {
+        order.push("a-released");
+        release.resolve();
+      }, 1500);
+      await drainedB;
+
+      // A must still be parked in its fetch: that is what makes B's completion
+      // evidence about the lock rather than about ordering luck.
+      expect(aFinished, "thread A completed before thread B started").toBe(
+        false,
+      );
+      expect(
+        order[0],
+        "thread B did not finish while thread A held its seed fetch. Usually that means B serialised behind _threadInitLock; on a heavily loaded machine it can also mean B simply exceeded the release timer",
+      ).toBe("b-finished");
+    } finally {
+      if (timer) clearTimeout(timer);
+      release.resolve();
+      // A's own failure must not replace an assertion error raised above; the
+      // completed-run check below is what reports it.
+      await drainedA.catch(() => {});
     }
-    for await (const _ of b) {
-      void _;
-    }
-    const total = Date.now() - t0;
-    expect(total).toBeGreaterThan(150); // A still paid its fetch cost
-    globalThis.fetch = origFetch;
+
+    // Both runs must actually have run: the ordering above holds just as well
+    // when the adapter fails internally and the failure is swallowed.
+    expectCompletedRun(eventsA, "thread a");
+    expectCompletedRun(eventsB, "thread b");
+    expect(model.calls).toBe(2);
   });
 });

--- a/integrations/aws-strands/typescript/src/__tests__/tool-approval-gate.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/tool-approval-gate.test.ts
@@ -1,0 +1,298 @@
+/**
+ * `toolBehaviors[name].interruptOnCall` approval semantics, driven through the
+ * real Strands SDK: a real `Agent` built by the adapter, the adapter's own
+ * `BeforeToolCallEvent` hook, and the SDK's real interrupt/resume machinery.
+ *
+ * Approval is granted only by a strict boolean `true`. Truthy strings and
+ * numbers must not coerce into approval, so a `!response.approved` regression
+ * in the gate is caught here rather than shipping.
+ *
+ * Two blocks reach past the public surface: the hook-level one dispatches
+ * through the agent's private hook registry, which is the only way to vary the
+ * resume response a single run can produce, and the client-tool case reads the
+ * adapter's private pending-interrupt map.
+ *
+ * Two independent layers reject a bad resume payload, and each is pinned
+ * separately below:
+ *   1. the run-level `responseSchema` check, which rejects a non-boolean
+ *      `approved` before Strands is resumed at all;
+ *   2. the approval hook itself, which is what actually decides whether the
+ *      tool runs once Strands hands the response back.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import {
+  BeforeToolCallEvent,
+  type Tool as StrandsTool,
+} from "@strands-agents/sdk";
+
+import {
+  collect,
+  errorCodes,
+  finishedOf,
+  interruptsOf,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+  recordingTool,
+  threadAgent,
+} from "./helpers";
+
+const TOOL = "confirm_delete";
+
+function approvalAgent() {
+  const { tool, calls } = recordingTool(TOOL);
+  const { agent, model } = realStrandsAgent(
+    [
+      modelTurn.toolUse({
+        toolUseId: "tu-1",
+        name: TOOL,
+        input: { target: "db" },
+      }),
+      modelTurn.text("done"),
+    ],
+    {
+      tools: [tool],
+      config: { toolBehaviors: { [TOOL]: { interruptOnCall: true } } },
+    },
+  );
+  return { agent, model, tool, calls };
+}
+
+function userTurn() {
+  return minimalRunInput({
+    messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+  });
+}
+
+describe("interruptOnCall halts the tool via the real SDK", () => {
+  it("suspends before the tool runs and reports the interrupt", async () => {
+    const { agent, calls } = approvalAgent();
+    const events = await collect(agent, userTurn());
+
+    expect(errorCodes(events)).toEqual([]);
+    expect(calls, "tool ran despite an unanswered approval interrupt").toEqual(
+      [],
+    );
+    expect(finishedOf(events).outcome?.type).toBe("interrupt");
+  });
+
+  it("names the interrupted tool and echoes its input", async () => {
+    const { agent } = approvalAgent();
+    const events = await collect(agent, userTurn());
+    const interrupt = interruptsOf(events)[0];
+    expect(interrupt.toolCallId).toBe("tu-1");
+    expect(interrupt.metadata?.tool_name).toBe(TOOL);
+    expect(interrupt.metadata?.tool_input).toEqual({ target: "db" });
+  });
+});
+
+describe("resuming an approval interrupt", () => {
+  async function resumeWith(payload: unknown) {
+    const { agent, model, calls } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const id = interruptsOf(first)[0].id;
+    const callsBeforeResume = model.calls;
+    const second = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+        resume: [{ interruptId: id, status: "resolved", payload }] as never,
+      }),
+    );
+    return { second, calls, model, callsBeforeResume };
+  }
+
+  it("runs the tool for approved: true", async () => {
+    const { second, calls } = await resumeWith({ approved: true });
+    expect(errorCodes(second)).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not run the tool for approved: false", async () => {
+    const { second, calls, model, callsBeforeResume } = await resumeWith({
+      approved: false,
+    });
+    expect(errorCodes(second)).toEqual([]);
+    expect(calls, "denied tool executed anyway").toEqual([]);
+    // Without this the test also passes when the resume never reached Strands
+    // at all, which is a different outcome that happens to look the same.
+    expect(model.calls, "Strands was never resumed").toBeGreaterThan(
+      callsBeforeResume,
+    );
+  });
+
+  it("rejects a string approved before Strands is resumed", async () => {
+    const { second, calls, model, callsBeforeResume } = await resumeWith({
+      approved: "true",
+    });
+    expect(errorCodes(second)).toEqual(["INVALID_PAYLOAD"]);
+    expect(calls, "truthy string approved the call").toEqual([]);
+    expect(model.calls, "Strands was resumed despite a rejected payload").toBe(
+      callsBeforeResume,
+    );
+  });
+
+  it("rejects a numeric approved before Strands is resumed", async () => {
+    const { second, calls, model, callsBeforeResume } = await resumeWith({
+      approved: 1,
+    });
+    expect(errorCodes(second)).toEqual(["INVALID_PAYLOAD"]);
+    expect(calls, "truthy number approved the call").toEqual([]);
+    expect(model.calls, "Strands was resumed despite a rejected payload").toBe(
+      callsBeforeResume,
+    );
+  });
+
+  it("rejects a payload missing approved entirely", async () => {
+    const { second, calls, model, callsBeforeResume } = await resumeWith({});
+    expect(errorCodes(second)).toEqual(["INVALID_PAYLOAD"]);
+    expect(calls).toEqual([]);
+    expect(model.calls, "Strands was resumed despite a rejected payload").toBe(
+      callsBeforeResume,
+    );
+  });
+
+  it("does not run the tool when the interrupt is cancelled", async () => {
+    const { agent, model, calls } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const id = interruptsOf(first)[0].id;
+    const callsBeforeResume = model.calls;
+    const second = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        messages: [{ id: "u1", role: "user", content: "delete db" } as never],
+        resume: [{ interruptId: id, status: "cancelled" }] as never,
+      }),
+    );
+    // A cancelled entry carries no payload to validate, so it reaches the hook
+    // without passing the responseSchema check first. The approved: false case
+    // above also reaches the hook; this one additionally shows the hook denies
+    // a response shape the schema gate never inspected.
+    expect(errorCodes(second)).toEqual([]);
+    expect(calls, "cancelled interrupt executed the tool").toEqual([]);
+    expect(model.calls, "Strands was never resumed").toBeGreaterThan(
+      callsBeforeResume,
+    );
+  });
+});
+
+describe("the approval hook grants only a strict boolean true", () => {
+  /**
+   * Dispatch a real `BeforeToolCallEvent` into the hook the adapter registered
+   * on the real per-thread agent. Only the resume response Strands would hand
+   * back is scripted, which is the one thing a single run cannot vary.
+   */
+  async function cancelFor(
+    response: unknown,
+  ): Promise<{ cancel: boolean | string; consulted: boolean }> {
+    const { agent, tool } = approvalAgent();
+    // Drive one run so the adapter constructs and hooks the per-thread agent.
+    await collect(agent, userTurn());
+    const core = threadAgent(agent)!;
+    const registry = (
+      core as unknown as {
+        _hooksRegistry: { invokeCallbacks: (e: unknown) => Promise<unknown> };
+      }
+    )._hooksRegistry;
+
+    const event = new BeforeToolCallEvent({
+      agent: core as unknown as ConstructorParameters<
+        typeof BeforeToolCallEvent
+      >[0]["agent"],
+      toolUse: { name: TOOL, input: { target: "db" }, toolUseId: "tu-1" },
+      tool: tool as unknown as StrandsTool,
+      invocationState: {} as ConstructorParameters<
+        typeof BeforeToolCallEvent
+      >[0]["invocationState"],
+    });
+    let consulted = false;
+    (event as unknown as { interrupt: () => unknown }).interrupt = () => {
+      consulted = true;
+      return response;
+    };
+    await registry.invokeCallbacks(event);
+    return { cancel: event.cancel, consulted };
+  }
+
+  it("grants approval for approved: true", async () => {
+    const { cancel, consulted } = await cancelFor({ approved: true });
+    // `cancel === false` is the event's constructed default, so on its own it
+    // cannot tell "the hook granted" from "the hook never ran".
+    expect(consulted, "the approval hook never ran").toBe(true);
+    expect(cancel).toBe(false);
+  });
+
+  it("grants approval when unrelated extra keys ride along", async () => {
+    const { cancel, consulted } = await cancelFor({
+      approved: true,
+      note: "looks fine",
+    });
+    expect(consulted, "the approval hook never ran").toBe(true);
+    expect(cancel).toBe(false);
+  });
+
+  it.each([
+    ["approved: false", { approved: false }],
+    ["a string 'true'", { approved: "true" }],
+    ["a string 'false'", { approved: "false" }],
+    ["the number 1", { approved: 1 }],
+    ["a missing approved key", {}],
+    ["a bare true", true],
+    ["a bare string", "y"],
+    ["a bare number", 1],
+    ["null", null],
+    ["undefined", undefined],
+  ])("denies %s", async (_label, response) => {
+    const { cancel, consulted } = await cancelFor(response);
+    expect(consulted, "the approval hook never ran").toBe(true);
+    expect(cancel).toBe(`User denied approval for '${TOOL}'.`);
+  });
+});
+
+describe("interruptOnCall for a client-provided tool", () => {
+  it("is ignored, leaving the client to gate execution", async () => {
+    const { agent } = realStrandsAgent(
+      [
+        modelTurn.toolUse({
+          toolUseId: "tu-1",
+          name: "client_tool",
+          input: {},
+        }),
+        modelTurn.text("done"),
+      ],
+      { config: { toolBehaviors: { client_tool: { interruptOnCall: true } } } },
+    );
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        messages: [{ id: "u1", role: "user", content: "go" } as never],
+        tools: [
+          { name: "client_tool", description: "d", parameters: {} },
+        ] as never,
+      }),
+    );
+    // The call is forwarded to the client rather than interrupted server-side.
+    expect(errorCodes(events)).toEqual([]);
+    expect(events.map((e) => e.type)).toContain(EventType.TOOL_CALL_START);
+    const finished = events.find((e) => e.type === EventType.RUN_FINISHED) as
+      | (BaseEvent & { outcome?: { type?: string } })
+      | undefined;
+    expect(finished, "no RUN_FINISHED emitted").toBeDefined();
+    // `outcome` is absent on this finish, so `not.toBe("interrupt")` would hold
+    // trivially. Assert the absence directly, and that the adapter recorded no
+    // interrupt to resume.
+    expect(finished!.outcome).toBeUndefined();
+    expect(
+      (
+        agent as unknown as {
+          _pendingInterruptsByThread: Map<string, unknown>;
+        }
+      )._pendingInterruptsByThread.get("thread-1"),
+      "an interrupt was recorded for a client-provided tool",
+    ).toBeUndefined();
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/tool-call-parent-message-id.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/tool-call-parent-message-id.test.ts
@@ -1,0 +1,338 @@
+/**
+ * How `ToolCallStartEvent.parentMessageId` is derived.
+ *
+ * The parent must identify the assistant message that owns the tool call, so a
+ * client can attach the call to the right bubble. With snapshots enabled that
+ * is the assistant message the final `MESSAGES_SNAPSHOT` carries the call on,
+ * which is deliberately NOT the id of the assistant text that preceded it.
+ *
+ * Driven through the real Strands SDK so the ids come from a genuine agent
+ * turn rather than a hand-rolled event list.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import {
+  collect,
+  expectNoRunError,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+  recordingTool,
+  snapshotsOf,
+  toolStartsOf,
+} from "./helpers";
+import type { StrandsAgentConfig } from "../config";
+
+const TOOL = "frontend_tool";
+const CLIENT_TOOLS = [
+  { name: TOOL, description: "d", parameters: {} },
+] as never;
+const BACKEND_TOOL = "backend_tool";
+const AFTER_TOOL_TEXT = "after the tool";
+
+async function run(
+  turns: Parameters<typeof realStrandsAgent>[0],
+  config?: StrandsAgentConfig,
+) {
+  const { agent } = realStrandsAgent(turns, { config });
+  const events = await collect(
+    agent,
+    minimalRunInput({
+      messages: [{ id: "u1", role: "user", content: "hello" } as never],
+      tools: CLIENT_TOOLS,
+    }),
+  );
+  // Interrogating events from a failed run would let a broken run satisfy
+  // every parent assertion below.
+  expectNoRunError(events);
+  return events;
+}
+
+type TextEvent = BaseEvent & { messageId: string };
+const lastTextEndId = (events: BaseEvent[]) =>
+  (
+    events.filter((e) => e.type === EventType.TEXT_MESSAGE_END) as TextEvent[]
+  ).at(-1)?.messageId;
+
+/** Id of the assistant message the final snapshot hangs `toolCallId` on. */
+function snapshotOwnerId(events: BaseEvent[], toolCallId: string): string {
+  const snapshots = snapshotsOf(events);
+  const owner = snapshots
+    .at(-1)!
+    .messages.find(
+      (m) =>
+        m.role === "assistant" && m.toolCalls?.some((t) => t.id === toolCallId),
+    );
+  expect(
+    owner,
+    `tool call ${toolCallId} missing from the final snapshot`,
+  ).toBeTruthy();
+  return owner!.id;
+}
+
+const TEXT_THEN_TOOL = [
+  modelTurn.textThenToolUse("Let me check:", {
+    toolUseId: "st-1",
+    name: TOOL,
+    input: { ok: true },
+  }),
+];
+
+describe("parentMessageId with MESSAGES_SNAPSHOT enabled", () => {
+  it("points at the snapshot's tool-call assistant message", async () => {
+    const events = await run(TEXT_THEN_TOOL);
+    const starts = toolStartsOf(events, 1);
+    const [start] = starts;
+    expect(start.parentMessageId).toBe(
+      snapshotOwnerId(events, start.toolCallId),
+    );
+  });
+
+  it("does not reuse the preceding assistant text message id", async () => {
+    const events = await run(TEXT_THEN_TOOL);
+    const starts = toolStartsOf(events, 1);
+    const [start] = starts;
+    expect(lastTextEndId(events)).toBeTruthy();
+    expect(start.parentMessageId, "parent regressed to undefined").toBeTruthy();
+    expect(start.parentMessageId).not.toBe(lastTextEndId(events));
+  });
+
+  it("gives a tool call with no preceding text its own parent", async () => {
+    const events = await run([
+      modelTurn.toolUse({ toolUseId: "st-1", name: TOOL, input: {} }),
+    ]);
+    expect(events.map((e) => e.type)).not.toContain(
+      EventType.TEXT_MESSAGE_START,
+    );
+    const starts = toolStartsOf(events, 1);
+    const [start] = starts;
+    expect(start.parentMessageId).toBeTruthy();
+    expect(start.parentMessageId).toBe(
+      snapshotOwnerId(events, start.toolCallId),
+    );
+  });
+});
+
+describe("parentMessageId with a custom argsStreamer", () => {
+  // A custom argsStreamer takes the burst emit path rather than the streaming
+  // one, and that path derives the parent separately. Without this the streaming path alone is covered and a
+  // regression on the other branch ships unnoticed.
+  const STREAMED_ARGS = '{"streamed":true}';
+  async function* argsStreamer() {
+    yield STREAMED_ARGS;
+  }
+
+  /**
+   * Prove the run took the argsStreamer branch. The model's own input is
+   * `{"ok":true}`, so seeing the streamer's payload on the wire is what
+   * distinguishes the two paths; without it these tests pass unchanged when
+   * the behavior is ignored.
+   */
+  function expectStreamerBranch(events: BaseEvent[]) {
+    const args = events
+      .filter((e) => e.type === EventType.TOOL_CALL_ARGS)
+      .map((e) => (e as BaseEvent & { delta: string }).delta)
+      .join("");
+    expect(args, "run did not take the argsStreamer branch").toBe(
+      STREAMED_ARGS,
+    );
+  }
+
+  it("points at the snapshot's tool-call assistant message", async () => {
+    const events = await run(TEXT_THEN_TOOL, {
+      toolBehaviors: { [TOOL]: { argsStreamer } },
+    });
+    expectStreamerBranch(events);
+    const starts = toolStartsOf(events, 1);
+    const [start] = starts;
+    expect(start.parentMessageId).toBe(
+      snapshotOwnerId(events, start.toolCallId),
+    );
+  });
+
+  it("does not reuse the preceding assistant text message id", async () => {
+    const events = await run(TEXT_THEN_TOOL, {
+      toolBehaviors: { [TOOL]: { argsStreamer } },
+    });
+    expectStreamerBranch(events);
+    const starts = toolStartsOf(events, 1);
+    const [start] = starts;
+    expect(lastTextEndId(events)).toBeTruthy();
+    expect(start.parentMessageId, "parent regressed to undefined").toBeTruthy();
+    expect(start.parentMessageId).not.toBe(lastTextEndId(events));
+  });
+});
+
+describe("parentMessageId when a tool skips the snapshot", () => {
+  // FINDING, pinned rather than fixed: the post-tool-call message id rotation
+  // lives INSIDE the snapshot-emitting block, so skipping the snapshot also
+  // skips the rotation. The tool call's parent is therefore the id the NEXT
+  // assistant message will use, and it is wrong in two ways depending on
+  // whether the run continues:
+  //   - the run halts (client tool): no later message claims it, so the parent
+  //     names nothing;
+  //   - the run continues (backend tool): the next assistant message takes the
+  //     same id, so the call attaches to the model's post-tool reply.
+  // The second is the more damaging case: the client sees a confident and
+  // wrong association rather than a missing one. The fix is to rotate outside
+  // the snapshot branch; it belongs with whoever owns the snapshot contract.
+  const SKIPPING = {
+    toolBehaviors: { [TOOL]: { skipMessagesSnapshot: true } },
+  };
+
+  // A halting run is deliberately not pinned. With the snapshot skipped, no
+  // snapshot carries the tool-call message id whether or not the rotation bug
+  // exists, so such a test would pass before and after a fix. The two
+  // continuing runs below are what actually discriminate.
+
+  it("reuses the parent for the next assistant message when the run continues", async () => {
+    const { tool } = recordingTool(BACKEND_TOOL);
+    const { agent } = realStrandsAgent(
+      [
+        modelTurn.textThenToolUse("checking:", {
+          toolUseId: "st-1",
+          name: BACKEND_TOOL,
+          input: {},
+        }),
+        modelTurn.text(AFTER_TOOL_TEXT),
+      ],
+      {
+        tools: [tool],
+        config: {
+          toolBehaviors: { [BACKEND_TOOL]: { skipMessagesSnapshot: true } },
+        },
+      },
+    );
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        messages: [{ id: "u1", role: "user", content: "hello" } as never],
+      }),
+    );
+
+    expectNoRunError(events);
+    const starts = toolStartsOf(events, 1);
+    const parent = starts[0].parentMessageId;
+    expect(parent).toBeTruthy();
+
+    const snapshots = snapshotsOf(events);
+    const owner = snapshots.at(-1)!.messages.find((m) => m.id === parent);
+    expect(owner, "parent resolved to no message").toBeDefined();
+    // The parent points at the model's reply that FOLLOWED the tool call,
+    // rather than at the assistant message that made the call.
+    expect((owner as { content?: string }).content).toBe(AFTER_TOOL_TEXT);
+  });
+
+  it("leaks the parent to the next message with snapshots off globally", async () => {
+    // Same root cause reached through the global flag rather than the per-tool
+    // one, so a fix that only covers one path still shows up here.
+    const { tool } = recordingTool(BACKEND_TOOL);
+    const { agent } = realStrandsAgent(
+      [
+        modelTurn.textThenToolUse("checking:", {
+          toolUseId: "st-1",
+          name: BACKEND_TOOL,
+          input: {},
+        }),
+        modelTurn.text(AFTER_TOOL_TEXT),
+      ],
+      { tools: [tool], config: { emitMessagesSnapshot: false } },
+    );
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        messages: [{ id: "u1", role: "user", content: "hello" } as never],
+      }),
+    );
+    expectNoRunError(events);
+
+    const parent = toolStartsOf(events, 1)[0].parentMessageId;
+    expect(parent).toBeTruthy();
+    const textStartIds = events
+      .filter((e) => e.type === EventType.TEXT_MESSAGE_START)
+      .map((e) => (e as BaseEvent & { messageId: string }).messageId);
+    // The assistant message that follows the tool call takes the same id.
+    expect(textStartIds.at(-1)).toBe(parent);
+  });
+});
+
+describe("parentMessageId for parallel tool calls", () => {
+  const PARALLEL = [
+    modelTurn.textThenToolUse(
+      "Calling two tools:",
+      { toolUseId: "st-a", name: TOOL, input: {} },
+      { toolUseId: "st-b", name: TOOL, input: {} },
+    ),
+  ];
+
+  it("gives each call a parent that owns it in the snapshot", async () => {
+    const events = await run(PARALLEL);
+    const starts = toolStartsOf(events, 2);
+    for (const start of starts) {
+      expect(start.parentMessageId).toBe(
+        snapshotOwnerId(events, start.toolCallId),
+      );
+    }
+  });
+
+  // Recorded, not endorsed: with snapshots on, one model turn's parallel calls
+  // become one assistant message per call, while the snapshot-off path below
+  // gives the same turn a single shared parent. The two paths disagree about
+  // how many assistant messages a turn produces. Pinning it here means a
+  // deliberate change to either path shows up as a failure rather than as a
+  // silent shift in what clients receive.
+  it("puts each call on its own assistant message", async () => {
+    const events = await run(PARALLEL);
+    const starts = toolStartsOf(events, 2);
+    expect(starts[0].parentMessageId).not.toBe(starts[1].parentMessageId);
+  });
+
+  it("shares one parent across the turn when snapshots are off", async () => {
+    const events = await run(PARALLEL, { emitMessagesSnapshot: false });
+    const starts = toolStartsOf(events, 2);
+    expect(starts[0].parentMessageId).toBe(starts[1].parentMessageId);
+    expect(starts[0].parentMessageId).toBeTruthy();
+  });
+});
+
+describe("parentMessageId with MESSAGES_SNAPSHOT disabled", () => {
+  const NO_SNAPSHOT = { emitMessagesSnapshot: false };
+
+  it("still emits a parent and no snapshot", async () => {
+    const events = await run(TEXT_THEN_TOOL, NO_SNAPSHOT);
+    expect(
+      events.filter((e) => e.type === EventType.MESSAGES_SNAPSHOT),
+    ).toEqual([]);
+    expect(toolStartsOf(events, 1)[0].parentMessageId).toBeTruthy();
+  });
+
+  // The Python bridge reuses the preceding text message id as the parent when
+  // snapshots are off, and leaves the parent unset when no assistant text
+  // preceded the call. TypeScript rotates to a fresh id unconditionally. This
+  // is a cross-bridge divergence owned elsewhere, so the TypeScript behaviour
+  // is pinned positively rather than fixed here: these assertions fail if the
+  // bridges converge, and a crash stays a crash instead of reading as
+  // "still diverged" the way an it.fails marker would.
+  it("rotates to a fresh parent instead of reusing the preceding text id", async () => {
+    const events = await run(TEXT_THEN_TOOL, NO_SNAPSHOT);
+    const starts = toolStartsOf(events, 1);
+    expect(lastTextEndId(events), "no TEXT_MESSAGE_END emitted").toBeTruthy();
+    expect(starts[0].parentMessageId).toBeTruthy();
+    // Python asserts equality here.
+    expect(starts[0].parentMessageId).not.toBe(lastTextEndId(events));
+  });
+
+  it("still emits a parent when no assistant text preceded the call", async () => {
+    const events = await run(
+      [modelTurn.toolUse({ toolUseId: "st-1", name: TOOL, input: {} })],
+      NO_SNAPSHOT,
+    );
+    expect(events.map((e) => e.type)).not.toContain(
+      EventType.TEXT_MESSAGE_START,
+    );
+    const starts = toolStartsOf(events, 1);
+    // Python leaves this undefined.
+    expect(starts[0].parentMessageId).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

The AWS Strands TypeScript suite had tests that passed without checking anything. This makes them honest, and closes three coverage gaps that Python tests heavily but TypeScript did not.

There are **no production changes**. `src/agent.ts` and every other source file are byte-identical to `main`: `git diff origin/main HEAD -- ':!*__tests__*'` is empty.

## The green-but-failing test

`seed-concurrency.test.ts` was the only file that built the agent bare without mocking the SDK, so the real Strands `Agent` received a stub model it could not use. Both runs it drove failed inside the adapter with:

```
TypeError: this.model.streamAggregated is not a function
```

The failure was swallowed. The test asserted only that one call had not completed and that two wall-clock thresholds held, so it stayed green.

**It is repaired, not deleted.** The property it tests is real: seed building must happen outside `_threadInitLock`, so a slow multimodal fetch on one thread does not serialise cold-cache init on another.

Repairing it surfaced two further defects in the same test. It timed only thread B's **first** event, and `RUN_STARTED` is emitted before the agent is built; since `run()` is a lazy generator, thread A was parked on `RUN_STARTED` and never reached the lock, so nothing ever contended and the assertion could not fail. Separately, the elapsed bound started before the warm-up and included B's whole run, so it was satisfiable with zero fetches. The test now holds A inside its seed fetch with a latch and asserts ordering.

## Real SDK instead of hand-rolled literals

`scriptedAgent()` handed the adapter an object literal cast to `Agent`, and `scriptedStrandsAgent()` pre-seeded `_agentsByThread`, skipping construction, tool syncing and seeding. Python's stubs subclass the real model type, so the real event loop runs.

`helpers.ts` gains the TypeScript equivalent. `ScriptedModel` subclasses the SDK's `Model`; because `streamAggregated()` is concrete on the base class, the real aggregation and the real agent loop run, and only the network boundary is scripted. `realStrandsAgent()` builds a real `Agent` and deliberately does not pre-seed the thread cache.

Worth knowing for anyone writing new fixtures: `stopReason` must use the SDK's camelCase spellings. The loop exits on `stopReason !== "toolUse"`, so a snake_case `"tool_use"` silently ends the turn and the tool never runs.

Converted to the real SDK with no cache pre-seeding: `interrupt-native.test.ts`, where interrupts are now raised by the real interrupt machinery on an adapter-constructed agent, and `interrupt-generic.test.ts`, where a real tool calls `context.interrupt()` inside the real loop.

## Three uncovered behaviours

**Strict approval** (`tool-approval-gate.test.ts`). Approval is granted only by a boolean `true`; the negative cases are explicit: `"true"`, `"false"`, `1`, `false`, `{}`, bare `true`, `"y"`, `null`, `undefined`.

Two independent layers reject a bad payload and they are pinned separately, because conflating them would hide a regression in either. The run-level `responseSchema` check rejects a non-boolean `approved` before Strands is resumed at all, so the end-to-end truthy cases never reach the gate. A `cancelled` entry carries no payload to validate and so reaches the hook directly.

**Parent message id** (`tool-call-parent-message-id.test.ts`). Covers both derivation branches. The `argsStreamer` branch was found only because mutation testing showed the streaming branch alone was covered.

**Interrupt atomicity and retryability** (`interrupt-atomicity.test.ts`). A rejected resume must not invoke the model or register the run's tools, and a rejected batch must still be accepted once corrected.

A resume that fails *mid-run* is covered separately and deliberately narrowly, as the fingerprint invariant only: such a run must not leave a fingerprint behind, because a stored one makes the next identical request look like a replay and answer it with a bare success. That test does not claim the batch is retryable, because it is not. See the findings below.

## Findings, not fixed

Per the ticket, behavioural differences are reported rather than fixed.

**A tool call's parent can name the wrong message.** The post-tool-call message id rotation lives inside the snapshot-emitting block, so skipping the snapshot skips the rotation and the id leaks. When the run halts, the parent names no message; when it continues, the next assistant message takes the same id and the call attaches to the model's post-tool reply. Reachable through both the per-tool `skipMessagesSnapshot` and the global `emitMessagesSnapshot` flag; both paths are pinned so a fix to one cannot look complete. The fix is to rotate outside the snapshot branch.

**TypeScript and Python derive the parent differently.** Python reuses the preceding text message id and omits the parent when no text preceded the call; TypeScript rotates unconditionally. Pinned as positive assertions rather than `it.fails`, so the markers flip red if the bridges converge and a crash stays a crash.

**Peer version floors admit versions that cannot work.** `@ag-ui/core` accepts `>=0.0.37`, but `InterruptSchema` is value-imported and first shipped in `0.0.54`; `@ag-ui/a2ui-toolkit` accepts `>=0.0.3`, which lacks two other value-imported symbols. A consumer installing at the floor would hit a TypeError on the interrupt path. Production packaging, so out of scope here.

**Cold start fetches each remote multimodal URL twice.** Found while instrumenting the seed test. Not pinned by an assertion: reaching the test's latch already requires a fetch, so any count check there would hold unconditionally, and pinning the observed value would make an unrelated test fail when the duplication is fixed. Recorded here instead.

**A resumed run that fails mid-flight cannot be retried.** The failed resume has already applied the answers and run the tools, so the interrupts are gone and an identical retry is rejected with `UNKNOWN_INTERRUPT_ID`. The client's work is not reflected in any completed run, and there is no way to re-drive that batch. Asserted as observed, so making the path retryable shows up as a failure.

**A Python test fails on clean `main`, unrelated to this change:** `test_template_agent_propagation.py::test_template_param_round_trips[interventions]`. It discovers `Agent.__init__` params by introspection, and `interventions` is a newer SDK param the adapter does not forward.

## Mutation testing

Every added or changed test was mutation-tested: break the implementation, confirm red, restore. **19 mutations, 19 caught**, including six added specifically to prove new assertions have teeth: a hook that never consults the resume response, a checkpoint target compared by value rather than identity, a checkpoint moved after `RUN_FINISHED`, an adapter that ignores `argsStreamer`, and a dropped resume payload.

Mutation testing earned its place twice. It showed the `argsStreamer` parent branch was uncovered, and it showed the seed-concurrency timing assertion could not detect lock contention at all.

## What review changed

Five review rounds ran. They were not finding unrelated bugs; they kept surfacing one root cause, including in the new tests: **an assertion that holds when its subject is absent.** `not.toBe` against an undefined parent, `not.toContain` against an empty array, an unguarded `[0]`, a grant asserted via the SDK's own constructor default, a helper reading events from a run it never checked succeeded.

Fixing those individually was not converging, so `helpers.ts` now exports shared assertions that fail loudly on an absent subject, and every file uses them. The class is now hard to write by accident.

## Verification

- TypeScript: 50 files, 367 tests, stable across repeated runs.
- `tsc --noEmit` clean; the whole monorepo suite green.
- Python untouched and unchanged from its `main` baseline.

