### PR TITLE
fix(aws-strands): reconcile a frontend result delivered on a later turn

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -3018,17 +3018,32 @@ class StrandsAgent:
                             exc_info=True,
                         )
 
-            # Scope to the TRAILING tool results (this continuation's just-
-            # returned results). ``pending_tool_result_ids`` holds those ids;
-            # without this, a multi-turn continuation re-sends already-reconciled
-            # historical results, which can never be re-corrected and would force
-            # the legacy fallback every turn.
+            # Scope: this continuation's just-returned results, plus any earlier
+            # frontend call whose placeholder is still uncorrected.
+            #
+            # ``pending_tool_result_ids`` holds the TRAILING ids only (it is built
+            # by a reversed scan that stops at the first non-tool message). On its
+            # own it misses a result the client delivers on a LATER turn, with a
+            # user message after it: that result never reaches reconciliation and
+            # the persisted toolResult keeps ``PROXY_RESULT_PLACEHOLDER`` forever.
+            #
+            # A live entry in ``wire_to_native`` is the second admission signal,
+            # and it is safe precisely because of how that map is maintained below:
+            # entries are dropped once their placeholder is actually corrected, and
+            # kept only so a later turn can retry. An already-reconciled historical
+            # result is therefore absent from the map and still cannot re-enter
+            # here — which is what scoping to the trailing ids was protecting.
             frontend_results: List[Dict[str, Any]] = []
             for msg in (input_data.messages or []):
                 if getattr(msg, "role", None) != "tool":
                     continue
                 wire_id = getattr(msg, "tool_call_id", None)
-                if not wire_id or wire_id not in pending_tool_result_ids:
+                if not wire_id:
+                    continue
+                if (
+                    wire_id not in pending_tool_result_ids
+                    and wire_id not in wire_to_native
+                ):
                     continue
                 name = _tool_call_id_to_name.get(wire_id)
                 if name not in frontend_tool_names and wire_id not in wire_to_native:

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -3034,7 +3034,9 @@ class StrandsAgent:
             # result is therefore absent from the map and still cannot re-enter
             # here — which is what scoping to the trailing ids was protecting.
             frontend_results: List[Dict[str, Any]] = []
-            for msg in (input_data.messages or []):
+            last_frontend_result_index: int | None = None
+            input_messages = input_data.messages or []
+            for msg_index, msg in enumerate(input_messages):
                 if getattr(msg, "role", None) != "tool":
                     continue
                 wire_id = getattr(msg, "tool_call_id", None)
@@ -3064,6 +3066,15 @@ class StrandsAgent:
                         "is_error": bool(getattr(msg, "error", None)),
                     }
                 )
+                last_frontend_result_index = msg_index
+
+            has_newer_user_message = (
+                last_frontend_result_index is not None
+                and any(
+                    getattr(msg, "role", None) == "user"
+                    for msg in input_messages[last_frontend_result_index + 1 :]
+                )
+            )
 
             # Translate the client's wire tool_call_id back to the native
             # toolUseId Strands persisted (they differ for frontend tools — see
@@ -3253,7 +3264,14 @@ class StrandsAgent:
                     getattr(strands_agent, "messages", None) or [],
                     only_ids=set(resolved_native_results),
                 )
-                resume_prompt = None if reconciled else user_message
+                # A non-trailing result can be repaired from native history, but
+                # a user message after it is still this run's new prompt. Passing
+                # None here would silently drop that newer turn.
+                resume_prompt = (
+                    None
+                    if reconciled and not has_newer_user_message
+                    else user_message
+                )
 
             # A client answering to an interrupt sends its responses
             # in ``RunAgentInput.resume`` (as per the AG-UI interrupt round-trip),

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -1024,6 +1024,75 @@ class TestSessionFrontendToolReconciliation:
         ]
 
     @pytest.mark.asyncio
