### PR TITLE
fix(aws-strands): reduce the frontend-call provenance store and keep parked proxies registered

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -18,7 +18,17 @@ import weakref
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from importlib.metadata import version as distribution_version
-from typing import Any, AsyncIterator, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    AsyncIterator,
+    Container,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from strands import Agent as StrandsAgentCore
 from strands.hooks import AfterModelCallEvent, BeforeModelCallEvent
@@ -320,11 +330,11 @@ def _extract_agent_kwargs(
     return kwargs, unreadable, template_owned
 
 
-# Upper bound on the per-agent wire->native map held in session state. Bounds
-# growth from frontend calls that never receive a client result (abandoned HITL)
-# and so are never consumed/pruned. Generous — a thread rarely has this many
-# outstanding frontend calls at once.
-_WIRE_MAP_MAX = 512
+# Upper bound on the per-agent frontend-call id store held in session state.
+# Bounds growth from frontend calls that never receive a client result
+# (abandoned HITL) and so are never consumed/pruned. Generous: a thread rarely
+# has this many outstanding frontend calls at once.
+_FRONTEND_CALL_IDS_MAX = 512
 
 # Upper bound on the per-agent tool-call metadata map held in session state.
 # It bounds abandoned entries (tool calls whose result never returns)
@@ -697,13 +707,39 @@ def _native_assistant_tool_call_ids(messages: Sequence[Any]) -> set[str]:
     return tool_call_ids
 
 
+def _native_tool_names_by_id(
+    messages: Sequence[Any], tool_use_ids: Container[str]
+) -> dict[str, str]:
+    """Map each of *tool_use_ids* to the name Strands history records for it.
+
+    Returns a name only for the ids it finds. An id missing from the result is
+    one the caller cannot reason about, which callers must treat as a failure
+    rather than as nothing to do.
+    """
+    names: dict[str, str] = {}
+    for message in messages:
+        if not isinstance(message, Mapping) or message.get("role") != "assistant":
+            continue
+        for block in message.get("content") or []:
+            tool_use = block.get("toolUse") if isinstance(block, Mapping) else None
+            if not isinstance(tool_use, Mapping):
+                continue
+            tool_use_id = tool_use.get("toolUseId")
+            if not isinstance(tool_use_id, str) or tool_use_id not in tool_use_ids:
+                continue
+            name = tool_use.get("name")
+            if isinstance(name, str) and name:
+                names[tool_use_id] = name
+    return names
+
+
 def _continuation_tool_name_error(tool_call_ids: list) -> "RunErrorEvent":
     return RunErrorEvent(
         type=EventType.RUN_ERROR,
         message=(
             "Cannot name the tool behind continuation tool result(s) "
-            f"{', '.join(tool_call_ids)}: absent from the input messages, from "
-            "the native session history, and from the wire->native map"
+            f"{', '.join(tool_call_ids)}: absent from the input messages and "
+            "from the native session history"
         ),
         code="CONTINUATION_TOOL_NAME_UNRESOLVED",
     )
@@ -902,6 +938,7 @@ from .a2ui_tool import (
 )
 from .client_proxy_tool import (
     _is_proxy,
+    registered_proxy_names,
     sync_proxy_tools,
     waits_for_frontend_call,
 )
@@ -913,13 +950,13 @@ from .frontend_tool_interrupt import (
     wrap_frontend_tool_response,
 )
 from .session_reconcile import (
+    AG_UI_FRONTEND_CALL_IDS_STATE_KEY,
     AG_UI_TOOL_CALL_MAP_STATE_KEY,
-    AG_UI_WIRE_MAP_STATE_KEY,
+    recorded_frontend_call_ids,
     _supports_repository_reconciliation,
     active_proxy_placeholder_ids,
     has_placeholder_results,
     reconcile_frontend_tool_results,
-    resolve_native_ids,
 )
 from .config import (
     StrandsAgentConfig,
@@ -3446,24 +3483,38 @@ class StrandsAgent:
         except Exception as e:
             logger.warning(f"Failed to set agui_context on strands_agent.state: {e}")
 
-        # Sync proxy tools from client-defined tools
+        # Sync proxy tools from client-defined tools. A proxy parked in a live
+        # frontend-tool interrupt is exempt from removal: Strands is about to
+        # resume that tool, and an absent registry entry turns the client's
+        # answer into a "tool not found" failure the model then re-fires.
+        parked_names_by_id = (
+            _native_tool_names_by_id(
+                getattr(strands_agent, "messages", None) or [],
+                frontend_wait_interrupts,
+            )
+            if frontend_wait_interrupts
+            else {}
+        )
+        parked_proxy_names = set(parked_names_by_id.values())
         if input_data.tools:
             proxy_names = sync_proxy_tools(
                 strands_agent.tool_registry,
                 input_data.tools,
                 self._proxy_tool_names_by_thread.get(thread_id, set()),
                 tool_behaviors=self.config.tool_behaviors,
+                exempt_names=parked_proxy_names,
             )
             self._proxy_tool_names_by_thread[thread_id] = proxy_names
         elif self._proxy_tool_names_by_thread.get(thread_id):
-            # Remove all stale proxy tools when no tools are sent
-            sync_proxy_tools(
+            # Drop the stale proxy tools when no tools are sent, except any the
+            # exemption above protects.
+            self._proxy_tool_names_by_thread[thread_id] = sync_proxy_tools(
                 strands_agent.tool_registry,
                 [],
                 self._proxy_tool_names_by_thread[thread_id],
                 tool_behaviors=self.config.tool_behaviors,
+                exempt_names=parked_proxy_names,
             )
-            self._proxy_tool_names_by_thread[thread_id] = set()
 
         # A2UI auto-injection. When the runtime forwards
         # ``injectA2UITool`` (or the host opts in via ``config.a2ui``), register
@@ -3541,6 +3592,53 @@ class StrandsAgent:
                 e,
                 exc_info=True,
             )
+
+        # Proxy registrations are per-process, so a restart between turns leaves
+        # a parked wait with nothing to resume into. Strands would report the
+        # tool missing, hand the model that error in place of the client's
+        # answer, and still finish the run as a success. Refuse instead: the
+        # caller only has to re-declare the tool.
+        #
+        # Placed after A2UI injection, which drops registrations of its own, and
+        # tested against the registry's own proxies, so neither a native tool
+        # holding the same name nor this thread's per-process bookkeeping can
+        # stand in for the tool Strands has to resume. Cancelling is not exempt:
+        # a cancelled entry still carries a response that Strands delivers into
+        # the tool body (see the resume translation below), so it fails the same
+        # silent way an answer would.
+        registered_proxies = registered_proxy_names(strands_agent.tool_registry)
+        unregistered_parked = sorted(
+            name for name in parked_proxy_names if name not in registered_proxies
+        )
+        # A parked call whose tool this history cannot name is equally
+        # unresumable, and silently skipping it here would let exactly the
+        # failure above through the gate meant to catch it.
+        unnamed_parked = sorted(
+            set(frontend_wait_interrupts) - set(parked_names_by_id)
+        )
+        if unregistered_parked or unnamed_parked:
+            reasons = []
+            if unregistered_parked:
+                reasons.append(
+                    f"{', '.join(unregistered_parked)} not registered; send "
+                    "the tool definitions in RunAgentInput.tools"
+                )
+            if unnamed_parked:
+                reasons.append(
+                    f"the tool behind call {', '.join(unnamed_parked)} is "
+                    "absent from this thread's history"
+                )
+            ev_started, ev_error = _error_events(
+                input_data,
+                (
+                    "Cannot resume the frontend tool calls waiting on this "
+                    f"thread: {'; '.join(reasons)}."
+                ),
+                "FRONTEND_TOOL_NOT_REGISTERED",
+            )
+            yield ev_started
+            yield ev_error
+            return
 
         # ── Interrupt resume handling ──────────────────────────────────────
         # If the client is resuming an interrupted run, validate the
@@ -3669,6 +3767,14 @@ class StrandsAgent:
                     )
                     if tool_name:
                         frontend_tool_names.add(tool_name)
+            # Every proxy in the registry is client-executed by construction,
+            # whether or not this turn re-declared it. A proxy kept for a parked
+            # checkpoint is still offered to the model, so leaving it out here
+            # files a re-fire as a backend call: the adapter would answer it
+            # itself and park an interrupt the client is never told about. Read
+            # the registry rather than this thread's bookkeeping, which is
+            # per-process and empty on a recreated wrapper.
+            frontend_tool_names |= registered_proxies
 
             # Collect tool_call_ids that already have results in the message history
             # so we suppress duplicate TOOL_CALL_START events only for those specific calls
@@ -3784,21 +3890,21 @@ class StrandsAgent:
                     last_msg_had_tool_calls = False
                     strands_messages.append(strands_msg)
 
-            # The durable wire->native map recorded at emission, read back from
+            # The ids of the frontend calls this adapter emitted, read back from
             # session state (restored from the store on a fresh process). Read
             # here rather than at the reconciliation block below because the
-            # continuation-message derivation needs it too: on a delta-only
-            # payload the tool result arrives under the wire id, while the tool
-            # name is only known under the native one.
-            wire_to_native: Dict[str, str] = {}
+            # continuation-message derivation needs it too: it is the only
+            # signal of who executed a tool result on a delta-only payload.
+            # Kept in persisted order, which the emission-time size cap relies
+            # on to drop the oldest entries first.
+            client_call_ids: list[str] = []
             reconciliation_setup_error: Exception | None = None
             if session_manager is not None:
                 try:
-                    wire_to_native = (
-                        strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-                    )
+                    client_call_ids = recorded_frontend_call_ids(strands_agent)
                 except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
                     reconciliation_setup_error = e
+            client_executed_ids = set(client_call_ids)
 
             # Build a lookup of tool_call_id -> tool_name from the input messages
             # directly (the assistant message in Run 2 already carries the name).
@@ -3844,28 +3950,19 @@ class StrandsAgent:
                 for msg in reversed(input_data.messages):
                     if msg.role == "tool" and hasattr(msg, "tool_call_id"):
                         tool_name = _tool_call_id_to_name.get(msg.tool_call_id)
-                        # An entry in the durable wire->native map is only ever
-                        # recorded when a frontend tool call is emitted, so its
-                        # presence proves this result came from a client-executed
-                        # tool. A backend tool never has one: its wire id IS the
-                        # native id.
-                        _native_id = wire_to_native.get(msg.tool_call_id)
-                        if tool_name is None and _native_id:
-                            # A frontend tool is emitted under a fresh wire id, so
-                            # the name recovered from native session history above is
-                            # keyed by the native ``toolUseId`` instead. Translate
-                            # through the durable map and retry. Kept as a fallback
-                            # rather than translating up front: when the assistant
-                            # message IS in the payload the lookup is already keyed
-                            # by the wire id.
-                            tool_name = _tool_call_id_to_name.get(_native_id)
+                        # An id is only recorded when a placeholder-mode
+                        # frontend tool call is emitted, so its presence proves
+                        # this result came from a client-executed tool. A backend
+                        # tool never has one, and neither does a native wait,
+                        # which writes no placeholder to reconcile.
+                        _client_executed = msg.tool_call_id in client_executed_ids
                         # Provenance is either signal, not membership alone: a
                         # continuation that declares no tools (``tools: []``) still
                         # carries a real frontend result, and reading membership
                         # alone would file it as a backend result and hand the model
                         # an empty prompt — the very loop this derivation prevents.
                         _is_frontend_result = bool(tool_name) and (
-                            tool_name in frontend_tool_names or bool(_native_id)
+                            tool_name in frontend_tool_names or _client_executed
                         )
                         if _is_frontend_result:
                             # Forward the ACTUAL result so the model can act on the
@@ -3908,7 +4005,7 @@ class StrandsAgent:
                                 )
                         elif tool_name:
                             # Named, but neither signal says frontend: not in
-                            # the current declarations and no wire-map entry.
+                            # the current declarations and no recorded id.
                             # That is a tool Strands ran itself, so the model
                             # already has it in the native history and the
                             # continuation prompt has nothing to carry.
@@ -3918,9 +4015,8 @@ class StrandsAgent:
                                 f"tool_call_id={msg.tool_call_id}"
                             )
                         else:
-                            # Neither the input messages, nor the native
-                            # session history, nor the durable wire->native
-                            # map name this call. Guessing stays off the
+                            # Neither the input messages nor the native session
+                            # history name this call. Guessing stays off the
                             # table: with several frontend tools declared,
                             # picking one feeds the model false context.
                             # Collected here and raised as a run error below
@@ -4039,8 +4135,8 @@ class StrandsAgent:
             # continuation run and are used to reconcile the session-persisted
             # "Forwarded to client" placeholder. A tool result is a frontend
             # result when its tool name is client-declared, or (for delta-only
-            # payloads that omit the assistant message) when its wire id was
-            # recorded in the wire->native map when the call was emitted.
+            # payloads that omit the assistant message) when its id was recorded
+            # as a frontend call at emission.
             # The durable per-``toolUseId`` call metadata map recorded at
             # emission (see the ``current_tool_use`` handler). On a RESUME
             # run this is the ONLY source of ``{name, args, input,
@@ -4076,28 +4172,35 @@ class StrandsAgent:
             # user message after it: that result never reaches reconciliation and
             # the persisted toolResult keeps ``PROXY_RESULT_PLACEHOLDER`` forever.
             #
