### PR TITLE
fix(aws-strands): make the two bridges emit the same events for the same run

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/a2ui_tool.py
@@ -52,6 +52,8 @@ from ag_ui_a2ui_toolkit import (
     wrap_error_envelope,
 )
 
+from .utils import dumps_wire
+
 # Re-export the toolkit constants/types for callers that import them from this
 # package — keeps the public surface aligned with the LangGraph adapter so
 # consumers can type their params bag without depending on the toolkit directly.
@@ -188,7 +190,7 @@ def _tool_result_text(content: Any) -> str:
         if isinstance(block.get("text"), str):
             parts.append(block["text"])
         elif "json" in block:
-            parts.append(json.dumps(block["json"]))
+            parts.append(dumps_wire(block["json"]))
     return "".join(parts)
 
 

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1024,6 +1024,7 @@ from .utils import (
     UrlFetchPolicy,
     _FetchBudget,
     convert_agui_content_to_strands,
+    dumps_wire,
     flatten_content_to_text,
 )
 
@@ -1280,7 +1281,7 @@ def _serialize_tool_result_data(result_data: Any) -> str:
             f"Object of type {type(value).__name__} is not JSON serializable"
         )
 
-    return json.dumps(result_data, default=encode_bytes)
+    return dumps_wire(result_data, default=encode_bytes)
 
 
 async def _forward_inner_agent_events(
@@ -1317,7 +1318,7 @@ async def _forward_inner_agent_events(
         raw_str = (
             raw_input
             if isinstance(raw_input, str)
-            else json.dumps(raw_input, default=str)
+            else dumps_wire(raw_input, default=str)
         )
         entry = inner_tool_calls_seen.get(call_id)
         if entry is None:
@@ -1397,7 +1398,7 @@ async def _forward_inner_agent_events(
                 type=EventType.TOOL_CALL_RESULT,
                 tool_call_id=call_id,
                 message_id=str(uuid.uuid4()),
-                content=json.dumps(result_data, default=str),
+                content=dumps_wire(result_data, default=str),
                 # role intentionally omitted — same as the parent-level result
                 # path, so the frontend closes the spinner without writing the
                 # inner call into conversation history.
@@ -2964,7 +2965,7 @@ class StrandsAgent:
               for closing in _close_open_multiagent(nodes, open_steps):
                   yield closing
 
-              outcome = None
+              outcome = RunFinishedSuccessOutcome(type="success")
               if native_interrupts:
                   ag_ui_interrupts = [
                       _strands_interrupt_to_agui(interrupt)
@@ -4164,6 +4165,17 @@ class StrandsAgent:
             # client dispatching its follow-up run before the backend results
             # reach it, narrowing the ConcurrencyException race window.
             deferred_frontend_tool_ends = []
+            # Set when a deferred end's tool call was appended to
+            # ``snapshot_messages``, so the flush closes the batch with one
+            # MESSAGES_SNAPSHOT after the last end it emitted. One is enough:
+            # the append is eager, so that snapshot is the full state every
+            # deferred call in the batch would otherwise have re-sent
+            # byte-identically. The append stays eager on purpose (a run that
+            # dies before the flush must not lose the assistant message), which
+            # is also why the deferral cannot keep a frontend call out of
+            # earlier snapshots: in a mixed turn the backend result's snapshot
+            # already carries it before its end goes out.
+            deferred_frontend_snapshot_owed = False
             # Native ``toolUseId``s whose ``toolResult`` was processed this
             # run. Drained after each result batch to prune the persisted
             # tool-call meta map.
@@ -5114,6 +5126,12 @@ class StrandsAgent:
                                     tool_call_id=_fe_tool_use_id,
                                 )
                             deferred_frontend_tool_ends = []
+                            if deferred_frontend_snapshot_owed:
+                                deferred_frontend_snapshot_owed = False
+                                yield MessagesSnapshotEvent(
+                                    type=EventType.MESSAGES_SNAPSHOT,
+                                    messages=list(snapshot_messages),
+                                )
 
                         # The batch is fully emitted; stop before Strands runs
                         # another model cycle. Breaking HERE rather than relying
@@ -5223,7 +5241,7 @@ class StrandsAgent:
                         raw_str = (
                             tool_input_raw
                             if isinstance(tool_input_raw, str)
-                            else json.dumps(tool_input_raw, default=str)
+                            else dumps_wire(tool_input_raw, default=str)
                         )
 
                         # Try to parse as JSON if it looks complete
@@ -5238,7 +5256,7 @@ class StrandsAgent:
                             tool_input = tool_input_raw
 
                         args_str = (
-                            json.dumps(tool_input)
+                            dumps_wire(tool_input)
                             if isinstance(tool_input, dict)
                             else str(tool_input)
                         )
@@ -5509,9 +5527,10 @@ class StrandsAgent:
                                     # flushed after this turn's backend results (see
                                     # the pending_halt handler). Backend tools and
                                     # continue_after_frontend_call tools emit now.
-                                    if is_frontend_tool and not (
+                                    defer_end = is_frontend_tool and not (
                                         behavior and behavior.continue_after_frontend_call
-                                    ):
+                                    )
+                                    if defer_end:
                                         deferred_frontend_tool_ends.append(tool_use_id)
                                     else:
                                         yield ToolCallEndEvent(
@@ -5537,10 +5556,15 @@ class StrandsAgent:
                                                 ],
                                             )
                                         )
-                                        yield MessagesSnapshotEvent(
-                                            type=EventType.MESSAGES_SNAPSHOT,
-                                            messages=list(snapshot_messages),
-                                        )
+                                        # Eager append, deferred event: see the
+                                        # deferral bookkeeping declared above.
+                                        if defer_end:
+                                            deferred_frontend_snapshot_owed = True
+                                        else:
+                                            yield MessagesSnapshotEvent(
+                                                type=EventType.MESSAGES_SNAPSHOT,
+                                                messages=list(snapshot_messages),
+                                            )
                                         # Rotate so the next assistant message
                                         # in the snapshot (text or another
                                         # tool call) carries a distinct id —
@@ -5771,6 +5795,12 @@ class StrandsAgent:
                             tool_call_id=_fe_tool_use_id,
                         )
                     deferred_frontend_tool_ends = []
+                    if deferred_frontend_snapshot_owed:
+                        deferred_frontend_snapshot_owed = False
+                        yield MessagesSnapshotEvent(
+                            type=EventType.MESSAGES_SNAPSHOT,
+                            messages=list(snapshot_messages),
+                        )
             except Exception:
                 if force_stop_error is None:
                     raise

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import http.client
 import ipaddress
+import json
 import logging
 import re
 import socket
