### PR TITLE
fix(dotnet): surface tool calls when TOOL_CALL_END arrives

### DIFF
--- a/sdks/dotnet/src/AGUI.Client/Internal/EventStreamConverter.cs
+++ b/sdks/dotnet/src/AGUI.Client/Internal/EventStreamConverter.cs
@@ -1132,8 +1132,15 @@ internal static class EventStreamConverter
                     break;
 
                 case ToolCallEndEvent toolEnd:
-                    toolCallBuilder.EndToolCall(toolEnd, jsonSerializerOptions);
+                {
+                    // Yield the completed FunctionCallContent now so a UI can show the
+                    // call as running. Waiting until TOOL_CALL_RESULT (or until every
+                    // sibling result arrived) hid long-running backend tools.
+                    var callUpdate = toolCallBuilder.EndToolCall(toolEnd, jsonSerializerOptions);
+                    toolCallBuilder.MarkCallYielded(toolEnd.ToolCallId);
+                    yield return callUpdate;
                     break;
+                }
 
                 case ToolCallResultEvent toolResult:
                 {
@@ -1151,8 +1158,9 @@ internal static class EventStreamConverter
 
                     if (toolCallBuilder.IsBuffering)
                     {
-                        // Add the result to the buffer and resolve the pending tool call.
-                        // If all pending tool calls now have results, flush the entire buffer.
+                        // Resolve this call only. Sibling calls stay pending so a slow
+                        // tool cannot delay an unrelated result (or its earlier call
+                        // update, which was already yielded at TOOL_CALL_END).
                         foreach (var flushed in toolCallBuilder.AddResult(toolResult.ToolCallId, resultUpdate))
                         {
                             yield return flushed;

--- a/sdks/dotnet/src/AGUI.Client/Internal/ToolCallBuilder.cs
+++ b/sdks/dotnet/src/AGUI.Client/Internal/ToolCallBuilder.cs
@@ -12,6 +12,9 @@ internal sealed class ToolCallBuilder
 {
     private readonly Dictionary<string, ToolCallState> _activeToolCalls = new();
     private readonly HashSet<string> _pendingToolCallIds = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ChatResponseUpdate> _heldCalls = new(StringComparer.Ordinal);
+    private readonly List<string> _heldCallOrder = new();
+    private readonly HashSet<string> _yieldedCallIds = new(StringComparer.Ordinal);
     private readonly List<ChatResponseUpdate> _buffer = new();
 
     // callId -> the message id the TypeScript reducer mints for the assistant message
@@ -60,7 +63,7 @@ internal sealed class ToolCallBuilder
         state.Arguments.Append(evt.Delta);
     }
 
-    public void EndToolCall(ToolCallEndEvent evt, JsonSerializerOptions jsonSerializerOptions)
+    public ChatResponseUpdate EndToolCall(ToolCallEndEvent evt, JsonSerializerOptions jsonSerializerOptions)
     {
         if (!_activeToolCalls.TryGetValue(evt.ToolCallId, out var state))
         {
@@ -75,8 +78,7 @@ internal sealed class ToolCallBuilder
             name: state.Name,
             arguments: DeserializeArguments(state.Arguments.ToString(), jsonSerializerOptions));
 
-        _pendingToolCallIds.Add(evt.ToolCallId);
-        _buffer.Add(new ChatResponseUpdate(ChatRole.Assistant, [functionCall])
+        var update = new ChatResponseUpdate(ChatRole.Assistant, [functionCall])
         {
             ConversationId = _conversationId,
             ResponseId = _responseId,
@@ -90,8 +92,15 @@ internal sealed class ToolCallBuilder
             MessageId = state.ParentMessageId ?? evt.ToolCallId,
             CreatedAt = DateTimeOffset.UtcNow,
             RawRepresentation = evt
-        });
+        };
+
+        _pendingToolCallIds.Add(evt.ToolCallId);
+        _heldCalls[evt.ToolCallId] = update;
+        _heldCallOrder.Add(evt.ToolCallId);
+        return update;
     }
+
+    public void MarkCallYielded(string toolCallId) => _yieldedCallIds.Add(toolCallId);
 
     /// <summary>
     /// The message id minted for the assistant message carrying <paramref name="toolCallId"/>,
@@ -103,16 +112,27 @@ internal sealed class ToolCallBuilder
     public IReadOnlyList<ChatResponseUpdate> AddResult(string toolCallId, ChatResponseUpdate resultUpdate)
     {
         _pendingToolCallIds.Remove(toolCallId);
-        _buffer.Add(resultUpdate);
+
+        var flushed = new List<ChatResponseUpdate>();
+        if (_heldCalls.TryGetValue(toolCallId, out var callUpdate))
+        {
+            _heldCalls.Remove(toolCallId);
+            _heldCallOrder.Remove(toolCallId);
+            if (!_yieldedCallIds.Contains(toolCallId))
+            {
+                flushed.Add(callUpdate);
+            }
+        }
+
+        flushed.Add(resultUpdate);
 
         if (_pendingToolCallIds.Count == 0)
         {
-            var flushed = new List<ChatResponseUpdate>(_buffer);
+            flushed.AddRange(_buffer);
             _buffer.Clear();
-            return flushed;
         }
 
-        return Array.Empty<ChatResponseUpdate>();
+        return flushed;
     }
 
     public void BufferUpdate(ChatResponseUpdate update)
@@ -122,13 +142,25 @@ internal sealed class ToolCallBuilder
 
     public IReadOnlyList<ChatResponseUpdate> FlushAsToolCalls()
     {
-        if (_buffer.Count == 0)
+        if (_heldCalls.Count == 0 && _buffer.Count == 0)
         {
             return Array.Empty<ChatResponseUpdate>();
         }
 
-        var flushed = new List<ChatResponseUpdate>(_buffer);
+        var flushed = new List<ChatResponseUpdate>();
+        foreach (var toolCallId in _heldCallOrder)
+        {
+            if (_heldCalls.TryGetValue(toolCallId, out var update)
+                && !_yieldedCallIds.Contains(toolCallId))
+            {
+                flushed.Add(update);
+            }
+        }
+
+        flushed.AddRange(_buffer);
         _buffer.Clear();
+        _heldCalls.Clear();
+        _heldCallOrder.Clear();
         _pendingToolCallIds.Clear();
         return flushed;
     }
@@ -136,7 +168,7 @@ internal sealed class ToolCallBuilder
     public IReadOnlyList<ChatResponseUpdate> FlushWithInterrupts(
         RunFinishedInterruptOutcome interruptOutcome)
     {
-        if (_buffer.Count == 0)
+        if (_heldCalls.Count == 0 && _buffer.Count == 0)
         {
             return Array.Empty<ChatResponseUpdate>();
         }
@@ -152,14 +184,22 @@ internal sealed class ToolCallBuilder
             }
         }
 
-        var updates = new List<ChatResponseUpdate>(_buffer.Count);
-        foreach (var update in _buffer)
+        var updates = new List<ChatResponseUpdate>();
+        foreach (var toolCallId in _heldCallOrder)
         {
+            if (!_heldCalls.TryGetValue(toolCallId, out var update))
+            {
+                continue;
+            }
+
             if (update.Contents.Count == 1
                 && update.Contents[0] is FunctionCallContent fcc
                 && interruptById.TryGetValue(fcc.CallId, out var interrupt))
             {
-                // This tool call is interrupted — replace with ToolApprovalRequestContent
+                // This tool call is interrupted — emit ToolApprovalRequestContent.
+                // The call update itself may already have been yielded at TOOL_CALL_END
+                // so a UI can show the in-progress call; this replacement is the HITL
+                // signal and must still be produced.
                 var approvalRequest = new ToolApprovalRequestContent(
                     interrupt.Id, fcc)
                 {
@@ -170,7 +210,7 @@ internal sealed class ToolCallBuilder
                 {
                     ConversationId = update.ConversationId,
                     ResponseId = update.ResponseId,
-                    // The buffered call update's message identity must survive the
+                    // The held call update's message identity must survive the
                     // replacement, or the coalescer hoists this update's attribution
                     // onto the ChatResponse and the approval comes back parent-owned
                     // (see EndToolCall).
@@ -179,13 +219,16 @@ internal sealed class ToolCallBuilder
                     RawRepresentation = update.RawRepresentation
                 });
             }
-            else
+            else if (!_yieldedCallIds.Contains(toolCallId))
             {
                 updates.Add(update);
             }
         }
 
+        updates.AddRange(_buffer);
         _buffer.Clear();
+        _heldCalls.Clear();
+        _heldCallOrder.Clear();
         _pendingToolCallIds.Clear();
         return updates;
     }
