### PR TITLE
test(spring-ai): record the 0.0.39 ceiling baseline and document the un-pin run

### DIFF
--- a/integrations/community/spring-ai/typescript/README.md
+++ b/integrations/community/spring-ai/typescript/README.md
@@ -31,14 +31,71 @@ const result = await agent.runAgent({
 
 ## Features
 
-- **HTTP connectivity** – Connect to LlamaIndex FastAPI servers
-- **Workflow support** – Full integration with LlamaIndex workflow orchestration
+- **HTTP connectivity** – Connect to Spring Boot servers streaming AG-UI over SSE
+- **Spring AI integration** – Drive Spring AI agents, advisors and tool callbacks
 - **RAG capabilities** – Document retrieval and reasoning workflows
-- **Python integration** – Complete FastAPI server implementation included
+- **Java server support** – Pairs with the AG-UI Java server SDK
 
-## To run the example server in the dojo
+## The paired backend
 
-```bash
-cd integrations/llama-index/python/examples
-uv sync && uv run dev
-```
+Unlike most integrations in this repo, the Spring AI backend is **not vendored
+here**. The Spring (WebFlux / Spring Boot starter) adapter and the Spring AI
+integration ship from a separate `ag-ui-spring` repository, so that
+`sdks/community/java/ag-ui/server` can stay dependency-free — see
+[the Java server README](../../../../sdks/community/java/ag-ui/server/README.md).
+
+The Dojo reaches it over HTTP at `SPRING_AI_URL` (default
+`http://localhost:8080`, see `apps/dojo/src/env.ts`) and wires these lanes:
+`agentic_chat`, `shared_state`, `tool_based_generative_ui`,
+`human_in_the_loop`, `agentic_generative_ui`.
+
+## Validating the protocol version ceiling
+
+`SpringAiAgent` pins `maxVersion` to `"0.0.39"`. That value is at or below all
+three backward-compat thresholds in `AbstractAgent`'s constructor, so every
+shim is active on this path:
+
+| Threshold | Effect while the ceiling stands                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------- |
+| ≤ 0.0.39  | Flattens structured message content to text, coerces absent content to `""`, strips `parentRunId` |
+| ≤ 0.0.45  | Rewrites legacy `THINKING_*` response events to `REASONING_*`                                     |
+| ≤ 0.0.47  | Converts legacy `BinaryInputContent` to typed content parts                                       |
+
+`src/__tests__/version-ceiling-baseline.test.ts` records what each of those
+does on this path, without needing a backend. Every assertion in its baseline
+block fails the moment the pin is removed, which is deliberate: the pin cannot
+come out silently.
+
+Removing it needs evidence from the real backend, in this order (PNI-219):
+
+1. **Before.** With the ceiling still in place, run the adapter's unit suite
+   and the Dojo lane against the real Spring AI backend. Record the result.
+
+   ```bash
+   pnpm nx run @ag-ui/spring-ai:test
+   # with the backend up and SPRING_AI_URL pointing at it:
+   cd apps/dojo/e2e && BASE_URL=http://localhost:9999 pnpm test -- tests/springAiTests
+   ```
+
+2. **Check the three risk axes** the shims currently paper over. None of them
+   are exercised by the `agentic_chat` lane — it sends plain-string content,
+   which reads identically with and without the ceiling — so a green chat run
+   is _not_ evidence for removing the pin:
+   - Does the backend accept structured (multimodal) `content` arrays, or does
+     it require a flattened string?
+   - Does it tolerate an assistant message whose `content` is absent rather
+     than `""`?
+   - Does it emit `REASONING_*` natively, or still legacy `THINKING_*`?
+
+3. **Fix only what 1.0 actually broke.** Anything else is a separate ticket.
+
+4. **Remove the ceiling** — delete the `maxVersion` getter outright; do not
+   rename it. Invert the baseline test block in the same commit so it asserts
+   pass-through instead of flattening.
+
+5. **After.** Re-run the identical adapter, backend and Dojo matrix from step 1
+   so the two runs are comparable.
+
+> The `springAiTests` suite is intentionally absent from the `dojo-e2e` CI
+> matrix: that workflow starts each backend from this repo, and Spring AI's
+> cannot be. Run it manually against a backend you host.

--- a/integrations/community/spring-ai/typescript/src/__tests__/version-ceiling-baseline.test.ts
+++ b/integrations/community/spring-ai/typescript/src/__tests__/version-ceiling-baseline.test.ts
@@ -1,0 +1,195 @@
+/**
+ * PNI-219 — recorded baseline for the SpringAiAgent 0.0.39 version ceiling.
+ *
+ * `SpringAiAgent` pins `maxVersion` to "0.0.39", which is at or below all
+ * three backward-compat thresholds in `AbstractAgent`'s constructor, so
+ * every one of the shims is active on this path:
+ *
+ *   ≤ 0.0.39  flattens structured message content, coerces absent content
+ *             to "", strips `parentRunId`
+ *   ≤ 0.0.45  rewrites legacy THINKING_* response events to REASONING_*
+ *   ≤ 0.0.47  converts legacy BinaryInputContent to typed content parts
+ *
+ * Spring AI's paired backend lives outside this repo (see
+ * sdks/community/java/ag-ui/server/README.md — the Spring adapter and Spring
+ * AI integration ship from a separate `ag-ui-spring` repository), so no test
+ * here can prove the backend tolerates the un-shimmed wire format. What these
+ * tests CAN do is record exactly what the ceiling changes, so that removing it
+ * produces a reviewable diff instead of a silent behavior change.
+ *
+ * The assertions below therefore describe behavior that the ceiling CAUSES.
+ * When PNI-219's real-backend run justifies removing the pin, these
+ * assertions must be inverted in the same commit — a green suite after the
+ * pin is deleted would mean the suite had stopped watching anything.
+ * See README.md ("Validating the protocol version ceiling") for the run.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  EventType,
+  type InputContent,
+  type Message,
+  type RunAgentInput,
+} from "@ag-ui/core";
+import type { BaseEvent } from "@ag-ui/core";
+import { SpringAiAgent } from "../index";
+
+/** A response script the fake backend replays, minus the run envelope. */
+type ResponseEvent = Record<string, unknown>;
+
+const multimodalContent: InputContent[] = [
+  { type: "text", text: "what is in " },
+  {
+    type: "image",
+    source: { type: "data", value: "ZmFrZS1wbmc=", mimeType: "image/png" },
+  },
+  { type: "text", text: "this image?" },
+];
+
+/**
+ * Drive one real run through the middleware chain against a fake Spring
+ * backend, capturing both what left the client and what reached the app.
+ */
+async function runSpringAgent(options: {
+  messages: Message[];
+  responseEvents?: ResponseEvent[];
+}) {
+  const requests: RunAgentInput[] = [];
+  const observed: BaseEvent[] = [];
+
+  const agent = new SpringAiAgent({
+    url: "http://spring-ai.invalid/agentic_chat/agui",
+    initialMessages: options.messages,
+    fetch: async (_url, requestInit) => {
+      if (typeof requestInit.body !== "string") {
+        throw new Error("expected a JSON string request body");
+      }
+      const input = JSON.parse(requestInit.body) as RunAgentInput;
+      requests.push(input);
+
+      const body = [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: input.threadId,
+          runId: input.runId,
+        },
+        ...(options.responseEvents ?? []),
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: input.threadId,
+          runId: input.runId,
+        },
+      ]
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join("");
+
+      return new Response(body, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+  });
+
+  await agent.runAgent(undefined, {
+    onEvent: ({ event }) => {
+      observed.push(event);
+    },
+  });
+
+  return { requests, observed };
+}
+
+/** The single user message that reached the backend, as sent on the wire. */
+function sentUserMessage(requests: RunAgentInput[]) {
+  expect(requests).toHaveLength(1);
+  const message = requests[0]!.messages.find(
+    (candidate) => candidate.role === "user",
+  );
+  if (message?.role !== "user") {
+    throw new Error("expected a user message to reach the backend");
+  }
+  return message;
+}
+
+describe("SpringAiAgent 0.0.39 ceiling — recorded baseline", () => {
+  it("pins maxVersion to 0.0.39, activating all three compat shims", () => {
+    const agent = new SpringAiAgent({ url: "http://spring-ai.invalid/agui" });
+    expect(agent.maxVersion).toBe("0.0.39");
+  });
+
+  it("flattens structured content parts to text, dropping the image", async () => {
+    const { requests } = await runSpringAgent({
+      messages: [{ id: "u1", role: "user", content: multimodalContent }],
+    });
+
+    // The image part is discarded and the text parts are concatenated: this is
+    // why the ceiling makes multimodal input impossible on this path.
+    expect(sentUserMessage(requests).content).toBe("what is in this image?");
+  });
+
+  it("coerces an assistant message with no content to an empty string", async () => {
+    const { requests } = await runSpringAgent({
+      messages: [
+        { id: "u1", role: "user", content: "call the tool" },
+        {
+          id: "a1",
+          role: "assistant",
+          toolCalls: [
+            {
+              id: "tc1",
+              type: "function",
+              function: { name: "get_weather", arguments: "{}" },
+            },
+          ],
+        },
+        { id: "t1", role: "tool", content: "sunny", toolCallId: "tc1" },
+      ],
+    });
+
+    const assistant = requests[0]!.messages.find(
+      (message) => message.role === "assistant",
+    );
+    if (assistant?.role !== "assistant") {
+      throw new Error("expected the assistant message to reach the backend");
+    }
+    expect(assistant.content).toBe("");
+  });
+
+  it("rewrites legacy THINKING_* response events into REASONING_*", async () => {
+    // The shim warns once per rewritten event. Silencing it keeps the output
+    // readable and lets the test assert the deprecation warning is what fires.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { observed } = await runSpringAgent({
+      messages: [{ id: "u1", role: "user", content: "think about it" }],
+      responseEvents: [
+        { type: "THINKING_START", title: "Thinking" },
+        { type: "THINKING_TEXT_MESSAGE_START" },
+        { type: "THINKING_TEXT_MESSAGE_CONTENT", delta: "hmm" },
+        { type: "THINKING_TEXT_MESSAGE_END" },
+        { type: "THINKING_END" },
+      ],
+    });
+
+    // A Spring backend still emitting legacy THINKING events depends on this
+    // rewrite; removing the ceiling stops it, so the run below must confirm
+    // the backend emits REASONING_* natively.
+    const types = observed.map((event) => event.type);
+    expect(types).toContain(EventType.REASONING_START);
+    expect(types).toContain(EventType.REASONING_MESSAGE_CONTENT);
+    expect(types).toContain(EventType.REASONING_END);
+    expect(types).not.toContain("THINKING_START");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("SpringAiAgent behavior independent of the ceiling", () => {
+  it("passes plain string content through untouched", async () => {
+    const { requests } = await runSpringAgent({
+      messages: [{ id: "u1", role: "user", content: "Hi, I am duaa" }],
+    });
+
+    // The one Dojo lane covered by e2e today (agentic_chat) is plain text, so
+    // it reads identically with and without the ceiling — which is exactly why
+    // a green agentic_chat run is not evidence for removing the pin.
+    expect(sentUserMessage(requests).content).toBe("Hi, I am duaa");
+  });
+});


### PR DESCRIPTION
Groundwork for un-pinning Spring AI. **This PR deliberately does not remove the ceiling** — that needs a real-backend run, and the backend isn't in this repo. What was missing was everything needed to *do* that run and to make the eventual removal reviewable.

Linear: [PNI-219](https://linear.app/copilotkit/issue/PNI-219/validate-spring-ai-on-10-and-remove-its-version-ceiling)

## What's actually in the repo for Spring AI

Worth stating plainly, because it shapes what can be done here:

| | |
|---|---|
| Adapter | `src/index.ts` — 11 lines, `SpringAiAgent extends HttpAgent` + the pin |
| Tests | **none** (before this PR) |
| Backend | **not in this repo** — the Spring adapter and Spring AI integration ship from a separate `ag-ui-spring` repo ([Java server README](https://github.com/ag-ui-protocol/ag-ui/blob/main/sdks/community/java/ag-ui/server/README.md)) |
| Dojo | 5 lanes wired via `SPRING_AI_URL` (default `:8080`) |
| E2E | one 17-line plain-text `agentic_chat` test, **not** in the `dojo-e2e` matrix |
| CI | `spring-ai` appears only in release/publish workflows |

So there is no in-repo way to prove the backend tolerates the un-shimmed wire format. The honest move is to record precisely what the ceiling changes, and make the removal a red/green decision.

## The risk surface is wider than the ticket assumes

The ticket frames this as a content-flattening pin. It isn't only that. `0.0.39` is at or below **all three** thresholds in `AbstractAgent`'s constructor, so three shims are live on this path:

| Threshold | Effect while the ceiling stands |
|---|---|
| ≤ 0.0.39 | Flattens structured content to text, coerces absent content to `""`, strips `parentRunId` |
| ≤ 0.0.45 | Rewrites legacy `THINKING_*` response events to `REASONING_*` |
| ≤ 0.0.47 | Converts legacy `BinaryInputContent` to typed content parts |

The 0.0.45 one is the non-obvious risk: if the Spring backend still emits legacy `THINKING_*`, removing the pin silently breaks reasoning display. That's a response-side failure no request-side test would catch.

## The baseline suite

`src/__tests__/version-ceiling-baseline.test.ts` (the package's first tests) drives real runs through the middleware chain against an injected `fetch` and records each effect: content arrays flattened with the image part dropped, absent assistant content coerced to `""`, `THINKING_*` rewritten to `REASONING_*`. A fifth test covers plain-string content, which behaves identically either way.

That last one matters: plain text is exactly what the existing e2e test sends, so **a green `agentic_chat` run is not evidence for removing the pin**. The suite makes that explicit rather than leaving it as folklore.

Verified as a tripwire, not decoration: temporarily deleting the pin fails all four baseline assertions and leaves the ceiling-independent one green.

```
× pins maxVersion to 0.0.39, activating all three compat shims
× flattens structured content parts to text, dropping the image
× coerces an assistant message with no content to an empty string
× rewrites legacy THINKING_* response events into REASONING_*
✓ passes plain string content through untouched
```

When the real-backend run justifies the removal, those assertions get inverted in the same commit — a suite that stayed green through an un-pin would mean it had stopped watching anything.

## README fix

The README was copy-pasted from llama-index. It advertised "Connect to LlamaIndex FastAPI servers" and "Complete FastAPI server implementation included", and under *"To run the example server in the dojo"* told you to boot `integrations/llama-index/python/examples`. For a ticket whose step 1 is "run its real paired backend", the docs pointed at the wrong backend entirely.

Replaced with the actual backend situation, the Dojo lanes that exist, the shim table, and the ordered before/after procedure with the three risk axes to check against the live backend.

## Verification

`test` (5 passed), `typecheck`, `test:exports` and `prettier --check` all pass. The adapter source is untouched.

## Follow-ups I deliberately left out

- **Expanding the e2e suite** to the discriminating lanes (`human_in_the_loop`, `tool_based_generative_ui` exercise the absent-content branch). I can't run them without a backend, and shipping unverified e2e specs seemed worse than leaving the runbook precise about what to check.
- **`runAgent({ messages })` in the usage example** is wrong — `RunAgentParameters` has no `messages` field. It's identical boilerplate across ~20 sibling integration READMEs, so fixing it here alone would create inconsistency; worth its own sweep.
- **Adding `springAiTests` to the `dojo-e2e` matrix** is not possible: that workflow starts each backend from this repo. Documented as a manual run instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)