### PR TITLE
fix(langgraph): preserve plain string entries in multimodal message conversion

### DIFF
--- a/integrations/langgraph/cross-runtime-parity-cases.json
+++ b/integrations/langgraph/cross-runtime-parity-cases.json
@@ -802,13 +802,13 @@
     {
       "id": "inbound/non-object-entry/bare-string",
       "direction": "inbound",
-      "axis": "malformed",
-      "why": "a bare string where a block is expected",
+      "axis": "wellformed",
+      "why": "a bare string entry is text content, not a malformed block",
       "content": ["just a string"],
       "expect": {
-        "kept": [],
-        "dropped": 1,
-        "loggedDrops": 1
+        "kept": [{ "kind": "text", "text": "just a string" }],
+        "dropped": 0,
+        "loggedDrops": 0
       }
     },
     {

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -396,8 +396,17 @@ def _agui_media_from_standard_block(item: Dict[str, Any]):
 # `convertLangchainMultimodalToAgui`. The two must not drift.
 
 
-def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[AGUIContentItem]:
+def convert_langchain_multimodal_to_agui(content: Union[str, List[Union[str, Dict[str, Any]]]]) -> List[AGUIContentItem]:
     """Convert LangChain's multimodal content to AG-UI format.
+
+    Plain string entries are preserved in place as text. LangChain declares
+    message content as ``str | list[str | dict]``, so a string sitting beside the
+    blocks is content rather than a malformed block, and dropping it lost the
+    user's words. A bare string ARGUMENT is normalized to a one-entry list as a
+    defensive convenience for direct callers — a str is itself iterable, so
+    walking one would shred it into a content item per character. The production
+    caller (:func:`langchain_messages_to_agui`) only routes list content here and
+    converts bare-string message content itself.
 
     ``image_url`` blocks are converted with the appropriate source type (data or
     URL) and to the media class their MIME type names — ``image_url`` is the
@@ -417,9 +426,25 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
     exception here does not degrade one attachment — it escapes the conversion
     and costs the client every message in the thread.
     """
+    if isinstance(content, str):
+        content = [content]
+    elif not isinstance(content, list):
+        # Rule 2, one level further out than the `else` at the end of this loop:
+        # the whole content value, not one of its items. A dict reaching here
+        # would otherwise be walked as a sequence of its own KEY NAMES.
+        logger.warning(
+            "Dropping content: not a str or list (%s)", _describe_type(content)
+        )
+        return []
+
     agui_content: List[AGUIContentItem] = []
     for item in content:
-        if isinstance(item, dict):
+        if isinstance(item, str):
+            agui_content.append(TextInputContent(
+                type="text",
+                text=item
+            ))
+        elif isinstance(item, dict):
             # Read ONCE, into a local. `item.get("type") in _AGUI_MEDIA_CLASSES`
             # below raises `TypeError: unhashable type` for a `type` that is a
             # list or a dict — a rule-1 violation that takes the whole snapshot
@@ -538,10 +563,12 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
                 )
         else:
             # Same rule, one level out. A content list relayed by the LangGraph
-            # server can carry a JSON `null`, a bare string, or a number where a
+            # server can carry a JSON `null`, a number, or a nested list where a
             # block is expected. `.get` on one of those would raise out of the
             # whole message list, so this loop never called it — but it said
-            # nothing either. The TypeScript adapter already warns here.
+            # nothing either. The TypeScript adapter already warns here. A bare
+            # string is NOT one of these — LangChain accepts one as content, and
+            # the branch at the top of the loop keeps it.
             logger.warning(
                 "Dropping content block: not a dict (%s)", _describe_type(item)
             )

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -280,6 +280,20 @@ class TestLangchainMessagesToAgui(unittest.TestCase):
         assert content[0].source.mime_type == "image/jpeg"
         assert content[0].source.value == "abc123"
 
