### PR TITLE
fix(langgraph): close the whitespace door into the empty-value defect (PNI-384)

### DIFF
--- a/integrations/langgraph/cross-runtime-parity-cases.json
+++ b/integrations/langgraph/cross-runtime-parity-cases.json
@@ -3799,6 +3799,109 @@
       }
     },
     {
+      "id": "inbound/image_url/url-whitespace-only",
+      "direction": "inbound",
+      "axis": "malformed",
+      "why": "a whitespace-only url is truthy, so a bare falsiness check lets it through to mint an attachment pointing at nothing",
+      "content": [
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "   "
+          }
+        }
+      ],
+      "expect": {
+        "kept": [],
+        "dropped": 1,
+        "loggedDrops": 1
+      }
+    },
+    {
+      "id": "inbound/image_url/url-bare-string-whitespace-only",
+      "direction": "inbound",
+      "axis": "malformed",
+      "why": "the same defect through the bare-string shape rather than the {url} object",
+      "content": [
+        {
+          "type": "image_url",
+          "image_url": "  \t "
+        }
+      ],
+      "expect": {
+        "kept": [],
+        "dropped": 1,
+        "loggedDrops": 1
+      }
+    },
+    {
+      "id": "inbound/image_url/data-url-leading-whitespace",
+      "direction": "inbound",
+      "axis": "data-url",
+      "why": "a LEADING space makes the data: test false, so base64 bytes are filed as a remote url the client then tries to fetch",
+      "content": [
+        {
+          "type": "image_url",
+          "image_url": "  data:image/png;base64,QUJD"
+        }
+      ],
+      "expect": {
+        "kept": [
+          {
+            "kind": "image",
+            "source": "data",
+            "value": "QUJD",
+            "mimeType": "image/png",
+            "filename": null
+          }
+        ],
+        "dropped": 0,
+        "loggedDrops": 0
+      }
+    },
+    {
+      "id": "inbound/image_url/data-url-payload-whitespace-only",
+      "direction": "inbound",
+      "axis": "data-url",
+      "why": "a whitespace-only payload is truthy and mints the same empty-valued attachment the no-payload guard rejects",
+      "content": [
+        {
+          "type": "image_url",
+          "image_url": "data:image/png;base64,   "
+        }
+      ],
+      "expect": {
+        "kept": [],
+        "dropped": 1,
+        "loggedDrops": 1
+      }
+    },
+    {
+      "id": "inbound/image_url/data-url-mediatype-blank",
+      "direction": "inbound",
+      "axis": "data-url",
+      "why": "a blank mediatype is present-but-empty wearing whitespace and must take the image/png default like the empty one; a PADDED REAL mediatype keeps its padding, which modality-padded-major pins",
+      "content": [
+        {
+          "type": "image_url",
+          "image_url": "data:   ;base64,QUJD"
+        }
+      ],
+      "expect": {
+        "kept": [
+          {
+            "kind": "image",
+            "source": "data",
+            "value": "QUJD",
+            "mimeType": "image/png",
+            "filename": null
+          }
+        ],
+        "dropped": 0,
+        "loggedDrops": 0
+      }
+    },
+    {
       "id": "outbound/malformed/unknown-type",
       "direction": "outbound",
       "axis": "malformed",

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -294,13 +294,32 @@ def _incoming_image_url(payload: Any) -> str | None:
     Mirrors the `item.image_url` read in the TypeScript adapter's
     `convertLangchainMultimodalToAgui`, which skips the same blocks.
     """
-    if isinstance(payload, str):
-        return payload or None
-    if isinstance(payload, dict):
-        url = payload.get("url")
-        if isinstance(url, str) and url:
-            return url
-    return None
+    url = payload if isinstance(payload, str) else None
+    if url is None and isinstance(payload, dict):
+        # `dict.get`, not `payload.get`, for the same reason `str.strip` is
+        # spelled that way below: a dict SUBCLASS off the wire can override
+        # `.get` and raise from it, and an exception here escapes the whole
+        # MESSAGES_SNAPSHOT.
+        candidate = dict.get(payload, "url")
+        url = candidate if isinstance(candidate, str) else None
+    if url is None:
+        return None
+
+    # `str.strip`, not `url.strip()`, and the reason is not style. It does two
+    # jobs at once:
+    #
+    # 1. Whitespace is the side door into the empty-value defect this function
+    #    already rejects. A url of "   " is truthy, so a bare falsiness check
+    #    lets it through to mint an attachment pointing at nothing, and a
+    #    LEADING space on "  data:image/png;base64,…" is worse than that: the
+    #    caller's `startswith("data:")` says False, so a base64 payload is
+    #    filed as a remote url the client then tries to fetch.
+    # 2. It returns a plain `str` even for a `str` SUBCLASS, so every operation
+    #    the caller runs downstream — startswith, split — is a built-in on a
+    #    built-in. A subclass arriving off the wire cannot override its way
+    #    into an exception that escapes MESSAGES_SNAPSHOT, which is rule 1 of
+    #    the malformed-input contract.
+    return str.strip(url) or None
 
 
 def _supplied_filename(
@@ -476,6 +495,13 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
                     # `_read_incoming_media_block` already rejects on the
                     # standard-block path, where an empty `data`/`base64` drops the
                     # block. This branch was the one place that kept it.
+                    # No `.strip()` here, deliberately: `_incoming_image_url`
+                    # already stripped the whole url, so a payload that is
+                    # nothing but whitespace has ALREADY become the empty
+                    # string by the time it reaches this guard. A payload with
+                    # INTERNAL whitespace keeps it, which is correct —
+                    # MIME-wrapped base64 legitimately carries newlines and
+                    # both atob and b64decode ignore them.
                     if not data:
                         logger.warning(
                             "Dropping image_url block: data URL carries no payload"
@@ -496,9 +522,17 @@ def convert_langchain_multimodal_to_agui(content: List[Dict[str, Any]]) -> List[
                     # answers "image" for both "" and "image/png" — so this only
                     # stops an unusable MIME type from being recorded, it does not
                     # retype anything.
-                    mime_type = (
+                    # The `or` guard treats a MIME-less "data:;base64,…" as
+                    # absent. "data:   ;base64,…" is the same thing wearing
+                    # whitespace: present-but-blank, and unusable for the same
+                    # reason. Note this collapses a BLANK mediatype only — a
+                    # padded but real one keeps its padding, which the
+                    # cross-runtime parity table pins because the TypeScript
+                    # adapter records it verbatim too.
+                    raw_mime = (
                         header.split(":")[1].split(";")[0] if ":" in header else ""
-                    ) or "image/png"
+                    )
+                    mime_type = (raw_mime if raw_mime.strip() else "") or "image/png"
 
                     # The MIME type this adapter put in the data URL on the way out
                     # is enough to recover the modality on the way back.

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import TypeAdapter
 from pydantic_core import PydanticSerializationError
 from typing import List, Any, Dict, NamedTuple, Union
+from collections.abc import Mapping
 from dataclasses import is_dataclass, asdict, fields
 from datetime import date, datetime
 
@@ -1887,7 +1888,17 @@ def resolve_encrypted_reasoning_content(chunk: Any) -> str | None:
     - `redacted_thinking` blocks with encrypted `data` (redacted chain-of-thought)
     """
     content = _dual_get(chunk, "content") if chunk is not None else None
-    if not content or not isinstance(content, list) or not content or not content[0]:
+    # `Mapping`, not a truthiness check: the next line dereferences
+    # `content[0].get(...)`, and `list[str]` is a first-class LangChain content
+    # shape, so a chunk of ["hello"] raised AttributeError straight out of a
+    # function that runs per streamed chunk in `_handle_single_event` with no
+    # enclosing try. Rule 1 of the malformed-input contract, on the streaming
+    # leg. `Mapping` rather than `dict` because the old check accepted any
+    # duck-typed mapping through `.get`, and narrowing to `dict` would silently
+    # drop the mapping-backed blocks some providers return; `Mapping` still
+    # excludes `str`, which is the shape that crashed. The sibling
+    # `resolve_reasoning_content` already guards its own block read.
+    if not isinstance(content, list) or not content or not isinstance(content[0], Mapping):
         return None
 
     # Anthropic redacted_thinking block: { type: "redacted_thinking", data: "..." }

--- a/integrations/langgraph/python/tests/test_multimodal.py
+++ b/integrations/langgraph/python/tests/test_multimodal.py
@@ -3774,6 +3774,85 @@ class TestMalformedInputContract(unittest.TestCase):
         self.assertEqual(second.content, first.content)
 
 
+class TestOverridableCallsOnOffWireValues(unittest.TestCase):
+    """Rule 1 of the malformed-input contract, for values that are the RIGHT
+    type but not the built-in one.
+
+    A `str`/`dict` arriving off the wire may be a SUBCLASS, and every method
+    the converter calls on it — ``strip``, ``startswith``, ``split``, ``get``
+    — is overridable. An override that raises escapes the whole
+    MESSAGES_SNAPSHOT, which is the failure the contract's first rule exists
+    to prevent, reached through a door an ``isinstance`` check holds open.
+
+    These cases live here rather than in ``cross-runtime-parity-cases.json``
+    because a subclass is not expressible in JSON, and because they are
+    Python-only: TypeScript strings and objects are primitives with no
+    equivalent hazard. The converter answers them by normalizing through the
+    BASE operations (``str.strip``, ``dict.get``), which both bypass the
+    override and return a built-in, so everything downstream is a built-in
+    method on a built-in value.
+    """
+
+    def test_str_subclass_that_raises_from_its_overrides_still_converts(self):
+        class Hostile(str):
+            def strip(self, *args):
+                raise RuntimeError("strip exploded")
+
+            def startswith(self, *args):
+                raise RuntimeError("startswith exploded")
+
+            def split(self, *args, **kwargs):
+                raise RuntimeError("split exploded")
+
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "image_url", "image_url": Hostile("  data:image/png;base64,QUJD  ")},
+        ])
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertIsInstance(agui_content[0].source, InputContentDataSource)
+        self.assertEqual(agui_content[0].source.value, "QUJD")
+        self.assertEqual(agui_content[0].source.mime_type, "image/png")
+
+    def test_str_subclass_in_the_nested_url_slot_still_converts(self):
+        class Hostile(str):
+            def strip(self, *args):
+                raise RuntimeError("strip exploded")
+
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "image_url", "image_url": {"url": Hostile("https://example.com/a.png")}},
+        ])
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertEqual(agui_content[0].source.value, "https://example.com/a.png")
+
+    def test_dict_subclass_that_raises_from_get_still_converts(self):
+        class Hostile(dict):
+            def get(self, *args, **kwargs):
+                raise RuntimeError("get exploded")
+
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "image_url", "image_url": Hostile(url="https://example.com/a.png")},
+        ])
+
+        self.assertEqual(len(agui_content), 1)
+        self.assertEqual(agui_content[0].source.value, "https://example.com/a.png")
+
+    def test_a_hostile_subclass_costs_only_its_own_block(self):
+        """Rule 3: even when the hostile value is unusable, the blocks around
+        it convert."""
+        class Hostile(str):
+            def strip(self, *args):
+                raise RuntimeError("strip exploded")
+
+        agui_content = convert_langchain_multimodal_to_agui([
+            {"type": "text", "text": "before"},
+            {"type": "image_url", "image_url": {"url": Hostile("   ")}},
+            {"type": "text", "text": "after"},
+        ])
+
+        self.assertEqual([c.text for c in agui_content], ["before", "after"])
+
+
 class TestCrossRuntimeParityTable(unittest.TestCase):
     """The cross-runtime parity table — the mechanism that makes DRIFT fail a test.
 

--- a/integrations/langgraph/python/tests/test_reasoning_content.py
+++ b/integrations/langgraph/python/tests/test_reasoning_content.py
@@ -4,6 +4,7 @@ Covers all supported AI provider formats including the Bedrock Converse API
 fix for issue #1361.
 """
 import unittest
