### PR TITLE
fix(aws-strands): forward Bedrock metadata as raw events

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -5522,6 +5522,17 @@ class StrandsAgent:
                                         )
                                         pending_halt = True
 
+                        elif "metadata" in inner_event:
+                            raw_payload = _sanitize_raw_event(
+                                event, run_invocation_state
+                            )
+                            if raw_payload is not None:
+                                yield RawEvent(
+                                    type=EventType.RAW,
+                                    event=raw_payload,
+                                    source="strands",
+                                )
+
                     # Strands' ``ModelMessageEvent`` re-announces the assistant
                     # turn as a whole once the model finishes it. Every part of
                     # it has already been streamed — text via

--- a/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
+++ b/integrations/aws-strands/python/tests/test_raw_and_inner_agent_events.py
@@ -116,6 +116,12 @@ CITATION = {
     "location": {"documentChar": {"documentIndex": 0, "start": 10, "end": 26}},
 }
 
+BEDROCK_METADATA = {
+    "usage": {"inputTokens": 67, "outputTokens": 324, "totalTokens": 391},
+    "metrics": {"latencyMs": 5199},
+    "trace": {"guardrail": {"actionReason": "Guardrail blocked."}},
+}
+
 
 def _find_citation_payload(event: Any) -> Optional[dict]:
     """Locate the citation payload in a RAW event, whatever shape it arrives in.
@@ -301,6 +307,23 @@ async def test_bedrock_citation_event_is_emitted_as_raw():
     event, payload = located[0]
     assert event.source == "strands"
     assert payload == CITATION
+
+
+@pytest.mark.asyncio
+async def test_bedrock_metadata_event_is_emitted_as_raw():
+    """Usage and guardrail metadata must reach the wire instead of being dropped."""
+    strands_agent = StrandsAgentCore(
+        model=ScriptedModel([_text_turn("Guardrail response.") + [{"metadata": BEDROCK_METADATA}]]),
+        callback_handler=None,
+    )
+
+    events = await _collect(_wrap(strands_agent))
+    _assert_stream_encodes(events)
+
+    raw_events = [event for event in events if event.type == EventType.RAW]
+    assert len(raw_events) == 1
+    assert raw_events[0].source == "strands"
+    assert raw_events[0].event == {"event": {"metadata": BEDROCK_METADATA}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Forward nested Strands `metadata` envelopes as sanitized AG-UI RAW events.
- Preserve all existing handling for content-block and lifecycle events.
- Add a real Strands event-loop regression covering usage, latency, and guardrail metadata.

Fixes #2561.

## Testing

- `uv run --locked python -m pytest tests/ -v` — 925 passed.
- `uv build` — source distribution and wheel built successfully.
- Targeted regression passed with `strands-agents` 1.15.0 and 1.47.0.