+    def test_multimodal_plain_string_entry_preserved(self):
+        msg = HumanMessage(
+            id="m3",
+            content=["hello", {"type": "text", "text": " world"}],
+        )
+        result = langchain_messages_to_agui([msg])
+        content = result[0].content
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0].type == "text"
+        assert content[0].text == "hello"
+        assert content[1].type == "text"
+        assert content[1].text == " world"
+
 
 class TestRoundTrip(unittest.TestCase):
     """Tests that messages survive conversion in both directions."""

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -700,6 +700,126 @@ class TestMultimodalConversion(unittest.TestCase):
         self.assertEqual(agui_content[0].source.mime_type, "image/jpeg")
         self.assertEqual(agui_content[0].source.value, "/9j/4AAQ")
 
+    def test_langchain_plain_string_entries_preserved(self):
+        """Test plain string entries survive conversion alongside structured blocks."""
+        lc_content = ["hello", {"type": "text", "text": " world"}]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 2)
+        self.assertIsInstance(agui_content[0], TextInputContent)
+        self.assertEqual(agui_content[0].text, "hello")
+        self.assertIsInstance(agui_content[1], TextInputContent)
+        self.assertEqual(agui_content[1].text, " world")
+
+    def test_langchain_plain_string_interleaved_with_image_keeps_order(self):
+        """Test plain strings keep their position among structured image blocks."""
+        lc_content = [
+            "before",
+            {"type": "image_url", "image_url": {"url": "https://example.com/pic.png"}},
+            "after",
+        ]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 3)
+        self.assertIsInstance(agui_content[0], TextInputContent)
+        self.assertEqual(agui_content[0].text, "before")
+        self.assertIsInstance(agui_content[1], ImageInputContent)
+        self.assertIsInstance(agui_content[1].source, InputContentUrlSource)
+        self.assertEqual(agui_content[1].source.value, "https://example.com/pic.png")
+        self.assertIsInstance(agui_content[2], TextInputContent)
+        self.assertEqual(agui_content[2].text, "after")
+
+    def test_langchain_plain_string_entries_preserved_verbatim(self):
+        """Test plain string entries keep whitespace, case and non-ASCII characters."""
+        lc_content = ["  Padded MixedCase  ", "\tGrüße 日本\n", "   "]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 3)
+        self.assertEqual(agui_content[0].text, "  Padded MixedCase  ")
+        self.assertEqual(agui_content[1].text, "\tGrüße 日本\n")
+        self.assertEqual(agui_content[2].text, "   ")
+
+    def test_langchain_empty_string_entry_preserved(self):
+        """Test an empty string entry still produces a text item."""
+        lc_content = ["", {"type": "text", "text": "world"}]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 2)
+        self.assertIsInstance(agui_content[0], TextInputContent)
+        self.assertEqual(agui_content[0].text, "")
+        self.assertEqual(agui_content[1].text, "world")
+
+    def test_langchain_bare_string_content_becomes_single_text_item(self):
+        """Test a bare string content is treated as the whole content, not iterated."""
+        agui_content = convert_langchain_multimodal_to_agui("hi there")
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0], TextInputContent)
+        self.assertEqual(agui_content[0].text, "hi there")
+
+    def test_langchain_bare_string_content_preserved_verbatim(self):
+        """Test a bare string keeps its padding, case and non-ASCII characters."""
+        agui_content = convert_langchain_multimodal_to_agui("  Hallö Wörld  ")
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertEqual(agui_content[0].text, "  Hallö Wörld  ")
+
+    def test_langchain_bare_empty_string_content_becomes_single_text_item(self):
+        """Test an empty bare string still yields one empty text item."""
+        agui_content = convert_langchain_multimodal_to_agui("")
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0], TextInputContent)
+        self.assertEqual(agui_content[0].text, "")
+
+    def test_langchain_non_list_content_yields_no_items(self):
+        """Test non-list content is not walked element-wise into fabricated text."""
+        # A stray dict must not be shredded into its key names, and no other
+        # iterable may be traversed as if it were a list of content blocks.
+        # Non-iterables yield [] too, where the pre-branch code raised TypeError.
+        self.assertEqual(
+            convert_langchain_multimodal_to_agui({"type": "text", "text": "x"}), []
+        )
+        self.assertEqual(convert_langchain_multimodal_to_agui(("a", "b")), [])
+        self.assertEqual(convert_langchain_multimodal_to_agui({"a", "b"}), [])
+        self.assertEqual(convert_langchain_multimodal_to_agui(None), [])
+
+    def test_langchain_unconvertible_entries_are_skipped(self):
+        """Test entries that are neither a string nor a dict are dropped, not raised on."""
+        lc_content = ["keep", 5, None, ["nested"], {"type": "text", "text": "also keep"}]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(len(agui_content), 2)
+        self.assertEqual(agui_content[0].text, "keep")
+        self.assertEqual(agui_content[1].text, "also keep")
+
+    def test_langchain_unknown_block_type_is_not_fabricated_into_content(self):
+        """Test an unrecognized content block is dropped, never fabricated into an item."""
+        # An unknown block must not reach the image_url handler, which would mint an
+        # ImageInputContent with an empty source. This asserts hollowness rather than
+        # a count: if the converter is later taught langchain-core's standard blocks,
+        # these should become real image and audio items — never sourceless ones.
+        lc_content = [
+            {"type": "text", "text": "look"},
+            {"type": "image", "base64": "AAAA", "mime_type": "image/png"},
+            {"type": "audio", "base64": "BBBB", "mime_type": "audio/wav"},
+            {"no_type_key": True},
+        ]
+
+        agui_content = convert_langchain_multimodal_to_agui(lc_content)
+
+        self.assertEqual(
+            [c.text for c in agui_content if isinstance(c, TextInputContent)], ["look"]
+        )
+        for item in agui_content:
+            if isinstance(item, ImageInputContent):
+                self.assertTrue(item.source.value, f"sourceless media item: {item!r}")
+
     # ── Round-trip tests ────────────────────────────────────────────────
 
     def test_round_trip_langchain_url_to_agui_and_back(self):
