### PR TITLE
fix(c++): count the per-event accumulator against the SSE buffer cap

### DIFF
--- a/sdks/community/c++/src/stream/sse_parser.cpp
+++ b/sdks/community/c++/src/stream/sse_parser.cpp
@@ -4,8 +4,12 @@
 namespace agui {
 
 void SseParser::feed(const std::string& chunk) {
-    // Check buffer size limit to prevent memory exhaustion
-    if (m_buffer.size() + chunk.size() > kMaxBufferSize) {
+    // Check buffer size limit to prevent memory exhaustion.
+    // m_currentData is included because processBuffer() erases consumed bytes
+    // from m_buffer, so a single unterminated event delivered as many small
+    // chunks would otherwise keep m_buffer small while the per-event
+    // accumulator grew without bound.
+    if (m_buffer.size() + m_currentData.size() + chunk.size() > kMaxBufferSize) {
         throw SseBufferExceededError(
             "SSE buffer size exceeded maximum limit of " + 
             std::to_string(kMaxBufferSize / (1024 * 1024)) + " MB");

--- a/sdks/community/c++/tests/test_sse_parser.cpp
+++ b/sdks/community/c++/tests/test_sse_parser.cpp
@@ -463,3 +463,20 @@ TEST(SseParserTest, BufferSizeExactlyAtLimit) {
     
     EXPECT_NO_THROW(parser.feed(exactLimitData));
 }
+
+TEST(SseParserTest, EventAccumulatorSizeExceeded) {
+    SseParser parser;
+
+    // A single event whose data is never terminated by a blank line, delivered
+    // as many small chunks. Each chunk is consumed out of m_buffer immediately,
+    // so the buffer stays small while the per-event accumulator keeps growing.
+    const size_t kChunkPayload = 64 * 1024;
+    const std::string chunk = "data: " + std::string(kChunkPayload, 'A') + "\n";
+    const size_t iterations = (SseParser::kMaxBufferSize / kChunkPayload) + 8;
+
+    EXPECT_THROW({
+        for (size_t i = 0; i < iterations; ++i) {
+            parser.feed(chunk);
+        }
+    }, SseBufferExceededError);
+}


### PR DESCRIPTION
The C++ SDK's SSE parser now counts the per-event accumulator against its size limit, so a peer that never terminates an event cannot grow memory without bound.

Thanks @ez-lbz. The report drew the distinction that matters here, which is easy to miss reading the code: the cap looked present and correct, and only failed for the buffer it was not watching.

## Sequence

`SseParser::feed` measured `kMaxBufferSize` against `m_buffer` only. `processBuffer` erases consumed bytes as it goes, so `m_buffer` stays small by design. Data lines are appended to `m_currentData`, which is only cleared when a blank line ends the event. A stream that sends data lines and never a blank line therefore keeps `m_buffer` under the cap on every chunk while `m_currentData` grows for as long as the connection lasts.

## Change

One line in `sse_parser.cpp`: the limit check includes `m_currentData.size()`. Retained bytes across both buffers are now bounded, worst case roughly twice the cap within a single oversized chunk.

## The second half of the issue is not addressed here

The report also covers `nlohmann::json::parse` running with the default unlimited-depth recursive parser. That is real, and there are **two** call sites rather than the one named: `src/agent/http_agent.cpp:389` and `src/core/subscriber.cpp:746`.

Leaving it out is deliberate. nlohmann exposes no depth limit, so bounding depth means a custom SAX handler or a pre-scan at both sites, plus a decision on what the limit should be and what error to raise. Worth knowing for whoever picks it up: in C++ this overflows the stack and segfaults rather than throwing, so the existing `catch (nlohmann::json::parse_error&)` at `http_agent.cpp:390` cannot catch it. That is a design call rather than a contained fix, so it stays open.

## Tests

New `SseParserTest.EventAccumulatorSizeExceeded` feeds 64 KB data-line chunks with no terminating blank line. It fails before the change and passes after.

`test_sse_parser` 33 → 34, full ctest suite 11/11 both before and after. Apple clang 17.0.0 (arm64-apple-darwin25.3.0), CMake 4.4.2, nlohmann_json 3.12.0, googletest 1.18.0, libcurl 8.7.1.

Mutation-checked: reverting the accumulator out of the check fails the new test, and widening the cap 100x fails both `BufferSizeExceeded` and the new test.

## Checklist

- [x] Failing test written first
- [x] Fix makes it pass
- [x] Full ctest suite passes
- [x] Build succeeds

Refs #2440