### PR TITLE
feat(core): add an optional error field to TOOL_CALL_RESULT

### DIFF
--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -388,20 +388,38 @@ the tool's output.
 | `toolCallId` | Matches the ID from the corresponding `ToolCallStart` event |
 | `content`    | The actual result/output content from the tool execution    |
 | `role`       | Optional role identifier, typically "tool" for tool results |
-| `error`      | Failure detail; present only when the producer reports it   |
+| `error`      | Failure detail; a non-null string reports a failed call     |
 
-Failure is signalled by the presence of `error`, not by its value: an empty
-string is a value the producer deliberately sent and every SDK preserves it, so
-a consumer that tests the field for truthiness reads `""` as a success. Test
-whether `error` is present instead.
+A tool call is reported as failed when `error` is a non-null string. The empty
+string counts: a producer that sends `""` chose to send it, so a consumer that
+tests `error` for truthiness misreads a reported failure as a success. Test the
+type, not the truthiness.
+
+A producer with no failure to report omits the key. Writing an explicit JSON
+null instead is not allowed: TypeScript rejects it outright, while Python and
+.NET read it back as their own null, indistinguishable from the key being
+absent — which is why this rule is stated on the value rather than on presence.
+And "no failure reported" is not "succeeded": it covers a call that succeeded
+and a call that failed without saying so. Producers adopt `error` at their own
+pace, so never read an absent `error` as a success signal.
 
 `content` and `error` are independent. A failed result conventionally leaves
 `content` empty and carries the detail in `error`, but the protocol does not
-require it, and a consumer must not infer failure from `content` alone. Absence
-does not yet prove success either: no producer in the SDKs populates `error`
-today, so an absent `error` covers both a call that succeeded and one that
-failed without reporting it. Treat a present `error` as a definite failure and
-an absent one as unreported.
+require it, and a consumer must not infer failure from `content` alone.
+
+Typing this key narrowed the wire. A value of any other shape used to be
+ignored: TypeScript and Python carried it through as an unrecognized key, and
+.NET dropped it. A structured `error` is now a hard parse failure that ends the
+run in all three — TypeScript's `EventSchemas.parse` throws, Python raises a
+`ValidationError`, and .NET throws a `JsonException` out of the SSE reader — and
+TypeScript rejects an explicit null on top of that. A producer already sending a
+structured `error` on `TOOL_CALL_RESULT` must flatten it to a string or move it
+to another key.
+
+Coverage is not uniform across SDKs. The TypeScript, Python and .NET SDKs model
+`error`; the community Go, Java, Kotlin and Dart SDKs have no such field on this
+event, and Go's strict decoder (`DisallowUnknownFields`) rejects the key outright
+rather than ignoring it.
 
 ### ToolCallChunk
 

--- a/docs/concepts/events.mdx
+++ b/docs/concepts/events.mdx
@@ -388,6 +388,20 @@ the tool's output.
 | `toolCallId` | Matches the ID from the corresponding `ToolCallStart` event |
 | `content`    | The actual result/output content from the tool execution    |
 | `role`       | Optional role identifier, typically "tool" for tool results |
+| `error`      | Failure detail; present only when the producer reports it   |
+
+Failure is signalled by the presence of `error`, not by its value: an empty
+string is a value the producer deliberately sent and every SDK preserves it, so
+a consumer that tests the field for truthiness reads `""` as a success. Test
+whether `error` is present instead.
+
+`content` and `error` are independent. A failed result conventionally leaves
+`content` empty and carries the detail in `error`, but the protocol does not
+require it, and a consumer must not infer failure from `content` alone. Absence
+does not yet prove success either: no producer in the SDKs populates `error`
+today, so an absent `error` covers both a call that succeeded and one that
+failed without reporting it. Treat a present `error` as a definite failure and
+an absent one as unreported.
 
 ### ToolCallChunk
 

--- a/docs/sdk/dotnet/abstractions/events.mdx
+++ b/docs/sdk/dotnet/abstractions/events.mdx
@@ -332,16 +332,31 @@ var evt = new ToolCallResultEvent
 | `ToolCallId` | `toolCallId` | `string` | Tool call ID |
 | `Content` | `content` | `string` | Tool result content |
 | `Role` | `role` | `string?` | Optional role, typically `"tool"` |
-| `Error` | `error` | `string?` | Failure detail; present only when the producer reports it |
+| `Error` | `error` | `string?` | Failure detail; a non-null string reports a failed call |
 
