### PR TITLE
fix(langgraph): harden subagent streaming edge cases

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -3563,7 +3563,7 @@ class LangGraphAgent:
                             ToolCallArgsEvent(
                                 type=EventType.TOOL_CALL_ARGS,
                                 tool_call_id=public_call_id,
-                                delta=json.dumps(event["data"].get("input", {})),
+                                delta=dump_json_safe(event["data"].get("input", {})),
                                 raw_event=event
                             )
                         )

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -847,14 +847,21 @@ class LangGraphAgent:
         if etype == EventType.STEP_STARTED:
             if in_window:
                 steps = state["steps"]
-                steps[event.step_name] = steps.get(event.step_name, 0) + 1
+                key = self._hidden_step_key(active_run, event)
+                steps[key] = steps.get(key, 0) + 1
                 return True
             return False
         if etype == EventType.STEP_FINISHED:
             steps = state["steps"]
-            if steps.get(event.step_name, 0) > 0:
-                steps[event.step_name] -= 1
+            key = self._hidden_step_key(active_run, event)
+            if steps.get(key, 0) > 0:
+                steps[key] -= 1
                 return True
+            if "subagent_run_id" not in getattr(event, "model_fields_set", set()):
+                matches = [k for k, count in steps.items() if k[1] == event.step_name and count > 0]
+                if len(matches) == 1:
+                    steps[matches[0]] -= 1
+                    return True
             # Closes a step whose open was emitted (e.g. the parent's `tools`
             # step closing mid-window) — must stay visible.
             return False
@@ -959,6 +966,12 @@ class LangGraphAgent:
         if etype in _SUBAGENT_ATTRIBUTABLE_EVENT_TYPES:
             return in_window
         return False
+
+    def _hidden_step_key(self, active_run, event: ProcessedEvents) -> tuple:
+        owner = getattr(event, "subagent_run_id", None)
+        if "subagent_run_id" not in getattr(event, "model_fields_set", set()):
+            owner = active_run.get("current_subagent_run_id")
+        return (owner, event.step_name)
 
     def _raw_payload_is_subagent_side(self, active_run, payload) -> bool:
         """Whether a RAW event's upstream payload originates inside a subagent.
@@ -4098,17 +4111,20 @@ class LangGraphAgent:
 
     def start_step(self, step_name: str, lane: str | None = None) -> Generator[ProcessedEvents, None, None]:
         """Emit STEP_STARTED for ``step_name``; node_name bookkeeping is done by handle_node_change."""
-        event = self._dispatch_event(
-            StepStartedEvent(
-                type=EventType.STEP_STARTED,
-                step_name=step_name
-            )
-        )
+        step_owner = lane if lane is not None else None
         # Remember who opened this step so end_step can attribute the close to the
         # same owner. Read back off the dispatched event rather than from
         # current_subagent_run_id so the two halves can never disagree about what the
         # chokepoint actually stamped.
-        self.active_run.setdefault("step_owners", {})[lane] = getattr(event, "subagent_run_id", None)
+        self.active_run.setdefault("step_owners", {})[lane] = step_owner
+        event = StepStartedEvent(
+            type=EventType.STEP_STARTED,
+            step_name=step_name
+        )
+        event.subagent_run_id = step_owner
+        event = self._dispatch_event(
+            event
+        )
         yield event
 
     def end_step(self, lane: str | None = None) -> ProcessedEvents:
@@ -4121,11 +4137,13 @@ class LangGraphAgent:
             raise ValueError("No active step to end")
 
         step_owner = self.active_run.get("step_owners", {}).get(lane)
+        event = StepFinishedEvent(
+            type=EventType.STEP_FINISHED,
+            step_name=node_name
+        )
+        event.subagent_run_id = step_owner
         event = self._dispatch_event(
-            StepFinishedEvent(
-                type=EventType.STEP_FINISHED,
-                step_name=node_name
-            )
+            event
         )
         if event is None:
             # Suppressed by subagent_visibility="hidden": the step bookkeeping

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -127,6 +127,22 @@ class SubagentContext:
     parent_subagent_run_id: Optional[str] = None
 
 
+def _command_update_tool_messages(messages: Any) -> List[ToolMessage]:
+    entries = [] if messages is None else (
+        messages if isinstance(messages, (list, tuple)) else [messages]
+    )
+    tool_messages = []
+    for entry in entries:
+        if isinstance(entry, ToolMessage):
+            tool_messages.append(entry)
+        elif (isinstance(entry, dict) and entry.get("tool_call_id")
+              and (entry.get("type") == "tool" or entry.get("role") == "tool")):
+            tool_messages.append(ToolMessage(content=entry.get("content") or "",
+                                             tool_call_id=entry["tool_call_id"],
+                                             name=entry.get("name"), id=entry.get("id")))
+    return tool_messages
+
+
 # Lane key for root/supervisor-level streaming state (events with no subagent).
 # Subagent lanes use the derived subagent id (e.g. "tools:<uuid>").
 _ROOT_LANE = "__root__"
@@ -1328,7 +1344,7 @@ class LangGraphAgent:
         output = (event.get("data") or {}).get("output")
         update = getattr(output, "update", None)
         if isinstance(update, dict):
-            msgs = update.get("messages")
+            msgs = _command_update_tool_messages(update.get("messages")) or update.get("messages")
             if isinstance(msgs, (list, tuple)):
                 # Prefer a genuine ToolMessage (the same filtering the OnToolEnd
                 # handler applies), since a Command update can also carry the
@@ -3502,7 +3518,7 @@ class LangGraphAgent:
                 # of crashing with AttributeError on ``.get``.
                 update = tool_call_output.update
                 if isinstance(update, dict):
-                    messages = update.get('messages', []) or []
+                    messages = _command_update_tool_messages(update.get('messages', []) or [])
                 else:
                     messages = []
 

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1019,6 +1019,7 @@ class LangGraphAgent:
             c for c in candidates
             if isinstance(c, dict) and c.get("name") == "task" and isinstance(c.get("id"), str)
         ]
+        task_calls = [c for c in task_calls if _is_deepagents_task_call(c)]
         active_run = getattr(self, "active_run", None)
         if active_run is None:
             return

--- a/integrations/langgraph/python/examples/agents/deepagents_subagents/agent.py
+++ b/integrations/langgraph/python/examples/agents/deepagents_subagents/agent.py
@@ -12,6 +12,7 @@ continues from where it paused.
 """
 
 import os
