### PR TITLE
fix: make zod and rxjs peer dependencies

### DIFF
--- a/integrations/a2a/typescript/package.json
+++ b/integrations/a2a/typescript/package.json
@@ -39,12 +39,12 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.2.2",
-    "rxjs": "7.8.1"
+    "@a2a-js/sdk": "^0.2.2"
   },
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.42",
-    "@ag-ui/client": ">=0.0.42"
+    "@ag-ui/client": ">=0.0.42",
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -55,6 +55,7 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "rxjs": "7.8.1"
   }
 }

--- a/integrations/adk-middleware/typescript/package.json
+++ b/integrations/adk-middleware/typescript/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.55",
     "@ag-ui/client": ">=0.0.55",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -43,7 +43,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "rxjs": "7.8.1"
   },
   "repository": {
     "type": "git",

--- a/integrations/ag2/typescript/package.json
+++ b/integrations/ag2/typescript/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -40,7 +40,8 @@
     "publint": "^0.3.12",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/agno/typescript/package.json
+++ b/integrations/agno/typescript/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -45,7 +45,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/claude-agent-sdk/typescript/package.json
+++ b/integrations/claude-agent-sdk/typescript/package.json
@@ -29,15 +29,14 @@
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },
-  "dependencies": {
-    "rxjs": "7.8.1"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.42",
     "@ag-ui/core": ">=0.0.42",
     "@anthropic-ai/claude-agent-sdk": "^0.2.58",
     "@anthropic-ai/sdk": ">=0.50.0",
-    "zod": ">=3.0.0"
+    "zod": ">=3.25.0 <4",
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/client": "workspace:*",
@@ -47,6 +46,8 @@
     "tsup": "^8.0.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "rxjs": "7.8.1",
+    "zod": "3.25.76"
   }
 }

--- a/integrations/claude-managed-agents/typescript/package.json
+++ b/integrations/claude-managed-agents/typescript/package.json
@@ -35,13 +35,12 @@
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },
-  "dependencies": {
-    "rxjs": "7.8.1"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.42",
     "@ag-ui/client": ">=0.0.42",
-    "@anthropic-ai/sdk": ">=0.109.0"
+    "@anthropic-ai/sdk": ">=0.109.0",
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -54,7 +53,8 @@
     "tsx": "^4.20.6",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/community/spring-ai/typescript/package.json
+++ b/integrations/community/spring-ai/typescript/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -45,7 +45,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/crew-ai/typescript/package.json
+++ b/integrations/crew-ai/typescript/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -45,7 +45,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/langchain/typescript/package.json
+++ b/integrations/langchain/typescript/package.json
@@ -30,14 +30,13 @@
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },
-  "dependencies": {
-    "rxjs": "7.8.1"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.42",
     "@ag-ui/client": ">=0.0.42",
     "@langchain/core": ">=0.3.0 <2.0.0",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -49,7 +48,9 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1",
+    "zod": "3.25.76"
   },
   "exports": {
     ".": {

--- a/integrations/langgraph/typescript/package.json
+++ b/integrations/langgraph/typescript/package.json
@@ -35,12 +35,12 @@
     "@langchain/core": "^1.1.40",
     "@langchain/langgraph-sdk": "^1.8.8",
     "langchain": ">=1.2.0",
-    "partial-json": "^0.1.7",
-    "rxjs": "7.8.1"
+    "partial-json": "^0.1.7"
   },
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.42",
-    "@ag-ui/client": ">=0.0.42"
+    "@ag-ui/client": ">=0.0.42",
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -51,7 +51,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/langroid/typescript/package.json
+++ b/integrations/langroid/typescript/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -33,7 +33,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "tsup": "^8.0.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   }
 }
-

--- a/integrations/llama-index/typescript/package.json
+++ b/integrations/llama-index/typescript/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.39",
     "@ag-ui/client": ">=0.0.39",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -45,7 +45,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -58,16 +58,16 @@
   "dependencies": {
     "@ag-ui/a2ui-toolkit": "workspace:*",
     "@ai-sdk/ui-utils": "^1.1.19",
-    "fast-json-patch": "^3.1.1",
-    "rxjs": "7.8.1",
-    "zod": "^3.25.76"
+    "fast-json-patch": "^3.1.1"
   },
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.44",
     "@ag-ui/client": ">=0.0.44",
     "@copilotkit/runtime": "^1.60.1",
     "@mastra/client-js": ">=1.0.0-0 <2.0.0-0",