-            # A live entry in ``wire_to_native`` is the second admission signal,
-            # and it is safe precisely because of how that map is maintained below:
-            # entries are dropped once their placeholder is actually corrected, and
-            # kept only so a later turn can retry. An already-reconciled historical
-            # result is therefore absent from the map and still cannot re-enter
-            # here — which is what scoping to the trailing ids was protecting.
+            # A live entry in ``client_executed_ids`` is the second admission
+            # signal. It is safe because of how that store is maintained below:
+            # ids are dropped once their placeholder is actually corrected, and
+            # kept only so a later turn can retry, so an already-reconciled
+            # result cannot re-enter here. That is what scoping to the trailing
+            # ids was protecting. With reconciliation off
+            # (``replay_history_into_strands=False``) nothing is ever corrected
+            # and so nothing is pruned; historical results keep re-entering, and
+            # the legacy continuation path they fall to is the same one they
+            # took on the turn they arrived.
             frontend_results: List[Dict[str, Any]] = []
             last_frontend_result_index: int | None = None
             input_messages = input_data.messages or []
             for msg_index, msg in enumerate(input_messages):
                 if getattr(msg, "role", None) != "tool":
                     continue
-                wire_id = getattr(msg, "tool_call_id", None)
-                if not wire_id:
+                tool_call_id = getattr(msg, "tool_call_id", None)
+                if not tool_call_id:
                     continue
                 if (
-                    wire_id not in pending_tool_result_ids
-                    and wire_id not in wire_to_native
+                    tool_call_id not in pending_tool_result_ids
+                    and tool_call_id not in client_executed_ids
                 ):
                     continue
-                name = _tool_call_id_to_name.get(wire_id)
-                if name not in frontend_tool_names and wire_id not in wire_to_native:
+                name = _tool_call_id_to_name.get(tool_call_id)
+                if (
+                    name not in frontend_tool_names
+                    and tool_call_id not in client_executed_ids
+                ):
                     continue
                 content = msg.content
                 text = (
@@ -4107,7 +4210,7 @@ class StrandsAgent:
                 )
                 frontend_results.append(
                     {
-                        "wire_id": wire_id,
+                        "tool_call_id": tool_call_id,
                         "text": text or "",
                         # Carry the client's failure signal alongside the text so
                         # reconciliation can stamp the persisted toolResult status
@@ -4125,17 +4228,16 @@ class StrandsAgent:
                 )
             )
 
-            # Translate the client's wire tool_call_id back to the native
-            # toolUseId Strands persisted (they differ for frontend tools — see
-            # the fresh-uuid assignment in the streaming loop). Only reconcile
-            # when there is at least one NON-EMPTY frontend result: a void tool
-            # returns nothing, and the synthetic "executed successfully with no
-            # return value" continuation message conveys that better than an
-            # empty toolResult. A failed void result is the exception: it must
-            # reconcile so its status replaces the proxy's hardcoded success.
-            # When reconciling, void placeholders in the same
-            # turn are still cleared (to "") so the literal "Forwarded to client"
-            # is never fed to the model.
+            # Reconcile only results whose call this adapter emitted: a
+            # persisted placeholder exists for those alone, and correcting
+            # anything else would be guesswork. Only reconcile when there is at
+            # least one NON-EMPTY frontend result: a void tool returns nothing,
+            # and the synthetic "executed successfully with no return value"
+            # continuation message conveys that better than an empty toolResult.
+            # A failed void result is the exception: it must reconcile so its
+            # status replaces the proxy's hardcoded success. When reconciling,
+            # void placeholders in the same turn are still cleared (to "") so the
+            # literal "Forwarded to client" is never fed to the model.
             resolved_native_results: Dict[str, Tuple[str, bool]] = {}
             corrected_native_ids: set[str] = set()
             has_nonvoid_frontend_result = any(
@@ -4145,12 +4247,11 @@ class StrandsAgent:
                 self.config.replay_history_into_strands
                 or (resume_submitted and bool(active_proxy_native_ids))
             ):
-                try:
-                    resolved_native_results = resolve_native_ids(
-                        wire_to_native, frontend_results
-                    )
-                except Exception as e:  # noqa: BLE001 - handled below by checkpoint state
-                    reconciliation_setup_error = e
+                resolved_native_results = {
+                    result["tool_call_id"]: (result["text"], result["is_error"])
+                    for result in frontend_results
+                    if result["tool_call_id"] in client_executed_ids
+                }
 
             if reconciliation_setup_error is not None:
                 if has_active_interrupt:
@@ -4296,8 +4397,8 @@ class StrandsAgent:
                     yield _interrupt_reconciliation_error()
                     return
                 # Continue from the corrected native history only when every
-                # NON-EMPTY frontend result this turn resolved to a native id
-                # (i.e. was present in the wire->native map) AND none of those
+                # NON-EMPTY frontend result this turn was admitted (i.e. its
+                # call id was recorded at emission) AND none of those
                 # placeholders remain uncleared. The scan is scoped to this
                 # turn's results so a stale placeholder from a prior (e.g. void)
                 # turn doesn't force the legacy path. Any shortfall means
@@ -4338,20 +4439,23 @@ class StrandsAgent:
             if resume_submitted:
                 resume_prompt = _resume_prompt
 