+from functools import partial
 
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
@@ -20,6 +21,11 @@ from langgraph.types import interrupt
 from deepagents import create_deep_agent
 from deepagents.middleware.subagents import SubAgent
 
+def _openai_api_key() -> str:
+    return os.environ["OPENAI_API_KEY"]
+
+
+ChatOpenAI = partial(ChatOpenAI, api_key=_openai_api_key)
 model = ChatOpenAI(model="gpt-4o-mini")
 
 

--- a/integrations/langgraph/python/examples/tests/test_deepagents_subagents_contract.py
+++ b/integrations/langgraph/python/examples/tests/test_deepagents_subagents_contract.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_deepagents_subagents_graph_imports_without_openai_key():
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "from agents.deepagents_subagents.agent import graph; assert graph"],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/integrations/langgraph/python/tests/test_parallel_subagent_streaming.py
+++ b/integrations/langgraph/python/tests/test_parallel_subagent_streaming.py
@@ -741,7 +741,7 @@ class TestNestedDuplicateTaskCallIds(unittest.TestCase):
                 "langgraph_node": "tools",
                 "langgraph_checkpoint_ns": "tools:outer|tools:inner",
             },
-            "data": {"input": {"type": "tool_call", "name": "task", "id": "dup"}},
+            "data": {"input": {"type": "tool_call", "name": "task", "id": "dup", "args": {"subagent_type": "researcher"}}},
         })
         agent._capture_subagent_task_meta({
             "event": LangGraphEventTypes.OnToolStart.value,
@@ -785,7 +785,7 @@ class TestNestedDuplicateTaskCallIds(unittest.TestCase):
                 "langgraph_node": "tools",
                 "langgraph_checkpoint_ns": "tools:outer|tools:inner",
             },
-            "data": {"input": {"type": "tool_call", "name": "task", "id": "dup"}},
+            "data": {"input": {"type": "tool_call", "name": "task", "id": "dup", "args": {"subagent_type": "researcher"}}},
         })
         agent._capture_subagent_task_meta({
             "event": LangGraphEventTypes.OnToolStart.value,
@@ -982,6 +982,26 @@ class TestOrdinaryToolIsNotASubagentBoundary(unittest.TestCase):
         self.assertEqual(agent.active_run["current_subagent_run_id"], "tools:outer")
         self.assertNotIn("tools:ordinary-call", agent.active_run["active_subagents"])
 
+    def test_task_named_tool_without_subagent_type_excludes_its_segment(self):
+        from ag_ui_langgraph.agent import reconcile_subagents
+        agent = self._agent_inside_outer()
+        agent._capture_task_tool_dispatch({
+            "event": LangGraphEventTypes.OnChainStart,
+            "name": "tools",
+            "metadata": {
+                "langgraph_node": "tools",
+                "langgraph_checkpoint_ns": "tools:outer|tools:ordinary-task-call",
+            },
+            "data": {"input": {"type": "tool_call", "name": "task", "id": "ordinary-task", "args": {"description": "not deepagents"}}},
+        })
+        events = reconcile_subagents(
+            agent.active_run,
+            "tools:outer|tools:ordinary-task-call|model:inside-tool",
+            "researcher",
+            set(),
+        )
+        self.assertEqual([e.type for e in events], [])
+
     def test_a_task_dispatch_still_creates_the_nested_boundary(self):
         from ag_ui_langgraph.agent import reconcile_subagents
 
@@ -993,7 +1013,7 @@ class TestOrdinaryToolIsNotASubagentBoundary(unittest.TestCase):
                 "langgraph_node": "tools",
                 "langgraph_checkpoint_ns": "tools:outer|tools:inner",
             },
-            "data": {"input": {"type": "tool_call", "name": "task", "id": "t1"}},
+            "data": {"input": {"type": "tool_call", "name": "task", "id": "t1", "args": {"subagent_type": "researcher"}}},
         })
         events = reconcile_subagents(
             agent.active_run,

--- a/integrations/langgraph/python/tests/test_subagent_emission.py
+++ b/integrations/langgraph/python/tests/test_subagent_emission.py
@@ -1122,7 +1122,7 @@ class TestRobustParentLinkJoin(unittest.TestCase):
             "run_id": run_id,
             "metadata": {"langgraph_node": "tools", "langgraph_checkpoint_ns": ns},
             "data": {"input": [
-                {"type": "tool_call", "id": c, "name": "task", "args": {}} for c in calls
+                {"type": "tool_call", "id": c, "name": "task", "args": {"subagent_type": "fixture"}} for c in calls
             ]},
         })
 
