### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+At **AG-UI**, we are continuously working to improve not only the project but also the open-source repository. To achieve this, we encourage you to take some time to responsibly disclose any issues you may encounter.
+
+## Reporting a Vulnerability
+
+We hope this project meets your expectations. However, if you notice anything that seems off, please feel free to report the issue by following the steps below:
+
+1. **Contact Information**:
+   - Email: [security@copilotkit.ai](mailto:security@copilotkit.ai)
+
+2. **Required Information**:
+   - A detailed description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact or risk
+   - Any possible mitigations or workarounds
+
+3. **Preferred Method of Disclosure**:
+   <br>
+   Since our community operates in a public domain, please **do not** discuss the details of the vulnerability publicly. When escalating the issue, simply mention that you are trying to reach someone from the security team.
+
+## Response Process
+
+- **Acknowledgment**: Within 48 hours of receiving your report, we will acknowledge your submission.
+- **Investigation**: We will investigate the issue within 5 business days.
+- **Resolution**: We aim to release a fix or mitigation within 30 days of confirming the vulnerability.
+
+### Note
+
+**If you do not receive an acknowledgment of your email within 48 hours, and you haven’t heard from our security team after 5 days, please directly message an AG-UI maintainer in our [Discord community](https://discord.gg/v6hxWPPyN).**
+
+## Security Best Practices
+
+While we strive to keep our project secure, here are a few best practices for users of our software:
+
+- Always keep your installation up to date with the latest security patches.
+- Avoid using outdated or unsupported versions of the project.
+- Regularly audit your dependencies and review their security advisories.
+
+---
+
+Thank you for helping us maintain the security and integrity of this project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-At **AG-UI**, we are continuously working to improve not only the project but also the open-source repository. To achieve this, we encourage you to take some time to responsibly disclose any issues you may encounter.
+At **CopilotKit**, we are continuously working to improve not only the project but also the open-source repository. To achieve this, we encourage you to take some time to responsibly disclose any issues you may encounter.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

- add an AG-UI security policy based on CopilotKit's disclosure process
- direct vulnerability reports to `security@copilotkit.ai`
- provide the AG-UI Discord community as the fallback escalation path

## Verification

- `pnpm nx format:check --files=SECURITY.md`
- Nx affected lint, typecheck, test, and build checks reported no applicable tasks
- `npx --yes markdown-link-check SECURITY.md`
