### PR TITLE
fix(aws-strands): stage non-breaking CORS migration and add auth hook

### DIFF
--- a/integrations/aws-strands/ARCHITECTURE.md
+++ b/integrations/aws-strands/ARCHITECTURE.md
@@ -132,12 +132,12 @@ Helper utilities:
 
 The transport layer is intentionally lightweight:
 
-- `add_strands_fastapi_endpoint(app, agent, path)` registers a POST route that:
+- `add_strands_fastapi_endpoint(app, agent, path, auth=None)` registers a POST route that:
   - Accepts a `RunAgentInput` body.
   - Instantiates `EventEncoder` using the requester's `Accept` header to choose between SSE (`text/event-stream`) and newline-delimited JSON.
   - Streams whatever `StrandsAgent.run` yields, automatically encoding every AG-UI event.
   - Sends a `RunErrorEvent` with `code="ENCODING_ERROR"` if serialization fails mid-stream.
-- `create_strands_app(agent, path="/")` bootstraps a FastAPI application, adds permissive CORS middleware (allowing any origin/method/header so AG-UI localhost builds can connect), and mounts the agent route.
+- `create_strands_app(agent, path="/", ping_path="/ping", origins=None, auth=None, allow_methods=None, allow_headers=None, cors_enabled=None)` bootstraps a FastAPI application and mounts the agent route. For backward compatibility, an implicit wildcard CORS configuration remains available with a `FutureWarning`; callers can pass an exact `origins` allowlist, explicitly acknowledge wildcard access, or disable CORS with `cors_enabled=False`. An optional `auth` dependency guards the agent route (the ping route stays open for health probes).
 
 ### Packaging Surface (`src/ag_ui_strands/__init__.py`)
 
@@ -188,7 +188,7 @@ Behaviors the Python adapter does not currently implement, added to match TypeSc
 - **Multi-agent orchestrator mode** (`_runOrchestrator`): accepts a Strands `Graph` or `Swarm` in place of a single `Agent` and drives its `.stream()` directly. Per-thread caching, session managers, and proxy-tool sync are bypassed because orchestrators are stateless per invocation.
 - **`THREAD_BUSY` guard**: `_activeRunsByThread` rejects concurrent runs on the same thread with `RUN_ERROR { code: "THREAD_BUSY" }`. The TS SDK throws `"Agent is already processing an invocation"` if this isn't caught up front; Python's SDK has no equivalent collision.
 - **`AbortController` wiring**: the Strands `.stream()` call receives a `cancelSignal`; the transport's disconnect listener fires it so Bedrock stops streaming when the HTTP client drops.
-- **Request-boundary validation** (`addStrandsExpressEndpoint`): returns `415` for non-JSON `Content-Type`, `400` for bodies that fail the shared Zod `RunAgentInputSchema`, and normalizes snake_case top-level keys (`thread_id`, `run_id`, `parent_run_id`, `forwarded_props`) into camelCase before validating. FastAPI's Pydantic layer handles the equivalent on the Python side.
+- **Request-boundary validation** (`addStrandsExpressEndpoint`): returns `415` for non-JSON `Content-Type`, `400` for bodies that fail the shared Zod `RunAgentInputSchema`, and normalizes snake_case top-level keys (`thread_id`, `run_id`, `parent_run_id`, `forwarded_props`) into camelCase before validating. Python mirrors the media-type boundary in FastAPI: `_require_json_content_type` rejects missing or non-JSON-compatible `Content-Type` values with HTTP `415` before body/model validation, while Pydantic still handles the request body shape validation.
 - **Client-disconnect handling**: HTTP/1.1 `res.close` and HTTP/2 `req.aborted` both trigger `iterator.return()`, firing the agent generator's `finally` so the `_activeRunsByThread` slot releases and the Bedrock stream aborts.
 - **Protobuf content negotiation**: only selected when `Accept` explicitly contains `application/vnd.ag-ui.event+proto`; `*/*` or omitted Accept falls back to SSE.
 - **Capabilities endpoint** (`addCapabilities`, `DEFAULT_CAPABILITIES`, `capabilitiesFor`): optional `GET /capabilities` returning a static matrix of supported event families, transports, and protocol features so frontends don't have to probe empirically.
@@ -226,9 +226,9 @@ The repository includes seven runnable FastAPI apps that showcase different feat
 
 The TypeScript package ships the same seven Python examples under the matching filenames (`agentic-chat.ts`, `agentic-chat-reasoning.ts`, `agentic-chat-multimodal.ts`, `backend-tool-rendering.ts`, `shared-state.ts`, `agentic-generative-ui.ts`, `human-in-the-loop.ts`) plus one TypeScript-only addition:
 
