### PR TITLE
fix(langgraph): preserve Bedrock reasoning signatures

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -3694,6 +3694,10 @@ class LangGraphAgent:
         if not reasoning_data["text"]:
             if reasoning_data.get("id"):
                 self.active_run.setdefault("pending_reasoning_ids", {})[lane] = reasoning_data["id"]
+            if reasoning_data.get("signature"):
+                reasoning_process = self._get_reasoning_process(lane)
+                if reasoning_process is not None:
+                    reasoning_process["signature"] = reasoning_data["signature"]
             return
 
         reasoning_step_index = reasoning_data.get("index", 0)

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -464,11 +464,11 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
         # AWS Bedrock Converse format: { type: "reasoning_content", reasoning_content: { text: "...", signature: "..." } }
         if block_type == "reasoning_content" and isinstance(block.get("reasoning_content"), dict):
             rc = block["reasoning_content"]
-            if rc.get("text"):
+            if "text" in rc or rc.get("signature"):
                 result = LangGraphReasoning(
-                    text=rc["text"],
+                    text=rc.get("text", ""),
                     type="text",
-                    index=rc.get("index", 0),
+                    index=rc.get("index", block.get("index", 0)),
                 )
                 if rc.get("signature"):
                     result["signature"] = rc["signature"]
@@ -509,16 +509,6 @@ def resolve_reasoning_content(chunk: Any) -> LangGraphReasoning | None:
                     if block.get("id") and data.get("index", 0) == 0:
                         result["id"] = str(block["id"])
                     return result
-
-        # Bedrock Converse API format: { type: "reasoning_content", reasoning_content: { type: "text", text: "..." } }
-        if block_type == "reasoning_content" and isinstance(block.get("reasoning_content"), dict):
-            inner = block["reasoning_content"]
-            if inner.get("text"):
-                return LangGraphReasoning(
-                    type="text",
-                    text=inner["text"],
-                    index=inner.get("index", 0)
-                )
 
     # OpenAI legacy format via additional_kwargs
     additional_kwargs = _dual_get(chunk, "additional_kwargs")

