### PR TITLE
fix(aws-strands): name the frontend tool via the wire->native map

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1959,19 +1959,30 @@ class StrandsAgent:
                 for msg in reversed(input_data.messages):
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
-                        if tool_name is None:
+                        # An entry in the durable wire->native map is only ever
+                        # recorded when a frontend tool call is emitted, so its
+                        # presence proves this result came from a client-executed
+                        # tool. A backend tool never has one: its wire id IS the
+                        # native id.
+                        _native_id = wire_to_native.get(msg.tool_call_id)
+                        if tool_name is None and _native_id:
                             # A frontend tool is emitted under a fresh wire id, so
                             # the name recovered from native session history above is
                             # keyed by the native ``toolUseId`` instead. Translate
                             # through the durable map and retry. Kept as a fallback
                             # rather than translating up front: when the assistant
                             # message IS in the payload the lookup is already keyed
-                            # by the wire id, and a backend tool has no wire entry at
-                            # all because its wire id is the native id.
-                            _native_id = wire_to_native.get(msg.tool_call_id)
-                            if _native_id:
-                                tool_name = _tool_call_id_to_name.get(_native_id)
-                        if tool_name and tool_name in frontend_tool_names:
+                            # by the wire id.
+                            tool_name = _tool_call_id_to_name.get(_native_id)
+                        # Provenance is either signal, not membership alone: a
+                        # continuation that declares no tools (``tools: []``) still
+                        # carries a real frontend result, and reading membership
+                        # alone would file it as a backend result and hand the model
+                        # an empty prompt — the very loop this derivation prevents.
+                        _is_frontend_result = bool(tool_name) and (
+                            tool_name in frontend_tool_names or bool(_native_id)
+                        )
+                        if _is_frontend_result:
                             # Forward the ACTUAL result so the model can act on the
                             # human's decision (e.g. an approval resolving to
                             # {"approved": false}). Hardcoding a success string here
@@ -2011,10 +2022,11 @@ class StrandsAgent:
                                     f"{tool_name} executed successfully with no return value."
                                 )
                         elif tool_name:
-                            # Named, but not client-declared: this result
-                            # belongs to a tool Strands ran itself, so the
-                            # model already has it in the native history and
-                            # the continuation prompt has nothing to carry.
+                            # Named, but neither signal says frontend: not in
+                            # the current declarations and no wire-map entry.
+                            # That is a tool Strands ran itself, so the model
+                            # already has it in the native history and the
+                            # continuation prompt has nothing to carry.
                             logger.debug(
                                 f"Skipping non-frontend tool result in the continuation "
                                 f"message: tool_name={tool_name}, "

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1887,6 +1887,22 @@ class StrandsAgent:
                     last_msg_had_tool_calls = False
                     strands_messages.append(strands_msg)
 
+            # The durable wire->native map recorded at emission, read back from
+            # session state (restored from the store on a fresh process). Read
+            # here rather than at the reconciliation block below because the
+            # continuation-message derivation needs it too: on a delta-only
+            # payload the tool result arrives under the wire id, while the tool
+            # name is only known under the native one.
+            wire_to_native: Dict[str, str] = {}
+            reconciliation_setup_error: Exception | None = None
+            if session_manager is not None:
+                try:
+                    wire_to_native = (
+                        strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
+                    )
+                except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
+                    reconciliation_setup_error = e
+
             # Build a lookup of tool_call_id -> tool_name from the input messages
             # directly (the assistant message in Run 2 already carries the name).
             _tool_call_id_to_name: dict = {}
@@ -1930,6 +1946,18 @@ class StrandsAgent:
                 for msg in reversed(input_data.messages):
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
+                        if tool_name is None:
+                            # A frontend tool is emitted under a fresh wire id, so
+                            # the name recovered from native session history above is
+                            # keyed by the native ``toolUseId`` instead. Translate
+                            # through the durable map and retry. Kept as a fallback
+                            # rather than translating up front: when the assistant
+                            # message IS in the payload the lookup is already keyed
+                            # by the wire id, and a backend tool has no wire entry at
+                            # all because its wire id is the native id.
+                            _native_id = wire_to_native.get(msg.tool_call_id)
+                            if _native_id:
+                                tool_name = _tool_call_id_to_name.get(_native_id)
                         if tool_name and tool_name in frontend_tool_names:
                             # Forward the ACTUAL result so the model can act on the
                             # human's decision (e.g. an approval resolving to
@@ -2055,18 +2083,6 @@ class StrandsAgent:
             # result when its tool name is client-declared, or (for delta-only
             # payloads that omit the assistant message) when its wire id was
             # recorded in the wire->native map when the call was emitted.
-            # The durable wire->native map recorded at emission, read back from
-            # session state (restored from the store on a fresh process).
-            wire_to_native: Dict[str, str] = {}
-            reconciliation_setup_error: Exception | None = None
-            if session_manager is not None:
-                try:
-                    wire_to_native = (
-                        strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-                    )
-                except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
-                    reconciliation_setup_error = e
-
             # The durable per-``toolUseId`` call metadata map recorded at
             # emission (see the ``current_tool_use`` handler). On a RESUME
             # run this is the ONLY source of ``{name, args, input,

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -330,6 +330,18 @@ def _interrupt_resume_error(message: str) -> "RunErrorEvent":
     )
 
 
