### PR TITLE
fix(core): add optional name to ToolMessage for tool-result routing

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -762,6 +762,7 @@ def langchain_messages_to_agui(messages: List[BaseMessage]) -> List[AGUIMessage]
                 role="tool",
                 content=stringify_if_needed(resolve_message_content(message.content)),
                 tool_call_id=message.tool_call_id,
+                name=message.name,
                 # A LangChain tool result signals failure only through `status`, with
                 # no error text. Restore AG-UI's `error` so the failure survives the
                 # round trip; the value is a fixed sentinel (#2305) because the
@@ -1770,6 +1771,7 @@ def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]
                 id=message.id,
                 content=message.content,
                 tool_call_id=message.tool_call_id,
+                name=getattr(message, "name", None),
                 # Carry the AG-UI failure signal onto LangChain's tool-result status, so a
                 # client-reported tool failure is not delivered to the model as a success.
                 status="error" if message.error else "success",

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -85,6 +85,25 @@ class TestAguiMessagesToLangchain(unittest.TestCase):
         # A tool result with no error maps to LangChain's default "success" status.
         assert result[0].status == "success"
 
+    def test_tool_message_name_round_trip(self):
+        # LangChain routes tool results by ToolMessage.name; the AG-UI tool
+        # message must carry the name in both conversion directions (#2530).
+        lc = ToolMessage(content="42", tool_call_id="tc1", name="request_page_oncall")
+        agui = langchain_messages_to_agui([lc])
+        assert isinstance(agui[0], AGUIToolMessage)
+        assert agui[0].name == "request_page_oncall"
+
+        msg = AGUIToolMessage(
+            id="t1",
+            role="tool",
+            content="42",
+            tool_call_id="tc1",
+            name="request_page_oncall",
+        )
+        result = agui_messages_to_langchain([msg])
+        assert isinstance(result[0], ToolMessage)
+        assert result[0].name == "request_page_oncall"
+
     def test_tool_message_error_maps_to_status(self):
         # A client-reported tool failure must reach the model as an error, not a
         # silent success -- AG-UI's ToolMessage.error becomes status="error".

--- a/sdks/python/ag_ui/core/types.py
+++ b/sdks/python/ag_ui/core/types.py
@@ -295,6 +295,7 @@ class ToolMessage(MetadataMixin):
     role: Literal["tool"] = "tool"
     content: str
     tool_call_id: str
+    name: Optional[str] = None
     error: Optional[str] = None
     encrypted_value: Optional[str] = None
     subagent_run_id: Optional[str] = None

--- a/sdks/python/tests/test_types.py
+++ b/sdks/python/tests/test_types.py
@@ -65,6 +65,22 @@ class TestBaseTypes(unittest.TestCase):
         self.assertIn("toolCallId", serialized)
         self.assertEqual(serialized["toolCallId"], "call_456")
 
+    def test_tool_message_optional_name(self):
+        """ToolMessage accepts an optional name and serializes it as camelCase-neutral"""
+        tool_msg = ToolMessage(
+            id="tool_123",
+            content="Tool result",
+            tool_call_id="call_456",
+            name="request_page_oncall",
+        )
+        self.assertEqual(tool_msg.name, "request_page_oncall")
+        serialized = tool_msg.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(serialized.get("name"), "request_page_oncall")
+
+        omitted = ToolMessage(id="t2", content="r", tool_call_id="c2")
+        self.assertIsNone(omitted.name)
+        self.assertNotIn("name", omitted.model_dump(by_alias=True, exclude_none=True))
+
     def test_activity_message(self):
         """Test creating and serializing an activity message"""
         content = {"steps": ["search", "summarize"]}

--- a/sdks/typescript/packages/core/src/__tests__/tool-message-name.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/tool-message-name.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { ToolMessageSchema } from "../types";
+
+describe("tool message name", () => {
+  it("accepts an optional name on a tool message", () => {
+    const parsed = ToolMessageSchema.parse({
+      id: "t1",
+      role: "tool",
+      content: "ok",
+      toolCallId: "tc1",
+      name: "request_page_oncall",
+    });
+    expect(parsed.name).toBe("request_page_oncall");
+  });
+
+  it("leaves name undefined when omitted", () => {
+    const parsed = ToolMessageSchema.parse({
+      id: "t1",
+      role: "tool",
+      content: "ok",
+      toolCallId: "tc1",
+    });
+    expect(parsed.name).toBeUndefined();
+  });
+});

--- a/sdks/typescript/packages/core/src/types.ts
+++ b/sdks/typescript/packages/core/src/types.ts
@@ -151,6 +151,7 @@ export const ToolMessageSchema = z.object({
   content: z.string(),
   role: z.literal("tool"),
   toolCallId: z.string(),
+  name: z.string().optional(),
   error: z.string().optional(),
   encryptedValue: z.string().optional(),
   subagentRunId: z.string().optional(),


### PR DESCRIPTION
Fixes #2530

## Summary

`ToolMessage` is the only AG-UI message role without a `name` field: the other roles inherit an optional `name` from `BaseMessage`, while `ToolMessage` stands alone (in both SDKs, the same block that dropped `error` before #2226 carried it). Because the adapters have no name to forward, LangGraph developers routing on LangChain's `ToolMessage.name` — the canonical pattern for gated nodes — see `name` arrive as `None` and the branch falls through silently.

This change adds the optional `name` field to the tool role and forwards it in both directions of the LangGraph adapter:

- **Python** (`sdks/python/ag_ui/core/types.py`): `ToolMessage` gains `name: Optional[str] = None`.
- **TypeScript** (`sdks/typescript/packages/core/src/types.ts`): `ToolMessageSchema` gains `name: z.string().optional()`.
- **LangGraph adapter** (`integrations/langgraph/python/ag_ui_langgraph/utils.py`): the LangChain → AG-UI conversion carries `message.name` onto the tool message, and the AG-UI → LangChain conversion forwards it onto LangChain's `ToolMessage(name=...)`.

The field is optional and omitted by default, so no existing wire payload or caller changes shape (mirroring how `error` was carried for #2226).

## Verification

- `uv run pytest tests/test_message_conversion.py` (langgraph integration) — 46 passed, including a new round-trip regression: LangChain `ToolMessage(name=...)` → AG-UI carries `name`, and AG-UI `ToolMessage(name=...)` → LangChain preserves it; a name-less tool message still serializes without the field.
- `uv run python -m unittest tests.test_types` (python SDK) — 27 passed, including a new optional-name serialization test (`exclude_none` omits it when unset).
- `pnpm --filter @ag-ui/core test` — 17 files / 211 tests passed, including a new `ToolMessageSchema` test covering the optional `name` (accepted when present, `undefined` when omitted).

## Type

- [x] Bug fix
