### PR TITLE
fix(aws-strands): close remaining auth fail-open paths

### DIFF
--- a/integrations/aws-strands/typescript/README.md
+++ b/integrations/aws-strands/typescript/README.md
@@ -109,8 +109,10 @@ const app = express();
 // endpoint's responses. Same-origin pages are unaffected: CORS governs
 // cross-origin requests only.
 // Add `cors` yourself only if a browser on another origin has to reach it.
-app.use(express.json({ limit: "50mb" }));
-addStrandsExpressEndpoint(app, aguiAgent, { path: "/invocations" });
+addStrandsExpressEndpoint(app, aguiAgent, {
+  path: "/invocations",
+  bodyParser: express.json({ limit: "50mb" }),
+});
 addPing(app, "/ping");
 app.listen(8080);
 ```
@@ -568,9 +570,14 @@ const app = await createStrandsApp(aguiAgent, {
 
 ```ts
 // Same option on the low-level helper, for an app you build yourself.
+import express from "express";
+import { addStrandsExpressEndpoint } from "@ag-ui/aws-strands/server";
+
+const app = express();
 addStrandsExpressEndpoint(app, aguiAgent, {
   path: "/invocations",
   auth: requireBearer,
+  bodyParser: express.json({ limit: "50mb" }),
 });
 ```
 
@@ -606,17 +613,20 @@ What the adapter guarantees around it:
   `next("router")` are Express control-flow signals rather than failures and are
   forwarded as such.
 - **`auth` runs before body parsing and before the request-boundary checks.**
-  `createStrandsApp` mounts the guard as a path-specific `POST` layer ahead of
-  its own `express.json()`, so an unauthenticated request is declined before
-  its body is read. A non-JSON `Content-Type` gets `401` rather than the `415`
-  it would get without a guard, and a body the JSON parser would reject gets
-  `401` rather than the parser's own `400`. Authenticating before telling an
+  `createStrandsApp` mounts the guard, `express.json()`, and the agent handler
+  in that order within one `POST` route. An unauthenticated request is declined
+  before its body is read, and `next("route")` skips the parser and agent
+  together. A non-JSON `Content-Type` gets `401` rather than the `415` it would
+  get without a guard, and a body the JSON parser would reject gets `401`
+  rather than the parser's own `400`. Authenticating before telling an
   anonymous caller anything about the request contract is the intended order;
   `415` and `400` still bite behind a guard that passes.
 
-  Mounting the endpoint yourself with `addStrandsExpressEndpoint` puts you in
-  charge of that ordering: register the endpoint before your own body parser,
-  or the parser will answer malformed bodies ahead of your guard.
+  With `addStrandsExpressEndpoint`, pass your parser through `bodyParser` as in
+  the example above. Do not put an app-wide body parser before the endpoint if
+  auth-before-parsing matters: Express always runs earlier app middleware
+  first. You can still mount an app-wide parser after the endpoint for other
+  routes.
 
 - **`/ping` and `/capabilities` stay open.** Health probes have to keep
   working, and the capabilities document is a static matrix of what this
@@ -686,8 +696,10 @@ import express from "express";
 import { addStrandsExpressEndpoint, addPing } from "@ag-ui/aws-strands/server";
 
 const app = express();
-app.use(express.json({ limit: "50mb" }));
-addStrandsExpressEndpoint(app, aguiAgent, { path: "/invocations" });
+addStrandsExpressEndpoint(app, aguiAgent, {
+  path: "/invocations",
+  bodyParser: express.json({ limit: "50mb" }),
+});
 addPing(app, "/ping");
 ```
 
