### PR TITLE
fix(client): never follow redirects with the credential-bearing run request

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/http-redirect.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/http-redirect.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { HttpAgent } from "../http";
+
+describe("HttpAgent redirect policy", () => {
+  it("pins redirect mode to error so redirects never carry the run request", () => {
+    const agent = new HttpAgent({
+      url: "https://api.example.com/v1/chat",
+      headers: { Authorization: "Bearer test-token" },
+    });
+
+    const input = {
+      threadId: agent.threadId,
+      runId: "mock-run-id",
+      tools: [],
+      context: [],
+      forwardedProps: {},
+      state: agent.state,
+      messages: [],
+    };
+
+    const init = (agent as unknown as { requestInit: (i: unknown) => RequestInit }).requestInit(
+      input,
+    );
+
+    expect(init.redirect).toBe("error");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeDefined();
+  });
+});

--- a/sdks/typescript/packages/client/src/agent/http.ts
+++ b/sdks/typescript/packages/client/src/agent/http.ts
@@ -59,6 +59,11 @@ export class HttpAgent extends AbstractAgent {
       },
       body: JSON.stringify(sanitizeOutgoingInput(input)),
       signal: this.abortController.signal,
+      // The run request carries the conversation and developer auth headers.
+      // Never let fetch follow a server-chosen redirect with that payload:
+      // surfacing redirects as errors keeps a compromised endpoint from
+      // re-issuing the POST (and everything in it) at another origin.
+      redirect: "error",
     };
   }
 


### PR DESCRIPTION
Fixes #2520

## Summary

The run POST carries the conversation and developer auth headers. `HttpAgent.requestInit` builds its fetch init without a `redirect` option, so `fetch` follows a server-chosen redirect with the credential-bearing request attached: a compromised or malicious agent endpoint can answer the run POST with a redirect and have the client re-issue the request (and, on 307/308 in browsers per spec, the full body) at another origin — CWE-601 / CWE-200, with a measured repro in the issue.

Pin `redirect: "error"` in `requestInit` so redirects surface as errors instead of being followed with the run request attached. Agent endpoints are configured URLs, not a redirect surface; the auditor's suggested remediation lists this as the minimal secure behavior (`redirect: "manual"` with re-follow logic was the heavier alternative).

Developer-supplied `fetch` overrides (`config.fetch`) are unaffected — the pin lives in the default `requestInit`.

## Verification

- New regression `src/agent/__tests__/http-redirect.test.ts` asserts the request init pins `redirect: "error"` while keeping the POST method and body.
- `pnpm --filter @ag-ui/client test` — 67 files / 733 tests passed (includes the new regression; the `esm-interop` suite requires `@ag-ui/core` and `@ag-ui/proto` dist builds first, as usual).
- `pnpm --filter @ag-ui/client lint` — clean.
- `pnpm exec prettier --check` on changed files — clean.
