### PR TITLE
fix(client): validate protobuf events with EventSchemas

### DIFF
--- a/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
+++ b/sdks/typescript/packages/client/src/transform/__tests__/proto.test.ts
@@ -470,4 +470,35 @@ describe("parseProtoStream", () => {
     // Complete the stream
     chunk$.complete();
   });
+
+  it("rejects protobuf-decoded events that fail EventSchemas.parse", async () => {
+    const decodeSpy = vi.spyOn(proto, "decode").mockReturnValue({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 12345,
+    } as never);
+
+    const chunk$ = new Subject<HttpEvent>();
+    const event$ = transformHttpEventStream(chunk$);
+    const errorPromise = firstValueFrom(event$).catch((err) => err);
+
+    const headers = new Headers();
+    headers.append("Content-Type", proto.AGUI_MEDIA_TYPE);
+    chunk$.next({
+      type: HttpEventType.HEADERS,
+      status: 200,
+      headers,
+    });
+
+    // Length-prefixed dummy payload so processBuffer calls decode.
+    chunk$.next({
+      type: HttpEventType.DATA,
+      data: new Uint8Array([0, 0, 0, 1, 0]),
+    });
+
+    const err = await errorPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect(String((err as Error).message)).toMatch(/invalid_type|Expected string|messageId/i);
+    decodeSpy.mockRestore();
+    chunk$.complete();
+  });
 });

--- a/sdks/typescript/packages/client/src/transform/proto.ts
+++ b/sdks/typescript/packages/client/src/transform/proto.ts
@@ -1,6 +1,6 @@
 import { Observable, Subject } from "rxjs";
 import { HttpEvent, HttpEventType } from "../run/http-request";
-import { BaseEvent } from "@ag-ui/core";
+import { BaseEvent, EventSchemas } from "@ag-ui/core";
 import * as proto from "@ag-ui/proto";
 
 /**
@@ -64,11 +64,10 @@ export const parseProtoStream = (source$: Observable<HttpEvent>): Observable<Bas
         // Extract the message (skipping the 4-byte header)
         const message = buffer.slice(4, totalLength);
 
-        // Decode the protocol buffer message using the imported decode function
-        const event = proto.decode(message);
+        // Decode, then apply the same EventSchemas contract as the SSE path.
+        const event = EventSchemas.parse(proto.decode(message));
 
-        // Emit the parsed event
-        eventSubject.next(event);
+        eventSubject.next(event as BaseEvent);
 
         // Remove the processed message from the buffer
         buffer = buffer.slice(totalLength);


### PR DESCRIPTION
## Summary
- The SSE HTTP parser already runs `EventSchemas.parse` before events reach the run reducer. The protobuf path emitted `proto.decode()` output unchanged, so a schema-invalid field (for example a numeric `messageId`) was accepted on one transport and rejected on the other.
- Validate decoded protobuf events with the same schema. Invalid events now fail the stream instead of corrupting reducer state.

Fixes #2524

## Test plan
- [x] `pnpm --dir sdks/typescript/packages/client exec vitest run src/transform/__tests__/proto.test.ts` (7 passing, including a decode mock with `messageId: 12345`)