@@ -3009,7 +3129,6 @@ class TestMalformedInputContract(unittest.TestCase):
         the loop never called it — but it said nothing either."""
         for entry, described in [
             (None, "NoneType"),
-            ("just a string", "str"),
             (7, "int"),
             (True, "bool"),
             (["x"], "list"),

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -1134,13 +1134,27 @@ function incomingImageUrl(payload: unknown): string | undefined {
  * MESSAGES_SNAPSHOT — a block kind missing here is an attachment that vanishes
  * from a reopened thread.
  */
-function convertLangchainMultimodalToAgui(content: IncomingMediaBlock[]): InputContent[] {
+function convertLangchainMultimodalToAgui(content: (IncomingMediaBlock | string)[]): InputContent[] {
   const aguiContent: InputContent[] = [];
 
   for (const item of content) {
-    // A content array relayed by the LangGraph server can carry a JSON `null`
-    // (or a bare string) where a block is expected, and `item.type` on one of
-    // those aborts the conversion of every OTHER block and every other message.
+    // A plain string entry is CONTENT, not a malformed block. LangChain types
+    // message content as `str | list[str | dict]` and folds a bare entry in as
+    // text — `convert_to_openai_messages(["hello", {type: "text", text: " world"}])`
+    // sends the model `"hello\n world"` — so dropping it loses the user's own
+    // words rather than discarding junk. Mirrors the `isinstance(item, str)`
+    // branch in the Python adapter.
+    if (typeof item === "string") {
+      aguiContent.push({
+        type: "text",
+        text: item,
+      });
+      continue;
+    }
+
+    // A content array relayed by the LangGraph server can carry a JSON `null`, a
+    // number, or a nested array where a block is expected, and `item.type` on one
+    // of those aborts the conversion of every OTHER block and every other message.
     // One unusable block is dropped like any other unusable block.
     if (!item || typeof item !== "object") {
       console.warn("[convertLangchainMultimodalToAgui] Dropping content block: not an object");


### PR DESCRIPTION
Closes PNI-383. Rebased onto `main` now that #2528 has merged.

## The bug

LangChain accepts plain strings inside list-form message content, but the multimodal converters only walked dict blocks, so string entries were silently dropped:

```python
["hello", {"type": "text", "text": " world"}]  # -> only " world" survived
```

## The fix

Both converters gain a string branch that turns a string entry into text content in place, so it survives in its original position among the structured blocks.

A `str` is itself iterable, so handing a bare string to that same branch would shred it into one item per character. Python normalizes a bare string to a one-entry list up front, and content that is neither a `str` nor a `list` is dropped and logged one level further out than the loop's own terminal `else` — a dict reaching there would otherwise be walked as a sequence of its own key names. The Python signature widens to `Union[str, List[Union[str, Dict[str, Any]]]]`.

## Why this touches both runtimes

This sits on top of #2476, which landed the malformed-input contract and the standard media blocks. That contract lists a bare string entry as malformed, alongside a JSON `null` and a number. LangChain does not:

```python
>>> convert_to_openai_messages([HumanMessage(content=["hello", {"type": "text", "text": " world"}])])
[{'role': 'user', 'content': 'hello\n world'}]
```

LangChain declares message content as `str | list[str | dict]` and folds a bare entry in as text, so the string is the user's own words — dropping it loses content rather than discarding junk. #2476's three rules are otherwise kept intact: the new drop is logged like every other, and one bad item still costs only itself. Its `test_non_dict_entries_are_dropped_and_logged` no longer lists `str` among the malformed shapes.

That contract is deliberately mirrored across the two adapters behind a single shared table, so the reclassification is applied to both halves:

- `integrations/langgraph/python/ag_ui_langgraph/utils.py` — the string branch, the bare-string normalization, the non-list guard.
- `integrations/langgraph/typescript/src/utils.ts` — the same string branch (the comment there previously named a bare string as one of the shapes to drop).
- `integrations/langgraph/cross-runtime-parity-cases.json` — five lines, the one affected case (`inbound/non-object-entry/bare-string`) now recording `kept: [text]` instead of a logged drop.

An earlier revision of this branch kept TypeScript out of scope and declared the divergence in a Python-side exemption list. That list was a second source of truth for the exact contract the shared table exists to be the only source of — the anti-pattern its own docstring calls "the exact failure this exists to prevent" — so it is gone.

## Verification

- **Python**: 738 pass (`uv run python -m pytest -q tests/`), and CI's `python -m unittest discover tests` is green.
- **TypeScript**: 763 pass (`pnpm test`) with a clean `pnpm typecheck` — including the 503 assertions in `utils.test.ts`, which read the corrected case from the shared table, so both runtimes now agree on it.
- Coverage added: the ticket's regression; string entries interleaved with an image block in order; verbatim preservation of empty, whitespace-only, mixed-case and non-ASCII entries; a bare string as a single text item; `dict`/`tuple`/`set`/`None` yielding no items; entries that are neither `str` nor `dict` skipped while their convertible neighbours come through; an unknown block never fabricated into a hollow item; and the fix pinned at the `langchain_messages_to_agui` entry point where the reported data loss actually manifested, not just on the helper.
- Confirmed working alongside #2476's new behavior: a standard `image` block still converts to an `ImageInputContent` carrying its real source, and the ticket's example returns `['hello', ' world']` through `langchain_messages_to_agui`.

## Deferred

- **Python sibling walkers** — `resolve_message_content` has the identical string-dropping bug on the AIMessage/SystemMessage/ToolMessage arms; `resolve_encrypted_reasoning_content` raises `AttributeError` on string-first list content. Both pre-existing and out of this ticket's scope.
- **Empty-string text blocks** — the TypeScript converter drops a `text` block whose `text` is `""` where Python keeps it. Pre-existing divergence, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)