+from collections import UserDict
 import pytest
 
 from ag_ui_langgraph.utils import resolve_reasoning_content, resolve_encrypted_reasoning_content
@@ -231,3 +232,26 @@ class TestResolveEncryptedReasoningContent(unittest.TestCase):
     def test_redacted_without_data(self):
         chunk = FakeChunk(content=[{"type": "redacted_thinking"}])
         assert resolve_encrypted_reasoning_content(chunk) is None
+
+    def test_string_content_block_does_not_raise(self):
+        """``list[str]`` is a first-class LangChain content shape, and this
+        function runs per streamed chunk in ``_handle_single_event`` with no
+        enclosing try — an unguarded ``.get`` here did not degrade one chunk,
+        it killed the stream. Rule 1 of the malformed-input contract on the
+        streaming leg. The sibling ``resolve_reasoning_content`` already
+        guarded its own block read.
+
+        Note this only ever inspects index 0, by pre-existing design: the
+        second case asserts None because the redacted block is not first, not
+        because a string anywhere disqualifies the chunk."""
+        for content in (["hello"], ["hello", {"type": "redacted_thinking", "data": "X"}]):
+            with self.subTest(content=content):
+                assert resolve_encrypted_reasoning_content(FakeChunk(content=content)) is None
+
+    def test_mapping_content_block_still_resolves(self):
+        """The guard this replaced was a truthiness check, so any duck-typed
+        mapping resolved through ``.get``. Tightening it to reject strings must
+        not also reject the mapping-backed blocks some providers return —
+        narrowing to ``dict`` would have."""
+        chunk = FakeChunk(content=[UserDict({"type": "redacted_thinking", "data": "ciphertext"})])
+        assert resolve_encrypted_reasoning_content(chunk) == "ciphertext"