-            # Drop only the entries whose placeholder was actually corrected
-            # this turn — they won't recur. Entries that were NOT corrected
-            # (unresolved, or a reconcile that raised) are kept so a later turn
-            # can retry; pruning them would strand the persisted placeholder
-            # forever. (Genuinely-abandoned entries are bounded by the size cap
-            # applied at emission.)
-            if wire_to_native and corrected_native_ids:
-                remaining = {
-                    wire: native
-                    for wire, native in wire_to_native.items()
-                    if native not in corrected_native_ids
-                }
-                if len(remaining) != len(wire_to_native):
-                    strands_agent.state.set(AG_UI_WIRE_MAP_STATE_KEY, remaining)
+            # Drop only the ids whose placeholder was actually corrected this
+            # turn; they won't recur. Ids that were NOT corrected (unresolved,
+            # or a reconcile that raised) are kept so a later turn can retry;
+            # pruning them would strand the persisted placeholder forever.
+            # (Genuinely-abandoned ids are bounded by the size cap applied at
+            # emission.) Order is preserved so that cap keeps dropping oldest
+            # first.
+            if client_call_ids and corrected_native_ids:
+                remaining = [
+                    call_id
+                    for call_id in client_call_ids
+                    if call_id not in corrected_native_ids
+                ]
+                if len(remaining) != len(client_call_ids):
+                    strands_agent.state.set(
+                        AG_UI_FRONTEND_CALL_IDS_STATE_KEY, remaining
+                    )
 
             prior_tool_call_ids = _native_assistant_tool_call_ids(
                 getattr(strands_agent, "messages", None) or []
@@ -4385,7 +4489,7 @@ class StrandsAgent:
                     # and MessageAddedEvent synced agent state (see
                     # SessionManager.register_hooks), so the next run's
                     # reconcile still finds a placeholder to overwrite and the
-                    # wire->native map to key it by.
+                    # recorded call id that admits it.
                     if halt_event_stream:
                         break
 
@@ -4720,9 +4824,10 @@ class StrandsAgent:
                             if not result_tool_id:
                                 continue
 
-                            # Direct lookup works for backend tools (keyed by Strands ID).
-                            # Frontend tools are keyed by a generated UUID, so we fall back
-                            # to scanning by strands_tool_id when the direct lookup misses.
+                            # Every call is keyed by Strands' own tool-use ID.
+                            # The scan by strands_tool_id is the fallback for a
+                            # result whose direct lookup misses (e.g. an entry
+                            # first seen under a partial event).
                             call_info = tool_calls_seen.get(result_tool_id, {})
                             if not call_info:
                                 for _tid, _data in tool_calls_seen.items():
@@ -4892,8 +4997,7 @@ class StrandsAgent:
                                 break
 
                         # Prune the persisted tool-call meta map for entries
-                        # whose native id (or ``strands_tool_id`` for frontend
-                        # tools stored under a wire key) was just consumed.
+                        # whose tool-use id was just consumed.
                         # The emission-time size cap (``_TOOL_CALL_MAP_MAX``) is
                         # only a backstop for abandoned entries.
                         if (
@@ -5005,26 +5109,23 @@ class StrandsAgent:
                             if (
                                 not is_native_frontend_wait
                                 and strands_tool_id
-                                and _get_strands_session_manager(
+                                and _get_strands_session_manager(strands_agent)
+                            ):
+                                _call_ids = recorded_frontend_call_ids(
                                     strands_agent
                                 )
-                            ):
-                                _wire_map = dict(
-                                    strands_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY)
-                                    or {}
-                                )
-                                _wire_map[tool_use_id] = strands_tool_id
-                                # Bound growth: entries for frontend calls that
+                                if tool_use_id not in _call_ids:
+                                    _call_ids.append(tool_use_id)
+                                # Bound growth: ids for frontend calls that
                                 # never get a client result (abandoned/dismissed
                                 # HITL) are never consumed/pruned. Keep only the
-                                # most-recent ``_WIRE_MAP_MAX`` (insertion order).
-                                if len(_wire_map) > _WIRE_MAP_MAX:
-                                    for _stale in list(_wire_map)[
-                                        : len(_wire_map) - _WIRE_MAP_MAX
-                                    ]:
-                                        _wire_map.pop(_stale, None)
+                                # most-recent ``_FRONTEND_CALL_IDS_MAX``.
+                                if len(_call_ids) > _FRONTEND_CALL_IDS_MAX:
+                                    del _call_ids[
+                                        : len(_call_ids) - _FRONTEND_CALL_IDS_MAX
+                                    ]
                                 strands_agent.state.set(
-                                    AG_UI_WIRE_MAP_STATE_KEY, _wire_map
+                                    AG_UI_FRONTEND_CALL_IDS_STATE_KEY, _call_ids
                                 )
                         else:
                             # Use Strands' ID for backend tools

--- a/integrations/aws-strands/python/src/ag_ui_strands/client_proxy_tool.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/client_proxy_tool.py
@@ -137,27 +137,42 @@ def _is_proxy(tool: Any) -> bool:
     return getattr(tool, _PROXY_MARKER, False) is True
 
 
+def registered_proxy_names(tool_registry: ToolRegistry) -> Set[str]:
+    """Return the names the registry currently holds a proxy under."""
+    return {
+        name
+        for name, tool in tool_registry.registry.items()
+        if _is_proxy(tool)
+    }
+
+
 def sync_proxy_tools(
     tool_registry: ToolRegistry,
     ag_ui_tools: list[AgUiTool],
     tracked_names: Set[str],
     *,
     tool_behaviors: Mapping[str, "ToolBehavior"] | None = None,
+    exempt_names: Set[str] | None = None,
 ) -> Set[str]:
     """Synchronise proxy tools in *tool_registry* with *ag_ui_tools*.
 
     * New tools present in *ag_ui_tools* but absent from the registry are
       registered (unless a native, non-proxy tool with the same name exists).
     * Stale proxy tools that are in *tracked_names* but absent from the
-      incoming list are removed.
+      incoming list are removed, unless they are in *exempt_names*.
 
     Args:
         tool_registry: The Strands ``ToolRegistry`` attached to the agent.
         ag_ui_tools: Tool definitions from the current ``RunAgentInput.tools``.
         tracked_names: Set of proxy tool names registered in previous calls.
+        exempt_names: Proxy names that must stay registered even when the
+            incoming list omits them. A tool parked in a live frontend-tool
+            interrupt is about to be resumed by Strands, so removing it turns
+            the client's answer into a "tool not found" failure.
 
     Returns:
-        Updated set of proxy tool names currently registered.
+        Updated set of proxy tool names currently registered, including any
+        exempt proxy retained across this call.
     """
     desired_names: Set[str] = set()
     for t in ag_ui_tools:
@@ -166,13 +181,25 @@ def sync_proxy_tools(
             desired_names.add(n)
 
     # --- Remove stale proxy tools ---
+    retained_names: Set[str] = set()
     stale = tracked_names - desired_names
     for name in stale:
         existing = tool_registry.registry.get(name)
-        if existing is not None and _is_proxy(existing):
-            del tool_registry.registry[name]
-            tool_registry.dynamic_tools.pop(name, None)
-            logger.debug("Removed stale proxy tool: %s", name)
+        if exempt_names is not None and name in exempt_names:
+            # Report an exempt name as retained only when the registry really
+            # still holds our proxy. Claiming one that is absent (or that a
+            # native tool now owns) would leave the caller tracking a proxy it
+            # does not have, and the caller checks the registry for exactly
+            # that case.
+            if existing is not None and _is_proxy(existing):
+                retained_names.add(name)
+                logger.debug("Retained proxy tool parked in an interrupt: %s", name)
+            continue
+        if existing is None or not _is_proxy(existing):
+            continue
+        del tool_registry.registry[name]
+        tool_registry.dynamic_tools.pop(name, None)
+        logger.debug("Removed stale proxy tool: %s", name)
 
     # --- Add / update proxy tools ---
     current_proxy_names: Set[str] = set()
@@ -196,4 +223,4 @@ def sync_proxy_tools(
         current_proxy_names.add(n)
         logger.debug("Registered proxy tool: %s", n)
 
-    return current_proxy_names
+    return current_proxy_names | retained_names

--- a/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
@@ -2,11 +2,16 @@
 
 Frontend tools are executed on the client, so server-side the proxy returns a
 placeholder ``toolResult`` (``"Forwarded to client"``). The real result only
-arrives on the next run inside ``RunAgentInput.messages``, keyed by the client's
-wire ``tool_call_id`` — which differs from the native ``toolUseId`` Strands
-persisted. The adapter records that wire->native mapping durably on the agent's
-session state (see ``AG_UI_WIRE_MAP_STATE_KEY``), so this module can find the
-persisted placeholder by native id and overwrite it with the real result.
+arrives on the next run inside ``RunAgentInput.messages``, under the same
+``toolUseId`` Strands persisted, so this module can find the persisted
+placeholder and overwrite it with the real result.
+
+Nothing on that continuation says who executed the call. The adapter therefore
+records the id of every frontend call it emits durably on the agent's session
+state (see ``AG_UI_FRONTEND_CALL_IDS_STATE_KEY``): membership there is what
+tells a client-executed result apart from one Strands produced itself. The ids
+are held in recorded order rather than as a bare set, because the size cap
+applied at emission evicts the oldest first.
 """
 
 from __future__ import annotations
@@ -15,10 +20,23 @@ from typing import Any, Iterable, Mapping, Tuple
 
 from .client_proxy_tool import PROXY_RESULT_PLACEHOLDER
 
-# Key under which the adapter stores the ``{wire_tool_call_id: native_toolUseId}``
-# map on the Strands agent's session state. Namespaced to avoid clashing with
-# user-managed state keys.
-AG_UI_WIRE_MAP_STATE_KEY = "__ag_ui_wire_to_native__"
+# Key under which the adapter stores the ids of the frontend tool calls it has
+# emitted, as a JSON list on the Strands agent's session state. Namespaced to
+# avoid clashing with user-managed state keys.
+#
+# The stored name predates the identifier unification, and so does the shape it
+# may hold: releases before that unification minted their own id per frontend
+# call and stored a ``{minted_id: toolUseId}`` mapping. Those minted ids name
+# nothing in the persisted history, so a reader that trusted them as provenance
+# would conclude there was nothing to correct and replay an uncorrected
+# placeholder to the model. The old shape is therefore discarded on read rather
+# than translated. Only a frontend call left in flight across the upgrade is
+# affected, and what happens to it depends on the checkpoint: an ordinary
+# continuation degrades to the legacy path, which forwards the client's answer
+# as a synthetic message, while one parked in an active checkpoint cannot be
+# resumed at all, because connecting the answer to the persisted placeholder
+# needs exactly the translation this adapter no longer performs.
+AG_UI_FRONTEND_CALL_IDS_STATE_KEY = "__ag_ui_wire_to_native__"
 
 # Key under which the adapter stores every ``toolUseId`` tool call metadata
 # (name, args, input, strands_tool_id) on the Strands agent's session state.
@@ -29,6 +47,28 @@ AG_UI_WIRE_MAP_STATE_KEY = "__ag_ui_wire_to_native__"
 # ``tool_behaviors`` gate + the frontend-placeholder skip) for the resumed
 # tool. Namespaced to avoid clashing with user-managed state keys.
 AG_UI_TOOL_CALL_MAP_STATE_KEY = "__ag_ui_tool_call_map__"
+
+
+def recorded_frontend_call_ids(agent: Any) -> list[str]:
+    """Return the frontend-call ids recorded on *agent*'s session state.
+
+    Both the continuation read and the emission write go through here so they
+    cannot disagree about the stored shape: a writer that coerced the legacy
+    mapping would persist its keys as a well-formed list, and every later read
+    would then trust ids that name nothing.
+    """
+    stored = agent.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) or ()
+    # Accept only the shape this adapter writes. Anything else is either the
+    # pre-unification mapping (see the key's definition) or state some other
+    # writer left behind; a permissive read turns a stored string into one id
+    # per character and a stored number into a TypeError at the write site.
+    if not isinstance(stored, (list, tuple)):
+        return []
+    return [
+        call_id
+        for call_id in stored
+        if isinstance(call_id, str) and call_id.strip()
+    ]
 
 
 def _supports_repository_reconciliation(session_manager: Any, agent: Any) -> bool:
@@ -52,40 +92,6 @@ def _supports_repository_reconciliation(session_manager: Any, agent: Any) -> boo
         and callable(update_message)
     )
 
-def resolve_native_ids(
-    wire_to_native: Mapping[str, str],
-    frontend_results: Iterable[Mapping[str, Any]],
-) -> dict[str, Tuple[str, bool]]:
-    """Map client frontend results to Strands-native ``toolUseId``s.
-
-    Frontend tools are emitted under a fresh wire ``tool_call_id`` that differs
-    from the native ``toolUseId`` Strands persists. ``wire_to_native`` is the
-    durable map recorded at emission on the agent's session state and restored
-    on a continuation run (works cross-process and for delta-only payloads,
-    since it is keyed on the wire id the client always sends). Results whose
-    wire id is not in the map are dropped — the caller then degrades to the
-    legacy path rather than guessing.
-
-    Args:
-        wire_to_native: Map of wire ``tool_call_id`` -> native ``toolUseId``.
-        frontend_results: Items with ``wire_id``, ``text`` and ``is_error``.
-
-    Returns:
-        Map of native ``toolUseId`` -> ``(real result text, is_error)``
-        (unresolvable dropped). The flag travels with the text so the
-        reconciled ``toolResult`` can carry the client's failure signal, not
-        just its output.
-    """
-    resolved: dict[str, Tuple[str, bool]] = {}
-    for result in frontend_results:
-        native = wire_to_native.get(result.get("wire_id"))
-        if native is not None:
-            resolved[native] = (
-                result.get("text", ""),
-                bool(result.get("is_error")),
-            )
-    return resolved
-
 
 def reconcile_frontend_tool_results(
     session_manager: Any,
@@ -94,14 +100,14 @@ def reconcile_frontend_tool_results(
 ) -> set[str]:
     """Overwrite persisted placeholder ``toolResult`` blocks with real results.
 
-    ``pending_results`` MUST be keyed by the Strands-native ``toolUseId`` (use
-    :func:`resolve_native_ids` to translate client wire ids first).
+    ``pending_results`` MUST be keyed by the ``toolUseId`` Strands persisted,
+    which for a frontend call is also the id the client answers under.
 
     Args:
         session_manager: A Strands ``RepositorySessionManager`` (exposes
             ``session_id`` and ``session_repository``).
         agent: The Strands agent (exposes ``agent_id``).
-        pending_results: Map of native ``toolUseId`` -> ``(real result text,
+        pending_results: Map of ``toolUseId`` -> ``(real result text,
             is_error)``.
 
     Returns:

--- a/integrations/aws-strands/python/tests/test_client_proxy_tool.py
+++ b/integrations/aws-strands/python/tests/test_client_proxy_tool.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import Tool as AgUiTool
@@ -171,6 +170,57 @@ class TestSyncProxyTools:
         assert result == set()
         assert "tool_x" not in registry.registry
 
+    def test_exempt_proxy_survives_removal_and_stays_tracked(self):
+        registry = self._fresh_registry()
+        registry.register_tool(create_proxy_tool(_make_ag_ui_tool("waiting")))
+        registry.register_tool(create_proxy_tool(_make_ag_ui_tool("idle")))
+
+        result = sync_proxy_tools(
+            registry, [], {"waiting", "idle"}, exempt_names={"waiting"}
+        )
+
+        assert result == {"waiting"}
+        assert "waiting" in registry.registry
+        assert "idle" not in registry.registry
+
+    def test_exempt_proxy_survives_a_partial_tool_list(self):
+        registry = self._fresh_registry()
+        registry.register_tool(create_proxy_tool(_make_ag_ui_tool("waiting")))
+
+        result = sync_proxy_tools(
+            registry,
+            [_make_ag_ui_tool("other")],
+            {"waiting"},
+            exempt_names={"waiting"},
+        )
+
+        assert result == {"waiting", "other"}
+        assert "waiting" in registry.registry
+
+    def test_exempting_a_native_tool_does_not_track_it_as_a_proxy(self):
+        registry = self._fresh_registry()
+        registry.register_tool(_make_native_tool("my_native"))
+
+        result = sync_proxy_tools(
+            registry, [], {"my_native"}, exempt_names={"my_native"}
+        )
+
+        assert result == set()
+        assert _is_proxy(registry.registry["my_native"]) is False
+
+    def test_exempting_an_absent_proxy_does_not_claim_it_is_retained(self):
+        # The caller tracks what comes back and separately checks the registry
+        # for a parked tool. Reporting a name the registry does not hold makes
+        # the two disagree and hides exactly the case that check is for.
+        registry = self._fresh_registry()
+
+        result = sync_proxy_tools(
+            registry, [], {"vanished"}, exempt_names={"vanished"}
+        )
+
+        assert result == set()
+        assert "vanished" not in registry.registry
+
     def test_idempotent_re_registration(self):
         """Re-syncing the same tools should work (hot reload)."""
         registry = self._fresh_registry()
@@ -208,4 +258,5 @@ class TestSyncProxyTools:
         )
 
         assert unconfigured_result["content"] == [{"text": "Forwarded to client"}]
+        assert waiting_events, "the waiting proxy emitted no events at all"
         assert "tool_interrupt_event" in waiting_events[0]

--- a/integrations/aws-strands/python/tests/test_frontend_call_id_persistence.py
+++ b/integrations/aws-strands/python/tests/test_frontend_call_id_persistence.py
@@ -1,11 +1,12 @@
-"""Durability guarantee for the wire->native map.
+"""Durability guarantee for the frontend-call id store.
 
-The reconciliation design records the ``{wire_tool_call_id: native_toolUseId}``
-map on the Strands agent's session state so a continuation run — even on a
-different process — can find the persisted placeholder. That only works if
-Strands actually persists agent state to the durable store after a run that
-executed a tool. This drives a REAL ``strands.Agent`` with a REAL
-``FileSessionManager`` and a stub model (no network) to prove it end to end.
+The reconciliation design records the id of every frontend call on the Strands
+agent's session state so a continuation run, even on a different process, can
+tell that the returning result is the client's and correct the persisted
+placeholder. That only works if Strands actually persists agent state to the
+durable store after a run that executed a tool. This drives a REAL
+``strands.Agent`` with a REAL ``FileSessionManager`` and a stub model (no
+network) to prove it end to end.
 """
 
 from __future__ import annotations
@@ -16,7 +17,8 @@ from strands.models.model import Model
 from strands.session.file_session_manager import FileSessionManager
 from strands.tools.tools import PythonAgentTool
 
-from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+from ag_ui_strands.client_proxy_tool import PROXY_RESULT_PLACEHOLDER
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
 
 
 class _StubModel(Model):
@@ -54,28 +56,35 @@ class _StubModel(Model):
             yield {"messageStop": {"stopReason": "end_turn"}}
 
 
-def _proxy_func(tool_use, **_kwargs):
-    return {
-        "toolUseId": tool_use["toolUseId"],
-        "status": "success",
-        "content": [{"text": "Forwarded to client"}],
-    }
+def _make_proxy_func(agent_holder):
+    """Record the call id from inside the tool, the way emission does."""
 
+    def _proxy_func(tool_use, **_kwargs):
+        agent_holder["agent"].state.set(
+            AG_UI_FRONTEND_CALL_IDS_STATE_KEY, [tool_use["toolUseId"]]
+        )
+        return {
+            "toolUseId": tool_use["toolUseId"],
+            "status": "success",
+            "content": [{"text": PROXY_RESULT_PLACEHOLDER}],
+        }
 
-_proxy_func.__name__ = "approveTool"
+    return _proxy_func
 
 
 @pytest.mark.asyncio
-async def test_agent_state_wire_map_persists_across_a_tool_using_run(tmp_path):
+async def test_recorded_call_ids_persist_across_a_tool_using_run(tmp_path):
     sm = FileSessionManager(session_id="s1", storage_dir=str(tmp_path))
+    agent_holder: dict = {}
+    proxy_func = _make_proxy_func(agent_holder)
+    proxy_func.__name__ = "approveTool"
     tool = PythonAgentTool(
         tool_name="approveTool",
         tool_spec={"name": "approveTool", "description": "x", "inputSchema": {"json": {}}},
-        tool_func=_proxy_func,
+        tool_func=proxy_func,
     )
     agent = Agent(model=_StubModel(), tools=[tool], session_manager=sm, agent_id="default")
-
-    agent.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-xyz"})
+    agent_holder["agent"] = agent
 
     # Consume to completion. The adapter itself does NOT run the invocation to
     # completion on a frontend-tool halt (it stops the loop — see
@@ -86,7 +95,23 @@ async def test_agent_state_wire_map_persists_across_a_tool_using_run(tmp_path):
     async for _ in agent.stream_async("please approve"):
         pass
 
-    # Read the map back from the DURABLE store (fresh repository read).
+    # The guarantee is about a run that USED a tool. Agent state also flushes
+    # on the opening user turn, so without pinning that the tool actually ran
+    # this passes for a stub that never calls one, and stops testing what it
+    # is named for.
+    persisted_messages = [
+        message.message
+        for message in sm.session_repository.list_messages("s1", "default")
+    ]
+    tool_results = [
+        block["toolResult"]
+        for message in persisted_messages
+        for block in message.get("content") or []
+        if isinstance(block, dict) and "toolResult" in block
+    ]
+    assert [result["toolUseId"] for result in tool_results] == ["native-xyz"]
+
+    # Read the ids back from the DURABLE store (fresh repository read).
     persisted = sm.session_repository.read_agent("s1", "default")
     assert persisted is not None
-    assert persisted.state.get(AG_UI_WIRE_MAP_STATE_KEY) == {"wire-1": "native-xyz"}
+    assert persisted.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == ["native-xyz"]

--- a/integrations/aws-strands/python/tests/test_frontend_tool_halt_stops_loop.py
+++ b/integrations/aws-strands/python/tests/test_frontend_tool_halt_stops_loop.py
@@ -33,7 +33,7 @@ from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.client_proxy_tool import PROXY_RESULT_PLACEHOLDER
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands.endpoint import add_strands_fastapi_endpoint
-from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
 from tests.endpoint_helpers import sse_payloads
 
 # Ceiling on model invocations. The halt should stop the loop after ONE, so any
@@ -502,7 +502,7 @@ async def test_event_stream_alone_replays_into_a_servable_transcript():
     client_history = list(
         [e for e in turn_1 if e.type == EventType.MESSAGES_SNAPSHOT][-1].messages
     )
-    fe_wire_id = next(
+    fe_tool_call_id = next(
         e.tool_call_id
         for e in turn_1
         if e.type == EventType.TOOL_CALL_START and e.tool_call_name == "get_cell"
@@ -511,7 +511,7 @@ async def test_event_stream_alone_replays_into_a_servable_transcript():
         ToolMessage(
             id="tm-fe",
             role="tool",
-            tool_call_id=fe_wire_id,
+            tool_call_id=fe_tool_call_id,
             content='{"cell": "B4", "value": 42}',
         )
     )
@@ -541,11 +541,11 @@ def _persisted_messages(sm: FileSessionManager, session_id: str) -> list[dict]:
 
 
 @pytest.mark.asyncio
-async def test_halted_turn_persists_tool_use_placeholder_and_wire_map(tmp_path):
+async def test_halted_turn_persists_tool_use_placeholder_and_call_id(tmp_path):
     """Stopping the loop must not cost the next run's reconcile inputs.
 
-    The reconcile overwrites a persisted placeholder ``toolResult``, keyed via
-    the wire->native map on agent state. Both are written before the halt
+    The reconcile overwrites a persisted placeholder ``toolResult``, admitted
+    by the frontend-call id on agent state. Both are written before the halt
     latches (``MessageAddedEvent`` drives ``append_message`` AND ``sync_agent``
     — see ``SessionManager.register_hooks``), so halting keeps them. If Strands
     ever stops syncing state on message-added, this test is the tripwire.
@@ -586,9 +586,9 @@ async def test_halted_turn_persists_tool_use_placeholder_and_wire_map(tmp_path):
     assert placeholders[0]["toolUseId"] == tool_uses[0]["toolUseId"]
 
     persisted_agent = sm.read_agent(session_id, "default")
-    wire_map = persisted_agent.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-    assert tool_uses[0]["toolUseId"] in wire_map.values(), (
-        "reconcile cannot locate the placeholder without the wire->native map"
+    recorded = persisted_agent.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) or []
+    assert tool_uses[0]["toolUseId"] in recorded, (
+        "reconcile cannot admit the result without the recorded call id"
     )
 
 

--- a/integrations/aws-strands/python/tests/test_frontend_tool_native_wait.py
+++ b/integrations/aws-strands/python/tests/test_frontend_tool_native_wait.py
@@ -23,6 +23,7 @@ from strands.session.file_session_manager import FileSessionManager
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands.frontend_tool_interrupt import index_frontend_tool_interrupts
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
 
 
 class _ParallelWaitModel(Model):
@@ -69,6 +70,35 @@ class _ParallelWaitModel(Model):
             yield {"messageStop": {"stopReason": "tool_use"}}
             return
         yield {"contentBlockDelta": {"delta": {"text": "continued once"}}}
+        yield {"contentBlockStop": {}}
+        yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+class _RefiringWaitModel(_ParallelWaitModel):
+    """Call the same waiting frontend tool again after the first is answered."""
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        self.calls += 1
+        self.seen_messages.append(copy.deepcopy(messages))
+        yield {"messageStart": {"role": "assistant"}}
+        if self.calls <= 2:
+            yield {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": f"native-{self.calls}",
+                            "name": "first_client_tool",
+                        }
+                    }
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+            return
+        yield {"contentBlockDelta": {"delta": {"text": "refire done"}}}
         yield {"contentBlockStop": {}}
         yield {"messageStop": {"stopReason": "end_turn"}}
 
@@ -199,6 +229,11 @@ def _server_approval(tool_context: ToolContext) -> str:
     return f"server response: {response!r}"
 
 
+@tool(name="first_client_tool", description="A server tool of the same name")
+def _squatting_native(value: str = "") -> str:
+    return "the server ran this"
+
+
 def _tools() -> list[Tool]:
     return [
         Tool(name=name, description=name, parameters={"type": "object"})
@@ -212,13 +247,14 @@ def _input(
     run_id: str,
     messages: Sequence[Any],
     resume: Sequence[ResumeEntry] | None = None,
+    tools: Sequence[Tool] | None = None,
 ) -> RunAgentInput:
     return RunAgentInput(
         thread_id=thread_id,
         run_id=run_id,
         state={},
         messages=list(messages),
-        tools=_tools(),
+        tools=list(tools) if tools is not None else _tools(),
         context=[],
         forwarded_props={},
         resume=list(resume) if resume is not None else None,
@@ -959,3 +995,462 @@ async def test_full_history_completion_after_a_partial_answer_is_repeatable(
     [error] = [event for event in divergent if event.type == EventType.RUN_ERROR]
     assert error.code == "FRONTEND_TOOL_RESULT_CONFLICT"
     assert model.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_toolless_continuation_answers_a_parked_wait_without_relooping(
+    tmp_path: Path,
+) -> None:
+    """A continuation declaring no tools must not strip a parked proxy.
+
+    A client that answers a waiting frontend tool without re-declaring its
+    tools still owns a live native interrupt whose tool Strands is about to
+    resume. Deregistering it makes the framework report the tool missing, and
+    the model re-fires the same call instead of seeing the client's answer.
+    """
+    thread_id = "toolless-native-wait"
+    model = _ParallelWaitModel()
+    adapter = _adapter(model, tmp_path, thread_id)
+
+    first = await _collect(
+        adapter,
+        _input(
+            thread_id,
+            run_id="run-1",
+            messages=[UserMessage(id="user-1", content="call both tools")],
+        ),
+    )
+    _assert_success(first)
+    assert model.calls == 1
+
+    final = await _collect(
+        adapter,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[],
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-0",
+                    content="first-value",
+                ),
+                ToolMessage(
+                    id="second-result",
+                    tool_call_id="native-1",
+                    content="second-value",
+                ),
+            ],
+        ),
+    )
+
+    _assert_success(final)
+    assert model.calls == 2
+    assert not any(event.type == EventType.TOOL_CALL_START for event in final)
+    final_messages = repr(model.seen_messages[-1])
+    assert "first-value" in final_messages
+    assert "second-value" in final_messages
+
+
+@pytest.mark.asyncio
+async def test_parked_proxy_exemption_lifts_once_the_wait_is_answered(
+    tmp_path: Path,
+) -> None:
+    """The exemption tracks the checkpoint, so it never pins a proxy forever."""
+    thread_id = "toolless-native-wait-release"
+    model = _ParallelWaitModel()
+    adapter = _adapter(model, tmp_path, thread_id)
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call both tools")],
+            ),
+        )
+    )
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-2",
+                tools=[],
+                messages=[
+                    ToolMessage(
+                        id="first-result",
+                        tool_call_id="native-0",
+                        content="first-value",
+                    ),
+                    ToolMessage(
+                        id="second-result",
+                        tool_call_id="native-1",
+                        content="second-value",
+                    ),
+                ],
+            ),
+        )
+    )
+    core = adapter._agents_by_thread[thread_id]
+    assert {tool.name for tool in _tools()} <= set(core.tool_registry.registry)
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-3",
+                tools=[],
+                messages=[UserMessage(id="user-2", content="anything else")],
+            ),
+        )
+    )
+
+    assert not {tool.name for tool in _tools()} & set(core.tool_registry.registry)
+    assert adapter._proxy_tool_names_by_thread[thread_id] == set()
+
+
+@pytest.mark.asyncio
+async def test_retained_proxy_stays_a_frontend_tool_on_a_toolless_turn(
+    tmp_path: Path,
+) -> None:
+    """A proxy kept for a parked wait must not read as a backend tool.
+
+    The turn's frontend-tool set is built from the client's declarations, which
+    a toolless continuation leaves empty. A proxy retained for the checkpoint is
+    still offered to the model, so classifying it as backend makes the adapter
+    answer a re-fire itself: it publishes a result the client never produced and
+    parks a fresh interrupt nobody is told about, wedging the next turn.
+    """
+    thread_id = "toolless-refire"
+    model = _RefiringWaitModel()
+    adapter = _adapter(model, tmp_path, thread_id)
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call the tool")],
+            ),
+        )
+    )
+
+    second = await _collect(
+        adapter,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[],
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-1",
+                    content="answer-one",
+                )
+            ],
+        ),
+    )
+
+    _assert_success(second)
+    # The re-fire is a frontend call: the client is asked to run it, rather than
+    # being handed a result the server invented for a tool it never executed.
+    assert [
+        event.tool_call_name
+        for event in second
+        if event.type == EventType.TOOL_CALL_START
+    ] == ["first_client_tool"]
+    assert not any(event.type == EventType.TOOL_CALL_RESULT for event in second)
+
+    # A re-fire the client was actually asked to run can be answered; one the
+    # adapter answered itself leaves a checkpoint that refuses every later turn.
+    third = await _collect(
+        adapter,
+        _input(
+            thread_id,
+            run_id="run-3",
+            tools=[],
+            messages=[
+                ToolMessage(
+                    id="second-result",
+                    tool_call_id="native-2",
+                    content="answer-two",
+                )
+            ],
+        ),
+    )
+    _assert_success(third)
+
+
+@pytest.mark.asyncio
+async def test_toolless_continuation_after_a_restart_fails_loudly(
+    tmp_path: Path,
+) -> None:
+    """A parked wait whose tool this process never registered must not proceed.
+
+    Proxy registrations live in memory, so a process that restarts between
+    turns holds none. A continuation that also declares no tools leaves the
+    checkpoint with nothing to resume into: Strands reports the tool missing,
+    the client's answer is replaced by an error the model then acts on, and the
+    run still reports success. Refusing the turn tells the caller what to do
+    (re-declare the tool) instead of silently discarding the answer.
+    """
+    thread_id = "restarted-native-wait"
+    model = _ParallelWaitModel()
+
+    _assert_success(
+        await _collect(
+            _adapter(model, tmp_path, thread_id),
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call both tools")],
+            ),
+        )
+    )
+
+    restarted = _adapter(model, tmp_path, thread_id)
+    events = await _collect(
+        restarted,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[],
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-0",
+                    content="first-value",
+                )
+            ],
+        ),
+    )
+
+    [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+    assert error.code == "FRONTEND_TOOL_NOT_REGISTERED"
+    assert "first_client_tool" in error.message
+    assert not any(e.type == EventType.RUN_FINISHED for e in events)
+    assert model.calls == 1
+
+    # Re-declaring the tools is the documented way out, and it still works.
+    recovered = await _collect(
+        _adapter(model, tmp_path, thread_id),
+        _input(
+            thread_id,
+            run_id="run-3",
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-0",
+                    content="first-value",
+                ),
+                ToolMessage(
+                    id="second-result",
+                    tool_call_id="native-1",
+                    content="second-value",
+                ),
+            ],
+        ),
+    )
+    _assert_success(recovered)
+    assert "first-value" in repr(model.seen_messages[-1])
+
+
+@pytest.mark.asyncio
+async def test_partial_tool_list_keeps_a_parked_proxy_registered(
+    tmp_path: Path,
+) -> None:
+    """Declaring some tools must not strip a parked one.
+
+    A client that re-declares only the tools it still offers is the same hazard
+    as one that declares none: the proxy Strands is about to resume disappears
+    from the registry because this turn's list omits it.
+    """
+    thread_id = "partial-list-native-wait"
+    model = _ParallelWaitModel()
+    adapter = _adapter(model, tmp_path, thread_id)
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call both tools")],
+            ),
+        )
+    )
+
+    final = await _collect(
+        adapter,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[_tools()[1]],
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-0",
+                    content="first-value",
+                ),
+                ToolMessage(
+                    id="second-result",
+                    tool_call_id="native-1",
+                    content="second-value",
+                ),
+            ],
+        ),
+    )
+
+    _assert_success(final)
+    assert model.calls == 2
+    final_messages = repr(model.seen_messages[-1])
+    assert "first-value" in final_messages
+    assert "second-value" in final_messages
+
+
+@pytest.mark.asyncio
+async def test_a_native_wait_is_not_recorded_as_a_reconcilable_call(
+    tmp_path: Path,
+) -> None:
+    """Waiting tools produce no placeholder, so they belong in no provenance.
+
+    The recorded ids exist to admit a returning result into placeholder
+    reconciliation. A native wait never writes a placeholder, so recording it
+    makes the next turn try to correct one that was never there, fail, and drop
+    the whole turn to the legacy path.
+    """
+    thread_id = "native-wait-not-recorded"
+    adapter = _adapter(_ParallelWaitModel(), tmp_path, thread_id)
+
+    _assert_success(
+        await _collect(
+            adapter,
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call both tools")],
+            ),
+        )
+    )
+
+    core = adapter._agents_by_thread[thread_id]
+    assert not core.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY)
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_parked_wait_needs_the_tool_too(tmp_path: Path) -> None:
+    """Cancelling is delivered into the tool body, so it needs it registered.
+
+    A cancelled entry carries a real response that Strands hands to the proxy,
+    exactly like an answer. Waving cancellation past the registration check
+    lets the same silent substitution through: the run reports success while
+    the framework's "tool not found" text lands in the thread's history.
+    """
+    thread_id = "restarted-cancel"
+    model = _ParallelWaitModel()
+
+    first_adapter = _adapter(model, tmp_path, thread_id)
+    _assert_success(
+        await _collect(
+            first_adapter,
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call both tools")],
+            ),
+        )
+    )
+    parked = index_frontend_tool_interrupts(
+        first_adapter._agents_by_thread[thread_id]
+    )
+    assert set(parked) == {"native-0", "native-1"}
+    cancellations = [
+        ResumeEntry(interrupt_id=interrupt.id, status="cancelled")
+        for interrupt in parked.values()
+    ]
+
+    refused_adapter = _adapter(model, tmp_path, thread_id)
+    refused = await _collect(
+        refused_adapter,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[],
+            messages=[UserMessage(id="user-2", content="never mind")],
+            resume=cancellations,
+        ),
+    )
+    [error] = [e for e in refused if e.type == EventType.RUN_ERROR]
+    assert error.code == "FRONTEND_TOOL_NOT_REGISTERED"
+    assert not any(e.type == EventType.RUN_FINISHED for e in refused)
+    # This is where the regression would land: without the gate the checkpoint
+    # resumes into nothing and the framework's text replaces the cancellation.
+    refused_core = refused_adapter._agents_by_thread[thread_id]
+    assert "Unknown tool" not in repr(refused_core.messages)
+
+    # Re-declaring the tools is the way out, and cancelling then works.
+    accepted = await _collect(
+        _adapter(model, tmp_path, thread_id),
+        _input(
+            thread_id,
+            run_id="run-3",
+            messages=[UserMessage(id="user-3", content="never mind")],
+            resume=cancellations,
+        ),
+    )
+    _assert_success(accepted)
+
+
+@pytest.mark.asyncio
+async def test_a_native_tool_under_the_parked_name_does_not_satisfy_the_gate(
+    tmp_path: Path,
+) -> None:
+    """The parked wait needs OUR proxy back, not merely the name occupied.
+
+    Checking the registry for the name alone lets an unrelated server tool
+    stand in: the run proceeds, Strands resumes into that tool instead, and the
+    client's answer is swallowed by something it never called.
+    """
+    thread_id = "squatted-native-wait"
+    model = _RefiringWaitModel()
+
+    _assert_success(
+        await _collect(
+            _adapter(model, tmp_path, thread_id),
+            _input(
+                thread_id,
+                run_id="run-1",
+                messages=[UserMessage(id="user-1", content="call the tool")],
+            ),
+        )
+    )
+
+    restarted = _adapter(
+        model, tmp_path, thread_id, core_tools=[_squatting_native]
+    )
+    events = await _collect(
+        restarted,
+        _input(
+            thread_id,
+            run_id="run-2",
+            tools=[],
+            messages=[
+                ToolMessage(
+                    id="first-result",
+                    tool_call_id="native-1",
+                    content="first-value",
+                )
+            ],
+        ),
+    )
+
+    [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+    assert error.code == "FRONTEND_TOOL_NOT_REGISTERED"
+    assert not any(e.type == EventType.RUN_FINISHED for e in events)
+    core = restarted._agents_by_thread[thread_id]
+    assert "the server ran this" not in repr(core.messages)

--- a/integrations/aws-strands/python/tests/test_interrupt.py
+++ b/integrations/aws-strands/python/tests/test_interrupt.py
@@ -46,10 +46,15 @@ from ag_ui_strands.agent import (
     StrandsAgent,
 )
 from ag_ui_strands.client_proxy_tool import PROXY_RESULT_PLACEHOLDER
+from ag_ui_strands.frontend_tool_interrupt import (
+    FRONTEND_TOOL_INTERRUPT_NAME,
+    frontend_tool_reason,
+)
 from ag_ui_strands.config import StrandsAgentConfig, ToolBehavior
 from ag_ui_strands.session_reconcile import (
+    AG_UI_FRONTEND_CALL_IDS_STATE_KEY,
     AG_UI_TOOL_CALL_MAP_STATE_KEY,
-    AG_UI_WIRE_MAP_STATE_KEY,
+    active_proxy_placeholder_ids,
 )
 from tests.interrupt_state_stub import InterruptStateStub
 from tests.hook_helpers import invoke_after_model_call, invoke_before_model_call
@@ -910,7 +915,7 @@ def _active_mixed_mock_core() -> _MockStrandsCore:
             ],
         }
     ]