-`Error` is the event-side twin of `AGUIToolMessage.Error`, so a consumer can
-render a failed tool call from the live stream instead of waiting for the
-messages snapshot. Failure is signalled by presence, not by value — an empty
-string is preserved and still marks the call as failed — so test `Error is not
-null` rather than `string.IsNullOrEmpty(Error)`. `Content` and `Error` are
-independent, and an absent `Error` does not yet prove success, because no
-producer populates it today. See [Events](/concepts/events#toolcallresult) for
-the full contract.
+`Error` is the event-side twin of `AGUIToolMessage.Error`. The call is reported
+as failed when `Error` is non-null — `string.Empty` included, since a producer
+that sends it chose to, so `string.IsNullOrEmpty(Error)` misreads a reported
+failure as a success. Test `Error is not null`; a non-string value never
+deserializes, so non-null already means a string. An absent JSON key and an
+explicit JSON `null` both leave `Error` as `null`, so the property cannot tell
+them apart — which is why the contract is stated on the value rather than on
+presence. `Content` and `Error` are independent, and a `null` `Error` reports
+nothing about failure, which is not the same as success.
+
+`AGUIChatClient` maps only `Content` when it converts the event to a
+`ChatResponseUpdate`, into a `FunctionResultContent`. To surface the failure from
+the live stream, read `Error` off the event itself — either by consuming
+`IAGUIEventStreamFormatter.ReadAsync` directly, or through
+`ChatResponseUpdate.RawRepresentation`, which holds the originating
+`ToolCallResultEvent`.
+
+Declaring `Error` narrows what the deserializer accepts: a structured value under
+this key used to be dropped, and now throws a `JsonException` out of the SSE
+reader, which ends the run. (An explicit JSON null is still accepted, as `null`.)
+A producer already sending a structured `error` must flatten it to a string.
+
+See [Events](/concepts/events#toolcallresult) for the language-neutral contract.
 
 ## State Management Events
 

--- a/docs/sdk/dotnet/abstractions/events.mdx
+++ b/docs/sdk/dotnet/abstractions/events.mdx
@@ -332,6 +332,16 @@ var evt = new ToolCallResultEvent
 | `ToolCallId` | `toolCallId` | `string` | Tool call ID |
 | `Content` | `content` | `string` | Tool result content |
 | `Role` | `role` | `string?` | Optional role, typically `"tool"` |
+| `Error` | `error` | `string?` | Failure detail; present only when the producer reports it |
+
+`Error` is the event-side twin of `AGUIToolMessage.Error`, so a consumer can
+render a failed tool call from the live stream instead of waiting for the
+messages snapshot. Failure is signalled by presence, not by value — an empty
+string is preserved and still marks the call as failed — so test `Error is not
+null` rather than `string.IsNullOrEmpty(Error)`. `Content` and `Error` are
+independent, and an absent `Error` does not yet prove success, because no
+producer populates it today. See [Events](/concepts/events#toolcallresult) for
+the full contract.
 
 ## State Management Events
 

--- a/docs/sdk/js/core/events.mdx
+++ b/docs/sdk/js/core/events.mdx
@@ -341,6 +341,7 @@ type ToolCallResultEvent = BaseEvent & {
   toolCallId: string
   content: string
   role?: "tool"
+  error?: string
 }
 ```
 
@@ -350,6 +351,11 @@ type ToolCallResultEvent = BaseEvent & {
 | `toolCallId` | `string`            | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`    | `string`            | The actual result/output content from the tool execution    |
 | `role`       | `"tool"` (optional) | Optional role identifier, typically "tool" for tool results |
+| `error`      | `string` (optional) | Failure detail when the call failed; absent when it succeeded |
+
+`error` is the event-side twin of `ToolMessage.error`. It lets a client render a
+failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
+that carries the finished message.
 
 ## State Management Events
 

--- a/docs/sdk/js/core/events.mdx
+++ b/docs/sdk/js/core/events.mdx
@@ -351,22 +351,30 @@ type ToolCallResultEvent = BaseEvent & {
 | `toolCallId` | `string`            | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`    | `string`            | The actual result/output content from the tool execution    |
 | `role`       | `"tool"` (optional) | Optional role identifier, typically "tool" for tool results |
-| `error`      | `string` (optional) | Failure detail; present only when the producer reports it   |
+| `error`      | `string` (optional) | Failure detail; a non-null string reports a failed call     |
 
-`error` is the event-side twin of `ToolMessage.error`. It lets a client render a
-failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
-that carries the finished message.
+`error` is the event-side twin of `ToolMessage.error`. The `defaultApplyEvents`
+reducer in `@ag-ui/client` copies it onto the tool message it accumulates, so a
+client can render a failed tool call as it streams instead of waiting for the
+`MESSAGES_SNAPSHOT` that carries the finished message.
 
-Failure is signalled by the presence of `error`, not by its truthiness: an empty
-string is a value the producer deliberately sent and the SDK preserves it, so
-`if (event.error)` reads `""` as a success. Check `event.error !== undefined`
-instead. `content` and `error` are independent — a failed result conventionally
-leaves `content` empty and carries the detail in `error`, but the protocol does
-not require it, and a consumer must not infer failure from `content` alone.
-Absence does not yet prove success either: no producer populates `error` today,
-so an absent `error` covers both a call that succeeded and one that failed
-without reporting it. Treat a present `error` as a definite failure and an
-absent one as unreported.
+The call is reported as failed when `error` is a string — `""` included, since a
+producer that sends it chose to, so `if (event.error)` misreads a reported
+failure as a success. Guard with `typeof event.error === "string"`, which is what
+the client itself does: an event reaching a subscriber has not necessarily been
+through `EventSchemas.parse`, so a nullish check would let a non-string through.
+`content` and `error` are independent — a failed result conventionally leaves
+`content` empty and carries the detail in `error`, but the protocol does not
+require it, and a consumer must not infer failure from `content` alone. An absent
+`error` reports nothing about failure, which is not the same as success.
+
+Declaring `error` narrows what the schema accepts. `BaseEventSchema` is
+`.passthrough()`, so an `error` of any other shape — a structured object, an
+explicit `null` — used to survive `EventSchemas.parse` as an unrecognized key. It
+now fails the parse, which aborts the run. A producer already sending a
+structured `error` must flatten it to a string.
+
+See [Events](/concepts/events#toolcallresult) for the language-neutral contract.
 
 ## State Management Events
 

--- a/docs/sdk/js/core/events.mdx
+++ b/docs/sdk/js/core/events.mdx
@@ -351,11 +351,22 @@ type ToolCallResultEvent = BaseEvent & {
 | `toolCallId` | `string`            | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`    | `string`            | The actual result/output content from the tool execution    |
 | `role`       | `"tool"` (optional) | Optional role identifier, typically "tool" for tool results |
-| `error`      | `string` (optional) | Failure detail when the call failed; absent when it succeeded |
+| `error`      | `string` (optional) | Failure detail; present only when the producer reports it   |
 
 `error` is the event-side twin of `ToolMessage.error`. It lets a client render a
 failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
 that carries the finished message.
+
+Failure is signalled by the presence of `error`, not by its truthiness: an empty
+string is a value the producer deliberately sent and the SDK preserves it, so
+`if (event.error)` reads `""` as a success. Check `event.error !== undefined`
+instead. `content` and `error` are independent — a failed result conventionally
+leaves `content` empty and carries the detail in `error`, but the protocol does
+not require it, and a consumer must not infer failure from `content` alone.
+Absence does not yet prove success either: no producer populates `error` today,
+so an absent `error` covers both a call that succeeded and one that failed
+without reporting it. Treat a present `error` as a definite failure and an
+absent one as unreported.
 
 ## State Management Events
 

--- a/docs/sdk/python/core/events.mdx
+++ b/docs/sdk/python/core/events.mdx
@@ -348,22 +348,31 @@ class ToolCallResultEvent(BaseEvent):
 | `tool_call_id` | `str`                       | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`      | `str`                       | The actual result/output content from the tool execution    |
 | `role`         | `Optional[Literal["tool"]]` | Optional role identifier, typically "tool" for tool results |
-| `error`        | `Optional[str]`             | Failure detail; present only when the producer reports it   |
+| `error`        | `Optional[str]`             | Failure detail; a non-null string reports a failed call     |
 
-`error` is the event-side twin of `ToolMessage.error`. It lets a client render a
-failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
+`error` is the event-side twin of `ToolMessage.error`. It lets a consumer render
+a failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
 that carries the finished message.
 
-Failure is signalled by the presence of `error`, not by its truthiness: an empty
-string is a value the producer deliberately sent and the SDK preserves it, so
-`if event.error:` reads `""` as a success. Check `event.error is not None`
-instead. `content` and `error` are independent — a failed result conventionally
-leaves `content` empty and carries the detail in `error`, but the protocol does
-not require it, and a consumer must not infer failure from `content` alone.
-Absence does not yet prove success either: no producer populates `error` today,
-so an absent `error` covers both a call that succeeded and one that failed
-without reporting it. Treat a present `error` as a definite failure and an
-absent one as unreported.
+The call is reported as failed when `error` is a non-null string — `""` included,
+since a producer that sends it chose to, so `if event.error:` misreads a reported
+failure as a success. Test `event.error is not None`; validation constrains the
+field to `str` or `None`, so non-`None` already means a string. An explicit JSON
+`null` and an absent key both leave `event.error` as `None`, so the attribute
+cannot tell them apart — which is why the contract is stated on the value rather
+than on presence. `content` and `error` are independent — a failed result
+conventionally leaves `content` empty and carries the detail in `error`, but the
+protocol does not require it, and a consumer must not infer failure from
+`content` alone. An `error` of `None` reports nothing about failure, which is not
+the same as success.
+
+Declaring `error` narrows what the model accepts. `extra="allow"` used to let an
+`error` of any shape ride along as an extra field; a structured one now raises a
+`ValidationError`, which ends the run. (An explicit JSON null is the one value
+that still validates, to `None`.) A producer already sending a structured `error`
+must flatten it to a string.
+
+See [Events](/concepts/events#toolcallresult) for the language-neutral contract.
 
 ## State Management Events
 

--- a/docs/sdk/python/core/events.mdx
+++ b/docs/sdk/python/core/events.mdx
@@ -339,6 +339,7 @@ class ToolCallResultEvent(BaseEvent):
     tool_call_id: str
     content: str
     role: Optional[Literal["tool"]] = None
+    error: Optional[str] = None
 ```
 
 | Property       | Type                        | Description                                                 |
@@ -347,6 +348,11 @@ class ToolCallResultEvent(BaseEvent):
 | `tool_call_id` | `str`                       | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`      | `str`                       | The actual result/output content from the tool execution    |
 | `role`         | `Optional[Literal["tool"]]` | Optional role identifier, typically "tool" for tool results |
+| `error`        | `Optional[str]`             | Failure detail when the call failed; absent when it succeeded |
+
+`error` is the event-side twin of `ToolMessage.error`. It lets a client render a
+failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
+that carries the finished message.
 
 ## State Management Events
 

--- a/docs/sdk/python/core/events.mdx
+++ b/docs/sdk/python/core/events.mdx
@@ -348,11 +348,22 @@ class ToolCallResultEvent(BaseEvent):
 | `tool_call_id` | `str`                       | Matches the ID from the corresponding ToolCallStartEvent    |
 | `content`      | `str`                       | The actual result/output content from the tool execution    |
 | `role`         | `Optional[Literal["tool"]]` | Optional role identifier, typically "tool" for tool results |
-| `error`        | `Optional[str]`             | Failure detail when the call failed; absent when it succeeded |
+| `error`        | `Optional[str]`             | Failure detail; present only when the producer reports it   |
 
 `error` is the event-side twin of `ToolMessage.error`. It lets a client render a
 failed tool call as it streams, instead of waiting for the `MESSAGES_SNAPSHOT`
 that carries the finished message.
+
+Failure is signalled by the presence of `error`, not by its truthiness: an empty
+string is a value the producer deliberately sent and the SDK preserves it, so
+`if event.error:` reads `""` as a success. Check `event.error is not None`
+instead. `content` and `error` are independent — a failed result conventionally
+leaves `content` empty and carries the detail in `error`, but the protocol does
+not require it, and a consumer must not infer failure from `content` alone.
+Absence does not yet prove success either: no producer populates `error` today,
+so an absent `error` covers both a call that succeeded and one that failed
+without reporting it. Treat a present `error` as a definite failure and an
+absent one as unreported.
 
 ## State Management Events
 

--- a/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
@@ -24,9 +24,12 @@ public sealed class ToolCallResultEvent : BaseEvent
     public string? Role { get; set; }
 
     /// <summary>
-    /// Gets or sets the failure detail for this tool call, absent when the call succeeded.
-    /// The event-side twin of <see cref="AGUIToolMessage.Error"/>, so a consumer can render
-    /// the failure from the live stream instead of waiting for the messages snapshot.
+    /// Gets or sets the failure detail for this tool call. The event-side twin of
+    /// <see cref="AGUIToolMessage.Error"/>. Schema only: no producer populates it yet, so an
+    /// absent error means the producer said nothing about failure, not that the call succeeded.
+    /// The client's event-to-<c>ChatResponseUpdate</c> conversion does not read it either, so a
+    /// consumer wanting the failure from the live stream has to read it off the event itself.
+    /// An explicit JSON null deserializes to <c>null</c>, as for every optional property here.
     /// </summary>
     [JsonPropertyName("error")]
     public string? Error { get; set; }

--- a/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
@@ -24,6 +24,14 @@ public sealed class ToolCallResultEvent : BaseEvent
     public string? Role { get; set; }
 
     /// <summary>
+    /// Gets or sets the failure detail for this tool call, absent when the call succeeded.
+    /// The event-side twin of <see cref="AGUIToolMessage.Error"/>, so a consumer can render
+    /// the failure from the live stream instead of waiting for the messages snapshot.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>
     /// Gets or sets the subagent that produced this event, absent when the parent agent
     /// produced it directly.
     /// </summary>

--- a/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Events/ToolCallResultEvent.cs
@@ -24,12 +24,14 @@ public sealed class ToolCallResultEvent : BaseEvent
     public string? Role { get; set; }
 
     /// <summary>
-    /// Gets or sets the failure detail for this tool call. The event-side twin of
-    /// <see cref="AGUIToolMessage.Error"/>. Schema only: no producer populates it yet, so an
-    /// absent error means the producer said nothing about failure, not that the call succeeded.
-    /// The client's event-to-<c>ChatResponseUpdate</c> conversion does not read it either, so a
-    /// consumer wanting the failure from the live stream has to read it off the event itself.
-    /// An explicit JSON null deserializes to <c>null</c>, as for every optional property here.
+    /// Gets or sets the failure detail for this tool call, the event-side twin of
+    /// <see cref="AGUIToolMessage.Error"/>. A non-null value reports a failed call,
+    /// <see cref="string.Empty"/> included: a producer that sends the empty string chose to
+    /// send it, so test <c>Error is not null</c> rather than <c>string.IsNullOrEmpty(Error)</c>.
+    /// A <see langword="null"/> value reports nothing about failure, which is not the same as
+    /// the call having succeeded. An absent JSON key and an explicit JSON null both deserialize
+    /// to <see langword="null"/>, as for every optional property here, so the contract is stated
+    /// on the value rather than on presence; a non-string value is a deserialization error.
     /// </summary>
     [JsonPropertyName("error")]
     public string? Error { get; set; }

--- a/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
+++ b/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
@@ -873,6 +873,8 @@ AGUI.Abstractions.ToolCallEndEvent.SubagentRunId.get -> string?
 AGUI.Abstractions.ToolCallEndEvent.SubagentRunId.set -> void
 AGUI.Abstractions.ToolCallResultEvent.SubagentRunId.get -> string?
 AGUI.Abstractions.ToolCallResultEvent.SubagentRunId.set -> void
+AGUI.Abstractions.ToolCallResultEvent.Error.get -> string?
+AGUI.Abstractions.ToolCallResultEvent.Error.set -> void
 AGUI.Abstractions.ToolCallStartEvent.SubagentRunId.get -> string?
 AGUI.Abstractions.ToolCallStartEvent.SubagentRunId.set -> void
 const AGUI.Abstractions.AGUIEventTypes.SubagentError = "SUBAGENT_ERROR" -> string!

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/Fixtures/tool-call-events.json
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/Fixtures/tool-call-events.json
@@ -37,5 +37,12 @@
     "toolCallId": "tc-1",
     "messageId": "msg-1",
     "content": "{\"ok\":true}"
+  },
+  {
+    "type": "TOOL_CALL_RESULT",
+    "messageId": "msg-2",
+    "toolCallId": "tc-2",
+    "content": "",
+    "error": "SearchTimeout: upstream did not respond within 30s"
   }
 ]

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/ToolCallEventsCompatibilityTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/ToolCallEventsCompatibilityTest.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace AGUI.Abstractions.UnitTests.Compatibility;
@@ -92,13 +93,33 @@ public sealed class ToolCallEventsCompatibilityTest
         var typed = Assert.IsType<ToolCallResultEvent>(evt);
         Assert.Equal("tc-2", typed.ToolCallId);
         Assert.Equal("msg-2", typed.MessageId);
-        Assert.Equal(string.Empty, typed.Content);
         Assert.Equal("SearchTimeout: upstream did not respond within 30s", typed.Error);
+
+        // `Content` is initialised to string.Empty, so `Assert.Equal(string.Empty, ...)` on
+        // its own passes whether or not the property ever read the wire — renaming its JSON
+        // property left this test green. Two assertions make the empty string mean "the
+        // producer sent one": the payload really does carry an explicit empty `content`, and
+        // the same payload with a sentinel in that slot reads the sentinel back.
+        Assert.True(_fixtures[7].TryGetProperty("content", out var wireContent));
+        Assert.Equal(string.Empty, wireContent.GetString());
+
+        var withSentinel = JsonNode.Parse(_fixtures[7].GetRawText())!.AsObject();
+        withSentinel["content"] = "not-empty";
+        var control = JsonSerializer.Deserialize(
+            withSentinel.ToJsonString(),
+            AGUIJsonSerializerContext.Default.BaseEvent);
+        Assert.Equal("not-empty", Assert.IsType<ToolCallResultEvent>(control).Content);
+
+        Assert.Equal(string.Empty, typed.Content);
     }
 
     [Fact]
-    public void AllToolCallEvents_RoundTrip_PreservesType()
+    public void AllToolCallEvents_RoundTrip_PreserveEveryPropertyOnTheWire()
     {
+        // `Type` alone is a compile-time constant on each event class, so a loop that
+        // asserted only that could not fail on a lost field: renaming `error`'s JSON
+        // property, which drops it from every payload, left this loop green. Every property
+        // the fixture carries therefore has to come back with the same value.
         foreach (var fixture in _fixtures)
         {
             var evt = FixtureLoader.DeserializeAsBaseEvent(fixture);
@@ -106,6 +127,17 @@ public sealed class ToolCallEventsCompatibilityTest
             var reDeserialized = JsonSerializer.Deserialize<BaseEvent>(reserialized, AGUIJsonSerializerContext.Default.BaseEvent)!;
 
             Assert.Equal(evt.Type, reDeserialized.Type);
+
+            var produced = JsonNode.Parse(reserialized)!.AsObject();
+            foreach (var property in fixture.EnumerateObject())
+            {
+                Assert.True(
+                    produced.TryGetPropertyValue(property.Name, out var written),
+                    $"round-tripping {fixture.GetRawText()} dropped '{property.Name}'");
+                Assert.True(
+                    JsonNode.DeepEquals(written, JsonNode.Parse(property.Value.GetRawText())),
+                    $"round-tripping {fixture.GetRawText()} changed '{property.Name}' to {written?.ToJsonString() ?? "null"}");
+            }
         }
     }
 }

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/ToolCallEventsCompatibilityTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/Compatibility/ToolCallEventsCompatibilityTest.cs
@@ -80,6 +80,20 @@ public sealed class ToolCallEventsCompatibilityTest
         Assert.Equal("tc-1", typed.ToolCallId);
         Assert.Equal("msg-1", typed.MessageId);
         Assert.Equal("{\"ok\":true}", typed.Content);
+        // A payload produced before `error` existed leaves it absent, not empty.
+        Assert.Null(typed.Error);
+    }
+
+    [Fact]
+    public void ToolCallResult_WithError_DeserializesFromTypeScriptPayload()
+    {
+        var evt = FixtureLoader.DeserializeAsBaseEvent(_fixtures[7]);
+
+        var typed = Assert.IsType<ToolCallResultEvent>(evt);
+        Assert.Equal("tc-2", typed.ToolCallId);
+        Assert.Equal("msg-2", typed.MessageId);
+        Assert.Equal(string.Empty, typed.Content);
+        Assert.Equal("SearchTimeout: upstream did not respond within 30s", typed.Error);
     }
 
     [Fact]

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/NullOmissionFixtureTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/NullOmissionFixtureTest.cs
@@ -33,12 +33,21 @@ public sealed class NullOmissionFixtureTest
         return data;
     }
 
+    /// <summary>
+    /// The number of fixture cases this SDK is held to.
+    /// </summary>
+    /// <remarks>
+    /// Pinned exactly, not as a floor. A floor cannot notice a deletion: under the previous
+    /// <c>&gt; 15</c> bound, with 33 cases present, deleting a case outright left this suite —
+    /// and the TypeScript and Python ones — green. Bump this deliberately when adding or
+    /// removing a case.
+    /// </remarks>
+    private const int ExpectedCaseCount = 34;
+
     [Fact]
-    public void FixtureCoversThisSdk()
+    public void FixtureStillCarriesEveryCaseThisSdkIsHeldTo()
     {
-        Assert.True(
-            NullOmissionFixture.CaseNames.Count > 15,
-            $"the fixture only has {NullOmissionFixture.CaseNames.Count} case(s) for .NET");
+        Assert.Equal(ExpectedCaseCount, NullOmissionFixture.CaseNames.Count);
     }
 
     [Theory]

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
@@ -117,17 +117,27 @@ public sealed class ToolCallResultEventTest
     [Fact]
     public void Serialize_OmitsError_WhenNull()
     {
-        var evt = new ToolCallResultEvent
-        {
-            ToolCallId = "call-1",
-            MessageId = "msg-1",
-            Content = "ok"
-        };
+        // Asserted against a populated sibling, because the omission on its own is
+        // result-forced: a type that declared no error at all, or wrote it under some other
+        // key, would satisfy "no 'error' property" just as well as one that honours null.
+        // The populated event establishes that "error" is a key this type does write, so the
+        // absence below is the serializer omitting a null rather than the key never existing.
+        static string SerializeWithError(string? error) => JsonSerializer.Serialize(
+            new ToolCallResultEvent
+            {
+                ToolCallId = "call-1",
+                MessageId = "msg-1",
+                Content = "ok",
+                Error = error
+            },
+            AGUIJsonSerializerContext.Default.ToolCallResultEvent);
 
-        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
-        using var doc = JsonDocument.Parse(json);
+        using var populated = JsonDocument.Parse(SerializeWithError("boom"));
+        Assert.True(populated.RootElement.TryGetProperty("error", out var written));
+        Assert.Equal("boom", written.GetString());
 
-        Assert.False(doc.RootElement.TryGetProperty("error", out _));
+        using var omitted = JsonDocument.Parse(SerializeWithError(null));
+        Assert.False(omitted.RootElement.TryGetProperty("error", out _));
     }
 
     [Fact]
@@ -163,6 +173,16 @@ public sealed class ToolCallResultEventTest
         };
 
         var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+
+        // Pin the wire key before round-tripping. A round-trip through this SDK's own
+        // serializer agrees with itself under any spelling — renaming the JSON property to
+        // "err" leaves the round-trip green — so the key the other SDKs read is asserted
+        // here explicitly rather than being assumed.
+        using (var doc = JsonDocument.Parse(json))
+        {
+            Assert.Equal("boom", doc.RootElement.GetProperty("error").GetString());
+        }
+
         var deserialized = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
 
         Assert.NotNull(deserialized);

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
@@ -200,6 +200,55 @@ public sealed class ToolCallResultEventTest
     }
 
     [Fact]
+    public void Deserialize_ExplicitNullError_ReadsAsAbsentAndIsOmittedOnReserialize()
+    {
+        // Documented on the property but pinned by nothing until now. Unlike the TypeScript
+        // schema, which rejects an explicit null on every new optional field, this SDK reads
+        // one back as `null` — as it does for every optional property here. What the
+        // cross-language contract guarantees is not that a null is refused but that none is
+        // ever WRITTEN, so re-serializing has to drop the key rather than echo the null.
+        var json = """{"type":"TOOL_CALL_RESULT","toolCallId":"call-5","messageId":"msg-5","content":"ok","error":null}""";
+
+        var evt = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.BaseEvent);
+
+        var typed = Assert.IsType<ToolCallResultEvent>(evt);
+        Assert.Null(typed.Error);
+
+        var reserialized = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.BaseEvent);
+        using var doc = JsonDocument.Parse(reserialized);
+        Assert.False(doc.RootElement.TryGetProperty("error", out _));
+        // ...and the rest of the event is untouched by the null having been there.
+        Assert.Equal("ok", doc.RootElement.GetProperty("content").GetString());
+        Assert.Equal("call-5", doc.RootElement.GetProperty("toolCallId").GetString());
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("{\"code\":\"SearchTimeout\"}")]
+    [InlineData("[\"SearchTimeout\"]")]
+    [InlineData("true")]
+    public void Deserialize_NonStringError_Throws(string errorLiteral)
+    {
+        // The narrowing half of what the property documents. Declaring `error` as `string?`
+        // means a producer that writes some other shape under this key does not quietly lose
+        // the field — System.Text.Json refuses the payload outright.
+        //
+        // All three SDKs refuse a non-string, but each fails in its own currency and the
+        // shape of the failure is what a consumer has to handle: Zod throws a ZodError,
+        // pydantic raises a ValidationError, and .NET surfaces it as a System.Text.Json
+        // JsonException from the reader itself. The assertions below are the observed
+        // behaviour — a JsonException whose Path names `$.error` — rather than an assumption
+        // about how the source-generated converter handles a type mismatch.
+        var json = $$"""{"type":"TOOL_CALL_RESULT","toolCallId":"call-6","messageId":"msg-6","content":"","error":{{errorLiteral}}}""";
+
+        var thrown = Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.BaseEvent));
+
+        Assert.Equal("$.error", thrown.Path);
+        Assert.Contains("could not be converted to System.String", thrown.Message);
+    }
+
+    [Fact]
     public void Deserialize_ExistingEventWithoutError_LeavesItNull()
     {
         // The additive guarantee: an event from before this field existed is

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/ToolCallResultEventTest.cs
@@ -90,4 +90,104 @@ public sealed class ToolCallResultEventTest
         Assert.Equal("msg-3", typed.MessageId);
         Assert.Equal("done", typed.Content);
     }
+
+    // `Error` is the event-side twin of AGUIToolMessage.Error: set when the tool call
+    // failed, so a consumer can render the failure from the live stream rather than
+    // waiting for the messages snapshot that carries the finished message.
+
+    [Fact]
+    public void Serialize_IncludesError_WhenSet()
+    {
+        var evt = new ToolCallResultEvent
+        {
+            ToolCallId = "call-1",
+            MessageId = "msg-1",
+            Content = string.Empty,
+            Error = "SearchTimeout: upstream did not respond within 30s"
+        };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Equal(
+            "SearchTimeout: upstream did not respond within 30s",
+            doc.RootElement.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public void Serialize_OmitsError_WhenNull()
+    {
+        var evt = new ToolCallResultEvent
+        {
+            ToolCallId = "call-1",
+            MessageId = "msg-1",
+            Content = "ok"
+        };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("error", out _));
+    }
+
+    [Fact]
+    public void Serialize_KeepsEmptyStringError()
+    {
+        // WhenWritingNull omits null, not empty — an empty string is a value the
+        // producer chose to send, and dropping it would read as "the call succeeded".
+        var evt = new ToolCallResultEvent
+        {
+            ToolCallId = "call-1",
+            MessageId = "msg-1",
+            Content = "ok",
+            Error = string.Empty
+        };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.True(doc.RootElement.TryGetProperty("error", out var error));
+        Assert.Equal(string.Empty, error.GetString());
+    }
+
+    [Fact]
+    public void Deserialize_RoundTripsError()
+    {
+        var evt = new ToolCallResultEvent
+        {
+            ToolCallId = "call-2",
+            MessageId = "msg-2",
+            Content = string.Empty,
+            Role = "tool",
+            Error = "boom"
+        };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+        var deserialized = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.ToolCallResultEvent);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("boom", deserialized.Error);
+    }
+
+    [Fact]
+    public void Deserialize_ViaBaseEvent_CarriesError()
+    {
+        var json = """{"type":"TOOL_CALL_RESULT","toolCallId":"call-3","messageId":"msg-3","content":"","error":"boom"}""";
+        var evt = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.BaseEvent);
+
+        var typed = Assert.IsType<ToolCallResultEvent>(evt);
+        Assert.Equal("boom", typed.Error);
+    }
+
+    [Fact]
+    public void Deserialize_ExistingEventWithoutError_LeavesItNull()
+    {
+        // The additive guarantee: an event from before this field existed is
+        // unchanged, and reads back with no error.
+        var json = """{"type":"TOOL_CALL_RESULT","toolCallId":"call-4","messageId":"msg-4","content":"done","role":"tool"}""";
+        var evt = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.BaseEvent);
+
+        var typed = Assert.IsType<ToolCallResultEvent>(evt);
+        Assert.Null(typed.Error);
+    }
 }

--- a/sdks/fixtures/README.md
+++ b/sdks/fixtures/README.md
@@ -63,6 +63,12 @@ events are absent from .NET, for instance. It is not an escape hatch for a case 
 | Python     | `sdks/python/tests/test_null_omission.py`                                  |
 | .NET       | `sdks/dotnet/tests/AGUI.Abstractions.UnitTests/NullOmissionFixtureTest.cs` |
 
+Each consumer also pins the number of cases it runs **exactly**, not as a lower bound. A lower
+bound cannot notice a deletion — with a `> 15` floor and 35 cases present, deleting a case
+outright left all three suites green — so removing or adding a case here means updating the pinned
+count in each consumer in the same commit. That is the intended friction: a case leaving this file
+should be a decision, not a side effect.
+
 Those fixture tests check that the SDKs agree with each other. Each SDK additionally has a
 reflection-driven test that walks _every_ wire type it defines — not just the ones named here — and
 fails on any `null` the contract does not permit. Adding a case here does not remove the need for

--- a/sdks/fixtures/null-omission.json
+++ b/sdks/fixtures/null-omission.json
@@ -294,7 +294,7 @@
         "python",
         "dotnet"
       ],
-      "note": "The failure twin of the case above: when `error` IS set every SDK must carry it on the wire under that exact key, so a consumer can render the failure from the stream rather than waiting for MESSAGES_SNAPSHOT. The preceding case pins the absent half.",
+      "note": "The failure twin of the case above: when `error` IS set every SDK must carry it on the wire under that exact key. This case pins round-trip fidelity for a populated `error`, not null omission — the omission half is covered by the reflection-driven sweep each SDK runs over every optional field, and by the preceding case only insofar as it carries no `error` at all.",
       "input": {
         "type": "TOOL_CALL_RESULT",
         "messageId": "msg_7",

--- a/sdks/fixtures/null-omission.json
+++ b/sdks/fixtures/null-omission.json
@@ -288,6 +288,29 @@
       }
     },
     {
+      "name": "tool_call_result_with_error",
+      "producedBy": [
+        "typescript",
+        "python",
+        "dotnet"
+      ],
+      "note": "The failure twin of the case above: when `error` IS set every SDK must carry it on the wire under that exact key, so a consumer can render the failure from the stream rather than waiting for MESSAGES_SNAPSHOT. The preceding case pins the absent half.",
+      "input": {
+        "type": "TOOL_CALL_RESULT",
+        "messageId": "msg_3",
+        "toolCallId": "tc_2",
+        "content": "",
+        "error": "SearchTimeout: upstream did not respond within 30s"
+      },
+      "expected": {
+        "type": "TOOL_CALL_RESULT",
+        "messageId": "msg_3",
+        "toolCallId": "tc_2",
+        "content": "",
+        "error": "SearchTimeout: upstream did not respond within 30s"
+      }
+    },
+    {
       "name": "state_snapshot_keeps_nulls_inside_the_snapshot",
       "producedBy": [
         "typescript",

--- a/sdks/fixtures/null-omission.json
+++ b/sdks/fixtures/null-omission.json
@@ -294,7 +294,7 @@
         "python",
         "dotnet"
       ],
-      "note": "The failure twin of the case above: when `error` IS set every SDK must carry it on the wire under that exact key. This case pins round-trip fidelity for a populated `error`, not null omission — the omission half is covered by the reflection-driven sweep each SDK runs over every optional field, and by the preceding case only insofar as it carries no `error` at all.",
+      "note": "The failure twin of the case above: when `error` IS set, every SDK listed here must carry it on the wire under that exact key, alongside the empty `content`. This case pins round-trip fidelity for a populated `error`, not null omission — Python and .NET cover the omission half with their own reflection sweeps over every optional field, TypeScript gets it from `JSON.stringify` dropping `undefined`, and the preceding case covers it here only insofar as it carries no `error` at all.",
       "input": {
         "type": "TOOL_CALL_RESULT",
         "messageId": "msg_7",

--- a/sdks/fixtures/null-omission.json
+++ b/sdks/fixtures/null-omission.json
@@ -297,15 +297,15 @@
       "note": "The failure twin of the case above: when `error` IS set every SDK must carry it on the wire under that exact key, so a consumer can render the failure from the stream rather than waiting for MESSAGES_SNAPSHOT. The preceding case pins the absent half.",
       "input": {
         "type": "TOOL_CALL_RESULT",
-        "messageId": "msg_3",
-        "toolCallId": "tc_2",
+        "messageId": "msg_7",
+        "toolCallId": "tc_3",
         "content": "",
         "error": "SearchTimeout: upstream did not respond within 30s"
       },
       "expected": {
         "type": "TOOL_CALL_RESULT",
-        "messageId": "msg_3",
-        "toolCallId": "tc_2",
+        "messageId": "msg_7",
+        "toolCallId": "tc_3",
         "content": "",
         "error": "SearchTimeout: upstream did not respond within 30s"
       }

--- a/sdks/fixtures/null-omission.json
+++ b/sdks/fixtures/null-omission.json
@@ -268,6 +268,25 @@
       }
     },
     {
+      "name": "tool_call_start_for_the_call_that_fails",
+      "producedBy": [
+        "typescript",
+        "python",
+        "dotnet"
+      ],
+      "note": "Opens tc_3, the tool call whose result two cases below carries an error. Without it that case names a call the stream never starts. Like the tc_1 opening above it leaves parentMessageId out; unlike tc_1 no TOOL_CALL_END follows, because the call timed out rather than finishing.",
+      "input": {
+        "type": "TOOL_CALL_START",
+        "toolCallId": "tc_3",
+        "toolCallName": "search"
+      },
+      "expected": {
+        "type": "TOOL_CALL_START",
+        "toolCallId": "tc_3",
+        "toolCallName": "search"
+      }
+    },
+    {
       "name": "tool_call_result_without_role",
       "producedBy": [
         "typescript",

--- a/sdks/python/ag_ui/core/events.py
+++ b/sdks/python/ag_ui/core/events.py
@@ -234,8 +234,15 @@ class ToolCallResultEvent(BaseEvent):
     role: Optional[Literal["tool"]] = None
     # The event-side twin of ToolMessage.error: set when the tool call failed,
     # so a consumer can render the failure from the live stream instead of
-    # waiting for the MESSAGES_SNAPSHOT that carries the message. Absent means
-    # the call succeeded, exactly as before this field existed.
+    # waiting for the MESSAGES_SNAPSHOT that carries the message. Schema only —
+    # no producer populates it yet, so an absent error means the producer said
+    # nothing about failure, not that the call succeeded.
+    #
+    # Declaring it narrows the wire rather than purely extending it: extra="allow"
+    # used to let an `error` of any shape ride along as an extra, and a non-string
+    # one now fails validation. An explicit JSON null still validates and reads
+    # back as None, as it does for every optional field here; only the TypeScript
+    # schema rejects it.
     error: Optional[str] = None
     subagent_run_id: Optional[str] = None
 

--- a/sdks/python/ag_ui/core/events.py
+++ b/sdks/python/ag_ui/core/events.py
@@ -232,6 +232,11 @@ class ToolCallResultEvent(BaseEvent):
     tool_call_id: str
     content: str
     role: Optional[Literal["tool"]] = None
+    # The event-side twin of ToolMessage.error: set when the tool call failed,
+    # so a consumer can render the failure from the live stream instead of
+    # waiting for the MESSAGES_SNAPSHOT that carries the message. Absent means
+    # the call succeeded, exactly as before this field existed.
+    error: Optional[str] = None
     subagent_run_id: Optional[str] = None
 
 class ThinkingStartEvent(BaseEvent):

--- a/sdks/python/ag_ui/core/events.py
+++ b/sdks/python/ag_ui/core/events.py
@@ -234,15 +234,17 @@ class ToolCallResultEvent(BaseEvent):
     role: Optional[Literal["tool"]] = None
     # The event-side twin of ToolMessage.error: set when the tool call failed,
     # so a consumer can render the failure from the live stream instead of
-    # waiting for the MESSAGES_SNAPSHOT that carries the message. Schema only —
-    # no producer populates it yet, so an absent error means the producer said
-    # nothing about failure, not that the call succeeded.
+    # waiting for the MESSAGES_SNAPSHOT that carries the message. A failure is
+    # reported when `error` is a non-null string, "" included — a producer that
+    # sends the empty string chose to send it. `None` reports nothing about
+    # failure, which is not the same as the call having succeeded.
     #
     # Declaring it narrows the wire rather than purely extending it: extra="allow"
     # used to let an `error` of any shape ride along as an extra, and a non-string
     # one now fails validation. An explicit JSON null still validates and reads
-    # back as None, as it does for every optional field here; only the TypeScript
-    # schema rejects it.
+    # back as None, as it does for every optional field here, so the contract is
+    # stated on the value rather than on presence; only the TypeScript schema
+    # rejects the null outright.
     error: Optional[str] = None
     subagent_run_id: Optional[str] = None
 

--- a/sdks/python/tests/test_null_omission.py
+++ b/sdks/python/tests/test_null_omission.py
@@ -1,19 +1,23 @@
 """
 Guards the rule that a producer omits a field with no value instead of writing ``null``.
 
-Three tests, each doing a different job:
+Four test classes, each doing a different job:
 
 * ``TestNullOmissionSweep`` walks every wire type the SDK defines, by reflection, and fails
   on any ``null`` for a field that has no value. It is deliberately not a list of known
   fields — a new optional field is covered the moment it is declared.
 * ``TestNullOmissionIsTheBaseModelsDoing`` reverts the setting on one class and shows the
   ``null`` come back, so a passing sweep can't be credited to something else.
+* ``TestLegitimateNullsRoundTrip`` guards the other side of the rule: a ``null`` that IS a
+  value — under a metadata key, inside a state snapshot, in a required field, in an extra —
+  has to survive, so the omission above cannot be implemented by stripping every ``null``.
 * ``TestNullOmissionCrossLanguageFixture`` runs the shared fixture that the TypeScript and
   .NET SDKs run too, so all three are held to the same text. Re-serializing a case is not on
   its own enough to hold *this* SDK to it, because ``ConfiguredBaseModel`` uses
   ``extra="allow"``: an undeclared key in a case's ``input`` survives validation as an extra
   and is written straight back out, so the round-trip would pass for a field Python has never
-  heard of. Each case therefore also asserts that every key it expects is a declared field.
+  heard of. Each case therefore also asserts that every key it expects is a declared field —
+  at every depth, because ``extra="allow"`` leaks at every depth too.
 """
 
 import enum
@@ -35,6 +39,10 @@ from ag_ui.encoder.encoder import EventEncoder
 FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "null-omission.json"
 
 SDK_NAME = "python"
+
+# The number of fixture cases this SDK is held to. See
+# TestNullOmissionCrossLanguageFixture.test_fixture_still_carries_every_case_this_sdk_is_held_to.
+EXPECTED_CASE_COUNT = 36
 
 # Placeholder values used to fill required fields when building a probe instance. Keyed by
 # the concrete type the annotation resolves to.
@@ -318,8 +326,18 @@ class TestNullOmissionCrossLanguageFixture(unittest.TestCase):
             if SDK_NAME in case["producedBy"]
         ]
 
-    def test_fixture_covers_this_sdk(self):
-        self.assertGreater(len(self._cases()), 15, "fixture lost most of its Python cases")
+    def test_fixture_still_carries_every_case_this_sdk_is_held_to(self):
+        """Pinned exactly, not as a floor.
+
+        A floor cannot notice a deletion: under the previous ``> 15`` bound, with 35 cases
+        present, deleting a case outright left this suite — and the TypeScript and .NET ones
+        — green. Bump this deliberately when adding or removing a case.
+        """
+        self.assertEqual(
+            EXPECTED_CASE_COUNT,
+            len(self._cases()),
+            "the fixture gained or lost a Python case; update EXPECTED_CASE_COUNT if deliberate",
+        )
 
     def test_every_case_reserializes_to_its_expected_json(self):
         encoder = EventEncoder()
@@ -336,23 +354,53 @@ class TestNullOmissionCrossLanguageFixture(unittest.TestCase):
         value rides through validation as an extra and is re-serialized unchanged. .NET gets
         this for free (System.Text.Json drops unknown keys) and the TypeScript harness
         asserts the same thing against the Zod variant's shape.
+
+        The walk is recursive because ``extra="allow"`` is not a top-level setting. Deleting
+        ``ToolMessage.tool_call_id`` or ``RunAgentInput.forwarded_props`` — both nested
+        inside a case's ``expected`` — used to leave every test in this file green, because a
+        top-level-only walk never looked at them and the extra carried the value straight
+        back out.
         """
         for name, payload, expected in self._cases():
             with self.subTest(case=name):
-                model = type(self.event_adapter.validate_python(payload))
-                declared = set()
-                for field_name, field in model.model_fields.items():
-                    declared.add(field_name)
-                    if field.alias is not None:
-                        declared.add(field.alias)
-                undeclared = sorted(set(expected) - declared)
-                self.assertEqual(
-                    [],
-                    undeclared,
-                    f"case '{name}' expects {undeclared} on the wire, which "
-                    f"{model.__qualname__} does not declare — the round-trip only passes "
-                    f"because extra='allow' carried the key through",
+                self._assert_keys_are_declared(
+                    expected, self.event_adapter.validate_python(payload), name, ""
                 )
+
+    def _assert_keys_are_declared(
+        self, expected: Dict[str, Any], instance: BaseModel, case_name: str, path: str
+    ) -> None:
+        """Assert every key of ``expected`` is declared by ``instance``'s model, recursively."""
+        field_for_key: Dict[str, str] = {}
+        for field_name, field in type(instance).model_fields.items():
+            field_for_key[field_name] = field_name
+            if field.alias is not None:
+                field_for_key[field.alias] = field_name
+
+        undeclared = sorted(set(expected) - set(field_for_key))
+        self.assertEqual(
+            [],
+            undeclared,
+            f"case '{case_name}' expects {undeclared} at '{path or '/'}' on the wire, which "
+            f"{type(instance).__qualname__} does not declare — the round-trip only passes "
+            f"because extra='allow' carried the key through",
+        )
+
+        for key, value in expected.items():
+            self._descend(value, getattr(instance, field_for_key[key]), case_name, f"{path}/{key}")
+
+    def _descend(self, expected: Any, actual: Any, case_name: str, path: str) -> None:
+        """Follow ``expected`` into ``actual`` as far as the model tree goes.
+
+        Descent stops wherever the validated value is not a model: an opaque JSON payload — a
+        state snapshot, a raw event, a metadata bag — validates to a plain ``dict``, and there
+        an arbitrary key IS the contract rather than an undeclared field riding through.
+        """
+        if isinstance(expected, dict) and isinstance(actual, BaseModel):
+            self._assert_keys_are_declared(expected, actual, case_name, path)
+        elif isinstance(expected, list) and isinstance(actual, list):
+            for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+                self._descend(expected_item, actual_item, case_name, f"{path}/{index}")
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_null_omission.py
+++ b/sdks/python/tests/test_null_omission.py
@@ -9,7 +9,11 @@ Three tests, each doing a different job:
 * ``TestNullOmissionIsTheBaseModelsDoing`` reverts the setting on one class and shows the
   ``null`` come back, so a passing sweep can't be credited to something else.
 * ``TestNullOmissionCrossLanguageFixture`` runs the shared fixture that the TypeScript and
-  .NET SDKs run too, so all three are held to the same text.
+  .NET SDKs run too, so all three are held to the same text. Re-serializing a case is not on
+  its own enough to hold *this* SDK to it, because ``ConfiguredBaseModel`` uses
+  ``extra="allow"``: an undeclared key in a case's ``input`` survives validation as an extra
+  and is written straight back out, so the round-trip would pass for a field Python has never
+  heard of. Each case therefore also asserts that every key it expects is a declared field.
 """
 
 import enum
@@ -324,6 +328,31 @@ class TestNullOmissionCrossLanguageFixture(unittest.TestCase):
                 event = self.event_adapter.validate_python(payload)
                 encoded = encoder.encode(event)
                 self.assertEqual(expected, json.loads(encoded[len("data: ") : -len("\n\n")]))
+
+    def test_every_expected_key_is_a_declared_field(self):
+        """The keys a case expects are fields this SDK declares, not ``extra="allow"`` extras.
+
+        Without this, deleting a field from the model leaves its fixture case green: the
+        value rides through validation as an extra and is re-serialized unchanged. .NET gets
+        this for free (System.Text.Json drops unknown keys) and the TypeScript harness
+        asserts the same thing against the Zod variant's shape.
+        """
+        for name, payload, expected in self._cases():
+            with self.subTest(case=name):
+                model = type(self.event_adapter.validate_python(payload))
+                declared = set()
+                for field_name, field in model.model_fields.items():
+                    declared.add(field_name)
+                    if field.alias is not None:
+                        declared.add(field.alias)
+                undeclared = sorted(set(expected) - declared)
+                self.assertEqual(
+                    [],
+                    undeclared,
+                    f"case '{name}' expects {undeclared} on the wire, which "
+                    f"{model.__qualname__} does not declare — the round-trip only passes "
+                    f"because extra='allow' carried the key through",
+                )
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_tool_call_result_error.py
+++ b/sdks/python/tests/test_tool_call_result_error.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from ag_ui.core.events import Event, EventType, ToolCallResultEvent
 
@@ -44,6 +44,60 @@ class TestToolCallResultError(unittest.TestCase):
         event = self._base(error="")
         self.assertEqual(event.error, "")
         self.assertEqual(json.loads(event.model_dump_json(by_alias=True))["error"], "")
+
+    def test_a_non_string_error_is_rejected(self):
+        # The narrowing half of the field's source comment, which nothing pinned: before
+        # `error` was declared, extra="allow" let an `error` of ANY shape ride through as an
+        # extra, and declaring it as Optional[str] is what makes a non-string fail
+        # validation. Widening the annotation back to Optional[Any] leaves every other test
+        # in this suite green, so this is the only assertion standing between the declared
+        # type and a silent return to "anything goes".
+        adapter = TypeAdapter(Event)
+        for value in (42, {"code": "SearchTimeout"}, ["SearchTimeout"], True):
+            with self.subTest(error=value):
+                with self.assertRaises(ValidationError) as caught:
+                    adapter.validate_python(
+                        {
+                            "type": "TOOL_CALL_RESULT",
+                            "messageId": "msg_1",
+                            "toolCallId": "tc_1",
+                            "content": "",
+                            "error": value,
+                        }
+                    )
+                self.assertEqual(
+                    ["string_type"], [detail["type"] for detail in caught.exception.errors()]
+                )
+
+    def test_an_explicit_null_error_validates_and_is_re_emitted_as_omission(self):
+        # The other half of the same comment. Unlike the TypeScript schema, which rejects an
+        # explicit null on every new optional field, this SDK accepts one and reads it back
+        # as None — as it does for every optional field here. What the contract guarantees is
+        # not that a null is refused but that none is ever WRITTEN, so the re-emitted payload
+        # has to carry no `error` key at all rather than `"error": null`.
+        event = TypeAdapter(Event).validate_python(
+            {
+                "type": "TOOL_CALL_RESULT",
+                "messageId": "msg_1",
+                "toolCallId": "tc_1",
+                "content": "ok",
+                "error": None,
+            }
+        )
+        self.assertIsInstance(event, ToolCallResultEvent)
+        self.assertIsNone(event.error)
+
+        encoded = event.model_dump_json(by_alias=True)
+        self.assertNotIn('"error"', encoded)
+        self.assertEqual(
+            {
+                "type": "TOOL_CALL_RESULT",
+                "messageId": "msg_1",
+                "toolCallId": "tc_1",
+                "content": "ok",
+            },
+            json.loads(encoded),
+        )
 
     def test_round_trips_through_json(self):
         event = self._base(content="", error="boom")

--- a/sdks/python/tests/test_tool_call_result_error.py
+++ b/sdks/python/tests/test_tool_call_result_error.py
@@ -1,0 +1,94 @@
+import json
+import unittest
+
+from pydantic import TypeAdapter
+
+from ag_ui.core.events import Event, EventType, ToolCallResultEvent
+
+
+class TestToolCallResultError(unittest.TestCase):
+    """The optional `error` on TOOL_CALL_RESULT — the event-side twin of ToolMessage.error."""
+
+    def _base(self, **overrides):
+        kwargs = dict(
+            type=EventType.TOOL_CALL_RESULT,
+            message_id="msg_1",
+            tool_call_id="tc_1",
+            content='{"hits":2}',
+        )
+        kwargs.update(overrides)
+        return ToolCallResultEvent(**kwargs)
+
+    def test_error_is_a_declared_field_not_an_extra(self):
+        # ConfiguredBaseModel uses extra="allow", so simply passing error= and
+        # reading it back would pass even if the field were never declared.
+        # model_fields is the assertion that actually proves the declaration.
+        self.assertIn("error", ToolCallResultEvent.model_fields)
+
+    def test_defaults_to_none_and_is_omitted_from_the_wire(self):
+        event = self._base()
+        self.assertIsNone(event.error)
+        self.assertNotIn("error", json.loads(event.model_dump_json(by_alias=True)))
+
+    def test_carries_a_real_error_string(self):
+        event = self._base(content="", error="SearchTimeout: upstream did not respond within 30s")
+        self.assertEqual(event.error, "SearchTimeout: upstream did not respond within 30s")
+        self.assertEqual(
+            json.loads(event.model_dump_json(by_alias=True))["error"],
+            "SearchTimeout: upstream did not respond within 30s",
+        )
+
+    def test_empty_string_error_survives_rather_than_being_dropped(self):
+        # Omission applies to None, not to a falsy value the producer chose to
+        # send. An empty string must not silently become "the call succeeded".
+        event = self._base(error="")
+        self.assertEqual(event.error, "")
+        self.assertEqual(json.loads(event.model_dump_json(by_alias=True))["error"], "")
+
+    def test_round_trips_through_json(self):
+        event = self._base(content="", error="boom")
+        restored = ToolCallResultEvent.model_validate_json(event.model_dump_json(by_alias=True))
+        self.assertEqual(restored.error, "boom")
+        self.assertEqual(restored.tool_call_id, "tc_1")
+
+    def test_discriminated_union_still_resolves_tool_call_result(self):
+        adapter = TypeAdapter(Event)
+        with_error = adapter.validate_python(
+            {
+                "type": "TOOL_CALL_RESULT",
+                "messageId": "msg_1",
+                "toolCallId": "tc_1",
+                "content": "",
+                "error": "boom",
+            }
+        )
+        self.assertIsInstance(with_error, ToolCallResultEvent)
+        self.assertEqual(with_error.error, "boom")
+
+        without_error = adapter.validate_python(
+            {
+                "type": "TOOL_CALL_RESULT",
+                "messageId": "msg_1",
+                "toolCallId": "tc_1",
+                "content": "ok",
+            }
+        )
+        self.assertIsInstance(without_error, ToolCallResultEvent)
+        self.assertIsNone(without_error.error)
+
+    def test_a_pre_existing_event_serializes_exactly_as_before(self):
+        # The additive guarantee: an event from before this field existed keeps
+        # the same keys and values, so no consumer sees a change.
+        legacy_wire = {
+            "type": "TOOL_CALL_RESULT",
+            "messageId": "msg_1",
+            "toolCallId": "tc_1",
+            "content": '{"hits":2}',
+            "role": "tool",
+        }
+        event = ToolCallResultEvent.model_validate(legacy_wire)
+        self.assertEqual(json.loads(event.model_dump_json(by_alias=True)), legacy_wire)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_tool_call_result_error.py
+++ b/sdks/python/tests/test_tool_call_result_error.py
@@ -76,9 +76,11 @@ class TestToolCallResultError(unittest.TestCase):
         self.assertIsInstance(without_error, ToolCallResultEvent)
         self.assertIsNone(without_error.error)
 
-    def test_a_pre_existing_event_serializes_exactly_as_before(self):
-        # The additive guarantee: an event from before this field existed keeps
-        # the same keys and values, so no consumer sees a change.
+    def test_an_event_without_an_error_round_trips_to_the_same_keys_and_values(self):
+        # The compat guarantee for a producer that never writes `error`: no key
+        # gains or loses a value. Not a byte comparison — dict equality ignores
+        # key order, which is the right strength here: key order is a serializer
+        # detail, not part of the wire contract.
         legacy_wire = {
             "type": "TOOL_CALL_RESULT",
             "messageId": "msg_1",

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -7,6 +7,7 @@ import {
   BaseEvent,
   EventType,
   Message,
+  MessagesSnapshotEvent,
   RunAgentInput,
   RunAgentInputSchema,
   RunStartedEvent,
@@ -1023,14 +1024,34 @@ describe("defaultApplyEvents with tool calls", () => {
   });
 
   /**
-   * Streams one completed tool call whose TOOL_CALL_RESULT carries `result`, and
-   * returns the ToolMessage that defaultApplyEvents accumulated for it.
+   * Narrows `messages` to the ToolMessage the reducer accumulated, throwing
+   * rather than casting: `ToolMessage` is the type the assertions below are
+   * checked against, and a cast would throw that away along with the
+   * compile-time half of every one of them.
    */
-  const toolMessageFromResult = async (result: {
+  const expectToolMessage = (messages: Message[]): ToolMessage => {
+    const toolMessage = messages.find((message): message is ToolMessage => {
+      return message.role === "tool";
+    });
+    if (toolMessage === undefined) {
+      throw new Error("defaultApplyEvents accumulated no tool message for the result event");
+    }
+    return toolMessage;
+  };
+
+  /**
+   * Streams one completed tool call whose TOOL_CALL_RESULT carries the given
+   * fields, and returns the messages defaultApplyEvents accumulated for it.
+   *
+   * `error` is `unknown` rather than `string` on purpose: the reducer's own
+   * `as ToolCallResultEvent` is an assertion, not validation, so the value a
+   * malformed producer puts on the wire has to be expressible here too.
+   */
+  const messagesFromResult = async (resultEvent: {
     messageId: string;
     content: string;
-    error?: string;
-  }): Promise<ToolMessage> => {
+    error?: unknown;
+  }): Promise<Message[]> => {
     const events$ = new Subject<BaseEvent>();
     const initialState = {
       messages: [],
@@ -1053,7 +1074,7 @@ describe("defaultApplyEvents with tool calls", () => {
     } as ToolCallStartEvent);
     events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
     events$.next({
-      ...result,
+      ...resultEvent,
       type: EventType.TOOL_CALL_RESULT,
       toolCallId: "tool1",
     } as ToolCallResultEvent);
@@ -1062,18 +1083,15 @@ describe("defaultApplyEvents with tool calls", () => {
     events$.complete();
 
     const stateUpdates = await stateUpdatesPromise;
-    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
-    // Narrow with a type predicate rather than casting: the ToolMessage type is
-    // what the assertions below are checked against, and a cast would throw it
-    // away along with the compile-time half of every one of them.
-    const toolMessage = finalMessages.find((message): message is ToolMessage => {
-      return message.role === "tool";
-    });
-    if (toolMessage === undefined) {
-      throw new Error("defaultApplyEvents accumulated no tool message for the result event");
-    }
-    return toolMessage;
+    return stateUpdates[stateUpdates.length - 1].messages ?? [];
   };
+
+  /** As `messagesFromResult`, narrowed to the ToolMessage the result produced. */
+  const toolMessageFromResult = async (resultEvent: {
+    messageId: string;
+    content: string;
+    error?: unknown;
+  }): Promise<ToolMessage> => expectToolMessage(await messagesFromResult(resultEvent));
 
   it("carries TOOL_CALL_RESULT.error onto the tool message it accumulates into", async () => {
     // Without this the streamed message and the MESSAGES_SNAPSHOT disagree
@@ -1092,11 +1110,90 @@ describe("defaultApplyEvents with tool calls", () => {
     expect(error).toBe("SearchTimeout: upstream did not respond within 30s");
   });
 
+  it("agrees with the later MESSAGES_SNAPSHOT about whether the call failed", async () => {
+    // The invariant the branch exists for. A backend that streams a failed tool
+    // call and then re-sends the same message in a MESSAGES_SNAPSHOT must not
+    // make the reducer flip its account of that call: if the streamed message
+    // carried no `error`, the UI would read "succeeded" until the snapshot
+    // landed and then silently change its mind.
+    const failure = "SearchTimeout: upstream did not respond within 30s";
+
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "res1",
+      toolCallId: "tool1",
+      content: "",
+      error: failure,
+    } as ToolCallResultEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // The backend now re-sends the whole history, the failed tool call
+    // included. No id changes: this is the same message, twice.
+    events$.next({
+      type: EventType.MESSAGES_SNAPSHOT,
+      messages: [
+        {
+          id: "tool1",
+          role: "assistant",
+          toolCalls: [
+            { id: "tool1", type: "function", function: { name: "search", arguments: "" } },
+          ],
+        },
+        { id: "res1", role: "tool", toolCallId: "tool1", content: "", error: failure },
+      ],
+    } as MessagesSnapshotEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+
+    // The first update carrying a tool message is the one TOOL_CALL_RESULT
+    // produced — `emitUpdates` deep-clones each emission, so this is the
+    // message as the stream built it, not as the snapshot later left it.
+    const streamedUpdate = stateUpdates.find((update) =>
+      update.messages?.some((message) => message.role === "tool"),
+    );
+    if (streamedUpdate === undefined) {
+      throw new Error("defaultApplyEvents emitted no update carrying the streamed tool message");
+    }
+    const streamed = expectToolMessage(streamedUpdate.messages ?? []);
+    const snapshotted = expectToolMessage(stateUpdates[stateUpdates.length - 1].messages ?? []);
+
+    // Compare the field itself, not its truthiness: a streamed message with no
+    // `error` reads as a success the snapshot never described.
+    expect(streamed.error).toBe(snapshotted.error);
+    expect(streamed.error).toBe(failure);
+  });
+
   it("carries an empty-string TOOL_CALL_RESULT.error instead of dropping it", async () => {
     // `""` is a value the producer deliberately sent: a failure it reported
-    // badly, not a success. defaultApplyEvents guards on `error != null`, and
-    // this is the only case in any SDK that holds the client to that spelling —
-    // a falsy guard would silently turn this failed call into a successful one.
+    // badly, not a success. The reducer narrows on `typeof error === "string"`,
+    // which keeps `""` — a falsy guard (`error && { error }`) would silently
+    // turn this failed call into a successful one. The Python SDK pins the same
+    // spelling in `test_empty_string_error_survives_rather_than_being_dropped`.
     const toolMessage = await toolMessageFromResult({
       messageId: "res1",
       content: "",
@@ -1121,118 +1218,59 @@ describe("defaultApplyEvents with tool calls", () => {
     expect(Object.keys(toolMessage)).not.toContain("error");
   });
 
-  it("drops a non-string `error` instead of poisoning the message for the next turn", async () => {
-    // `defaultApplyEvents` receives events that have not necessarily been
-    // through `EventSchemas.parse` — the `as ToolCallResultEvent` cast inside is
-    // an assertion, not validation. A nullish check would let `error: 42` onto
-    // the `ToolMessage`, where it survives into `messages` and only blows up a
-    // full turn later inside `RunAgentInputSchema` ("Expected string, received
-    // number" at `messages.N.error`), far from the event that caused it.
-    //
-    // Spelled out as its own shape rather than cast: an unvalidated producer can
-    // put anything on the wire, and the whole point is that this reaches the
-    // reducer as a `BaseEvent` the reducer only *asserts* is a result event.
-    const malformedResult: BaseEvent & {
-      type: EventType.TOOL_CALL_RESULT;
-      messageId: string;
-      toolCallId: string;
-      content: string;
-      error: number;
-    } = {
-      type: EventType.TOOL_CALL_RESULT,
-      messageId: "res1",
-      toolCallId: "tool1",
-      content: "",
-      error: 42,
-    };
+  it("warns when it drops a non-string `error` rather than dropping it silently", async () => {
+    // A serialized exception object is the natural shape a Python or LangChain
+    // producer emits, and `defaultApplyEvents` receives events that have not
+    // necessarily been through `EventSchemas.parse` — the `as
+    // ToolCallResultEvent` inside is an assertion, not validation — so it
+    // arrives at the branch as-is. Dropping it is right; dropping it in silence
+    // is not, because the ToolMessage that survives is byte-identical to the
+    // one a successful call would have produced.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const toolMessage = await toolMessageFromResult({
+        messageId: "res1",
+        content: "",
+        error: { type: "ToolException", message: "upstream refused the connection" },
+      });
 
-    const events$ = new Subject<BaseEvent>();
-    const initialState = {
-      messages: [],
-      state: {},
-      threadId: "test-thread",
-      runId: "test-run",
-      tools: [],
-      context: [],
-    };
-
-    const agent = createAgent(initialState.messages);
-    const result$ = defaultApplyEvents(initialState, events$, agent, []);
-    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
-
-    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_START,
-      toolCallId: "tool1",
-      toolCallName: "search",
-    } as ToolCallStartEvent);
-    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
-    events$.next(malformedResult);
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    events$.complete();
-
-    const stateUpdates = await stateUpdatesPromise;
-    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
-    const toolMessage = finalMessages.find((m): m is ToolMessage => m.role === "tool");
-
-    expect(toolMessage).toBeDefined();
-    expect(Object.keys(toolMessage as object)).not.toContain("error");
-
-    // And the history it accumulated into is still valid input for the next run.
-    const nextTurn = RunAgentInputSchema.safeParse({
-      threadId: "test-thread",
-      runId: "test-run-2",
-      state: {},
-      messages: finalMessages,
-      tools: [],
-      context: [],
-      forwardedProps: {},
-    });
-    expect(nextTurn.success).toBe(true);
+      expect(Object.keys(toolMessage)).not.toContain("error");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("TOOL_CALL_RESULT"));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("tool1"));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it("keeps an empty-string `error` — a deliberately sent value, not an absent one", async () => {
-    // "" is falsy but present: a producer that reports a failure badly must not
-    // have it read back as a success.
-    const events$ = new Subject<BaseEvent>();
-    const initialState = {
-      messages: [],
-      state: {},
-      threadId: "test-thread",
-      runId: "test-run",
-      tools: [],
-      context: [],
-    };
+  it("drops a non-string `error` instead of putting it on `agent.messages`", async () => {
+    // Nothing in the client parses `RunAgentInputSchema` in production, so
+    // there is no later validation that would catch a non-string that got past
+    // this branch: it would simply reach every consumer of `agent.messages`.
+    // The safeParse below is this test pinning the shape the protocol
+    // declares — not a runtime check the client performs.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const finalMessages = await messagesFromResult({
+        messageId: "res1",
+        content: "",
+        error: 42,
+      });
 
-    const agent = createAgent(initialState.messages);
-    const result$ = defaultApplyEvents(initialState, events$, agent, []);
-    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+      const toolMessage = expectToolMessage(finalMessages);
+      expect(Object.keys(toolMessage)).not.toContain("error");
 
-    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_START,
-      toolCallId: "tool1",
-      toolCallName: "search",
-    } as ToolCallStartEvent);
-    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_RESULT,
-      messageId: "res1",
-      toolCallId: "tool1",
-      content: "",
-      error: "",
-    } as ToolCallResultEvent);
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    events$.complete();
-
-    const stateUpdates = await stateUpdatesPromise;
-    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
-    const toolMessage = finalMessages.find((m): m is ToolMessage => m.role === "tool");
-
-    expect(toolMessage).toBeDefined();
-    expect(Object.keys(toolMessage as object)).toContain("error");
-    expect(toolMessage?.error).toBe("");
+      const nextTurn = RunAgentInputSchema.safeParse({
+        threadId: "test-thread",
+        runId: "test-run-2",
+        state: {},
+        messages: finalMessages,
+        tools: [],
+        context: [],
+        forwardedProps: {},
+      });
+      expect(nextTurn.success).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -1019,4 +1019,90 @@ describe("defaultApplyEvents with tool calls", () => {
       }
     });
   });