@@ -203,6 +246,9 @@ internal sealed class ToolCallBuilder
     {
         _activeToolCalls.Clear();
         _pendingToolCallIds.Clear();
+        _heldCalls.Clear();
+        _heldCallOrder.Clear();
+        _yieldedCallIds.Clear();
         _buffer.Clear();
         // Minted identities are per run like everything else here: entity ids are
         // run-global, so a later run reusing a call id must not coalesce its

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/ProtocolRuleTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/ProtocolRuleTest.cs
@@ -288,6 +288,78 @@ public sealed class ProtocolRuleTest
     }
 
     [Fact]
+    public async Task ToolCall_EndSurfacesFunctionCallBeforeSiblingResult()
+    {
+        // TOOL_CALL_END must yield FunctionCallContent immediately. Waiting until
+        // every parallel TOOL_CALL_RESULT arrived hid in-progress backend tools
+        // and delayed unrelated calls (issue #2577).
+        var events = new BaseEvent[]
+        {
+            new RunStartedEvent { ThreadId = "t1", RunId = "r1" },
+            new ToolCallStartEvent { ToolCallId = "c1", ToolCallName = "slow" },
+            new ToolCallEndEvent { ToolCallId = "c1" },
+            new ToolCallStartEvent { ToolCallId = "c2", ToolCallName = "fast" },
+            new ToolCallEndEvent { ToolCallId = "c2" },
+            new ToolCallResultEvent { MessageId = "r2", ToolCallId = "c2", Content = "done-2" },
+            new ToolCallResultEvent { MessageId = "r1", ToolCallId = "c1", Content = "done-1" },
+            new RunFinishedEvent { ThreadId = "t1", RunId = "r1" }
+        };
+
+        var result = await ProcessEventsAsync(events);
+        var kinds = result
+            .Select(u => u.Contents.FirstOrDefault() switch
+            {
+                FunctionCallContent fcc => $"call:{fcc.CallId}",
+                FunctionResultContent frc => $"result:{frc.CallId}",
+                _ => null
+            })
+            .Where(s => s is not null)
+            .ToList();
+
+        Assert.Equal(["call:c1", "call:c2", "result:c2", "result:c1"], kinds);
+    }
+
+    [Fact]
+    public async Task ToolCall_InterruptEmitsApprovalAfterTheCallHasAlreadySurfaced()
+    {
+        // TOOL_CALL_END yields FunctionCallContent immediately so a UI can show
+        // the in-progress call. RUN_FINISHED with a tool-call interrupt still
+        // emits ToolApprovalRequestContent for HITL; it must not swallow the
+        // earlier call update or skip the approval.
+        var events = new BaseEvent[]
+        {
+            new RunStartedEvent { ThreadId = "t1", RunId = "r1" },
+            new ToolCallStartEvent { ToolCallId = "tc1", ToolCallName = "delete_file" },
+            new ToolCallArgsEvent { ToolCallId = "tc1", Delta = "{}" },
+            new ToolCallEndEvent { ToolCallId = "tc1" },
+            new RunFinishedEvent
+            {
+                ThreadId = "t1",
+                RunId = "r1",
+                Outcome = new RunFinishedInterruptOutcome
+                {
+                    Interrupts =
+                    {
+                        new AGUIInterrupt
+                        {
+                            Id = "int-1",
+                            Reason = InterruptReasons.ToolCall,
+                            ToolCallId = "tc1"
+                        }
+                    }
+                }
+            }
+        };
+
+        var result = await ProcessEventsAsync(events);
+        var callIndex = result.FindIndex(u => u.Contents.OfType<FunctionCallContent>().Any());
+        var approvalIndex = result.FindIndex(u => u.Contents.OfType<ToolApprovalRequestContent>().Any());
+        Assert.InRange(callIndex, 0, result.Count - 1);
+        Assert.InRange(approvalIndex, 0, result.Count - 1);
+        Assert.True(callIndex < approvalIndex);
+    }
+
+    [Fact]
     public async Task ToolCall_ConcurrentWithDifferentIds_AllComplete()
     {
         var events = new BaseEvent[]

--- a/sdks/dotnet/tests/AGUI.Client.UnitTests/ToolCallBuilderTest.cs
+++ b/sdks/dotnet/tests/AGUI.Client.UnitTests/ToolCallBuilderTest.cs
@@ -253,7 +253,7 @@ public sealed class ToolCallBuilderTest
     }
 
     [Fact]
