### PR TITLE
fix(langgraph): prevent future state in boundary snapshots

### DIFF
--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1021,7 +1021,7 @@ export class LangGraphAgent extends AbstractAgent {
 
         if (currentSubgraph !== this.currentSubgraph) {
           this.currentSubgraph = currentSubgraph;
-          await this.getStateAndMessagesSnapshots(
+          latestStateValues = await this.getStateAndMessagesSnapshots(
             threadId,
             latestRootStateValues,
             hasOrderedRootStateValues,
@@ -1225,7 +1225,7 @@ export class LangGraphAgent extends AbstractAgent {
     threadId: string,
     orderedStateValues?: ThreadState<State>["values"],
     hasOrderedStateValues = false,
-  ): Promise<void> {
+  ): Promise<ThreadState<State>["values"]> {
     const state: ThreadState<State> = hasOrderedStateValues
       ? ({ values: orderedStateValues ?? {} } as ThreadState<State>)
       : await this.client.threads.getState(threadId);
@@ -1239,6 +1239,7 @@ export class LangGraphAgent extends AbstractAgent {
       type: EventType.MESSAGES_SNAPSHOT,
       messages: langchainMessagesToAgui(checkpointMessages),
     });
+    return state.values;
   }
 
   /**

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -890,7 +890,8 @@ export class LangGraphAgent extends AbstractAgent {
 
     this.activeRun!.prevNodeName = null;
     let latestStateValues = {} as ThreadState<State>["values"];
-    let hasOrderedStateValues = false;
+    let latestRootStateValues = {} as ThreadState<State>["values"];
+    let hasOrderedRootStateValues = false;
     let updatedState = state;
 
     try {
@@ -982,7 +983,8 @@ export class LangGraphAgent extends AbstractAgent {
             ...latestStateValues,
             ...chunk.data,
           };
-          hasOrderedStateValues = true;
+          latestRootStateValues = chunk.data;
+          hasOrderedRootStateValues = true;
           continue;
         } else if (
           subgraphsStreamEnabled &&
@@ -992,7 +994,6 @@ export class LangGraphAgent extends AbstractAgent {
             ...latestStateValues,
             ...chunk.data,
           };
-          hasOrderedStateValues = true;
           continue;
         }
 
@@ -1022,8 +1023,8 @@ export class LangGraphAgent extends AbstractAgent {
           this.currentSubgraph = currentSubgraph;
           await this.getStateAndMessagesSnapshots(
             threadId,
-            latestStateValues,
-            hasOrderedStateValues,
+            latestRootStateValues,
+            hasOrderedRootStateValues,
           );
         }
 

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1026,6 +1026,10 @@ export class LangGraphAgent extends AbstractAgent {
             latestRootStateValues,
             hasOrderedRootStateValues,
           );
+          // A root values snapshot describes the boundary that follows it. Do
+          // not reuse it after crossing that boundary: a subgraph may commit
+          // newer state before the next root values event arrives.
+          hasOrderedRootStateValues = false;
         }
 
         // Set server-assigned run id as soon as available

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -1021,10 +1021,16 @@ export class LangGraphAgent extends AbstractAgent {
 
         if (currentSubgraph !== this.currentSubgraph) {
           this.currentSubgraph = currentSubgraph;
+          const boundaryCheckpointStep =
+            currentSubgraph === ROOT_SUBGRAPH_NAME &&
+            typeof metadata.langgraph_step === "number"
+              ? metadata.langgraph_step - 1
+              : undefined;
           latestStateValues = await this.getStateAndMessagesSnapshots(
             threadId,
             latestRootStateValues,
             hasOrderedRootStateValues,
+            boundaryCheckpointStep,
           );
           // A root values snapshot describes the boundary that follows it. Do
           // not reuse it after crossing that boundary: a subgraph may commit
@@ -1225,10 +1231,25 @@ export class LangGraphAgent extends AbstractAgent {
     threadId: string,
     orderedStateValues?: ThreadState<State>["values"],
     hasOrderedStateValues = false,
+    boundaryCheckpointStep?: number,
   ): Promise<ThreadState<State>["values"]> {
-    const state: ThreadState<State> = hasOrderedStateValues
-      ? ({ values: orderedStateValues ?? {} } as ThreadState<State>)
-      : await this.client.threads.getState(threadId);
+    let state: ThreadState<State>;
+    if (hasOrderedStateValues) {
+      state = { values: orderedStateValues ?? {} } as ThreadState<State>;
+    } else if (boundaryCheckpointStep !== undefined) {
+      const [boundaryState] = await this.client.threads.getHistory(threadId, {
+        limit: 1,
+        metadata: { step: boundaryCheckpointStep },
+      });
+      if (!boundaryState) {
+        throw new Error(
+          `No LangGraph checkpoint found for boundary step ${boundaryCheckpointStep}`,
+        );
+      }
+      state = boundaryState;
+    } else {
+      state = await this.client.threads.getState(threadId);
+    }
     this.dispatchEvent({
       type: EventType.STATE_SNAPSHOT,
       snapshot: this.getStateSnapshot(state),

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -890,6 +890,7 @@ export class LangGraphAgent extends AbstractAgent {
 
     this.activeRun!.prevNodeName = null;
     let latestStateValues = {} as ThreadState<State>["values"];
+    let hasOrderedStateValues = false;
     let updatedState = state;
 
     try {
@@ -981,6 +982,7 @@ export class LangGraphAgent extends AbstractAgent {
             ...latestStateValues,
             ...chunk.data,
           };
+          hasOrderedStateValues = true;
           continue;
         } else if (
           subgraphsStreamEnabled &&
@@ -990,6 +992,7 @@ export class LangGraphAgent extends AbstractAgent {
             ...latestStateValues,
             ...chunk.data,
           };
+          hasOrderedStateValues = true;
           continue;
         }
 
@@ -1017,7 +1020,11 @@ export class LangGraphAgent extends AbstractAgent {
 
         if (currentSubgraph !== this.currentSubgraph) {
           this.currentSubgraph = currentSubgraph;
-          await this.getStateAndMessagesSnapshots(threadId);
+          await this.getStateAndMessagesSnapshots(
+            threadId,
+            latestStateValues,
+            hasOrderedStateValues,
+          );
         }
 
         // Set server-assigned run id as soon as available
@@ -1209,9 +1216,14 @@ export class LangGraphAgent extends AbstractAgent {
     }
   }
 
-  private async getStateAndMessagesSnapshots(threadId: string): Promise<void> {
-    const state: ThreadState<State> =
-      await this.client.threads.getState(threadId);
+  private async getStateAndMessagesSnapshots(
+    threadId: string,
+    orderedStateValues?: ThreadState<State>["values"],
+    hasOrderedStateValues = false,
+  ): Promise<void> {
+    const state: ThreadState<State> = hasOrderedStateValues
+      ? ({ values: orderedStateValues ?? {} } as ThreadState<State>)
+      : await this.client.threads.getState(threadId);
     this.dispatchEvent({
       type: EventType.STATE_SNAPSHOT,
       snapshot: this.getStateSnapshot(state),

--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -69,7 +69,10 @@ import {
   buildLgCommandResumeFromAgui,
   reconcileLegacyResumeInterrupts,
 } from "./interrupts";
-import { RunsStreamPayload } from "@langchain/langgraph-sdk/dist/types";
+import type {
+  Durability,
+  RunsStreamPayload,
+} from "@langchain/langgraph-sdk/dist/types";
 import {
   aguiMessagesToLangChain,
   DEFAULT_SCHEMA_KEYS,
@@ -193,6 +196,8 @@ export interface LangGraphAgentConfig extends AgentConfig {
 }
 
 const ROOT_SUBGRAPH_NAME = "root";
+const ASYNC_BOUNDARY_CHECKPOINT_ATTEMPTS = 3;
+const ASYNC_BOUNDARY_CHECKPOINT_RETRY_DELAY_MS = 25;
 
 export class LangGraphAgent extends AbstractAgent {
   client: LangGraphClient;
@@ -1031,6 +1036,7 @@ export class LangGraphAgent extends AbstractAgent {
             latestRootStateValues,
             hasOrderedRootStateValues,
             boundaryCheckpointStep,
+            input.forwardedProps?.durability ?? "async",
           );
           // A root values snapshot describes the boundary that follows it. Do
           // not reuse it after crossing that boundary: a subgraph may commit
@@ -1232,15 +1238,33 @@ export class LangGraphAgent extends AbstractAgent {
     orderedStateValues?: ThreadState<State>["values"],
     hasOrderedStateValues = false,
     boundaryCheckpointStep?: number,
+    durability: Durability = "async",
   ): Promise<ThreadState<State>["values"]> {
     let state: ThreadState<State>;
     if (hasOrderedStateValues) {
       state = { values: orderedStateValues ?? {} } as ThreadState<State>;
     } else if (boundaryCheckpointStep !== undefined) {
-      const [boundaryState] = await this.client.threads.getHistory(threadId, {
-        limit: 1,
-        metadata: { step: boundaryCheckpointStep },
-      });
+      if (durability === "exit") {
+        throw new Error(
+          `Cannot snapshot LangGraph boundary step ${boundaryCheckpointStep} with durability "exit": the checkpoint is not persisted until the run exits`,
+        );
+      }
+
+      const attempts =
+        durability === "async" ? ASYNC_BOUNDARY_CHECKPOINT_ATTEMPTS : 1;
+      let boundaryState: ThreadState<State> | undefined;
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        [boundaryState] = await this.client.threads.getHistory(threadId, {
+          limit: 1,
+          metadata: { step: boundaryCheckpointStep },
+        });
+        if (boundaryState) break;
+        if (attempt < attempts - 1) {
+          await new Promise<void>((resolve) =>
+            setTimeout(resolve, ASYNC_BOUNDARY_CHECKPOINT_RETRY_DELAY_MS),
+          );
+        }
+      }
       if (!boundaryState) {
         throw new Error(
           `No LangGraph checkpoint found for boundary step ${boundaryCheckpointStep}`,

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -65,7 +65,7 @@ type SnapshotHarness = {
     threadId: string,
     orderedStateValues?: LangGraphThreadState<unknown>["values"],
     hasOrderedStateValues?: boolean,
-  ) => Promise<void>;
+  ) => Promise<LangGraphThreadState<unknown>["values"]>;
 };
 
 type LangGraphClient = NonNullable<LangGraphAgentConfig["client"]>;
@@ -544,19 +544,20 @@ describe("subgraph change trigger", () => {
 
     expect(getState).not.toHaveBeenCalled();
 
-    const stateSnap = dispatched.find(
+    const stateSnapshots = dispatched.filter(
       (event): event is StateSnapshotEvent =>
         event?.type === EventType.STATE_SNAPSHOT,
     );
-    expect(stateSnap).toBeDefined();
-    expect(stateSnap?.snapshot).toEqual({
+    expect(stateSnapshots.map((event) => event.snapshot)).toContainEqual({
       messages: [user, rootAssistant],
       itinerary: {
         route: "root route",
       },
     });
-    expect(stateSnap?.snapshot).not.toHaveProperty("futureOnly");
-    expect(stateSnap?.snapshot.itinerary).not.toHaveProperty("hotel");
+    for (const stateSnapshot of stateSnapshots) {
+      expect(stateSnapshot.snapshot).not.toHaveProperty("futureOnly");
+      expect(stateSnapshot.snapshot.itinerary).not.toHaveProperty("hotel");
+    }
 
     const messagesSnap = dispatched.find(
       (event): event is MessagesSnapshotEvent =>

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -12,11 +12,16 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MockedFunction } from "vitest";
 import { Subject } from "rxjs";
 import { EventType } from "@ag-ui/core";
+import type { MessagesSnapshotEvent, StateSnapshotEvent } from "@ag-ui/core";
 import { LangGraphAgent } from "./agent";
 import type { LangGraphAgentConfig } from "./agent";
-import type { Message as LangGraphMessage } from "@langchain/langgraph-sdk";
+import type {
+  Message as LangGraphMessage,
+  ThreadState as LangGraphThreadState,
+} from "@langchain/langgraph-sdk";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,6 +57,58 @@ function makeAgent(config = makeConfig()) {
     return event as any;
   };
   return { agent, dispatched };
+}
+
+type SnapshotHarness = {
+  activeRun: unknown;
+  getStateSnapshot: ReturnType<typeof vi.fn>;
+  getStateAndMessagesSnapshots: (
+    threadId: string,
+    orderedStateValues?: LangGraphThreadState<unknown>["values"],
+    hasOrderedStateValues?: boolean,
+  ) => Promise<void>;
+};
+
+type LangGraphClient = NonNullable<LangGraphAgentConfig["client"]>;
+type GetState = LangGraphClient["threads"]["getState"];
+type GetStateMock = MockedFunction<GetState>;
+type MockThreadState = Pick<LangGraphThreadState<unknown>, "values"> &
+  Partial<Omit<LangGraphThreadState<unknown>, "values">>;
+
+function snapshotHarness(agent: LangGraphAgent): SnapshotHarness {
+  return agent as unknown as SnapshotHarness;
+}
+
+function setMockGetState(
+  config: LangGraphAgentConfig,
+  state: MockThreadState,
+): GetStateMock {
+  const threadState: LangGraphThreadState<unknown> = {
+    next: [],
+    checkpoint: {
+      thread_id: "thread-1",
+      checkpoint_ns: "",
+      checkpoint_id: null,
+      checkpoint_map: null,
+    },
+    metadata: {},
+    created_at: null,
+    parent_checkpoint: null,
+    tasks: [],
+    ...state,
+  };
+  const getState = vi.mocked(config.client!.threads.getState);
+  getState.mockResolvedValue(threadState);
+  return getState;
+}
+
+function setupSnapshotHarness(state: MockThreadState) {
+  const config = makeConfig();
+  const getState = setMockGetState(config, state);
+  const { agent, dispatched } = makeAgent(config);
+  const agentHarness = snapshotHarness(agent);
+  agentHarness.activeRun = { id: "run-1" };
+  return { agentHarness, dispatched, getState };
 }
 
 function eventTypes(dispatched: any[]): string[] {
@@ -165,6 +222,117 @@ describe("getStateAndMessagesSnapshots", () => {
     const ids = snap.messages.map((m: any) => m.id);
     expect(ids).toContain("h1");
     expect(ids.indexOf("f1")).toBeLessThan(ids.indexOf("h1"));
+  });
+
+  it("uses ordered values for boundary snapshots when getState is ahead", async () => {
+    const user = msg("u1", "human", "AMS to SF");
+    const hotels = msg("h1", "ai", "Booked Hotel Zoe");
+    const futureExperience = msg(
+      "e1",
+      "ai",
+      "Booked experience after boundary",
+    );
+    const orderedValues = {
+      messages: [user, hotels],
+      itinerary: {
+        hotel: "Hotel Zoe",
+        refundable: true,
+      },
+    };
+    const { agentHarness, dispatched, getState } = setupSnapshotHarness({
+      values: {
+        messages: [user, hotels, futureExperience],
+        itinerary: {
+          hotel: "Hotel Zoe",
+          experience: "Ferry Building tasting",
+        },
+        futureOnly: true,
+      },
+    });
+
+    await agentHarness.getStateAndMessagesSnapshots(
+      "thread-1",
+      orderedValues,
+      true,
+    );
+
+    expect(getState).not.toHaveBeenCalled();
+    const messagesSnap = dispatched.find(
+      (event): event is MessagesSnapshotEvent =>
+        event?.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(messagesSnap).toBeDefined();
+    const ids = messagesSnap?.messages.map((message) => message.id);
+    expect(ids).toEqual(["u1", "h1"]);
+    expect(ids).not.toContain("e1");
+
+    const stateSnap = dispatched.find(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnap).toBeDefined();
+    expect(stateSnap?.snapshot).toEqual(orderedValues);
+    expect(stateSnap?.snapshot).not.toHaveProperty("futureOnly");
+    expect(stateSnap?.snapshot.itinerary).not.toHaveProperty("experience");
+  });
+
+  it("uses available empty ordered state instead of falling back to getState", async () => {
+    const checkpointOnly = msg("c1", "ai", "Checkpoint-only response");
+    const { agentHarness, dispatched, getState } = setupSnapshotHarness({
+      values: {
+        messages: [checkpointOnly],
+        futureOnly: true,
+      },
+    });
+
+    await agentHarness.getStateAndMessagesSnapshots("thread-1", {}, true);
+
+    expect(getState).not.toHaveBeenCalled();
+    const stateSnap = dispatched.find(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnap?.snapshot).toEqual({});
+    const messagesSnap = dispatched.find(
+      (event): event is MessagesSnapshotEvent =>
+        event?.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(messagesSnap?.messages).toEqual([]);
+  });
+
+  it("falls back to getState for STATE_SNAPSHOT and MESSAGES_SNAPSHOT when no ordered values exist", async () => {
+    const user = msg("u1", "human", "AMS to SF");
+    const checkpointOnly = msg("c1", "ai", "Checkpoint-only response");
+    const { agentHarness, dispatched, getState } = setupSnapshotHarness({
+      values: {
+        messages: [user, checkpointOnly],
+        itinerary: {
+          hotels: ["Checkpoint Hotel"],
+        },
+      },
+    });
+
+    await agentHarness.getStateAndMessagesSnapshots("thread-1");
+
+    expect(getState).toHaveBeenCalledWith("thread-1");
+    const stateSnap = dispatched.find(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnap).toBeDefined();
+    expect(stateSnap?.snapshot).toEqual({
+      messages: [user, checkpointOnly],
+      itinerary: {
+        hotels: ["Checkpoint Hotel"],
+      },
+    });
+    const messagesSnap = dispatched.find(
+      (event): event is MessagesSnapshotEvent =>
+        event?.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(messagesSnap).toBeDefined();
+    const ids = messagesSnap?.messages.map((message) => message.id);
+    expect(ids).toEqual(["u1", "c1"]);
   });
 });
 

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -13,7 +13,6 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { MockedFunction } from "vitest";
-import { Subject } from "rxjs";
 import { EventType } from "@ag-ui/core";
 import type { MessagesSnapshotEvent, StateSnapshotEvent } from "@ag-ui/core";
 import { LangGraphAgent } from "./agent";
@@ -377,13 +376,11 @@ describe("subgraph change trigger", () => {
     return { agent, dispatched, config };
   }
 
-  async function driveAgent(agent: LangGraphAgent, chunks: any[]) {
-    let resolve: () => void;
-    const done = new Promise<void>((r) => (resolve = r));
-
-    const events$ = new Subject<any>();
-    const results: any[] = [];
-
+  async function driveAgent(
+    agent: LangGraphAgent,
+    chunks: any[],
+    expectedError?: Error,
+  ) {
     // Patch prepareStream to return our synthetic chunk stream
     (agent as any).prepareStream = vi.fn().mockResolvedValue({
       streamResponse: (async function* () {
@@ -410,8 +407,8 @@ describe("subgraph change trigger", () => {
       await new Promise<void>((res, rej) => {
         obs.subscribe({ next: () => {}, error: rej, complete: res });
       });
-    } catch (_) {
-      // Expected — we don't have a real server
+    } catch (error) {
+      if (error !== expectedError) throw error;
     }
   }
 
@@ -507,6 +504,7 @@ describe("subgraph change trigger", () => {
       "Subgraph has a future-only route",
     );
 
+    const stopAfterBoundary = new Error("stop after boundary snapshot");
     const chunks = [
       {
         event: "values",
@@ -539,10 +537,10 @@ describe("subgraph change trigger", () => {
           },
         },
       },
-      new Error("stop after boundary snapshot"),
+      stopAfterBoundary,
     ];
 
-    await driveAgent(agent, chunks);
+    await driveAgent(agent, chunks, stopAfterBoundary);
 
     expect(getState).not.toHaveBeenCalled();
 
@@ -572,6 +570,97 @@ describe("subgraph change trigger", () => {
     expect(messagesSnap?.messages.map((message) => message.id)).not.toContain(
       "s1",
     );
+  });
+
+  it("falls back after ordered root values are consumed by an earlier boundary", async () => {
+    const { agent, dispatched, config } = makeStreamingAgent();
+    const user = msg("u1", "human", "AMS to SF");
+    const rootAssistant = msg("r1", "ai", "Root has current route");
+    const committedSubgraphAssistant = msg(
+      "s1",
+      "ai",
+      "Subgraph committed a hotel",
+    );
+    const getState = setMockGetState(config, {
+      values: {
+        messages: [user, rootAssistant, committedSubgraphAssistant],
+        itinerary: {
+          route: "root route",
+          hotel: "Hotel Zoe",
+        },
+      },
+      metadata: { writes: {} },
+    });
+    (agent as any).getStateSnapshot = vi
+      .fn()
+      .mockImplementation((state: LangGraphThreadState<unknown>) => state.values);
+
+    const stopAfterExitBoundary = new Error("stop after exit boundary snapshot");
+    const chunks = [
+      {
+        event: "values",
+        data: {
+          messages: [user, rootAssistant],
+          itinerary: { route: "root route" },
+        },
+      },
+      {
+        event: "events",
+        data: {
+          event: "on_chain_start",
+          metadata: {
+            langgraph_node: "hotels_agent",
+            langgraph_checkpoint_ns:
+              "hotels_agent:abc|hotels_agent_chat_node:xyz",
+          },
+        },
+      },
+      {
+        event: "values|hotels_agent:abc",
+        data: {
+          messages: [committedSubgraphAssistant],
+          itinerary: { hotel: "Hotel Zoe" },
+        },
+      },
+      {
+        event: "events",
+        data: {
+          event: "on_chain_end",
+          metadata: {
+            langgraph_node: "supervisor",
+            langgraph_checkpoint_ns: "supervisor:def",
+          },
+          data: { output: {} },
+        },
+      },
+      stopAfterExitBoundary,
+    ];
+
+    await driveAgent(agent, chunks, stopAfterExitBoundary);
+
+    expect(getState).toHaveBeenCalledTimes(1);
+    const stateSnapshots = dispatched.filter(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnapshots.map((event) => event.snapshot)).toContainEqual({
+      messages: [user, rootAssistant, committedSubgraphAssistant],
+      itinerary: {
+        route: "root route",
+        hotel: "Hotel Zoe",
+      },
+    });
+
+    const messagesSnapshots = dispatched.filter(
+      (event): event is MessagesSnapshotEvent =>
+        event?.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(messagesSnapshots).toHaveLength(2);
+    expect(messagesSnapshots[1].messages.map((message) => message.id)).toEqual([
+      "u1",
+      "r1",
+      "s1",
+    ]);
   });
 });
 

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -387,7 +387,10 @@ describe("subgraph change trigger", () => {
     // Patch prepareStream to return our synthetic chunk stream
     (agent as any).prepareStream = vi.fn().mockResolvedValue({
       streamResponse: (async function* () {
-        for (const c of chunks) yield c;
+        for (const c of chunks) {
+          if (c instanceof Error) throw c;
+          yield c;
+        }
       })(),
       state: { values: { messages: [] } } as any,
     });
@@ -487,6 +490,88 @@ describe("subgraph change trigger", () => {
     if (ids.includes("f1")) {
       expect(ids.indexOf("f1")).toBeLessThan(ids.indexOf("h1"));
     }
+  });
+
+  it("uses only root values for subgraph boundary snapshots", async () => {
+    const { agent, dispatched, config } = makeStreamingAgent();
+    const getState = vi.mocked(config.client!.threads.getState);
+    (agent as any).getStateSnapshot = vi
+      .fn()
+      .mockImplementation((state: LangGraphThreadState<unknown>) => state.values);
+
+    const user = msg("u1", "human", "AMS to SF");
+    const rootAssistant = msg("r1", "ai", "Root has current route");
+    const futureSubgraphAssistant = msg(
+      "s1",
+      "ai",
+      "Subgraph has a future-only route",
+    );
+
+    const chunks = [
+      {
+        event: "values",
+        data: {
+          messages: [user, rootAssistant],
+          itinerary: {
+            route: "root route",
+          },
+        },
+      },
+      {
+        event: "values|hotels_agent:abc",
+        data: {
+          messages: [futureSubgraphAssistant],
+          itinerary: {
+            route: "subgraph route",
+            hotel: "Hotel Zoe",
+          },
+          futureOnly: true,
+        },
+      },
+      {
+        event: "events",
+        data: {
+          event: "on_chain_start",
+          metadata: {
+            langgraph_node: "hotels_agent",
+            langgraph_checkpoint_ns:
+              "hotels_agent:abc|hotels_agent_chat_node:xyz",
+          },
+        },
+      },
+      new Error("stop after boundary snapshot"),
+    ];
+
+    await driveAgent(agent, chunks);
+
+    expect(getState).not.toHaveBeenCalled();
+
+    const stateSnap = dispatched.find(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnap).toBeDefined();
+    expect(stateSnap?.snapshot).toEqual({
+      messages: [user, rootAssistant],
+      itinerary: {
+        route: "root route",
+      },
+    });
+    expect(stateSnap?.snapshot).not.toHaveProperty("futureOnly");
+    expect(stateSnap?.snapshot.itinerary).not.toHaveProperty("hotel");
+
+    const messagesSnap = dispatched.find(
+      (event): event is MessagesSnapshotEvent =>
+        event?.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(messagesSnap).toBeDefined();
+    expect(messagesSnap?.messages.map((message) => message.id)).toEqual([
+      "u1",
+      "r1",
+    ]);
+    expect(messagesSnap?.messages.map((message) => message.id)).not.toContain(
+      "s1",
+    );
   });
 });
 

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -37,7 +37,7 @@ function makeConfig(): LangGraphAgentConfig {
     deploymentUrl: "http://localhost:2024",
     graphId: "test-graph",
     client: {
-      threads: { getState: vi.fn() },
+      threads: { getState: vi.fn(), getHistory: vi.fn() },
       runs: { cancel: vi.fn() },
       assistants: {
         search: vi.fn().mockResolvedValue([]),
@@ -65,12 +65,15 @@ type SnapshotHarness = {
     threadId: string,
     orderedStateValues?: LangGraphThreadState<unknown>["values"],
     hasOrderedStateValues?: boolean,
+    boundaryCheckpointStep?: number,
   ) => Promise<LangGraphThreadState<unknown>["values"]>;
 };
 
 type LangGraphClient = NonNullable<LangGraphAgentConfig["client"]>;
 type GetState = LangGraphClient["threads"]["getState"];
 type GetStateMock = MockedFunction<GetState>;
+type GetHistory = LangGraphClient["threads"]["getHistory"];
+type GetHistoryMock = MockedFunction<GetHistory>;
 type MockThreadState = Pick<LangGraphThreadState<unknown>, "values"> &
   Partial<Omit<LangGraphThreadState<unknown>, "values">>;
 
@@ -78,11 +81,10 @@ function snapshotHarness(agent: LangGraphAgent): SnapshotHarness {
   return agent as unknown as SnapshotHarness;
 }
 
-function setMockGetState(
-  config: LangGraphAgentConfig,
+function makeMockThreadState(
   state: MockThreadState,
-): GetStateMock {
-  const threadState: LangGraphThreadState<unknown> = {
+): LangGraphThreadState<unknown> {
+  return {
     next: [],
     checkpoint: {
       thread_id: "thread-1",
@@ -96,9 +98,25 @@ function setMockGetState(
     tasks: [],
     ...state,
   };
+}
+
+function setMockGetState(
+  config: LangGraphAgentConfig,
+  state: MockThreadState,
+): GetStateMock {
+  const threadState = makeMockThreadState(state);
   const getState = vi.mocked(config.client!.threads.getState);
   getState.mockResolvedValue(threadState);
   return getState;
+}
+
+function setMockGetHistory(
+  config: LangGraphAgentConfig,
+  states: MockThreadState[],
+): GetHistoryMock {
+  const getHistory = vi.mocked(config.client!.threads.getHistory);
+  getHistory.mockResolvedValue(states.map(makeMockThreadState));
+  return getHistory;
 }
 
 function setupSnapshotHarness(state: MockThreadState) {
@@ -573,7 +591,7 @@ describe("subgraph change trigger", () => {
     );
   });
 
-  it("falls back after ordered root values are consumed by an earlier boundary", async () => {
+  it("uses the boundary checkpoint after ordered root values are consumed", async () => {
     const { agent, dispatched, config } = makeStreamingAgent();
     const user = msg("u1", "human", "AMS to SF");
     const rootAssistant = msg("r1", "ai", "Root has current route");
@@ -582,16 +600,35 @@ describe("subgraph change trigger", () => {
       "ai",
       "Subgraph committed a hotel",
     );
+    const futureAssistant = msg("future", "ai", "Future root response");
     const getState = setMockGetState(config, {
       values: {
-        messages: [user, rootAssistant, committedSubgraphAssistant],
+        messages: [
+          user,
+          rootAssistant,
+          committedSubgraphAssistant,
+          futureAssistant,
+        ],
         itinerary: {
           route: "root route",
           hotel: "Hotel Zoe",
         },
+        futureOnly: true,
       },
       metadata: { writes: {} },
     });
+    const getHistory = setMockGetHistory(config, [
+      {
+        values: {
+          messages: [user, rootAssistant, committedSubgraphAssistant],
+          itinerary: {
+            route: "root route",
+            hotel: "Hotel Zoe",
+          },
+        },
+        metadata: { step: 6, writes: {} },
+      },
+    ]);
     (agent as any).getStateSnapshot = vi
       .fn()
       .mockImplementation((state: LangGraphThreadState<unknown>) => state.values);
@@ -630,6 +667,7 @@ describe("subgraph change trigger", () => {
           metadata: {
             langgraph_node: "supervisor",
             langgraph_checkpoint_ns: "supervisor:def",
+            langgraph_step: 7,
           },
           data: { output: {} },
         },
@@ -639,7 +677,11 @@ describe("subgraph change trigger", () => {
 
     await driveAgent(agent, chunks, stopAfterExitBoundary);
 
-    expect(getState).toHaveBeenCalledTimes(1);
+    expect(getHistory).toHaveBeenCalledWith("thread-1", {
+      limit: 1,
+      metadata: { step: 6 },
+    });
+    expect(getState).not.toHaveBeenCalled();
     const stateSnapshots = dispatched.filter(
       (event): event is StateSnapshotEvent =>
         event?.type === EventType.STATE_SNAPSHOT,
@@ -651,6 +693,9 @@ describe("subgraph change trigger", () => {
         hotel: "Hotel Zoe",
       },
     });
+    for (const stateSnapshot of stateSnapshots) {
+      expect(stateSnapshot.snapshot).not.toHaveProperty("futureOnly");
+    }
 
     const messagesSnapshots = dispatched.filter(
       (event): event is MessagesSnapshotEvent =>
@@ -662,6 +707,9 @@ describe("subgraph change trigger", () => {
       "r1",
       "s1",
     ]);
+    expect(
+      messagesSnapshots[1].messages.map((message) => message.id),
+    ).not.toContain("future");
   });
 });
 

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -17,10 +17,13 @@ import { EventType } from "@ag-ui/core";
 import type { MessagesSnapshotEvent, StateSnapshotEvent } from "@ag-ui/core";
 import { LangGraphAgent } from "./agent";
 import type { LangGraphAgentConfig } from "./agent";
+// @langchain/langgraph-sdk is a graph persistence client, not an LLM provider;
+// aimock does not apply to these checkpoint-history tests.
 import type {
   Message as LangGraphMessage,
   ThreadState as LangGraphThreadState,
 } from "@langchain/langgraph-sdk";
+import type { Durability } from "@langchain/langgraph-sdk/dist/types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -66,6 +69,7 @@ type SnapshotHarness = {
     orderedStateValues?: LangGraphThreadState<unknown>["values"],
     hasOrderedStateValues?: boolean,
     boundaryCheckpointStep?: number,
+    durability?: Durability,
   ) => Promise<LangGraphThreadState<unknown>["values"]>;
 };
 
@@ -125,7 +129,7 @@ function setupSnapshotHarness(state: MockThreadState) {
   const { agent, dispatched } = makeAgent(config);
   const agentHarness = snapshotHarness(agent);
   agentHarness.activeRun = { id: "run-1" };
-  return { agentHarness, dispatched, getState };
+  return { agentHarness, config, dispatched, getState };
 }
 
 function eventTypes(dispatched: any[]): string[] {
@@ -365,6 +369,111 @@ describe("getStateAndMessagesSnapshots", () => {
     const ids = messagesSnap?.messages.map((message) => message.id);
     expect(ids).toEqual(["u1", "c1"]);
   });
+});
+
+describe("boundary checkpoint durability", () => {
+  it("retries an empty default-async history lookup", async () => {
+    const user = msg("u1", "human", "AMS to SF");
+    const committedSubgraphAssistant = msg(
+      "s1",
+      "ai",
+      "Subgraph committed a hotel",
+    );
+    const { agentHarness, config, dispatched, getState } = setupSnapshotHarness(
+      {
+        values: {
+          messages: [
+            user,
+            committedSubgraphAssistant,
+            msg("future", "ai", "Future root response"),
+          ],
+          futureOnly: true,
+        },
+      },
+    );
+    const boundaryState = makeMockThreadState({
+      values: {
+        messages: [user, committedSubgraphAssistant],
+        itinerary: { hotel: "Hotel Zoe" },
+      },
+      metadata: { step: 6 },
+    });
+    const getHistory = vi.mocked(config.client!.threads.getHistory);
+    getHistory.mockResolvedValueOnce([]).mockResolvedValueOnce([boundaryState]);
+
+    await agentHarness.getStateAndMessagesSnapshots(
+      "thread-1",
+      undefined,
+      false,
+      6,
+    );
+
+    expect(getHistory).toHaveBeenCalledTimes(2);
+    expect(getState).not.toHaveBeenCalled();
+    const stateSnapshot = dispatched.find(
+      (event): event is StateSnapshotEvent =>
+        event?.type === EventType.STATE_SNAPSHOT,
+    );
+    expect(stateSnapshot?.snapshot).toEqual(boundaryState.values);
+    expect(stateSnapshot?.snapshot).not.toHaveProperty("futureOnly");
+  });
+
+  it("fails explicitly for exit durability without reading thread head", async () => {
+    const { agentHarness, config, dispatched, getState } = setupSnapshotHarness(
+      {
+        values: {
+          messages: [msg("future", "ai", "Future root response")],
+          futureOnly: true,
+        },
+      },
+    );
+    const getHistory = setMockGetHistory(config, []);
+
+    await expect(
+      agentHarness.getStateAndMessagesSnapshots(
+        "thread-1",
+        undefined,
+        false,
+        6,
+        "exit",
+      ),
+    ).rejects.toThrow('durability "exit"');
+
+    expect(getHistory).not.toHaveBeenCalled();
+    expect(getState).not.toHaveBeenCalled();
+    expect(dispatched).toEqual([]);
+  });
+
+  it.each([
+    ["async", 3],
+    ["sync", 1],
+  ] as const)(
+    "bounds %s durability checkpoint lookup to %i attempt(s)",
+    async (durability, expectedAttempts) => {
+      const { agentHarness, config, dispatched, getState } =
+        setupSnapshotHarness({
+          values: {
+            messages: [msg("future", "ai", "Future root response")],
+            futureOnly: true,
+          },
+        });
+      const getHistory = setMockGetHistory(config, []);
+
+      await expect(
+        agentHarness.getStateAndMessagesSnapshots(
+          "thread-1",
+          undefined,
+          false,
+          6,
+          durability,
+        ),
+      ).rejects.toThrow("No LangGraph checkpoint found for boundary step 6");
+
+      expect(getHistory).toHaveBeenCalledTimes(expectedAttempts);
+      expect(getState).not.toHaveBeenCalled();
+      expect(dispatched).toEqual([]);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
+++ b/integrations/langgraph/typescript/src/subgraph-streaming.test.ts
@@ -132,8 +132,16 @@ function eventTypes(dispatched: any[]): string[] {
   return dispatched.map((e) => e?.type).filter(Boolean);
 }
 
-function msg(id: string, role: "human" | "ai", content: string): LangGraphMessage {
-  return { id, type: role === "human" ? "human" : "ai", content } as LangGraphMessage;
+function msg(
+  id: string,
+  role: "human" | "ai",
+  content: string,
+): LangGraphMessage {
+  return {
+    id,
+    type: role === "human" ? "human" : "ai",
+    content,
+  } as LangGraphMessage;
 }
 
 // ---------------------------------------------------------------------------
@@ -142,10 +150,14 @@ function msg(id: string, role: "human" | "ai", content: string): LangGraphMessag
 
 describe("nsRoot extraction", () => {
   it("empty ns → empty string", () => expect(nsRoot("")).toBe(""));
-  it("root supervisor → supervisor", () => expect(nsRoot("supervisor:cf4865ae")).toBe("supervisor"));
-  it("subgraph boundary → subgraph name", () => expect(nsRoot("flights_agent:17b1922c")).toBe("flights_agent"));
+  it("root supervisor → supervisor", () =>
+    expect(nsRoot("supervisor:cf4865ae")).toBe("supervisor"));
+  it("subgraph boundary → subgraph name", () =>
+    expect(nsRoot("flights_agent:17b1922c")).toBe("flights_agent"));
   it("inside subgraph (|) → first segment", () =>
-    expect(nsRoot("flights_agent:17b1922c|flights_agent_chat_node:0a492c87")).toBe("flights_agent"));
+    expect(
+      nsRoot("flights_agent:17b1922c|flights_agent_chat_node:0a492c87"),
+    ).toBe("flights_agent"));
   it("deeply nested → outermost", () =>
     expect(nsRoot("outer:aaa|inner:bbb|deepest:ccc")).toBe("outer"));
 });
@@ -234,7 +246,9 @@ describe("getStateAndMessagesSnapshots", () => {
 
     await (agent as any).getStateAndMessagesSnapshots("thread-1");
 
-    const snap = dispatched.find((e) => e?.type === EventType.MESSAGES_SNAPSHOT);
+    const snap = dispatched.find(
+      (e) => e?.type === EventType.MESSAGES_SNAPSHOT,
+    );
     expect(snap).toBeDefined();
     const ids = snap.messages.map((m: any) => m.id);
     expect(ids).toContain("h1");
@@ -370,9 +384,9 @@ describe("subgraph change trigger", () => {
       next: [],
       metadata: { writes: {} },
     });
-    (config.client as any).assistants.search = vi.fn().mockResolvedValue([
-      { assistant_id: "asst-1", graph_id: "test-graph" },
-    ]);
+    (config.client as any).assistants.search = vi
+      .fn()
+      .mockResolvedValue([{ assistant_id: "asst-1", graph_id: "test-graph" }]);
     (config.client as any).assistants.getGraph = vi.fn().mockResolvedValue({
       nodes: [{ id: "supervisor" }, { id: "hotels_agent" }],
       edges: [],
@@ -380,7 +394,10 @@ describe("subgraph change trigger", () => {
 
     const { agent, dispatched } = makeAgent(config);
     agent.threadId = "thread-1";
-    (agent as any).assistant = { assistant_id: "asst-1", graph_id: "test-graph" };
+    (agent as any).assistant = {
+      assistant_id: "asst-1",
+      graph_id: "test-graph",
+    };
     (agent as any).activeRun = {
       id: "run-1",
       nodeName: null,
@@ -442,7 +459,8 @@ describe("subgraph change trigger", () => {
           event: "on_chain_start",
           metadata: {
             langgraph_node: "hotels_agent",
-            langgraph_checkpoint_ns: "hotels_agent:abc|hotels_agent_chat_node:xyz",
+            langgraph_checkpoint_ns:
+              "hotels_agent:abc|hotels_agent_chat_node:xyz",
           },
         },
       },
@@ -462,7 +480,7 @@ describe("subgraph change trigger", () => {
     await driveAgent(agent, chunks);
 
     const snapCount = eventTypes(dispatched).filter(
-      (t) => t === EventType.MESSAGES_SNAPSHOT
+      (t) => t === EventType.MESSAGES_SNAPSHOT,
     ).length;
     expect(snapCount).toBeGreaterThanOrEqual(1);
   });
@@ -477,7 +495,8 @@ describe("subgraph change trigger", () => {
           event: "on_chain_start",
           metadata: {
             langgraph_node: "hotels_agent",
-            langgraph_checkpoint_ns: "hotels_agent:abc|hotels_agent_chat_node:xyz",
+            langgraph_checkpoint_ns:
+              "hotels_agent:abc|hotels_agent_chat_node:xyz",
           },
         },
       },
@@ -496,7 +515,9 @@ describe("subgraph change trigger", () => {
 
     await driveAgent(agent, chunks);
 
-    const snapshots = dispatched.filter((e) => e?.type === EventType.MESSAGES_SNAPSHOT);
+    const snapshots = dispatched.filter(
+      (e) => e?.type === EventType.MESSAGES_SNAPSHOT,
+    );
     expect(snapshots.length).toBeGreaterThanOrEqual(1);
 
     const first = snapshots[0];
@@ -512,7 +533,9 @@ describe("subgraph change trigger", () => {
     const getState = vi.mocked(config.client!.threads.getState);
     (agent as any).getStateSnapshot = vi
       .fn()
-      .mockImplementation((state: LangGraphThreadState<unknown>) => state.values);
+      .mockImplementation(
+        (state: LangGraphThreadState<unknown>) => state.values,
+      );
 
     const user = msg("u1", "human", "AMS to SF");
     const rootAssistant = msg("r1", "ai", "Root has current route");
@@ -631,9 +654,13 @@ describe("subgraph change trigger", () => {
     ]);
     (agent as any).getStateSnapshot = vi
       .fn()
-      .mockImplementation((state: LangGraphThreadState<unknown>) => state.values);
+      .mockImplementation(
+        (state: LangGraphThreadState<unknown>) => state.values,
+      );
 
-    const stopAfterExitBoundary = new Error("stop after exit boundary snapshot");
+    const stopAfterExitBoundary = new Error(
+      "stop after exit boundary snapshot",
+    );
     const chunks = [
       {
         event: "values",
@@ -729,7 +756,7 @@ describe("getState error propagation", () => {
     (agent as any).getStateSnapshot = vi.fn().mockReturnValue({});
 
     await expect(
-      (agent as any).getStateAndMessagesSnapshots("thread-1")
+      (agent as any).getStateAndMessagesSnapshots("thread-1"),
     ).rejects.toThrow("checkpoint unavailable");
   });
 });


### PR DESCRIPTION
## Summary

- build subgraph-boundary state and message snapshots from complete ordered root `values` state when it is available
- when an exit boundary has consumed those values, resolve the persisted root checkpoint associated with `langgraph_step - 1` instead of reading the moving thread head
- briefly retry an empty boundary-checkpoint lookup for default `async` durability, keep `sync` to one lookup, and fail explicitly for `exit`, where the checkpoint is not persisted mid-run
- retain `getState()` only when neither ordered state nor a boundary step is available
- cover future message and non-message leakage, root/subgraph scoping, fallback behavior, durability timing, bounded exhaustion, and error propagation

## Verification

- `NX_DAEMON=false NX_TUI=false NX_ISOLATE_PLUGINS=false pnpm nx run @ag-ui/langgraph:typecheck --skip-nx-cache`
- `NX_DAEMON=false NX_TUI=false NX_ISOLATE_PLUGINS=false pnpm nx run @ag-ui/langgraph:test --skip-nx-cache`
- `NX_DAEMON=false NX_TUI=false NX_ISOLATE_PLUGINS=false pnpm nx run @ag-ui/langgraph:build --skip-nx-cache`
- 19 test files passed; 288 tests passed, 2 todo; 26 focused subgraph-streaming tests passed