+def _continuation_tool_name_error(tool_call_ids: list) -> "RunErrorEvent":
+    return RunErrorEvent(
+        type=EventType.RUN_ERROR,
+        message=(
+            "Cannot name the tool behind continuation tool result(s) "
+            f"{', '.join(tool_call_ids)}: absent from the input messages, from "
+            "the native session history, and from the wire->native map"
+        ),
+        code="CONTINUATION_TOOL_NAME_UNRESOLVED",
+    )
+
+
 def _preflight_resume_entries(
     agent: Any,
     resume_entries: Any,
@@ -1943,6 +1955,7 @@ class StrandsAgent:
                 # frontend-tool turn sends N results in one continuation run; the model
                 # must see every answer.
                 _result_parts: list[str] = []
+                _unresolved_result_ids: list[str] = []
                 for msg in reversed(input_data.messages):
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
@@ -1971,27 +1984,67 @@ class StrandsAgent:
                                 if isinstance(msg.content, str)
                                 else flatten_content_to_text(msg.content)
                             )
-                            if result_text and result_text.strip():
+                            # A client-reported failure carries its reason on
+                            # ``error``, and an empty ``content`` alongside it
+                            # is normal. Reading ``content`` alone announces
+                            # that failure to the model as "executed
+                            # successfully with no return value" — the same
+                            # inversion the toolResult ``status`` mapping
+                            # avoids on the native path, which this text
+                            # prompt replaces whenever replay and
+                            # reconciliation are both off.
+                            error_text = getattr(msg, "error", None)
+                            if error_text:
+                                if result_text and result_text.strip():
+                                    _result_parts.append(
+                                        f"{tool_name} failed: {error_text} "
+                                        f"(returned: {result_text})"
+                                    )
+                                else:
+                                    _result_parts.append(
+                                        f"{tool_name} failed: {error_text}"
+                                    )
+                            elif result_text and result_text.strip():
                                 _result_parts.append(f"{tool_name} returned: {result_text}")
                             else:
                                 _result_parts.append(
                                     f"{tool_name} executed successfully with no return value."
                                 )
+                        elif tool_name:
+                            # Named, but not client-declared: this result
+                            # belongs to a tool Strands ran itself, so the
+                            # model already has it in the native history and
+                            # the continuation prompt has nothing to carry.
+                            logger.debug(
+                                f"Skipping non-frontend tool result in the continuation "
+                                f"message: tool_name={tool_name}, "
+                                f"tool_call_id={msg.tool_call_id}"
+                            )
                         else:
-                            # Could not resolve this tool's name from input messages
-                            # or session history (e.g. a delta-only payload with no
-                            # assistant tool_calls). Skip it rather than guessing:
-                            # picking an arbitrary frontend tool would feed false
-                            # context to the LLM when several frontend tools exist.
-                            # Strands still has the real result in session history to
-                            # conclude the round-trip from.
+                            # Neither the input messages, nor the native
+                            # session history, nor the durable wire->native
+                            # map name this call. Guessing stays off the
+                            # table: with several frontend tools declared,
+                            # picking one feeds the model false context.
+                            # Collected here and raised as a run error below
+                            # rather than skipped — skipping is what left the
+                            # prompt empty, and an empty prompt is the re-fire
+                            # loop this derivation exists to prevent.
+                            _unresolved_result_ids.append(msg.tool_call_id)
                             logger.warning(
                                 f"Could not resolve tool name for tool_call_id={msg.tool_call_id} "
                                 f"from input messages or session history (delta-only payload). "
-                                f"Skipping this tool result in the continuation message."
+                                f"Failing the run instead of prompting the model with no result."
                             )
                     else:
                         break