-    public void AddResult_MultipleToolCalls_FlushesWhenAllResolved()
+    public void AddResult_MultipleToolCalls_FlushesEachCallIndependently()
     {
         var builder = new ToolCallBuilder();
         builder.SetIds("thread1", "run1");
@@ -266,23 +266,20 @@ public sealed class ToolCallBuilderTest
         var result1 = new ChatResponseUpdate(ChatRole.Tool,
             [new FunctionResultContent("c1", "result_a")]);
 
-        // First result — c2 still pending, should not flush
+        // First result — release c1 immediately; c2 stays pending for interrupt rewrite
         var flushed1 = builder.AddResult("c1", result1);
-        Assert.Empty(flushed1);
+        Assert.Equal(2, flushed1.Count);
+        Assert.IsType<FunctionCallContent>(flushed1[0].Contents[0]);
+        Assert.IsType<FunctionResultContent>(flushed1[1].Contents[0]);
         Assert.True(builder.IsBuffering);
 
         var result2 = new ChatResponseUpdate(ChatRole.Tool,
             [new FunctionResultContent("c2", "result_b")]);
 
-        // Second result — all resolved, should flush everything in order
         var flushed2 = builder.AddResult("c2", result2);
-        Assert.Equal(4, flushed2.Count);
-
-        // FCC(c1), FCC(c2), FRC(c1), FRC(c2)
+        Assert.Equal(2, flushed2.Count);
         Assert.IsType<FunctionCallContent>(flushed2[0].Contents[0]);
-        Assert.IsType<FunctionCallContent>(flushed2[1].Contents[0]);
-        Assert.IsType<FunctionResultContent>(flushed2[2].Contents[0]);
-        Assert.IsType<FunctionResultContent>(flushed2[3].Contents[0]);
+        Assert.IsType<FunctionResultContent>(flushed2[1].Contents[0]);
         Assert.False(builder.IsBuffering);
     }
 