-| Module                          | Focus                                                              |
-| ------------------------------- | ------------------------------------------------------------------ |
-| `tool-based-generative-ui.ts`   | Frontend-rendered tool (haiku card) auto-registered as a proxy tool — exercises the `TOOL_CALL_*` stream the dojo's `tool_based_generative_ui` page consumes. No Python equivalent. |
+| Module                        | Focus                                                                                                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tool-based-generative-ui.ts` | Frontend-rendered tool (haiku card) auto-registered as a proxy tool — exercises the `TOOL_CALL_*` stream the dojo's `tool_based_generative_ui` page consumes. No Python equivalent. |
 
 Each file is self-contained and can be run standalone (`pnpm <name>` from `examples/`). `examples/server/server.ts` is a "dojo" that mounts all eight at the paths the Python reference server uses, so both implementations can be driven by the same curl payloads.
 

--- a/integrations/aws-strands/ARCHITECTURE.md
+++ b/integrations/aws-strands/ARCHITECTURE.md
@@ -134,6 +134,7 @@ The transport layer is intentionally lightweight:
 
 - `add_strands_fastapi_endpoint(app, agent, path, auth=None)` registers a POST route that:
   - Accepts a `RunAgentInput` body.
+  - Evaluates the optional authentication dependency before parsing and validating that body.
   - Instantiates `EventEncoder` using the requester's `Accept` header to choose between SSE (`text/event-stream`) and newline-delimited JSON.
   - Streams whatever `StrandsAgent.run` yields, automatically encoding every AG-UI event.
   - Sends a `RunErrorEvent` with `code="ENCODING_ERROR"` if serialization fails mid-stream.

--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -96,7 +96,9 @@ app = create_strands_app(
 )
 ```
 
-The same `auth` argument is accepted by `add_strands_fastapi_endpoint`. The ping endpoint is left unauthenticated so load balancer and AgentCore health probes keep working.
+The same `auth` argument is accepted by `add_strands_fastapi_endpoint` and is
+evaluated before JSON decoding or model validation. The ping endpoint is left
+unauthenticated so load balancer and AgentCore health probes keep working.
 
 Agent POST requests must send a JSON-compatible `Content-Type`: either
 `application/json` or an `application/*+json` media type. Requests with a

--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -37,7 +37,7 @@ The integration has three main layers:
 - **Configuration** – `StrandsAgentConfig` + `ToolBehavior` + `PredictStateMapping` let you describe tool-specific quirks declaratively (skip message snapshots, emit state, stream args, send confirm actions, etc.).
 - **Transport helpers** – `create_strands_app` and `add_strands_fastapi_endpoint` expose the agent via SSE. They are thin shells over the shared `ag_ui.encoder.EventEncoder`.
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for diagrams and a deeper dive.
+See [ARCHITECTURE.md](../ARCHITECTURE.md) for diagrams and a deeper dive.
 
 ## Key Files
 
@@ -69,11 +69,45 @@ You can also use the helper functions `add_strands_fastapi_endpoint` and `add_pi
     add_ping(app, "/ping")
 ```
 
+## Securing the endpoint
+
+`create_strands_app` remains backward-compatible with earlier releases: when no
+CORS option is supplied it installs permissive wildcard CORS and emits a
+`FutureWarning`. Choose the intended policy explicitly to silence the warning:
+
+- Prefer an exact browser allowlist, e.g. `create_strands_app(agui_agent, origins=["http://localhost:3000"])`.
+- Pass `cors_enabled=False` for same-origin or server-to-server deployments that need no CORS middleware.
+- Pass `origins=["*"]` (or `cors_enabled=True`) to explicitly retain wildcard CORS for local development.
+- The implicit wildcard fallback will be removed in a future release.
+- The agent route has no authentication unless you pass an `auth` dependency:
+
+```python
+import os
+from fastapi import Header, HTTPException
+
+def require_token(authorization: str | None = Header(default=None)) -> None:
+    if authorization != f"Bearer {os.environ['AGENT_TOKEN']}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+app = create_strands_app(
+    agui_agent,
+    origins=["https://app.example"],
+    auth=require_token,
+)
+```
+
+The same `auth` argument is accepted by `add_strands_fastapi_endpoint`. The ping endpoint is left unauthenticated so load balancer and AgentCore health probes keep working.
+
+Agent POST requests must send a JSON-compatible `Content-Type`: either
+`application/json` or an `application/*+json` media type. Requests with a
+missing or non-JSON `Content-Type` are rejected with HTTP 415 before the agent
+runs.
+
 Requests to the AC endpoint must be authenticated. You can configure your agent runtime to accept JWT bearer tokens (via Amazon Cognito) or use SigV4. See [Set up authentication](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui.html) in the AgentCore documentation.
 
 For details on how AgentCore handles AG-UI requests, event streaming, and error formatting, see the [AG-UI protocol contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-agui-protocol-contract.html).
 
