### PR TITLE
fix(langgraph): keep non-image attachments non-image on the way back

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -68,12 +68,39 @@ def stringify_if_needed(item: Any) -> str:
         return item
     return json.dumps(item)
 
+_AGUI_MEDIA_BY_MIME_PREFIX = (
+    ("image/", ImageInputContent, "image"),
+    ("audio/", AudioInputContent, "audio"),
+    ("video/", VideoInputContent, "video"),
+)
+
+
+def _agui_media_for_mime(mime_type: str):
+    """Pick the AG-UI content class and ``type`` literal for a mime type.
+
+    Anything that is not image/audio/video is a document. That default is the
+    point: a mime type this adapter has never heard of is still not a picture,
+    and calling it one is what makes a client try to decode it as one.
+    """
+    for prefix, content_class, type_literal in _AGUI_MEDIA_BY_MIME_PREFIX:
+        if mime_type.startswith(prefix):
+            return content_class, type_literal
+    return DocumentInputContent, "document"
+
+
 def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[Union[TextInputContent, ImageInputContent]]:
     """Convert LangChain's multimodal content to AG-UI format.
 
-    LangChain only supports ``text`` and ``image_url`` content blocks.
-    ``image_url`` blocks are converted to ``ImageInputContent`` with the
-    appropriate source type (data or URL).
+    LangChain only supports ``text`` and ``image_url`` content blocks, so
+    EVERYTHING media-shaped left for LangChain as ``image_url`` regardless of
+    what it actually was (see ``convert_agui_multimodal_to_langchain``). The
+    mime type carried in a data URL is therefore the only surviving record of
+    the original modality, and reading it is what keeps a PDF a PDF across the
+    round trip.
+
+    A ``data:`` URL is mapped back to the content class its mime type belongs
+    to. A bare ``https://`` URL announces no mime type, so there is nothing to
+    decide on and it stays an image — the case that has always worked.
     """
     agui_content: List[Union[TextInputContent, ImageInputContent]] = []
     for item in content:
@@ -95,8 +122,9 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
                     data = parts[1] if len(parts) > 1 else ""
                     mime_type = header.split(":")[1].split(";")[0] if ":" in header else "image/png"
 
-                    agui_content.append(ImageInputContent(
-                        type="image",
+                    content_class, type_literal = _agui_media_for_mime(mime_type)
+                    agui_content.append(content_class(
+                        type=type_literal,
                         source=InputContentDataSource(
                             type="data",
                             value=data,

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -393,6 +393,79 @@ class TestMultimodalConversion(unittest.TestCase):
         self.assertEqual(agui_content[0].source.mime_type, "image/jpeg")
         self.assertEqual(agui_content[0].source.value, "/9j/4AAQ")
 
+    def test_langchain_pdf_data_url_to_agui_produces_document_input_content(self):
+        """A non-image data URL must come back as a DOCUMENT, not an image.
+
+        Everything media-shaped leaves for LangChain as an ``image_url`` block,
+        because that is the only media block LangChain takes. Coming back, the
+        mime type in the data URL is the only surviving record of what the
+        attachment actually was — so reading it is what keeps a PDF a PDF.
+        Answering ``image`` for ``application/pdf`` makes a client render the
+        attachment as a picture, which fails to decode and shows a broken image
+        where the document should be.
+        """
+        lc_content = [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:application/pdf;base64,JVBERi0xLjMK"}
+            },
+        ]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0], DocumentInputContent)
+        self.assertEqual(agui_content[0].type, "document")
+        self.assertIsInstance(agui_content[0].source, InputContentDataSource)
+        self.assertEqual(agui_content[0].source.mime_type, "application/pdf")
+        self.assertEqual(agui_content[0].source.value, "JVBERi0xLjMK")
+
+    def test_langchain_audio_data_url_to_agui_produces_audio_input_content(self):
+        """Same rule for audio: the mime type decides the modality."""
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "image_url", "image_url": {"url": "data:audio/mpeg;base64,SUQzBA"}},
+        ])
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0], AudioInputContent)
+        self.assertEqual(agui_content[0].source.mime_type, "audio/mpeg")
+
+    def test_langchain_video_data_url_to_agui_produces_video_input_content(self):
+        """Same rule for video."""
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "image_url", "image_url": {"url": "data:video/mp4;base64,AAAAIGZ0"}},
+        ])
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0], VideoInputContent)
+        self.assertEqual(agui_content[0].source.mime_type, "video/mp4")
+
+    def test_round_trip_document_survives_as_a_document(self):
+        """A document must still be a document after AG-UI -> LangChain -> AG-UI.
+
+        This is the defect as a user meets it: attach a PDF, and the run's echo
+        of the conversation turns it into an image.
+        """
+        original = [
+            DocumentInputContent(
+                type="document",
+                source=InputContentDataSource(
+                    type="data",
+                    value="JVBERi0xLjMK",
+                    mime_type="application/pdf",
+                ),
+            ),
+        ]
+
+        round_tripped = convert_langchain_multimodal_to_agui(
+            convert_agui_multimodal_to_langchain(original)
+        )
+
+        self.assertEqual(len(round_tripped), 1)
+        self.assertIsInstance(round_tripped[0], DocumentInputContent)
+        self.assertEqual(round_tripped[0].source.mime_type, "application/pdf")
+        self.assertEqual(round_tripped[0].source.value, "JVBERi0xLjMK")
+
     # ── Round-trip tests ────────────────────────────────────────────────
 
     def test_round_trip_langchain_url_to_agui_and_back(self):


