### PR TITLE
fix(mastra): raise the core and client peer floors to 0.0.58

### DIFF
--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -63,8 +63,8 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@ag-ui/core": ">=0.0.44",
-    "@ag-ui/client": ">=0.0.44",
+    "@ag-ui/core": ">=0.0.58",
+    "@ag-ui/client": ">=0.0.58",
     "@copilotkit/runtime": "^1.60.1",
     "@mastra/client-js": ">=1.0.0-0 <2.0.0-0",
     "@mastra/core": ">=1.29.0 <2.0.0-0"

--- a/integrations/mastra/typescript/src/__tests__/peer-dependencies.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/peer-dependencies.test.ts
@@ -1,0 +1,61 @@
+import pkg from "../../package.json";
+
+/**
+ * Regression guard for #2418.
+ *
+ * In the workspace, `@ag-ui/core` and `@ag-ui/client` resolve through
+ * `workspace:*` devDependencies, so CI never exercises the floor declared in
+ * `peerDependencies`. A consumer installing `@ag-ui/mastra` from npm resolves
+ * that floor instead — if it is lower than the version that actually exports
+ * the symbols `src/` imports, the package fails to load at require time.
+ *
+ * `tokenUsageFromAiSdkUsage` (imported by src/mastra.ts) first ships in
+ * `@ag-ui/core@0.0.58`, so the declared floors must not admit anything older.
+ */
+const MIN_CORE = "0.0.58";
+const MIN_CLIENT = "0.0.58";
+
+/** Minimum version admitted by a `>=x.y.z` range. */
+function floorOf(range: string): string {
+  const match = /^>=\s*(\d+\.\d+\.\d+)$/.exec(range.trim());
+  if (!match) {
+    throw new Error(
+      `Expected a ">=x.y.z" peer range so the floor can be checked, got "${range}"`,
+    );
+  }
+  return match[1];
+}
+
+function compare(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+describe("peer dependency floors (#2418)", () => {
+  it("declares an @ag-ui/core floor that exports every symbol src/ imports", () => {
+    const range = pkg.peerDependencies["@ag-ui/core"];
+    expect(compare(floorOf(range), MIN_CORE)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("declares an @ag-ui/client floor that exports every symbol src/ imports", () => {
+    const range = pkg.peerDependencies["@ag-ui/client"];
+    expect(compare(floorOf(range), MIN_CLIENT)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not declare a floor above the workspace version under test", () => {
+    // The floors must stay reachable: a floor newer than what the workspace
+    // builds and tests against would be untested by CI.
+    const coreVersion = require("@ag-ui/core/package.json").version;
+    const clientVersion = require("@ag-ui/client/package.json").version;
+    expect(
+      compare(floorOf(pkg.peerDependencies["@ag-ui/core"]), coreVersion),
+    ).toBeLessThanOrEqual(0);
+    expect(
+      compare(floorOf(pkg.peerDependencies["@ag-ui/client"]), clientVersion),
+    ).toBeLessThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Fixes #2418

`@ag-ui/mastra` declares the `@ag-ui/core` and `@ag-ui/client` versions it needs as peer dependencies. This raises both floors to the version that actually contains the symbols the package imports.

Thanks @ozzaii for the report, and for pinning it to the exact symbol. That made it verifiable rather than a guess.

## What was happening

`npm view @ag-ui/mastra@1.1.2 peerDependencies` returns `>=0.0.44` for both. `src/mastra.ts` imports `tokenUsageFromAiSdkUsage`, so an install that resolves core anywhere below the version that ships it fails to load.

I packed and inspected core 0.0.55, 0.0.56, 0.0.57 and 0.0.58 rather than trusting the changelog: the symbol is absent through 0.0.57 and first ships in 0.0.58, which is also current latest.

CI does not catch this because the workspace resolves `@ag-ui/core` through a `workspace:*` devDependency, so the declared floor is never exercised.

## The change

Both floors go to `>=0.0.58` in `integrations/mastra/typescript/package.json`. `pnpm install --frozen-lockfile` succeeds with no lockfile change. Grepping every non-`node_modules` package.json, these were the only two stale `>=0.0.44` floors left in the repo.

## Tests

`src/__tests__/peer-dependencies.test.ts`, 3 tests. Rather than a lint check, it parses the declared floors out of the package's own `package.json` and asserts the core floor is at least 0.0.58, the client floor is at least 0.0.58, and neither floor exceeds the workspace version actually under test, so a floor cannot be over-bumped past what CI exercises either. It deliberately does not pin to "current core version", which would break on every unrelated core release.

309 → 312 passed across 21 files. `@mastra/core@1.47.0`, `@ag-ui/core@0.0.58` (workspace), vitest 4.0.18. `tsc --noEmit` clean, `prettier --check` clean.

Mutation-checked: restoring both floors to `>=0.0.44` fails 2 tests, overshooting both to `>=0.0.99` fails the over-bump guard, restoring `>=0.0.58` passes all 312.

## Checklist

- [x] Regression test written first
- [x] Fix makes it pass
- [x] Full package suite passes
- [x] Build succeeds
- [x] Lockfile unchanged