-To deploy, use the [AgentCore Starter Toolkit](https://github.com/awslabs/bedrock-agentcore-starter-toolkit):
+To deploy, use the [AgentCore Starter Toolkit](https://github.com/aws/bedrock-agentcore-starter-toolkit):
 
 ```bash
 pip install bedrock-agentcore-starter-toolkit

--- a/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
@@ -1,11 +1,16 @@
 """FastAPI endpoint utilities for AWS Strands integration."""
 
+import json
 from typing import Any, Callable, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
+from pydantic import ValidationError
+
 from ag_ui.core import RunAgentInput
 from ag_ui.encoder import EventEncoder
+
 from .agent import StrandsAgent
 
 
@@ -25,12 +30,46 @@ async def _require_json_content_type(request: Request) -> None:
         )
 
 
+async def _parse_run_agent_input(request: Request) -> RunAgentInput:
+    """Parse and validate the request body after route dependencies run."""
+    try:
+        body = await request.json()
+    except json.JSONDecodeError as exc:
+        raise RequestValidationError(
+            [
+                {
+                    "type": "json_invalid",
+                    "loc": ("body", exc.pos),
+                    "msg": "JSON decode error",
+                    "input": {},
+                    "ctx": {"error": exc.msg},
+                }
+            ],
+            body=exc.doc,
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="There was an error parsing the body",
+        ) from exc
+
+    try:
+        return RunAgentInput.model_validate(body)
+    except ValidationError as exc:
+        errors = []
+        for error in exc.errors():
+            request_error = dict(error)
+            request_error["loc"] = ("body", *error["loc"])
+            errors.append(request_error)
+        raise RequestValidationError(errors, body=body) from exc
+
+
 def add_strands_fastapi_endpoint(
     app: FastAPI,
     agent: StrandsAgent,
     path: str,
+    *,
     auth: Optional[Callable[..., Any]] = None,
-    **kwargs
 ) -> None:
     """Add a Strands agent endpoint to FastAPI app.
 
@@ -40,16 +79,32 @@ def add_strands_fastapi_endpoint(
         path: Path for the agent endpoint
         auth: Optional FastAPI dependency callable used to authenticate requests.
             It should raise ``fastapi.HTTPException`` to reject a request. The
-            endpoint is unauthenticated when this is ``None``.
+            endpoint is unauthenticated when this is ``None``. Authentication
+            runs before the request body is parsed and validated.
     """
 
-    dependencies = [Depends(_require_json_content_type)]
+    dependencies = []
     if auth is not None:
         dependencies.append(Depends(auth))
+    dependencies.append(Depends(_require_json_content_type))
 
-    @app.post(path, dependencies=dependencies)
-    async def strands_endpoint(input_data: RunAgentInput, request: Request):
+    @app.post(
+        path,
+        dependencies=dependencies,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": RunAgentInput.model_json_schema(by_alias=True)
+                    }
+                },
+            }
+        },
+    )
+    async def strands_endpoint(request: Request):
         """AWS Strands agent endpoint."""
+        input_data = await _parse_run_agent_input(request)
         accept_header = request.headers.get("accept")
         encoder = EventEncoder(accept=accept_header)
         

--- a/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/endpoint.py
@@ -1,20 +1,53 @@
 """FastAPI endpoint utilities for AWS Strands integration."""
 
-from fastapi import FastAPI, Request
+from typing import Any, Callable, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from ag_ui.core import RunAgentInput
 from ag_ui.encoder import EventEncoder
 from .agent import StrandsAgent
 
+
+async def _require_json_content_type(request: Request) -> None:
+    """Reject requests whose media type cannot carry JSON."""
+    content_type = request.headers.get("content-type")
+    media_type = content_type.split(";", 1)[0].strip().lower() if content_type else ""
+    is_json = media_type == "application/json"
+    is_structured_json = media_type.startswith("application/") and media_type.endswith(
+        "+json"
+    )
+
+    if not (is_json or is_structured_json):
+        raise HTTPException(
+            status_code=415,
+            detail="Content-Type must be application/json or application/*+json",
+        )
+
+
 def add_strands_fastapi_endpoint(
     app: FastAPI,
     agent: StrandsAgent,
     path: str,
+    auth: Optional[Callable[..., Any]] = None,
     **kwargs
 ) -> None:
-    """Add a Strands agent endpoint to FastAPI app."""
-    
-    @app.post(path)
+    """Add a Strands agent endpoint to FastAPI app.
+
+    Args:
+        app: FastAPI application instance
+        agent: The StrandsAgent instance
+        path: Path for the agent endpoint
+        auth: Optional FastAPI dependency callable used to authenticate requests.
+            It should raise ``fastapi.HTTPException`` to reject a request. The
+            endpoint is unauthenticated when this is ``None``.
+    """
+
+    dependencies = [Depends(_require_json_content_type)]
+    if auth is not None:
+        dependencies.append(Depends(auth))
+
+    @app.post(path, dependencies=dependencies)
     async def strands_endpoint(input_data: RunAgentInput, request: Request):
         """AWS Strands agent endpoint."""
         accept_header = request.headers.get("accept")

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -284,10 +284,11 @@ def create_strands_app(
                 app = create_strands_app(agent, auth=require_token)
 
             The ping endpoint stays unauthenticated so health probes keep working.
-        allow_methods: CORS methods to allow (default: ``["*"]`` for backward
-            compatibility).
-        allow_headers: CORS request headers to allow (default: ``["*"]`` for
-            backward compatibility).
+        allow_methods: CORS methods to allow. ``None`` defaults to ``["*"]``
+            for backward compatibility; ``[]`` allows none.
+        allow_headers: CORS request headers to allow. ``None`` defaults to
+            ``["*"]`` for backward compatibility; ``[]`` allows none beyond
+            CORS-safelisted request headers.
         cors_enabled: Explicit CORS switch. Pass ``False`` to add no CORS
             middleware, even if *origins* is supplied. Pass ``True`` to retain
             CORS explicitly; when *origins* is empty, this uses ``["*"]`` without
@@ -318,8 +319,8 @@ def create_strands_app(
             CORSMiddleware,
             allow_origins=cors_origins,
             allow_credentials=bool(origins) and not is_wildcard,
-            allow_methods=allow_methods or ["*"],
-            allow_headers=allow_headers or ["*"],
+            allow_methods=allow_methods if allow_methods is not None else ["*"],
+            allow_headers=allow_headers if allow_headers is not None else ["*"],
         )
 
     # Add the agent endpoint

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -4,7 +4,8 @@ import base64
 import logging
 import re
 import urllib.request
-from typing import Any, Dict, List, Optional, Set
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, urlsplit, urlunsplit
 
 from ag_ui.core import (
@@ -249,37 +250,80 @@ def create_strands_app(
     path: str = "/",
     ping_path: str | None = "/ping",
     origins: Optional[List[str]] = None,
+    auth: Optional[Callable[..., Any]] = None,
+    allow_methods: Optional[List[str]] = None,
+    allow_headers: Optional[List[str]] = None,
+    cors_enabled: Optional[bool] = None,
 ) -> "Any":
     """Create a FastAPI app with a single Strands agent endpoint and optional ping endpoint.
+
+    The agent endpoint is unauthenticated unless *auth* is supplied. For
+    backward compatibility, permissive wildcard CORS remains enabled when no
+    CORS option is supplied, but that implicit fallback emits a
+    :class:`FutureWarning` and will be removed in a future release.
 
     Args:
         agent: The StrandsAgent instance
         path: Path for the agent endpoint (default: "/")
         ping_path: Path for the ping endpoint (default: "/ping"). Pass None to disable.
-        origins: Allowed CORS origins. Defaults to ``["*"]`` (wildcard) for local
-            development. Credentials are only enabled when explicit, non-wildcard
-            origins are supplied — a wildcard origin can never be combined with
-            ``allow_credentials=True``.
+        origins: Allowed CORS origins. A non-empty list configures those origins
+            and silences the implicit-wildcard warning. ``None`` and ``[]``
+            preserve the legacy ``["*"]`` fallback. Pass the exact origins your
+            frontend is served from, e.g. ``["http://localhost:3000"]``, or pass
+            ``["*"]`` to explicitly acknowledge wildcard CORS. Credentials are
+            only enabled for explicit, non-wildcard origins — a wildcard origin
+            can never be combined with ``allow_credentials=True``.
+        auth: Optional FastAPI dependency callable used to authenticate requests
+            to the agent endpoint. It should raise
+            :class:`fastapi.HTTPException` to reject a request, e.g.::
+
+                def require_token(authorization: str | None = Header(default=None)):
+                    if authorization != f"Bearer {os.environ['AGENT_TOKEN']}":
+                        raise HTTPException(status_code=401, detail="Unauthorized")
+
+                app = create_strands_app(agent, auth=require_token)
+
+            The ping endpoint stays unauthenticated so health probes keep working.
+        allow_methods: CORS methods to allow (default: ``["*"]`` for backward
+            compatibility).
+        allow_headers: CORS request headers to allow (default: ``["*"]`` for
+            backward compatibility).
+        cors_enabled: Explicit CORS switch. Pass ``False`` to add no CORS
+            middleware, even if *origins* is supplied. Pass ``True`` to retain
+            CORS explicitly; when *origins* is empty, this uses ``["*"]`` without
+            emitting the implicit-wildcard warning. ``None`` preserves the
+            legacy behavior and warns when *origins* is empty.
     """
     from fastapi import FastAPI
     from .endpoint import add_strands_fastapi_endpoint, add_ping
 
     app = FastAPI(title=f"AWS Strands - {agent.name}")
 
-    # Add CORS middleware
-    from fastapi.middleware.cors import CORSMiddleware
-    cors_origins = origins or ["*"]
-    is_wildcard = "*" in cors_origins
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=cors_origins,
-        allow_credentials=bool(origins) and not is_wildcard,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    if cors_enabled is None and not origins:
+        warnings.warn(
+            "Implicit wildcard CORS is insecure and deprecated. Pass origins=[...] "
+            "to allow only trusted browser origins, origins=['*'] to explicitly "
+            "retain wildcard CORS, or cors_enabled=False to disable CORS. The "
+            "implicit wildcard default will be removed in a future release.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    # Preserve the legacy permissive CORS behavior unless explicitly disabled.
+    if cors_enabled is not False:
+        from fastapi.middleware.cors import CORSMiddleware
+        cors_origins = origins or ["*"]
+        is_wildcard = "*" in cors_origins
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=bool(origins) and not is_wildcard,
+            allow_methods=allow_methods or ["*"],
+            allow_headers=allow_headers or ["*"],
+        )
 
     # Add the agent endpoint
-    add_strands_fastapi_endpoint(app, agent, path)
+    add_strands_fastapi_endpoint(app, agent, path, auth=auth)
 
     # Add ping endpoint if path is provided
     if ping_path is not None:

--- a/integrations/aws-strands/python/tests/test_cors_and_auth.py
+++ b/integrations/aws-strands/python/tests/test_cors_and_auth.py
@@ -8,9 +8,11 @@ import warnings
 from types import SimpleNamespace
 
 import pytest
-from fastapi import Header, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.testclient import TestClient
 
+from ag_ui.core import EventType, RunStartedEvent
+from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
 from ag_ui_strands.utils import create_strands_app
 
 
@@ -185,6 +187,45 @@ class TestCorsDefaults:
         allowed = resp.headers.get("access-control-allow-headers", "").lower()
         assert "x-not-allowed" not in allowed
 
+    def test_empty_method_allowlist_rejects_every_method(self, agent):
+        client = TestClient(
+            create_strands_app(
+                agent,
+                origins=["https://app.example"],
+                allow_methods=[],
+            )
+        )
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+
+        assert resp.status_code == 400
+
+    def test_empty_header_allowlist_rejects_non_safelisted_headers(self, agent):
+        client = TestClient(
+            create_strands_app(
+                agent,
+                origins=["https://app.example"],
+                allow_headers=[],
+            )
+        )
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "x-not-allowed",
+            },
+        )
+
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # Content type
@@ -199,8 +240,11 @@ class _RecordingAgent:
 
     async def run(self, input_data):
         self.calls += 1
-        if False:
-            yield input_data
+        yield RunStartedEvent(
+            type=EventType.RUN_STARTED,
+            thread_id=input_data.thread_id,
+            run_id=input_data.run_id,
+        )
 
 
 _VALID_BODY = {
@@ -221,11 +265,16 @@ _VALID_BODY = {
 
 
 class TestContentType:
+    def test_endpoint_keeps_run_input_request_schema(self):
+        app = FastAPI()
+        add_strands_fastapi_endpoint(app, _RecordingAgent(), "/agent")
+
+        request_body = app.openapi()["paths"]["/agent"]["post"]["requestBody"]
+
+        assert request_body["required"] is True
+        assert "application/json" in request_body["content"]
+
     def test_missing_content_type_rejects_valid_body_before_agent_run(self):
-        from fastapi import FastAPI
-
-        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
-
         agent = _RecordingAgent()
         app = FastAPI()
         add_strands_fastapi_endpoint(app, agent, "/agent")
@@ -237,10 +286,6 @@ class TestContentType:
         assert resp.status_code == 415
 
     def test_non_json_content_type_rejects_valid_body_before_agent_run(self):
-        from fastapi import FastAPI
-
-        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
-
         agent = _RecordingAgent()
         app = FastAPI()
         add_strands_fastapi_endpoint(app, agent, "/agent")
@@ -260,10 +305,6 @@ class TestContentType:
         ["application/json", "application/vnd.ag-ui+json; charset=utf-8"],
     )
     def test_json_compatible_content_type_reaches_agent(self, content_type):
-        from fastapi import FastAPI
-
-        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
-
         agent = _RecordingAgent()
         app = FastAPI()
         add_strands_fastapi_endpoint(app, agent, "/agent")
@@ -290,26 +331,80 @@ def _require_token(authorization: str | None = Header(default=None)) -> None:
 
 
 class TestAuthHook:
-    def test_agent_endpoint_rejects_unauthenticated_request(self, agent):
+    def test_agent_endpoint_rejects_unauthenticated_request_before_agent_run(self):
+        agent = _RecordingAgent()
         client = TestClient(
             create_strands_app(agent, auth=_require_token, cors_enabled=False)
         )
 
-        resp = client.post("/", json={})
+        resp = client.post("/", json=_VALID_BODY)
 
         assert resp.status_code == 401
+        assert agent.calls == 0
 
-    def test_agent_endpoint_accepts_authenticated_request(self, agent):
+    def test_agent_endpoint_executes_authenticated_request(self):
+        agent = _RecordingAgent()
         client = TestClient(
             create_strands_app(agent, auth=_require_token, cors_enabled=False)
         )
 
         resp = client.post(
-            "/", json={}, headers={"Authorization": "Bearer secret"}
+            "/", json=_VALID_BODY, headers={"Authorization": "Bearer secret"}
         )
 
-        # Not 401: the auth hook passed and the request reached body validation.
-        assert resp.status_code != 401
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "text/event-stream; charset=utf-8"
+        assert resp.text == (
+            'data: {"type":"RUN_STARTED","threadId":"thread-1",'
+            '"runId":"run-1"}\n\n'
+        )
+        assert agent.calls == 1
+
+    def test_authentication_runs_before_json_body_parsing(self):
+        auth_calls = 0
+
+        def reject_request() -> None:
+            nonlocal auth_calls
+            auth_calls += 1
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        agent = _RecordingAgent()
+        client = TestClient(
+            create_strands_app(agent, auth=reject_request, cors_enabled=False)
+        )
+
+        resp = client.post(
+            "/",
+            content="{",
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert resp.status_code == 401
+        assert auth_calls == 1
+        assert agent.calls == 0
+
+    @pytest.mark.parametrize("body", ["{", "{}"])
+    def test_invalid_body_returns_422_after_successful_auth(self, body):
+        auth_calls = 0
+
+        def accept_request() -> None:
+            nonlocal auth_calls
+            auth_calls += 1
+
+        agent = _RecordingAgent()
+        client = TestClient(
+            create_strands_app(agent, auth=accept_request, cors_enabled=False)
+        )
+
+        resp = client.post(
+            "/",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert resp.status_code == 422
+        assert auth_calls == 1
+        assert agent.calls == 0
 
     def test_ping_stays_unauthenticated(self, agent):
         """The health probe must keep working for load balancers / AgentCore."""
@@ -319,18 +414,28 @@ class TestAuthHook:
 
         assert client.get("/ping").status_code == 200
 
-    def test_endpoint_helper_accepts_auth_dependency(self, agent):
-        from fastapi import FastAPI
-
-        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
-
+    def test_endpoint_helper_accepts_auth_dependency(self):
+        agent = _RecordingAgent()
         app = FastAPI()
         add_strands_fastapi_endpoint(app, agent, "/agent", auth=_require_token)
         client = TestClient(app)
 
-        assert client.post("/agent", json={}).status_code == 401
+        resp = client.post("/agent", json=_VALID_BODY)
 
-    def test_no_auth_by_default_is_unchanged(self, agent):
+        assert resp.status_code == 401
+        assert agent.calls == 0
+
+    def test_endpoint_helper_rejects_unknown_options(self, agent):
+        app = FastAPI()
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'ath'"):
+            add_strands_fastapi_endpoint(app, agent, "/agent", ath=_require_token)
+
+    def test_no_auth_by_default_is_unchanged(self):
+        agent = _RecordingAgent()
         client = TestClient(create_strands_app(agent, cors_enabled=False))
 
-        assert client.post("/", json={}).status_code != 401
+        resp = client.post("/", json=_VALID_BODY)
+
+        assert resp.status_code == 200
+        assert agent.calls == 1

--- a/integrations/aws-strands/python/tests/test_cors_and_auth.py
+++ b/integrations/aws-strands/python/tests/test_cors_and_auth.py
@@ -1,0 +1,336 @@
+"""Tests for CORS defaults, content-type enforcement, and authentication."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import warnings
+from types import SimpleNamespace
+
+import pytest
+from fastapi import Header, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_strands.utils import create_strands_app
+
+
+def _implicit_cors_warnings(caught):
+    return [
+        warning
+        for warning in caught
+        if issubclass(warning.category, FutureWarning)
+        and "Implicit wildcard CORS" in str(warning.message)
+    ]
+
+
+@pytest.fixture
+def agent():
+    return SimpleNamespace(name="test-agent")
+
+
+# ---------------------------------------------------------------------------
+# CORS defaults
+# ---------------------------------------------------------------------------
+
+
+class TestCorsDefaults:
+    def test_factory_exposes_explicit_cors_switch(self):
+        parameters = inspect.signature(create_strands_app).parameters
+
+        assert "cors_enabled" in parameters
+        assert parameters["cors_enabled"].default is None
+
+    def test_implicit_default_preserves_wildcard_origin(self, agent):
+        with pytest.warns(FutureWarning, match="Implicit wildcard CORS"):
+            client = TestClient(create_strands_app(agent))
+
+        resp = client.get("/ping", headers={"Origin": "https://evil.example"})
+
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") == "*"
+
+    def test_empty_origins_preserve_legacy_wildcard_origin(self, agent):
+        with pytest.warns(FutureWarning, match="Implicit wildcard CORS"):
+            client = TestClient(create_strands_app(agent, origins=[]))
+
+        resp = client.get("/ping", headers={"Origin": "https://evil.example"})
+
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") == "*"
+
+    def test_explicit_origin_is_allowed(self, agent):
+        client = TestClient(create_strands_app(agent, origins=["https://app.example"]))
+
+        resp = client.get("/ping", headers={"Origin": "https://app.example"})
+
+        assert resp.headers.get("access-control-allow-origin") == "https://app.example"
+
+    def test_other_origin_still_rejected_when_allowlist_set(self, agent):
+        client = TestClient(create_strands_app(agent, origins=["https://app.example"]))
+
+        resp = client.get("/ping", headers={"Origin": "https://evil.example"})
+
+        assert resp.headers.get("access-control-allow-origin") is None
+
+    def test_wildcard_remains_available_as_explicit_opt_in(self, agent):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = TestClient(create_strands_app(agent, origins=["*"]))
+
+        assert _implicit_cors_warnings(caught) == []
+
+        resp = client.get("/ping", headers={"Origin": "https://anything.example"})
+
+        assert resp.headers.get("access-control-allow-origin") == "*"
+        # A wildcard origin must never be paired with credentials.
+        assert resp.headers.get("access-control-allow-credentials") is None
+
+    def test_explicit_cors_disable_adds_no_middleware_or_warning(self, agent):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = TestClient(create_strands_app(agent, cors_enabled=False))
+
+        assert _implicit_cors_warnings(caught) == []
+
+        resp = client.get("/ping", headers={"Origin": "https://evil.example"})
+
+        assert resp.status_code == 200
+        assert resp.headers.get("access-control-allow-origin") is None
+
+    def test_explicit_cors_enable_acknowledges_wildcard(self, agent):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = TestClient(create_strands_app(agent, cors_enabled=True))
+
+        assert _implicit_cors_warnings(caught) == []
+
+        resp = client.get("/ping", headers={"Origin": "https://anything.example"})
+
+        assert resp.headers.get("access-control-allow-origin") == "*"
+
+    def test_existing_origin_configuration_keeps_wildcard_methods(self, agent):
+        client = TestClient(create_strands_app(agent, origins=["https://app.example"]))
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "DELETE",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+
+        assert resp.status_code == 200
+        allowed = resp.headers.get("access-control-allow-methods", "")
+        assert "DELETE" in allowed
+
+    def test_existing_origin_configuration_keeps_wildcard_headers(self, agent):
+        client = TestClient(create_strands_app(agent, origins=["https://app.example"]))
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "x-not-allowed",
+            },
+        )
+
+        assert resp.status_code == 200
+        allowed = resp.headers.get("access-control-allow-headers", "").lower()
+        assert "x-not-allowed" in allowed
+
+    def test_explicit_method_allowlist_rejects_unlisted_method(self, agent):
+        client = TestClient(
+            create_strands_app(
+                agent,
+                origins=["https://app.example"],
+                allow_methods=["POST"],
+            )
+        )
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "DELETE",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+
+        assert resp.status_code == 400
+        allowed = resp.headers.get("access-control-allow-methods", "")
+        assert "DELETE" not in allowed
+        assert "POST" in allowed
+
+    def test_explicit_header_allowlist_rejects_unlisted_header(self, agent):
+        client = TestClient(
+            create_strands_app(
+                agent,
+                origins=["https://app.example"],
+                allow_headers=["Content-Type"],
+            )
+        )
+
+        resp = client.options(
+            "/",
+            headers={
+                "Origin": "https://app.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "x-not-allowed",
+            },
+        )
+
+        assert resp.status_code == 400
+        allowed = resp.headers.get("access-control-allow-headers", "").lower()
+        assert "x-not-allowed" not in allowed
+
+
+# ---------------------------------------------------------------------------
+# Content type
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAgent:
+    name = "test-agent"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def run(self, input_data):
+        self.calls += 1
+        if False:
+            yield input_data
+
+
+_VALID_BODY = {
+    "threadId": "thread-1",
+    "runId": "run-1",
+    "state": {},
+    "messages": [
+        {
+            "id": "message-1",
+            "role": "user",
+            "content": "hello",
+        }
+    ],
+    "tools": [],
+    "context": [],
+    "forwardedProps": {},
+}
+
+
+class TestContentType:
+    def test_missing_content_type_rejects_valid_body_before_agent_run(self):
+        from fastapi import FastAPI
+
+        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
+
+        agent = _RecordingAgent()
+        app = FastAPI()
+        add_strands_fastapi_endpoint(app, agent, "/agent")
+        client = TestClient(app)
+
+        resp = client.post("/agent", content=json.dumps(_VALID_BODY))
+
+        assert agent.calls == 0
+        assert resp.status_code == 415
+
+    def test_non_json_content_type_rejects_valid_body_before_agent_run(self):
+        from fastapi import FastAPI
+
+        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
+
+        agent = _RecordingAgent()
+        app = FastAPI()
+        add_strands_fastapi_endpoint(app, agent, "/agent")
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent",
+            content=json.dumps(_VALID_BODY),
+            headers={"Content-Type": "text/plain"},
+        )
+
+        assert agent.calls == 0
+        assert resp.status_code == 415
+
+    @pytest.mark.parametrize(
+        "content_type",
+        ["application/json", "application/vnd.ag-ui+json; charset=utf-8"],
+    )
+    def test_json_compatible_content_type_reaches_agent(self, content_type):
+        from fastapi import FastAPI
+
+        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
+
+        agent = _RecordingAgent()
+        app = FastAPI()
+        add_strands_fastapi_endpoint(app, agent, "/agent")
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent",
+            content=json.dumps(_VALID_BODY),
+            headers={"Content-Type": content_type},
+        )
+
+        assert resp.status_code == 200
+        assert agent.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Authentication hook
+# ---------------------------------------------------------------------------
+
+
+def _require_token(authorization: str | None = Header(default=None)) -> None:
+    if authorization != "Bearer secret":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+class TestAuthHook:
+    def test_agent_endpoint_rejects_unauthenticated_request(self, agent):
+        client = TestClient(
+            create_strands_app(agent, auth=_require_token, cors_enabled=False)
+        )
+
+        resp = client.post("/", json={})
+
+        assert resp.status_code == 401
+
+    def test_agent_endpoint_accepts_authenticated_request(self, agent):
+        client = TestClient(
+            create_strands_app(agent, auth=_require_token, cors_enabled=False)
+        )
+
+        resp = client.post(
+            "/", json={}, headers={"Authorization": "Bearer secret"}
+        )
+
+        # Not 401: the auth hook passed and the request reached body validation.
+        assert resp.status_code != 401
+
+    def test_ping_stays_unauthenticated(self, agent):
+        """The health probe must keep working for load balancers / AgentCore."""
+        client = TestClient(
+            create_strands_app(agent, auth=_require_token, cors_enabled=False)
+        )
+
+        assert client.get("/ping").status_code == 200
+
+    def test_endpoint_helper_accepts_auth_dependency(self, agent):
+        from fastapi import FastAPI
+
+        from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
+
+        app = FastAPI()
+        add_strands_fastapi_endpoint(app, agent, "/agent", auth=_require_token)
+        client = TestClient(app)
+
+        assert client.post("/agent", json={}).status_code == 401
+
+    def test_no_auth_by_default_is_unchanged(self, agent):
+        client = TestClient(create_strands_app(agent, cors_enabled=False))
+
+        assert client.post("/", json={}).status_code != 401


### PR DESCRIPTION
Refs #2433

`create_strands_app` builds a FastAPI app around a Strands agent. This PR adds
an authentication hook and a staged migration away from its implicit wildcard
CORS policy without silently breaking existing cross-origin clients.

> **Migration scope:** this PR deliberately does not flip the existing
> wildcard default or close #2433. It provides explicit controls, a deprecation
> warning, and request-boundary defenses so consumers can migrate before that
> default changes in a future breaking release.

Thanks @ez-lbz for the report, and for separating this from #2432. The issues
compound, but they require different defenses.

## What was happening

The factory always installed CORS middleware with wildcard origins, methods,
and headers. It also mounted the agent route without an authentication hook.
Any browser origin could therefore invoke an unauthenticated deployment and
read its SSE output.

Separately, supported FastAPI versions can parse a valid JSON body without a
JSON `Content-Type`. On an app without permissive CORS, that lets a hostile page
send a simple, non-preflighted request that invokes the agent even though the
page cannot read the response.

## What changes

- **Compatibility-preserving CORS migration** — omitted `origins`,
  `origins=None`, and `origins=[]` retain the existing wildcard origins,
  methods, and headers. That implicit fallback now emits a visible
  `FutureWarning` explaining how to choose a policy explicitly.
- **Explicit CORS policies** — callers can pass an exact `origins` allowlist,
  acknowledge wildcard access with `origins=["*"]` or `cors_enabled=True`, or
  disable CORS middleware with `cors_enabled=False`. Optional `allow_methods`
  and `allow_headers` arguments support narrower policies without changing the
  legacy defaults; explicitly empty method or header allowlists remain empty
  instead of falling back to wildcards.
- **Authentication hook** — `create_strands_app(..., auth=...)` and
  `add_strands_fastapi_endpoint(..., auth=...)` accept a FastAPI dependency that
  guards the agent route before JSON decoding and model validation. The ping
  route stays open for health probes.
- **Fail-closed endpoint configuration** — `auth` is keyword-only and unknown
  endpoint-helper options raise `TypeError`, preventing an authentication typo
  from silently registering an unauthenticated route.
- **JSON media-type enforcement** — the agent endpoint accepts
  `application/json` and `application/*+json`; missing or incompatible content
  types return HTTP 415 before the agent runs. This applies to custom FastAPI
  apps that use `add_strands_fastapi_endpoint`, too.
- **Documentation** — README and architecture guidance describe the migration,
  explicit CORS choices, authentication, and the future default change.

## Compatibility and security posture

Existing CORS behavior is preserved in this release, including for callers
that explicitly pass `None` or an empty `origins` list. The pre-existing
positional `app`, `agent`, and `path` arguments retain their meanings. Unknown
endpoint-helper keyword arguments, which were previously accepted and ignored,
now fail closed so misspelled security configuration cannot be silently lost.

The strict JSON media-type check is intentionally observable: clients that
send JSON without a JSON-compatible `Content-Type` now receive HTTP 415 and
must add the correct header.

Implicit wildcard CORS remains unsafe during the migration period. The warning
does not claim otherwise: deployments should pass an exact allowlist, disable
CORS for same-origin or server-to-server use, and configure authentication as
appropriate. A separately drafted follow-up updates every Python example to
choose its CORS policy explicitly before the default is changed in a future
breaking release.

Equivalent TypeScript authentication and configurable CORS work is tracked
separately in #2514. The original report in #2433 and this PR are scoped to the
Python factory; #1931 addressed a narrower TypeScript origin-reflection bug.

## Tests

`integrations/aws-strands/python/tests/test_cors_and_auth.py` covers:

- preserved wildcard behavior for omitted, `None`, and empty origins;
- warnings for implicit wildcard use and no warning for explicit choices;
- explicit CORS disable, allowlists, wildcard acknowledgement, method/header
  overrides, and empty allowlists that do not fail open;
- authentication before body parsing, exact successful SSE output, zero agent
  calls for rejected requests, fail-closed unknown options, and an
  unauthenticated ping route; and
- rejection of missing/non-JSON content types before agent invocation, plus
  acceptance of standard and structured JSON media types while retaining the
  OpenAPI request-body schema.

Verification on Python 3.13:

- Targeted CORS/auth/content-type tests: 28 passed on both locked FastAPI and
  the declared FastAPI 0.115.12 floor.
- Full package suite: 451 passed, 2 skipped.
- Wheel and source distribution build successfully.
- Diff whitespace check passes.

## Checklist

- [x] Regression tests were observed failing before implementation.
- [x] Existing CORS behavior remains compatible.
- [x] Full package suite passes.
- [x] Package distributions build successfully.
- [x] Lockfile and dependency constraints are unchanged.