-    core.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-proxy": "native-proxy"})
+    core.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["native-proxy"])
     return core
 
 
@@ -920,7 +925,7 @@ def _mixed_resume_input(*, include_proxy_result: bool) -> RunAgentInput:
             ToolMessage(
                 id="tool-result",
                 role="tool",
-                tool_call_id="wire-proxy",
+                tool_call_id="native-proxy",
                 content='{"approved": true}',
             )
         ]
@@ -1055,9 +1060,7 @@ async def test_active_mixed_capability_accessor_failure_is_atomic_and_retryable(
     ]
 
 
-@pytest.mark.parametrize(
-    "failure_point", ["wire-map-read", "id-resolution", "repository"]
-)
+@pytest.mark.parametrize("failure_point", ["call-id-read", "repository"])
 @pytest.mark.asyncio
 async def test_active_reconciliation_failure_is_atomic_and_retryable(failure_point):
     core = _active_mixed_mock_core()
@@ -1069,18 +1072,13 @@ async def test_active_reconciliation_failure_is_atomic_and_retryable(failure_poi
     before = _snapshot_mutable_core_state(core)
     original_state_get = core.state.get
 
-    def fail_wire_map_read(key=None):
-        if key == AG_UI_WIRE_MAP_STATE_KEY:
-            raise RuntimeError("wire map unavailable")
+    def fail_call_id_read(key=None):
+        if key == AG_UI_FRONTEND_CALL_IDS_STATE_KEY:
+            raise RuntimeError("recorded call ids unavailable")
         return original_state_get(key)
 
-    if failure_point == "wire-map-read":
-        failure_patch = patch.object(core.state, "get", side_effect=fail_wire_map_read)
-    elif failure_point == "id-resolution":
-        failure_patch = patch(
-            "ag_ui_strands.agent.resolve_native_ids",
-            side_effect=RuntimeError("id resolution unavailable"),
-        )
+    if failure_point == "call-id-read":
+        failure_patch = patch.object(core.state, "get", side_effect=fail_call_id_read)
     else:
         failure_patch = patch(
             "ag_ui_strands.agent.reconcile_frontend_tool_results",
@@ -1107,6 +1105,57 @@ async def test_active_reconciliation_failure_is_atomic_and_retryable(failure_poi
     assert core._interrupt_state.context["tool_results"][0]["content"] == [
         {"text": '{"approved": true}'}
     ]
+
+
+@pytest.mark.asyncio
+async def test_active_call_id_read_failure_fails_closed_without_parked_placeholders(
+    caplog,
+):
+    """The provenance read fails closed on its own, not via a later guard.
+
+    An unreadable store leaves the adapter unable to tell a client-executed
+    result from one Strands produced itself. With an interrupt live and no
+    parked proxy placeholder, the missing-results guard downstream has nothing
+    to catch, so only the read itself can stop the run before the checkpoint is
+    consumed.
+    """
+    core = _MockStrandsCore(
+        interrupts=[StrandsInterrupt(id="native-interrupt", name="confirm")],
+        session_manager=_repository_manager(),
+    )
+    core.state.set("agui_context", [])
+    assert not active_proxy_placeholder_ids(core)
+    agent = _make_base_agent(StrandsAgentConfig())
+    input_data = _mixed_resume_input(include_proxy_result=True).model_copy(
+        update={"tools": []}
+    )
+    before = _snapshot_mutable_core_state(core)
+    original_state_get = core.state.get
+
+    def fail_call_id_read(key=None):
+        if key == AG_UI_FRONTEND_CALL_IDS_STATE_KEY:
+            raise RuntimeError("recorded call ids unavailable")
+        return original_state_get(key)
+
+    with (
+        patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core),
+        patch.object(core.state, "get", side_effect=fail_call_id_read),
+    ):
+        rejected = await _collect_events(agent, input_data)
+
+    _assert_single_run_error(rejected, "INTERRUPT_RECONCILIATION_ERROR")
+    assert "Active interrupt tool result reconciliation failed" in caplog.text
+    assert core.stream_prompts == []
+    assert _snapshot_mutable_core_state(core) == before
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+        retried = await _collect_events(
+            agent,
+            input_data.model_copy(update={"run_id": "run-2"}),
+        )
+
+    assert not any(event.type == EventType.RUN_ERROR for event in retried)
+    assert len(core.stream_prompts) == 1
 
 
 @pytest.mark.asyncio
@@ -1163,10 +1212,6 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
         "native-proxy-1": '{"approved": true}',
         "native-proxy-2": '{"approved": false}',
     }
-    wire_to_native = {
-        "wire-proxy-1": "native-proxy-1",
-        "wire-proxy-2": "native-proxy-2",
-    }
 
     session_manager = FileSessionManager(
         session_id="session-1", storage_dir=str(tmp_path)
@@ -1218,7 +1263,7 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
         tool_result(native_id, PROXY_RESULT_PLACEHOLDER)
         for native_id in native_results
     ]
-    core.state.set(AG_UI_WIRE_MAP_STATE_KEY, wire_to_native)
+    core.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, list(native_results))
     core.state.set("agui_context", [])
 
     async def consume_checkpoint(prompt):
