### PR TITLE
fix(langgraph): report a failed run as RUN_ERROR before it propagates

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -106,6 +106,9 @@ ProcessedEvents = Union[
 
 logger = logging.getLogger(__name__)
 
+#: Events that close a run. The protocol allows exactly one of them per run.
+_TERMINAL_EVENT_TYPES = frozenset({EventType.RUN_FINISHED, EventType.RUN_ERROR})
+
 ROOT_SUBGRAPH_NAME = "root"
 
 
@@ -210,6 +213,56 @@ class LangGraphAgent:
             yield event_str
 
     async def _handle_stream_events(self, input: RunAgentInput) -> AsyncGenerator[ProcessedEvents, None]:
+        """Report a failed run as ``RUN_ERROR`` before letting it propagate.
+
+        ``concepts/events.mdx``: "The ``RunStarted`` and either
+        ``RunFinished`` or ``RunError`` events are mandatory, forming the
+        boundaries of an agent run."
+
+        ``_stream_run_events`` emits ``RUN_ERROR`` for one case only: an
+        upstream ``error`` event out of ``astream_events``. Anything *raised*
+        inside the run -- a provider fault, a checkpointer failure,
+        ``GraphRecursionError`` from Pregel, a bug in user middleware -- used
+        to leave the generator without one, so the stream ended with no
+        terminal event at all. A client rendering from the event stream
+        cannot tell that apart from a completed run: ``verifyEvents`` rejects
+        illegal events that are *sent*, and a stream that ends sends nothing
+        to reject (#2300).
+
+        The exception is still re-raised afterwards. Callers that treat a
+        raised failure as a failure keep working unchanged, and the traceback
+        is not swallowed on the way out -- ``TestAgetStateMidStreamError``
+        pins exactly that. The consumer receives the terminal event first
+        because it was yielded first.
+
+        A run that already emitted a terminal event is not given a second
+        one: the ``@ag-ui/client`` state machine rejects the second (#1892).
+
+        ``CancelledError`` is a ``BaseException`` and never reaches here. A
+        caller that walked away is not owed an error event.
+        """
+        emitted_terminal = False
+        try:
+            async for event in self._stream_run_events(input):
+                emitted_terminal = emitted_terminal or event.type in _TERMINAL_EVENT_TYPES
+                yield event
+        except Exception as error:
+            logger.exception(
+                "Run %s on thread %s ended with an unhandled exception",
+                input.run_id,
+                input.thread_id,
+            )
+            if not emitted_terminal:
+                yield self._dispatch_event(
+                    RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message=str(error) or type(error).__name__,
+                        code=type(error).__name__,
+                    )
+                )
+            raise
+
+    async def _stream_run_events(self, input: RunAgentInput) -> AsyncGenerator[ProcessedEvents, None]:
         thread_id = input.thread_id or str(uuid.uuid4())
         INITIAL_ACTIVE_RUN: RunMetadata = {
             "id": input.run_id,

--- a/integrations/langgraph/python/tests/test_terminal_event_guarantee.py
+++ b/integrations/langgraph/python/tests/test_terminal_event_guarantee.py
@@ -1,0 +1,98 @@
+"""A run that raises must still report ``RUN_ERROR`` before it propagates.
+
+``concepts/events.mdx``:
+
+> The ``RunStarted`` and either ``RunFinished`` or ``RunError`` events are
+> mandatory, forming the boundaries of an agent run.
+
+``_stream_run_events`` emits ``RUN_ERROR`` for one case only: an upstream
+``error`` event out of ``astream_events``. Anything *raised* inside the run
+-- a provider fault, a checkpointer failure, ``GraphRecursionError`` from
+Pregel, a bug in user middleware -- used to leave the generator without one.
+The generator died, the caller's ``async for`` stopped, and the stream ended
+with no terminal event of any kind.
+
+A client rendering from the event stream cannot tell that apart from a
+completed run: ``verifyEvents`` rejects illegal events that are *sent*, and a
+stream that ends sends nothing to reject (#2300). The same defect class was
+reported for the Mastra integration in #2416.
+
+The exception is still re-raised after the event, so callers that treat a
+raised failure as a failure keep working unchanged; ``TestAgetStateMidStreamError``
+in ``test_subgraph_streaming.py`` pins that invariant.
+
+``CancelledError`` is deliberately not covered: it is a ``BaseException``, so
+it never reaches the handler. A caller that walked away is not owed an error
+event, and reporting the cancellation as a run failure would be a lie.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from ag_ui.core import EventType, RunAgentInput, UserMessage
+
+from tests._helpers import make_agent
+
+TERMINAL = {EventType.RUN_FINISHED, EventType.RUN_ERROR}
+
+
+def _make_state(messages):
+    state = MagicMock()
+    state.values = {"messages": messages}
+    state.tasks = []
+    state.next = []
+    state.metadata = {"writes": {}}
+    return state
+
+
+def _make_input():
+    return RunAgentInput(
+        thread_id="t1",
+        run_id="run-1",
+        messages=[UserMessage(id="u1", role="user", content="hi")],
+        tools=[],
+        context=[],
+        state={},
+        forwarded_props={},
+    )
+
+
+def _raising_stream(exc):
+    """A stream that produces nothing and then fails, like a graph would."""
+
+    async def stream():
+        if False:  # pragma: no cover - keeps this an async generator
+            yield None
+        raise exc
+
+    return stream()
+
+
+class TestTerminalEventGuarantee(unittest.IsolatedAsyncioTestCase):
+    async def _run(self, exc):
+        """Drive a failing run; return the event types seen before it raised."""
+        agent = make_agent()
+        agent.graph.aget_state = AsyncMock(return_value=_make_state([]))
+        agent.graph.astream_events = MagicMock(return_value=_raising_stream(exc))
+        seen = []
+        with self.assertRaises(type(exc)):
+            async for event in agent.run(_make_input()):
+                seen.append(event.type)
+        return seen
+
+    async def test_exception_inside_the_run_emits_run_error(self):
+        seen = await self._run(RuntimeError("provider exploded"))
+
+        self.assertTrue(seen, "the run produced no events at all")
+        self.assertEqual(seen[-1], EventType.RUN_ERROR)
+
+    async def test_terminal_event_is_emitted_exactly_once(self):
+        seen = await self._run(RuntimeError("provider exploded"))
+
+        self.assertEqual(len([kind for kind in seen if kind in TERMINAL]), 1)
+
+    async def test_cancellation_gets_no_error_event(self):
+        seen = await self._run(asyncio.CancelledError())
+
+        self.assertNotIn(EventType.RUN_ERROR, seen)


### PR DESCRIPTION
Fixes #2531

## Problem

`_handle_stream_events` emits `RUN_ERROR` in exactly one place — `if event["event"] == "error"`, for an upstream error *event* out of `astream_events`. Its own structure is `try: … finally: self.active_run = None`; there is no `except`.

Anything *raised* inside the run therefore propagates straight out of the async generator: a provider fault, a checkpointer failure, `GraphRecursionError` from Pregel, an exception from user middleware. The generator dies, the caller's `async for` stops, and the stream ends with no terminal event of any kind — which the protocol forbids:

> The `RunStarted` and either `RunFinished` or `RunError` events are mandatory, forming the boundaries of an agent run.

A client rendering from the event stream cannot tell that apart from a completed run: `verifyEvents` rejects illegal events that are *sent*, and a stream that ends sends nothing to reject (#2300).

Downstream it gets papered over rather than fixed — `@copilotkit/runtime`'s `finalizeRunEvents` notices the missing terminal and synthesizes `Run ended without emitting a terminal event` / `INCOMPLETE_STREAM`. The adapter is the only layer that knows the actual cause, and it is the layer that drops it. `GraphRecursionError` makes that concrete: hitting the graph's step limit is a normal outcome, and today the user reads a protocol diagnostic instead.

## Change

The stream body moves to `_stream_run_events` unchanged; `_handle_stream_events` becomes a thin wrapper that reports the failure and then re-raises.

Deliberately conservative — nothing callers rely on changes:

- **the exception still propagates.** Callers that treat a raised failure as a failure keep working unchanged, and the traceback is not swallowed on the way out. `TestAgetStateMidStreamError` in `test_subgraph_streaming.py` pins exactly that and still passes untouched.
- **the terminal event comes first**, because it is yielded before the re-raise. A consumer rendering the stream gets its boundary; a consumer catching the exception gets its exception.
- **no second terminal event.** A run that already emitted one is not given another — `@ag-ui/client`'s state machine rejects the second (#1892).
- **`CancelledError` is untouched.** It is a `BaseException`, so it never reaches the handler: a caller that walked away is not owed an error event, and reporting cancellation as a run failure would be a lie.

## Tests

`tests/test_terminal_event_guarantee.py`, three cases:

- an exception inside the run ends the stream with `RUN_ERROR`;
- exactly one terminal event is emitted;
- a cancelled run gets no error event.

The first two fail on `main` (the exception reaches the caller with no terminal event on the stream).

## Verification

```
uv run pytest -q
400 passed, 5 subtests passed
```

+53 lines in `agent.py`, no behavior removed.

---

Per `CONTRIBUTING.md` I filed #2531 first and am not assigned yet — happy to hold, rework, or close this if you would rather take it a different way.