--- a/integrations/langgraph/typescript/src/utils.ts
+++ b/integrations/langgraph/typescript/src/utils.ts
@@ -1081,11 +1081,21 @@ function suppliedFilename(
  * Mirrors Python's `_incoming_image_url`, which already read it this way.
  */
 function incomingImageUrl(payload: unknown): string | undefined {
-  if (typeof payload === "string") return payload || undefined;
-  if (payload !== null && typeof payload === "object") {
-    return firstNonEmptyString((payload as { url?: unknown }).url);
-  }
-  return undefined;
+  const url =
+    typeof payload === "string"
+      ? payload
+      : payload !== null && typeof payload === "object"
+        ? firstNonEmptyString((payload as { url?: unknown }).url)
+        : undefined;
+  if (url === undefined) return undefined;
+  // TRIMMED, because whitespace is the side door into the empty-value defect
+  // this function already rejects. A url of `"   "` is truthy, so the checks
+  // above let it through to mint an attachment pointing at nothing, and a
+  // LEADING space on `"  data:image/png;base64,…"` is worse than that: the
+  // caller's `startsWith("data:")` says false, so a base64 payload is filed as
+  // a remote url the client then tries to fetch. Mirrors Python's
+  // `_incoming_image_url`.
+  return url.trim() || undefined;
 }
 
 /**
@@ -1249,6 +1259,12 @@ function convertLangchainMultimodalToAgui(content: IncomingMediaBlock[]): InputC
         // {@link readIncomingMediaBlock} already rejects on the standard-block
         // path, where an empty `data`/`base64` drops the block. This branch was
         // the one place that kept it.
+        // No `.trim()` here, deliberately: {@link incomingImageUrl} already
+        // trimmed the whole url, so a payload that is nothing but whitespace
+        // has ALREADY become the empty string by the time it reaches this
+        // guard. A payload with INTERNAL whitespace keeps it, which is correct
+        // — MIME-wrapped base64 legitimately carries newlines and both atob and
+        // Python's b64decode ignore them.
         if (!data) {
           console.warn(
             "[convertLangchainMultimodalToAgui] Dropping image_url block: data URL carries no payload"
@@ -1265,8 +1281,12 @@ function convertLangchainMultimodalToAgui(content: IncomingMediaBlock[]): InputC
         // The MEDIA TYPE is unaffected either way — `aguiMediaTypeForMimeType`
         // answers "image" for both `""` and `image/png` — so this only stops an
         // unusable MIME type from being recorded, it does not retype anything.
-        const mimeType =
-          (header.includes(":") ? header.split(":")[1].split(";")[0] : "") || "image/png";
+        // A BLANK mediatype (`data:   ;base64,…`) is "present but empty" wearing
+        // whitespace, and unusable for the same reason the empty one is. Only a
+        // blank one collapses — a padded but REAL mediatype keeps its padding,
+        // which the parity table pins on both runtimes.
+        const rawMimeType = header.includes(":") ? header.split(":")[1].split(";")[0] : "";
+        const mimeType = (rawMimeType.trim() ? rawMimeType : "") || "image/png";
 
         aguiContent.push({
           // The MIME type this adapter put in the data URL on the way out is


### PR DESCRIPTION
[PNI-384](https://linear.app/copilotkit/issue/PNI-384/handle-non-string-image-url-values-safely-in-langgraph-multimodal).

## This PR shrank

It was opened against `mme/langgraph-subagents` to fix the original PNI-384 crash: a non-string `image_url` reaching `url.startswith("data:")`. While it sat, #2528 merged and the malformed-input contract work landed on `main`, which fixes that crash properly — `_incoming_image_url` / `incomingImageUrl` reject every non-string shape, and the drop logs name the type via `_describe_type` rather than the value.

So I rebased onto `main` and dropped everything now redundant, rather than forcing a parallel implementation in. What is left is the delta that contract does not yet cover.

## 1. Whitespace walks around the empty-value guard

The contract already rejects a payload yielding `""`, because an attachment whose value is the empty string points at nothing. Three doors were open in **both** runtimes:

| input | before | after |
|---|---|---|
| `{"url": "   "}` | kept — `InputContentUrlSource(value="   ")` | dropped + logged |
| `"  data:image/png;base64,QUJD"` | **filed as a remote url** — `startswith("data:")` is False on the padded string, so base64 bytes became an href the client fetches | data source, `QUJD` |
| `"data:   ;base64,QUJD"` | `mime_type="   "` | `image/png` |

All three are answered by trimming the url once where it is read. The mediatype guard collapses a **blank** type only — a padded but real one keeps its padding, which `modality-padded-major` pins on both runtimes. The data payload needs no guard of its own once the url is trimmed.

Five cases added to `cross-runtime-parity-cases.json`, once, per its own instructions. Both suites pick them up with no edit and agree.

## 2. Reasoning blocks (`resolve_encrypted_reasoning_content`)

Same rule-1 defect on the streaming leg, which the contract's tests do not reach because they cover the two content converters. `AIMessageChunk(content=["hello"])` raised `AttributeError` out of a function that runs per streamed chunk with no enclosing try — it killed the stream rather than degrading one chunk.

Guarded with `Mapping`, not `dict`: the old check was truthiness, so any duck-typed mapping resolved through `.get`, and narrowing to `dict` would have silently dropped the mapping-backed blocks some providers return. `Mapping` still excludes `str`, the shape that crashed.

## Review feedback

Both of @contextablemark's points are addressed — details inline on the threads.

- **[P1] payloads in logs** — resolved by deletion. My `_bounded_repr` value-logging is gone; the delta uses `main`'s type-only convention, so no warning I add copies a payload.
- **[P2] `never raises` for accepted subclasses** — Python normalizes through the **base** operations, `str.strip(url)` and `dict.get(payload, "url")`. Both bypass a subclass override *and* return a built-in, so every downstream call is a built-in method on a built-in value. Four regression tests, in the Python suite rather than the table (a subclass is not expressible in JSON).

## Verification

- Python **746 passed / 734 subtests** (pytest) and **734 OK** (`unittest discover`, CI's runner)
- TypeScript `utils.test.ts` **508 passed**, including the 5 new shared cases
- Six mutants — url trim, `str.strip` vs `.strip()`, `dict.get` vs `.get`, blank-mime collapse, and both halves of the `Mapping` guard — each have a test that dies with them
- Both commits independently green, so the branch bisects

⚠️ The 13 TypeScript test files failing on an unbuilt `@ag-ui/client` fail identically on clean `main` (595 passed there vs 600 here — exactly my 5 new cases). Not introduced by this PR.