+
+  it("carries TOOL_CALL_RESULT.error onto the tool message it accumulates into", async () => {
+    // Without this the streamed message and the MESSAGES_SNAPSHOT disagree
+    // about whether the call failed — the snapshot's ToolMessage has `error`,
+    // the one built from the stream would not.
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "res1",
+      toolCallId: "tool1",
+      content: "",
+      error: "SearchTimeout: upstream did not respond within 30s",
+    } as ToolCallResultEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
+    const toolMessage = finalMessages.find((m) => m.role === "tool");
+
+    expect(toolMessage).toBeDefined();
+    expect((toolMessage as any).error).toBe("SearchTimeout: upstream did not respond within 30s");
+  });
+
+  it("leaves `error` off the tool message when the event carries none", async () => {
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "res1",
+      toolCallId: "tool1",
+      content: "sunny",
+    } as ToolCallResultEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
+    const toolMessage = finalMessages.find((m) => m.role === "tool");
+
+    expect(toolMessage).toBeDefined();
+    // The key is absent, not present-and-undefined: the message must serialize
+    // identically to how it did before this field existed.
+    expect(Object.keys(toolMessage as object)).not.toContain("error");
+  });
 });

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -1022,90 +1022,103 @@ describe("defaultApplyEvents with tool calls", () => {
     });
   });
 