@@ -304,11 +301,12 @@ public sealed class ToolCallBuilderTest
 
         var flushed = builder.AddResult("c1", resultUpdate);
 
-        // Order: FCC, text, FRC
+        // Call and result for this id first; pass-through updates that arrived
+        // while another call was still pending flush after the last pending id.
         Assert.Equal(3, flushed.Count);
         Assert.IsType<FunctionCallContent>(flushed[0].Contents[0]);
-        Assert.Equal("thinking...", flushed[1].Text);
-        Assert.IsType<FunctionResultContent>(flushed[2].Contents[0]);
+        Assert.IsType<FunctionResultContent>(flushed[1].Contents[0]);
+        Assert.Equal("thinking...", flushed[2].Text);
     }
 
     [Fact]
@@ -337,5 +335,84 @@ public sealed class ToolCallBuilderTest
         var flushed2 = builder.AddResult("c2", result2);
         Assert.Equal(2, flushed2.Count);
         Assert.False(builder.IsBuffering);
+    }
+
+    [Fact]
+    public void MarkCallYielded_AddResult_DoesNotReemitTheCall()
+    {
+        var builder = new ToolCallBuilder();
+        builder.StartToolCall(new ToolCallStartEvent { ToolCallId = "c1", ToolCallName = "tool" });
+        var callUpdate = builder.EndToolCall(new ToolCallEndEvent { ToolCallId = "c1" }, s_options);
+        builder.MarkCallYielded("c1");
+
+        Assert.IsType<FunctionCallContent>(callUpdate.Contents[0]);
+
+        var flushed = builder.AddResult("c1", new ChatResponseUpdate(ChatRole.Tool,
+            [new FunctionResultContent("c1", "done")]));
+
+        Assert.Single(flushed);
+        Assert.IsType<FunctionResultContent>(flushed[0].Contents[0]);
+        Assert.False(builder.IsBuffering);
+    }
+
+    [Fact]
+    public void MarkCallYielded_FlushAsToolCalls_DoesNotReemitTheCall()
+    {
+        var builder = new ToolCallBuilder();
+        builder.StartToolCall(new ToolCallStartEvent { ToolCallId = "c1", ToolCallName = "tool" });
+        builder.EndToolCall(new ToolCallEndEvent { ToolCallId = "c1" }, s_options);
+        builder.MarkCallYielded("c1");
+
+        Assert.Empty(builder.FlushAsToolCalls());
+        Assert.False(builder.IsBuffering);
+    }
+
+    [Fact]
+    public void FlushWithInterrupts_ReplacesHeldCallWithApproval()
+    {
+        var builder = new ToolCallBuilder();
+        builder.SetIds("thread1", "run1");
+        builder.StartToolCall(new ToolCallStartEvent { ToolCallId = "c1", ToolCallName = "delete_file" });
+        builder.EndToolCall(new ToolCallEndEvent { ToolCallId = "c1" }, s_options);
+
+        var flushed = builder.FlushWithInterrupts(InterruptForCall("int-1", "c1"));
+
+        Assert.Single(flushed);
+        var approval = Assert.IsType<ToolApprovalRequestContent>(flushed[0].Contents[0]);
+        Assert.Equal("int-1", approval.RequestId);
+        Assert.Equal("c1", approval.ToolCall.CallId);
+        Assert.False(builder.IsBuffering);
+    }
+
+    [Fact]
+    public void FlushWithInterrupts_AfterYield_EmitsApprovalWithoutDuplicatingTheCall()
+    {
+        var builder = new ToolCallBuilder();
+        builder.SetIds("thread1", "run1");
+        builder.StartToolCall(new ToolCallStartEvent { ToolCallId = "c1", ToolCallName = "delete_file" });
+        builder.EndToolCall(new ToolCallEndEvent { ToolCallId = "c1" }, s_options);
+        builder.MarkCallYielded("c1");
+
+        var flushed = builder.FlushWithInterrupts(InterruptForCall("int-1", "c1"));
+
+        Assert.Single(flushed);
+        Assert.IsType<ToolApprovalRequestContent>(flushed[0].Contents[0]);
+        Assert.DoesNotContain(flushed, u => u.Contents.OfType<FunctionCallContent>().Any());
+    }
+
+    private static RunFinishedInterruptOutcome InterruptForCall(string interruptId, string toolCallId)
+    {
+        return new RunFinishedInterruptOutcome
+        {
+            Interrupts =
+            {
+                new AGUIInterrupt
+                {
+                    Id = interruptId,
+                    Reason = InterruptReasons.ToolCall,
+                    ToolCallId = toolCallId
+                }
+            }
+        };
     }
 }