@@ -1230,12 +1275,12 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
     input_data = _make_run_input(
         messages=[
             ToolMessage(
-                id=f"result-{wire_id}",
+                id=f"result-{native_id}",
                 role="tool",
-                tool_call_id=wire_id,
-                content=native_results[native_id],
+                tool_call_id=native_id,
+                content=result,
             )
-            for wire_id, native_id in wire_to_native.items()
+            for native_id, result in native_results.items()
         ],
         resume=[
             ResumeEntry(
@@ -1270,7 +1315,7 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
     assert core.stream_prompts == []
     assert core._interrupt_state.activated
     assert set(core._interrupt_state.interrupts) == {"native-interrupt"}
-    assert core.state.get(AG_UI_WIRE_MAP_STATE_KEY) == wire_to_native
+    assert core.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == list(native_results)
 
     partially_updated = repository.list_messages("session-1", "default")
     assert partially_updated[0].message["content"][0]["toolResult"]["content"] == [
@@ -1289,7 +1334,7 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
     assert any(event.type == EventType.RUN_FINISHED for event in retried)
     assert len(core.stream_prompts) == 1
     assert not core._interrupt_state.activated
-    assert core.state.get(AG_UI_WIRE_MAP_STATE_KEY) == {}
+    assert core.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == []
     persisted = repository.list_messages("session-1", "default")
     for index, expected_text in enumerate(native_results.values()):
         assert persisted[index].message["content"][0]["toolResult"]["content"] == [
@@ -1300,12 +1345,12 @@ async def test_active_reconciliation_retry_counts_already_applied_results(tmp_pa
 @pytest.mark.asyncio
 async def test_non_active_reconciliation_exception_keeps_legacy_fallback(caplog):
     core = _MockStrandsCore(session_manager=_repository_manager())
-    core.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-proxy": "native-proxy"})
-    # The wire map above points ``wire-proxy`` at a native call, so the native
-    # history has to contain that call. Without the ``toolUse`` block the
-    # fixture maps onto a call that exists nowhere and the continuation cannot
-    # name the tool at all — which is a separate failure from the reconcile
-    # exception this test is about.
+    core.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["native-proxy"])
+    # The recorded id above names a real call, so the native history has to
+    # contain it. Without the ``toolUse`` block the fixture points at a call
+    # that exists nowhere and the continuation cannot name the tool at all,
+    # which is a separate failure from the reconcile exception this test is
+    # about.
     core.messages = [
         {
             "role": "assistant",
@@ -1326,7 +1371,7 @@ async def test_non_active_reconciliation_exception_keeps_legacy_fallback(caplog)
             ToolMessage(
                 id="tool-result",
                 role="tool",
-                tool_call_id="wire-proxy",
+                tool_call_id="native-proxy",
                 content='{"approved": true}',
             )
         ],
@@ -1686,7 +1731,7 @@ async def test_mixed_resume_batch_with_falsy_payload_and_tool_behaviors(
     assert finished1.outcome is not None
     assert finished1.outcome.type == "interrupt"
     interrupt_id = finished1.outcome.interrupts[0].id
-    fe_wire_id = next(
+    fe_tool_call_id = next(
         e.tool_call_id
         for e in events1
         if e.type == EventType.TOOL_CALL_START and e.tool_call_name == "approveTool"
@@ -1694,7 +1739,7 @@ async def test_mixed_resume_batch_with_falsy_payload_and_tool_behaviors(
 
     if recreate_agent:
         # Discard the wrapper and underlying core entirely — turn 2 must
-        # restore interrupt state, the wire->native map, and history purely
+        # restore interrupt state, the recorded call ids, and history purely
         # from the FileSessionManager-backed session, not from memory. Carry
         # over the turn count so it reads the same as the non-recreated case.
         prior_turn = model.turn
@@ -1707,7 +1752,7 @@ async def test_mixed_resume_batch_with_falsy_payload_and_tool_behaviors(
             ToolMessage(
                 id="t-fe",
                 role="tool",
-                tool_call_id=fe_wire_id,
+                tool_call_id=fe_tool_call_id,
                 content='{"approved": true}',
             )
         ],
@@ -1735,3 +1780,51 @@ async def test_mixed_resume_batch_with_falsy_payload_and_tool_behaviors(
     assert any(
         e.type == EventType.STATE_SNAPSHOT and e.snapshot.get("confirmed_key") for e in events2
     ), "state_from_result did not fire for confirm_action on the resume run"
+
+
+@pytest.mark.asyncio
+async def test_a_parked_wait_the_history_cannot_name_is_refused() -> None:
+    """An unnameable parked call is as unresumable as an unregistered one.
+
+    The gate protects a parked wait by looking its tool up by name. A call the
+    native history does not name yields no name at all, so skipping it there
+    waves through exactly the silent substitution the gate exists to catch.
+    """
+    interrupt = StrandsInterrupt(
+        id="native-interrupt",
+        name=FRONTEND_TOOL_INTERRUPT_NAME,
+        reason=frontend_tool_reason("native-unnamed"),
+    )
+    core = _MockStrandsCore(
+        interrupts=[interrupt],
+        session_manager=_repository_manager(),
+    )
+    core.state.set("agui_context", [])
+    # History holds no toolUse for the parked id, so its tool cannot be named.
+    core.messages = []
+    agent = _make_base_agent(StrandsAgentConfig())
+
+    # The client answers the parked call, which is what carries the run past
+    # the pending-interrupt refusal and into the gate under test.
+    input_data = _make_run_input(
+        tools=[],
+        messages=[
+            ToolMessage(
+                id="answer",
+                role="tool",
+                tool_call_id="native-unnamed",
+                content="the client's answer",
+            )
+        ],
+    )
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+        events = await _collect_events(agent, input_data)
+
+    [error] = [e for e in events if e.type == EventType.RUN_ERROR]
+    assert error.code == "FRONTEND_TOOL_NOT_REGISTERED"
+    # The remedy differs per cause, so the message must not file an opaque call
+    # id under the one that asks for tool definitions.
+    assert "the tool behind call native-unnamed" in error.message
+    assert "RunAgentInput.tools" not in error.message
+    assert core.stream_prompts == []

--- a/integrations/aws-strands/python/tests/test_invocation_state.py
+++ b/integrations/aws-strands/python/tests/test_invocation_state.py
@@ -18,7 +18,7 @@ from ag_ui.core import (
 )
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig
-from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
 from strands import Agent
 from strands.agent.state import AgentState
 from strands.tools.registry import ToolRegistry
@@ -38,7 +38,7 @@ def _run_input(thread_id: str, *, reconcile: bool = False) -> RunAgentInput:
                 content="",
                 tool_calls=[
                     ToolCall(
-                        id="wire-1",
+                        id="native-1",
                         function=FunctionCall(name="approve", arguments="{}"),
                     )
                 ],
@@ -47,7 +47,7 @@ def _run_input(thread_id: str, *, reconcile: bool = False) -> RunAgentInput:
                 id="tool-1",
                 role="tool",
                 content="approved",
-                tool_call_id="wire-1",
+                tool_call_id="native-1",
             )
         ]
         if reconcile
@@ -74,7 +74,7 @@ class _CapturingCore:
     def __init__(self, **_kwargs):
         self.tool_registry = ToolRegistry()
         self.state = AgentState()
-        self.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-1"})
+        self.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["native-1"])
         self.messages = []
         self.calls: list[tuple[object, dict]] = []
         type(self).instances.append(self)

--- a/integrations/aws-strands/python/tests/test_session_manager.py
+++ b/integrations/aws-strands/python/tests/test_session_manager.py
@@ -10,7 +10,7 @@ from strands.agent.state import AgentState
 from strands.hooks.registry import HookRegistry
 from strands.session import SessionManager
 
-from ag_ui_strands.session_reconcile import AG_UI_WIRE_MAP_STATE_KEY
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
 
 from ag_ui.core import (
     AssistantMessage,
@@ -426,12 +426,11 @@ class TestFrontendToolContinuation:
 
 
     @pytest.mark.asyncio
-    async def test_delta_only_continuation_resolves_name_through_wire_map(self):
-        """A frontend tool is emitted under a FRESH wire id, so the native
-        history that carries its name is keyed by the native ``toolUseId``.
-        The durable wire->native map is the only bridge between them; without
-        consulting it the derivation misses and the model is handed an empty
-        prompt, then re-fires the same tool (issue #2376)."""
+    async def test_delta_only_continuation_carries_the_client_result_text(self):
+        """A delta-only continuation omits the assistant message, so the tool
+        name comes from native session history alone. Missing it hands the
+        model an empty prompt and it re-fires the same tool (issue #2376), so
+        the client's answer must reach the prompt verbatim."""
         mock_session_manager = _mock_session_manager()
         provider = MagicMock(return_value=mock_session_manager)
         agent = _make_base_agent(session_manager_provider=provider)
@@ -446,7 +445,7 @@ class TestFrontendToolContinuation:
                     id="t1",
                     role="tool",
                     content='{"approved": true}',
-                    tool_call_id="wire-1",
+                    tool_call_id="native-1",
                 ),
             ],
             tools=tools,
@@ -473,8 +472,6 @@ class TestFrontendToolContinuation:
         instance = _MockSessionAgentWithHistory(
             mock_session_manager, messages=session_history
         )
-        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-1": "native-1"})
-
         with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
             MockCore.return_value = instance
             await _collect_events(agent, input_data)
@@ -484,12 +481,12 @@ class TestFrontendToolContinuation:
         ]
 
     @pytest.mark.asyncio
-    async def test_delta_only_continuation_fails_closed_when_wire_map_misses(self):
-        """The wire map is a fallback, not a guess: an id it does not hold is
-        never matched to some other recorded call. With no name there is no
-        result context to carry, so the run fails closed rather than calling
-        the model with ``""`` — that empty prompt is the original trigger for
-        re-firing the same frontend tool every run (#2376)."""
+    async def test_delta_only_continuation_fails_closed_on_an_unknown_id(self):
+        """Naming is never a guess: an id the history does not hold is never
+        matched to some other recorded call. With no name there is no result
+        context to carry, so the run fails closed rather than calling the model
+        with ``""``; that empty prompt is the original trigger for re-firing
+        the same frontend tool every run (#2376)."""
         mock_session_manager = _mock_session_manager()
         provider = MagicMock(return_value=mock_session_manager)
         agent = _make_base_agent(session_manager_provider=provider)
@@ -514,9 +511,6 @@ class TestFrontendToolContinuation:
         instance = _MockSessionAgentWithHistory(
             mock_session_manager, messages=session_history
         )
-        # The map holds a different call; ``call-xyz`` from the payload is absent.
-        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"wire-other": "native-1"})
-
         with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
             MockCore.return_value = instance
             events = await _collect_events(agent, input_data)
@@ -588,14 +582,14 @@ def _store_placeholder(native_id, text="Forwarded to client"):
     }
 
 
-def _payload_assistant(wire_id, name, args="{}"):
+def _payload_assistant(tool_call_id, name, args="{}"):
     return AssistantMessage(
-        id="a-" + wire_id,
+        id="a-" + tool_call_id,
         role="assistant",
         content="",
         tool_calls=[
             ToolCall(
-                id=wire_id,
+                id=tool_call_id,
                 type="function",
                 function=FunctionCall(name=name, arguments=args),
             )
@@ -603,12 +597,12 @@ def _payload_assistant(wire_id, name, args="{}"):
     )
 
 
-def _payload_tool(wire_id, content, error=None):
+def _payload_tool(tool_call_id, content, error=None):
     return ToolMessage(
-        id="t-" + wire_id,
+        id="t-" + tool_call_id,
         role="tool",
         content=content,
-        tool_call_id=wire_id,
+        tool_call_id=tool_call_id,
         error=error,
     )
 
@@ -623,7 +617,7 @@ async def _run_session_continuation(
     agent_id,
     messages,
     tools,
-    wire_map,
+    client_call_ids,
     store,
     config_kwargs=None,
     context=None,
@@ -646,19 +640,25 @@ async def _run_session_continuation(
     instance = _MockSessionAgentReal(
         sm, agent_id=agent_id, messages=copy.deepcopy(store)
     )
-    # The wire->native map lives on the agent's session state (durable), set on
-    # the prior emission run. Seed it directly to simulate that.
-    if wire_map:
-        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, dict(wire_map))
+    # The frontend-call id store lives on the agent's session state (durable),
+    # written on the prior emission run. Seed it directly to simulate that.
+    if client_call_ids:
+        # A dict is the shape releases before the identifier unification wrote.
+        instance.state.set(
+            AG_UI_FRONTEND_CALL_IDS_STATE_KEY,
+            dict(client_call_ids)
+            if isinstance(client_call_ids, dict)
+            else list(client_call_ids),
+        )
     with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
         MockCore.return_value = instance
-        await _collect_events(agent, input_data)
+        instance.collected_events = await _collect_events(agent, input_data)
     return instance
 
 
 class _MockStreamingAgent:
     """Mock whose ``stream_async`` replays canned Strands events, exercising the
-    real tool-call handling in ``run()`` (including wire->native map capture)."""
+    real tool-call handling in ``run()`` (including frontend-call id capture)."""
 
     def __init__(self, events, session_manager=None):
         self._events = events
@@ -673,13 +673,12 @@ class _MockStreamingAgent:
             yield event
 
 
-class TestWireToNativeMapCapture:
+class TestFrontendCallIdCapture:
     @pytest.mark.asyncio
-    async def test_emission_populates_wire_to_native_map(self):
-        # Driving a frontend tool-call event through run() must record the fresh
-        # wire id -> Strands native toolUseId, which reconciliation later relies
-        # on. (Primary resolution path's data source.) Capture is gated on a
-        # session manager being configured.
+    async def test_emission_records_the_frontend_call_id(self):
+        # Driving a frontend tool-call event through run() must record the call
+        # id, which is what later proves a returning result was executed by the
+        # client. Capture is gated on a session manager being configured.
         agent = _make_base_agent(
             session_manager_provider=MagicMock(return_value=_mock_session_manager())
         )
@@ -700,16 +699,129 @@ class TestWireToNativeMapCapture:
             MockCore.return_value = instance
             await _collect_events(agent, input_data)
 
-        wire_map = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-        assert list(wire_map.values()) == ["native-1"]
+        assert instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == ["native-1"]
 
     @pytest.mark.asyncio
-    async def test_wire_map_is_size_capped(self, monkeypatch):
-        # Abandoned frontend calls are never consumed/pruned, so the map is
-        # bounded at emission: an emission over the cap drops the oldest entries.
+    async def test_re_emitting_a_recorded_call_id_does_not_duplicate_it(self):
+        # A model that reuses a tool-use id, or a turn replayed against a store
+        # that already holds the id, must not append it twice: duplicates count
+        # against the size cap and evict the outstanding ids it exists to
+        # protect, and the prune drops every copy at once anyway.
+        agent = _make_base_agent(
+            session_manager_provider=MagicMock(return_value=_mock_session_manager())
+        )
+        input_data = RunAgentInput(
+            thread_id="t-repeat",
+            run_id="r1",
+            state={},
+            messages=[UserMessage(id="u1", content="please approve")],
+            tools=[_frontend_tool("approve")],
+            context=[],
+            forwarded_props={},
+        )
+        instance = _MockStreamingAgent(
+            [
+                {
+                    "current_tool_use": {
+                        "name": "approve",
+                        "toolUseId": "native-1",
+                        "input": {},
+                    }
+                }
+            ],
+            session_manager=_mock_session_manager(),
+        )
+        instance.state.set(
+            AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["native-older", "native-1"]
+        )
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == [
+            "native-older",
+            "native-1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_new_emission_does_not_promote_legacy_keys(self):
+        # The write path reads the store back before appending. Coercing the old
+        # mapping here turns its keys into the new list, and every later read
+        # then sees a well-formed list of ids that name nothing, so the discard
+        # on read never fires again and the bogus ids are trusted forever.
+        agent = _make_base_agent(
+            session_manager_provider=MagicMock(return_value=_mock_session_manager())
+        )
+        input_data = RunAgentInput(
+            thread_id="t-legacy-emit",
+            run_id="r1",
+            state={},
+            messages=[UserMessage(id="u1", content="please approve")],
+            tools=[_frontend_tool("approve")],
+            context=[],
+            forwarded_props={},
+        )
+        instance = _MockStreamingAgent(
+            [
+                {
+                    "current_tool_use": {
+                        "name": "approve",
+                        "toolUseId": "native-1",
+                        "input": {},
+                    }
+                }
+            ],
+            session_manager=_mock_session_manager(),
+        )
+        instance.state.set(
+            AG_UI_FRONTEND_CALL_IDS_STATE_KEY, {"minted-old": "native-old"}
+        )
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == ["native-1"]
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_recorded_without_a_session_manager(self):
+        # The continuation read and the prune are both gated on a session
+        # manager, so recording without one writes ids that are never read and
+        # never pruned: they sit in memory until the cap evicts the real ones.
+        agent = _make_base_agent()
+        input_data = RunAgentInput(
+            thread_id="t-no-session",
+            run_id="r1",
+            state={},
+            messages=[UserMessage(id="u1", content="please approve")],
+            tools=[_frontend_tool("approve")],
+            context=[],
+            forwarded_props={},
+        )
+        instance = _MockStreamingAgent(
+            [
+                {
+                    "current_tool_use": {
+                        "name": "approve",
+                        "toolUseId": "native-1",
+                        "input": {},
+                    }
+                }
+            ],
+            session_manager=None,
+        )
+        with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
+            MockCore.return_value = instance
+            await _collect_events(agent, input_data)
+
+        assert not instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY)
+
+    @pytest.mark.asyncio
+    async def test_recorded_call_ids_are_size_capped(self, monkeypatch):
+        # Abandoned frontend calls are never consumed/pruned, so the store is
+        # bounded at emission: an emission over the cap drops the oldest ids.
         import ag_ui_strands.agent as agent_mod
 
-        monkeypatch.setattr(agent_mod, "_WIRE_MAP_MAX", 2)
+        monkeypatch.setattr(agent_mod, "_FRONTEND_CALL_IDS_MAX", 2)
         agent = _make_base_agent(
             session_manager_provider=MagicMock(return_value=_mock_session_manager())
         )
@@ -726,40 +838,38 @@ class TestWireToNativeMapCapture:
             [{"current_tool_use": {"name": "approve", "toolUseId": "native-new", "input": {}}}],
             session_manager=_mock_session_manager(),
         )
-        # Pre-seed a full map (oldest first).
-        instance.state.set(AG_UI_WIRE_MAP_STATE_KEY, {"w-a": "n-a", "w-b": "n-b"})
+        # Pre-seed a full store (oldest first).
+        instance.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["n-a", "n-b"])
         with patch("ag_ui_strands.agent.StrandsAgentCore") as MockCore:
             MockCore.return_value = instance
             await _collect_events(agent, input_data)
 
-        wire_map = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-        assert len(wire_map) == 2
-        assert "w-a" not in wire_map  # oldest evicted
-        assert "native-new" in wire_map.values()
+        recorded = instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) or []
+        assert recorded == ["n-b", "native-new"]  # oldest evicted
 
 
 class TestSessionFrontendToolReconciliation:
     """Approach (B): on a session-manager continuation carrying a real frontend
     tool result, the persisted ``"Forwarded to client"`` placeholder is
-    overwritten with the real result (found via the wire->native id map, since
-    the client's wire id differs from Strands' native toolUseId) and the model
-    continues from the corrected native history (``stream_async(None)``)."""
+    overwritten with the real result and the model continues from the corrected
+    native history (``stream_async(None)``). Which results may be corrected is
+    decided by the recorded frontend-call ids, the only proof on a continuation
+    that a result came from the client."""
 
     @pytest.mark.asyncio
-    async def test_reconciles_via_wire_to_native_map_delta_only(self, tmp_path):
-        # Native id in the store differs from the client's wire id, and the
-        # payload is delta-only (no assistant message) — only the wire->native
-        # map can bridge them. This is the E1 regression: keying on the wire id
-        # would match nothing and stream the uncorrected placeholder.
+    async def test_reconciles_a_delta_only_continuation(self, tmp_path):
+        # The payload is delta-only (no assistant message), so the recorded call
+        # id is the only signal that this result is the client's. Without it the
+        # adapter would stream the uncorrected placeholder.
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-map", storage_dir=str(tmp_path))
         instance = await _run_session_continuation(
             sm,
             "default",
-            messages=[_payload_tool("wire-1", '{"approved": false}')],
+            messages=[_payload_tool("native-1", '{"approved": false}')],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
         )
         assert instance.stream_prompts == [None]
@@ -781,9 +891,9 @@ class TestSessionFrontendToolReconciliation:
         instance = await _run_session_continuation(
             sm,
             "default",
-            messages=[_payload_tool("wire-1", '{"approved": false}')],
+            messages=[_payload_tool("native-1", '{"approved": false}')],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
             context=[Context(description="account", value="premium")],
         )
@@ -804,18 +914,18 @@ class TestSessionFrontendToolReconciliation:
         with ``replay_history_into_strands=False``. The reconcile branch is
         gated on that flag and the replay branch is off whenever a session
         manager exists, so ``stream_async(user_message)`` is the only channel
-        left. Naming the tool there requires translating the wire id through
-        the map; without it the model is prompted with ``""`` and re-fires the
-        same call."""
+        left. Naming the tool there requires the native session history;
+        without it the model is prompted with ``""`` and re-fires the same
+        call."""
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-noreplay", storage_dir=str(tmp_path))
         instance = await _run_session_continuation(
             sm,
             "default",
-            messages=[_payload_tool("wire-1", '{"approved": false}')],
+            messages=[_payload_tool("native-1", '{"approved": false}')],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
             config_kwargs={"replay_history_into_strands": False},
         )
@@ -850,9 +960,9 @@ class TestSessionFrontendToolReconciliation:
         instance = await _run_session_continuation(
             sm,
             "default",
-            messages=[_payload_tool("wire-1", content, error="invalid id")],
+            messages=[_payload_tool("native-1", content, error="invalid id")],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[
                 _store_tool_use("native-1", "approve"),
                 _store_placeholder("native-1"),
@@ -880,13 +990,13 @@ class TestSessionFrontendToolReconciliation:
         ],
     )
     @pytest.mark.asyncio
-    async def test_wire_map_hit_is_frontend_provenance_without_declarations(
+    async def test_recorded_call_id_is_frontend_provenance_without_declarations(
         self, tmp_path, content, error, expected
     ):
         """A continuation that declares no tools still carries a real
         frontend result. Membership in ``input_data.tools`` is not the only
-        proof of provenance: the durable wire->native entry is recorded when
-        the call is emitted, so it establishes the same thing by itself.
+        proof of provenance: the call id is recorded when the call is
+        emitted, so it establishes the same thing by itself.
         Reading membership alone files the result as a backend one and hands
         the model ``""`` — the re-fire loop this derivation exists to stop."""
         from strands.session.file_session_manager import FileSessionManager
@@ -897,9 +1007,9 @@ class TestSessionFrontendToolReconciliation:
         instance = await _run_session_continuation(
             sm,
             "default",
-            messages=[_payload_tool("wire-1", content, error=error)],
+            messages=[_payload_tool("native-1", content, error=error)],
             tools=[],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[
                 _store_tool_use("native-1", "approve"),
                 _store_placeholder("native-1"),
@@ -925,11 +1035,11 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", content, error="invalid id"),
+                _payload_assistant("native-1", "approve"),
+                _payload_tool("native-1", content, error="invalid id"),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
         )
         assert instance.stream_prompts == [None]
@@ -946,20 +1056,20 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", '{"approved": true}'),
+                _payload_assistant("native-1", "approve"),
+                _payload_tool("native-1", '{"approved": true}'),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
         )
         assert _result_content(sm, "default", 1)[0]["toolResult"]["status"] == "success"
 
     @pytest.mark.asyncio
-    async def test_no_wire_map_degrades_to_legacy(self, tmp_path):
-        # No durable wire->native map for this result's wire id (e.g. a session
-        # created before this feature): the wire id can't be resolved, so the
-        # adapter degrades to the legacy synthetic-message path and leaves the
+    async def test_unrecorded_call_id_degrades_to_legacy(self, tmp_path):
+        # No recorded id for this result (e.g. a session created before this
+        # feature): its provenance cannot be established, so the adapter
+        # degrades to the legacy synthetic-message path and leaves the
         # placeholder rather than streaming a stub.
         from strands.session.file_session_manager import FileSessionManager
 
@@ -968,11 +1078,11 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-2", "setColor", '{"color": "blue"}'),
-                _payload_tool("wire-2", "ok"),
+                _payload_assistant("native-2", "setColor", '{"color": "blue"}'),
+                _payload_tool("native-2", "ok"),
             ],
             tools=[_frontend_tool("setColor")],
-            wire_map={},  # nothing recorded -> unresolvable
+            client_call_ids=[],  # nothing recorded -> unresolvable
             store=[
                 _store_tool_use("native-2", "setColor", {"color": "blue"}),
                 _store_placeholder("native-2"),
@@ -1011,13 +1121,13 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-A", "doThing"),
-                _payload_assistant("wire-B", "approve"),
-                _payload_tool("wire-A", ""),  # void
-                _payload_tool("wire-B", '{"approved": true}'),  # real
+                _payload_assistant("native-A", "doThing"),
+                _payload_assistant("native-B", "approve"),
+                _payload_tool("native-A", ""),  # void
+                _payload_tool("native-B", '{"approved": true}'),  # real
             ],
             tools=[_frontend_tool("doThing"), _frontend_tool("approve")],
-            wire_map={"wire-A": "native-A", "wire-B": "native-B"},
+            client_call_ids=["native-A", "native-B"],
             store=store,
         )
         assert instance.stream_prompts == [None]
@@ -1028,11 +1138,11 @@ class TestSessionFrontendToolReconciliation:
     @pytest.mark.asyncio
     async def test_multi_turn_reconciles_only_the_trailing_result(self, tmp_path):
         # The client re-sends full history: two earlier identical approve() calls
-        # (already reconciled, and whose wire->native entries were pruned) plus
-        # the just-returned one. Only the trailing result may gate
-        # reconciliation. This PINS trailing-scoping: without it, the historical
-        # calls would be re-collected, fail to resolve (their entries are gone
-        # from the durable map), and force the legacy fallback every turn.
+        # (already reconciled, and whose recorded ids were pruned) plus the
+        # just-returned one. Only the trailing result may gate reconciliation.
+        # This PINS trailing-scoping: without it, the historical calls would be
+        # re-collected, fail to resolve (their ids are gone from the durable
+        # store), and force the legacy fallback every turn.
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-multi", storage_dir=str(tmp_path))
@@ -1048,15 +1158,15 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-o1", "approve", "{}"),
-                _payload_tool("wire-o1", "OLD1"),
-                _payload_assistant("wire-o2", "approve", "{}"),
-                _payload_tool("wire-o2", "OLD2"),
-                _payload_assistant("wire-new", "approve", "{}"),
-                _payload_tool("wire-new", '{"approved": true}'),
+                _payload_assistant("native-o1", "approve", "{}"),
+                _payload_tool("native-o1", "OLD1"),
+                _payload_assistant("native-o2", "approve", "{}"),
+                _payload_tool("native-o2", "OLD2"),
+                _payload_assistant("native-new", "approve", "{}"),
+                _payload_tool("native-new", '{"approved": true}'),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-new": "native-new"},  # historical entries already pruned
+            client_call_ids=["native-new"],  # historical entries already pruned
             store=store,
         )
         assert instance.stream_prompts == [None]
@@ -1074,7 +1184,7 @@ class TestSessionFrontendToolReconciliation:
         # ``pending_tool_result_ids`` is empty. Scoping collection to the
         # trailing ids alone drops the result entirely and the persisted
         # toolResult keeps the proxy placeholder for the rest of the thread's
-        # life. Admission rests on the durable map instead: this call's entry
+        # life. Admission rests on the durable store instead: this call's id
         # is still there precisely because it was never corrected.
         from strands.session.file_session_manager import FileSessionManager
 
@@ -1083,12 +1193,12 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", '{"approved": true}'),
+                _payload_assistant("native-1", "approve"),
+                _payload_tool("native-1", '{"approved": true}'),
                 UserMessage(id="u2", content="do the next thing"),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},
+            client_call_ids=["native-1"],
             store=[
                 _store_tool_use("native-1", "approve"),
                 _store_placeholder("native-1"),
@@ -1099,18 +1209,18 @@ class TestSessionFrontendToolReconciliation:
         assert block["content"] == [{"text": '{"approved": true}'}]
         assert block["status"] == "success"
         assert instance.stream_prompts == ["do the next thing"]
-        # Corrected, so the entry is pruned and cannot be re-collected later.
-        assert (instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}) == {}
+        # Corrected, so the id is pruned and cannot be re-collected later.
+        assert (instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) or []) == []
 
     @pytest.mark.asyncio
     async def test_non_trailing_result_without_a_live_map_entry_is_left_alone(
         self, tmp_path
     ):
         # The counterpart. An earlier call that was already reconciled had its
-        # wire->native entry pruned, so re-sending it in history — with no
-        # trailing result at all — must not pull it back into reconciliation.
+        # recorded id pruned, so re-sending it in history, with no trailing
+        # result at all, must not pull it back into reconciliation.
         # That is the property the trailing-only scope protected, and it now
-        # rests on the map directly: the same assumption
+        # rests on the store directly: the same assumption
         # ``test_multi_turn_reconciles_only_the_trailing_result`` already
         # encodes when it prunes its historical entries.
         from strands.session.file_session_manager import FileSessionManager
@@ -1120,12 +1230,12 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", "OLD"),
+                _payload_assistant("native-1", "approve"),
+                _payload_tool("native-1", "OLD"),
                 UserMessage(id="u2", content="do the next thing"),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={},  # already corrected on an earlier turn -> pruned
+            client_call_ids=[],  # already corrected on an earlier turn -> pruned
             store=[
                 _store_tool_use("native-1", "approve"),
                 _store_placeholder("native-1", text="OLD"),
@@ -1140,8 +1250,8 @@ class TestSessionFrontendToolReconciliation:
     @pytest.mark.asyncio
     async def test_partially_resolvable_turn_falls_back_to_legacy(self, tmp_path):
         # Two frontend results in one turn, both recognized as frontend, but only
-        # one resolves to a native id (wire-2 is not in the map and its
-        # name+args match no stored toolUse). Streaming None would feed wire-2's
+        # one has a recorded id (native-2 was never recorded and its name+args
+        # match no stored toolUse). Streaming None would feed native-2's
         # uncorrected placeholder to the model, so the adapter falls back.
         from strands.session.file_session_manager import FileSessionManager
 
@@ -1154,13 +1264,13 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve", "{}"),
-                _payload_assistant("wire-2", "approve", '{"x": 1}'),  # no store match
-                _payload_tool("wire-1", "R1"),
-                _payload_tool("wire-2", "R2"),
+                _payload_assistant("native-1", "approve", "{}"),
+                _payload_assistant("native-2", "approve", '{"x": 1}'),  # no store match
+                _payload_tool("native-1", "R1"),
+                _payload_tool("native-2", "R2"),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1"},  # wire-2 missing -> unresolvable
+            client_call_ids=["native-1"],  # native-2 unrecorded -> unresolvable
             store=store,
         )
         # Not all non-void results resolved -> legacy fallback: a synthetic user
@@ -1177,7 +1287,7 @@ class TestSessionFrontendToolReconciliation:
     @pytest.mark.asyncio
     async def test_legacy_fallback_forwards_every_frontend_result(self, tmp_path):
         # A parallel frontend-tool turn returns N results in one continuation. On
-        # the legacy path (here: no wire->native map, so nothing reconciles) the
+        # the legacy path (here: no recorded ids, so nothing reconciles) the
         # synthetic user message must carry EVERY result, in call order — not just
         # the last one. Guards against re-introducing a ``break`` after the first
         # result, which would silently drop the model's view of the other answers.
@@ -1188,13 +1298,13 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve", "{}"),
-                _payload_assistant("wire-2", "setColor", '{"color": "blue"}'),
-                _payload_tool("wire-1", "R1"),
-                _payload_tool("wire-2", "R2"),
+                _payload_assistant("native-1", "approve", "{}"),
+                _payload_assistant("native-2", "setColor", '{"color": "blue"}'),
+                _payload_tool("native-1", "R1"),
+                _payload_tool("native-2", "R2"),
             ],
             tools=[_frontend_tool("approve"), _frontend_tool("setColor")],