+  /**
+   * Streams one completed tool call whose TOOL_CALL_RESULT carries `result`, and
+   * returns the ToolMessage that defaultApplyEvents accumulated for it.
+   */
+  const toolMessageFromResult = async (result: {
+    messageId: string;
+    content: string;
+    error?: string;
+  }): Promise<ToolMessage> => {
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next({
+      ...result,
+      type: EventType.TOOL_CALL_RESULT,
+      toolCallId: "tool1",
+    } as ToolCallResultEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
+    // Narrow with a type predicate rather than casting: the ToolMessage type is
+    // what the assertions below are checked against, and a cast would throw it
+    // away along with the compile-time half of every one of them.
+    const toolMessage = finalMessages.find((message): message is ToolMessage => {
+      return message.role === "tool";
+    });
+    if (toolMessage === undefined) {
+      throw new Error("defaultApplyEvents accumulated no tool message for the result event");
+    }
+    return toolMessage;
+  };
+
   it("carries TOOL_CALL_RESULT.error onto the tool message it accumulates into", async () => {
     // Without this the streamed message and the MESSAGES_SNAPSHOT disagree
     // about whether the call failed — the snapshot's ToolMessage has `error`,
     // the one built from the stream would not.
-    const events$ = new Subject<BaseEvent>();
-    const initialState = {
-      messages: [],
-      state: {},
-      threadId: "test-thread",
-      runId: "test-run",
-      tools: [],
-      context: [],
-    };
-
-    const agent = createAgent(initialState.messages);
-    const result$ = defaultApplyEvents(initialState, events$, agent, []);
-    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
-
-    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_START,
-      toolCallId: "tool1",
-      toolCallName: "search",
-    } as ToolCallStartEvent);
-    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_RESULT,
+    const toolMessage = await toolMessageFromResult({
       messageId: "res1",
-      toolCallId: "tool1",
       content: "",
       error: "SearchTimeout: upstream did not respond within 30s",
-    } as ToolCallResultEvent);
+    });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    events$.complete();
+    // Read through an annotated local: the annotation is the compile-time half
+    // of this assertion, so removing `error` from ToolMessage in @ag-ui/core
+    // fails the typecheck here rather than leaving the test green.
+    const error: string | undefined = toolMessage.error;
+    expect(error).toBe("SearchTimeout: upstream did not respond within 30s");
+  });
 
