### PR TITLE
fix(dojo): normalize App Context forwarded headers case-insensitively

### DIFF
--- a/apps/dojo/e2e/lib/event-trace-events.test.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.test.ts
@@ -426,6 +426,7 @@ test("rewrites a forwarded-header bag only when it is record-shaped", () => {
   // corrupt it into `{"0": ...}`, so each must come back byte-for-byte.
   const untouched = [
     "Retrieve the recipe, then stop.",
+    "App Context:\n{not-json",
     // Compact JSON: the only row that can tell "returned verbatim" apart from
     // "re-serialized", since every appContextContent row is already 2-space.
     'App Context:\n{"copilotkit_forwarded_headers":false}',

--- a/apps/dojo/e2e/lib/event-trace-events.test.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.test.ts
@@ -293,6 +293,16 @@ const systemMessageTrace = (...contents: readonly string[]) => [
 const appContextTrace = (context: Record<string, unknown>) =>
   systemMessageTrace(appContextContent(context));
 
+// A bag the rewrite must always tokenize. Pairing it with a payload that must
+// come back untouched keeps those assertions from passing vacuously: a fixture
+// that stopped reaching the rewrite fails on this half.
+const CONTROL_BAG = {
+  copilotkit_forwarded_headers: { "X-Forwarded-For": "::1" },
+};
+const CONTROL_REWRITTEN = {
+  copilotkit_forwarded_headers: { "x-forwarded-for": "<forwarded-for>" },
+};
+
 test("normalizes forwarded headers whatever casing reached the agent", () => {
   // The producer selects forwarded headers by matching the `x-` prefix
   // case-insensitively but emits each key verbatim, so the spelling that lands
@@ -404,6 +414,37 @@ test("collapses two spellings of one forwarded header into a single entry", () =
     assert.deepStrictEqual(
       normalizeEventTrace(appContextTrace({ copilotkit_forwarded_headers })),
       expected,
+    );
+  }
+});
+
+test("rewrites a forwarded-header bag only when it is record-shaped", () => {
+  // Shapes a real trace carries, none of which the rewrite understands. The bag
+  // is absent whenever no `x-` header reached the agent, so undefined is the
+  // ordinary case rather than a malformed one — and `Object.entries(undefined)`
+  // throws. Reshaping a string or an array through `Object.entries` would
+  // corrupt it into `{"0": ...}`, so each must come back byte-for-byte.
+  const untouched = [
+    "Retrieve the recipe, then stop.",
+    // Compact JSON: the only row that can tell "returned verbatim" apart from
+    // "re-serialized", since every appContextContent row is already 2-space.
+    'App Context:\n{"copilotkit_forwarded_headers":false}',
+    "App Context:\nnull",
+    appContextContent({ other: 1 }),
+    appContextContent({ copilotkit_forwarded_headers: null }),
+    appContextContent({ copilotkit_forwarded_headers: "x-forwarded-for" }),
+    appContextContent({ copilotkit_forwarded_headers: ["x-forwarded-for"] }),
+    appContextContent({ copilotkit_forwarded_headers: 0 }),
+    appContextContent({ copilotkit_forwarded_headers: false }),
+  ];
+
+  for (const content of untouched) {
+    assert.deepStrictEqual(
+      normalizeEventTrace(
+        systemMessageTrace(content, appContextContent(CONTROL_BAG)),
+      ),
+      systemMessageTrace(content, appContextContent(CONTROL_REWRITTEN)),
+      content,
     );
   }
 });

--- a/apps/dojo/e2e/lib/event-trace-events.test.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.test.ts
@@ -274,3 +274,136 @@ test("drops LangSmith tracing env metadata, whose presence varies by environment
     },
   ]);
 });