@@ -35,6 +36,22 @@ InvocationStateProvider: TypeAlias = Callable[
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def dumps_wire(value: Any, **kwargs: Any) -> str:
+    """Serialize the way the TypeScript adapter's ``JSON.stringify`` does.
+
+    Both adapters re-serialize tool arguments and tool results before putting
+    them on the wire, so ``json.dumps`` defaults would make identical values
+    differ byte-for-byte across the two bridges: it pads its separators, and it
+    escapes non-ASCII that ``JSON.stringify`` emits verbatim.
+
+    One divergence is deliberately left in place: Python renders a float
+    ``1.0`` as ``1.0`` where JavaScript renders it as ``1``. Python has a float
+    type JavaScript lacks, and collapsing it would misreport the value's type.
+    """
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False, **kwargs)
+
 
 # Allowed formats per media type for Strands ContentBlock
 _IMAGE_FORMATS: Set[str] = {"png", "jpeg", "gif", "webp"}

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -39,16 +39,15 @@ logger = logging.getLogger(__name__)
 
 
 def dumps_wire(value: Any, **kwargs: Any) -> str:
-    """Serialize the way the TypeScript adapter's ``JSON.stringify`` does.
+    """Serialize compact JSON with JavaScript-style separators and Unicode.
 
     Both adapters re-serialize tool arguments and tool results before putting
-    them on the wire, so ``json.dumps`` defaults would make identical values
-    differ byte-for-byte across the two bridges: it pads its separators, and it
-    escapes non-ASCII that ``JSON.stringify`` emits verbatim.
+    them on the wire. Python's default encoder pads separators and escapes
+    non-ASCII; those two representations are normalized here.
 
-    One divergence is deliberately left in place: Python renders a float
-    ``1.0`` as ``1.0`` where JavaScript renders it as ``1``. Python has a float
-    type JavaScript lacks, and collapsing it would misreport the value's type.
+    Number formatting remains Python-native and can differ from
+    ``JSON.stringify``, including ``1.0`` vs ``1``, ``-0.0`` vs ``0``, and
+    fixed-versus-exponent notation.
     """
     return json.dumps(value, separators=(",", ":"), ensure_ascii=False, **kwargs)
 

--- a/integrations/aws-strands/python/tests/json_wire_fixture.py
+++ b/integrations/aws-strands/python/tests/json_wire_fixture.py
@@ -1,0 +1,22 @@
+"""The canonical value the wire-serialization tests round through the bridge.
+
+One fixture carries every axis on which Python's ``json.dumps`` and the
+TypeScript adapter's ``JSON.stringify`` can diverge: nesting, a non-ASCII
+letter, an astral character, a forward slash and a control character.
+"""
+
+from __future__ import annotations
+
+import json
+
+PARITY_VALUE = {
+    "note": "café 😀 a/b \u0007",
+    "nested": {"items": [1, "é"]},
+}
+
+# What JSON.stringify(PARITY_VALUE) produces, character for character.
+PARITY_JSON = '{"note":"café 😀 a/b \\u0007","nested":{"items":[1,"é"]}}'
+
+# The padded, ASCII-escaped form a bare json.dumps produces. Used as input
+# wherever a test needs a string the site under test has to re-serialize.
+PARITY_JSON_PYTHON_DEFAULT = json.dumps(PARITY_VALUE)

--- a/integrations/aws-strands/python/tests/json_wire_fixture.py
+++ b/integrations/aws-strands/python/tests/json_wire_fixture.py
@@ -1,8 +1,8 @@
-"""The canonical value the wire-serialization tests round through the bridge.
+"""Canonical fixture for wire serialization normalized by ``dumps_wire``.
 
-One fixture carries every axis on which Python's ``json.dumps`` and the
-TypeScript adapter's ``JSON.stringify`` can diverge: nesting, a non-ASCII
-letter, an astral character, a forward slash and a control character.
+It covers nesting, non-ASCII and astral characters, forward slashes, and
+control characters. Numeric formatting is intentionally excluded because it
+remains Python-native.
 """
 
 from __future__ import annotations

--- a/integrations/aws-strands/python/tests/test_interrupt.py
+++ b/integrations/aws-strands/python/tests/test_interrupt.py
@@ -1632,7 +1632,7 @@ async def test_native_interrupt_resumes_live_without_session_and_restores_callba
     saved_meta = live_core.state.get(AG_UI_TOOL_CALL_MAP_STATE_KEY)
     assert saved_meta["native-confirm"] == {
         "name": "confirm_action",
-        "args": '{"key": "widget-1"}',
+        "args": '{"key":"widget-1"}',
         "input": {"key": "widget-1"},
         "strands_tool_id": "native-confirm",
     }
@@ -1658,7 +1658,7 @@ async def test_native_interrupt_resumes_live_without_session_and_restores_callba
         assert ctx.tool_name == "confirm_action"
         assert ctx.tool_use_id == "native-confirm"
         assert ctx.tool_input == {"key": "widget-1"}