@@ -698,6 +710,10 @@ and give it an explicit allowlist when you do.
 `addStrandsExpressEndpoint` takes the same
 [`auth`](#authenticating-the-agent-route) option as `createStrandsApp`, so the
 guard travels with the route rather than with the app you built around it.
+Pass `express.json()` (or another compatible request handler) as `bodyParser`
+to place it between that guard and the agent. Both entry points reject unknown
+option keys and invalid option value types during setup instead of silently
+discarding a misspelled or malformed security option.
 
 ## Development
 

--- a/integrations/aws-strands/typescript/src/__tests__/auth-middleware.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/auth-middleware.test.ts
@@ -172,6 +172,8 @@ interface BareApp extends StartedApp {
 
 interface BareAppOptions<A extends StrandsAgent> {
   auth?: StrandsAuthMiddleware;
+  /** Route-scoped parser to mount after auth and before the agent. */
+  bodyParser?: RequestHandler;
   /** Agent to mount. Defaults to a plain `FixedAgent`. */
   agent?: A;
   /**
@@ -192,9 +194,15 @@ async function startBareAppWith<A extends StrandsAgent>(
   const expressModule = await import("express");
   const express = expressModule.default ?? expressModule;
   const app = express();
-  app.use(express.json());
+  if (!options.bodyParser) {
+    app.use(express.json());
+  }
   const agent = options.agent;
-  addStrandsExpressEndpoint(app, agent, { path: "/", auth: options.auth });
+  addStrandsExpressEndpoint(app, agent, {
+    path: "/",
+    auth: options.auth,
+    bodyParser: options.bodyParser,
+  });
   options.mountAfter?.(app);
   const appErrors: string[] = [];
   app.use(
@@ -471,6 +479,46 @@ describe("auth on addStrandsExpressEndpoint directly", () => {
     }
   });
 
+  it("can keep auth and parsing in the same route, in that order", async () => {
+    const expressModule = await import("express");
+    const express = expressModule.default ?? expressModule;
+    const jsonParser = express.json();
+    let authCalls = 0;
+    let parserCalls = 0;
+    const bodyParser: RequestHandler = (req, res, next) => {
+      parserCalls += 1;
+      jsonParser(req, res, next);
+    };
+    const agent = new FixedAgent();
+    const { port, close } = await startBareAppWith({
+      agent,
+      bodyParser,
+      auth: (req, res, next) => {
+        authCalls += 1;
+        if (req.header("authorization") === "Bearer secret") {
+          next();
+          return;
+        }
+        res.status(401).json(CALLER_401);
+      },
+    });
+    try {
+      const rejected = await postRaw(port, "{ this is not json");
+      expect(rejected.status).toBe(401);
+      expect(authCalls).toBe(1);
+      expect(parserCalls).toBe(0);
+      expect(agent.runs).toBe(0);
+
+      const admitted = await postRun(port, { headers: AUTHORIZED });
+      expect(admitted.status).toBe(200);
+      expect(authCalls).toBe(2);
+      expect(parserCalls).toBe(1);
+      expect(agent.runs).toBe(1);
+    } finally {
+      await close();
+    }
+  });
+
   it("does not advance a guard that answered the request and continued anyway", async () => {
     const answeredThenContinued: StrandsAuthMiddleware = (_req, res, next) => {
       res.status(401).json(CALLER_401);
@@ -679,6 +727,37 @@ describe("auth forwards Express control-flow signals", () => {
       expect(logger.error).not.toHaveBeenCalled();
     } finally {
       await close();
+    }
+  });
+
+  it('skips the factory agent route for next("route")', async () => {
+    const agent = new FixedAgent();
+    let authCalls = 0;
+    const app = await createStrandsApp(agent, {
+      auth: (_req, _res, next) => {
+        authCalls += 1;
+        next("route");
+      },
+    });
+    app.post("/", (req, res) => {
+      res.status(299).json({
+        answered: "next-route",
+        threadId: req.body.threadId,
+      });
+    });
+    const server = await listen(app);
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const res = await postRun(port, { headers: AUTHORIZED });
+      expect(res.status).toBe(299);
+      expect(JSON.parse(res.body)).toEqual({
+        answered: "next-route",
+        threadId: "t",
+      });
+      expect(authCalls).toBe(1);
+      expect(agent.runs).toBe(0);
+    } finally {
+      await closeServer(server);
     }
   });
 
@@ -970,7 +1049,7 @@ describe("auth runs ahead of the factory's body parser", () => {
   });
 });
 
-describe("createStrandsApp refuses unknown options", () => {
+describe("createStrandsApp validates options", () => {
   it("throws for a misspelled security option instead of ignoring it", async () => {
     const agent = new FixedAgent();
     await expect(
@@ -990,6 +1069,31 @@ describe("createStrandsApp refuses unknown options", () => {
     ).rejects.toThrow(/unknown options `autth`, `corsOrigns`[\s\S]*`auth`/);
   });
 
+  it.each([
+    ["path", 1, "a string"],
+    ["pingPath", false, "a string, null, or undefined"],
+    ["capabilitiesPath", false, "a string, null, or undefined"],
+    ["capabilities", [], "an object or undefined"],
+    ["corsOrigin", 1, "a string, boolean, string array, or undefined"],
+    [
+      "corsOrigin",
+      ["https://app.example.com", 1],
+      "a string, boolean, string array, or undefined",
+    ],
+    ["corsEnabled", "true", "a boolean or undefined"],
+    ["allowMethods", ["POST", 1], "a string array or undefined"],
+    ["allowHeaders", "Content-Type", "a string array or undefined"],
+    ["auth", false, "a function or undefined"],
+  ])("rejects an invalid %s value", async (option, value, expected) => {
+    await expect(
+      createStrandsApp(new FixedAgent(), {
+        [option]: value,
+      } as never),
+    ).rejects.toThrow(
+      `createStrandsApp option \`${option}\` must be ${expected}`,
+    );
+  });
+
   it("still accepts every documented option together", async () => {
     const app = await createStrandsApp(new FixedAgent(), {
       path: "/",
@@ -1003,5 +1107,37 @@ describe("createStrandsApp refuses unknown options", () => {
       auth: (_req, _res, next) => next(),
     });
     expect(app).toBeDefined();
+  });
+});
+
+describe("addStrandsExpressEndpoint validates options", () => {
+  it("throws for a misspelled security option before mounting a route", () => {
+    const post = vi.fn();
+    const app = { post } as unknown as Express;
+    expect(() =>
+      addStrandsExpressEndpoint(app, new FixedAgent(), {
+        path: "/",
+        autth: (_req: unknown, _res: unknown, next: () => void) => next(),
+      } as never),
+    ).toThrow(/unknown option `autth`/);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["path", 1, "a string"],
+    ["auth", false, "a function or undefined"],
+    ["bodyParser", false, "an Express request handler or undefined"],
+  ])("rejects an invalid %s value", (option, value, expected) => {
+    const post = vi.fn();
+    const app = { post } as unknown as Express;
+    expect(() =>
+      addStrandsExpressEndpoint(app, new FixedAgent(), {
+        path: "/",
+        [option]: value,
+      } as never),
+    ).toThrow(
+      `addStrandsExpressEndpoint option \`${option}\` must be ${expected}`,
+    );
+    expect(post).not.toHaveBeenCalled();
   });
 });

--- a/integrations/aws-strands/typescript/src/endpoint.ts
+++ b/integrations/aws-strands/typescript/src/endpoint.ts
@@ -1,6 +1,12 @@
 /** Express endpoint utilities for AWS Strands integration. */
 
-import type { Express, NextFunction, Request, Response } from "express";
+import type {
+  Express,
+  NextFunction,
+  Request,
+  RequestHandler,
+  Response,
+} from "express";
 import { STATUS_CODES } from "http";
 import {
   EventType,
@@ -53,6 +59,72 @@ export interface AddStrandsEndpointOptions {
    * which is the default and unchanged behaviour.
    */
   auth?: StrandsAuthMiddleware;
+  /**
+   * Optional route-scoped body parser. It is mounted after `auth` and before
+   * the agent handler, so an unauthenticated request can be rejected without
+   * first buffering or parsing its body. For example:
+   * `bodyParser: express.json({ limit: "50mb" })`.
+   *
+   * Omit this when the app has already populated `req.body`. In that case the
+   * caller owns the order of its app-wide middleware relative to this route.
+   */
+  bodyParser?: RequestHandler;
+}
+
+const ADD_STRANDS_ENDPOINT_OPTION_KEYS = [
+  "path",
+  "auth",
+  "bodyParser",
+] as const;
+
+const ADD_STRANDS_ENDPOINT_OPTION_KEY_SET = new Set<string>(
+  ADD_STRANDS_ENDPOINT_OPTION_KEYS,
+);
+
+function assertAddStrandsEndpointOptions(
+  options: unknown,
+): asserts options is AddStrandsEndpointOptions {
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    throw new TypeError("addStrandsExpressEndpoint options must be an object.");
+  }
+
+  const values = options as Record<string, unknown>;
+  const unknown = Object.keys(values).filter(
+    (key) => !ADD_STRANDS_ENDPOINT_OPTION_KEY_SET.has(key),
+  );
+  if (unknown.length > 0) {
+    const plural = unknown.length === 1 ? "option" : "options";
+    throw new Error(
+      `addStrandsExpressEndpoint received unknown ${plural} ${unknown
+        .map((key) => `\`${key}\``)
+        .join(", ")}. A misspelled security option would be ignored and ` +
+        `silently leave the route without it. Valid options are ` +
+        `${ADD_STRANDS_ENDPOINT_OPTION_KEYS.map((key) => `\`${key}\``).join(", ")}.`,
+    );
+  }
+
+  if (typeof values.path !== "string") {
+    throw new TypeError(
+      "addStrandsExpressEndpoint option `path` must be a string.",
+    );
+  }
+  if (values.auth !== undefined && typeof values.auth !== "function") {
+    throw new TypeError(
+      "addStrandsExpressEndpoint option `auth` must be a function or undefined.",
+    );
+  }
+  if (
+    values.bodyParser !== undefined &&
+    typeof values.bodyParser !== "function"
+  ) {
+    throw new TypeError(
+      "addStrandsExpressEndpoint option `bodyParser` must be an Express request handler or undefined.",
+    );
+  }
 }
 
 /**
@@ -118,10 +190,9 @@ function bodyForAuthStatus(status: number): { error: string } {
  * 4 (still an accepted peer range) does not await handlers at all, so a
  * rejection there would hang the request. Owning both paths here keeps the
  * behaviour identical across the supported range.
- */
-/**
- * Exported for `createStrandsApp`, which mounts this ahead of its body parser
- * rather than as route middleware. Not part of the package's public surface.
+ *
+ * Used by `addStrandsExpressEndpoint` to keep auth ahead of the optional body
+ * parser in one route. Not part of the package's public surface.
  */
 export function authGuard(
   auth: StrandsAuthMiddleware,
@@ -252,6 +323,8 @@ export function addStrandsExpressEndpoint(
   agent: StrandsAgent,
   options: AddStrandsEndpointOptions,
 ): void {
+  assertAddStrandsEndpointOptions(options);
+
   const runAgent = async (req: Request, res: Response): Promise<void> => {
     // Request boundary validation. Express's `express.json()` middleware
     // skips bodies whose Content-Type isn't JSON — it leaves `req.body` as
@@ -391,16 +464,20 @@ export function addStrandsExpressEndpoint(
     }
   };
 
+  const handlers: RequestHandler[] = [];
   if (options.auth) {
     // Auth failures go through the adapter's own injectable logger
     // (`StrandsAgentConfig.logger`), not straight to the console, so an app
     // that redirected the adapter's output gets these in the same place as
     // everything else the adapter logs.
     const logger = resolveLogger(agent.config.logger);
-    app.post(options.path, authGuard(options.auth, logger), runAgent);
-  } else {
-    app.post(options.path, runAgent);
+    handlers.push(authGuard(options.auth, logger));
   }
+  if (options.bodyParser) {
+    handlers.push(options.bodyParser);
+  }
+  handlers.push(runAgent);
+  app.post(options.path, ...handlers);
 }
 
 /** Add a ping endpoint returning `{status: "healthy"}`. */

--- a/integrations/aws-strands/typescript/src/server.ts
+++ b/integrations/aws-strands/typescript/src/server.ts
@@ -12,8 +12,6 @@ import {
   addPing,
   addCapabilities,
 } from "./endpoint";
-import { authGuard } from "./endpoint";
-import { resolveLogger } from "./logger";
 import type { StrandsAgent } from "./agent";
 import type {
   StrandsAguiCapabilitiesOverrides,
@@ -206,12 +204,6 @@ async function loadCors(): Promise<typeof import("cors")> {
 }
 
 /**
- * A CORS option that only means something once the middleware is installed,
- * passed with nothing to install it. Silently ignoring it would leave the
- * caller believing cross-origin access is configured, so name what was passed
- * and what it needs.
- */
-/**
  * Every key `CreateStrandsAppOptions` accepts. An unknown key is refused rather
  * than ignored: TypeScript's excess-property check only fires on object
  * literals in TypeScript, so a JavaScript caller, a spread, or an `any` can
@@ -230,22 +222,120 @@ const CREATE_STRANDS_APP_OPTION_KEYS = [
   "auth",
 ] as const;
 
-function assertKnownOptions(options: CreateStrandsAppOptions): void {
-  const known = new Set<string>(CREATE_STRANDS_APP_OPTION_KEYS);
-  const unknown = Object.keys(options).filter((key) => !known.has(key));
-  if (unknown.length === 0) {
-    return;
-  }
-  const plural = unknown.length === 1 ? "option" : "options";
-  throw new Error(
-    `createStrandsApp received unknown ${plural} ${unknown
-      .map((key) => `\`${key}\``)
-      .join(", ")}. A misspelled option would be ignored, and for a ` +
-      `security option that means silently running without it. Valid options ` +
-      `are ${CREATE_STRANDS_APP_OPTION_KEYS.map((key) => `\`${key}\``).join(", ")}.`,
+const CREATE_STRANDS_APP_OPTION_KEY_SET = new Set<string>(
+  CREATE_STRANDS_APP_OPTION_KEYS,
+);
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    Array.from(value).every((item) => typeof item === "string")
   );
 }
 
+function assertCreateStrandsAppOption(
+  option: string,
+  value: unknown,
+  valid: boolean,
+  expected: string,
+): void {
+  if (!valid) {
+    const received =
+      value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+    throw new TypeError(
+      `createStrandsApp option \`${option}\` must be ${expected}; received ${received}.`,
+    );
+  }
+}
+
+function assertCreateStrandsAppOptions(
+  options: unknown,
+): asserts options is CreateStrandsAppOptions {
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    throw new TypeError("createStrandsApp options must be an object.");
+  }
+
+  const values = options as Record<string, unknown>;
+  const unknown = Object.keys(values).filter(
+    (key) => !CREATE_STRANDS_APP_OPTION_KEY_SET.has(key),
+  );
+  if (unknown.length > 0) {
+    const plural = unknown.length === 1 ? "option" : "options";
+    throw new Error(
+      `createStrandsApp received unknown ${plural} ${unknown
+        .map((key) => `\`${key}\``)
+        .join(", ")}. A misspelled option would be ignored, and for a ` +
+        `security option that means silently running without it. Valid options ` +
+        `are ${CREATE_STRANDS_APP_OPTION_KEYS.map((key) => `\`${key}\``).join(", ")}.`,
+    );
+  }
+
+  assertCreateStrandsAppOption(
+    "path",
+    values.path,
+    values.path === undefined || typeof values.path === "string",
+    "a string or undefined",
+  );
+  for (const option of ["pingPath", "capabilitiesPath"] as const) {
+    const value = values[option];
+    assertCreateStrandsAppOption(
+      option,
+      value,
+      value === undefined || value === null || typeof value === "string",
+      "a string, null, or undefined",
+    );
+  }
+  assertCreateStrandsAppOption(
+    "capabilities",
+    values.capabilities,
+    values.capabilities === undefined ||
+      (typeof values.capabilities === "object" &&
+        values.capabilities !== null &&
+        !Array.isArray(values.capabilities)),
+    "an object or undefined",
+  );
+  assertCreateStrandsAppOption(
+    "corsOrigin",
+    values.corsOrigin,
+    values.corsOrigin === undefined ||
+      typeof values.corsOrigin === "string" ||
+      typeof values.corsOrigin === "boolean" ||
+      isStringArray(values.corsOrigin),
+    "a string, boolean, string array, or undefined",
+  );
+  assertCreateStrandsAppOption(
+    "corsEnabled",
+    values.corsEnabled,
+    values.corsEnabled === undefined || typeof values.corsEnabled === "boolean",
+    "a boolean or undefined",
+  );
+  for (const option of ["allowMethods", "allowHeaders"] as const) {
+    const value = values[option];
+    assertCreateStrandsAppOption(
+      option,
+      value,
+      value === undefined || isStringArray(value),
+      "a string array or undefined",
+    );
+  }
+  assertCreateStrandsAppOption(
+    "auth",
+    values.auth,
+    values.auth === undefined || typeof values.auth === "function",
+    "a function or undefined",
+  );
+}
+
+/**
+ * A CORS option that only means something once the middleware is installed,
+ * passed with nothing to install it. Silently ignoring it would leave the
+ * caller believing cross-origin access is configured, so name what was passed
+ * and what it needs.
+ */
 function corsOptionsWithoutOrigin(names: string[]): string {
   return (
     `${names.join(", ")} ${names.length === 1 ? "was" : "were"} passed to ` +
@@ -332,7 +422,7 @@ export async function createStrandsApp(
   agent: StrandsAgent,
   options: CreateStrandsAppOptions = {},
 ): Promise<import("express").Express> {
-  assertKnownOptions(options);
+  assertCreateStrandsAppOptions(options);
 
   const {
     path = "/",
@@ -405,21 +495,18 @@ export async function createStrandsApp(
       }),
     );
   }
-  // Auth goes ahead of the body parser, not on the route. `express.json()` is
-  // app-wide, so a route-mounted guard would let an unauthenticated caller
-  // reach the parser first: malformed JSON would answer `400` from the parser
-  // with the guard never consulted, and a valid body would be buffered to the
-  // limit below before being rejected. Mounted as a path-specific POST layer
-  // so `next()` falls through to the parser and then the agent route, while
-  // `/ping` and `/capabilities` stay open.
-  if (auth) {
-    app.post(path, authGuard(auth, resolveLogger(agent.config.logger)));
-  }
-  app.use(express.json({ limit: "50mb" }));
+  // Keep auth, parsing, and dispatch in one route. Besides putting auth ahead
+  // of body parsing, one route makes Express control flow safe: `next("route")`
+  // skips the parser and agent together instead of falling through from an
+  // auth-only route into an unguarded copy of the agent endpoint.
+  const bodyParser = express.json({ limit: "50mb" });
+  addStrandsExpressEndpoint(app, agent, { path, auth, bodyParser });
 
-  // `auth` is deliberately not forwarded: it is already mounted above, and
-  // passing it again would run the caller's guard twice per request.
-  addStrandsExpressEndpoint(app, agent, { path });
+  // Preserve the factory's existing app-wide parsing for routes callers add
+  // to the returned app. The agent route above owns its parser and finishes
+  // before reaching this layer; a guard that deliberately calls
+  // `next("route")` may still hand a parsed body to a later fallback route.
+  app.use(bodyParser);
 
   if (pingPath) {
     addPing(app, pingPath);


### PR DESCRIPTION
## Summary

This is a dependent fix PR for #2512. It closes the remaining fail-open paths found during review:

- keep auth, body parsing, and agent dispatch in one Express route so `next("route")` cannot fall through to an unguarded agent route
- add a route-scoped `bodyParser` option for low-level callers that need auth to run before parsing
- reject unknown and invalid option values at both server entry points
- document the safe low-level middleware order

## Verification

- `pnpm nx run @ag-ui/aws-strands:typecheck --skip-nx-cache`
- `pnpm nx run @ag-ui/aws-strands:test --skip-nx-cache -- --no-file-parallelism` (59 files, 657 tests)
- `pnpm nx run @ag-ui/aws-strands:build --skip-nx-cache`
- `pnpm nx run @ag-ui/aws-strands:test:exports --skip-nx-cache`
- `pnpm nx exec --projects=@ag-ui/aws-strands-examples -- pnpm exec tsc --noEmit`

## Integration

Base: `ran/pni-371-strands-ts-cors-opt-in` (PR #2512). Merge this PR into that branch, then #2512 can be re-evaluated.