+
+// The App Context envelope the normalizer emits: APP_CONTEXT_PREFIX followed by
+// 2-space JSON. Real traces carry it as a LangChain system message nested in
+// `rawEvent`, which is the shape these fixtures reproduce.
+const appContextContent = (context: Record<string, unknown>) =>
+  `App Context:\n${JSON.stringify(context, null, 2)}`;
+
+const systemMessageTrace = (...contents: readonly string[]) => [
+  {
+    type: "STATE_SNAPSHOT",
+    rawEvent: {
+      data: contents.map((content) => ({ type: "system", content })),
+    },
+  },
+];
+
+const appContextTrace = (context: Record<string, unknown>) =>
+  systemMessageTrace(appContextContent(context));
+
+test("normalizes forwarded headers whatever casing reached the agent", () => {
+  // The producer selects forwarded headers by matching the `x-` prefix
+  // case-insensitively but emits each key verbatim, so the spelling that lands
+  // in the payload is not guaranteed to be lowercase. Each row carries
+  // different values so a value-passthrough bug cannot hide behind a shared one.
+  const spellings: Record<string, Record<string, string>> = {
+    lowercase: {
+      "x-forwarded-for": "::1",
+      "x-forwarded-host": "localhost:8989",
+      "x-forwarded-port": "8989",
+      "x-forwarded-proto": "http",
+    },
+    canonical: {
+      "X-Forwarded-For": "10.0.0.7",
+      "X-Forwarded-Host": "dojo.internal:3000",
+      "X-Forwarded-Port": "3000",
+      "X-Forwarded-Proto": "https",
+    },
+    mixed: {
+      "X-FORWARDED-for": "192.168.1.4",
+      "x-Forwarded-HOST": "ci-runner:9000",
+      "X-forwarded-PORT": "9000",
+      "x-FORWARDED-Proto": "https",
+    },
+  };
+  const expected = appContextTrace({
+    copilotkit_forwarded_headers: {
+      "x-forwarded-for": "<forwarded-for>",
+      "x-forwarded-host": "<forwarded-host>",
+      "x-forwarded-port": "<forwarded-port>",
+      "x-forwarded-proto": "<forwarded-proto>",
+    },
+  });
+
+  for (const [casing, copilotkit_forwarded_headers] of Object.entries(
+    spellings,
+  )) {
+    assert.deepStrictEqual(
+      normalizeEventTrace(appContextTrace({ copilotkit_forwarded_headers })),
+      expected,
+      `${casing} forwarded headers must normalize like the lowercase spelling`,
+    );
+  }
+});
+
+test("tokenizes forwarded headers without touching data owned elsewhere", () => {
+  // Only headers the token map names are known to vary by environment. An entry
+  // it does not name keeps its spelling and its value, as does a header-shaped
+  // key that belongs to the application rather than to the forwarded-header bag.
+  const normalized = normalizeEventTrace(
+    appContextTrace({
+      copilotkit_forwarded_headers: {
+        "X-Forwarded-For": "10.0.0.7",
+        // An unnamed entry keeps its value exactly, structure included.
+        "X-Dojo-Demo": { mode: "agentic-chat" },
+      },
+      "X-Forwarded-Proto": "app-owned",
+      recipe: { "x-forwarded-host": "app-owned" },
+    }),
+  );
+
+  assert.deepStrictEqual(
+    normalized,
+    appContextTrace({
+      copilotkit_forwarded_headers: {
+        "x-forwarded-for": "<forwarded-for>",
+        "X-Dojo-Demo": { mode: "agentic-chat" },
+      },
+      "X-Forwarded-Proto": "app-owned",
+      recipe: { "x-forwarded-host": "app-owned" },
+    }),
+  );
+});
+
+test("tokenizes a named header whatever type its value has", () => {
+  // A named header's value is environment-dependent whatever shape it arrives
+  // in, and a caller can supply the bag directly, so every JSON type is
+  // reachable. Asserting the rule across types rather than sampling one keeps
+  // substitution from being narrowed to a subset of them later.
+  const expected = appContextTrace({
+    copilotkit_forwarded_headers: { "x-forwarded-for": "<forwarded-for>" },
+  });
+
+  for (const value of ["::1", 8989, "", false, null, { hop: 1 }, ["::1"]]) {
+    assert.deepStrictEqual(
+      normalizeEventTrace(
+        appContextTrace({
+          copilotkit_forwarded_headers: { "X-Forwarded-For": value },
+        }),
+      ),
+      expected,
+      `value ${JSON.stringify(value)} must not survive tokenization`,
+    );
+  }
+});
+
+test("collapses two spellings of one forwarded header into a single entry", () => {
+  // Deliberate: both spellings are the same field, and how many hops spelled it
+  // is environment metadata like the values themselves. Order-insensitive,
+  // because both entries resolve to the same key and the same token.
+  const expected = appContextTrace({
+    copilotkit_forwarded_headers: { "x-forwarded-for": "<forwarded-for>" },
+  });
+
+  for (const copilotkit_forwarded_headers of [
+    { "X-Forwarded-For": "203.0.113.9", "x-forwarded-for": "::1" },
+    { "x-forwarded-for": "::1", "X-Forwarded-For": "203.0.113.9" },
+  ]) {
+    assert.deepStrictEqual(
+      normalizeEventTrace(appContextTrace({ copilotkit_forwarded_headers })),
+      expected,
+    );
+  }
+});

