### PR TITLE
fix(mastra): keep replay conversion alive on malformed tool-call arguments

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { convertAGUIMessagesToMastra } from "../utils";
 import type { Message } from "@ag-ui/client";
 
@@ -442,6 +443,165 @@ describe("convertAGUIMessagesToMastra", () => {
               args: { q: "test" },
             },
           ],
+        },
+      ]);
+    });
+
+    it("recovers the first JSON object when replayed arguments are concatenated", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tc-1",
+              type: "function",
+              function: {
+                name: "anyTool",
+                arguments: '{"mine":true}{"mine":true}',
+              },
+            },
+          ],
+        },
+      ];
+
+      const first = convertAGUIMessagesToMastra(messages);
+      const second = convertAGUIMessagesToMastra(messages);
+
+      expect(first).toEqual(second);
+      expect(first).toEqual([
+        {
+          id: "1",
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tc-1",
+              toolName: "anyTool",
+              args: { mine: true },
+            },
+          ],
+        },
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Recovered first JSON value"),
+      );
+      warn.mockRestore();
+    });
+
+    it("does not truncate a recovered object at a brace that is inside a string", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tc-1",
+              type: "function",
+              function: {
+                name: "anyTool",
+                arguments: '{"note":"use } here"}{"note":"dup"}',
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result[0].content).toEqual([
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "anyTool",
+          args: { note: "use } here" },
+        },
+      ]);
+      warn.mockRestore();
+    });
+
+    it("skips a malformed tool-call instead of failing the whole conversion", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "assistant",
+          content: "still usable",
+          toolCalls: [
+            {
+              id: "tc-bad",
+              type: "function",
+              function: {
+                name: "broken",
+                arguments: "not-json",
+              },
+            },
+            {
+              id: "tc-good",
+              type: "function",
+              function: {
+                name: "search",
+                arguments: JSON.stringify({ q: "ok" }),
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result).toEqual([
+        {
+          id: "1",
+          role: "assistant",
+          content: [
+            { type: "text", text: "still usable" },
+            {
+              type: "tool-call",
+              toolCallId: "tc-good",
+              toolName: "search",
+              args: { q: "ok" },
+            },
+          ],
+        },
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping tool-call broken (tc-bad)"),
+      );
+      warn.mockRestore();
+    });
+
+    it("treats empty tool-call arguments as an empty object", () => {
+      const messages: Message[] = [
+        {
+          id: "1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tc-1",
+              type: "function",
+              function: {
+                name: "noop",
+                arguments: "   ",
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertAGUIMessagesToMastra(messages);
+
+      expect(result[0].content).toEqual([
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "noop",
+          args: {},
         },
       ]);
     });

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -135,6 +135,88 @@ const toMastraContent = (content: Message["content"]): string | any[] => {
   return parts;
 };
 
+function parseReplayToolCallArguments(
+  raw: string | undefined,
+): { args: unknown; recovered: boolean } | undefined {
+  const trimmed = (raw ?? "").trim();
+  if (trimmed === "") {
+    return { args: {}, recovered: false };
+  }
+
+  try {
+    return { args: JSON.parse(trimmed), recovered: false };
+  } catch {
+    const recovered = recoverFirstJsonValue(trimmed);
+    if (recovered !== undefined) {
+      return { args: recovered, recovered: true };
+    }
+    return undefined;
+  }
+}
+
+function recoverFirstJsonValue(text: string): unknown | undefined {
+  const end = endOfFirstJsonContainer(text);
+  if (end <= 0 || end >= text.length) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text.slice(0, end));
+  } catch {
+    return undefined;
+  }
+}
+
+function endOfFirstJsonContainer(text: string): number {
+  const open = text[0];
+  if (open !== "{" && open !== "[") {
+    return -1;
+  }
+
+  let objectDepth = 0;
+  let arrayDepth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      objectDepth += 1;
+    } else if (ch === "}") {
+      objectDepth -= 1;
+    } else if (ch === "[") {
+      arrayDepth += 1;
+    } else if (ch === "]") {
+      arrayDepth -= 1;
+    }
+    if (objectDepth < 0 || arrayDepth < 0) {
+      return -1;
+    }
+    if (objectDepth === 0 && arrayDepth === 0) {
+      return i + 1;
+    }
+  }
+
+  return -1;
+}
+
 export function convertAGUIMessagesToMastra(
   messages: Message[],
   // Messages to resolve a tool message's toolName against. Defaults to
@@ -164,11 +246,23 @@ export function convertAGUIMessagesToMastra(
         parts.push({ type: "text", text: assistantContent });
       }
       for (const toolCall of message.toolCalls ?? []) {
+        const parsed = parseReplayToolCallArguments(toolCall.function.arguments);
+        if (parsed === undefined) {
+          console.warn(
+            `[convertAGUIMessagesToMastra] Skipping tool-call ${toolCall.function.name} (${toolCall.id}): arguments are not valid JSON`,
+          );
+          continue;
+        }
+        if (parsed.recovered) {
+          console.warn(
+            `[convertAGUIMessagesToMastra] Recovered first JSON value from concatenated tool-call arguments for ${toolCall.function.name} (${toolCall.id})`,
+          );
+        }
         parts.push({
           type: "tool-call",
           toolCallId: toolCall.id,
           toolName: toolCall.function.name,
-          args: JSON.parse(toolCall.function.arguments),
+          args: parsed.args,
         });
       }
       result.push({


### PR DESCRIPTION
Fixes #2568

## Summary

`convertAGUIMessagesToMastra` parsed replayed tool-call `arguments` with a bare `JSON.parse`. After concurrent runs leave concatenated JSON in in-memory history (`{"mine":true}{"mine":true}`), every later `agent/run` on that thread throws before reaching the model, so the thread stays unrunnable until process restart.

On parse failure the converter now recovers the first complete JSON object or array when the rest is trailing concatenation, and skips a tool-call that still cannot be parsed. The rest of the history continues through conversion. Valid JSON is unchanged.

This is the robustness half of #2568. It does not claim to fix the unisolated concurrency path that writes concatenated arguments into process memory.

## Verification

- New regressions in `integrations/mastra/typescript/src/__tests__/message-conversion.test.ts` cover concatenated objects (including a `}` inside a string), skipping irreparable arguments while keeping a sibling tool-call, and empty arguments becoming `{}`.
- `pnpm --filter @ag-ui/mastra test` — 23 files / 340 tests passed (workspace `@ag-ui/core`, `@ag-ui/client`, `@ag-ui/proto`, and `@ag-ui/a2ui-toolkit` dist builds first, as usual).
- `pnpm --filter @ag-ui/mastra typecheck` — clean.