-            wire_map={},  # nothing resolves -> legacy fallback for the whole turn
+            client_call_ids=[],  # nothing resolves -> legacy fallback for the whole turn
             store=[
                 _store_tool_use("native-1", "approve", {}),
                 _store_placeholder("native-1"),
@@ -1225,11 +1335,11 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-new", "approve"),
-                _payload_tool("wire-new", '{"approved": true}'),
+                _payload_assistant("native-new", "approve"),
+                _payload_tool("native-new", '{"approved": true}'),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-new": "native-new"},
+            client_call_ids=["native-new"],
             store=store,
         )
         assert instance.stream_prompts == [None]
@@ -1239,7 +1349,7 @@ class TestSessionFrontendToolReconciliation:
         ]
 
     @pytest.mark.asyncio
-    async def test_wire_to_native_map_pruned_after_reconcile(self, tmp_path):
+    async def test_recorded_call_ids_pruned_after_reconcile(self, tmp_path):
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-prune", storage_dir=str(tmp_path))
@@ -1247,25 +1357,34 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_tool("wire-1", '{"approved": true}'),
+                _payload_assistant("native-1", "approve"),
+                _payload_tool("native-1", '{"approved": true}'),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-1": "native-1", "wire-other": "native-other"},
+            client_call_ids=[
+                "native-zulu",
+                "native-1",
+                "native-alpha",
+                "native-mike",
+            ],
             store=[_store_tool_use("native-1", "approve"), _store_placeholder("native-1")],
         )
 