--- a/apps/dojo/e2e/lib/event-trace-events.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.ts
@@ -49,6 +49,8 @@ const LANGCHAIN_MESSAGE_TYPES = new Set([
   "tool",
   "function",
 ]);
+// Keys MUST be lowercase: normalizeForwardedHeaders looks them up by the
+// lowercased header name, so a title-cased key here would never match.
 const FORWARDED_HEADER_TOKENS = new Map([
   ["x-forwarded-for", "<forwarded-for>"],
   ["x-forwarded-host", "<forwarded-host>"],
@@ -208,6 +210,32 @@ function isGeneratedIdentityField(
   );
 }
 
+// `copilotkit_forwarded_headers` keys carry whatever spelling reached the agent.
+// The producer builds the bag by matching the `x-` prefix case-insensitively and
+// then emits each key verbatim, and a caller can put the key in
+// `config.configurable` themselves, so nothing upstream promises lowercase. Field names are case-insensitive (RFC 9110
+// §5.1), so match on the lowercased name — an upstream spelling change must not
+// turn a stable trace into an environment-dependent one.
+//
+// An entry the map does not name keeps its spelling and its value. That set is
+// open — the producer forwards every `x-` header verbatim — so an unnamed one
+// carrying a per-request value (`x-request-id`, `x-amzn-trace-id`) would churn
+// every golden it appears in. The remedy is to name it in
+// FORWARDED_HEADER_TOKENS, not to widen the match. Two spellings of one named
+// header collapse into a single entry, which is correct — they are the same
+// field, and how many hops spelled it is environment metadata too.
+function normalizeForwardedHeaders(
+  headers: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([header, value]): [string, unknown] => {
+      const lowercasedHeader = header.toLowerCase();
+      const token = FORWARDED_HEADER_TOKENS.get(lowercasedHeader);
+      return token === undefined ? [header, value] : [lowercasedHeader, token];
+    }),
+  );
+}
+
 function normalizeAppContextContent(value: string) {
   if (!value.startsWith(APP_CONTEXT_PREFIX)) return value;
 
@@ -217,9 +245,11 @@ function normalizeAppContextContent(value: string) {
     const headers = Reflect.get(context, "copilotkit_forwarded_headers");
     if (typeof headers !== "object" || headers === null) return value;
 
-    for (const [header, token] of FORWARDED_HEADER_TOKENS) {
-      if (Object.hasOwn(headers, header)) Reflect.set(headers, header, token);
-    }
+    Reflect.set(
+      context,
+      "copilotkit_forwarded_headers",
+      normalizeForwardedHeaders(headers),
+    );
     return `${APP_CONTEXT_PREFIX}${JSON.stringify(context, null, 2)}`;
   } catch {
     // This is ordinary message content unless it is valid App Context JSON.

--- a/apps/dojo/e2e/lib/event-trace-events.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.ts
@@ -253,25 +253,29 @@ function normalizeForwardedHeaders(
 function normalizeAppContextContent(value: string) {
   if (!value.startsWith(APP_CONTEXT_PREFIX)) return value;
 
+  let context: unknown;
   try {
-    const context: unknown = JSON.parse(value.slice(APP_CONTEXT_PREFIX.length));
-    if (!isPlainRecord(context)) return value;
-    const headers = context.copilotkit_forwarded_headers;
-    // Neither the presence nor the shape of this key is ours to assume: it is
-    // absent until an `x-` header arrives, and a caller can put any JSON value
-    // there. So this guard is what keeps `Object.entries(undefined)` from throwing
-    // on an everyday payload, and what keeps `Object.entries`/`Object.fromEntries`
-    // from reshaping a primitive or array bag into `{}` or `{"0": ...}`. Leave the
-    // whole content string untouched rather than re-serializing it, so a payload
-    // this rewrite does not understand survives byte-for-byte.
-    if (!isPlainRecord(headers)) return value;
-
-    context.copilotkit_forwarded_headers = normalizeForwardedHeaders(headers);
-    return `${APP_CONTEXT_PREFIX}${JSON.stringify(context, null, 2)}`;
+    context = JSON.parse(value.slice(APP_CONTEXT_PREFIX.length));
   } catch {
     // This is ordinary message content unless it is valid App Context JSON.
+    // Only the parse is guarded: a bug in the rewrite below must surface, not
+    // degrade into silently unnormalized content.
     return value;
   }
+
+  if (!isPlainRecord(context)) return value;
+  const headers = context.copilotkit_forwarded_headers;
+  // Neither the presence nor the shape of this key is ours to assume: it is
+  // absent until an `x-` header arrives, and a caller can put any JSON value
+  // there. So this guard is what keeps `Object.entries(undefined)` from throwing
+  // on an everyday payload, and what keeps `Object.entries`/`Object.fromEntries`
+  // from reshaping a primitive or array bag into `{}` or `{"0": ...}`. Leave the
+  // whole content string untouched rather than re-serializing it, so a payload
+  // this rewrite does not understand survives byte-for-byte.
+  if (!isPlainRecord(headers)) return value;
+
+  context.copilotkit_forwarded_headers = normalizeForwardedHeaders(headers);
+  return `${APP_CONTEXT_PREFIX}${JSON.stringify(context, null, 2)}`;
 }
 
 /**

--- a/apps/dojo/e2e/lib/event-trace-events.ts
+++ b/apps/dojo/e2e/lib/event-trace-events.ts
@@ -210,6 +210,20 @@ function isGeneratedIdentityField(
   );
 }
 
+// The predicate, not an inline `typeof` chain, is what lets the callee declare
+// a `Record<string, unknown>` parameter at all: reading the bag through
+// `Reflect.get` hands back `any`, which satisfies any parameter type and let an
+// array through unchecked, while an inline chain over `unknown` narrows only as
+// far as `object` and would not typecheck at the call site.
+//
+// All three clauses are load-bearing at runtime, not just for narrowing:
+// `typeof null === "object"`, so dropping the null check makes this accept
+// `null`, and dropping the `typeof` check makes it accept a string — both of
+// which `Object.entries` then reshapes or throws on.
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 // `copilotkit_forwarded_headers` keys carry whatever spelling reached the agent.
 // The producer builds the bag by matching the `x-` prefix case-insensitively and
 // then emits each key verbatim, and a caller can put the key in
@@ -241,15 +255,18 @@ function normalizeAppContextContent(value: string) {
 
   try {
     const context: unknown = JSON.parse(value.slice(APP_CONTEXT_PREFIX.length));
-    if (typeof context !== "object" || context === null) return value;
-    const headers = Reflect.get(context, "copilotkit_forwarded_headers");
-    if (typeof headers !== "object" || headers === null) return value;
+    if (!isPlainRecord(context)) return value;
+    const headers = context.copilotkit_forwarded_headers;
+    // Neither the presence nor the shape of this key is ours to assume: it is
+    // absent until an `x-` header arrives, and a caller can put any JSON value
+    // there. So this guard is what keeps `Object.entries(undefined)` from throwing
+    // on an everyday payload, and what keeps `Object.entries`/`Object.fromEntries`
+    // from reshaping a primitive or array bag into `{}` or `{"0": ...}`. Leave the
+    // whole content string untouched rather than re-serializing it, so a payload
+    // this rewrite does not understand survives byte-for-byte.
+    if (!isPlainRecord(headers)) return value;
 
-    Reflect.set(
-      context,
-      "copilotkit_forwarded_headers",
-      normalizeForwardedHeaders(headers),
-    );
+    context.copilotkit_forwarded_headers = normalizeForwardedHeaders(headers);
     return `${APP_CONTEXT_PREFIX}${JSON.stringify(context, null, 2)}`;
   } catch {
     // This is ordinary message content unless it is valid App Context JSON.


### PR DESCRIPTION
Closes PNI-385. Stacked on #2528 (base: `mme/langgraph-subagents`) — found while reviewing that PR and explicitly excluded from it.

## The problem

`apps/dojo/e2e/lib/event-trace-events.ts` stored forwarded-header tokens lowercase and matched `copilotkit_forwarded_headers` keys with `Object.hasOwn` — exact casing. HTTP header names are case-insensitive (RFC 9110 §5.1), so behind a proxy that forwards the canonical `X-Forwarded-For` spelling the header's environment-dependent value survived normalization, and the golden trace became environment-dependent.

## The fix

Match on the lowercased header name and emit that spelling, so every equivalent spelling of a known forwarded header collapses to the same token. Narrow by design:

- Entries the token map does not know keep **both** their spelling and their value — they are application-owned data.
- A header-shaped key elsewhere in the App Context payload is untouched.
- An array-shaped `copilotkit_forwarded_headers` is left alone rather than reshaped into an object.

## Verification

- Table-driven test over lowercase / canonical / mixed-case spellings, each carrying different values, asserting all three normalize to the identical trace.
- Second test pins the untouched-application-data boundary.
- `pnpm test:event-trace-unit` — 29/29 pass; `pnpm check:event-trace-types` clean.
- **No golden churn**: ran the previous and the new normalizer over every golden journey in both LangGraph event-trace suites (677 events across 6 journeys) and deep-compared — output is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)