### PR TITLE
release: middleware-mcp-apps

### DIFF
--- a/middlewares/mcp-apps-middleware/package.json
+++ b/middlewares/mcp-apps-middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ag-ui/mcp-apps-middleware",
   "author": "Markus Ecker",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Git now records `@ag-ui/mcp-apps-middleware` as `0.0.3`. npm already published `0.0.3`, so merge of this PR does not publish a new tarball.

If the goal is to ship the MIT `license` field that git already has, bump again to `0.0.4` after this lands.

## Testing

**Commands run**

- `pnpm tsx scripts/release/prepare-release.ts --scope middleware-mcp-apps --bump patch` (0.0.2 → 0.0.3)
- I did not run lint, typecheck, tests, or a full build. This PR only changes the version string.

**Manual test**

1. Open `middlewares/mcp-apps-middleware/package.json`.
2. Confirm `"version": "0.0.3"`.
3. After merge, run `npm view @ag-ui/mcp-apps-middleware version`. It stays `0.0.3`.

**How this PR makes testing easy**

There is no new test. This is a version string only.

## Risk / rollback

Low. Revert the PR to restore `0.0.2` in git. npm is unchanged.