-        assert ctx.args_str == '{"key": "widget-1"}'
+        assert ctx.args_str == '{"key":"widget-1"}'
     assert [
         event.value
         for event in resumed_events

--- a/integrations/aws-strands/python/tests/test_json_wire_parity.py
+++ b/integrations/aws-strands/python/tests/test_json_wire_parity.py
@@ -1,11 +1,8 @@
-"""Every place the bridge re-serializes JSON onto the wire matches the
-TypeScript adapter's ``JSON.stringify``.
+"""Verify compact, Unicode-preserving output at every JSON wire site.
 
-Both adapters re-serialize tool arguments and tool results rather than
-forwarding what the model emitted, so a Python default that ``JSON.stringify``
-does not share shows up as a byte difference between the two bridges for the
-same value. Each test below drives one such call site with the same fixture and
-pins the exact string.
+The fixture covers separator and string-escaping behavior shared with the
+TypeScript adapter's ``JSON.stringify``. Numeric spelling remains Python-native
+and is outside this parity fixture.
 """
 
 from __future__ import annotations
@@ -30,7 +27,7 @@ from tests.json_wire_fixture import (
 )
 
 
-def test_the_fixture_covers_the_axes_that_can_diverge():
+def test_the_fixture_covers_the_normalized_axes():
     assert PARITY_JSON != PARITY_JSON_PYTHON_DEFAULT
     assert json.loads(PARITY_JSON) == PARITY_VALUE
 

--- a/integrations/aws-strands/python/tests/test_json_wire_parity.py
+++ b/integrations/aws-strands/python/tests/test_json_wire_parity.py
@@ -1,0 +1,191 @@
+"""Every place the bridge re-serializes JSON onto the wire matches the
+TypeScript adapter's ``JSON.stringify``.
+
+Both adapters re-serialize tool arguments and tool results rather than
+forwarding what the model emitted, so a Python default that ``JSON.stringify``
+does not share shows up as a byte difference between the two bridges for the
+same value. Each test below drives one such call site with the same fixture and
+pins the exact string.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import EventType, RunAgentInput, Tool, UserMessage
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.a2ui_tool import _tool_result_text
+from ag_ui_strands.agent import (
+    StrandsAgent,
+    _forward_inner_agent_events,
+    _serialize_tool_result_data,
+)
+from tests.json_wire_fixture import (
+    PARITY_JSON,
+    PARITY_JSON_PYTHON_DEFAULT,
+    PARITY_VALUE,
+)
+
+
+def test_the_fixture_covers_the_axes_that_can_diverge():
+    assert PARITY_JSON != PARITY_JSON_PYTHON_DEFAULT
+    assert json.loads(PARITY_JSON) == PARITY_VALUE
+
+
+# ---------------------------------------------------------------------------
+# Sites reachable as plain functions
+# ---------------------------------------------------------------------------
+
+
+def test_a2ui_detection_text_from_a_json_result_block():
+    assert _tool_result_text([{"json": PARITY_VALUE}]) == PARITY_JSON
+
+
+def test_backend_tool_result_content():
+    assert _serialize_tool_result_data(PARITY_VALUE) == PARITY_JSON
+
+
+async def _forwarded(inner_event, seen) -> list:
+    return [
+        event
+        async for event in _forward_inner_agent_events(
+            inner_event, {"toolUseId": "parent-1"}, seen
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_tool_call_arguments():
+    events = await _forwarded(
+        {
+            "current_tool_use": {
+                "toolUseId": "inner-1",
+                "name": "lookup",
+                "input": PARITY_VALUE,
+            }
+        },
+        {},
+    )
+
+    args = [e for e in events if e.type == EventType.TOOL_CALL_ARGS]
+    assert [e.delta for e in args] == [PARITY_JSON]
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_tool_result_content():
+    seen: dict = {}
+    await _forwarded(
+        {
+            "current_tool_use": {
+                "toolUseId": "inner-1",
+                "name": "lookup",
+                "input": "{}",
+            }
+        },
+        seen,
+    )
+
+    events = await _forwarded(
+        {
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "inner-1",
+                            "content": [{"text": PARITY_JSON_PYTHON_DEFAULT}],
+                        }
+                    }
+                ],
+            }
+        },
+        seen,
+    )
+
+    results = [e for e in events if e.type == EventType.TOOL_CALL_RESULT]
+    assert [e.content for e in results] == [PARITY_JSON]
+
+
+# ---------------------------------------------------------------------------
+# Sites inside the run loop, driven through a scripted Strands stream
+# ---------------------------------------------------------------------------
+
+
+def _template_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+async def _run_with_tool_input(thread_id: str, tool_input) -> list:
+    """Stream one frontend tool call whose ``input`` is *tool_input*."""
+    adapter = StrandsAgent(_template_agent(), name="wire-parity")
+
+    core = MagicMock()
+    core.tool_registry = ToolRegistry()
+    stream = [
+        {
+            "current_tool_use": {
+                "name": "render",
+                "toolUseId": "st-1",
+                "input": tool_input,
+            }
+        },
+        {"event": {"contentBlockStop": {}}},
+    ]
+
+    async def _stream(_message: str):
+        for event in stream:
+            yield event
+
+    core.stream_async = _stream
+    adapter._agents_by_thread[thread_id] = core
+
+    input_data = RunAgentInput(
+        thread_id=thread_id,
+        run_id="r-1",
+        state={},
+        messages=[UserMessage(id="u1", role="user", content="render")],
+        tools=[Tool(name="render", description="render", parameters={})],
+        context=[],
+        forwarded_props={},
+    )
+    return [event async for event in adapter.run(input_data)]
+
+
+@pytest.mark.asyncio
+async def test_streamed_tool_call_argument_deltas():
+    """A provider that hands the adapter a dict rather than a JSON string.
+
+    The delta stream is what the frontend incrementally parses for
+    predict_state, so it is serialized on the same terms as everything else.
+    """
+    events = await _run_with_tool_input("wire-parity-deltas", PARITY_VALUE)
+
+    deltas = [
+        event.delta for event in events if event.type == EventType.TOOL_CALL_ARGS
+    ]
+    assert "".join(deltas) == PARITY_JSON
+
+
+@pytest.mark.asyncio
+async def test_tool_call_arguments_in_the_messages_snapshot():
+    """The snapshot re-serializes the parsed input rather than forwarding it."""
+    events = await _run_with_tool_input(
+        "wire-parity-snapshot", PARITY_JSON_PYTHON_DEFAULT
+    )
+
+    arguments = [
+        call.function.arguments
+        for event in events
+        if event.type == EventType.MESSAGES_SNAPSHOT
+        for message in event.messages
+        for call in (getattr(message, "tool_calls", None) or [])
+    ]
+    assert arguments and set(arguments) == {PARITY_JSON}