-    const stateUpdates = await stateUpdatesPromise;
-    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
-    const toolMessage = finalMessages.find((m) => m.role === "tool");
+  it("carries an empty-string TOOL_CALL_RESULT.error instead of dropping it", async () => {
+    // `""` is a value the producer deliberately sent: a failure it reported
+    // badly, not a success. defaultApplyEvents guards on `error != null`, and
+    // this is the only case in any SDK that holds the client to that spelling —
+    // a falsy guard would silently turn this failed call into a successful one.
+    const toolMessage = await toolMessageFromResult({
+      messageId: "res1",
+      content: "",
+      error: "",
+    });
 
-    expect(toolMessage).toBeDefined();
-    expect((toolMessage as any).error).toBe("SearchTimeout: upstream did not respond within 30s");
+    const error: string | undefined = toolMessage.error;
+    expect(error).toBe("");
+    expect(Object.keys(toolMessage)).toContain("error");
   });
 
   it("leaves `error` off the tool message when the event carries none", async () => {
-    const events$ = new Subject<BaseEvent>();
-    const initialState = {
-      messages: [],
-      state: {},
-      threadId: "test-thread",
-      runId: "test-run",
-      tools: [],
-      context: [],
-    };
+    const toolMessage = await toolMessageFromResult({ messageId: "res1", content: "sunny" });
 
-    const agent = createAgent(initialState.messages);
-    const result$ = defaultApplyEvents(initialState, events$, agent, []);
-    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
-
-    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_START,
-      toolCallId: "tool1",
-      toolCallName: "search",
-    } as ToolCallStartEvent);
-    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
-    events$.next({
-      type: EventType.TOOL_CALL_RESULT,
-      messageId: "res1",
-      toolCallId: "tool1",
-      content: "sunny",
-    } as ToolCallResultEvent);
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    events$.complete();
-
-    const stateUpdates = await stateUpdatesPromise;
-    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
-    const toolMessage = finalMessages.find((m) => m.role === "tool");
-
-    expect(toolMessage).toBeDefined();
+    // The annotated read is what keeps this from being vacuous: it pins `error`
+    // as a real optional field of ToolMessage, so the absence asserted below
+    // means "no error was reported", not "ToolMessage has no such field".
+    const error: string | undefined = toolMessage.error;
+    expect(error).toBeUndefined();
     // The key is absent, not present-and-undefined: the message must serialize
     // identically to how it did before this field existed.
