### PR TITLE
fix(client): add configurable agent error logger

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
@@ -45,9 +45,11 @@ describe("AbstractAgent cloning", () => {
 
 describe("HttpAgent cloning", () => {
   it("produces a new HttpAgent with cloned configuration and abort controller", () => {
+    const logger = { error: () => undefined };
     const httpAgent = new HttpAgent({
       url: "https://example.com/agent",
       headers: { Authorization: "Bearer token" },
+      logger,
       threadId: "thread-http",
       initialMessages: [
         {
@@ -73,6 +75,7 @@ describe("HttpAgent cloning", () => {
     expect(cloned.messages).not.toBe(httpAgent.messages);
     expect(cloned.state).toEqual(httpAgent.state);
     expect(cloned.state).not.toBe(httpAgent.state);
+    expect((cloned as unknown as { logger: typeof logger }).logger).toBe(logger);
     expect(cloned.abortController).not.toBe(httpAgent.abortController);
     expect(cloned.abortController).toBeInstanceOf(AbortController);
     expect(cloned.abortController.signal.aborted).toBe(true);

--- a/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/subscriber.test.ts
@@ -501,6 +501,33 @@ describe("AgentSubscriber", () => {
 
       consoleErrorSpy.mockRestore();
     });
+
+    it("should use the configured logger when default error behavior runs", async () => {
+      class ErrorAgent extends AbstractAgent {
+        run(input: RunAgentInput): Observable<BaseEvent> {
+          return from([
+            {
+              type: EventType.RUN_STARTED,
+              threadId: input.threadId,
+              runId: input.runId,
+            } as RunStartedEvent,
+          ]).pipe(mergeMap(() => throwError(() => new Error("Test error"))));
+        }
+      }
+
+      const logger = {
+        error: vi.fn(),
+      };
+      const errorAgent = new ErrorAgent({ logger });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      await expect(errorAgent.runAgent({})).rejects.toThrow("Test error");
+
+      expect(logger.error).toHaveBeenCalledWith("Agent execution failed:", expect.any(Error));
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe("subscriber order and chaining", () => {

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -11,6 +11,7 @@ import {
 import {
   AgentConfig,
   AgentDebugConfig,
+  AgentLogger,
   RunAgentParameters,
   ResolvedAgentDebugConfig,
   resolveAgentDebugConfig,
@@ -59,6 +60,7 @@ export abstract class AbstractAgent {
   public state: State;
   private _debug: ResolvedAgentDebugConfig;
   private _debugLogger: DebugLogger | undefined;
+  private logger: AgentLogger | undefined;
   public subscribers: AgentSubscriber[] = [];
   public isRunning: boolean = false;
   /** Interrupts emitted by the most recent run that have not yet been resolved.
@@ -104,6 +106,7 @@ export abstract class AbstractAgent {
     initialMessages,
     initialState,
     debug,
+    logger,
   }: AgentConfig = {}) {
     this.agentId = agentId;
     this.description = description ?? "";
@@ -112,6 +115,7 @@ export abstract class AbstractAgent {
     this.state = structuredClone_(initialState ?? {});
     this._debug = resolveAgentDebugConfig(debug);
     this._debugLogger = createDebugLogger(this._debug);
+    this.logger = logger;
 
     if (compareVersions(this.maxVersion, "0.0.39") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_39());
@@ -529,7 +533,11 @@ export abstract class AbstractAgent {
             error.message === "component unmounted" ||
             errStr === "component unmounted";
           if (!isAbort) {
-            console.error("Agent execution failed:", error);
+            if (this.logger) {
+              this.logger.error("Agent execution failed:", error);
+            } else {
+              console.error("Agent execution failed:", error);
+            }
             throw error;
           }
         }
@@ -588,6 +596,7 @@ export abstract class AbstractAgent {
     cloned.state = structuredClone_(this.state);
     cloned._debug = this._debug;
     cloned._debugLogger = this._debugLogger;
+    cloned.logger = this.logger;
     cloned.isRunning = this.isRunning;
     cloned.subscribers = [...this.subscribers];
     cloned.middlewares = [...this.middlewares];

--- a/sdks/typescript/packages/client/src/agent/index.ts
+++ b/sdks/typescript/packages/client/src/agent/index.ts
@@ -3,6 +3,7 @@ export type { RunAgentResult } from "./agent";
 export { HttpAgent } from "./http";
 export type {
   AgentConfig,
+  AgentLogger,
   HttpAgentConfig,
   HttpAgentFetchFn,
   RunAgentParameters,

--- a/sdks/typescript/packages/client/src/agent/types.ts
+++ b/sdks/typescript/packages/client/src/agent/types.ts
@@ -30,6 +30,11 @@ export function resolveAgentDebugConfig(
   return { enabled: events || lifecycle, events, lifecycle, verbose };
 }
 
+/** Injectable error logger used by the agent execution lifecycle. */
+export interface AgentLogger {
+  error(message: string, ...args: unknown[]): void;
+}
+
 export interface AgentConfig {
   agentId?: string;
   description?: string;
@@ -37,6 +42,8 @@ export interface AgentConfig {
   initialMessages?: Message[];
   initialState?: State;
   debug?: AgentDebugConfig;
+  /** Receives agent execution errors. Defaults to `console.error`. */
+  logger?: AgentLogger;
 }
 
 export type HttpAgentFetchFn = (url: string, requestInit: RequestInit) => Promise<Response>;


### PR DESCRIPTION
## Summary

- Add an exported `AgentLogger` interface with an `error(message, ...args)` method.
- Add an optional `logger` property to `AgentConfig`.
- Route unexpected agent execution errors through the configured logger.
- Preserve `console.error` as the default fallback.
- Preserve the configured logger when cloning an agent.
- Add regression coverage for custom error logging and clone behavior.

Existing error lifecycle behavior remains unchanged: subscriber handling, abort suppression, `stopPropagation`, and error rethrowing continue to work as before.

Closes #2360

## Test plan

- [x] Custom logger receives unexpected agent execution errors.
- [x] `console.error` is not called when a custom logger is configured.
- [x] The original error is still rethrown.
- [x] Cloned agents retain the configured logger.
- [x] `NX_DAEMON=false pnpm nx affected -t lint typecheck test build --outputStyle=static`
- [x] Nx successfully completed lint, typecheck, test, and build for 36 projects and one dependent task.