-    "@mastra/core": ">=1.29.0 <2.0.0-0"
+    "@mastra/core": ">=1.29.0 <2.0.0-0",
+    "rxjs": ">=7.8.0 <8",
+    "zod": ">=3.25.0 <4"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -82,6 +82,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1",
+    "zod": "3.25.76"
   }
 }

--- a/integrations/pydantic-ai/typescript/package.json
+++ b/integrations/pydantic-ai/typescript/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.37",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -40,7 +40,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/server-starter-all-features/typescript/package.json
+++ b/integrations/server-starter-all-features/typescript/package.json
@@ -27,7 +27,7 @@
     "@ag-ui/client": "workspace:*"
   },
   "peerDependencies": {
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
@@ -36,7 +36,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/server-starter/typescript/package.json
+++ b/integrations/server-starter/typescript/package.json
@@ -27,7 +27,7 @@
     "@ag-ui/client": "workspace:*"
   },
   "peerDependencies": {
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
@@ -36,7 +36,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/integrations/vercel-ai-sdk/typescript/package.json
+++ b/integrations/vercel-ai-sdk/typescript/package.json
@@ -29,7 +29,8 @@
   "peerDependencies": {
     "@ag-ui/core": ">=0.0.37",
     "@ag-ui/client": ">=0.0.40",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8",
+    "zod": ">=3.25.0 <4"
   },
   "devDependencies": {
     "@ag-ui/core": "workspace:*",
@@ -40,11 +41,12 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1",
+    "zod": "3.25.76"
   },
   "dependencies": {
-    "ai": "^4.3.16",
-    "zod": "^3.22.4"
+    "ai": "^4.3.16"
   },
   "exports": {
     ".": {

--- a/middlewares/a2a-middleware/package.json
+++ b/middlewares/a2a-middleware/package.json
@@ -28,12 +28,11 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.2.2",
-    "ai": "^4.3.16",
-    "zod": "^3.22.4"
+    "ai": "^4.3.16"
   },
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.40",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/client": "workspace:*",
@@ -43,7 +42,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/middlewares/a2ui-middleware/package.json
+++ b/middlewares/a2ui-middleware/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.40",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "dependencies": {
     "@ag-ui/a2ui-toolkit": "workspace:*",

--- a/middlewares/event-throttle-middleware/package.json
+++ b/middlewares/event-throttle-middleware/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.40",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/client": "workspace:*",

--- a/middlewares/mcp-apps-middleware/package.json
+++ b/middlewares/mcp-apps-middleware/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.40",
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@ag-ui/client": "workspace:*",

--- a/middlewares/mcp-middleware/package.json
+++ b/middlewares/mcp-middleware/package.json
@@ -31,7 +31,7 @@
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "peerDependencies": {
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
@@ -40,7 +40,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/middlewares/middleware-starter/package.json
+++ b/middlewares/middleware-starter/package.json
@@ -27,7 +27,7 @@
     "@ag-ui/client": "workspace:*"
   },
   "peerDependencies": {
-    "rxjs": "7.8.1"
+    "rxjs": ">=7.8.0 <8"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
@@ -36,7 +36,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,9 +403,6 @@ importers:
       '@a2a-js/sdk':
         specifier: ^0.2.2
         version: 0.2.5
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -425,6 +422,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -436,10 +436,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/adk-middleware/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -456,6 +452,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -467,10 +466,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/ag2/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -487,6 +482,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -498,10 +496,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/agno/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -521,6 +515,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -645,12 +642,6 @@ importers:
       '@anthropic-ai/sdk':
         specifier: '>=0.50.0'
         version: 0.57.0
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -664,6 +655,9 @@ importers:
       '@types/node':
         specifier: ^20.11.19
         version: 20.19.21
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsup:
         specifier: ^8.0.2
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.4)
@@ -676,12 +670,11 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   integrations/claude-managed-agents/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -704,6 +697,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -757,10 +753,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/community/spring-ai/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -780,6 +772,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -791,10 +786,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/crew-ai/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -814,6 +805,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -825,13 +819,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/langchain/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -854,6 +841,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -863,6 +853,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   integrations/langgraph/typescript:
     dependencies:
@@ -881,9 +874,6 @@ importers:
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -903,6 +893,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -914,10 +907,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   integrations/langroid/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -934,6 +923,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.21)(babel-plugin-macros@3.1.0)
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       ts-jest:
         specifier: ^29.1.2
         version: 29.4.6(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.21)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
@@ -945,10 +937,6 @@ importers:
         version: 5.9.3
 
   integrations/llama-index/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -968,6 +956,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -989,12 +980,6 @@ importers:
       fast-json-patch:
         specifier: ^3.1.1
         version: 3.1.1
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -1026,6 +1011,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1035,6 +1023,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   integrations/mastra/typescript/examples:
     dependencies:
@@ -1071,10 +1062,6 @@ importers:
         version: 5.9.3
 
   integrations/pydantic-ai/typescript:
-    dependencies:
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -1094,6 +1081,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1109,9 +1099,6 @@ importers:
       '@ag-ui/client':
         specifier: workspace:*
         version: link:../../../sdks/typescript/packages/client
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -1125,6 +1112,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1140,9 +1130,6 @@ importers:
       '@ag-ui/client':
         specifier: workspace:*
         version: link:../../../sdks/typescript/packages/client
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -1156,6 +1143,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1171,12 +1161,6 @@ importers:
       ai:
         specifier: ^4.3.16
         version: 4.3.19(react@19.2.3)(zod@3.25.76)
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -1196,6 +1180,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1205,6 +1192,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   integrations/watsonx/typescript:
     devDependencies:
@@ -1247,12 +1237,6 @@ importers:
       ai:
         specifier: ^4.3.16
         version: 4.3.19(react@19.2.3)(zod@3.25.76)
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -1269,6 +1253,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1382,9 +1369,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -1398,6 +1382,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1413,9 +1400,6 @@ importers:
       '@ag-ui/client':
         specifier: workspace:*
         version: link:../../sdks/typescript/packages/client
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -1429,6 +1413,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1566,9 +1553,6 @@ importers:
       fast-json-patch:
         specifier: ^3.1.1
         version: 3.1.1
-      rxjs:
-        specifier: 7.8.1
-        version: 7.8.1
       untruncate-json:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1594,6 +1578,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.17
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
       tsdown:
         specifier: ^0.20.1
         version: 0.20.1(publint@0.3.17)(typescript@5.9.3)
@@ -1605,10 +1592,6 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
 
   sdks/typescript/packages/core:
-    dependencies:
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -1631,6 +1614,9 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.4)
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   sdks/typescript/packages/encoder:
     dependencies:
