### PR TITLE
feat(langgraph): add TypeScript raw event emission toggle

### DIFF
--- a/integrations/langgraph/typescript/src/agent.ts
+++ b/integrations/langgraph/typescript/src/agent.ts
@@ -183,6 +183,13 @@ export interface LangGraphAgentConfig extends AgentConfig {
    * before structured interrupts existed.
    */
   emitInterruptOutcome?: boolean;
+  /**
+   * Emit the underlying LangGraph events on the AG-UI event stream.
+   *
+   * When disabled, RAW events are suppressed and `rawEvent` is removed from
+   * typed AG-UI events. AG-UI event metadata is preserved. Defaults to true.
+   */
+  emitRawEvents?: boolean;
 }
 
 const ROOT_SUBGRAPH_NAME = "root";
@@ -222,12 +229,15 @@ export class LangGraphAgent extends AbstractAgent {
   config: LangGraphAgentConfig;
   enableLegacyOnInterruptEvent: boolean;
   emitInterruptOutcome: boolean;
+  emitRawEvents: boolean;
 
   constructor(config: LangGraphAgentConfig) {
     super(config);
     this.config = config;
-    this.enableLegacyOnInterruptEvent = config.enableLegacyOnInterruptEvent ?? true;
+    this.enableLegacyOnInterruptEvent =
+      config.enableLegacyOnInterruptEvent ?? true;
     this.emitInterruptOutcome = config.emitInterruptOutcome ?? false;
+    this.emitRawEvents = config.emitRawEvents ?? true;
     this.messagesInProcess = {};
     this.agentName = config.agentName;
     this.graphId = config.graphId;
@@ -284,6 +294,7 @@ export class LangGraphAgent extends AbstractAgent {
       client: this.client,
       enableLegacyOnInterruptEvent: this.enableLegacyOnInterruptEvent,
       emitInterruptOutcome: this.emitInterruptOutcome,
+      emitRawEvents: this.emitRawEvents,
 
       assistant: this.assistant,
       activeRun: this.activeRun ? structuredClone(this.activeRun) : undefined,
@@ -320,6 +331,17 @@ export class LangGraphAgent extends AbstractAgent {
   }
 
   dispatchEvent(event: ProcessedEvents) {
+    if (!this.emitRawEvents) {
+      if (event.type === EventType.RAW) {
+        return false;
+      }
+
+      const eventWithoutRawEvent = { ...event };
+      delete eventWithoutRawEvent.rawEvent;
+      this.subscriber.next(eventWithoutRawEvent);
+      return true;
+    }
+
     this.subscriber.next(event);
     return true;
   }
@@ -794,7 +816,10 @@ export class LangGraphAgent extends AbstractAgent {
           openInterrupts: this.interruptsToAGUI(interrupts),
         }),
       };
-    } else if (effectiveCommand?.resume && typeof effectiveCommand.resume === "string") {
+    } else if (
+      effectiveCommand?.resume &&
+      typeof effectiveCommand.resume === "string"
+    ) {
       try {
         effectiveCommand.resume = JSON.parse(effectiveCommand.resume);
       } catch {
@@ -1820,7 +1845,8 @@ export class LangGraphAgent extends AbstractAgent {
       // one: the snapshot converter re-emits this same reasoning under that
       // id, and only a matching id lets the client reconcile the streamed
       // copy with the snapshot copy instead of rendering both.
-      const messageId = reasoningData.id ?? this.pendingReasoningId ?? randomUUID();
+      const messageId =
+        reasoningData.id ?? this.pendingReasoningId ?? randomUUID();
       this.pendingReasoningId = undefined;
       this.dispatchEvent({
         type: EventType.REASONING_START,
@@ -2163,8 +2189,7 @@ export class LangGraphAgent extends AbstractAgent {
    * bubbles. See #1317.
    */
   private getOrPinTextMessageId(fallbackId: string): string {
-    const messageId =
-      this.activeRun!.currentTextMessageId ?? fallbackId;
+    const messageId = this.activeRun!.currentTextMessageId ?? fallbackId;
     this.activeRun!.currentTextMessageId = messageId;
     return messageId;
   }

--- a/integrations/langgraph/typescript/src/raw-events.test.ts
+++ b/integrations/langgraph/typescript/src/raw-events.test.ts
@@ -1,0 +1,112 @@
+import { EventType } from "@ag-ui/client";
+import { Subscriber } from "rxjs";
+import { describe, expect, it } from "vitest";
+
+import { LangGraphAgent, ProcessedEvents } from "./agent";
+
+function createAgent(emitRawEvents?: boolean) {
+  const agent = new LangGraphAgent({
+    graphId: "test-graph",
+    deploymentUrl: "http://localhost:8000",
+    ...(emitRawEvents === undefined ? {} : { emitRawEvents }),
+  });
+  const events: ProcessedEvents[] = [];
+
+  agent.subscriber = new Subscriber<ProcessedEvents>({
+    next: (event: ProcessedEvents) => {
+      events.push(event);
+    },
+    error: () => undefined,
+    complete: () => undefined,
+  });
+
+  return { agent, events };
+}
+
+describe("LangGraphAgent emitRawEvents", () => {
+  it("emits raw events and typed-event rawEvent data by default", () => {
+    const { agent, events } = createAgent();
+    const rawEvent = {
+      type: EventType.RAW,
+      event: { source: "langgraph" },
+    } as const;
+    const stateEvent = {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { answer: 42 },
+      rawEvent: { source: "langgraph" },
+    } as const;
+
+    expect(agent.dispatchEvent(rawEvent)).toBe(true);
+    expect(agent.dispatchEvent(stateEvent)).toBe(true);
+    expect(events).toEqual([rawEvent, stateEvent]);
+  });
+
+  it("suppresses raw events and removes rawEvent data when disabled", () => {
+    const { agent, events } = createAgent(false);
+    const stateEvent = {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { answer: 42 },
+      rawEvent: { source: "langgraph" },
+    } as const;
+
+    expect(
+      agent.dispatchEvent({
+        type: EventType.RAW,
+        event: { source: "langgraph" },
+      }),
+    ).toBe(false);
+    expect(agent.dispatchEvent(stateEvent)).toBe(true);
+    expect(events).toEqual([
+      {
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { answer: 42 },
+      },
+    ]);
+  });
+
+  it("preserves metadata without mutating the source event when disabled", () => {
+    const { agent, events } = createAgent(false);
+    const metadata = {
+      traceId: "trace-1",
+      "ag-ui": { usage: { inputTokens: 3, outputTokens: 5 } },
+    };
+    const stateEvent = {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { answer: 42 },
+      rawEvent: { source: "langgraph" },
+      metadata,
+    } as const;
+
+    agent.dispatchEvent(stateEvent);
+
+    expect(events).toEqual([
+      {
+        type: EventType.STATE_SNAPSHOT,
+        snapshot: { answer: 42 },
+        metadata,
+      },
+    ]);
+    expect(stateEvent.rawEvent).toEqual({ source: "langgraph" });
+  });
+
+  it("retains disabled raw-event emission across clones", () => {
+    const { agent } = createAgent(false);
+    const clone = agent.clone();
+    const events: ProcessedEvents[] = [];
+    clone.subscriber = new Subscriber<ProcessedEvents>({
+      next: (event: ProcessedEvents) => {
+        events.push(event);
+      },
+      error: () => undefined,
+      complete: () => undefined,
+    });
+
+    expect(
+      clone.dispatchEvent({
+        type: EventType.RAW,
+        event: { source: "langgraph" },
+      }),
+    ).toBe(false);
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add `emitRawEvents` to the TypeScript `LangGraphAgentConfig`, defaulting to `true`
- when disabled, suppress first-class `RAW` events and remove `rawEvent` payloads from typed AG-UI events at the central dispatch boundary
- preserve first-class AG-UI event metadata and carry the setting across agent clones

## Context

This extracts the remaining TypeScript parity from #1385. The Python equivalent already landed in #2244, while #2349 established first-class metadata across AG-UI messages and events. Filtering at dispatch keeps that metadata intact and avoids coupling the option to LangGraph stream metadata or individual stream modes.

## Test plan

- `pnpm nx run @ag-ui/langgraph:typecheck`
- `pnpm nx run @ag-ui/langgraph:test` (279 passed, 2 todo)
- `pnpm nx run @ag-ui/langgraph:build`
- `pnpm nx run @ag-ui/langgraph:test:exports`
- scoped Prettier check on the two touched files