+    async def test_non_trailing_frontend_result_is_still_reconciled(self, tmp_path):
+        # The client delivers the frontend result on a LATER turn: it sits in
+        # history with a user message after it, so nothing is trailing and
+        # ``pending_tool_result_ids`` is empty. Scoping collection to the
+        # trailing ids alone drops the result entirely and the persisted
+        # toolResult keeps the proxy placeholder for the rest of the thread's
+        # life. Admission rests on the durable map instead: this call's entry
+        # is still there precisely because it was never corrected.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-late", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_tool("wire-1", '{"approved": true}'),
+                UserMessage(id="u2", content="do the next thing"),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={"wire-1": "native-1"},
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1"),
+            ],
+        )
+
+        block = _result_content(sm, "default", 1)[0]["toolResult"]
+        assert block["content"] == [{"text": '{"approved": true}'}]
+        assert block["status"] == "success"
+        # Corrected, so the entry is pruned and cannot be re-collected later.
+        assert (instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}) == {}
+
+    @pytest.mark.asyncio
+    async def test_non_trailing_result_without_a_live_map_entry_is_left_alone(
+        self, tmp_path
+    ):
+        # The counterpart. An earlier call that was already reconciled had its
+        # wire->native entry pruned, so re-sending it in history — with no
+        # trailing result at all — must not pull it back into reconciliation.
+        # That is the property the trailing-only scope protected, and it now
+        # rests on the map directly: the same assumption
+        # ``test_multi_turn_reconciles_only_the_trailing_result`` already
+        # encodes when it prunes its historical entries.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-done", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("wire-1", "approve"),
+                _payload_tool("wire-1", "OLD"),
+                UserMessage(id="u2", content="do the next thing"),
+            ],
+            tools=[_frontend_tool("approve")],
+            wire_map={},  # already corrected on an earlier turn -> pruned
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1", text="OLD"),
+            ],
+        )
+
+        assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
+            {"text": "OLD"}
+        ]
+        assert instance.stream_prompts == ["do the next thing"]
+
+    @pytest.mark.asyncio
     async def test_partially_resolvable_turn_falls_back_to_legacy(self, tmp_path):
         # Two frontend results in one turn, both recognized as frontend, but only
         # one resolves to a native id (wire-2 is not in the map and its

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -1054,6 +1054,7 @@ class TestSessionFrontendToolReconciliation:
         block = _result_content(sm, "default", 1)[0]["toolResult"]
         assert block["content"] == [{"text": '{"approved": true}'}]
         assert block["status"] == "success"
+        assert instance.stream_prompts == ["do the next thing"]
         # Corrected, so the entry is pruned and cannot be re-collected later.
         assert (instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}) == {}
 


### PR DESCRIPTION
Fixes #2537.

## The gap

`pending_tool_result_ids` is built by a reversed scan that stops at the first non-tool message (`agent.py:2627` onwards), so it holds the TRAILING tool results only. The frontend-result collection was scoped to that set. When the client delivers a frontend tool result on a later turn — the result sits in history with a user message after it — nothing is trailing, the set is empty, and the result never enters `frontend_results`. `has_nonvoid_frontend_result` therefore stays `False`, the `reconcile_session_results` gate never opens, `reconcile_frontend_tool_results` never runs for that call, and the persisted `toolResult` keeps `PROXY_RESULT_PLACEHOLDER` for the rest of the thread.

This is reachable on the default configuration: `replay_history_into_strands` is `True` (`config.py`), and the reconcile gate reads that flag directly.

## The change

Admit a tool result that is either trailing, as before, or whose wire id is still present in the durable wire->native map.

The map is the right discriminator, and this is not a new invariant — the code already maintains it deliberately. Entries are dropped for exactly the native ids corrected on a turn, and uncorrected ones are kept so a later turn can retry (the pruning block near `agent.py:3274`, whose comment states that pruning them "would strand the persisted placeholder forever"). A live entry therefore already means "this frontend call's placeholder is still outstanding", and an already-reconciled result is absent from the map.

That is precisely the property the trailing-only scope was protecting. `test_multi_turn_reconciles_only_the_trailing_result` already encodes the same assumption: it prunes its two historical entries from the wire map and comments that they would "fail to resolve (their entries are gone from the durable map)". The scope was using trailing position as a proxy for a signal the map carries directly; this change reads the signal instead. That test passes unchanged.

There is a second, independent guard downstream: the correction short-circuits a `toolResult` whose content and status already match, and mutates only when `_is_placeholder` holds (`session_reconcile.py`). An already-reconciled result cannot be overwritten even if it were collected.

## Scope

`pending_tool_result_ids` itself is left untouched. It also drives `TOOL_CALL_*` suppression elsewhere in `run()`, so widening the shared set would change event emission. The change stays inside the collection loop.

## Tests

`test_non_trailing_frontend_result_is_still_reconciled` — the reported case: assistant tool call, tool result, then a user message. Asserts the persisted `toolResult` is corrected, its status is `success`, and the entry is pruned afterwards so it cannot be collected again.

`test_non_trailing_result_without_a_live_map_entry_is_left_alone` — the counterpart: the same non-trailing shape with the map entry already pruned. The stored value is untouched and the run takes the legacy path. This test passes both with and WITHOUT the fix — it pins a property the change preserves rather than one it creates.

Suite: 699 passed, 2 skipped (699 = 697 on `main` plus these two). With the collection scoped back to the trailing ids, the first test fails as `{'text': 'Forwarded to client'} != {'text': '{"approved": true}'}` — the placeholder from the report.

## One question

A turn whose payload carries no trailing tool result at all will now run repository reconciliation whenever the durable map still holds an uncorrected entry. That is the point of the fix, but it does mean repository access on turns that previously skipped it. If you would rather bound that, the natural narrowing is to admit a non-trailing result only when its native id's stored `toolResult` is still a placeholder — at the cost of a repository read inside the collection loop. I can switch to that shape if you prefer it.