### PR DESCRIPTION
Fixes #2489.

## The bug

Everything media-shaped leaves for LangChain as an `image_url` block, because that is the only media block LangChain takes. Coming back, `convert_langchain_multimodal_to_agui` rebuilt **every** one of them as `ImageInputContent` — so a PDF made the round trip as an image.

What makes it self-contradictory rather than merely lossy is that the mime type was already being parsed out of the data URL and stored on the source:

```python
ImageInputContent(type="image", source=...(mime_type="application/pdf"))
```

A client that switches on `type` renders that as a picture, the decode fails, and the user gets a broken image where their document should be. Confirmed in a CopilotKit app by sampling the attachment renderer's props through one run — correct at the composer (`document | application/pdf | invoice.pdf`), corrupted two seconds later when the run echoed the conversation back (`image | application/pdf | undefined`), and still broken after a reload because the persisted history is the corrupted form.

## The fix

Read the mime type the function already has, and pick the content class from it: `image/` → image, `audio/` → audio, `video/` → video, anything else → document.

Defaulting the unknown case to document is deliberate — a mime type this adapter has never heard of is still not a picture, and calling it one is what makes a client try to decode it as one.

Only the `data:` branch changes. A bare `https://` URL announces no mime type, so there is nothing to decide on and it stays an image, which is the case that already worked.

**Outbound is untouched**, so the model payload is byte-identical and stays spec-compliant for strict OpenAI-compatible providers (#2100).

## Tests

Four new tests in `tests/test_multimodal.py`, written before the fix and confirmed failing against `main` — the failure message was the bug verbatim:

```
AssertionError: ImageInputContent(type='image', source=InputContentDataSource(
  type='data', value='JVBERi0xLjMK', mime_type='application/pdf'))
  is not an instance of <class 'ag_ui.core.types.DocumentInputContent'>
```

- a PDF data URL comes back as `DocumentInputContent`
- an audio data URL comes back as `AudioInputContent`
- a video data URL comes back as `VideoInputContent`
- a document survives AG-UI → LangChain → AG-UI as a document

`401 passed` across the integration's full Python suite.

## Verified on a real app, not just unit tests

Applied to the adapter installed in a running CopilotKit banking demo and re-ran the attach-a-PDF beat end to end. Before: "Failed to load image". After: a proper `PDF · application/pdf` chip, and the agent's reply cites real content from the file ("the Meridian Creative invoice from page 1 under Marketing"), so the attachment is being read as well as rendered.

## Deliberately not fixed here

`InputContent.metadata` is still dropped outbound, so a document's **filename** does not survive the round trip — clients fall back to displaying the mime type. That is legible where a broken image was not, but restoring the filename means carrying it across the LangChain hop, which is the provider-compatibility question #2100 was about. Worth doing separately rather than smuggling it in behind a modality fix.