-        # The corrected wire id is pruned from the durable state map; unrelated
-        # outstanding entries are kept.
-        remaining = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-        assert "wire-1" not in remaining
-        assert remaining == {"wire-other": "native-other"}
+        # The corrected id is pruned from the durable store; unrelated
+        # outstanding ids are kept, in the order they were recorded. The
+        # emission-time cap evicts from the front, so an unordered rewrite
+        # would start discarding the newest ids instead of the oldest.
+        assert instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == [
+            "native-zulu",
+            "native-alpha",
+            "native-mike",
+        ]
 
     @pytest.mark.asyncio
-    async def test_reconcile_failure_keeps_map_and_falls_back(self, tmp_path):
-        # If reconciliation raises, the wire->native entry must NOT be pruned
-        # (so a later turn can retry) and the run must degrade to the legacy
-        # path rather than streaming an uncorrected stub.
+    async def test_reconcile_failure_keeps_recorded_ids_and_falls_back(self, tmp_path):
+        # If reconciliation raises, the recorded id must NOT be pruned (so a
+        # later turn can retry) and the run must degrade to the legacy path
+        # rather than streaming an uncorrected stub.
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-reconfail", storage_dir=str(tmp_path))
@@ -1277,11 +1396,11 @@ class TestSessionFrontendToolReconciliation:
                 sm,
                 "default",
                 messages=[
-                    _payload_assistant("wire-1", "approve"),
-                    _payload_tool("wire-1", '{"approved": true}'),
+                    _payload_assistant("native-1", "approve"),
+                    _payload_tool("native-1", '{"approved": true}'),
                 ],
                 tools=[_frontend_tool("approve")],
