### PR TITLE
chore(langgraph-py): sync uv.lock to ag-ui-protocol 0.1.21

### DIFF
--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -59,7 +59,7 @@ dev = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.20"
+version = "0.1.21"
 source = { directory = "../../../sdks/python" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Unblocks #2553, whose `lockfiles` and `langgraph-python` jobs are both red.

## Why they fail

`integrations/langgraph/python/pyproject.toml` pulls `ag-ui-protocol` in from the filesystem — the TEMPORARY override PNI-274 tracks removing:

```toml
[tool.uv.sources]
ag-ui-protocol = { path = "../../../sdks/python" }
```

A path source makes the consumer's lock embed the *version*, not just the name:

```toml
[[package]]
name = "ag-ui-protocol"
version = "0.1.20"
source = { directory = "../../../sdks/python" }
```

#2553 bumps `sdks/python` to 0.1.21, so that entry went stale the moment the bump landed:

- `lockfiles` → `error: The lockfile at uv.lock needs to be updated, but --check was provided` for `./integrations/langgraph/python`
- `langgraph-python` → the same, via `uv sync --locked`

Nothing is wrong with the release PR. `prepare-release.ts` re-locks only the bumped package's own lock, so it never touched this one — the same gap that needed hand-pushed syncs for crew-ai 0.3.0 (#2366) and aws-strands 0.2.5 (#2374).

## This PR

`uv lock` in `integrations/langgraph/python`, which is exactly one line:

```diff
 name = "ag-ui-protocol"
-version = "0.1.20"
+version = "0.1.21"
 source = { directory = "../../../sdks/python" }
```

Verified locally that the resulting tree passes a replica of the `lockfiles` gate — all 10 first-party locks match their manifests.

## Follow-up

The durable fix belongs in the release tooling: `relockPythonPackage` should also re-lock any first-party lock whose path source resolves to the bumped package. That change is ready on a separate branch against `main` and I'll open it separately — without it, every future `ag-ui-protocol` bump reproduces this.