--- a/integrations/langgraph/python/tests/test_bedrock_reasoning_signature_stream.py
+++ b/integrations/langgraph/python/tests/test_bedrock_reasoning_signature_stream.py
@@ -1,0 +1,111 @@
+"""Regression coverage for Bedrock Converse signature-only reasoning chunks."""
+
+import unittest
+
+from ag_ui.core import EventType
+
+from ag_ui_langgraph.types import LangGraphEventTypes
+from tests._helpers import make_agent, _record_dispatch
+
+
+def _active_run() -> dict:
+    return {
+        "id": "run-1",
+        "thread_id": "thread-1",
+        "mode": "start",
+        "reasoning_processes": {},
+        "pending_reasoning_ids": {},
+        "current_subagent_run_id": None,
+        "node_name": "agent",
+        "has_function_streaming": False,
+        "streamed_tool_call_ids": set(),
+        "model_made_tool_call": False,
+        "state_reliable": True,
+        "manually_emitted_state": None,
+        "schema_keys": {
+            "input": ["messages", "tools"],
+            "output": ["messages", "tools"],
+            "config": [],
+            "context": [],
+        },
+    }
+
+
+def _stream_event(content: list[dict]) -> dict:
+    return {
+        "event": LangGraphEventTypes.OnChatModelStream,
+        "metadata": {"emit-messages": True, "emit-tool-calls": True},
+        "data": {
+            "chunk": {
+                "id": "bedrock-message",
+                "content": content,
+                "tool_call_chunks": [],
+                "response_metadata": {},
+            }
+        },
+    }
+
+
+class TestBedrockReasoningSignatureStream(unittest.IsolatedAsyncioTestCase):
+    async def _handle(self, agent, content: list[dict]) -> None:
+        async for _ in agent._handle_single_event(_stream_event(content), {}):
+            pass
+
+    async def test_empty_flush_keeps_reasoning_open_and_signature_is_emitted(self):
+        agent = _record_dispatch(make_agent())
+        agent.active_run = _active_run()
+
+        await self._handle(
+            agent,
+            [{
+                "type": "reasoning_content",
+                "reasoning_content": {"text": "The"},
+                "index": 0,
+            }],
+        )
+        reasoning_message_id = agent.active_run["reasoning_processes"]["__root__"]["message_id"]
+
+        await self._handle(
+            agent,
+            [{
+                "type": "reasoning_content",
+                "reasoning_content": {"text": ""},
+                "index": 0,
+            }],
+        )
+        self.assertIsNotNone(agent.active_run["reasoning_processes"]["__root__"])
+        self.assertFalse(
+            any(event.type == EventType.REASONING_END for event in agent.dispatched)
+        )
+
+        await self._handle(
+            agent,
+            [{
+                "type": "reasoning_content",
+                "reasoning_content": {"signature": "EpcCC=="},
+                "index": 0,
+            }],
+        )
+        self.assertEqual(
+            agent.active_run["reasoning_processes"]["__root__"]["signature"], "EpcCC=="
+        )
+
+        await self._handle(agent, [{"type": "text", "text": "Done", "index": 1}])
+
+        encrypted_events = [
+            event
+            for event in agent.dispatched
+            if event.type == EventType.REASONING_ENCRYPTED_VALUE
+        ]
+        self.assertEqual(len(encrypted_events), 1)
+        self.assertEqual(encrypted_events[0].entity_id, reasoning_message_id)
+        self.assertEqual(encrypted_events[0].encrypted_value, "EpcCC==")
+        self.assertEqual(
+            sum(event.type == EventType.REASONING_END for event in agent.dispatched),
+            1,
+        )
+        self.assertIsNone(agent.active_run["reasoning_processes"].get("__root__"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langgraph/python/tests/test_reasoning_content.py
+++ b/integrations/langgraph/python/tests/test_reasoning_content.py
@@ -99,6 +99,30 @@ class TestResolveReasoningContent(unittest.TestCase):
         assert result is not None
         assert result["index"] == 3
 
+    def test_bedrock_converse_empty_text_flush_is_preserved(self):
+        chunk = FakeChunk(content=[{
+            "type": "reasoning_content",
+            "reasoning_content": {"text": ""},
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        assert result is not None
+        assert result["text"] == ""
+        assert result["index"] == 0
+        assert result.get("signature") is None
+
+    def test_bedrock_converse_signature_only_chunk_is_preserved(self):
+        chunk = FakeChunk(content=[{
+            "type": "reasoning_content",
+            "reasoning_content": {"signature": "EpcCC=="},
+            "index": 0,
+        }])
+        result = resolve_reasoning_content(chunk)
+        assert result is not None
+        assert result["text"] == ""
+        assert result["index"] == 0
+        assert result["signature"] == "EpcCC=="
+
     def test_empty_content_returns_none(self):
         chunk = FakeChunk(content=[])
         assert resolve_reasoning_content(chunk) is None


### PR DESCRIPTION
## Summary

Fixes #2174.

Amazon Bedrock Converse can split an extended-thinking block into an empty-text flush followed by a signature-only `reasoning_content` chunk. The resolver previously dropped those chunks, and the stream handler could close the reasoning message before the signature arrived, so no `REASONING_ENCRYPTED_VALUE` event was emitted.

This change:

- preserves empty-text and signature-only Bedrock reasoning carriers;
- keeps the active reasoning message open through the flush;
- accumulates the signature before the text-less early return; and
- adds resolver and full-stream regression coverage for the emitted encrypted value.

## Verification

- `uv run python -m pytest tests/test_reasoning_content.py tests/test_bedrock_reasoning_signature_stream.py -q` -> 31 passed
- `uv run python -m pytest tests -q` -> 394 passed, 10 warnings, 5 subtests passed
- `git diff HEAD^ --check` -> passed

The commit is SSH-signed.