-                wire_map={"wire-1": "native-1"},
+                client_call_ids=["native-1"],
                 store=[
                     _store_tool_use("native-1", "approve"),
                     _store_placeholder("native-1"),
@@ -1289,14 +1408,14 @@ class TestSessionFrontendToolReconciliation:
             )
 
         assert instance.stream_prompts != [None]  # legacy fallback on error
-        remaining = instance.state.get(AG_UI_WIRE_MAP_STATE_KEY) or {}
-        assert remaining == {"wire-1": "native-1"}  # entry kept for retry
+        assert instance.state.get(AG_UI_FRONTEND_CALL_IDS_STATE_KEY) == [
+            "native-1"
+        ]  # kept for retry
 
     @pytest.mark.asyncio
-    async def test_unmapped_results_do_not_corrupt_store_and_fall_back(self, tmp_path):
-        # Two same-turn calls with no durable wire->native entries: neither
-        # resolves, so nothing is written (no corruption) and the turn degrades
-        # to the legacy path.
+    async def test_unrecorded_results_do_not_corrupt_store_and_fall_back(self, tmp_path):
+        # Two same-turn calls with no recorded ids: neither resolves, so nothing
+        # is written (no corruption) and the turn degrades to the legacy path.
         from strands.session.file_session_manager import FileSessionManager
 
         sm = FileSessionManager(session_id="thread-collide", storage_dir=str(tmp_path))
@@ -1320,13 +1439,13 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-1", "approve"),
-                _payload_assistant("wire-2", "approve"),
-                _payload_tool("wire-1", "R1"),
-                _payload_tool("wire-2", "R2"),
+                _payload_assistant("native-1", "approve"),
+                _payload_assistant("native-2", "approve"),
+                _payload_tool("native-1", "R1"),
+                _payload_tool("native-2", "R2"),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={},  # nothing recorded -> unresolvable
+            client_call_ids=[],  # nothing recorded -> unresolvable
             store=store,
         )
         assert instance.stream_prompts != [None]  # unresolvable -> legacy
@@ -1350,11 +1469,11 @@ class TestSessionFrontendToolReconciliation:
             sm,
             "default",
             messages=[
-                _payload_assistant("wire-Z", "approve"),
-                _payload_tool("wire-Z", '{"approved": false}'),
+                _payload_assistant("native-Z", "approve"),
+                _payload_tool("native-Z", '{"approved": false}'),
             ],
             tools=[_frontend_tool("approve")],
-            wire_map={"wire-Z": "native-Z"},
+            client_call_ids=["native-Z"],
             store=[
                 _store_tool_use("native-Z", "approve"),
                 _store_placeholder("native-Z", text="already real"),
@@ -1364,3 +1483,66 @@ class TestSessionFrontendToolReconciliation:
         assert _result_content(sm, "default", 1)[0]["toolResult"]["content"] == [
             {"text": "already real"}
         ]
+
+
+class TestPreUnificationSessionState:
+    """Sessions written before the identifier unification hold the old shape.
+
+    Those releases minted an id per frontend call and stored
+    ``{minted_id: toolUseId}``. The minted ids name nothing in the persisted
+    history, so the adapter discards that shape instead of reading its keys as
+    provenance.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_history_forwards_the_answer_instead_of_the_placeholder(
+        self, tmp_path
+    ):
+        # Trusting the old keys makes the adapter believe the result was already
+        # reconciled, so it replays the native history with the proxy stub still
+        # in it and the model reads "Forwarded to client" as the tool's answer.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(session_id="thread-legacy", storage_dir=str(tmp_path))
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[
+                _payload_assistant("minted-1", "approve"),
+                _payload_tool("minted-1", '{"approved": true}'),
+            ],
+            tools=[_frontend_tool("approve")],
+            client_call_ids={"minted-1": "native-1"},
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1"),
+            ],
+        )
+
+        assert instance.stream_prompts == ['approve returned: {"approved": true}']
+
+    @pytest.mark.asyncio
+    async def test_delta_only_fails_closed_rather_than_guessing(self, tmp_path):
+        # Without the assistant message the tool cannot be named at all: the old
+        # keys are the only thing that ever bridged them, and bridging is what
+        # the unification removed. Failing closed beats prompting the model with
+        # an empty string, which is what makes it re-fire the same call.
+        from strands.session.file_session_manager import FileSessionManager
+
+        sm = FileSessionManager(
+            session_id="thread-legacy-delta", storage_dir=str(tmp_path)
+        )
+        instance = await _run_session_continuation(
+            sm,
+            "default",
+            messages=[_payload_tool("minted-1", '{"approved": true}')],
+            tools=[_frontend_tool("approve")],
+            client_call_ids={"minted-1": "native-1"},
+            store=[
+                _store_tool_use("native-1", "approve"),
+                _store_placeholder("native-1"),
+            ],
+        )
+
+        assert instance.stream_prompts == []
+        _assert_continuation_name_error(instance.collected_events, ["minted-1"])

--- a/integrations/aws-strands/python/tests/test_session_reconcile.py
+++ b/integrations/aws-strands/python/tests/test_session_reconcile.py
@@ -17,9 +17,9 @@ from strands.types.session import SessionAgent, SessionMessage
 
 from ag_ui_strands import session_reconcile
 from ag_ui_strands.session_reconcile import (
+    AG_UI_FRONTEND_CALL_IDS_STATE_KEY,
     has_placeholder_results,
     reconcile_frontend_tool_results,
-    resolve_native_ids,
 )
 
 PLACEHOLDER = "Forwarded to client"
@@ -348,32 +348,6 @@ def test_reconcile_handles_parallel_tool_calls_in_one_message(tmp_path):
     assert blocks[1]["toolResult"]["content"] == [{"text": "R2"}]
 
 
-def test_resolve_maps_wire_id_to_native_id():
-    # Client speaks the wire id; the store holds the native id. The durable
-    # wire->native map (from session state) bridges them.
-    resolved = resolve_native_ids(
-        wire_to_native={"wire-1": "native-1", "wire-2": "native-2"},
-        frontend_results=[
-            {"wire_id": "wire-1", "text": "R1", "is_error": False},
-            {"wire_id": "wire-2", "text": "R2", "is_error": True},
-        ],
-    )
-    assert resolved == {"native-1": ("R1", False), "native-2": ("R2", True)}
-
-
-def test_resolve_skips_results_absent_from_map():
-    # A wire id not in the map (fresh session with no recorded mapping, or a
-    # pruned entry) is dropped — the caller then degrades to the legacy path.
-    resolved = resolve_native_ids(
-        wire_to_native={"wire-1": "native-1"},
-        frontend_results=[
-            {"wire_id": "wire-1", "text": "R1", "is_error": False},
-            {"wire_id": "wire-unknown", "text": "R2", "is_error": False},
-        ],
-    )
-    assert resolved == {"native-1": ("R1", False)}
-
-
 def test_has_placeholder_results_detects_remaining_stub():
     assert has_placeholder_results(
         [{"role": "user", "content": [_tool_result_block("tu-1", PLACEHOLDER)]}]
@@ -533,3 +507,31 @@ def test_reconcile_leaves_status_alone_when_the_block_is_not_a_placeholder(tmp_p
         "content"
     ][0]["toolResult"]
     assert block["status"] == "success"
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param("native-xyz", id="string"),
+        pytest.param(7, id="number"),
+        pytest.param({"minted-1": "native-1"}, id="legacy-mapping"),
+        pytest.param(["native-1", "", "  ", 4, None], id="list-with-junk"),
+    ],
+)
+def test_recorded_call_ids_accepts_only_ids_this_adapter_wrote(stored):
+    """A permissive read fabricates provenance out of whatever is stored.
+
+    A bare string iterates one character per id, and every fabricated id is
+    then written back by the emission path, so the damage outlives the turn.
+    """
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            get=lambda key=None: (
+                stored if key == AG_UI_FRONTEND_CALL_IDS_STATE_KEY else None
+            )
+        )
+    )
+
+    assert session_reconcile.recorded_frontend_call_ids(agent) == (
+        ["native-1"] if isinstance(stored, list) else []
+    )


### PR DESCRIPTION
Closes the follow-up to the identifier unification: the compensating map is
reduced to what it still does, and a continuation carrying no tools no longer
breaks a parked native wait.

## Item A: the provenance store

The unification made the bridge reuse the model's tool-use id for frontend
calls instead of minting its own, which killed the translation half of the map.
Provenance is still required: on a continuation carrying a tool result and no
assistant message, membership is the only remaining signal that a result was
executed by the client rather than by the server.

The store is now a list of call ids rather than a mapping of pairs. Its durable
storage, size cap, ordered pruning and fail-closed read all stay; the order
matters because the cap evicts oldest-first. The translation helper and the
name-recovery fallback are deleted, along with every comment that described our
identifier and the model's as different things.

Both access sites now go through one reader, so they cannot disagree about the
stored shape, and that reader accepts only the shape this adapter writes. A
permissive read turned a stored string into one id per character and a stored
number into an error at the write site.

### Upgrading from a release before the unification

Those releases stored a mapping whose keys were ids this adapter minted. Those
ids name nothing in the persisted history, so a reader that trusted them would
conclude there was nothing to correct and replay an uncorrected "Forwarded to
client" placeholder to the model. The old shape is therefore discarded on read
rather than translated.

Only a frontend call left in flight across the upgrade is affected. An ordinary
continuation degrades to the legacy path, which forwards the client's answer as
a synthetic message. One parked in an active checkpoint cannot be resumed at
all, because connecting the answer to the persisted placeholder needs exactly
the translation this adapter no longer performs; it fails loudly rather than
silently. Both outcomes are covered by tests.

## Item B: a continuation with no tools

The bridge deregistered every proxy tool unconditionally, with no check for a
parked interrupt. For a tool configured to wait for its client result, the run
was parked in a native interrupt whose tool had just been removed: the resume
landed in a registry without it, the framework reported the tool missing, the
result came back as an error, and the model re-fired the same call. The client's
answer was dropped entirely.

Proxies parked in a live frontend-tool interrupt are now exempt from removal,
at the deregistration site, for a partial tool list as well as an empty one.

Two consequences of that exemption are handled here:

- A retained proxy is still offered to the model, and the turn's frontend-tool
  set was built from the client's declarations alone, so on a no-tools turn a
  retained proxy read as a server-side tool. The adapter answered a re-fire
  itself, published a result the client never produced, and parked a fresh
  interrupt nobody was told about, wedging the next turn. Any proxy the registry
  holds now counts as a frontend tool for the turn, so a re-fire is surfaced to
  the client instead.
- A parked wait this process cannot resume into, because the proxy is not
  registered or its tool cannot be named from the thread's history, now refuses
  the turn with a specific error naming the cause. Previously the run reported
  success while the framework's "tool not found" text reached the model in place
  of the client's answer. Cancelling is not exempt from that check: a cancelled
  entry is delivered into the tool body exactly like an answer.

## Verification

- 944 tests pass on the locked framework version and 941 plus three pre-existing
  version-gated skips at the declared 1.15.0 floor.
- Every fix carries a test verified to fail when that fix is reverted, and the
  sweep was re-run after rebasing onto main.
- Lint is unchanged against main's baseline, minus one import this change made
  redundant.

## Known limitation

A thread parked mid frontend call at the moment of an upgrade from a
pre-unification release cannot be resumed. Delivering that answer needs the
identifier translation this change removes by design. It fails loudly with a
reconciliation error rather than corrupting the transcript.