@@ -8578,6 +8564,7 @@ packages:
   eslint@9.37.0:
     resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/sdks/typescript/packages/client/package.json
+++ b/sdks/typescript/packages/client/package.json
@@ -39,10 +39,12 @@
     "@types/uuid": "^10.0.0",
     "compare-versions": "^6.1.1",
     "fast-json-patch": "^3.1.1",
-    "rxjs": "7.8.1",
     "untruncate-json": "^0.0.1",
-    "uuid": "^11.1.0",
-    "zod": "^3.22.4"
+    "uuid": "^11.1.0"
+  },
+  "peerDependencies": {
+    "rxjs": ">=7.8.0 <8",
+    "zod": ">=3.25.0 <4"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
@@ -52,7 +54,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "rxjs": "7.8.1"
   },
   "exports": {
     ".": {

--- a/sdks/typescript/packages/core/package.json
+++ b/sdks/typescript/packages/core/package.json
@@ -27,8 +27,8 @@
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global"
   },
-  "dependencies": {
-    "zod": "^3.22.4"
+  "peerDependencies": {
+    "zod": ">=3.25.0 <4"
   },
   "devDependencies": {
     "@vitest/coverage-istanbul": "^4.0.18",
@@ -37,7 +37,8 @@
     "@arethetypeswrong/cli": "^0.17.4",
     "vitest": "^4.0.18",
     "tsdown": "^0.20.1",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "zod": "3.25.76"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Update zod and RxJS dependencies to peer dependencies. This is necessary because both are part of the SDK's public API surface.

Related:

- https://github.com/ag-ui-protocol/ag-ui/pull/1637