### PR TITLE
fix(aws-strands): close zero-net and hostile response gaps

### DIFF
--- a/integrations/aws-strands/typescript/src/__tests__/url-fetch-policy.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/url-fetch-policy.test.ts
@@ -12,7 +12,7 @@ import dns from "node:dns";
 import { readFileSync } from "node:fs";
 import { builtinModules } from "node:module";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo, type Socket } from "node:net";
 import type { InputContent } from "@ag-ui/core";
 
 import {
@@ -2170,6 +2170,105 @@ describe("URL fetch policy: limits that cannot work", () => {
 // ---------------------------------------------------------------------------
 
 describe("URL fetch policy: transport binding", () => {
+  async function rawResponseListener(response: string) {
+    const sockets = new Set<Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+      socket.once("data", () => socket.end(response));
+    });
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error);
+      server.once("error", onError);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", onError);
+        resolve();
+      });
+    });
+    const { port } = server.address() as AddressInfo;
+    return {
+      port,
+      close: async () => {
+        for (const socket of sockets) socket.destroy();
+        if (!server.listening) return;
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      },
+    };
+  }
+
+  async function settleWithin<T>(promise: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("transport did not settle")),
+            500,
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  function requestRawResponse(port: number) {
+    return urlFetchTransport.request(
+      `http://hostile.example:${port}/probe`,
+      [{ version: 4, bytes: new Uint8Array([127, 0, 0, 1]) }],
+      policy({ timeoutMs: 250 }),
+      new AbortController().signal,
+    );
+  }
+
+  it.each([204, 205, 304])(
+    "represents HTTP %i without constructing a forbidden body",
+    async (status) => {
+      const listener = await rawResponseListener(
+        `HTTP/1.1 ${status} Empty\r\nConnection: close\r\n\r\n`,
+      );
+      try {
+        const response = await settleWithin(requestRawResponse(listener.port));
+
+        expect(response.status).toBe(status);
+        expect(response.body).toBeNull();
+      } finally {
+        await listener.close();
+      }
+    },
+  );
+
+  it("rejects an HTTP status outside the Fetch response range", async () => {
+    const listener = await rawResponseListener(
+      "HTTP/1.1 600 Hostile\r\nConnection: close\r\n\r\n",
+    );
+    try {
+      await expect(
+        settleWithin(requestRawResponse(listener.port)),
+      ).rejects.toThrow(/unsupported HTTP status 600/);
+    } finally {
+      await listener.close();
+    }
+  });
+
+  it("rejects and closes a protocol upgrade", async () => {
+    const listener = await rawResponseListener(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Connection: upgrade\r\n" +
+        "Upgrade: hostile\r\n\r\n",
+    );
+    try {
+      await expect(
+        settleWithin(requestRawResponse(listener.port)),
+      ).rejects.toThrow(/protocol upgrade/);
+    } finally {
+      await listener.close();
+    }
+  });
+
   /** A listener that records connections and serves a sentinel if reached. */
   async function sentinelListener() {
     const connections: string[] = [];

--- a/integrations/aws-strands/typescript/src/__tests__/url-fetch-policy.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/url-fetch-policy.test.ts
@@ -682,6 +682,21 @@ describe("URL fetch policy: configuration", () => {
     expect(bytes && Buffer.from(bytes).toString()).toBe("local");
   });
 
+  it("keeps 0.0.0.0/8 blocked when private networks are opted into", async () => {
+    const { spy } = stubFetch(() => new Response("should not be reached"));
+    const log = makeLog();
+
+    expect(
+      await fetchUrlBytes(
+        "http://0.1.2.3/probe",
+        log,
+        policy({ allowPrivateNetworks: true }),
+      ),
+    ).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+    expect(String(log.error.mock.calls[0][0])).toContain("0.1.2.3");
+  });
+
   it.each([["ftp"], ["data"], ["file"], ["blob"]])(
     "refuses a policy that allows the %s scheme",
     async (scheme) => {
@@ -890,6 +905,75 @@ describe("URL fetch policy: IPv6 transition forms", () => {
 
     expect(await fetchUrlBytes(url, makeLog())).toBeNull();
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the well-known prefix", "http://[64:ff9b::1]/"],
+    ["the local-use prefix", "http://[64:ff9b:1:0:0:100::]/"],
+  ])("refuses 0.0.0.1 through %s", async (_label, url) => {
+    const { spy } = stubFetch(() => new Response("should not be reached"));
+    const log = makeLog();
+
+    expect(await fetchUrlBytes(url, log)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+    expect(String(log.error.mock.calls[0][0])).toContain("0.0.0.1");
+  });
+
+  it.each([
+    ["the well-known prefix", "http://[64:ff9b::1]/"],
+    ["the local-use prefix", "http://[64:ff9b:1:0:0:100::]/"],
+  ])(
+    "keeps 0.0.0.1 through %s blocked under the private-network opt-in",
+    async (_label, url) => {
+      const { spy } = stubFetch(() => new Response("should not be reached"));
+      const log = makeLog();
+
+      expect(
+        await fetchUrlBytes(url, log, policy({ allowPrivateNetworks: true })),
+      ).toBeNull();
+      expect(spy).not.toHaveBeenCalled();
+      expect(String(log.error.mock.calls[0][0])).toContain("0.0.0.1");
+    },
+  );
+
+  it.each([
+    {
+      label: "direct IPv4 zero-net under the default policy",
+      url: "http://0.0.0.1/probe",
+      fetchPolicy: undefined,
+    },
+    {
+      label: "direct IPv4 zero-net with the private-network opt-in",
+      url: "http://0.0.0.1/probe",
+      fetchPolicy: policy({ allowPrivateNetworks: true }),
+    },
+    {
+      label: "well-known NAT64 zero-net under the default policy",
+      url: "http://[64:ff9b::1]/probe",
+      fetchPolicy: undefined,
+    },
+    {
+      label: "well-known NAT64 zero-net with the private-network opt-in",
+      url: "http://[64:ff9b::1]/probe",
+      fetchPolicy: policy({ allowPrivateNetworks: true }),
+    },
+    {
+      label: "local-use NAT64 zero-net under the default policy",
+      url: "http://[64:ff9b:1:0:0:100::]/probe",
+      fetchPolicy: undefined,
+    },
+    {
+      label: "local-use NAT64 zero-net with the private-network opt-in",
+      url: "http://[64:ff9b:1:0:0:100::]/probe",
+      fetchPolicy: policy({ allowPrivateNetworks: true }),
+    },
+  ])("keeps $label blocked", async ({ url, fetchPolicy }) => {
+    const { spy } = stubFetch(() => new Response("should not be reached"));
+    const log = makeLog();
+
+    expect(await fetchUrlBytes(url, log, fetchPolicy)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+    expect(String(log.error.mock.calls[0][0])).toContain("0.0.0.1");
   });
 
   it.each([

--- a/integrations/aws-strands/typescript/src/utils.ts
+++ b/integrations/aws-strands/typescript/src/utils.ts
@@ -203,9 +203,10 @@ function scrubSecrets(text: string, ...urls: string[]): string {
  * Relaxing the address checks requires passing a custom policy to
  * `fetchUrlBytes`. No supported AG-UI-to-Strands conversion path currently
  * accepts one, so in practice the defaults are what a consumer gets. Even
- * under `allowPrivateNetworks`, link-local ranges and the cloud metadata
- * endpoints listed in `ALWAYS_BLOCKED_IPV4`/`ALWAYS_BLOCKED_IPV6` stay
- * blocked; that list covers the major providers rather than every provider.
+ * under `allowPrivateNetworks`, this-network, link-local ranges and the cloud
+ * metadata endpoints listed in `ALWAYS_BLOCKED_IPV4`/`ALWAYS_BLOCKED_IPV6`
+ * stay blocked; that list covers the major providers rather than every
+ * provider.
  */
 /** The NAT64 prefixes every deployment can be assumed to use. */
 const WELL_KNOWN_NAT64_PREFIX = "64:ff9b::/96"; // RFC 6052
@@ -450,6 +451,7 @@ const BLOCKED_IPV6 = [
 // services, and the individual addresses below are metadata endpoints outside
 // it. None is ever a legitimate source of URL content.
 const ALWAYS_BLOCKED_IPV4 = [
+  cidr("0.0.0.0/8"), // this-network is never a legitimate URL destination
   cidr("169.254.0.0/16"), // link-local, including 169.254.169.254 and 169.254.170.2
   cidr("100.100.100.200/32"), // Alibaba Cloud metadata
   cidr("192.0.0.192/32"), // Oracle Cloud metadata
@@ -552,8 +554,7 @@ function addressesToCheck(
   for (const { prefix } of nat64Prefixes(policy)) {
     if (!inCidr(ip.bytes, prefix)) continue;
     const translated = embeddedNat64Address(ip, prefix[1]);
-    // A candidate in 0.0.0.0/8 is not a real destination.
-    if (translated && translated.bytes[0] !== 0) embedded.push(translated);
+    if (translated) embedded.push(translated);
   }
   for (const { prefix, offset } of IPV4_EMBEDDING_PREFIXES) {
     if (!inCidr(ip.bytes, prefix)) continue;
@@ -599,8 +600,9 @@ function blockedAddress(
   // public one, so the embedded address carries the decision instead.
   const wrapperIsNat64 = isNat64(address, policy);
   for (const ip of addressesToCheck(address, policy)) {
-    // Cloud metadata and other link-local services are never legitimate URL
-    // content sources, even when an application opts into its private network.
+    // This-network, cloud metadata and other link-local services are never
+    // legitimate URL content sources, even when an application opts into its
+    // private network.
     if (isAlwaysBlocked(ip)) return ip;
     if (wrapperIsNat64 && ip === address) continue;
     if (!allowPrivateNetworks && isNonGlobal(ip)) return ip;
@@ -612,7 +614,11 @@ function blockedAddress(
 function isNat64(ip: IpAddress, policy: UrlFetchPolicy): boolean {
   return (
     ip.version === 6 &&
-    nat64Prefixes(policy).some(({ prefix }) => inCidr(ip.bytes, prefix))
+    nat64Prefixes(policy).some(
+      ({ prefix }) =>
+        inCidr(ip.bytes, prefix) &&
+        embeddedNat64Address(ip, prefix[1]) !== null,
+    )
   );
 }
 

--- a/integrations/aws-strands/typescript/src/utils.ts
+++ b/integrations/aws-strands/typescript/src/utils.ts
@@ -904,6 +904,8 @@ function pinnedLookup(approved: IpAddress[]) {
   };
 }
 
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
 /**
  * Perform one request, reaching only `approved`.
  *
@@ -924,6 +926,22 @@ async function pinnedRequest(
   const agent = new mod.Agent({ keepAlive: false, maxSockets: 1 });
 
   return await new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const resolveOnce = (response: Response) => {
+      if (settled) return;
+      settled = true;
+      resolve(response);
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      agent.destroy();
+      reject(
+        error instanceof Error
+          ? error
+          : new UrlFetchUnavailableError("HTTP request failed"),
+      );
+    };
     const request = mod.request(
       {
         protocol: url.protocol,
@@ -938,34 +956,104 @@ async function pinnedRequest(
         // environment, so the socket cannot be routed somewhere unvalidated.
       },
       (message) => {
-        const headers = new Headers();
-        for (const [name, value] of Object.entries(message.headers)) {
-          if (value === undefined) continue;
-          for (const single of Array.isArray(value) ? value : [value]) {
-            headers.append(name, single);
-          }
-        }
-        const body = new ReadableStream<Uint8Array>({
-          start(controller) {
-            message.on("data", (chunk: Buffer) =>
-              controller.enqueue(new Uint8Array(chunk)),
-            );
-            message.on("end", () => controller.close());
-            message.on("error", (error) => controller.error(error));
-          },
-          cancel() {
+        try {
+          const status = message.statusCode;
+          if (status === undefined || status < 200 || status > 599) {
             message.destroy();
-          },
-        });
-        resolve(
-          new Response(body, {
-            status: message.statusCode ?? 0,
-            headers,
-          }),
-        );
+            rejectOnce(
+              new UrlFetchUnavailableError(
+                status === undefined
+                  ? "response carried no HTTP status"
+                  : `response carried unsupported HTTP status ${status}`,
+              ),
+            );
+            return;
+          }
+
+          const headers = new Headers();
+          for (const [name, value] of Object.entries(message.headers)) {
+            if (value === undefined) continue;
+            for (const single of Array.isArray(value) ? value : [value]) {
+              headers.append(name, single);
+            }
+          }
+
+          let body: ReadableStream<Uint8Array> | null = null;
+          if (NULL_BODY_STATUSES.has(status)) {
+            message.resume();
+          } else {
+            body = new ReadableStream<Uint8Array>({
+              start(controller) {
+                let streamSettled = false;
+                const errorStream = (error: unknown) => {
+                  if (streamSettled) return;
+                  streamSettled = true;
+                  try {
+                    controller.error(error);
+                  } catch {
+                    message.destroy();
+                  }
+                };
+                message.on("data", (chunk: Buffer) => {
+                  if (streamSettled) return;
+                  try {
+                    controller.enqueue(new Uint8Array(chunk));
+                  } catch (error) {
+                    errorStream(error);
+                    message.destroy();
+                  }
+                });
+                message.on("end", () => {
+                  if (streamSettled) return;
+                  streamSettled = true;
+                  try {
+                    controller.close();
+                  } catch {
+                    message.destroy();
+                  }
+                });
+                message.on("error", errorStream);
+                message.on("aborted", () =>
+                  errorStream(
+                    new UrlFetchUnavailableError("response body was aborted"),
+                  ),
+                );
+              },
+              cancel() {
+                message.destroy();
+              },
+            });
+          }
+
+          resolveOnce(new Response(body, { status, headers }));
+        } catch {
+          message.destroy();
+          rejectOnce(
+            new UrlFetchUnavailableError(
+              "HTTP response could not be represented safely",
+            ),
+          );
+        }
       },
     );
-    request.on("error", reject);
+    request.once("error", rejectOnce);
+    request.once("upgrade", (_message, socket) => {
+      socket.destroy();
+      rejectOnce(
+        new UrlFetchUnavailableError(
+          "HTTP protocol upgrades are not supported",
+        ),
+      );
+    });
+    request.once("close", () => {
+      if (!settled) {
+        rejectOnce(
+          new UrlFetchUnavailableError(
+            "connection closed before an HTTP response was received",
+          ),
+        );
+      }
+    });
     request.setTimeout(policy.timeoutMs, () => {
       request.destroy(
         new UrlFetchUnavailableError(


### PR DESCRIPTION
This is the focused follow-up to #2513. The main URL-fetch hardening is solid; this closes the two remaining failure modes we could reproduce without expanding the public policy surface.

What changed:

- Always reject `0.0.0.0/8`, whether it appears directly or inside either
  recognized NAT64 prefix, including with private-network opt-in enabled.
- Safely represent HTTP `204`, `205`, and `304` responses, reject unsupported
  status values and protocol upgrades, and settle request/stream failures
  exactly once so a hostile peer cannot crash or indefinitely suspend the
  caller.
- Add a direct/NAT64 policy matrix and raw TCP regressions for statuses `204`,
  `205`, `304`, `600`, and `101`.

The patch is intentionally limited to the AWS Strands transport and its regression tests: two files and two commits.

Validation:

- Nx format check
- Nx affected lint
- Nx affected typecheck
- Nx affected tests: 52/52 files and 697/697 tests
- URL-fetch policy suite: 318/318 tests
- Nx affected build