@@ -1438,4 +1438,3 @@ class TestEmitSubagentEventsOff(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/integrations/langgraph/python/tests/test_subagent_emission.py
+++ b/integrations/langgraph/python/tests/test_subagent_emission.py
@@ -1290,6 +1290,24 @@ class TestSubagentNewFields(unittest.TestCase):
         self.assertEqual([e.type for e in evs], [EventType.SUBAGENT_FINISHED])
         self.assertEqual(evs[0].result, "the subagent result")
 
+    def test_finish_accepts_command_single_tool_message_and_direct_dict(self):
+        from langchain_core.messages import ToolMessage
+        class _Cmd:
+            def __init__(self, messages):
+                self.update = {"messages": messages}
+        for messages, expected in [
+            (ToolMessage(content="live result", tool_call_id="tc1"), "live result"),
+            ({"type": "tool", "content": "dict result", "tool_call_id": "tc2"}, "dict result"),
+        ]:
+            agent = _make_agent()
+            agent.active_run = {"active_subagents": {"tools:sub1": "alpha"},
+                                "current_subagent_run_id": "tools:sub1",
+                                "subagent_task_runs": {"run-1": "tools:sub1"}}
+            evs = agent._finish_subagent_on_task_end(
+                {"event": "on_tool_end", "run_id": "run-1", "data": {"output": _Cmd(messages)}}
+            )
+            self.assertEqual(evs[0].result, expected)
+
 
 class TestNestedSubagentParent(unittest.TestCase):
     def test_parent_derived_from_boundary_segments(self):

--- a/integrations/langgraph/python/tests/test_subagent_flag_off_contract.py
+++ b/integrations/langgraph/python/tests/test_subagent_flag_off_contract.py
@@ -579,6 +579,21 @@ class TestCommandToolEndResultExtraction(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(results[0].tool_call_id, tool_call_id)
             self.assertEqual(results[0].content, content)
 
+    async def test_command_tool_args_are_safely_serialized(self):
+        from langgraph.types import Command
+        from datetime import datetime, timezone; import uuid
+
+        collected = await _drive(_make_agent(), [_chain_start("model", {"langgraph_node": "model"}), {
+            "event": "on_tool_end", "run_id": "run-1", "name": "tools", "metadata": {"langgraph_node": "tools"},
+            "data": {
+                "output": Command(update={"messages": ToolMessage(content="single", tool_call_id="tc-single", name="my_tool")}),
+                "input": {"id": uuid.UUID("12345678-1234-5678-1234-567812345678"), "at": datetime(2026, 8, 25, tzinfo=timezone.utc)},
+            },
+        }])
+        args = [e for e in collected if getattr(e, "type", None) == EventType.TOOL_CALL_ARGS]
+        self.assertEqual(len(args), 1)
+        self.assertTrue("12345678-1234-5678-1234-567812345678" in args[0].delta and "datetime.datetime(2026, 8, 25" in args[0].delta)
+
 
 class TestTaskToolErrorTerminatesTheSubagent(unittest.TestCase):
     """A failed `task` delegation must end in SUBAGENT_ERROR, not FINISHED.

--- a/integrations/langgraph/python/tests/test_subagent_flag_off_contract.py
+++ b/integrations/langgraph/python/tests/test_subagent_flag_off_contract.py
@@ -530,10 +530,7 @@ class TestTaskEndResultExtraction(unittest.TestCase):
 
         events = self._finish(_Cmd())
         self.assertEqual([e.type for e in events], [EventType.SUBAGENT_FINISHED])
-        self.assertIsNone(
-            events[0].result,
-            "an un-listed payload yields no result rather than killing the run",
-        )
+        self.assertEqual(events[0].result, "solo")
 
     def test_a_dict_shaped_message_still_yields_its_content(self):
         class _Cmd:
@@ -563,6 +560,24 @@ class TestTaskEndResultExtraction(unittest.TestCase):
             events = self._finish(_Cmd())
         self.assertIsNone(events[0].result)
         self.assertTrue(any("result" in r.getMessage() for r in logs.records))
+
+
+class TestCommandToolEndResultExtraction(unittest.IsolatedAsyncioTestCase):
+    async def test_single_tool_message_and_direct_dict_emit_tool_results(self):
+        from langgraph.types import Command
+        for message, tool_call_id, content in [
+            (ToolMessage(content="single", tool_call_id="tc-single", name="my_tool"), "tc-single", "single"),
+            ({"type": "tool", "content": "dict", "tool_call_id": "tc-dict", "name": "my_tool"}, "tc-dict", "dict"),
+        ]:
+            collected = await _drive(_make_agent(), [_chain_start("model", {"langgraph_node": "model"}), {
+                "event": "on_tool_end", "run_id": "run-1", "name": "tools",
+                "metadata": {"langgraph_node": "tools"},
+                "data": {"output": Command(update={"messages": message}), "input": {}},
+            }])
+            results = [e for e in collected if getattr(e, "type", None) == EventType.TOOL_CALL_RESULT]
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].tool_call_id, tool_call_id)
+            self.assertEqual(results[0].content, content)
 
 
 class TestTaskToolErrorTerminatesTheSubagent(unittest.TestCase):

--- a/integrations/langgraph/python/tests/test_subagent_hidden_contract.py
+++ b/integrations/langgraph/python/tests/test_subagent_hidden_contract.py
@@ -341,6 +341,24 @@ class TestHiddenPairing(unittest.TestCase):
             "or the wire carries an unpaired STEP_STARTED",
         )
 
+    def test_same_name_hidden_subagent_step_does_not_close_the_parent(self):
+        agent = self._agent()
+        agent.active_run["lane_nodes"] = {None: "model", "tools:s1": "model"}
+        parent_opened = list(agent.start_step("model", None))
+        self.assertIsNotNone(parent_opened[0])
+
+        self._enter_window(agent, "tools:s1")
+        hidden_opened = list(agent.start_step("model", "tools:s1"))
+        self.assertIsNone(hidden_opened[0])
+
+        parent_closed = agent.end_step(None)
+        self.assertIsNotNone(
+            parent_closed,
+            "a hidden subagent's same-name step must not consume the visible "
+            "parent close",
+        )
+        self.assertIsNone(parent_closed.subagent_run_id)
+
     def test_a_visible_messages_continuation_survives_the_window(self):
         agent = self._agent()
         start = agent._dispatch_event(TextMessageStartEvent(


### PR DESCRIPTION
## Summary

Stacked review for [#2528](https://github.com/ag-ui-protocol/ag-ui/pull/2528), targeting its `mme/langgraph-subagents` head branch.

- require the DeepAgents task-call shape before creating subagent boundaries
- preserve hidden-step ownership when parent and child steps share a name
- normalize single and dictionary-shaped `Command.update` tool messages
- serialize Command tool inputs with the existing JSON-safe helper
- defer the example's `OPENAI_API_KEY` lookup until runtime

## Scope

Exactly 7 files, +170/-26: 2 implementation files and 5 regression-test files. No dependency, lockfile, generated-file, public-schema, Dojo, or unrelated cleanup changes.

Broader findings are intentionally excluded and tracked for PNI triage in PNI-383 through PNI-388.

## Verification

- Python unit suite: 602 passed
- no-key example import contract: 1 passed
- Nx LangGraph tests: 272 passed, 2 existing todo
- Nx LangGraph typecheck: passed
- Python package build and Nx LangGraph build: passed
- both Python lock checks and final clean-tree/diff checks: passed