-    expect(Object.keys(toolMessage as object)).not.toContain("error");
+    expect(Object.keys(toolMessage)).not.toContain("error");
   });
 
   it("drops a non-string `error` instead of poisoning the message for the next turn", async () => {

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.tool-calls.test.ts
@@ -8,11 +8,13 @@ import {
   EventType,
   Message,
   RunAgentInput,
+  RunAgentInputSchema,
   RunStartedEvent,
   ToolCallArgsEvent,
   ToolCallEndEvent,
   ToolCallResultEvent,
   ToolCallStartEvent,
+  ToolMessage,
 } from "@ag-ui/core";
 import { defaultApplyEvents } from "../default";
 import { AbstractAgent } from "@/agent";
@@ -1104,5 +1106,120 @@ describe("defaultApplyEvents with tool calls", () => {
     // The key is absent, not present-and-undefined: the message must serialize
     // identically to how it did before this field existed.
     expect(Object.keys(toolMessage as object)).not.toContain("error");
+  });
+
+  it("drops a non-string `error` instead of poisoning the message for the next turn", async () => {
+    // `defaultApplyEvents` receives events that have not necessarily been
+    // through `EventSchemas.parse` — the `as ToolCallResultEvent` cast inside is
+    // an assertion, not validation. A nullish check would let `error: 42` onto
+    // the `ToolMessage`, where it survives into `messages` and only blows up a
+    // full turn later inside `RunAgentInputSchema` ("Expected string, received
+    // number" at `messages.N.error`), far from the event that caused it.
+    //
+    // Spelled out as its own shape rather than cast: an unvalidated producer can
+    // put anything on the wire, and the whole point is that this reaches the
+    // reducer as a `BaseEvent` the reducer only *asserts* is a result event.
+    const malformedResult: BaseEvent & {
+      type: EventType.TOOL_CALL_RESULT;
+      messageId: string;
+      toolCallId: string;
+      content: string;
+      error: number;
+    } = {
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "res1",
+      toolCallId: "tool1",
+      content: "",
+      error: 42,
+    };
+
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next(malformedResult);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
+    const toolMessage = finalMessages.find((m): m is ToolMessage => m.role === "tool");
+
+    expect(toolMessage).toBeDefined();
+    expect(Object.keys(toolMessage as object)).not.toContain("error");
+
+    // And the history it accumulated into is still valid input for the next run.
+    const nextTurn = RunAgentInputSchema.safeParse({
+      threadId: "test-thread",
+      runId: "test-run-2",
+      state: {},
+      messages: finalMessages,
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    });
+    expect(nextTurn.success).toBe(true);
+  });
+
+  it("keeps an empty-string `error` — a deliberately sent value, not an absent one", async () => {
+    // "" is falsy but present: a producer that reports a failure badly must not
+    // have it read back as a success.
+    const events$ = new Subject<BaseEvent>();
+    const initialState = {
+      messages: [],
+      state: {},
+      threadId: "test-thread",
+      runId: "test-run",
+      tools: [],
+      context: [],
+    };
+
+    const agent = createAgent(initialState.messages);
+    const result$ = defaultApplyEvents(initialState, events$, agent, []);
+    const stateUpdatesPromise = firstValueFrom(result$.pipe(toArray()));
+
+    events$.next({ type: EventType.RUN_STARTED } as RunStartedEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "tool1",
+      toolCallName: "search",
+    } as ToolCallStartEvent);
+    events$.next({ type: EventType.TOOL_CALL_END, toolCallId: "tool1" } as ToolCallEndEvent);
+    events$.next({
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "res1",
+      toolCallId: "tool1",
+      content: "",
+      error: "",
+    } as ToolCallResultEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    events$.complete();
+
+    const stateUpdates = await stateUpdatesPromise;
+    const finalMessages = stateUpdates[stateUpdates.length - 1].messages ?? [];
+    const toolMessage = finalMessages.find((m): m is ToolMessage => m.role === "tool");
+
+    expect(toolMessage).toBeDefined();
+    expect(Object.keys(toolMessage as object)).toContain("error");
+    expect(toolMessage?.error).toBe("");
   });
 });

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -609,6 +609,28 @@ export const defaultApplyEvents = (
             const { messageId, toolCallId, content, role, error, subagentRunId } =
               event as ToolCallResultEvent;
 
+            // Narrow `error` on its type, not on nullishness. The cast above is
+            // an assertion, not validation — events reaching here have not
+            // necessarily been through `EventSchemas.parse` — so a producer can
+            // put any shape on the wire, and a serialized exception object is
+            // the natural thing a Python or LangChain producer emits. Nothing
+            // downstream re-validates: no production code parses
+            // `RunAgentInputSchema`, so a non-string that got past this point
+            // would simply reach every consumer of `agent.messages` as-is.
+            // `typeof === "string"` still keeps `""` — an empty string is a
+            // value the producer chose to send, not an absent one.
+            //
+            // Warn on the drop. Silently discarding it would leave a ToolMessage
+            // byte-identical to the one a successful call produces, so a
+            // reported failure would read back as a success with nothing in the
+            // logs to say otherwise.
+            if (error !== undefined && typeof error !== "string") {
+              console.warn(
+                `TOOL_CALL_RESULT: dropping non-string 'error' (${typeof error}) reported for ` +
+                  `tool call '${toolCallId}' — the failure will not reach 'agent.messages'`,
+              );
+            }
+
             const toolMessage: ToolMessage = {
               id: messageId,
               toolCallId,
@@ -617,13 +639,6 @@ export const defaultApplyEvents = (
               // Carry the event's `error` onto the message it accumulates into.
               // Without this the streamed message and the MESSAGES_SNAPSHOT
               // disagree about whether the call failed.
-              //
-              // Narrow on the type, not on nullishness: events reaching here have
-              // not necessarily been through `EventSchemas.parse`, so a producer
-              // sending e.g. `error: 42` would otherwise land a non-string on the
-              // message and only fail `RunAgentInputSchema` a full turn later.
-              // `typeof === "string"` still keeps `""` — an empty string is a
-              // value the producer chose to send, not an absent one.
               ...(typeof error === "string" && { error }),
               ...(subagentRunId != null && { subagentRunId }),
             };

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -606,7 +606,7 @@ export const defaultApplyEvents = (
           applyMutation(mutation);
 
           if (mutation.stopPropagation !== true) {
-            const { messageId, toolCallId, content, role, subagentRunId } =
+            const { messageId, toolCallId, content, role, error, subagentRunId } =
               event as ToolCallResultEvent;
 
             const toolMessage: ToolMessage = {
@@ -614,6 +614,10 @@ export const defaultApplyEvents = (
               toolCallId,
               role: role || "tool",
               content: content,
+              // Carry the event's `error` onto the message it accumulates into.
+              // Without this the streamed message and the MESSAGES_SNAPSHOT
+              // disagree about whether the call failed.
+              ...(error != null && { error }),
               ...(subagentRunId != null && { subagentRunId }),
             };
 

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -617,7 +617,14 @@ export const defaultApplyEvents = (
               // Carry the event's `error` onto the message it accumulates into.
               // Without this the streamed message and the MESSAGES_SNAPSHOT
               // disagree about whether the call failed.
-              ...(error != null && { error }),
+              //
+              // Narrow on the type, not on nullishness: events reaching here have
+              // not necessarily been through `EventSchemas.parse`, so a producer
+              // sending e.g. `error: 42` would otherwise land a non-string on the
+              // message and only fail `RunAgentInputSchema` a full turn later.
+              // `typeof === "string"` still keeps `""` — an empty string is a
+              // value the producer chose to send, not an absent one.
+              ...(typeof error === "string" && { error }),
               ...(subagentRunId != null && { subagentRunId }),
             };
 

--- a/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
@@ -3,10 +3,14 @@ import {
   EventSchemas,
   EventType,
   ToolCallChunkEventSchema,
+  type ToolCallResultEvent,
+  type ToolCallResultEventProps,
+  ToolCallResultEventSchema,
   type ToolCallStartEvent,
   type ToolCallStartEventProps,
   ToolCallStartEventSchema,
 } from "../events";
+import { createToolCallResultEvent } from "../event-factories";
 
 describe("ToolCallStartEventSchema — parentMessageId is optional and back-compat", () => {
   it("parses an event with no parentMessageId", () => {
@@ -106,5 +110,132 @@ describe("ToolCallStart — public type contract is not broken (compile-time)", 
     expect(propsWithNull.parentMessageId).toBeNull();
     expect(propsWithString.parentMessageId).toBe("msg-1");
     expect(propsOmitted.parentMessageId).toBeUndefined();
+  });
+});
+
+describe("ToolCallResultEventSchema — optional `error`", () => {
+  const base = {
+    type: EventType.TOOL_CALL_RESULT as const,
+    messageId: "msg-1",
+    toolCallId: "tc-1",
+    content: '{"hits":2}',
+  };
+
+  it("parses an event with no error, leaving the field undefined", () => {
+    const parsed = ToolCallResultEventSchema.parse(base);
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it("preserves a real error string", () => {
+    const parsed = ToolCallResultEventSchema.parse({
+      ...base,
+      content: "",
+      error: "SearchTimeout: upstream did not respond within 30s",
+    });
+    expect(parsed.error).toBe("SearchTimeout: upstream did not respond within 30s");
+  });
+
+  it("preserves an empty-string error rather than collapsing it to undefined", () => {
+    // An empty string is a value the producer chose to send. Treating it as
+    // absent would turn a (badly reported) failure into a success.
+    const parsed = ToolCallResultEventSchema.parse({ ...base, error: "" });
+    expect(parsed.error).toBe("");
+  });
+
+  it("rejects an explicit null, like every other new optional field", () => {
+    // No null tolerance on new fields: since PNI-199 the Python and .NET SDKs
+    // omit valueless fields at the source, so no producer legally writes null
+    // here. The three legacy tolerances stay a closed set.
+    expect(() => ToolCallResultEventSchema.parse({ ...base, error: null })).toThrow();
+  });
+
+  it("round-trips through JSON with the error intact", () => {
+    const event = ToolCallResultEventSchema.parse({ ...base, error: "boom" });
+    const reparsed = ToolCallResultEventSchema.parse(JSON.parse(JSON.stringify(event)));
+    expect(reparsed).toEqual(event);
+  });
+
+  it("omits the key entirely on the wire when no error is set", () => {
+    // The cross-language contract in sdks/fixtures/null-omission.json: absent
+    // means the key is gone, never `"error": null`.
+    const event = ToolCallResultEventSchema.parse(base);
+    expect(Object.keys(JSON.parse(JSON.stringify(event)))).not.toContain("error");
+  });
+
+  it("still resolves TOOL_CALL_RESULT through the EventSchemas union, with and without error", () => {
+    // EventSchemas is what the HTTP transport validates each streamed event
+    // against, so the discriminated union has to keep resolving the variant.
+    const withError = EventSchemas.parse({ ...base, error: "boom" });
+    expect(withError.type).toBe(EventType.TOOL_CALL_RESULT);
+    if (withError.type === EventType.TOOL_CALL_RESULT) {
+      expect(withError.error).toBe("boom");
+    }
+
+    const withoutError = EventSchemas.parse(base);
+    expect(withoutError.type).toBe(EventType.TOOL_CALL_RESULT);
+    if (withoutError.type === EventType.TOOL_CALL_RESULT) {
+      expect(withoutError.error).toBeUndefined();
+    }
+  });
+
+  it("parses a pre-existing stream byte-identically to before the field existed", () => {
+    // The additive guarantee: an old producer's event is unchanged by the new
+    // field, key-for-key and value-for-value.
+    const legacyWire = {
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "msg-1",
+      toolCallId: "tc-1",
+      content: '{"hits":2}',
+      role: "tool",
+    };
+    const parsed = ToolCallResultEventSchema.parse(legacyWire);
+    expect(JSON.parse(JSON.stringify(parsed))).toEqual(legacyWire);
+  });
+
+  it("carries the error through createToolCallResultEvent", () => {
+    const event = createToolCallResultEvent({
+      messageId: "msg-1",
+      toolCallId: "tc-1",
+      content: "",
+      error: "boom",
+    });
+    expect(event.type).toBe(EventType.TOOL_CALL_RESULT);
+    expect(event.error).toBe("boom");
+  });
+
+  it("declares `error` on the type, not merely tolerates it on the wire (compile-time)", () => {
+    // The runtime asserts above are NOT sufficient on their own. BaseEventSchema
+    // passes unknown keys through, so deleting `error` from the schema leaves
+    // almost all of them green — the value survives parsing as an unrecognized
+    // key. The `const x: Type = {...}` annotations below are the real guard:
+    // they are checked by `tsc`, so removing the field fails the build.
+    const props: ToolCallResultEventProps = {
+      messageId: "msg-1",
+      toolCallId: "tc-1",
+      content: "",
+      error: "boom",
+    };
+    expect(props.error).toBe("boom");
+
+    // Consumer/output type: an OPTIONAL key whose value is `string | undefined`,
+    // never null — matching ToolMessage.error.
+    const event: ToolCallResultEvent = {
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "msg-1",
+      toolCallId: "tc-1",
+      content: "",
+      error: "boom",
+    };
+    const read: string | undefined = event.error;
+    expect(read).toBe("boom");
+
+    // Omitting it still type-checks: the field is additive, not required.
+    const omitted: ToolCallResultEvent = {
+      type: EventType.TOOL_CALL_RESULT,
+      messageId: "msg-1",
+      toolCallId: "tc-1",
+      content: "ok",
+    };
+    expect(omitted.error).toBeUndefined();
   });
 });

--- a/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
@@ -142,10 +142,15 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     expect(parsed.error).toBe("");
   });
 
-  it("rejects an explicit null, like every other new optional field", () => {
-    // No null tolerance on new fields: since PNI-199 the Python and .NET SDKs
-    // omit valueless fields at the source, so no producer legally writes null
-    // here. The three legacy tolerances stay a closed set.
+  it("rejects an explicit null, like every other new optional field in these schemas", () => {
+    // No null tolerance on new fields in the Zod schemas: since PNI-199 the
+    // Python and .NET SDKs omit valueless fields at the source, so no producer
+    // legally writes null here. The three legacy tolerances stay a closed set.
+    //
+    // The rejection is TypeScript's alone. The Python model and the .NET class
+    // both accept an explicit null and read it back as absent — as they do for
+    // every optional field, `subagent_run_id` and `role` included — so the
+    // guarantee is that nothing writes null, not that every SDK refuses one.
     expect(() => ToolCallResultEventSchema.parse({ ...base, error: null })).toThrow();
   });
 
@@ -178,9 +183,11 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     }
   });
 
-  it("parses a pre-existing stream byte-identically to before the field existed", () => {
-    // The additive guarantee: an old producer's event is unchanged by the new
-    // field, key-for-key and value-for-value.
+  it("re-serializes an event that carries no error to the same keys and values", () => {
+    // The compat guarantee for a producer that never writes `error`: no key
+    // gains or loses a value. Not a byte comparison — `toEqual` ignores key
+    // order and undefined-valued keys, which is the right strength here: key
+    // order is a serializer detail, not part of the wire contract.
     const legacyWire = {
       type: EventType.TOOL_CALL_RESULT,
       messageId: "msg-1",
@@ -229,7 +236,7 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     const read: string | undefined = event.error;
     expect(read).toBe("boom");
 
-    // Omitting it still type-checks: the field is additive, not required.
+    // Omitting it still type-checks: the field is optional, not required.
     const omitted: ToolCallResultEvent = {
       type: EventType.TOOL_CALL_RESULT,
       messageId: "msg-1",

--- a/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
@@ -122,12 +122,14 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
 
   it("declares `error` in the schema's own shape, not as a tolerated unknown key", () => {
     // BaseEventSchema is `.passthrough()`, so an undeclared `error` still comes
-    // back out of `.parse()` as an unrecognized key — which means none of the
-    // parse-and-read assertions below can fail on their own if the field is
-    // deleted from the schema. The schema's `shape` is the one runtime fact
-    // that can: it is the TypeScript analogue of the Python suite's
-    // `model_fields` check, and it is a compile error as well as a failed
-    // expectation once `error` is gone.
+    // back out of `.parse()` as an unrecognized key — which means the
+    // parse-and-read assertions below mostly cannot fail on their own if the
+    // field is deleted from the schema. Deleting `error` fails exactly two
+    // tests in this block at runtime: this one, and "rejects an explicit null"
+    // further down. This is the direct one — the schema's `shape` is the
+    // TypeScript analogue of the Python suite's `model_fields` check, and it is
+    // a compile error as well as a failed expectation once `error` is gone. The
+    // other is incidental, and says so where it sits.
     expect(Object.keys(ToolCallResultEventSchema.shape)).toContain("error");
 
     const errorField = ToolCallResultEventSchema.shape.error;
@@ -176,9 +178,11 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     // every optional field, `subagent_run_id` and `role` included — so the
     // guarantee is that nothing writes null, not that every SDK refuses one.
     //
-    // This is also the one runtime case here that fails on its own if the field
-    // is deleted: passthrough lets an undeclared `null` through instead of
-    // throwing.
+    // This is the second of the two tests in this block that fail at runtime if
+    // the field is deleted — passthrough lets an undeclared `null` through
+    // instead of throwing — but it fails incidentally, as a side effect of what
+    // it is really about. The declaration itself is pinned deliberately by the
+    // `shape` assertion at the top.
     expect(() => ToolCallResultEventSchema.parse({ ...base, error: null })).toThrow();
   });
 

--- a/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-call-events.test.ts
@@ -4,7 +4,6 @@ import {
   EventType,
   ToolCallChunkEventSchema,
   type ToolCallResultEvent,
-  type ToolCallResultEventProps,
   ToolCallResultEventSchema,
   type ToolCallStartEvent,
   type ToolCallStartEventProps,
@@ -121,9 +120,32 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     content: '{"hits":2}',
   };
 
+  it("declares `error` in the schema's own shape, not as a tolerated unknown key", () => {
+    // BaseEventSchema is `.passthrough()`, so an undeclared `error` still comes
+    // back out of `.parse()` as an unrecognized key — which means none of the
+    // parse-and-read assertions below can fail on their own if the field is
+    // deleted from the schema. The schema's `shape` is the one runtime fact
+    // that can: it is the TypeScript analogue of the Python suite's
+    // `model_fields` check, and it is a compile error as well as a failed
+    // expectation once `error` is gone.
+    expect(Object.keys(ToolCallResultEventSchema.shape)).toContain("error");
+
+    const errorField = ToolCallResultEventSchema.shape.error;
+    expect(errorField.safeParse("boom").success).toBe(true);
+    expect(errorField.safeParse("").success).toBe(true);
+    expect(errorField.safeParse(undefined).success).toBe(true);
+    expect(errorField.safeParse(null).success).toBe(false);
+    expect(errorField.safeParse(42).success).toBe(false);
+  });
+
   it("parses an event with no error, leaving the field undefined", () => {
     const parsed = ToolCallResultEventSchema.parse(base);
-    expect(parsed.error).toBeUndefined();
+    // Read through an annotated local rather than asserting on `parsed.error`
+    // directly: under passthrough an undeclared key types as `unknown`, so this
+    // line is the half of the assertion that stops compiling if `error` is
+    // deleted from the schema. Same idiom in every case below.
+    const error: string | undefined = parsed.error;
+    expect(error).toBeUndefined();
   });
 
   it("preserves a real error string", () => {
@@ -132,14 +154,16 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
       content: "",
       error: "SearchTimeout: upstream did not respond within 30s",
     });
-    expect(parsed.error).toBe("SearchTimeout: upstream did not respond within 30s");
+    const error: string | undefined = parsed.error;
+    expect(error).toBe("SearchTimeout: upstream did not respond within 30s");
   });
 
   it("preserves an empty-string error rather than collapsing it to undefined", () => {
     // An empty string is a value the producer chose to send. Treating it as
     // absent would turn a (badly reported) failure into a success.
     const parsed = ToolCallResultEventSchema.parse({ ...base, error: "" });
-    expect(parsed.error).toBe("");
+    const error: string | undefined = parsed.error;
+    expect(error).toBe("");
   });
 
   it("rejects an explicit null, like every other new optional field in these schemas", () => {
@@ -151,6 +175,10 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     // both accept an explicit null and read it back as absent — as they do for
     // every optional field, `subagent_run_id` and `role` included — so the
     // guarantee is that nothing writes null, not that every SDK refuses one.
+    //
+    // This is also the one runtime case here that fails on its own if the field
+    // is deleted: passthrough lets an undeclared `null` through instead of
+    // throwing.
     expect(() => ToolCallResultEventSchema.parse({ ...base, error: null })).toThrow();
   });
 
@@ -158,12 +186,16 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     const event = ToolCallResultEventSchema.parse({ ...base, error: "boom" });
     const reparsed = ToolCallResultEventSchema.parse(JSON.parse(JSON.stringify(event)));
     expect(reparsed).toEqual(event);
+    const error: string | undefined = reparsed.error;
+    expect(error).toBe("boom");
   });
 
   it("omits the key entirely on the wire when no error is set", () => {
     // The cross-language contract in sdks/fixtures/null-omission.json: absent
     // means the key is gone, never `"error": null`.
     const event = ToolCallResultEventSchema.parse(base);
+    const error: string | undefined = event.error;
+    expect(error).toBeUndefined();
     expect(Object.keys(JSON.parse(JSON.stringify(event)))).not.toContain("error");
   });
 
@@ -173,13 +205,15 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     const withError = EventSchemas.parse({ ...base, error: "boom" });
     expect(withError.type).toBe(EventType.TOOL_CALL_RESULT);
     if (withError.type === EventType.TOOL_CALL_RESULT) {
-      expect(withError.error).toBe("boom");
+      const error: string | undefined = withError.error;
+      expect(error).toBe("boom");
     }
 
     const withoutError = EventSchemas.parse(base);
     expect(withoutError.type).toBe(EventType.TOOL_CALL_RESULT);
     if (withoutError.type === EventType.TOOL_CALL_RESULT) {
-      expect(withoutError.error).toBeUndefined();
+      const error: string | undefined = withoutError.error;
+      expect(error).toBeUndefined();
     }
   });
 
@@ -197,9 +231,19 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
     };
     const parsed = ToolCallResultEventSchema.parse(legacyWire);
     expect(JSON.parse(JSON.stringify(parsed))).toEqual(legacyWire);
+    // ...and the field it does not carry reads back as absent, not as some
+    // other falsy value a consumer would have to special-case.
+    const error: string | undefined = parsed.error;
+    expect(error).toBeUndefined();
   });
 
   it("carries the error through createToolCallResultEvent", () => {
+    // The factory is the construction path, and its `props` argument is where
+    // `error` has to be accepted on the input side. Note that the exported
+    // `ToolCallResultEventProps` alias cannot carry that guard: `EventProps` is
+    // `Omit<z.input<Schema>, "type">`, and `Omit` over a passthrough input type
+    // collapses to a bare index signature, so annotating a literal with it
+    // asserts nothing about `error`. The factory's typed return does.
     const event = createToolCallResultEvent({
       messageId: "msg-1",
       toolCallId: "tc-1",
@@ -207,25 +251,20 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
       error: "boom",
     });
     expect(event.type).toBe(EventType.TOOL_CALL_RESULT);
-    expect(event.error).toBe("boom");
+    const error: string | undefined = event.error;
+    expect(error).toBe("boom");
   });
 
   it("declares `error` on the type, not merely tolerates it on the wire (compile-time)", () => {
-    // The runtime asserts above are NOT sufficient on their own. BaseEventSchema
-    // passes unknown keys through, so deleting `error` from the schema leaves
-    // almost all of them green — the value survives parsing as an unrecognized
-    // key. The `const x: Type = {...}` annotations below are the real guard:
-    // they are checked by `tsc`, so removing the field fails the build.
-    const props: ToolCallResultEventProps = {
-      messageId: "msg-1",
-      toolCallId: "tc-1",
-      content: "",
-      error: "boom",
-    };
-    expect(props.error).toBe("boom");
-
-    // Consumer/output type: an OPTIONAL key whose value is `string | undefined`,
-    // never null — matching ToolMessage.error.
+    // A passthrough schema genuinely cannot reject an unknown key at runtime,
+    // so `expect(...)` alone can never distinguish "declared field" from
+    // "unrecognized key that survived parsing". What separates them is the
+    // *type* of the value read back: a declared `error` reads as
+    // `string | undefined`, an unrecognized one reads as `unknown` off the
+    // passthrough index signature. So the annotated locals — here and in every
+    // case above — are the load-bearing assertions, and they are checked by
+    // `tsc` (`nx run @ag-ui/core:typecheck`), not by vitest. Deleting the field
+    // from the schema fails the typecheck on each of them.
     const event: ToolCallResultEvent = {
       type: EventType.TOOL_CALL_RESULT,
       messageId: "msg-1",
@@ -243,6 +282,7 @@ describe("ToolCallResultEventSchema — optional `error`", () => {
       toolCallId: "tc-1",
       content: "ok",
     };
-    expect(omitted.error).toBeUndefined();
+    const omittedRead: string | undefined = omitted.error;
+    expect(omittedRead).toBeUndefined();
   });
 });

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -170,6 +170,11 @@ export const ToolCallResultEventSchema = BaseEventSchema.extend({
   toolCallId: z.string(),
   content: z.string(),
   role: z.literal("tool").optional(),
+  // The event-side twin of `ToolMessage.error`: set when the tool call failed,
+  // so a consumer can render the failure from the live stream instead of
+  // waiting for the MESSAGES_SNAPSHOT that carries the message. Absent means
+  // the call succeeded, exactly as before this field existed.
+  error: z.string().optional(),
   subagentRunId: z.string().optional(),
 });
 

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -172,9 +172,10 @@ export const ToolCallResultEventSchema = BaseEventSchema.extend({
   role: z.literal("tool").optional(),
   // The event-side twin of `ToolMessage.error`: set when the tool call failed,
   // so a consumer can render the failure from the live stream instead of
-  // waiting for the MESSAGES_SNAPSHOT that carries the message. Schema only —
-  // no producer populates it yet, so an absent error means the producer said
-  // nothing about failure, not that the call succeeded.
+  // waiting for the MESSAGES_SNAPSHOT that carries the message. A failure is
+  // reported when `error` is a string, `""` included — a producer that sends
+  // the empty string chose to send it. An absent `error` reports nothing about
+  // failure, which is not the same as the call having succeeded.
   //
   // Typing it narrows the wire rather than purely extending it: BaseEventSchema
   // is `.passthrough()`, so an `error` of any other shape — an object, an

--- a/sdks/typescript/packages/core/src/events.ts
+++ b/sdks/typescript/packages/core/src/events.ts
@@ -172,8 +172,16 @@ export const ToolCallResultEventSchema = BaseEventSchema.extend({
   role: z.literal("tool").optional(),
   // The event-side twin of `ToolMessage.error`: set when the tool call failed,
   // so a consumer can render the failure from the live stream instead of
-  // waiting for the MESSAGES_SNAPSHOT that carries the message. Absent means
-  // the call succeeded, exactly as before this field existed.
+  // waiting for the MESSAGES_SNAPSHOT that carries the message. Schema only —
+  // no producer populates it yet, so an absent error means the producer said
+  // nothing about failure, not that the call succeeded.
+  //
+  // Typing it narrows the wire rather than purely extending it: BaseEventSchema
+  // is `.passthrough()`, so an `error` of any other shape — an object, an
+  // explicit null — used to survive parsing as an unrecognized key and now
+  // fails it. That is the intended no-null-tolerance reading for new fields
+  // (see the note above SubagentStartedEventSchema), but it does tighten what
+  // an existing stream may carry under this key.
   error: z.string().optional(),
   subagentRunId: z.string().optional(),
 });

--- a/sdks/typescript/packages/encoder/src/__tests__/null-omission.test.ts
+++ b/sdks/typescript/packages/encoder/src/__tests__/null-omission.test.ts
@@ -13,6 +13,14 @@ import { EventEncoder } from "../encoder";
  * this side is what makes it the shared contract rather than a Python/.NET convention: if a
  * case is added that TypeScript would not actually produce, this test says so instead of the
  * other two SDKs being held to something the reference implementation does not do.
+ *
+ * The re-serialization check alone is not enough to hold this SDK to a case, because
+ * `BaseEventSchema` is `.passthrough()`: a key this SDK does not declare survives `.parse()`
+ * as an unrecognized key and is re-encoded verbatim, so the round-trip would pass for a
+ * field TypeScript has never heard of. Every case therefore also asserts that each key it
+ * expects on the wire is a DECLARED field of the event variant. (.NET gets this for free —
+ * System.Text.Json drops unknown keys — and the Python harness makes the same assertion
+ * against `model_fields`.)
  */
 
 const SDK_NAME = "typescript";
@@ -27,6 +35,15 @@ interface FixtureCase {
 
 const cases: FixtureCase[] = fixture.stream.filter((entry) => entry.producedBy.includes(SDK_NAME));
 
+/** The field names the event variant for `type` actually declares. */
+function declaredFields(type: unknown): string[] {
+  const variant = EventSchemas.optionsMap.get(type as string);
+  if (variant === undefined) {
+    throw new Error(`EventSchemas declares no variant for type ${JSON.stringify(type)}`);
+  }
+  return Object.keys(variant.shape);
+}
+
 describe("null omission cross-language fixture", () => {
   it("covers this SDK", () => {
     expect(cases.length).toBeGreaterThan(15);
@@ -40,6 +57,13 @@ describe("null omission cross-language fixture", () => {
       const payload = JSON.parse(encoded.slice("data: ".length, -"\n\n".length));
 
       expect(payload).toEqual(entry.expected);
+
+      // ...and every key the case expects is a field this SDK declares, not one
+      // that merely rode through the passthrough schema untouched.
+      const declared = declaredFields(entry.expected.type);
+      for (const key of Object.keys(entry.expected)) {
+        expect(declared).toContain(key);
+      }
     },
   );
 });

--- a/sdks/typescript/packages/encoder/src/__tests__/null-omission.test.ts
+++ b/sdks/typescript/packages/encoder/src/__tests__/null-omission.test.ts
@@ -14,13 +14,19 @@ import { EventEncoder } from "../encoder";
  * case is added that TypeScript would not actually produce, this test says so instead of the
  * other two SDKs being held to something the reference implementation does not do.
  *
- * The re-serialization check alone is not enough to hold this SDK to a case, because
- * `BaseEventSchema` is `.passthrough()`: a key this SDK does not declare survives `.parse()`
- * as an unrecognized key and is re-encoded verbatim, so the round-trip would pass for a
- * field TypeScript has never heard of. Every case therefore also asserts that each key it
- * expects on the wire is a DECLARED field of the event variant. (.NET gets this for free —
- * System.Text.Json drops unknown keys — and the Python harness makes the same assertion
- * against `model_fields`.)
+ * The re-serialization check alone is not enough to hold this SDK to a case's TOP-LEVEL
+ * keys, because `BaseEventSchema` is `.passthrough()`: a key this SDK does not declare
+ * survives `.parse()` as an unrecognized key and is re-encoded verbatim, so the round-trip
+ * would pass for a field TypeScript has never heard of. Every case therefore also asserts
+ * that each top-level key it expects is a DECLARED field of the event variant.
+ *
+ * That check stops at the top level, and deliberately: `.passthrough()` is used exactly once
+ * in this SDK, on `BaseEventSchema`. Every nested schema is a plain `z.object`, which STRIPS
+ * an unknown key, so a nested key the SDK stopped declaring disappears from the encoded
+ * payload and the round-trip above fails on its own. `passthrough is the only leak` below
+ * pins that asymmetry rather than leaving it as a claim in this comment. (.NET gets top-level
+ * and nested for free — System.Text.Json drops unknown keys at every depth — and Python,
+ * whose `extra="allow"` leaks at every depth, walks its fixture cases recursively.)
  */
 
 const SDK_NAME = "typescript";
@@ -35,6 +41,15 @@ interface FixtureCase {
 
 const cases: FixtureCase[] = fixture.stream.filter((entry) => entry.producedBy.includes(SDK_NAME));
 
+/**
+ * The number of cases this SDK is held to.
+ *
+ * Pinned exactly, not as a floor. A floor cannot notice a deletion: under the previous
+ * `> 15` bound, with 35 cases present, deleting a case outright left this suite — and the
+ * Python and .NET ones — green. Bump this deliberately when adding or removing a case.
+ */
+const EXPECTED_CASE_COUNT = 36;
+
 /** The field names the event variant for `type` actually declares. */
 function declaredFields(type: unknown): string[] {
   const variant = EventSchemas.optionsMap.get(type as string);
@@ -44,21 +59,24 @@ function declaredFields(type: unknown): string[] {
   return Object.keys(variant.shape);
 }
 
+function encodeToPayload(event: Parameters<EventEncoder["encode"]>[0]): Record<string, unknown> {
+  const encoded = new EventEncoder().encode(event);
+  return JSON.parse(encoded.slice("data: ".length, -"\n\n".length));
+}
+
 describe("null omission cross-language fixture", () => {
-  it("covers this SDK", () => {
-    expect(cases.length).toBeGreaterThan(15);
+  it("still carries every case this SDK is held to", () => {
+    expect(cases.length).toBe(EXPECTED_CASE_COUNT);
   });
 
   it.each(cases.map((entry) => [entry.name, entry] as const))(
     "%s re-serializes to its expected JSON",
     (_name, entry) => {
-      const event = EventSchemas.parse(entry.input);
-      const encoded = new EventEncoder().encode(event);
-      const payload = JSON.parse(encoded.slice("data: ".length, -"\n\n".length));
+      const payload = encodeToPayload(EventSchemas.parse(entry.input));
 
       expect(payload).toEqual(entry.expected);
 
-      // ...and every key the case expects is a field this SDK declares, not one
+      // ...and every top-level key the case expects is a field this SDK declares, not one
       // that merely rode through the passthrough schema untouched.
       const declared = declaredFields(entry.expected.type);
       for (const key of Object.keys(entry.expected)) {
@@ -66,4 +84,42 @@ describe("null omission cross-language fixture", () => {
       }
     },
   );
+
+  it("passthrough is the only leak: an undeclared key survives at the top level and nowhere else", () => {
+    // Why the declared-field assertion above is top-level only. An undeclared TOP-LEVEL key
+    // rides through `BaseEventSchema.passthrough()` untouched, which is exactly why that
+    // assertion has to exist. An undeclared NESTED key is stripped by the plain `z.object`
+    // it lands in, so it never reaches the wire — which is why the round-trip assertion
+    // already fails when a nested field stops being declared, and no recursive walk is
+    // needed on this side. If a nested schema ever gains `.passthrough()`, this test fails
+    // and the declared-field walk above has to become recursive.
+    const topLevel = encodeToPayload(
+      EventSchemas.parse({
+        type: "TOOL_CALL_RESULT",
+        messageId: "msg_1",
+        toolCallId: "tc_1",
+        content: "{}",
+        undeclaredTopLevelKey: "rode through",
+      }),
+    );
+    expect(topLevel.undeclaredTopLevelKey).toBe("rode through");
+
+    const nested = encodeToPayload(
+      EventSchemas.parse({
+        type: "MESSAGES_SNAPSHOT",
+        messages: [
+          {
+            id: "msg_3",
+            role: "tool",
+            content: "{}",
+            toolCallId: "tc_1",
+            undeclaredNestedKey: "stripped",
+          },
+        ],
+      }),
+    );
+    expect(nested.messages).toEqual([
+      { id: "msg_3", role: "tool", content: "{}", toolCallId: "tc_1" },
+    ]);
+  });
 });


### PR DESCRIPTION
## The gap

`ToolMessage` carries an optional `error`. `ToolCallResultEvent` does not.

A UI rendering a live stream therefore cannot show a failed tool call as failed. It has to wait for
the `MESSAGES_SNAPSHOT` that carries the finished `ToolMessage` — which arrives after the run, too
late to be useful for anything the user is watching happen.

Reported by S&P Global, who hit exactly this in their frontend integration.

## What this adds

An optional `error` string on `TOOL_CALL_RESULT`, in TypeScript, Python and .NET — the event-side
twin of `ToolMessage.error`.

| SDK | Field |
| --- | --- |
| TypeScript | `error: z.string().optional()` on `ToolCallResultEventSchema` |
| Python | `error: Optional[str] = None` on `ToolCallResultEvent` |
| .NET | `public string? Error` on `ToolCallResultEvent`, recorded in `PublicAPI.Unshipped.txt` |

Plus `@ag-ui/client` threading the value onto the `ToolMessage` that `defaultApplyEvents`
accumulates — without which the message built from the stream and the one in the `MESSAGES_SNAPSHOT`
disagree about whether the call failed, which is the confusion the field exists to remove. There is
now a test that streams both and asserts they agree.

## The contract

**A tool call is reported as failed when `error` is a non-null string.** The empty string counts — a
producer that sends `""` chose to send it.

Test the type, not the truthiness, and not presence:

- `if (event.error)` reads `""` as a success.
- Presence is not testable in two of the three SDKs. In Python and .NET an absent key and an
  explicit JSON null both land as the language's null, so the contract is stated on the value.

Each SDK page gives its own idiom and names the wrong one. A producer with no failure to report
omits the key; writing an explicit JSON null instead is not allowed.

## Compatibility — this narrows the wire

Additive for a producer that never writes `error`. **A tightening for one that does.**

`BaseEventSchema` is `.passthrough()` and the Python models use `extra="allow"`, so an `error` key
of any other shape previously survived. It is now typed:

- TypeScript — `EventSchemas.parse` throws and the run ends. Also rejects an explicit `null`.
- Python — `ValidationError`.
- .NET — `JsonException` out of the SSE reader. (Previously .NET *dropped* such a key silently
  rather than carrying it, so its old behaviour differed from the other two.)

A producer already sending a structured `error` on this event must flatten it to a string or move it
to another key. This narrowing is the intended reading of the no-null-tolerance rule for fields
added since PNI-199, but it is a tightening, and the schema comments and docs now say so.

**The null rule is enforced in TypeScript only.** Zod rejects an explicit null; Python coerces it to
`None` and .NET deserializes it to `null`. That is pre-existing behaviour of every optional field on
those models — `subagent_run_id` and `role` behave identically — and this change neither introduces
nor fixes it. The guarantee is that no producer writes null, not that every SDK refuses one.

**Coverage is not uniform.** The community Go, Java, Kotlin and Dart SDKs have no `error` field on
this event, and Go's strict decoder (`DisallowUnknownFields`) rejects the key outright rather than
ignoring it — as it already does for the pre-existing `subagentRunId`.

## Deliberately not in this PR

- **No protobuf.** `TOOL_CALL_RESULT` is not in the proto schema at all — a documented parity
  boundary, tracked as PNI-214.
- **No producers.** Nothing populates `error` yet, so an absent `error` still means the producer said
  nothing about failure. LangGraph, the MCP middleware and the Claude managed-agents integration all
  have an error signal today and drop it; wiring them is the follow-up that makes this useful.
- **No .NET consumer wiring.** `EventStreamConverter` maps this event to a `FunctionResultContent`
  built from `ToolCallId` and `Content` only. On .NET the value is reachable off the event itself
  (or via `ChatResponseUpdate.RawRepresentation`); the XML doc and docs page say exactly that rather
  than promising a live-stream render. Mapping a string onto an `Exception`-shaped API is a design
  decision, not a mechanical one.
- **No community SDKs.** They are already behind core on `subagentRunId`.

## Review

Two full review rounds, 30 reviewer agents on an unbiased prompt, 9 isolated fix agents. What it
changed, beyond the wording above:

- The `@ag-ui/client` guard narrows on the value's **type**, not on nullishness — the event reaching
  that reducer has not necessarily been parsed, and a serialized exception object is the natural
  shape a Python or LangChain producer emits. A non-string is dropped **with a warning**; silently
  discarding it would leave a `ToolMessage` byte-identical to a successful one.
- The tests were substantially rewritten because they could not fail. Deleting the schema field
  originally produced one type error and left the shared cross-language fixture case fully green in
  two of three SDKs; it now produces twelve type errors and three runtime failures. The
  fixture harnesses assert that every expected wire key is a *declared* field, and each SDK asserts
  an exact case count so a deleted case is noticed.
- Added the Compatibility parity asset the repo's own cross-SDK rule requires, generated by calling
  the TypeScript factory rather than hand-written.

## Verification

- TypeScript: 220 (core) + 42 (encoder) + 734 (client) passed; `tsc --noEmit` and lint clean
- Python: 183 passed
- .NET: 330 passed (`AGUI.Abstractions.UnitTests`)
- TS ↔ .NET cross-language wire harness: 149 passed
- Mutation, merged tree: deleting the field → 12 typecheck errors, 3 runtime failures

Pre-existing and unrelated, verified on a clean `origin/main` checkout: `AGUI.Client.UnitTests` and
`AGUI.Hosting.AspNetCore.IntegrationTests` do not compile (`CS0122`; `SignAssembly` is always true,
which kills the `InternalsVisibleTo` condition). Filed as follow-up.

Refs PNI-362.
