### PR TITLE
fix(adk-middleware): avoid session scan for direct thread IDs

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/session_manager.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/session_manager.py
@@ -317,11 +317,11 @@ class SessionManager:
         user_id: str,
         thread_id: str
     ) -> Optional[Any]:
-        """Find existing session by thread_id stored in session state.
+        """Find an existing session for an AG-UI thread ID.
 
-        This is the recovery path after middleware restart. Since we always let
-        the backend generate session_id, we can only find existing sessions by
-        searching their state for _ag_ui_thread_id.
+        When thread IDs are also session IDs, use a direct lookup. Otherwise,
+        recover backend-generated session IDs by scanning session state for
+        _ag_ui_thread_id.
 
         Args:
             app_name: Application name
@@ -331,6 +331,9 @@ class SessionManager:
         Returns:
             Session object if found, None otherwise
         """
+        if self._use_thread_id_as_session_id:
+            return await self.get_session(thread_id, app_name, user_id)
+
         if hasattr(self._session_service, 'list_sessions'):
             try:
                 response = await self._session_service.list_sessions(

--- a/integrations/adk-middleware/python/tests/test_use_thread_id_as_session_id.py
+++ b/integrations/adk-middleware/python/tests/test_use_thread_id_as_session_id.py
@@ -87,6 +87,55 @@ class TestSessionManagerDirectLookup:
             spy.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_find_session_by_thread_id_uses_direct_lookup(
+        self, manager, session_service
+    ):
+        """Cold-cache recovery should look up the thread ID without scanning."""
+        await manager.get_or_create_session(
+            thread_id="thread-cold-cache",
+            app_name="app1",
+            user_id="user1",
+        )
+
+        with (
+            patch.object(
+                session_service,
+                "get_session",
+                wraps=session_service.get_session,
+            ) as get_session,
+            patch.object(
+                session_service,
+                "list_sessions",
+                wraps=session_service.list_sessions,
+            ) as list_sessions,
+            patch.object(
+                manager,
+                "_cache_session",
+                wraps=manager._cache_session,
+            ) as cache_session,
+        ):
+            session = await manager._find_session_by_thread_id(
+                app_name="app1",
+                user_id="user1",
+                thread_id="thread-cold-cache",
+            )
+
+        assert session is not None
+        assert session.id == "thread-cold-cache"
+        get_session.assert_awaited_once_with(
+            session_id="thread-cold-cache",
+            app_name="app1",
+            user_id="user1",
+        )
+        list_sessions.assert_not_called()
+        cache_session.assert_called_once_with(
+            "thread-cold-cache",
+            "app1",
+            "user1",
+            session,
+        )
+
+    @pytest.mark.asyncio
     async def test_stores_thread_id_in_state(self, manager, session_service):
         """Even with direct lookup, thread_id metadata is stored in state."""
         session, _ = await manager.get_or_create_session(


### PR DESCRIPTION
## Summary

- make `_find_session_by_thread_id` use an O(1) `get_session` lookup when `use_thread_id_as_session_id=True`
- preserve the existing `list_sessions` recovery path for backend-generated session IDs
- verify the direct path avoids `list_sessions` and still populates the session read cache through `_cache_session`, matching the scan path

## Testing

- `uv run pytest tests/test_use_thread_id_as_session_id.py -q` (18 passed)
- `uv run python -m compileall -q src/ag_ui_adk/session_manager.py tests/test_use_thread_id_as_session_id.py`

Fixes #2207