--- a/integrations/aws-strands/python/tests/test_messages_snapshot.py
+++ b/integrations/aws-strands/python/tests/test_messages_snapshot.py
@@ -1,0 +1,430 @@
+"""Where a tool call's MESSAGES_SNAPSHOT sits on the wire.
+
+A tool call's snapshot follows its own TOOL_CALL_END. On the backend path the
+two go out together, one snapshot per call. On the frontend path the end is
+deferred until this turn's backend results have been emitted, and the deferred
+batch is closed by a SINGLE snapshot after the last flushed end: the append
+into the running snapshot is eager, so one full-state snapshot carries exactly
+what a per-call snapshot would have repeated byte for byte.
+
+That eagerness is also what the deferral does not buy. In a mixed
+frontend-plus-backend turn the backend result's snapshot already carries the
+frontend tool call before that call's deferred end goes out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import (
+    AssistantMessage,
+    EventType,
+    FunctionCall,
+    MessagesSnapshotEvent,
+    RunAgentInput,
+    Tool,
+    ToolCall,
+    ToolCallEndEvent,
+    UserMessage,
+)
+from strands import Agent
+from strands.models.model import Model
+from strands.tools.registry import ToolRegistry
+
+from ag_ui_strands.agent import StrandsAgent
+
+_TOOL_ARGS = '{"cell": "B4"}'
+
+
+# ---------------------------------------------------------------------------
+# The ordering claim, as a predicate over events
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_lists_call(snapshot, tool_call_id: str) -> bool:
+    return any(
+        call.id == tool_call_id
+        for message in snapshot.messages
+        for call in (getattr(message, "tool_calls", None) or [])
+    )
+
+
+def snapshot_follows_every_tool_call_end(events: list) -> bool:
+    """Does every TOOL_CALL_END have a later snapshot that lists its call?
+
+    Written as a predicate over a list rather than as an assertion helper:
+    positional pairing would accept one call's snapshot standing in for
+    another's, and a helper that only looks forward from an end can never be
+    shown to reject anything. The counterexamples below construct inputs it
+    has to return False for.
+    """
+    for index, event in enumerate(events):
+        if event.type != EventType.TOOL_CALL_END:
+            continue
+        if not any(
+            later.type == EventType.MESSAGES_SNAPSHOT
+            and _snapshot_lists_call(later, event.tool_call_id)
+            for later in events[index + 1 :]
+        ):
+            return False
+    return True
+
+
+def _end(tool_call_id: str) -> ToolCallEndEvent:
+    return ToolCallEndEvent(
+        type=EventType.TOOL_CALL_END, tool_call_id=tool_call_id
+    )
+
+
+def _snapshot(*tool_call_ids: str) -> MessagesSnapshotEvent:
+    return MessagesSnapshotEvent(
+        type=EventType.MESSAGES_SNAPSHOT,
+        messages=[
+            AssistantMessage(
+                id=f"a-{tool_call_id}",
+                role="assistant",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id=tool_call_id,
+                        type="function",
+                        function=FunctionCall(name="t", arguments="{}"),
+                    )
+                ],
+            )
+            for tool_call_id in tool_call_ids
+        ],
+    )
+
+
+def test_ordering_holds_when_the_snapshot_follows_the_end():
+    assert snapshot_follows_every_tool_call_end([_end("a"), _snapshot("a")])
+
+
+def test_ordering_holds_when_one_batch_snapshot_closes_several_ends():
+    assert snapshot_follows_every_tool_call_end(
+        [_end("a"), _end("b"), _snapshot("a", "b")]
+    )
+
+
+def test_ordering_is_violated_when_the_snapshot_precedes_the_end():
+    assert not snapshot_follows_every_tool_call_end([_snapshot("a"), _end("a")])
+
+
+def test_ordering_is_violated_when_the_later_snapshot_omits_the_call():
+    assert not snapshot_follows_every_tool_call_end([_end("a"), _snapshot("b")])
+
+
+# ---------------------------------------------------------------------------
+# Driving the adapter
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedToolUse(Model):
+    """Turn 1 emits the scripted tool-use blocks; later turns narrate and stop."""
+
+    def __init__(self, blocks: list[tuple[str, str, str]]) -> None:
+        self.blocks = blocks
+        self.calls = 0
+
+    def get_config(self):
+        return {}
+
+    def update_config(self, **kwargs):
+        pass
+
+    async def structured_output(self, output_model, prompt=None, **kwargs):  # pragma: no cover
+        if False:
+            yield {}
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        self.calls += 1
+        yield {"messageStart": {"role": "assistant"}}
+        if self.calls == 1:
+            for tool_use_id, name, args in self.blocks:
+                yield {
+                    "contentBlockStart": {
+                        "start": {"toolUse": {"toolUseId": tool_use_id, "name": name}}
+                    }
+                }
+                yield {"contentBlockDelta": {"delta": {"toolUse": {"input": args}}}}
+                yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockDelta": {"delta": {"text": "Done."}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+def _cell_tool(name: str) -> Tool:
+    return Tool(
+        name=name,
+        description="Read a cell",
+        parameters={
+            "type": "object",
+            "properties": {"cell": {"type": "string"}},
+            "required": ["cell"],
+        },
+    )
+
+
+def _server_tool(name: str):
+    from strands.tools.decorator import tool
+
+    @tool(name=name)
+    def _run_on_server(cell: str) -> dict:
+        """Read a cell."""
+        return {"cell": cell, "value": 7}
+
+    return _run_on_server
+
+
+async def _run(
+    thread_id: str,
+    *,
+    blocks: list[tuple[str, str, str]],
+    server_tool_names: tuple[str, ...],
+    client_tool_names: tuple[str, ...],
+) -> list:
+    """Drive one turn of the scripted model through the adapter."""
+    core = Agent(
+        model=_ScriptedToolUse(blocks),
+        tools=[_server_tool(name) for name in server_tool_names],
+    )
+    adapter = StrandsAgent(core, name="snapshot-order")
+    input_data = RunAgentInput(
+        thread_id=thread_id,
+        run_id="r-1",
+        state={},
+        messages=[UserMessage(id="u1", role="user", content="read B4")],
+        tools=[_cell_tool(name) for name in client_tool_names],
+        context=[],
+        forwarded_props={},
+    )
+
+    async def drive():
+        return [event async for event in adapter.run(input_data)]
+
+    return await asyncio.wait_for(drive(), timeout=30)
+
+
+async def _run_one_call(thread_id: str, *, frontend: bool) -> list:
+    """One ``get_cell`` call, executing on the client or on the server."""
+    return await _run(
+        thread_id,
+        blocks=[("native-1", "get_cell", _TOOL_ARGS)],
+        server_tool_names=() if frontend else ("get_cell",),
+        client_tool_names=("get_cell",) if frontend else (),
+    )
+
+
+def _index_of_end(events: list, tool_call_id: str) -> int:
+    for index, event in enumerate(events):
+        if (
+            event.type == EventType.TOOL_CALL_END
+            and event.tool_call_id == tool_call_id
+        ):
+            return index
+    raise AssertionError(f"no TOOL_CALL_END for {tool_call_id}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("frontend", [False, True], ids=["backend", "frontend"])
+async def test_tool_call_snapshot_follows_its_tool_call_end(frontend: bool):
+    events = await _run_one_call(f"snapshot-order-{frontend}", frontend=frontend)
+
+    assert snapshot_follows_every_tool_call_end(events)
+
+
+@pytest.mark.asyncio
+async def test_one_snapshot_closes_the_whole_deferred_batch():
+    """Two frontend calls in one turn: both ends, then one snapshot for both."""
+    events = await _run(
+        "snapshot-two-frontend",
+        blocks=[
+            ("native-1", "pick_a", '{"cell": "A1"}'),
+            ("native-2", "pick_b", '{"cell": "B2"}'),
+        ],
+        server_tool_names=(),
+        client_tool_names=("pick_a", "pick_b"),
+    )
+
+    assert snapshot_follows_every_tool_call_end(events)
+
+    # Both ends are deferred to the end of the turn, after both starts.
+    starts = [
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_START
+    ]
+    first_end = _index_of_end(events, "native-1")
+    last_end = _index_of_end(events, "native-2")
+    assert max(starts) < first_end
+
+    # One snapshot for the batch, not one per deferred call: nothing between
+    # the two ends, one after the last of them.
+    trailing = [
+        (index, event)
+        for index, event in enumerate(events)
+        if index > first_end and event.type == EventType.MESSAGES_SNAPSHOT
+    ]
+    assert len(trailing) == 1
+    index, snapshot = trailing[0]
+    assert index > last_end
+    assert _snapshot_lists_call(snapshot, "native-1")
+    assert _snapshot_lists_call(snapshot, "native-2")
+
+
+@pytest.mark.asyncio
+async def test_no_two_snapshots_in_a_turn_are_byte_identical():
+    events = await _run(
+        "snapshot-no-duplicates",
+        blocks=[
+            ("native-1", "pick_a", '{"cell": "A1"}'),
+            ("native-2", "pick_b", '{"cell": "B2"}'),
+        ],
+        server_tool_names=(),
+        client_tool_names=("pick_a", "pick_b"),
+    )
+
+    payloads = [
+        event.model_dump_json()
+        for event in events
+        if event.type == EventType.MESSAGES_SNAPSHOT
+    ]
+    assert len(payloads) == len(set(payloads)), "duplicate MESSAGES_SNAPSHOT payloads"
+
+
+@pytest.mark.asyncio
+async def test_mixed_turn_defers_the_frontend_end_past_the_backend_result():
+    """The deferral holds in a mixed turn, and what it does not buy.
+
+    The frontend end still lands after the backend TOOL_CALL_RESULT. What it
+    does not get is exclusivity: the append into history is eager, so the
+    backend result's snapshot already carries the frontend tool call before
+    that call's end goes out.
+    """
+    events = await _run(
+        "snapshot-mixed",
+        blocks=[
+            ("native-1", "read_cell", '{"cell": "A1"}'),
+            ("native-2", "pick_b", '{"cell": "B2"}'),
+        ],
+        server_tool_names=("read_cell",),
+        client_tool_names=("pick_b",),
+    )
+
+    result_index = next(
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_RESULT
+        and event.tool_call_id == "native-1"
+    )
+    frontend_end_index = _index_of_end(events, "native-2")
+    assert result_index < frontend_end_index
+    assert snapshot_follows_every_tool_call_end(events)
+
+    # The eager append: a snapshot between the backend result and the deferred
+    # end already lists the frontend call.
+    early = [
+        event
+        for index, event in enumerate(events)
+        if result_index < index < frontend_end_index
+        and event.type == EventType.MESSAGES_SNAPSHOT
+        and _snapshot_lists_call(event, "native-2")
+    ]
+    assert early, "expected the backend result's snapshot to carry the frontend call"
+
+
+# ---------------------------------------------------------------------------
+# The safety flush: a stream that ends with no backend tool-result message
+# ---------------------------------------------------------------------------
+
+
+def _mock_core_agent() -> MagicMock:
+    mock = MagicMock()
+    mock.model = MagicMock()
+    mock.system_prompt = "You are helpful"
+    mock.tool_registry.registry = {}
+    mock.record_direct_tool_call = True
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_deferred_batch_is_flushed_when_no_tool_result_message_arrives():
+    """A frontend-only turn whose stream stops after the tool-use blocks.
+
+    Strands normally follows a tool batch with a user-role message carrying the
+    results, and the per-batch flush rides on that message. When the stream
+    simply ends instead, the buffered ends and the snapshot they owe are
+    flushed on the way out rather than lost.
+    """
+    thread_id = "snapshot-safety-flush"
+    adapter = StrandsAgent(_mock_core_agent(), name="safety-flush")
+
+    core = MagicMock()
+    core.tool_registry = ToolRegistry()
+    stream = [
+        {"current_tool_use": {"name": "pick_a", "toolUseId": "st-a", "input": {}}},
+        {"current_tool_use": {"name": "pick_b", "toolUseId": "st-b", "input": {}}},
+        {"event": {"contentBlockStop": {}}},
+        {"event": {"contentBlockStop": {}}},
+    ]
+
+    async def _stream(_message: str):
+        for event in stream:
+            yield event
+
+    core.stream_async = _stream
+    adapter._agents_by_thread[thread_id] = core
+
+    input_data = RunAgentInput(
+        thread_id=thread_id,
+        run_id="r-1",
+        state={},
+        messages=[UserMessage(id="u1", role="user", content="pick")],
+        tools=[
+            Tool(name="pick_a", description="a", parameters={}),
+            Tool(name="pick_b", description="b", parameters={}),
+        ],
+        context=[],
+        forwarded_props={},
+    )
+    events = [event async for event in adapter.run(input_data)]
+
+    assert not any(
+        event.type == EventType.TOOL_CALL_RESULT for event in events
+    ), "this scenario must not produce a tool-result message"
+
+    starts = {
+        event.tool_call_id
+        for event in events
+        if event.type == EventType.TOOL_CALL_START
+    }
+    ends = {
+        event.tool_call_id
+        for event in events
+        if event.type == EventType.TOOL_CALL_END
+    }
+    assert starts == ends and len(ends) == 2
+    assert snapshot_follows_every_tool_call_end(events)
+
+    first_end = min(
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_END
+    )
+    last_end = max(
+        index
+        for index, event in enumerate(events)
+        if event.type == EventType.TOOL_CALL_END
+    )
+    trailing = [
+        index
+        for index, event in enumerate(events)
+        if index > first_end and event.type == EventType.MESSAGES_SNAPSHOT
+    ]
+    assert trailing == [index for index in trailing if index > last_end]
+    assert len(trailing) == 1

--- a/integrations/aws-strands/python/tests/test_multiagent_orchestrator.py
+++ b/integrations/aws-strands/python/tests/test_multiagent_orchestrator.py
@@ -756,6 +756,25 @@ async def test_incoming_state_is_snapshotted_without_messages():
 
 
 @pytest.mark.asyncio
+async def test_successful_run_reports_the_success_outcome():
+    # Parity with the single-agent path: a client reading RUN_FINISHED.outcome
+    # must see success, not an absent outcome.
+    orchestrator = FakeOrchestrator(
+        [
+            {"type": "multiagent_node_start", "node_id": "a", "node_type": "agent"},
+            node_stream("a", {"data": "hi"}),
+            {"type": "multiagent_node_stop", "node_id": "a"},
+        ]
+    )
+    events = await collect(make_agent(orchestrator))
+    finished = events[-1]
+
+    assert finished.type == EventType.RUN_FINISHED
+    assert finished.outcome is not None
+    assert finished.outcome.type == "success"
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_failure_becomes_run_error():
     orchestrator = FakeOrchestrator([], raises=RuntimeError("graph exploded"))
     events = await collect(make_agent(orchestrator))
@@ -1326,7 +1345,7 @@ async def test_a_completed_run_clears_the_pending_interrupt():
     resume_input.resume = [_ResumeEntry()]
     events = await collect(agent, resume_input)
 
-    assert events[-1].outcome is None
+    assert events[-1].outcome.type == "success"
     assert not agent._pending_interrupts_by_thread.get("test-thread")
 
 

--- a/integrations/aws-strands/python/tests/test_non_text_tool_results.py
+++ b/integrations/aws-strands/python/tests/test_non_text_tool_results.py
@@ -168,8 +168,8 @@ async def test_text_results_keep_the_existing_last_text_block_semantics():
     assert json.loads(content) == "second"
 
 
-async def test_a_json_result_reaches_the_wire_as_json_stringify_would_write_it():
-    """The TypeScript adapter re-serializes with ``JSON.stringify``; the
-    Python defaults would make the same value differ byte-for-byte."""
+async def test_a_json_result_reaches_the_wire_compact_and_unicode_preserving():
+    """A JSON result block is re-serialized through ``dumps_wire``, so the
+    padded separators and ASCII escapes of the Python defaults are gone."""
     content = await _tool_result_content([{"json": PARITY_VALUE}])
     assert content == PARITY_JSON

--- a/integrations/aws-strands/python/tests/test_non_text_tool_results.py
+++ b/integrations/aws-strands/python/tests/test_non_text_tool_results.py
@@ -12,6 +12,7 @@ from strands.tools.registry import ToolRegistry
 
 from ag_ui_strands.agent import StrandsAgent
 from ag_ui_strands.config import StrandsAgentConfig
+from tests.json_wire_fixture import PARITY_JSON, PARITY_VALUE
 
 
 def _build_agent(thread_id: str, result_content: list[dict]) -> StrandsAgent:
@@ -165,3 +166,10 @@ async def test_text_results_keep_the_existing_last_text_block_semantics():
         ]
     )
     assert json.loads(content) == "second"
+
+
+async def test_a_json_result_reaches_the_wire_as_json_stringify_would_write_it():
+    """The TypeScript adapter re-serializes with ``JSON.stringify``; the
+    Python defaults would make the same value differ byte-for-byte."""
+    content = await _tool_result_content([{"json": PARITY_VALUE}])
+    assert content == PARITY_JSON

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-client-tool-guard.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-client-tool-guard.test.ts
@@ -166,7 +166,7 @@ describe("interruptOnCall client-tool guard", () => {
     expect(finished).toEqual(
       expect.objectContaining({ type: EventType.RUN_FINISHED }),
     );
-    expect(finished).not.toHaveProperty("outcome");
+    expect(finished).toHaveProperty("outcome", { type: "success" });
     expect(agent).toHaveProperty("_pendingInterruptsByThread", new Map());
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(TOOL_NAME));
@@ -192,7 +192,7 @@ describe("interruptOnCall client-tool guard", () => {
     model.beginRun();
 
     const firstEvents = await collect(agent, input("run-1", [CLIENT_TOOL]));
-    expect(firstEvents.at(-1)).not.toHaveProperty("outcome");
+    expect(firstEvents.at(-1)).toHaveProperty("outcome", { type: "success" });
 
     const liveAgent = agentsByThread.get(THREAD_ID);
     if (!liveAgent) {

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-cold-restart.test.ts
@@ -1022,13 +1022,14 @@ describe("A resume the SDK parked after recording its answers", () => {
     expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
       false,
     );
-    // The terminal finish carries no outcome, which is what separates a run
-    // Strands actually completed from the fingerprint shortcut's synthetic
-    // success outcome and from the interrupt variant of a run still parked.
+    // A plain success finish, not the interrupt variant of a run still
+    // parked. The parked tool's output above is what separates this from the
+    // fingerprint shortcut, which emits no text.
     expect(events[events.length - 1]).toEqual({
       type: EventType.RUN_FINISHED,
       threadId: "cold-thread-parked-replay",
       runId: "run-1",
+      outcome: { type: "success" },
     });
     // The SDK cleared its own checkpoint once the parked work succeeded, and
     // the adapter never reached for it.
@@ -1076,11 +1077,13 @@ describe("A resume the SDK parked after recording its answers", () => {
       [{ interruptId: INTERRUPT_ID, response: { approved: true } }],
     ]);
     expect(emittedText(events)).toEqual([PARKED_OUTPUT]);
-    // No outcome, so this finish came from Strands rather than the shortcut.
+    // The two submitted answer batches and the parked output above are what
+    // show this finish came from Strands rather than the shortcut.
     expect(events[events.length - 1]).toEqual({
       type: EventType.RUN_FINISHED,
       threadId: THREAD,
       runId: "run-2",
+      outcome: { type: "success" },
     });
     expect(checkpoint.activated).toBe(false);
   });

--- a/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/interrupt-native.test.ts
@@ -248,6 +248,40 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     ).toBeUndefined();
   });
 
+  it("closes a cancelled tool card with exactly one result", async () => {
+    // The denial reaches the approval hook, which sets `cancel`, and the SDK
+    // then produces the error tool result the afterToolCallEvent branch turns
+    // into TOOL_CALL_RESULT. A second, synthetic result for the same call
+    // would leave the client reconciling two answers to one tool card.
+    const { agent } = approvalAgent();
+    const first = await collect(agent, userTurn());
+    const id = soleInterruptId(first);
+
+    const second = await collect(
+      agent,
+      minimalRunInput({
+        runId: "run-2",
+        resume: [{ interruptId: id, status: "cancelled" }] as never,
+      }),
+    );
+    expectNoRunError(second, "cancelled resume");
+
+    const results = second.filter(
+      (e) => e.type === EventType.TOOL_CALL_RESULT,
+    ) as (BaseEvent & { toolCallId: string; content: string })[];
+    expect(results.map((r) => r.toolCallId)).toEqual(["tu-1"]);
+    expect(results[0].content).toContain("denied approval");
+    // Inside the run envelope: after RUN_STARTED and before the finish, so a
+    // client that closes the card on RUN_FINISHED still sees the result.
+    const types = second.map((e) => e.type);
+    const resultIndex = second.indexOf(results[0]);
+    const finishedIndex = types.indexOf(EventType.RUN_FINISHED);
+    expect(types[0]).toBe(EventType.RUN_STARTED);
+    expect(types).toContain(EventType.RUN_FINISHED);
+    expect(resultIndex).toBeGreaterThan(0);
+    expect(resultIndex).toBeLessThan(finishedIndex);
+  });
+
   it("logs a debug trace when a paused result carries no interrupts", async () => {
     // The run finishes as a success with nothing to resume, so the only trace
     // an operator can get that the checkpoint may still be parked is this log.
@@ -269,7 +303,7 @@ describe("StrandsAgent native interrupt bridge (Strands SDK 1.1.0+)", () => {
     // Control flow is unchanged: still a plain success finish, no extra event.
     const finished = events.at(-1) as BaseEvent & { outcome?: { type: string } };
     expect(finished.type).toBe(EventType.RUN_FINISHED);
-    expect(finished.outcome).toBeUndefined();
+    expect(finished.outcome).toEqual({ type: "success" });
     expect(events.map((e) => e.type)).not.toContain(EventType.RUN_ERROR);
 
     const traced = debug.mock.calls.map(([message]) => String(message));

--- a/integrations/aws-strands/typescript/src/__tests__/run-outcome.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/run-outcome.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Every RUN_FINISHED reports how the run ended. A client switching on
+ * `outcome.type` has to work on the ordinary path too, not only on the
+ * interrupt and resume paths that already reported one.
+ */
+
+import { describe, it, expect } from "vitest";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+
+import { StrandsAgent } from "../agent";
+import {
+  collect,
+  expectNoRunError,
+  finishedOf,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+  recordingTool,
+} from "./helpers";
+
+/**
+ * Pin the success outcome only alongside the observation that proves the run
+ * actually reached the scenario the test is named for. Both arguments are
+ * required, so a caller cannot pin the outcome of a run that never got there:
+ * every one of these outcomes is also what an empty or short-circuited run
+ * reports.
+ */
+function expectSuccessAfter(
+  events: BaseEvent[],
+  premise: { what: string; observed: unknown; expected: unknown },
+): void {
+  expect(
+    premise.observed,
+    `the run never ${premise.what}, so its outcome pins nothing`,
+  ).toEqual(premise.expected);
+  expectNoRunError(events);
+  expect(finishedOf(events).outcome).toEqual({ type: "success" });
+}
+
+/** Assistant text the run streamed, concatenated in emission order. */
+function streamedText(events: BaseEvent[]): string {
+  return events
+    .filter((e) => e.type === EventType.TEXT_MESSAGE_CONTENT)
+    .map((e) => (e as BaseEvent & { delta: string }).delta)
+    .join("");
+}
+
+/** Names of the steps the run opened, in order. */
+function startedSteps(events: BaseEvent[]): string[] {
+  return events
+    .filter((e) => e.type === EventType.STEP_STARTED)
+    .map((e) => (e as BaseEvent & { stepName: string }).stepName);
+}
+
+/**
+ * Orchestrator shape: `.stream()` but no `.model`, which is how the
+ * constructor discriminates a Graph/Swarm from an Agent.
+ */
+function fakeOrchestrator(events: unknown[]) {
+  return {
+    id: "test-graph",
+    async *stream(_input: string) {
+      for (const e of events) yield e;
+    },
+  };
+}
+
+const userTurn = () =>
+  minimalRunInput({
+    messages: [{ id: "u1", role: "user", content: "go" } as never],
+  });
+
+describe("RUN_FINISHED outcome", () => {
+  it("reports success on a plain single-agent run", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("hi")]);
+
+    const finished = finishedOf(await collect(agent, userTurn()));
+
+    expect(finished.outcome).toEqual({ type: "success" });
+  });
+
+  it("reports success on a run that called a backend tool", async () => {
+    const { tool, calls } = recordingTool("get_cell");
+    const { agent } = realStrandsAgent(
+      [
+        modelTurn.toolUse({
+          toolUseId: "tu-1",
+          name: "get_cell",
+          input: { cell: "B4" },
+        }),
+        modelTurn.text("done"),
+      ],
+      { tools: [tool] },
+    );
+
+    const events = await collect(agent, userTurn());
+
+    expectSuccessAfter(events, {
+      what: "ran the backend tool",
+      observed: calls,
+      expected: [{ cell: "B4" }],
+    });
+  });
+
+  it("reports success on the orchestrator path", async () => {
+    const orchestrator = fakeOrchestrator([
+      { type: "beforeNodeCallEvent", nodeId: "researcher" },
+      {
+        type: "nodeStreamUpdateEvent",
+        nodeId: "researcher",
+        inner: {
+          source: "agent",
+          event: {
+            type: "modelContentBlockDeltaEvent",
+            delta: { type: "textDelta", text: "Found it." },
+          },
+        },
+      },
+      // `AfterNodeCallEvent` carries no `nodeType` on SDK 1.1.0 (only
+      // `NodeStreamUpdateEvent` does), so neither does the fixture.
+      { type: "afterNodeCallEvent", nodeId: "researcher" },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = new StrandsAgent({ agent: orchestrator as any, name: "t" });
+
+    const events = await collect(agent);
+
+    expectSuccessAfter(events, {
+      what: "translated the scripted node events onto the wire",
+      observed: { steps: startedSteps(events), text: streamedText(events) },
+      expected: { steps: ["agent:researcher"], text: "Found it." },
+    });
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/tool-approval-gate.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/tool-approval-gate.test.ts
@@ -282,10 +282,10 @@ describe("interruptOnCall for a client-provided tool", () => {
       | (BaseEvent & { outcome?: { type?: string } })
       | undefined;
     expect(finished, "no RUN_FINISHED emitted").toBeDefined();
-    // `outcome` is absent on this finish, so `not.toBe("interrupt")` would hold
-    // trivially. Assert the absence directly, and that the adapter recorded no
+    // `not.toBe("interrupt")` would also hold on a finish carrying no outcome
+    // at all. Pin the success outcome itself, and that the adapter recorded no
     // interrupt to resume.
-    expect(finished!.outcome).toBeUndefined();
+    expect(finished!.outcome).toEqual({ type: "success" });
     expect(
       (
         agent as unknown as {

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -2142,20 +2142,12 @@ export class StrandsAgent {
               pendingToolResultIds.add(interrupt.toolCallId);
             }
           }
-          // Handle cancelled tool-bound interrupts: emit ToolCallResult immediately
-          for (const entry of resumeEntries) {
-            if (entry.status === "cancelled") {
-              const interrupt = priorPending.get(entry.interruptId);
-              if (interrupt?.toolCallId) {
-                yield {
-                  type: EventType.TOOL_CALL_RESULT,
-                  messageId: randomUUID(),
-                  toolCallId: interrupt.toolCallId,
-                  content: "Tool call cancelled by user.",
-                };
-              }
-            }
-          }
+          // A cancelled tool-bound interrupt gets no synthetic result here.
+          // The denial is forwarded to Strands below, its approval hook sets
+          // `cancel`, and the SDK produces the error tool result the
+          // afterToolCallEvent branch already turns into TOOL_CALL_RESULT.
+          // Emitting one here too gave the same toolCallId two results.
+          //
           // Note: even when ALL entries are cancelled, we still forward the
           // denial responses to Strands via stream() below rather than
           // short-circuiting here. This ensures native interrupt-state
@@ -3309,6 +3301,7 @@ export class StrandsAgent {
         type: EventType.RUN_FINISHED,
         threadId: inputData.threadId,
         runId: inputData.runId,
+        outcome: { type: "success" },
       };
     } catch (e) {
       const code =
@@ -3782,6 +3775,7 @@ export class StrandsAgent {
         type: EventType.RUN_FINISHED,
         threadId: inputData.threadId,
         runId: inputData.runId,
+        outcome: { type: "success" },
       };
     } catch (e) {
       const code =


### PR DESCRIPTION
Closes PNI-352.

## Summary

Five wire-level differences between the AWS Strands Python and TypeScript bridges, found by driving both and comparing the emitted streams. Each was re-confirmed against current `main` before being touched, per the parent ticket's caveat that Python-side findings might predate a landed commit. That caveat earned its keep: both differences that moved were Python-side claims.

Three reproduced and are fixed. One reproduced with the opposite side at fault. One no longer reproduces at all.

## What changed, and why on that side

### 1. A run's outcome, fixed on both sides

`RUN_FINISHED` carried no `outcome` on the TypeScript single-agent path, the TypeScript orchestrator path, or the Python orchestrator path. A client switching on `outcome.type` fell through on an ordinary run. TypeScript was inconsistent with itself, since its resume and interrupt paths already set one.

The Python orchestrator was not in the original finding. It surfaced during review and is the same defect, so it is fixed here rather than deferred.

```
- {"type":"RUN_FINISHED","threadId":"t","runId":"r"}
+ {"type":"RUN_FINISHED","threadId":"t","runId":"r","outcome":{"type":"success"}}
```

Verified by intercepting every emission across both suites: 318 of 318 Python finishes now carry an outcome, and every TypeScript finish that is not a hand-authored fixture does too.

An existing Python test asserted `outcome is None` on the orchestrator path, so the defect was actively pinned by a test claiming to check something else. That assertion now pins the success outcome.

### 2. A backend tool returning nothing: does not reproduce

The recorded difference was that a void backend tool emitted no result on Python, leaving the spinner running. It does not reproduce on current `main`. Python emits `TOOL_CALL_RESULT` with empty content when the tool result content list is empty, absent, or null, and `test_non_text_tool_results.py` already pins both the single emission and the empty content. Checked against the real SDK as well: a `@tool` returning `None` produces `content: [{"text": "None"}]`, which is also emitted.

No fix. The one thing genuinely wrong on that path is the serialization in item 5.

### 3. Cancelling a tool-bound approval: the wrong side was TypeScript

The recorded difference had Python leaving the card open and TypeScript synthesising a result. Driving a real cancelled approval through both SDKs shows the reverse.

When the approval hook denies a call, both SDKs skip the tool and produce an error tool result carrying the denial, which both adapters already translate. TypeScript emitted a second synthetic result ahead of it, so one tool card got two answers. Python emits exactly one and has a test pinning that.

```
- TOOL_CALL_RESULT toolCallId=tu-1 content="Tool call cancelled by user."
  TOOL_CALL_RESULT toolCallId=tu-1 content="\"User denied approval for 'confirm_delete'.\""
```

Three reviewers independently confirmed against the SDK source that the cancel branch really does yield that result, so the removal is safe. TypeScript has no native frontend-tool interrupt channel, so approval interrupts are the only ones carrying a `toolCallId`, and the SDK always produces a result for those.

### 4. Snapshot ordering on the frontend-tool path, fixed on Python

A tool call's `MESSAGES_SNAPSHOT` follows its `TOOL_CALL_END` on Python's backend path and on both TypeScript paths. Python's frontend path emitted it first, because that path defers the end until the turn's backend results have gone out and the snapshot did not travel with it. Python contradicted itself, so Python is the side that changed.

```
- TOOL_CALL_START, TOOL_CALL_ARGS, MESSAGES_SNAPSHOT, TOOL_CALL_END
+ TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END, MESSAGES_SNAPSHOT
```

Two design choices here, both defensible, both stated because the ticket asks for it:

**One snapshot per flush batch, not one per end.** Deferred ends flush together, and because the history append stays eager, a per-end snapshot would emit N byte-identical copies. A single snapshot after the batch carries exactly what N copies carried, and no end is preceded by its own snapshot. Measured on a two-frontend-call turn: before, 3 snapshots of which 2 distinct; now, 2 snapshots, 2 distinct.

**The history append stays eager.** Deferring it would keep the frontend call out of earlier snapshots entirely, but a run that dies before the flush would then lose the assistant message altogether. Losing a message is worse than an imprecise ordering. The consequence is that in a mixed frontend-plus-backend turn, the backend result's snapshot already carries the frontend call before that call's end goes out. That limit is pinned by a test rather than left implicit.

### 5. Serialization, fixed on Python

Both adapters re-serialize tool arguments and results from the parsed value rather than forwarding raw model text, so both owe the same output. Python used `json.dumps` defaults, which differ from `JSON.stringify` on two axes, not one: separator padding, and non-ASCII escaping.

```
- "arguments": "{\"cell\": \"B4\"}"     "content": "{\"note\": \"café\"}"
+ "arguments": "{\"cell\":\"B4\"}"      "content": "{\"note\":\"café\"}"
```

A single `dumps_wire` helper sets both flags at all six call sites: the tool result content, the snapshot `arguments`, the `TOOL_CALL_ARGS` delta where the SDK hands a dict rather than raw text, the inner agent-as-tool arguments and results, and the A2UI json-block flattener. Python was changed rather than TypeScript because matching `JSON.stringify` is the narrower and more conventional wire form.

**Numeric spelling stays Python-native, deliberately.** `dumps_wire` normalises two axes, separators and non-ASCII escaping. It does not normalise numbers, and three cases still differ:

```
python {"one":1.0}       javascript {"one":1}
python {"negzero":-0.0}  javascript {"negzero":0}
python {"small":1e-07}   javascript {"small":1e-7}
```

Collapsing these would mean misreporting the value's type. The helper docstring and the fixture both state outright that numeric formatting is out of scope, rather than implying full `JSON.stringify` equivalence.

`TOOL_CALL_ARGS` deltas built from raw streamed model text are unchanged on both sides. The resume fingerprint hash and the model-facing prompt strings are not wire values and are untouched.

## Wire record

For seeding the deferred cross-language comparison, the canonical fixture in `tests/json_wire_fixture.py` carries the axes this change normalises: nesting, a non-ASCII letter, an astral character, a forward slash, and a control character. Numeric formatting is deliberately excluded, per the section above. The fixture's expected output was cross-checked character for character against `node`'s `JSON.stringify`, and verified again by hand before this PR was opened.

## Tests

Every fix has a test in its own language's suite, and every source site was mutation-verified individually rather than through a shared switch. That distinction mattered: an earlier pass flipped the shared separator constant, killed three tests, and thereby hid that four of the six call sites were pinned by nothing.

Each of the six serialization sites now goes red when reverted, on both the separator axis and the escaping axis. The ordering claim is a pure predicate with counterexample tests over literal event lists, so an assertion that cannot fail is no longer expressible. The outcome tests assert the scenario they name before they look at the outcome, and go red when the tool is absent or the orchestrator emits nothing.

Suites: 994 Python, 1057 TypeScript, `tsc --noEmit` clean.

## Not regressed

The interrupt protocol, cold-restart durability, idempotent resume, resume payload type checking, the client-tool guard, the typed error paths, and the recent Python frontend-tool rework all pass unchanged. Assertions were updated only where they read the newly present `outcome`; none lost the behaviour it was pinning.

## Scope

The snapshot-ordering guarantee is claimed only for the paths this change touches. TypeScript emits no snapshot at all when a custom argument streamer throws. That is pre-existing, was found while verifying the claim, and is deliberately left alone rather than widening this change.

The two adapters also send different native payloads to Strands for a cancelled resume. That is the resume contract rather than the emitted event stream, and a sibling change is settling it.