+                if _unresolved_result_ids:
+                    # Fail closed: without a name there is no result context
+                    # to give the model, and invoking it with an empty prompt
+                    # is exactly how the same frontend tool gets re-fired
+                    # every run (issue #2376).
+                    yield _continuation_tool_name_error(list(reversed(_unresolved_result_ids)))
+                    return
                 user_message = "\n".join(reversed(_result_parts))
             elif input_data.messages:
                 for msg in reversed(input_data.messages):

--- a/integrations/aws-strands/python/tests/test_interrupt.py
+++ b/integrations/aws-strands/python/tests/test_interrupt.py
@@ -1272,6 +1272,25 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
 async def test_non_active_reconciliation_exception_keeps_legacy_fallback(caplog):
     core = _MockStrandsCore(session_manager=_repository_manager())
     core.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-proxy": "native-proxy"})
+    # The wire map above points ``wire-proxy`` at a native call, so the native
+    # history has to contain that call. Without the ``toolUse`` block the
+    # fixture maps onto a call that exists nowhere and the continuation cannot
+    # name the tool at all — which is a separate failure from the reconcile
+    # exception this test is about.
+    core.messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "native-proxy",
+                        "name": "approveTool",
+                        "input": {},
+                    }
+                }
+            ],
+        }
+    ]
     agent = _make_base_agent(StrandsAgentConfig())
     input_data = _make_run_input(
         messages=[

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -63,7 +63,7 @@ async def _empty_async_gen():
     yield  # pragma: no cover — makes this an async generator
 
 
-def _make_base_agent(session_manager_provider=None) -> StrandsAgent:
+def _make_base_agent(session_manager_provider=None, **config_kwargs) -> StrandsAgent:
     """Create a StrandsAgent with a mocked underlying Strands agent."""
     mock_core = MagicMock()
     mock_core.model = MagicMock()
@@ -72,7 +72,9 @@ def _make_base_agent(session_manager_provider=None) -> StrandsAgent:
     mock_core.tool_registry.registry = {}
     mock_core.record_direct_tool_call = True
 
-    config = StrandsAgentConfig(session_manager_provider=session_manager_provider)
+    config = StrandsAgentConfig(
+        session_manager_provider=session_manager_provider, **config_kwargs
+    )
     return StrandsAgent(agent=mock_core, name="test_agent", config=config)
 
 
@@ -402,6 +404,102 @@ class TestFrontendToolContinuation:
         assert "Hello" not in instance.stream_prompts
 
 
+    @pytest.mark.asyncio
+    async def test_delta_only_continuation_resolves_name_through_wire_map(self):
+        """A frontend tool is emitted under a FRESH wire id, so the native
+        history that carries its name is keyed by the native ``toolUseId``.
+        The durable wire->native map is the only bridge between them; without
+        consulting it the derivation misses and the model is handed an empty
+        prompt, then re-fires the same tool (issue #2376)."""
+        mock_session_manager = _mock_session_manager()
+        provider = MagicMock(return_value=mock_session_manager)
+        agent = _make_base_agent(session_manager_provider=provider)
+
+        tools = [_frontend_tool("setBackground"), _frontend_tool("setForeground")]
+        input_data = RunAgentInput(
+            thread_id="thread-delta",
+            run_id="run-2",
+            state={},
+            messages=[
+                ToolMessage(
+                    id="t1",
+                    role="tool",
+                    content='{"approved": true}',
+                    tool_call_id="wire-1",
+                ),
+            ],
+            tools=tools,
+            context=[],
+            forwarded_props={},
+        )
+
+        # Native history knows the call under the native id only.
+        session_history = [
+            {"role": "user", "content": [{"text": "make it blue"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "native-1",
+                            "name": "setBackground",
+                            "input": {"color": "blue"},
+                        }
+                    }
+                ],
+            },
+        ]
+        instance = _MockSessionAgentWithHistory(
+            mock_session_manager, messages=session_history
+        )
+        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-1"})
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert instance.stream_prompts == [
+            'setBackground returned: {"approved": true}'
+        ]
+
+    @pytest.mark.asyncio
+    async def test_delta_only_continuation_keeps_degrading_when_wire_map_misses(self):
+        """The wire map is a fallback, not a guess: an id it does not hold is
+        still skipped rather than matched to some other recorded call."""
+        mock_session_manager = _mock_session_manager()
+        provider = MagicMock(return_value=mock_session_manager)
+        agent = _make_base_agent(session_manager_provider=provider)
+
+        tools = [_frontend_tool("setBackground"), _frontend_tool("setForeground")]
+        input_data = _delta_continuation_input(tools)
+
+        session_history = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "native-1",
+                            "name": "setBackground",
+                            "input": {},
+                        }
+                    }
+                ],
+            },
+        ]
+        instance = _MockSessionAgentWithHistory(
+            mock_session_manager, messages=session_history
+        )
+        # The map holds a different call; ``call-xyz`` from the payload is absent.
+        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-other": "native-1"})
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert instance.stream_prompts == [""]
+
+
 class _MockSessionAgentReal:
     """Session-manager-backed mock exposing a real ``session_manager`` (public
     attribute, like ``StrandsAgentCore``) plus an ``agent_id`` and native
@@ -490,11 +588,15 @@ def _result_content(sm, agent_id, index):
     return persisted[index].message["content"]
 
 
-async def _run_session_continuation(sm, agent_id, messages, tools, wire_map, store):
+async def _run_session_continuation(
+    sm, agent_id, messages, tools, wire_map, store, config_kwargs=None
+):
     """Drive run() for a continuation and return the mock agent instance."""
     _seed_session(sm, agent_id, store)
     provider = MagicMock(return_value=sm)
-    agent = _make_base_agent(session_manager_provider=provider)
+    agent = _make_base_agent(
+        session_manager_provider=provider, **(config_kwargs or {})
+    )
     input_data = RunAgentInput(
         thread_id=sm.session_id,
         run_id="run-2",
@@ -627,6 +729,31 @@ class TestSessionFrontendToolReconciliation:
         assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
             {"text": '{"approved": false}'}
         ]
+
+    @pytest.mark.asyncio
+    async def test_legacy_continuation_names_the_tool_when_replay_is_disabled(
+        self, tmp_path
+    ):
+        """The configuration from issue #2376: the same delta-only continuation
+        with ``replay_history_into_strands=False``. The reconcile branch is
+        gated on that flag and the replay branch is off whenever a session
+        manager exists, so ``stream_async(user_message)`` is the only channel
+        left. Naming the tool there requires translating the wire id through
+        the map; without it the model is prompted with ``""`` and re-fires the
+        same call."""
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-noreplay", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[_payload_tool("wire-1", '{"approved": false}')],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
+            config_kwargs={"replay_history_into_strands": False},
+        )
+        assert instance.stream_prompts == ['approve returned: {"approved": false}']
 
     @pytest.mark.parametrize(
         "content", ["tool failed: invalid id", ""], ids=["with-text", "empty"]

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -819,6 +819,52 @@ class TestSessionFrontendToolReconciliation:
         assert "executed successfully" not in instance.stream_prompts[0]
 
     @pytest.mark.parametrize(
+        ("content", "error", "expected"),
+        [
+            pytest.param(
+                '{"approved": false}',
+                None,
+                'approve returned: {"approved": false}',
+                id="normal-result",
+            ),
+            pytest.param(
+                "",
+                "invalid id",
+                "approve failed: invalid id",
+                id="empty-content-error",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_wire_map_hit_is_frontend_provenance_without_declarations(
+        self, tmp_path, content, error, expected
+    ):
+        """A continuation that declares no tools still carries a real
+        frontend result. Membership in ``input_data.tools`` is not the only
+        proof of provenance: the durable wire->native entry is recorded when
+        the call is emitted, so it establishes the same thing by itself.
+        Reading membership alone files the result as a backend one and hands
+        the model ``""`` — the re-fire loop this derivation exists to stop."""
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(
+            session_id="thread-no-declarations", storage_dir=str(tmp_path)
+        )
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[_payload_tool("wire-1", content, error=error)],
+            tools=[],
+            wire_map={"wire-1": "native-1"},
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1"),
+            ],
+            config_kwargs={"replay_history_into_strands": False},
+        )
+        assert instance.stream_prompts == [expected]
+
+    @pytest.mark.parametrize(
         "content", ["tool failed: invalid id", ""], ids=["with-text", "empty"]
     )
     @pytest.mark.asyncio

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -333,6 +333,17 @@ def _frontend_tool(name: str) -> Tool:
     return Tool(name=name, description=f"{name} tool", parameters={})
 
 
+def _assert_continuation_name_error(events: list, tool_call_ids: list) -> None:
+    """An unnameable continuation result ends the run on a structured error
+    naming the offending ids, and never on a success outcome."""
+    errors = [event for event in events if event.type == EventType.RUN_ERROR]
+    assert len(errors) == 1
+    assert errors[0].code == "CONTINUATION_TOOL_NAME_UNRESOLVED"
+    for tool_call_id in tool_call_ids:
+        assert tool_call_id in errors[0].message
+    assert not any(event.type == EventType.RUN_FINISHED for event in events)
+
+
 class TestFrontendToolContinuation:
     """Regression tests for the 'Hello' injection on delta-only frontend-tool
     continuation runs (PR #1761)."""
@@ -341,7 +352,11 @@ class TestFrontendToolContinuation:
     async def test_delta_only_continuation_does_not_inject_hello(self):
         """Session-manager path + delta-only trailing tool message + missing
         assistant tool_calls: ``stream_async`` must NOT receive ``"Hello"``,
-        and must not guess an arbitrary frontend tool when several exist."""
+        and must not guess an arbitrary frontend tool when several exist.
+
+        Both guarantees now hold in their strongest form: with no name
+        recoverable from anywhere, the run fails closed and the model is
+        never invoked at all, instead of being prompted with ``""``."""
         mock_session_manager = _mock_session_manager()
         provider = MagicMock(return_value=mock_session_manager)
         agent = _make_base_agent(session_manager_provider=provider)
@@ -354,14 +369,17 @@ class TestFrontendToolContinuation:
         instance = _MockSessionAgentWithHistory(mock_session_manager, messages=[])
         with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
             MockCore.return_value = instance
-            await _collect_events(agent, input_data)
+            events = await _collect_events(agent, input_data)
 
-        assert instance.stream_prompts == [""]
+        # The model is not prompted at all, which subsumes #1761's two
+        # guards; they are kept so the original regression stays visible.
+        assert instance.stream_prompts == []
         assert "Hello" not in instance.stream_prompts
         # No arbitrary frontend tool name leaked into the prompt.
         assert not any(
             "executed successfully" in (p or "") for p in instance.stream_prompts
         )
+        _assert_continuation_name_error(events, ["call-xyz"])
 
     @pytest.mark.asyncio
     async def test_delta_only_continuation_resolves_name_from_session_history(self):
@@ -463,9 +481,12 @@ class TestFrontendToolContinuation:
         ]
 
     @pytest.mark.asyncio
-    async def test_delta_only_continuation_keeps_degrading_when_wire_map_misses(self):
+    async def test_delta_only_continuation_fails_closed_when_wire_map_misses(self):
         """The wire map is a fallback, not a guess: an id it does not hold is
-        still skipped rather than matched to some other recorded call."""
+        never matched to some other recorded call. With no name there is no
+        result context to carry, so the run fails closed rather than calling
+        the model with ``""`` — that empty prompt is the original trigger for
+        re-firing the same frontend tool every run (#2376)."""
         mock_session_manager = _mock_session_manager()
         provider = MagicMock(return_value=mock_session_manager)
         agent = _make_base_agent(session_manager_provider=provider)
@@ -495,9 +516,10 @@ class TestFrontendToolContinuation:
 
         with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
             MockCore.return_value = instance
-            await _collect_events(agent, input_data)
+            events = await _collect_events(agent, input_data)
 
-        assert instance.stream_prompts == [""]
+        assert instance.stream_prompts == []
+        _assert_continuation_name_error(events, ["call-xyz"])
 
 
 class _MockSessionAgentReal:
@@ -754,6 +776,47 @@ class TestSessionFrontendToolReconciliation:
             config_kwargs={"replay_history_into_strands": False},
         )
         assert instance.stream_prompts == ['approve returned: {"approved": false}']
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            pytest.param(
+                "denied by policy",
+                "approve failed: invalid id (returned: denied by policy)",
+                id="with-text",
+            ),
+            pytest.param("", "approve failed: invalid id", id="empty"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_client_failure_is_not_prompted_as_success_when_replay_is_disabled(
+        self, tmp_path, content, expected
+    ):
+        """With replay and reconciliation both off, the synthetic prompt is
+        the only channel to the model, and a failure whose body is empty is
+        the common shape. Deriving the prompt from ``content`` alone reports
+        it as "executed successfully with no return value" — the same
+        inversion the toolResult ``status`` mapping already prevents on the
+        native path."""
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(
+            session_id="thread-noreplay-err", storage_dir=str(tmp_path)
+        )
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[_payload_tool("wire-1", content, error="invalid id")],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1"),
+            ],
+            config_kwargs={"replay_history_into_strands": False},
+        )
+        assert instance.stream_prompts == [expected]
+        assert "executed successfully" not in instance.stream_prompts[0]
 
     @pytest.mark.parametrize(
         "content", ["tool failed: invalid id", ""], ids=["with-text", "empty"]


### PR DESCRIPTION
Fixes #2376.

## The bug

On a delta-only continuation the client sends the frontend tool result under the wire `tool_call_id`. The tool name is recoverable only from the native session history, which is keyed by the native `toolUseId`, so the lookup at the derivation site missed and the result was skipped with a warning. `user_message` stayed `""`, and `stream_async("")` gave the model nothing to act on, so it re-fired the same tool on every run.

Skipping on a miss is deliberate and stays that way: guessing a tool name would feed the model false context when several frontend tools exist. What was missing is the one lookup that is not a guess.

## Why the existing safety net does not cover it

The comment at the skip says Strands still has the real result in session history. That holds on the replay path and on the reconcile path, but both can be off at once:

- `replay_history` is `False` whenever a session manager is present (`agent.py:2197`).
- `reconcile_session_results` requires `replay_history_into_strands` to be `True`, or a resume run (`agent.py:2202-2214`).

With `replay_history_into_strands=False` and a session manager — the configuration in the report — neither runs, and `stream_async(user_message)` is the only channel left. The same happens with a session manager that does not expose the repository rewrite API, because `_supports_repository_reconciliation` then fails closed.

## The change

`agent.py` reads the durable wire->native map (`AG_UI_WIRE_MAP_STATE_KEY`) before the derivation, instead of only at the reconciliation block below it. There is no `state.get` or `state.set` between the old position and the new one, so the move preserves behaviour.

At the lookup, the id as sent is tried first and the translated native id only as a fallback. This differs from the plan I posted on the issue, on purpose: translating up front would break payloads that do carry the assistant message, since `_tool_call_id_to_name` is keyed by the wire id there. Backend tools are unaffected either way, because their wire id is the native id.

## Tests

Three tests in `tests/test_session_manager.py`:

- `test_delta_only_continuation_resolves_name_through_wire_map` — the wire id differs from the native id, the map is in agent state, the native history holds the name; the prompt must carry the real result.
- `test_legacy_continuation_names_the_tool_when_replay_is_disabled` — the reported configuration end to end, with a real `FileSessionManager` and `replay_history_into_strands=False`.
- `test_delta_only_continuation_keeps_degrading_when_wire_map_misses` — an id the map does not hold still yields `""` and the warning, so the fallback cannot turn into a guess.

On the pre-existing coverage: `test_delta_only_continuation_resolves_name_from_session_history` passes today only because its fixture uses the same value for the wire id and the native `toolUseId`, which a real frontend tool never has. That is why the gap went unnoticed.

`_make_base_agent` and `_run_session_continuation` take optional config kwargs so the reported flag can be set. Existing callers are unchanged.

## Checks

`pytest` in `integrations/aws-strands/python`: 426 passed, 2 skipped. Removing the fallback fails exactly the two positive tests, both with `assert [''] == [...]` — the empty prompt from the report.