--- a/sdks/dotnet/tests/AGUI.Hosting.AspNetCore.IntegrationTests/Samples/GettingStarted/baselines/Step09_InterruptsApproval/PostRun_DeleteRequest_EmitsInterruptThenResumes#Turn_01.08.Response.Client.NET.verified.json
+++ b/sdks/dotnet/tests/AGUI.Hosting.AspNetCore.IntegrationTests/Samples/GettingStarted/baselines/Step09_InterruptsApproval/PostRun_DeleteRequest_EmitsInterruptThenResumes#Turn_01.08.Response.Client.NET.verified.json
@@ -16,6 +16,56 @@
     "role": "assistant",
     "contents": [
       {
+        "$type": "functionCall",
+        "name": "delete_file",
+        "arguments": {
+          "filename": "report-draft.txt"
+        },
+        "informationalOnly": true,
+        "callId": "call_Id_1"
+      }
+    ],
+    "responseId": "run_Id_1",
+    "messageId": "call_Id_1",
+    "rawRepresentation": {
+      "type": "TOOL_CALL_END",
+      "toolCallId": "call_Id_1",
+      "rawEvent": {
+        "authorName": null,
+        "role": "assistant",
+        "contents": [
+          {
+            "$type": "toolApprovalRequest",
+            "toolCall": {
+              "$type": "functionCall",
+              "name": "delete_file",
+              "arguments": {
+                "filename": "report-draft.txt"
+              },
+              "informationalOnly": false,
+              "callId": "call_Id_1",
+              "annotations": null,
+              "additionalProperties": null
+            },
+            "requestId": "ficc_Id_1",
+            "annotations": null,
+            "additionalProperties": null
+          }
+        ],
+        "additionalProperties": null,
+        "responseId": "",
+        "messageId": "",
+        "conversationId": null,
+        "finishReason": "tool_calls",
+        "modelId": "",
+        "continuationToken": null
+      }
+    }
+  },
+  {
+    "role": "assistant",
+    "contents": [
+      {
         "$type": "toolApprovalRequest",
         "toolCall": {
           "$type": "functionCall",
@@ -23,7 +73,7 @@
           "arguments": {
             "filename": "report-draft.txt"
           },
-          "informationalOnly": false,
+          "informationalOnly": true,
           "callId": "call_Id_1"
         },
         "requestId": "ficc_Id_1"

--- a/sdks/dotnet/tests/AGUI.Hosting.AspNetCore.IntegrationTests/Samples/GettingStarted/baselines/Step09_InterruptsApproval/PostRun_DeleteRequest_EmitsInterruptThenResumes#Turn_02.01.Request.Client.NET.verified.json
+++ b/sdks/dotnet/tests/AGUI.Hosting.AspNetCore.IntegrationTests/Samples/GettingStarted/baselines/Step09_InterruptsApproval/PostRun_DeleteRequest_EmitsInterruptThenResumes#Turn_02.01.Request.Client.NET.verified.json
@@ -19,7 +19,7 @@
           "arguments": {
             "filename": "report-draft.txt"
           },
-          "informationalOnly": false,
+          "informationalOnly": true,
           "callId": "call_Id_1"
         },
         "requestId": "ficc_Id_1"
@@ -38,7 +38,7 @@
           "arguments": {
             "filename": "report-draft.txt"
           },
-          "informationalOnly": false,
+          "informationalOnly": true,
           "callId": "call_Id_1"
         },
         "requestId": "ficc_Id_1"


### PR DESCRIPTION
## Summary

`AGUI.Client` buffered `FunctionCallContent` until every pending `TOOL_CALL_RESULT` arrived. A long-running backend tool therefore produced no `IChatClient` update after `TOOL_CALL_END`, and a slow sibling hid unrelated calls and results.

This change:

- Yields the completed `FunctionCallContent` as soon as `TOOL_CALL_END` has the name and arguments.
- Flushes each `FunctionResultContent` by `toolCallId` instead of waiting for the rest of the batch.
- Still emits `ToolApprovalRequestContent` on `RUN_FINISHED` with a tool-call interrupt, so HITL approval is unchanged aside from the call becoming visible first (the in-progress window the UI needs).

Fixes #2577.

## Test plan

From `sdks/dotnet`:

- [x] `dotnet build src/AGUI.Client/AGUI.Client.csproj -c Release` (net10.0, net9.0, net8.0, netstandard2.0, net472)
- [x] `dotnet test tests/AGUI.Client.UnitTests -c Release -p:SignAssembly=false -f net10.0`
- [x] `dotnet test tests/AGUI.Hosting.AspNetCore.IntegrationTests -c Release -p:SignAssembly=false -f net10.0 --filter "FullyQualifiedName~Step09|FullyQualifiedName~Step04|FullyQualifiedName~Step02_Backend|FullyQualifiedName~Step03_Frontend|FullyQualifiedName~Step12_Parallel|FullyQualifiedName~ToolCallIntegration|FullyQualifiedName~ClientTool|FullyQualifiedName~MixedTool"`

The Step09 Client.NET baselines now include the `TOOL_CALL_END` `FunctionCallContent` update before the approval request. Resume still goes through `ToolApprovalRequestContent` / `ToolApprovalResponseContent`.