### PR TITLE
fix(aws-strands): fix media conversion end to end in TypeScript

### DIFF
--- a/integrations/aws-strands/typescript/src/__tests__/cold-continuation-replay-disabled.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/cold-continuation-replay-disabled.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A frontend-tool continuation that arrives on a cold agent with
+ * `replayHistoryIntoStrands: false` and no session manager.
+ *
+ * Cold here means the adapter holds no cached Strands `Agent` for the thread,
+ * so it builds one and seeds it from `RunAgentInput.messages`. A continuation
+ * routed to a fresh process, or arriving after a restart, looks like this.
+ *
+ * With replay disabled the seed is the whole history, and its last message is
+ * the user-role `toolResult`. Handing the synthetic continuation prompt to
+ * `stream()` would then have Strands append a SECOND user message, and the
+ * provider-bound roles become user -> assistant -> user -> user, which Bedrock
+ * refuses for failing role alternation. The continuation has to stay one user
+ * turn carrying both the tool result and the prompt.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Message as StrandsMessage } from "@strands-agents/sdk";
+import type { BaseEvent } from "@ag-ui/core";
+import {
+  expectCompletedRun,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+} from "./helpers";
+
+/**
+ * The messages the model was actually handed, per invocation.
+ *
+ * Snapshotted, not aliased: the SDK keeps mutating the same array after the
+ * call, so holding the reference would report the end-of-run history rather
+ * than what the model was given.
+ */
+function recordModelInput(model: {
+  stream: (...a: unknown[]) => unknown;
+}): StrandsMessage[][] {
+  const seen: StrandsMessage[][] = [];
+  const original = model.stream.bind(model);
+  model.stream = (...args: unknown[]) => {
+    seen.push([...((args[0] ?? []) as StrandsMessage[])]);
+    return original(...args);
+  };
+  return seen;
+}
+
+function continuationInput(threadId: string) {
+  return minimalRunInput({
+    threadId,
+    messages: [
+      { id: "u1", role: "user", content: "call the tool" } as never,
+      {
+        id: "a1",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "tc1",
+            type: "function",
+            function: { name: "doIt", arguments: "{}" },
+          },
+        ],
+      } as never,
+      // Render-only frontend tools legitimately return nothing.
+      { id: "t1", role: "tool", toolCallId: "tc1", content: "" } as never,
+    ],
+    tools: [
+      {
+        name: "doIt",
+        description: "a frontend tool",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+  });
+}
+
+describe("cold frontend-tool continuation with replay disabled", () => {
+  it("keeps the continuation in one user turn", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("done")], {
+      config: { replayHistoryIntoStrands: false },
+    });
+    const seen = recordModelInput(model as never);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(continuationInput("cold-1"))) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(seen).toHaveLength(1);
+
+    const roles = seen[0]!.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "user"]);
+
+    // The final turn carries the native tool result AND the synthetic prompt,
+    // rather than the prompt arriving as a fourth message of its own.
+    const last = seen[0]![seen[0]!.length - 1]!;
+    const blocks = (last.content ?? []) as unknown[];
+    const hasToolResult = blocks.some(
+      (b) =>
+        (b as { toolResult?: unknown }).toolResult !== undefined ||
+        (b as { type?: string }).type === "toolResultBlock",
+    );
+    const texts = blocks
+      .map((b) => (b as { text?: unknown }).text)
+      .filter((t): t is string => typeof t === "string");
+    expect(hasToolResult).toBe(true);
+    expect(texts.join("")).not.toBe("");
+  });
+
+  it("never seeds a blank block for an empty tool result", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("done")], {
+      config: { replayHistoryIntoStrands: false },
+    });
+    const seen = recordModelInput(model as never);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(continuationInput("cold-2"))) {
+      events.push(e);
+    }
+    expectCompletedRun(events);
+
+    // A render-only tool's empty result must reach the provider as the
+    // non-empty acknowledgement the replay path already substitutes, not as
+    // the blank text block the provider rejects.
+    const serialised = JSON.stringify(
+      seen[0]!.map(
+        (m) => (m as unknown as { toJSON?: () => unknown }).toJSON?.() ?? m,
+      ),
+    );
+    expect(serialised).not.toContain('"text":""');
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/multimodal-conversion.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/multimodal-conversion.test.ts
@@ -4,6 +4,8 @@ import type { InputContent } from "@ag-ui/core";
 
 import {
   convertAguiContentToStrands,
+  convertAguiContentToStrandsDetailed,
+  createUrlFetchCache,
   flattenContentToText,
   urlFetchTransport,
 } from "../utils";
@@ -29,6 +31,20 @@ function makeLog() {
 
 function messages(log: { warn: { mock: { calls: unknown[][] } } }): string {
   return log.warn.mock.calls.map((call) => String(call[0])).join("\n");
+}
+
+/** Discards diagnostics, for cases that assert on blocks rather than logs. */
+const quietLog = {
+  debug: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/** The fetch policy resolves the host first, so it has to answer publicly. */
+function mockPublicDns() {
+  return vi
+    .spyOn(dns.promises, "lookup")
+    .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
 }
 
 describe("convertAguiContentToStrands", () => {
@@ -80,9 +96,7 @@ describe("convertAguiContentToStrands", () => {
       .mockResolvedValue(new Response(new Uint8Array([1, 2, 3])));
     // The fetch policy resolves the host before connecting, so the fixture
     // host has to answer with a public address.
-    const dnsSpy = vi
-      .spyOn(dns.promises, "lookup")
-      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    const dnsSpy = mockPublicDns();
     try {
       const blocks = await convertAguiContentToStrands([
         {
@@ -108,6 +122,7 @@ describe("convertAguiContentToStrands", () => {
 
   it("maps DocumentInputContent to a DocumentBlock", async () => {
     const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "read this" },
       {
         type: "document",
         source: {
@@ -117,8 +132,9 @@ describe("convertAguiContentToStrands", () => {
         },
       },
     ] as InputContent[]);
-    expect(blocks).toHaveLength(1);
-    expect((blocks[0] as { type: string }).type).toBe("documentBlock");
+    expect(blocks).toHaveLength(2);
+    expect((blocks[1] as { type: string }).type).toBe("documentBlock");
+    expect((blocks[1] as unknown as { format: string }).format).toBe("pdf");
   });
 
   it("maps VideoInputContent to a VideoBlock", async () => {
@@ -186,7 +202,15 @@ describe("convertAguiContentToStrands", () => {
   });
 
   it("prefers inline data over a URL on the deprecated binary path", async () => {
-    const fetchMock = vi.spyOn(urlFetchTransport, "request");
+    // A bare spy calls through to the real socket, so a regression here would
+    // be caught (if at all) by the network refusing the fixture host rather
+    // than by the assertion below. The stub makes the fetch observable.
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(
+        new Response(new Uint8Array([9, 9, 9]), { status: 200 }),
+      );
     const log = makeLog();
 
     const blocks = await convertAguiContentToStrands(
@@ -202,7 +226,11 @@ describe("convertAguiContentToStrands", () => {
     );
 
     expect(blocks).toHaveLength(1);
+    expect(
+      (blocks[0] as unknown as { source: { bytes: Uint8Array } }).source.bytes,
+    ).toEqual(new Uint8Array(Buffer.from("PNG")));
     expect(fetchMock).not.toHaveBeenCalled();
+    dnsSpy.mockRestore();
   });
 
   it("drops deprecated binary content with an unsupported MIME type", async () => {
@@ -248,6 +276,26 @@ describe("convertAguiContentToStrands", () => {
     expect(messages(log)).toContain("carrier-pigeon");
   });
 
+  it("bounds and strips an unknown content type before reporting it", async () => {
+    // Newline and ESC are the obvious ones, but a log or terminal sink is
+    // driven just as well by DEL, the C1 8-bit CSI, and the file separators
+    // between them, so the whole control range has to go.
+    const controls = "\n\u001b\u001c\u007f\u009b";
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        { type: `evil${controls}type${"x".repeat(200)}` },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    const reported = dropped[0]!.type;
+    // The value is whatever the client sent, and it goes out on the wire
+    // beside a field documented as safe to put there.
+    for (const ch of controls) {
+      expect(reported).not.toContain(ch);
+    }
+    expect(reported.length).toBeLessThanOrEqual(45);
+  });
+
   it("reports an unknown content type rather than dropping it quietly", async () => {
     const log = makeLog();
     const blocks = await convertAguiContentToStrands(
@@ -256,6 +304,1170 @@ describe("convertAguiContentToStrands", () => {
     );
     expect(blocks).toEqual([]);
     expect(messages(log)).toContain("hologram");
+  });
+
+  it("reads the response content type when the source declares none", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi.spyOn(urlFetchTransport, "request").mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    try {
+      const blocks = await convertAguiContentToStrands([
+        {
+          type: "image",
+          source: { type: "url", value: "https://example.test/untyped" },
+        },
+      ] as InputContent[]);
+      expect(blocks).toHaveLength(1);
+      expect((blocks[0] as unknown as { format: string }).format).toBe("png");
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("drops a url attachment when neither the source nor the response types it", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+      );
+    const log = makeLog();
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: { type: "url", value: "https://example.test/untyped" },
+          },
+        ] as InputContent[],
+        log,
+      );
+      expect(blocks).toEqual([]);
+      expect(messages(log)).toContain("No MIME type provided");
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("prefers the declared type over the response content type", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi.spyOn(urlFetchTransport, "request").mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "image/gif" },
+      }),
+    );
+    try {
+      const blocks = await convertAguiContentToStrands([
+        {
+          type: "image",
+          source: {
+            type: "url",
+            value: "https://example.test/x.png",
+            mimeType: "image/png",
+          },
+        },
+      ] as InputContent[]);
+      expect((blocks[0] as unknown as { format: string }).format).toBe("png");
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("inserts a text block when the message carries only documents", async () => {
+    const blocks = await convertAguiContentToStrands([
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("pdfdata"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[]);
+    // The provider rejects a request whose message has documents and no text.
+    expect(blocks).toHaveLength(2);
+    expect((blocks[0] as { type: string }).type).toBe("textBlock");
+    expect((blocks[0] as unknown as { text: string }).text).toBe(" ");
+    expect((blocks[1] as { type: string }).type).toBe("documentBlock");
+  });
+
+  it("pads a document message whose only text item is empty", async () => {
+    const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "" },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("pdfdata"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[]);
+    // toContain(" ") would pass on ["", " "], which is the shape that still
+    // fails at the provider. The whole list is the assertion.
+    const texts = blocks
+      .filter((b) => (b as { type: string }).type === "textBlock")
+      .map((b) => (b as unknown as { text: string }).text);
+    expect(texts).toEqual([" "]);
+  });
+
+  it.each([
+    ["no source at all", { type: "image" }],
+    ["a null source", { type: "image", source: null }],
+    [
+      "a non-string mimeType",
+      {
+        type: "image",
+        source: { type: "data", value: "UE5H", mimeType: 42 },
+      },
+    ],
+  ])("drops an image with %s instead of throwing", async (_label, item) => {
+    const blocks = await convertAguiContentToStrands(
+      [item, { type: "text", text: "survivor" }] as unknown as InputContent[],
+      quietLog,
+    );
+    // The surrounding content must survive a malformed neighbour.
+    expect(blocks.map((b) => (b as unknown as { text?: string }).text)).toEqual(
+      ["survivor"],
+    );
+  });
+
+  it("does not believe a served type from the wrong family", async () => {
+    const dnsSpy = mockPublicDns();
+    const log = makeLog();
+    // `text/png` is the case that discriminates: the subtype is a valid image
+    // format, so the format check alone would accept it, and only the
+    // top-level check notices that the server relabelled the payload across
+    // families. A response whose subtype is also wrong is already refused by
+    // the format check, so it would not test this at all.
+    vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "text/png" },
+        }),
+    );
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: { type: "url", value: "https://example.test/missing" },
+          },
+        ] as InputContent[],
+        log,
+      );
+      expect(blocks).toEqual([]);
+      // Named specifically: without this, a refusal for any other reason
+      // satisfies the assertion above.
+      expect(messages(log)).toContain("text/png");
+      expect(messages(log)).toContain("not one of");
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("still believes a served type from the right family", async () => {
+    const dnsSpy = mockPublicDns();
+    vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      async () =>
+        new Response("id,name\n1,a", {
+          status: 200,
+          headers: { "content-type": "text/csv" },
+        }),
+    );
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          { type: "text", text: "read" },
+          {
+            type: "document",
+            source: { type: "url", value: "https://example.test/data" },
+          },
+        ] as InputContent[],
+        quietLog,
+      );
+      expect((blocks[1] as unknown as { format: string }).format).toBe("csv");
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("drops a null element instead of crashing the conversion", async () => {
+    const log = makeLog();
+    const { blocks, dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        null,
+        undefined,
+        "not an object",
+        { type: "text", text: "survivor" },
+      ] as unknown as InputContent[],
+      log,
+    );
+    expect(blocks.map((b) => (b as unknown as { text?: string }).text)).toEqual(
+      ["survivor"],
+    );
+    expect(messages(log)).toContain("not an object");
+    // Same rule as a malformed text item: `dropped` is the media report, so a
+    // bare null in the array is not announced to the client as lost media.
+    expect(dropped).toEqual([]);
+  });
+
+  it.each([
+    [
+      "an unsupported type",
+      { type: "data", value: "eA==", mimeType: "image/bmp" },
+      "image/bmp",
+    ],
+    [
+      "bad base64",
+      { type: "data", value: "!!!not base64!!!", mimeType: "image/png" },
+      "base64",
+    ],
+    [
+      "a non-string value",
+      { type: "data", value: 42, mimeType: "image/png" },
+      "no usable value",
+    ],
+  ])(
+    "logs one line per dropped item, not two: %s",
+    async (_l, source, needle) => {
+      const log = makeLog();
+      await convertAguiContentToStrands(
+        [{ type: "image", source }] as unknown as InputContent[],
+        log,
+      );
+      // The reason and the item's position belong on the same line; two lines
+      // for one drop is what makes a multi-attachment failure hard to read. The
+      // first version of this test used the one branch where that already held.
+      expect(log.warn.mock.calls).toHaveLength(1);
+      const only = String(log.warn.mock.calls[0]![0]);
+      expect(only).toContain(needle);
+      expect(only).toContain("item 0");
+    },
+  );
+
+  it("names the message a dropped item came from", async () => {
+    const log = makeLog();
+    await convertAguiContentToStrands(
+      [
+        {
+          type: "image",
+          source: { type: "data", value: b64("x"), mimeType: "image/bmp" },
+        },
+      ] as InputContent[],
+      log,
+      { messageId: "msg-42" },
+    );
+    expect(messages(log)).toContain("msg-42");
+  });
+
+  it.each([
+    ["a url source", "url"],
+    ["a data source", "data"],
+  ])("drops %s whose value is not a string", async (_label, kind) => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        {
+          type: "image",
+          source: { type: kind, value: 42, mimeType: "image/png" },
+        },
+        { type: "text", text: "survivor" },
+      ] as unknown as InputContent[],
+      log,
+    );
+    // Both are refused at the source before either branch runs. Left to the
+    // branches, the data case would be coerced by atob and shipped as content,
+    // and the url case would throw from inside the fetch's own error handler,
+    // where the URL is hashed for logging, escaping the catch written to
+    // contain it.
+    expect(blocks.map((b) => (b as unknown as { text?: string }).text)).toEqual(
+      ["survivor"],
+    );
+    expect(messages(log)).toContain("no usable value");
+  });
+
+  it("falls back to the url on the deprecated binary path when data is absent", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+        }),
+    );
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "binary",
+            mimeType: "image/png",
+            url: "https://example.test/legacy.png",
+          },
+        ] as unknown as InputContent[],
+        quietLog,
+      );
+      // Every other test on this path asserts the negative, so the branch that
+      // actually succeeds was never run.
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(blocks).toHaveLength(1);
+      expect((blocks[0] as { type: string }).type).toBe("imageBlock");
+      expect(
+        (blocks[0] as unknown as { source: { bytes: Uint8Array } }).source
+          .bytes,
+      ).toEqual(new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("reports a malformed source as malformed, not as unresolvable", async () => {
+    const log = makeLog();
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [{ type: "image" }] as unknown as InputContent[],
+      log,
+    );
+    // A caller can fix a malformed item and cannot fix a host that will not
+    // answer, so the two must not read the same.
+    expect(dropped).toEqual([
+      { type: "image", reason: "content item is malformed" },
+    ]);
+    // And it has to be visible: this drop had no log line at all for a while.
+    expect(messages(log)).toContain("malformed");
+  });
+
+  it("reports a binary item with non-string data as malformed", async () => {
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        { type: "binary", mimeType: "image/png", data: 42 },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    // Not "empty": a caller can fix a malformed payload, and the two read
+    // differently to whoever receives the report.
+    expect(dropped).toEqual([
+      { type: "binary", reason: "content item is malformed" },
+    ]);
+  });
+
+  it("reports a binary item with a non-string type as untyped", async () => {
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        { type: "binary", mimeType: 42, data: "UE5H" },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    // The log says no usable type, so the wire reason must agree.
+    expect(dropped).toEqual([
+      { type: "binary", reason: "no media type declared or returned" },
+    ]);
+  });
+
+  it("keeps a malformed text item out of the media drop report", async () => {
+    const { blocks, dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        { type: "text" },
+        {
+          type: "image",
+          source: { type: "data", value: b64("PNG"), mimeType: "image/png" },
+        },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    expect(blocks).toHaveLength(1);
+    // The report reaches a client beside a count of media delivered; a text
+    // item in it would read as a lost attachment.
+    expect(dropped).toEqual([]);
+  });
+
+  it("drops a binary item with a non-string type instead of throwing", async () => {
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "binary", mimeType: 42, data: "UE5H" },
+        { type: "text", text: "survivor" },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    expect(blocks.map((b) => (b as unknown as { text?: string }).text)).toEqual(
+      ["survivor"],
+    );
+  });
+
+  it("reports a binary item with no type as untyped", async () => {
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [{ type: "binary", data: "UE5H" }] as unknown as InputContent[],
+      quietLog,
+    );
+    expect(dropped).toEqual([
+      { type: "binary", reason: "no media type declared or returned" },
+    ]);
+  });
+
+  it("drops a malformed text item instead of failing the conversion", async () => {
+    const log = makeLog();
+    // A throw here would take the surrounding attachments down with it, which
+    // is the one outcome the whole drop-and-report design exists to avoid.
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "text" },
+        { type: "text", text: null },
+        {
+          type: "image",
+          source: { type: "data", value: b64("PNG"), mimeType: "image/png" },
+        },
+      ] as unknown as InputContent[],
+      log,
+    );
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { type: string }).type).toBe("imageBlock");
+    expect(messages(log)).toContain("no usable text field");
+  });
+
+  it("does not throw when a malformed text item sits beside a document", async () => {
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "text" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: b64("pdfdata"),
+            mimeType: "application/pdf",
+          },
+        },
+      ] as unknown as InputContent[],
+      quietLog,
+    );
+    // The document survives and still gets its padding.
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "textBlock",
+      "documentBlock",
+    ]);
+  });
+
+  it("drops an empty text item rather than sending an empty block", async () => {
+    const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "" },
+      { type: "text", text: "real" },
+    ] as InputContent[]);
+    expect(blocks.map((b) => (b as unknown as { text: string }).text)).toEqual([
+      "real",
+    ]);
+  });
+
+  it("does not pad a document message that already carries text", async () => {
+    const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "summarise this" },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("pdfdata"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[]);
+    expect(blocks).toHaveLength(2);
+    expect((blocks[0] as unknown as { text: string }).text).toBe(
+      "summarise this",
+    );
+  });
+
+  it("does not pad an image-only message", async () => {
+    const blocks = await convertAguiContentToStrands([
+      {
+        type: "image",
+        source: { type: "data", value: b64("PNG"), mimeType: "image/png" },
+      },
+    ] as InputContent[]);
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { type: string }).type).toBe("imageBlock");
+  });
+
+  it("gives two documents in one message distinct names", async () => {
+    const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "compare" },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("one"),
+          mimeType: "application/pdf",
+        },
+      },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("two"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[]);
+    const names = blocks
+      .filter((b) => (b as { type: string }).type === "documentBlock")
+      .map((b) => (b as unknown as { name: string }).name);
+    expect(names).toHaveLength(2);
+    expect(new Set(names).size).toBe(2);
+  });
+
+  it("gives byte-identical documents in one message distinct names", async () => {
+    const same = {
+      type: "document",
+      source: { type: "data", value: b64("same"), mimeType: "application/pdf" },
+    };
+    const blocks = await convertAguiContentToStrands([
+      { type: "text", text: "compare" },
+      same,
+      same,
+    ] as InputContent[]);
+    const names = blocks
+      .filter((b) => (b as { type: string }).type === "documentBlock")
+      .map((b) => (b as unknown as { name: string }).name);
+    expect(new Set(names).size).toBe(2);
+  });
+
+  it("derives the name from the content, not just the position", async () => {
+    // A bare index satisfies the replay-stability case below just as well, so
+    // this is what separates the content digest from a counter.
+    const nameOf = (blocks: unknown[]) => (blocks[1] as { name: string }).name;
+    const docOf = (value: string) =>
+      [
+        { type: "text", text: "read" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: b64(value),
+            mimeType: "application/pdf",
+          },
+        },
+      ] as InputContent[];
+    const one = await convertAguiContentToStrands(docOf("one"), quietLog, {
+      messageId: "msg-1",
+    });
+    const two = await convertAguiContentToStrands(docOf("two"), quietLog, {
+      messageId: "msg-1",
+    });
+    expect(nameOf(one)).not.toBe(nameOf(two));
+  });
+
+  it("gives identical documents in two messages distinct names", async () => {
+    // Each message is converted by its own call, so a per-call counter would
+    // give both of these the same name and the provider would reject the one
+    // request they share.
+    const content = [
+      { type: "text", text: "read" },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("same"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[];
+    const first = await convertAguiContentToStrands(content, quietLog, {
+      messageId: "msg-1",
+    });
+    const second = await convertAguiContentToStrands(content, quietLog, {
+      messageId: "msg-2",
+    });
+    expect((first[1] as unknown as { name: string }).name).not.toBe(
+      (second[1] as unknown as { name: string }).name,
+    );
+  });
+
+  it("names the same document identically across replays", async () => {
+    const content = [
+      { type: "text", text: "read" },
+      {
+        type: "document",
+        source: {
+          type: "data",
+          value: b64("stable"),
+          mimeType: "application/pdf",
+        },
+      },
+    ] as InputContent[];
+    const first = await convertAguiContentToStrands(content, quietLog, {
+      messageId: "msg-1",
+    });
+    const second = await convertAguiContentToStrands(content, quietLog, {
+      messageId: "msg-1",
+    });
+    const nameOf = (blocks: unknown[]) => (blocks[1] as { name: string }).name;
+    expect(nameOf(first)).toBe(nameOf(second));
+  });
+
+  it.each([
+    ["text/plain", "txt"],
+    ["text/markdown", "md"],
+    ["text/x-markdown", "md"],
+    ["application/msword", "doc"],
+    [
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "docx",
+    ],
+    ["application/vnd.ms-excel", "xls"],
+    [
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "xlsx",
+    ],
+    ["application/pdf", "pdf"],
+    ["text/csv", "csv"],
+    ["text/html", "html"],
+  ])("reaches the %s document format", async (mimeType, format) => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "text", text: "read" },
+        {
+          type: "document",
+          source: { type: "data", value: b64("body"), mimeType },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect((blocks[1] as unknown as { format: string }).format).toBe(format);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["video/mp4", "mp4"],
+    ["video/webm", "webm"],
+    ["video/mpeg", "mpeg"],
+    ["video/quicktime", "mov"],
+    ["video/x-matroska", "mkv"],
+    // "3gp", not Bedrock's "three_gp": the SDK's own Bedrock provider does
+    // that translation on the way out, so emitting three_gp here would skip
+    // it and hand every other provider a format it does not know.
+    ["video/3gpp", "3gp"],
+    ["video/x-flv", "flv"],
+    ["video/x-ms-wmv", "wmv"],
+  ])("reaches the %s video format", async (mimeType, format) => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        {
+          type: "video",
+          source: { type: "data", value: b64("movie"), mimeType },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect((blocks[0] as unknown as { format: string }).format).toBe(format);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["image/jpeg", "jpeg"],
+    ["image/jpg", "jpeg"],
+    ["image/png", "png"],
+    ["image/gif", "gif"],
+    ["image/webp", "webp"],
+  ])("reaches the %s image format", async (mimeType, format) => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        {
+          type: "image",
+          source: { type: "data", value: b64("PNG"), mimeType },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect((blocks[0] as unknown as { format: string }).format).toBe(format);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it.each(["constructor", "__proto__"])(
+    "treats the inherited key %s as an unknown format",
+    async (subtype) => {
+      const log = makeLog();
+      // These two are the discriminators: they are the Object.prototype keys
+      // that survive the lowercasing in `mimeSubtype`, so they are the only
+      // subtypes that would reach through a plain-object alias map. The other
+      // prototype keys are camelCased and never match. The map is already
+      // prototype-free, so this pins that rather than describing a live
+      // hazard.
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: {
+              type: "data",
+              value: b64("x"),
+              mimeType: `image/${subtype}`,
+            },
+          },
+        ] as InputContent[],
+        log,
+      );
+      expect(blocks).toEqual([]);
+      // A prototype lookup puts a Function or an object where the format
+      // string goes, and this line would quote that instead of the subtype.
+      expect(messages(log)).toContain(`parsed format '${subtype}'`);
+    },
+  );
+
+  it.each([
+    ["text/html, application/pdf", "a comma-merged pair"],
+    // Under an "at least two parts" reading, destructuring takes text/pdf and
+    // this is accepted as a document, so it is the case that discriminates.
+    ["text/pdf/anything", "two slashes"],
+    ["noslash", "no slash"],
+    ["/pdf", "an empty family"],
+    ["application/", "an empty subtype"],
+  ])("refuses %s (%s)", async (mimeType) => {
+    const log = makeLog();
+    // Taking the family from the front and the subtype from the back
+    // independently would let a value carrying two types satisfy the family
+    // check with one and supply its format from the other.
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "text", text: "read" },
+        {
+          type: "document",
+          source: { type: "data", value: b64("body"), mimeType },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect(
+      blocks.filter((b) => (b as { type: string }).type === "documentBlock"),
+    ).toEqual([]);
+  });
+
+  it.each(["application/json", "application/xml", "text/xml"])(
+    "refuses %s, which the SDK allows but Bedrock does not",
+    async (mimeType) => {
+      const log = makeLog();
+      // The SDK's DocumentFormat union carries json and xml, but document
+      // formats reach Bedrock untranslated and its enum has neither, so
+      // accepting them would turn one unsupported attachment into a rejected
+      // request.
+      const blocks = await convertAguiContentToStrands(
+        [
+          { type: "text", text: "read" },
+          {
+            type: "document",
+            source: { type: "data", value: b64("body"), mimeType },
+          },
+        ] as InputContent[],
+        log,
+      );
+      expect(
+        blocks.filter((b) => (b as { type: string }).type === "documentBlock"),
+      ).toEqual([]);
+      expect(messages(log)).toContain(mimeType);
+    },
+  );
+
+  it("strips MIME parameters before matching the format", async () => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        { type: "text", text: "read" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: b64("hello"),
+            mimeType: "text/plain; charset=utf-8",
+          },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect((blocks[1] as unknown as { format: string }).format).toBe("txt");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a type that is unsupported once parameters are stripped", async () => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        {
+          type: "image",
+          source: {
+            type: "data",
+            value: b64("x"),
+            mimeType: "image/bmp; charset=utf-8",
+          },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect(blocks).toEqual([]);
+    expect(messages(log)).toContain("image/bmp");
+  });
+
+  it("drops an inline attachment whose body is empty", async () => {
+    const log = makeLog();
+    const blocks = await convertAguiContentToStrands(
+      [
+        {
+          type: "image",
+          source: { type: "data", value: "", mimeType: "image/png" },
+        },
+      ] as InputContent[],
+      log,
+    );
+    expect(blocks).toEqual([]);
+    expect(messages(log)).toContain("empty");
+  });
+
+  it("drops a url attachment whose response has no body", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const log = makeLog();
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: {
+              type: "url",
+              value: "https://example.test/empty.png",
+              mimeType: "image/png",
+            },
+          },
+        ] as InputContent[],
+        log,
+      );
+      expect(blocks).toEqual([]);
+      expect(messages(log)).toContain("empty");
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("does not fetch a url attachment whose declared type is unsupported", async () => {
+    const dnsSpy = mockPublicDns();
+    // Stubbed rather than a bare spy: a bare spy would call through, and a
+    // regressed guard would then fail on a socket timeout instead of on the
+    // assertion written for it.
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }));
+    try {
+      const blocks = await convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: {
+              type: "url",
+              value: "https://example.test/x.bmp",
+              mimeType: "image/bmp",
+            },
+          },
+        ] as InputContent[],
+        quietLog,
+      );
+      expect(blocks).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("fetches a url once per request when a shared cache is passed", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    const cache = createUrlFetchCache();
+    const content = [
+      {
+        type: "image",
+        source: {
+          type: "url",
+          value: "https://example.test/shared.png",
+          mimeType: "image/png",
+        },
+      },
+    ] as InputContent[];
+    try {
+      const first = await convertAguiContentToStrands(content, quietLog, {
+        fetchCache: cache,
+      });
+      const second = await convertAguiContentToStrands(content, quietLog, {
+        fetchCache: cache,
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(
+        (first[0] as unknown as { source: { bytes: Uint8Array } }).source.bytes,
+      ).toEqual(new Uint8Array([1, 2, 3]));
+      expect(
+        (second[0] as unknown as { source: { bytes: Uint8Array } }).source
+          .bytes,
+      ).toEqual(new Uint8Array([1, 2, 3]));
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("does not retry a refused url within one request", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(new Response("nope", { status: 404 }));
+    const cache = createUrlFetchCache();
+    const content = [
+      {
+        type: "image",
+        source: {
+          type: "url",
+          value: "https://example.test/gone.png",
+          mimeType: "image/png",
+        },
+      },
+    ] as InputContent[];
+    try {
+      await convertAguiContentToStrands(content, quietLog, {
+        fetchCache: cache,
+      });
+      await convertAguiContentToStrands(content, quietLog, {
+        fetchCache: cache,
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("fetches every request separately when no cache is shared", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    const content = [
+      {
+        type: "image",
+        source: {
+          type: "url",
+          value: "https://example.test/uncached.png",
+          mimeType: "image/png",
+        },
+      },
+    ] as InputContent[];
+    try {
+      await convertAguiContentToStrands(content);
+      await convertAguiContentToStrands(content);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchMock.mockRestore();
+      dnsSpy.mockRestore();
+    }
+  });
+});
+
+describe("media drop reasons", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("separates an untyped response from an unsupported one", async () => {
+    const dnsSpy = mockPublicDns();
+    const cases: Array<[string | undefined, string]> = [
+      [undefined, "no media type declared or returned"],
+      // image/* so the top-level check passes and the format check is what
+      // actually decides, which is the distinction under test.
+      ["image/bmp", "unsupported media type"],
+    ];
+    try {
+      for (const [contentType, reason] of cases) {
+        // mockImplementation, not mockResolvedValue: a Response body reads
+        // once, so a shared instance would make the second iteration behave
+        // differently from the first for reasons this test is not about.
+        vi.spyOn(urlFetchTransport, "request").mockImplementation(
+          async () =>
+            new Response(new Uint8Array([1, 2, 3]), {
+              status: 200,
+              ...(contentType
+                ? { headers: { "content-type": contentType } }
+                : {}),
+            }),
+        );
+        const { dropped } = await convertAguiContentToStrandsDetailed(
+          [
+            {
+              type: "image",
+              source: { type: "url", value: "https://example.test/x" },
+            },
+          ] as InputContent[],
+          quietLog,
+        );
+        // A caller can declare a type to fix the first and cannot fix the
+        // second, so the two must not read the same on the wire.
+        expect(dropped).toEqual([{ type: "image", reason }]);
+      }
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+
+  it("does not fetch a binary url when inline data is present but empty", async () => {
+    const dnsSpy = mockPublicDns();
+    const fetchMock = vi
+      .spyOn(urlFetchTransport, "request")
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }));
+    try {
+      const { blocks, dropped } = await convertAguiContentToStrandsDetailed(
+        [
+          {
+            type: "binary",
+            mimeType: "image/png",
+            data: "",
+            url: "https://example.test/fallback.png",
+          },
+        ] as unknown as InputContent[],
+        quietLog,
+      );
+      expect(blocks).toEqual([]);
+      // Sending an empty `data` is sending nothing, not asking for the URL.
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(dropped).toEqual([
+        { type: "binary", reason: "content was empty" },
+      ]);
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+});
+
+describe("cancellation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("abandons an in-flight download when the caller goes away", async () => {
+    const dnsSpy = mockPublicDns();
+    // Parks until the transport's own signal fires, which is the only way this
+    // resolves: if the caller's abort never reaches the fetch, the await below
+    // never returns and the test times out.
+    vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      (_t, _a, _p, signal) =>
+        new Promise((_resolve, reject) => {
+          const s = signal as AbortSignal;
+          const stop = () => reject(new Error("aborted"));
+          // Already aborted is the ordinary case here: the caller gives up
+          // while the fetch is still resolving DNS, so the signal has fired
+          // before the transport is reached and no event is coming.
+          if (s.aborted) stop();
+          else s.addEventListener("abort", stop, { once: true });
+        }) as never,
+    );
+    const controller = new AbortController();
+    try {
+      const pending = convertAguiContentToStrands(
+        [
+          {
+            type: "image",
+            source: {
+              type: "url",
+              value: "https://example.test/slow.png",
+              mimeType: "image/png",
+            },
+          },
+        ] as InputContent[],
+        quietLog,
+        { signal: controller.signal },
+      );
+      controller.abort();
+      expect(await pending).toEqual([]);
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+});
+
+describe("convertAguiContentToStrandsDetailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports nothing dropped when every item converts", async () => {
+    const { blocks, dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        { type: "text", text: "look" },
+        {
+          type: "image",
+          source: { type: "data", value: b64("PNG"), mimeType: "image/png" },
+        },
+      ] as InputContent[],
+      quietLog,
+    );
+    expect(blocks).toHaveLength(2);
+    expect(dropped).toEqual([]);
+  });
+
+  it("distinguishes a partial loss from a message that carried no media", async () => {
+    const withoutMedia = await convertAguiContentToStrandsDetailed(
+      [{ type: "text", text: "no attachments here" }] as InputContent[],
+      quietLog,
+    );
+    const partiallyLost = await convertAguiContentToStrandsDetailed(
+      [
+        { type: "text", text: "one of these two survived" },
+        {
+          type: "image",
+          source: { type: "data", value: b64("PNG"), mimeType: "image/png" },
+        },
+        {
+          type: "image",
+          source: { type: "data", value: b64("BMP"), mimeType: "image/bmp" },
+        },
+      ] as InputContent[],
+      quietLog,
+    );
+    expect(withoutMedia.dropped).toEqual([]);
+    expect(partiallyLost.blocks).toHaveLength(2);
+    expect(partiallyLost.dropped).toEqual([
+      { type: "image", reason: "unsupported media type" },
+    ]);
+  });
+
+  it("reports the reason a document was dropped", async () => {
+    const { dropped } = await convertAguiContentToStrandsDetailed(
+      [
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: "",
+            mimeType: "application/pdf",
+          },
+        },
+      ] as InputContent[],
+      quietLog,
+    );
+    expect(dropped).toEqual([
+      { type: "document", reason: "content was empty" },
+    ]);
   });
 });
 
@@ -283,6 +1495,36 @@ describe("flattenContentToText", () => {
       ]),
     ).toBe("hello world");
   });
+  it("converts a bare {text} block rather than reporting it as lost media", async () => {
+    const { blocks, dropped } = await convertAguiContentToStrandsDetailed(
+      [{ text: "serialized" }] as unknown as InputContent[],
+      quietLog,
+    );
+    // flattenContentToText already reads this shape as text, so reporting it
+    // to the client as a lost attachment contradicted the sibling path.
+    expect((blocks[0] as unknown as { text: string }).text).toBe("serialized");
+    expect(dropped).toEqual([]);
+  });
+
+  it("reads the SDK's serialized bare {text} blocks", () => {
+    // What TextBlock.toJSON() produces and _buildStrandsHistory stores: no
+    // type discriminant at all. Missing this made a replayed turn flatten to
+    // the empty string.
+    expect(
+      flattenContentToText([{ text: "serialized" }, { text: "blocks" }]),
+    ).toBe("serialized blocks");
+  });
+
+  it("does not treat a non-text block's text field as text", () => {
+    expect(flattenContentToText([{ type: "jsonBlock", text: "nope" }])).toBe(
+      "",
+    );
+  });
+
+  it("reads a single block that is not in a list", () => {
+    expect(flattenContentToText({ type: "text", text: "alone" })).toBe("alone");
+  });
+
   it("ignores non-text blocks", () => {
     expect(
       flattenContentToText([

--- a/integrations/aws-strands/typescript/src/__tests__/multimodal-passthrough.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/multimodal-passthrough.test.ts
@@ -45,6 +45,94 @@ function makeAgent(stub: import("@strands-agents/sdk").Agent): StrandsAgent {
   return sa;
 }
 
+describe("history replay of an attachment that cannot be converted", () => {
+  it("does not seed a blank text block", async () => {
+    const { stub, calls } = recordingAgent();
+    const agent = makeAgent(stub);
+
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        threadId: "thread-1",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            // No text alongside it, and the type is one the converter
+            // cannot deliver, so the conversion yields nothing.
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "data",
+                  value: b64("BMP"),
+                  mimeType: "image/bmp",
+                },
+              },
+            ],
+          } as never,
+          { id: "a1", role: "assistant", content: "seen" } as never,
+          { id: "u2", role: "user", content: "and now?" } as never,
+        ],
+      }),
+    );
+
+    expect(events.map((e) => e.type)).toContain(EventType.RUN_FINISHED);
+    // Without this the assertion below passes vacuously: a run that never
+    // reached the model contributes no entries to check.
+    expect(calls).toHaveLength(1);
+    const seeded = calls[0]!.messages;
+    const texts = seeded.flatMap((m) =>
+      ((m as { content?: unknown[] }).content ?? []).map(
+        (c) => (c as { text?: unknown }).text,
+      ),
+    );
+    // The provider rejects a blank text block and a message with no content
+    // at all, so seeding either turns a single dead attachment into a thread
+    // that fails on every later run.
+    expect(texts).not.toContain("");
+    for (const m of seeded as { content?: unknown[] }[]) {
+      expect((m.content ?? []).length).toBeGreaterThan(0);
+    }
+    // And it must still occupy its place. Dropping the turn instead leaves an
+    // assistant-first or consecutive-assistant history, which the provider
+    // rejects just as surely, so per-message shape alone is not enough.
+    const roles = (seeded as { role: string }[]).map((m) => m.role);
+    expect(roles[0]).toBe("user");
+    for (let i = 1; i < roles.length; i++) {
+      expect(roles[i]).not.toBe(roles[i - 1]);
+    }
+  });
+});
+
+describe("replayed turns the provider would refuse", () => {
+  it("never seeds a blank text block for an empty assistant turn", async () => {
+    const { stub, calls } = recordingAgent();
+    const agent = makeAgent(stub);
+
+    await collect(
+      agent,
+      minimalRunInput({
+        threadId: "thread-1",
+        messages: [
+          { id: "u1", role: "user", content: "hello" } as never,
+          // Neither text nor tool calls: the replay builder used to seed this
+          // as an empty text block, which the provider rejects on its own
+          // account just as it rejects an empty user turn.
+          { id: "a1", role: "assistant", content: "" } as never,
+          { id: "u2", role: "user", content: "again" } as never,
+        ],
+      }),
+    );
+
+    expect(calls).toHaveLength(1);
+    const texts = (
+      calls[0]!.messages as { content: { text?: string }[] }[]
+    ).flatMap((m) => m.content.map((c) => c.text));
+    expect(texts).not.toContain("");
+  });
+});
+
 describe("multimodal pass-through", () => {
   it("passes ContentBlock[] to agent.stream when the message contains an image", async () => {
     const { stub, calls } = recordingAgent();
@@ -82,7 +170,7 @@ describe("multimodal pass-through", () => {
     expect(replayed[0]!.content[1]!.type).toBe("imageBlock");
   });
 
-  it("falls back to text when ALL media blocks fail conversion (unsupported MIME)", async () => {
+  it("errors when every media block fails and there is no text to fall back to", async () => {
     const { stub, calls } = recordingAgent();
     const agent = makeAgent(stub);
     const content: InputContent[] = [
@@ -110,6 +198,43 @@ describe("multimodal pass-through", () => {
       | undefined;
     expect(error).toBeTruthy();
     expect(error!.code).toBe("MEDIA_RESOLUTION_FAILED");
+  });
+
+  it("falls back to the text alongside a media block that fails conversion", async () => {
+    const { stub, calls } = recordingAgent();
+    const agent = makeAgent(stub);
+    const events = await collect(
+      agent,
+      minimalRunInput({
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              { type: "text", text: "what is in this?" },
+              {
+                type: "image",
+                source: {
+                  type: "data",
+                  value: b64("anything"),
+                  mimeType: "image/bmp",
+                },
+              },
+            ] as InputContent[],
+          },
+        ],
+      }),
+    );
+
+    // The branch the test above is named after: some text survives, so the
+    // run proceeds with it rather than refusing.
+    expect(events.map((e) => e.type)).toContain(EventType.RUN_FINISHED);
+    expect(calls).toHaveLength(1);
+    const replayed = (calls[0]!.messages ?? []) as {
+      content: { text?: string }[];
+    }[];
+    const texts = replayed.flatMap((m) => m.content.map((c) => c.text));
+    expect(texts).toContain("what is in this?");
   });
 
   it("preserves ContentBlock[] even when stateContextBuilder is configured", async () => {

--- a/integrations/aws-strands/typescript/src/__tests__/multimodal-run-egress.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/multimodal-run-egress.test.ts
@@ -1,0 +1,491 @@
+/**
+ * What one cold run costs a deployment in egress, and what it tells a client
+ * when an attachment does not make it to the model.
+ *
+ * A cold run converts the same turns more than once: once to build the
+ * construction-time seed, and again to reconcile the replayed history. Both
+ * conversions resolve the same attachments, so the number of requests a run
+ * makes has to be asserted rather than assumed.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import dns from "node:dns";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import {
+  expectCompletedRun,
+  minimalRunInput,
+  modelTurn,
+  realStrandsAgent,
+} from "./helpers";
+import { urlFetchTransport } from "../utils";
+
+/** The fetch policy resolves the host first, so it has to answer publicly. */
+function mockPublicDns() {
+  return vi
+    .spyOn(dns.promises, "lookup")
+    .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+}
+
+function mockPngFetch() {
+  return vi.spyOn(urlFetchTransport, "request").mockImplementation(
+    async () =>
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+  );
+}
+
+function imageAt(url: string, mimeType?: string) {
+  return {
+    type: "image",
+    source: mimeType
+      ? { type: "url", value: url, mimeType }
+      : { type: "url", value: url },
+  };
+}
+
+function customNamed(events: BaseEvent[], name: string): BaseEvent[] {
+  return events.filter(
+    (e) =>
+      e.type === EventType.CUSTOM && (e as { name?: string }).name === name,
+  );
+}
+
+describe("remote attachments over one cold run", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("downloads an attachment once even though the run converts it twice", async () => {
+    mockPublicDns();
+    const fetchMock = mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "egress-1",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [imageAt("https://example.test/a.png", "image/png")],
+          } as never,
+          { id: "a1", role: "assistant", content: "seen" } as never,
+          { id: "u2", role: "user", content: "and now?" } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("downloads one url once however many turns carry it", async () => {
+    mockPublicDns();
+    const fetchMock = mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "egress-2",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [imageAt("https://example.test/same.png", "image/png")],
+          } as never,
+          { id: "a1", role: "assistant", content: "seen" } as never,
+          {
+            id: "u2",
+            role: "user",
+            content: [imageAt("https://example.test/same.png", "image/png")],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps separate urls separate", async () => {
+    mockPublicDns();
+    const fetchMock = mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "egress-3",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [imageAt("https://example.test/one.png", "image/png")],
+          } as never,
+          { id: "a1", role: "assistant", content: "seen" } as never,
+          {
+            id: "u2",
+            role: "user",
+            content: [imageAt("https://example.test/two.png", "image/png")],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not carry one run's downloads into the next on the same thread", async () => {
+    mockPublicDns();
+    const fetchMock = mockPngFetch();
+    const { agent } = realStrandsAgent([
+      modelTurn.text("ok"),
+      modelTurn.text("ok"),
+    ]);
+    const messages = [
+      {
+        id: "u1",
+        role: "user",
+        content: [imageAt("https://example.test/a.png", "image/png")],
+      } as never,
+    ];
+
+    // One thread, deliberately. Varying the thread as well lets a cache that
+    // outlives its run keep this green: the second run would then miss for the
+    // wrong reason.
+    for (const runId of ["run-1", "run-2"]) {
+      const events: BaseEvent[] = [];
+      for await (const e of agent.run(
+        minimalRunInput({ threadId: "egress-same-thread", runId, messages }),
+      )) {
+        events.push(e);
+      }
+      expectCompletedRun(events, runId);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("attachments that do not reach the model", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not interrupt a seed download on abandonment, and says so", async () => {
+    mockPublicDns();
+    let sawAbort = false;
+    vi.spyOn(urlFetchTransport, "request").mockImplementation(
+      (_t, _a, _p, signal) =>
+        new Promise((resolve) => {
+          const s = signal as AbortSignal;
+          if (s.aborted) sawAbort = true;
+          else
+            s.addEventListener("abort", () => (sawAbort = true), {
+              once: true,
+            });
+          // Settles on its own so the run completes; the point is whether the
+          // abort arrived BEFORE it did.
+          setTimeout(
+            () =>
+              resolve(
+                new Response(new Uint8Array([1]), {
+                  status: 200,
+                  headers: { "content-type": "image/png" },
+                }),
+              ),
+            30,
+          );
+        }) as never,
+    );
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const iterator = agent
+      .run(
+        minimalRunInput({
+          threadId: "abandon-1",
+          messages: [
+            {
+              id: "u1",
+              role: "user",
+              content: [imageAt("https://example.test/slow.png", "image/png")],
+            } as never,
+            { id: "a1", role: "assistant", content: "seen" } as never,
+            { id: "u2", role: "user", content: "and now?" } as never,
+          ],
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    const parked = iterator.next();
+    await new Promise((r) => setImmediate(r));
+    const returned = iterator.return!(undefined);
+    // The abort has NOT arrived, and this test exists to keep that honest. An
+    // async generator parked inside an `await` cannot be interrupted, and
+    // every media fetch happens inside one, so the endpoint's `return()` on
+    // client disconnect queues behind the download rather than cancelling it.
+    // The signal does reach the fetch and does cancel it when something aborts
+    // mid-flight (see the cancellation case in multimodal-conversion), but
+    // nothing reaches it from a disconnect. Closing that needs a cancellation
+    // channel that does not go through generator abandonment.
+    expect(sawAbort).toBe(false);
+
+    await parked.catch(() => {});
+    await returned.catch(() => {});
+  });
+
+  it("still resolves an attachment that declares no type", async () => {
+    mockPublicDns();
+    const fetchMock = mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "untyped-1",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [imageAt("https://example.test/untyped")],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(customNamed(events, "MediaDropped")).toEqual([]);
+  });
+
+  it("reports a partial loss on the live turn", async () => {
+    mockPublicDns();
+    mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "loss-1",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              { type: "text", text: "two images" },
+              imageAt("https://example.test/ok.png", "image/png"),
+              imageAt("https://example.test/nope.bmp", "image/bmp"),
+            ],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    const reported = customNamed(events, "MediaDropped");
+    expect(reported).toHaveLength(1);
+    expect((reported[0] as unknown as { value: unknown }).value).toEqual({
+      dropped: [{ type: "image", reason: "unsupported media type" }],
+      // The text block alongside the image is not counted: the question the
+      // report answers is how many attachments arrived.
+      delivered: 1,
+    });
+  });
+
+  it("says nothing when every attachment reaches the model", async () => {
+    mockPublicDns();
+    mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "loss-2",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              { type: "text", text: "one image" },
+              imageAt("https://example.test/ok.png", "image/png"),
+            ],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(customNamed(events, "MediaDropped")).toEqual([]);
+  });
+
+  it("reports only the live turn, not attachments lost from history", async () => {
+    mockPublicDns();
+    mockPngFetch();
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "loss-history",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              { type: "text", text: "an old turn" },
+              imageAt("https://example.test/old.bmp", "image/bmp"),
+            ],
+          } as never,
+          { id: "a1", role: "assistant", content: "seen" } as never,
+          { id: "u2", role: "user", content: "and now?" } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    // Deliberate scope. The report answers "what did the turn I just sent
+    // lose", so a drop from an earlier turn stays quiet rather than being
+    // re-announced on every subsequent run of the thread.
+    expect(customNamed(events, "MediaDropped")).toEqual([]);
+  });
+
+  it("converts a deprecated binary attachment instead of losing it", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "binary-1",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              { type: "text", text: "what is this" },
+              {
+                type: "binary",
+                mimeType: "image/png",
+                data: Buffer.from("PNG").toString("base64"),
+              },
+            ],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    // The gate omitted this type, so the converter's binary branch was
+    // unreachable and the attachment was dropped before conversion with no
+    // report. It now converts, so nothing is reported lost.
+    expectCompletedRun(events);
+    expect(customNamed(events, "MediaDropped")).toEqual([]);
+  });
+
+  it("fails loudly when a binary-only message cannot be converted", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "binary-2",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [
+              {
+                type: "binary",
+                mimeType: "image/bmp",
+                data: Buffer.from("BMP").toString("base64"),
+              },
+            ],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    // Previously the gate skipped this message, leaving the prompt as the
+    // empty string that flattening a binary-only message produces, and the
+    // model was asked nothing at all. Refusing the run is the honest outcome.
+    const errors = events.filter((e) => e.type === EventType.RUN_ERROR);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as unknown as { code: string }).code).toBe(
+      "MEDIA_RESOLUTION_FAILED",
+    );
+  });
+
+  it("reports what was lost before refusing a turn it cannot send", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "loss-total",
+        messages: [
+          {
+            id: "u1",
+            role: "user",
+            content: [imageAt("https://example.test/x.bmp", "image/bmp")],
+          } as never,
+        ],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    // This is the case where the reasons matter most, and it used to be the
+    // one case the client never got them: the refusal returned first.
+    const reported = customNamed(events, "MediaDropped");
+    expect(reported).toHaveLength(1);
+    expect(
+      (reported[0] as unknown as { value: { dropped: unknown[] } }).value
+        .dropped,
+    ).toEqual([{ type: "image", reason: "unsupported media type" }]);
+    const errors = events.filter((e) => e.type === EventType.RUN_ERROR);
+    expect(errors).toHaveLength(1);
+    // Order matters: the account has to arrive before the refusal.
+    expect(events.indexOf(reported[0]!)).toBeLessThan(
+      events.indexOf(errors[0]!),
+    );
+  });
+
+  it("says nothing when the turn carried no attachments at all", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events: BaseEvent[] = [];
+    for await (const e of agent.run(
+      minimalRunInput({
+        threadId: "loss-3",
+        messages: [{ id: "u1", role: "user", content: "plain text" } as never],
+      }),
+    )) {
+      events.push(e);
+    }
+
+    expectCompletedRun(events);
+    expect(customNamed(events, "MediaDropped")).toEqual([]);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/seed-concurrency.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/seed-concurrency.test.ts
@@ -7,12 +7,13 @@
  * held open inside its seed fetch by a latch, and thread B must run to
  * completion before that latch is released.
  *
- * The release timer is the discriminator, so this is a time bound rather than
- * a pure ordering check. It sits orders of magnitude above B's observed cost
- * (single-digit ms) to keep the margin wide, and under vitest's default 5000ms
- * timeout so a serialised B fails on the assertion below rather than aborting
- * as a bare timeout. A machine that cannot run B inside it reports the
- * serialisation message misleadingly.
+ * The release timer is a watchdog, not the discriminator: its only job is to
+ * turn a serialised B (which would otherwise deadlock) into a readable
+ * assertion. It is therefore set far above B's steady-state cost rather than
+ * close to it. An earlier 1500ms timer against vitest's default 5000ms was
+ * observed losing to a cold-cache B and failing the run, so the test now pays
+ * the module-load and JIT cost up front with a warm-up run, and gives both the
+ * watchdog and the test generous headroom above what B actually needs.
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
@@ -39,123 +40,155 @@ describe("seed build is outside _threadInitLock", () => {
     vi.restoreAllMocks();
   });
 
-  it("concurrent cold-inits on different threads don't serialise on a slow seed", async () => {
-    const firstFetch = deferred();
-    const release = deferred();
+  it(
+    "concurrent cold-inits on different threads don't serialise on a slow seed",
+    { timeout: 30_000 },
+    async () => {
+      const firstFetch = deferred();
+      const release = deferred();
 
-    // The fetch policy resolves the host before connecting, so the fixture
-    // host has to answer with a public address.
-    vi.spyOn(dns.promises, "lookup").mockResolvedValue([
-      { address: "93.184.216.34", family: 4 },
-    ] as never);
+      // The fetch policy resolves the host before connecting, so the fixture
+      // host has to answer with a public address.
+      vi.spyOn(dns.promises, "lookup").mockResolvedValue([
+        { address: "93.184.216.34", family: 4 },
+      ] as never);
 
-    // A's seed fetch parks until the test releases it, so A provably holds
-    // whatever it is going to hold for as long as the test needs.
-    vi.spyOn(urlFetchTransport, "request").mockImplementation(async () => {
-      firstFetch.resolve();
-      await release.promise;
-      // The fixture's source carries no mimeType, and the converter reads
-      // that rather than the response Content-Type, so it logs "No MIME type
-      // provided" and drops the block harmlessly. The body is incidental.
-      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
-        status: 200,
+      // A's seed fetch parks until the test releases it, so A provably holds
+      // whatever it is going to hold for as long as the test needs.
+      vi.spyOn(urlFetchTransport, "request").mockImplementation(async () => {
+        firstFetch.resolve();
+        await release.promise;
+        return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        });
       });
-    });
 
-    // One script cursor is shared across both threads, so the turns are
-    // consumed in whatever order the threads reach the model. Nothing here
-    // depends on which thread got which, so both turns are identical.
-    const { agent, model } = realStrandsAgent([
-      modelTurn.text("ok"),
-      modelTurn.text("ok"),
-    ]);
+      // One script cursor is shared across both threads, so the turns are
+      // consumed in whatever order the threads reach the model. Nothing here
+      // depends on which thread got which, so both turns are identical. The
+      // warm-up below runs first and consumes one of the three.
+      const { agent, model } = realStrandsAgent([
+        modelTurn.text("ok"),
+        modelTurn.text("ok"),
+        modelTurn.text("ok"),
+      ]);
 
-    const inputA = minimalRunInput({
-      threadId: "a",
-      messages: [
-        {
-          id: "u-a1",
-          role: "user",
-          content: [
-            {
-              type: "image",
-              source: {
-                type: "url",
-                value: "https://example.invalid/slow.png",
+      // A cold first run through this path costs module loading and JIT, which
+      // is what beat the watchdog before. Paying it here means the B measured
+      // below is a steady-state B.
+      const warmup: BaseEvent[] = [];
+      for await (const e of agent.run(
+        minimalRunInput({
+          threadId: "warmup",
+          messages: [{ id: "u-w1", role: "user", content: "hi" } as never],
+        }),
+      )) {
+        warmup.push(e);
+      }
+      expectCompletedRun(warmup, "warm-up");
+
+      const inputA = minimalRunInput({
+        threadId: "a",
+        messages: [
+          {
+            id: "u-a1",
+            role: "user",
+            content: [
+              // The declared type is what makes the fetch reachable: the
+              // converter checks it before spending any egress, so an
+              // attachment typed as something it cannot deliver never gets as
+              // far as the latch below.
+              {
+                type: "image",
+                source: {
+                  type: "url",
+                  value: "https://example.invalid/slow.png",
+                  mimeType: "image/png",
+                },
               },
-            },
-          ],
-        } as never,
-        { id: "u-a2", role: "user", content: "hi" } as never,
-      ],
-    });
-    const inputB = minimalRunInput({
-      threadId: "b",
-      messages: [{ id: "u-b1", role: "user", content: "hi" } as never],
-    });
+            ],
+          } as never,
+          { id: "u-a2", role: "user", content: "hi" } as never,
+        ],
+      });
+      const inputB = minimalRunInput({
+        threadId: "b",
+        messages: [{ id: "u-b1", role: "user", content: "hi" } as never],
+      });
 
-    const eventsA: BaseEvent[] = [];
-    const eventsB: BaseEvent[] = [];
-    const order: string[] = [];
+      const eventsA: BaseEvent[] = [];
+      const eventsB: BaseEvent[] = [];
+      const order: string[] = [];
 
-    // Drain A in the background. `run()` is a lazy generator: pulling a single
-    // event only parks it on RUN_STARTED, which is emitted before the agent is
-    // built, so A has to be actively consumed to reach the seed fetch at all.
-    let aFinished = false;
-    const drainedA = (async () => {
-      for await (const e of agent.run(inputA)) eventsA.push(e);
-      aFinished = true;
-    })();
+      // Drain A in the background. `run()` is a lazy generator: pulling a single
+      // event only parks it on RUN_STARTED, which is emitted before the agent is
+      // built, so A has to be actively consumed to reach the seed fetch at all.
+      let aFinished = false;
+      const drainedA = (async () => {
+        for await (const e of agent.run(inputA)) eventsA.push(e);
+        aFinished = true;
+      })();
 
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      // A is now inside the seed fetch and cannot proceed until released.
-      // If A fails before fetching, surface that instead of hanging here.
-      await Promise.race([
-        firstFetch.promise,
-        drainedA.then(() => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        // A is now inside the seed fetch and cannot proceed until released.
+        // If A fails before fetching, surface that instead of hanging here.
+        // Held in a variable so its rejection is always handled. Left inline,
+        // this derived promise rejects unhandled once A completes after the
+        // release below, and surfaces as a stray failure in whichever test
+        // happens to be running then.
+        const aFinishedEarly = drainedA.then(() => {
           throw new Error(
             `thread A finished without fetching its remote image; events: ${eventsA
               .map((e) => e.type)
               .join(", ")}`,
           );
-        }),
-      ]);
+        });
+        aFinishedEarly.catch(() => {});
+        await Promise.race([firstFetch.promise, aFinishedEarly]);
 
-      const drainedB = (async () => {
-        for await (const e of agent.run(inputB)) eventsB.push(e);
-        order.push("b-finished");
-      })();
+        const drainedB = (async () => {
+          for await (const e of agent.run(inputB)) eventsB.push(e);
+          order.push("b-finished");
+        })();
 
-      // Watchdog only: releases A so a serialised B reports the assertion
-      // below rather than hanging. B costs single-digit ms in practice.
-      timer = setTimeout(() => {
-        order.push("a-released");
+        // Watchdog only: releases A so a serialised B reports the assertion
+        // below rather than hanging. Warmed up, B costs single-digit ms, so this
+        // is three orders of magnitude of headroom.
+        timer = setTimeout(() => {
+          order.push("a-released");
+          release.resolve();
+        }, 10_000);
+        await drainedB;
+
+        // Order matters here. The watchdog is the only thing that can release A
+        // early, so if it fired, that is the fact worth reporting: asserting on
+        // `aFinished` first would blame A for finishing when the real cause was
+        // B outrunning the timer, and the message written for that case would
+        // never print.
+        expect(
+          order[0],
+          "thread B did not finish while thread A held its seed fetch. Usually that means B serialised behind _threadInitLock; on a heavily loaded machine it can also mean B simply exceeded the release timer",
+        ).toBe("b-finished");
+        // A must still be parked in its fetch: that is what makes B's completion
+        // evidence about the lock rather than about ordering luck.
+        expect(aFinished, "thread A completed before thread B finished").toBe(
+          false,
+        );
+      } finally {
+        if (timer) clearTimeout(timer);
         release.resolve();
-      }, 1500);
-      await drainedB;
+        // A's own failure must not replace an assertion error raised above; the
+        // completed-run check below is what reports it.
+        await drainedA.catch(() => {});
+      }
 
-      // A must still be parked in its fetch: that is what makes B's completion
-      // evidence about the lock rather than about ordering luck.
-      expect(aFinished, "thread A completed before thread B started").toBe(
-        false,
-      );
-      expect(
-        order[0],
-        "thread B did not finish while thread A held its seed fetch. Usually that means B serialised behind _threadInitLock; on a heavily loaded machine it can also mean B simply exceeded the release timer",
-      ).toBe("b-finished");
-    } finally {
-      if (timer) clearTimeout(timer);
-      release.resolve();
-      // A's own failure must not replace an assertion error raised above; the
-      // completed-run check below is what reports it.
-      await drainedA.catch(() => {});
-    }
-
-    // Both runs must actually have run: the ordering above holds just as well
-    // when the adapter fails internally and the failure is swallowed.
-    expectCompletedRun(eventsA, "thread a");
-    expectCompletedRun(eventsB, "thread b");
-    expect(model.calls).toBe(2);
-  });
+      // Both runs must actually have run: the ordering above holds just as well
+      // when the adapter fails internally and the failure is swallowed.
+      expectCompletedRun(eventsA, "thread a");
+      expectCompletedRun(eventsB, "thread b");
+      expect(model.calls).toBe(3);
+    },
+  );
 });

--- a/integrations/aws-strands/typescript/src/__tests__/seed-messages.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/seed-messages.test.ts
@@ -8,6 +8,51 @@ import type { Message as AguiMessage } from "@ag-ui/core";
 import { convertMessagesForStrandsSeed, buildStrandsSeed } from "../agent";
 
 describe("convertMessagesForStrandsSeed", () => {
+  it("seeds only real text from a content array", async () => {
+    const seed = await convertMessagesForStrandsSeed([
+      {
+        id: "u1",
+        role: "user",
+        content: [
+          { type: "text", text: "" },
+          { type: "text", text: null },
+          { type: "jsonBlock", text: "not the user's words" },
+          { type: "text", text: "keep me" },
+        ],
+      } as unknown as AguiMessage,
+    ]);
+    // Copying `text` off anything carrying the key sent the provider an empty
+    // block, a null, and a tool result's payload as if the user had typed it.
+    expect(seed).toEqual([{ role: "user", content: [{ text: "keep me" }] }]);
+  });
+
+  it("keeps a turn that yields no text so roles still alternate", async () => {
+    const seed = await convertMessagesForStrandsSeed([
+      { id: "u1", role: "user", content: "hello" },
+      { id: "a1", role: "assistant", content: "hi" },
+      {
+        id: "u2",
+        role: "user",
+        content: [{ type: "text", text: "" }],
+      },
+      { id: "a2", role: "assistant", content: "still here" },
+    ] as unknown as AguiMessage[]);
+
+    // Dropping the empty turn leaves ["user","assistant","assistant"], which
+    // the provider rejects just as surely as the blank text block that
+    // dropping it was meant to avoid.
+    expect(seed.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    const texts = seed.flatMap((m) =>
+      (m.content as { text?: string }[]).map((c) => c.text),
+    );
+    expect(texts).not.toContain("");
+  });
+
   it("drops system and developer messages", async () => {
     const seed = await convertMessagesForStrandsSeed([
       {

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -52,7 +52,14 @@ import {
   isAutoInjectedA2UITool,
   A2UI_STREAM_KEY,
 } from "./a2ui-tool";
-import { convertAguiContentToStrands, flattenContentToText } from "./utils";
+import {
+  convertAguiContentToStrands,
+  convertAguiContentToStrandsDetailed,
+  createUrlFetchCache,
+  flattenContentToText,
+  type DroppedMedia,
+  type MediaConversionOptions,
+} from "./utils";
 import type { SeenToolCall } from "./types";
 import { DEFAULT_LOGGER, resolveLogger, type Logger } from "./logger";
 
@@ -1087,9 +1094,36 @@ export function buildSnapshotMessages(
  * Multimodal content is routed through ``convertAguiContentToStrands`` so
  * image/document/video blocks reach the LLM intact across replay.
  */
+/**
+ * Does this message content carry an attachment the converter should handle?
+ *
+ * One definition for all three conversion sites. They previously each spelled
+ * this out, and two of the three dereferenced `item.type` on an element that
+ * arrives off the wire, so a null in the array threw before the converter's
+ * own guards could drop it.
+ */
+function _contentHasMedia(content: readonly unknown[]): boolean {
+  return content.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const type = (item as { type?: unknown }).type;
+    return (
+      type === "image" ||
+      type === "audio" ||
+      type === "video" ||
+      type === "document" ||
+      // The deprecated form. Omitting it made the converter's binary branch
+      // unreachable: the attachment was dropped before conversion, with no
+      // report, and on the live turn the prompt was replaced by the empty
+      // string that flattening a binary-only message produces.
+      type === "binary"
+    );
+  });
+}
+
 async function _buildStrandsHistory(
   input_messages: AguiMessage[],
   log: Logger,
+  fetchOptions?: MediaConversionOptions,
 ): Promise<Array<{ role: "user" | "assistant"; content: unknown[] }>> {
   const out: Array<{ role: "user" | "assistant"; content: unknown[] }> = [];
   for (const msg of input_messages ?? []) {
@@ -1098,12 +1132,14 @@ async function _buildStrandsHistory(
       const content: unknown[] = [];
       const raw = msg.content;
       if (Array.isArray(raw)) {
-        const hasMedia = raw.some((item: { type?: string }) =>
-          ["image", "audio", "video", "document"].includes(item.type ?? ""),
-        );
+        const hasMedia = _contentHasMedia(raw);
         if (hasMedia) {
           try {
-            const blocks = await convertAguiContentToStrands(raw as never, log);
+            const blocks = await convertAguiContentToStrands(
+              raw as never,
+              log,
+              { ...fetchOptions, messageId: msg.id },
+            );
             for (const b of blocks) {
               if (b instanceof TextBlock) {
                 content.push({ text: b.text });
@@ -1122,14 +1158,26 @@ async function _buildStrandsHistory(
             );
           }
           if (content.length === 0) {
-            content.push({ text: flattenContentToText(raw as never) || "" });
+            // An empty string here is rejected by the provider, which turns
+            // one dead attachment URL into a thread that fails on every
+            // subsequent run. The seed and live-turn paths both avoid it.
+            const fallback = flattenContentToText(raw as never);
+            if (fallback) content.push({ text: fallback });
           }
         } else {
-          content.push({ text: flattenContentToText(raw as never) });
+          const text = flattenContentToText(raw as never);
+          if (text) content.push({ text });
         }
       } else {
-        content.push({ text: _coerceText(raw) });
+        const text = _coerceText(raw);
+        if (text) content.push({ text });
       }
+      // A turn that produced nothing still has to occupy its place. The
+      // provider rejects an empty content array and a blank text block, but it
+      // also rejects the assistant-first or consecutive-assistant history that
+      // dropping this turn would leave behind, so the repair is the same
+      // single space the document-only guard uses.
+      if (content.length === 0) content.push({ text: " " });
       out.push({ role: "user", content });
     } else if (role === "assistant") {
       const blocks: unknown[] = [];
@@ -1163,7 +1211,10 @@ async function _buildStrandsHistory(
           toolUse: { toolUseId: tc.id, name, input: parsed },
         });
       }
-      if (blocks.length === 0) blocks.push({ text: "" });
+      // A blank text block is rejected by the provider, so an assistant turn
+      // with neither text nor tool calls keeps its place with a space rather
+      // than an empty string.
+      if (blocks.length === 0) blocks.push({ text: " " });
       out.push({ role: "assistant", content: blocks });
     } else if (role === "tool") {
       const toolCallId = (msg as { toolCallId?: string }).toolCallId || "";
@@ -1388,6 +1439,7 @@ export class StrandsAgent {
   private async _ensureAgent(
     inputData: RunAgentInput,
     threadId: string,
+    fetchOptions?: MediaConversionOptions,
   ): Promise<{ agent: StrandsAgentCore } | { error: BaseEvent }> {
     let strandsAgent = this._agentsByThread.get(threadId);
     if (strandsAgent) return { agent: strandsAgent };
@@ -1399,6 +1451,7 @@ export class StrandsAgent {
         seedMessages = await buildStrandsSeed(
           inputData.messages ?? [],
           this._log,
+          fetchOptions,
         );
       } catch (e) {
         this._log.error(
@@ -1821,10 +1874,61 @@ export class StrandsAgent {
     inputData: RunAgentInput,
     threadId: string,
   ): AsyncGenerator<BaseEvent, void, void> {
+    // Covers the whole run, including the seed's attachment downloads, which
+    // an inner `finally` did not reach.
+    //
+    // What this does NOT do is cancel a download on client disconnect. The
+    // endpoint signals a disconnect by calling `return()` on this generator,
+    // and a generator parked inside an `await` cannot be interrupted that way:
+    // the call queues behind whatever is in flight. Every media fetch happens
+    // inside such an await. The signal is wired through to the fetch and does
+    // cancel it when something aborts mid-flight, but nothing reaches it from
+    // a disconnect; that needs a cancellation channel independent of
+    // generator abandonment. `multimodal-run-egress` pins the current limit.
+    const runAbort = new AbortController();
+    try {
+      yield* this._runSingleAgentInner(inputData, threadId, runAbort);
+    } finally {
+      runAbort.abort();
+    }
+  }
+
+  /** Tell the client which attachments did not reach the model, and why. */
+  private async *_reportDroppedMedia(
+    dropped: DroppedMedia[],
+    delivered: number,
+  ): AsyncGenerator<BaseEvent, void, void> {
+    if (dropped.length === 0) return;
+    yield {
+      type: EventType.CUSTOM,
+      name: "MediaDropped",
+      value: {
+        dropped: dropped.map((d) => ({ type: d.type, reason: d.reason })),
+        delivered,
+      },
+    } as BaseEvent;
+  }
+
+  private async *_runSingleAgentInner(
+    inputData: RunAgentInput,
+    threadId: string,
+    runAbort: AbortController,
+  ): AsyncGenerator<BaseEvent, void, void> {
     yield _runStarted(inputData);
 
+    // One memo for the whole run. A cold run converts the same turns more than
+    // once (construction seed, then replayed history), so without this every
+    // remote attachment in the thread is downloaded once per conversion.
+    const fetchCache = createUrlFetchCache();
+
+    const fetchOptions = { fetchCache, signal: runAbort.signal };
+
     // Get or create agent instance for this thread.
-    const agentResult = await this._ensureAgent(inputData, threadId);
+    const agentResult = await this._ensureAgent(
+      inputData,
+      threadId,
+      fetchOptions,
+    );
     if ("error" in agentResult) {
       yield agentResult.error;
       return;
@@ -1974,6 +2078,10 @@ export class StrandsAgent {
       // tool results in history), synthesise a "frontend tool executed"
       // message so the model understands the context.
       let userMessage: string | ContentBlock[] = "Hello";
+      // Attachments on the live turn that could not be delivered. Reported
+      // below so a client can tell a partial delivery from a turn that
+      // carried no attachments at all.
+      let droppedMedia: DroppedMedia[] = [];
       if (pendingToolResultIds.size > 0 && inputData.messages) {
         // Collect EVERY trailing tool result, not just the last: a parallel
         // frontend-tool turn resolves N results in one continuation run and
@@ -2022,16 +2130,15 @@ export class StrandsAgent {
             msg.content != null
           ) {
             if (Array.isArray(msg.content)) {
-              const hasMedia = msg.content.some((item: { type?: string }) =>
-                ["image", "audio", "video", "document"].includes(
-                  item.type ?? "",
-                ),
-              );
+              const hasMedia = _contentHasMedia(msg.content);
               if (hasMedia) {
-                const blocks = await convertAguiContentToStrands(
-                  msg.content,
-                  this._log,
-                );
+                const { blocks, dropped } =
+                  await convertAguiContentToStrandsDetailed(
+                    msg.content,
+                    this._log,
+                    { ...fetchOptions, messageId: msg.id },
+                  );
+                droppedMedia = dropped;
                 if (blocks.length > 0) {
                   userMessage = blocks;
                 } else {
@@ -2042,6 +2149,11 @@ export class StrandsAgent {
                       `${LOG_PREFIX} all media content blocks failed conversion; falling back to text`,
                     );
                   } else {
+                    // Report what was lost BEFORE refusing: this is the one
+                    // case where the per-item reasons matter most, and
+                    // returning first meant the client only ever saw the
+                    // refusal with no account of why.
+                    yield* this._reportDroppedMedia(dropped, 0);
                     yield _runError(
                       "All media content blocks failed conversion and no text fallback is available",
                       "MEDIA_RESOLUTION_FAILED",
@@ -2089,6 +2201,18 @@ export class StrandsAgent {
           };
         }
       }
+
+      // Attachments that never reached the model are reported before it runs,
+      // so a client sees the loss alongside the turn it belongs to rather than
+      // having to infer it from an answer that ignores the attachment.
+      yield* this._reportDroppedMedia(
+        droppedMedia,
+        Array.isArray(userMessage)
+          ? // Media blocks only: the text blocks alongside them are not what a
+            // client is asking about when it asks what arrived.
+            userMessage.filter((b) => !(b instanceof TextBlock)).length
+          : 0,
+      );
 
       // Per-run state.
       let messageId = uuid();
@@ -2177,6 +2301,7 @@ export class StrandsAgent {
         const nativeHistory = await _buildStrandsHistory(
           inputData.messages ?? [],
           this._log,
+          fetchOptions,
         );
         if (nativeHistory.length > 0) {
           // Apply stateContextBuilder to the last user-text message in the
@@ -2238,7 +2363,6 @@ export class StrandsAgent {
       // AbortController wired into Strands's `cancelSignal` so that abandoning
       // the outer generator (HTTP client disconnect) stops the underlying
       // Bedrock streaming call rather than silently burning tokens.
-      const runAbort = new AbortController();
       const agentStream = strandsAgent.stream(invokeArgs as never, {
         cancelSignal: runAbort.signal,
       });
@@ -4288,6 +4412,7 @@ async function* collapseToChunkEvents(
 export async function buildStrandsSeed(
   messages: AguiMessage[],
   log?: Logger,
+  fetchOptions?: MediaConversionOptions,
 ): Promise<AgentConfig["messages"]> {
   if (messages.length === 0) return undefined;
 
@@ -4299,6 +4424,7 @@ export async function buildStrandsSeed(
   const seed = await convertMessagesForStrandsSeed(
     messages.slice(0, sliceEnd),
     log,
+    fetchOptions,
   );
   if (seed.length === 0) return undefined;
 
@@ -4318,6 +4444,7 @@ export async function buildStrandsSeed(
 export async function convertMessagesForStrandsSeed(
   messages: AguiMessage[],
   log?: Logger,
+  fetchOptions?: MediaConversionOptions,
 ): Promise<Array<{ role: "user" | "assistant"; content: unknown[] }>> {
   const out: Array<{ role: "user" | "assistant"; content: unknown[] }> = [];
   let pendingToolCalls: Map<string, string> | null = null;
@@ -4351,8 +4478,20 @@ export async function convertMessagesForStrandsSeed(
       } else if (Array.isArray(msg.content)) {
         // Assistant-side multimodal history is rare — preserve text only.
         for (const c of msg.content) {
-          if (c && typeof c === "object" && "text" in (c as object)) {
-            content.push({ text: (c as { text: string }).text });
+          // Same three shapes `flattenContentToText` accepts, and no others:
+          // copying `text` off anything carrying the key sent a tool result's
+          // payload to the model as if the user had typed it.
+          const typed = c as { type?: unknown; text?: unknown };
+          const carriesText =
+            typed?.type === undefined ||
+            typed?.type === "text" ||
+            typed?.type === "textBlock";
+          if (
+            carriesText &&
+            typeof typed?.text === "string" &&
+            typed.text.length > 0
+          ) {
+            content.push({ text: typed.text });
           }
         }
       }
@@ -4418,21 +4557,13 @@ export async function convertMessagesForStrandsSeed(
     if (typeof rawUserContent === "string") {
       if (rawUserContent.length > 0) content.push({ text: rawUserContent });
     } else if (Array.isArray(rawUserContent)) {
-      const hasMedia = rawUserContent.some((c: unknown) => {
-        if (!c || typeof c !== "object") return false;
-        const type = (c as { type?: string }).type;
-        return (
-          type === "image" ||
-          type === "audio" ||
-          type === "video" ||
-          type === "document"
-        );
-      });
+      const hasMedia = _contentHasMedia(rawUserContent);
       if (hasMedia) {
         try {
           const blocks = await convertAguiContentToStrands(
             rawUserContent as never,
             log,
+            { ...fetchOptions, messageId: msg.id },
           );
           for (const b of blocks) {
             if (b instanceof TextBlock) {
@@ -4457,13 +4588,29 @@ export async function convertMessagesForStrandsSeed(
         }
       } else {
         for (const c of rawUserContent) {
-          if (c && typeof c === "object" && "text" in (c as object)) {
-            content.push({ text: (c as { text: string }).text });
+          // Same three shapes `flattenContentToText` accepts, and no others:
+          // copying `text` off anything carrying the key sent a tool result's
+          // payload to the model as if the user had typed it.
+          const typed = c as { type?: unknown; text?: unknown };
+          const carriesText =
+            typed?.type === undefined ||
+            typed?.type === "text" ||
+            typed?.type === "textBlock";
+          if (
+            carriesText &&
+            typeof typed?.text === "string" &&
+            typed.text.length > 0
+          ) {
+            content.push({ text: typed.text });
           }
         }
       }
     }
-    if (content.length === 0) continue;
+    // A user turn that yielded nothing still has to occupy its place: dropping
+    // it leaves the assistant-first or consecutive-assistant history the
+    // provider refuses, which is the same failure in a different shape. The
+    // repair is the single space the document-only guard uses.
+    if (content.length === 0) content.push({ text: " " });
     out.push({ role: "user", content });
   }
 

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -2354,6 +2354,58 @@ export class StrandsAgent {
         }
       }
 
+      // Replay disabled, cold agent, continuation run: the seed already ends
+      // with the user-role toolResult turn, so handing the synthetic
+      // continuation prompt to `stream()` would have Strands append a SECOND
+      // user message. The provider-bound roles become user -> assistant ->
+      // user -> user, which Bedrock refuses for failing role alternation.
+      // Folding the prompt into the turn that is already there keeps the
+      // continuation as one user turn carrying both the toolResult block and
+      // the prompt. Only reached on the opt-out; the documented default
+      // returns above with `invokeArgs = undefined`.
+      if (
+        !replayHistory &&
+        resumeEntries.length === 0 &&
+        typeof invokeArgs === "string"
+      ) {
+        const seeded = (strandsAgent as { messages?: unknown[] }).messages;
+        const tail = seeded?.[seeded.length - 1] as
+          | { role?: string; content?: unknown[] }
+          | undefined;
+        const tailCarriesToolResult =
+          tail?.role === "user" &&
+          Array.isArray(tail.content) &&
+          tail.content.some((b) => {
+            // Seeded history arrives as ContentBlock INSTANCES, which carry a
+            // `type` discriminant; the plain-object form carries the key
+            // itself. Both shapes reach here depending on the path.
+            const block = b as { toolResult?: unknown; type?: string };
+            return (
+              block?.toolResult !== undefined ||
+              block?.type === "toolResultBlock"
+            );
+          });
+        if (tailCarriesToolResult) {
+          // Rebuilt from the serialized form so the appended text block is a
+          // real instance like the ones already there; Bedrock's formatter
+          // dispatches on `block.type`, which only instances carry.
+          const tailData = (
+            tail as unknown as { toJSON?: () => { content?: unknown[] } }
+          ).toJSON?.() ?? { content: tail!.content };
+          (strandsAgent as { messages: unknown[] }).messages = [
+            ...seeded!.slice(0, -1),
+            StrandsMessage.fromMessageData({
+              role: "user",
+              content: [
+                ...((tailData.content ?? []) as never[]),
+                { text: invokeArgs } as never,
+              ] as never,
+            }),
+          ];
+          invokeArgs = undefined;
+        }
+      }
+
       this._log.debug(
         `${LOG_PREFIX} Starting agent run: threadId=${inputData.threadId}, runId=${inputData.runId}, ` +
           `pendingToolResultIds=${JSON.stringify([...pendingToolResultIds])}, ` +
@@ -4526,25 +4578,18 @@ export async function convertMessagesForStrandsSeed(
       const toolCallId = (msg as { toolCallId?: string }).toolCallId;
       if (!toolCallId || !pendingToolCalls || !pendingToolCalls.has(toolCallId))
         continue;
-      const rawContent: unknown = (msg as { content?: unknown }).content;
-      const textContent =
-        typeof rawContent === "string"
-          ? rawContent
-          : Array.isArray(rawContent)
-            ? (rawContent as unknown[])
-                .map((c) =>
-                  c && typeof c === "object" && "text" in (c as object)
-                    ? ((c as { text?: string }).text ?? "")
-                    : "",
-                )
-                .join("")
-            : "";
       pendingToolResults ??= [];
       pendingToolResults.push({
         toolResult: {
           toolUseId: toolCallId,
           status: _readToolResult(msg).status,
-          content: [{ text: textContent }],
+          // Through the same builder the replay path uses. Hand-rolling the
+          // text here sent a render-only tool's empty result as a blank block,
+          // which the provider rejects; the builder substitutes the non-empty
+          // acknowledgement instead.
+          content: [
+            _buildToolResultContent((msg as { content?: unknown }).content),
+          ],
         },
       });
       continue;

--- a/integrations/aws-strands/typescript/src/logger.ts
+++ b/integrations/aws-strands/typescript/src/logger.ts
@@ -21,8 +21,8 @@ export interface Logger {
 /**
  * Internal fallback used when `StrandsAgentConfig.logger` is omitted.
  * Mirrors Python's stdlib default: warnings + errors go to the console,
- * debug is dropped. Not exported — callers who want different behaviour
- * inject their own logger.
+ * debug is dropped. Callers who want different behaviour inject their own
+ * logger rather than reaching for this one.
  */
 export const DEFAULT_LOGGER: Logger = {
   debug() {},

--- a/integrations/aws-strands/typescript/src/utils.ts
+++ b/integrations/aws-strands/typescript/src/utils.ts
@@ -24,6 +24,16 @@ const LOG_PREFIX = "[@ag-ui/aws-strands]";
 
 // Allowed formats per media type for Strands ContentBlock
 const IMAGE_FORMATS = new Set<string>(["png", "jpeg", "gif", "webp"]);
+// `3gp` is the SDK's spelling: its Bedrock provider translates that to
+// Bedrock's own `three_gp` on the way out, so emitting `three_gp` here would
+// skip the translation and hand every other provider a format it does not
+// know.
+//
+// Documents are the opposite case. The SDK's `DocumentFormat` union also
+// carries `json` and `xml`, but document formats reach Bedrock UNtranslated
+// and Bedrock's own enum has neither, so accepting them would turn one
+// unsupported attachment into a rejected request. Dropping the attachment
+// loses less than failing the turn, so this list stays Bedrock's.
 const DOCUMENT_FORMATS = new Set<string>([
   "pdf",
   "csv",
@@ -42,27 +52,104 @@ const VIDEO_FORMATS = new Set<string>([
   "mpeg",
   "mpg",
   "mp4",
-  "three_gp",
+  "3gp",
   "webm",
   "wmv",
 ]);
 
+/**
+ * MIME subtypes that do not spell the Strands format string they mean.
+ *
+ * Without these, most of the formats the sets above claim to support are
+ * unreachable: `text/plain` parses to `plain`, not `txt`, and the registered
+ * subtypes for Word, Excel, Matroska and 3GPP (`msword`, `vnd.ms-excel`,
+ * `x-matroska`, `3gpp`) do not match the format strings `doc`, `xls`, `mkv` or
+ * `3gp` that the sets are keyed on. The mapping is a superset of the
+ * Python sibling's, which covers the document and image entries but not the
+ * video ones.
+ */
+const MIME_FORMAT_ALIASES: Readonly<Record<string, string>> = Object.freeze(
+  Object.assign(Object.create(null) as Record<string, string>, {
+    // Documents
+    plain: "txt",
+    markdown: "md",
+    "x-markdown": "md",
+    msword: "doc",
+    "vnd.ms-excel": "xls",
+    "vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    // Images
+    jpg: "jpeg",
+    // Videos
+    "3gpp": "3gp",
+    quicktime: "mov",
+    "x-matroska": "mkv",
+    "x-flv": "flv",
+    "x-ms-wmv": "wmv",
+  }),
+);
+
+/**
+ * Split a MIME type into its family and subtype, or null if it is not one.
+ *
+ * Parameters are stripped first: `text/plain; charset=utf-8` carries the same
+ * subtype as `text/plain`, and reading a slash-separated segment out of the
+ * whole string would otherwise yield `plain; charset=utf-8` and fail.
+ *
+ * Exactly one slash is required. Taking the family from the front and the
+ * subtype from the back independently would let a value carrying two types,
+ * such as the `text/html, application/pdf` a merged duplicate header produces,
+ * satisfy a family check with one of them and supply its format from the
+ * other.
+ */
+function parseMime(
+  mimeType: string,
+): { topLevel: string; subtype: string } | null {
+  const essence = (mimeType.split(";")[0] ?? "").trim().toLowerCase();
+  const parts = essence.split("/");
+  if (parts.length !== 2) return null;
+  const [topLevel, subtype] = parts as [string, string];
+  if (!topLevel || !subtype) return null;
+  return { topLevel: topLevel.trim(), subtype: subtype.trim() };
+}
+
+/** Resolve an already-parsed subtype to a format in `allowed`, or null. */
+function formatFromSubtype(
+  subtype: string,
+  allowed: Set<string>,
+): string | null {
+  const fmt = MIME_FORMAT_ALIASES[subtype] ?? subtype;
+  return allowed.has(fmt) ? fmt : null;
+}
+
 /** Parse a MIME type into a short format string; returns null if absent or unsupported. */
 function mimeToFormat(
-  mimeType: string | undefined,
+  mimeType: string | undefined | null,
   allowed: Set<string>,
   log: Logger,
+  where?: string,
+  preparsed?: { topLevel: string; subtype: string },
 ): string | null {
+  const at = where ? ` (${where})` : "";
   if (!mimeType) {
-    log.warn(`${LOG_PREFIX} No MIME type provided, cannot determine format`);
+    log.warn(
+      `${LOG_PREFIX} No MIME type provided${at}, cannot determine format`,
+    );
     return null;
   }
-  const fmt = mimeType.split("/").pop()?.toLowerCase() ?? "";
-  if (allowed.has(fmt)) {
+  const parsed = preparsed ?? parseMime(mimeType);
+  if (!parsed) {
+    log.warn(
+      `${LOG_PREFIX} Unusable MIME type '${forLog(mimeType)}'${at}: not a single type/subtype pair`,
+    );
+    return null;
+  }
+  const fmt = formatFromSubtype(parsed.subtype, allowed);
+  if (fmt) {
     return fmt;
   }
   log.warn(
-    `${LOG_PREFIX} Unsupported MIME type '${forLog(mimeType)}' (parsed format '${forLog(fmt)}' not in ${JSON.stringify([...allowed].sort())})`,
+    `${LOG_PREFIX} Unsupported MIME type '${forLog(mimeType)}'${at} (parsed format '${forLog(MIME_FORMAT_ALIASES[parsed.subtype] ?? parsed.subtype)}' not in ${JSON.stringify([...allowed].sort())})`,
   );
   return null;
 }
@@ -113,8 +200,6 @@ let cryptoModule: typeof import("node:crypto") | undefined;
  * for the same URL can still be correlated with each other and, given the URL,
  * confirmed by hand.
  *
- * This is a deliberate divergence from the Python sibling, which logs the URL
- * as given.
  */
 function describeUrl(url: string): string {
   if (!cryptoModule) return "url<digest unavailable>";
@@ -126,7 +211,7 @@ function describeUrl(url: string): string {
   return `url#${digest}`;
 }
 
-/** Load the hash used by {@link describeUrl}. Called before any logging. */
+/** Load the hash used by {@link describeUrl}. Called before any log line that names a URL. */
 async function loadCrypto(): Promise<void> {
   cryptoModule ??= await import("node:crypto");
 }
@@ -139,10 +224,13 @@ async function loadCrypto(): Promise<void> {
  */
 function forLog(value: unknown, max = 120): string {
   const text = String(value).replace(
-    // CR, LF, TAB, VT, FF, NUL, ESC, NEL, LS and PS. Several of these are
-    // treated as line breaks by log consumers, and ESC lets a terminal sink be
-    // driven with control sequences.
-    /[\r\n\t\v\f\0\u001b\u0085\u2028\u2029]+/g,
+    // The whole C0 range and DEL, the whole C1 range (which includes NEL at
+    // U+0085 and the 8-bit CSI at U+009B), and the Unicode line and paragraph
+    // separators. Several of these are treated as line breaks by log
+    // consumers, and the escape introducers let a terminal sink be driven with
+    // control sequences. Named individually, the set was missing U+001C to
+    // U+001F, DEL and most of C1.
+    /[\u0000-\u001f\u007f-\u009f\u2028\u2029]+/g,
     " ",
   );
   return text.length > max ? `${text.slice(0, max)}...` : text;
@@ -200,9 +288,9 @@ function scrubSecrets(text: string, ...urls: string[]): string {
  * There is no port dimension: a host whose addresses are all public is
  * reachable on any port, as in the Python fix this mirrors (#2491).
  *
- * Relaxing the address checks requires passing a custom policy to
- * `fetchUrlBytes`. No supported AG-UI-to-Strands conversion path currently
- * accepts one, so in practice the defaults are what a consumer gets. Even
+ * Relaxing the address checks requires passing a custom policy directly to
+ * `fetchUrlContent`, which no conversion path does, so in practice the
+ * defaults are what a consumer gets. Even
  * under `allowPrivateNetworks`, this-network, link-local ranges and the cloud
  * metadata endpoints listed in `ALWAYS_BLOCKED_IPV4`/`ALWAYS_BLOCKED_IPV6`
  * stay blocked; that list covers the major providers rather than every
@@ -1163,8 +1251,16 @@ async function readBoundedBody(
   return body;
 }
 
+/** A fetched body together with the content type the response declared. */
+export interface FetchedContent {
+  readonly bytes: Uint8Array;
+  /** The response `Content-Type`, or `null` when the response omitted one. */
+  readonly contentType: string | null;
+}
+
 /**
- * Fetch raw bytes from a URL using the global fetch (Node 20+).
+ * Fetch a URL's body and declared content type using the global fetch
+ * (Node 20+).
  *
  * The URL is validated against `policy` before any request is made and again
  * on every redirect hop, so requests to private, loopback or cloud-metadata
@@ -1177,11 +1273,12 @@ async function readBoundedBody(
  *
  * @internal not part of the package's public API; exported for tests.
  */
-export async function fetchUrlBytes(
+export async function fetchUrlContent(
   url: string,
   log: Logger,
   policy: UrlFetchPolicy = DEFAULT_URL_FETCH_POLICY,
-): Promise<Uint8Array | null> {
+  callerSignal?: AbortSignal,
+): Promise<FetchedContent | null> {
   assertUsablePolicy(policy);
   // Loaded up front so every failure path below can name the URL opaquely.
   await loadCrypto();
@@ -1197,6 +1294,14 @@ export async function fetchUrlBytes(
     policy.timeoutMs,
   );
   const deadlineAt = now() + policy.timeoutMs;
+  // The caller's signal only ever aborts sooner; it grants no reach the
+  // policy did not already allow.
+  const onCallerAbort = () =>
+    controller.abort(
+      new UrlFetchUnavailableError("the caller abandoned the request"),
+    );
+  if (callerSignal?.aborted) onCallerAbort();
+  callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
   try {
     let target = url;
     for (let hop = 0; ; hop++) {
@@ -1277,7 +1382,10 @@ export async function fetchUrlBytes(
         );
         return null;
       }
-      return await readBoundedBody(res, policy.maxBytes);
+      return {
+        bytes: await readBoundedBody(res, policy.maxBytes),
+        contentType: res.headers.get("content-type"),
+      };
     }
   } catch (e) {
     if (e instanceof UrlFetchPolicyError) {
@@ -1301,10 +1409,29 @@ export async function fetchUrlBytes(
     return null;
   } finally {
     clearTimeout(timeout);
+    callerSignal?.removeEventListener("abort", onCallerAbort);
   }
 }
 
-function decodeBase64(value: string, log: Logger): Uint8Array | null {
+/**
+ * {@link fetchUrlContent} for callers that only need the body.
+ *
+ * @internal not part of the package's public API; exported for tests.
+ */
+export async function fetchUrlBytes(
+  url: string,
+  log: Logger,
+  policy: UrlFetchPolicy = DEFAULT_URL_FETCH_POLICY,
+): Promise<Uint8Array | null> {
+  const fetched = await fetchUrlContent(url, log, policy);
+  return fetched ? fetched.bytes : null;
+}
+
+function decodeBase64(
+  value: string,
+  log: Logger,
+  where: string,
+): Uint8Array | null {
   try {
     const bin = globalThis.atob(value);
     const out = new Uint8Array(bin.length);
@@ -1313,95 +1440,468 @@ function decodeBase64(value: string, log: Logger): Uint8Array | null {
     }
     return out;
   } catch (e) {
-    log.warn(`${LOG_PREFIX} Failed to decode base64 content:`, e);
+    log.warn(`${LOG_PREFIX} Failed to decode base64 content (${where}):`, e);
     return null;
   }
 }
 
-/** Resolve bytes from an AG-UI content source. */
-async function resolveSourceBytes(
+/**
+ * Per-request memo of what each URL returned, keyed by URL.
+ *
+ * One conversation turn is converted more than once on a cold run: once
+ * building the construction-time seed and again reconciling the replayed
+ * history. Sharing one of these across those conversions is what keeps a
+ * remote attachment to a single download per run instead of one per
+ * conversion.
+ *
+ * Promises rather than values, so two conversions asking for the same URL at
+ * the same time share the one request. Failures are memoised too: a URL the
+ * policy refused stays refused for the rest of the run rather than being
+ * retried per conversion.
+ *
+ * Every consumer of one URL receives the SAME `Uint8Array`, not a copy. That
+ * is the point (the bytes are held once however many blocks reference them),
+ * and it holds because content blocks treat their source bytes as read-only.
+ * A consumer that needs to mutate them must copy first.
+ *
+ * A memoised fetch is bound to the signal of whichever caller started it. That
+ * is sound because a cache and a cancellation signal both belong to one
+ * request and are passed together: every caller sharing a cache shares the
+ * signal that filled it. Pairing a cache with a different signal per call
+ * would break that.
+ */
+export type UrlFetchCache = Map<string, Promise<FetchedContent | null>>;
+
+/** Create a cache for one request. */
+export function createUrlFetchCache(): UrlFetchCache {
+  return new Map();
+}
+
+/**
+ * What one request shares across every conversion it makes.
+ *
+ * `messageId` is the field that varies between the conversions of a single
+ * request: it scopes document names to the message they came from, so two
+ * messages carrying byte-identical documents still produce the distinct names
+ * Bedrock requires.
+ */
+export interface MediaConversionOptions {
+  /** Shared so one URL is fetched once per request, not once per conversion. */
+  readonly fetchCache?: UrlFetchCache;
+  /** The AG-UI id of the message this content belongs to. */
+  readonly messageId?: string;
+  /**
+   * Aborts in-flight downloads when the caller goes away. Media resolution
+   * runs long before the model does, so without this a client disconnect
+   * leaves a slow attachment transferring until it finishes or times out.
+   */
+  readonly signal?: AbortSignal;
+}
+
+function fetchUrlContentCached(
+  url: string,
+  log: Logger,
+  options: MediaConversionOptions | undefined,
+): Promise<FetchedContent | null> {
+  const cache = options?.fetchCache;
+  const signal = options?.signal;
+  // Every conversion runs under the default policy: nothing plumbs another
+  // one this far. The cache key is therefore the URL alone, which stops being
+  // true the moment a per-conversion policy exists.
+  if (!cache) {
+    return fetchUrlContent(url, log, DEFAULT_URL_FETCH_POLICY, signal);
+  }
+  let pending = cache.get(url);
+  if (!pending) {
+    pending = fetchUrlContent(url, log, DEFAULT_URL_FETCH_POLICY, signal);
+    cache.set(url, pending);
+  }
+  return pending;
+}
+
+/** Resolve an AG-UI content source to bytes and whatever type it declared. */
+async function resolveSource(
   source: InputContentSource,
   log: Logger,
-): Promise<Uint8Array | null> {
+  options: MediaConversionOptions | undefined,
+  where: string,
+): Promise<FetchedContent | null> {
+  // `value` is typed as a string on both variants but arrives off the wire.
+  // A non-string reaching `atob` is silently coerced and shipped as content;
+  // one reaching the fetch throws from inside its own error handler, where
+  // `describeUrl` hashes it. Both are refused here instead.
+  if (typeof source.value !== "string") {
+    log.warn(
+      `${LOG_PREFIX} Content source (${where}) has no usable value, cannot resolve bytes`,
+    );
+    return null;
+  }
   if (source.type === "data") {
-    return decodeBase64(source.value, log);
+    const bytes = decodeBase64(source.value, log, where);
+    return bytes ? { bytes, contentType: null } : null;
   }
   if (source.type === "url") {
-    return await fetchUrlBytes(source.value, log);
+    return await fetchUrlContentCached(source.value, log, options);
   }
   log.warn(
-    `${LOG_PREFIX} Unknown content source type: ${forLog((source as { type?: string }).type)}, cannot resolve bytes`,
+    `${LOG_PREFIX} Unknown content source type (${where}): ${forLog((source as { type?: string }).type)}, cannot resolve bytes`,
   );
   return null;
 }
 
+/** A media item that could not be turned into a ContentBlock, and why. */
+export interface DroppedMedia {
+  /**
+   * The AG-UI content type of the item that was dropped. Bounded and stripped
+   * of control characters like every other client-supplied value that leaves
+   * this module, because an unknown type is whatever the client sent.
+   */
+  readonly type: string;
+  /** A short, non-sensitive reason, safe to put on the wire. */
+  readonly reason: string;
+}
+
+/** What one conversion produced, including what it could not convert. */
+export interface MediaConversionResult {
+  readonly blocks: ContentBlock[];
+  /**
+   * Media items the conversion could not deliver. Empty on a clean
+   * conversion, so a caller can tell a partial delivery from a message that
+   * carried no attachments at all.
+   *
+   * Every conversion reports its own drops. Which of those reach the wire is
+   * the adapter's decision, and it reports only the live turn's: re-announcing
+   * a drop from an earlier turn on every replay of the thread would say
+   * nothing new.
+   */
+  readonly dropped: DroppedMedia[];
+}
+
+const IMAGE_TOP_LEVEL: ReadonlySet<string> = new Set(["image"]);
+const VIDEO_TOP_LEVEL: ReadonlySet<string> = new Set(["video"]);
+// Documents legitimately arrive as either, e.g. application/pdf and text/csv.
+const DOCUMENT_TOP_LEVEL: ReadonlySet<string> = new Set([
+  "application",
+  "text",
+]);
+
+const DROP_UNSUPPORTED_TYPE = "unsupported media type";
+const DROP_UNRESOLVABLE = "content could not be resolved";
+// Kept apart from DROP_UNRESOLVABLE: a caller can fix a malformed item, and
+// cannot fix a remote host that would not answer.
+const DROP_MALFORMED = "content item is malformed";
+const DROP_EMPTY = "content was empty";
+// Kept distinct from DROP_UNSUPPORTED_TYPE: a caller can fix a missing type by
+// declaring one, and cannot fix a type this adapter does not carry.
+const DROP_UNTYPED = "no media type declared or returned";
+
 /**
- * Convert an AG-UI `InputContent` list to Strands `ContentBlock` values.
+ * Resolve one media item to the format string and bytes a ContentBlock needs.
+ *
+ * The declared type is checked before anything is fetched or decoded, so an
+ * attachment that could never be delivered costs no egress. A URL source that
+ * declares no type is the one case that has to be fetched first: the
+ * response's own content type is then the only thing left to read it from.
+ */
+async function resolveMedia(
+  source: InputContentSource,
+  allowed: Set<string>,
+  topLevel: ReadonlySet<string>,
+  log: Logger,
+  options: MediaConversionOptions | undefined,
+  where: string,
+): Promise<{ bytes: Uint8Array; format: string } | { drop: string }> {
+  // Typed as present, but it arrives off the wire. A malformed item is
+  // dropped like any other rather than throwing out of the conversion and
+  // taking the message's other attachments with it.
+  if (!source || typeof source !== "object") {
+    log.warn(`${LOG_PREFIX} Skipping content (${where}): ${DROP_MALFORMED}`);
+    return { drop: DROP_MALFORMED };
+  }
+  const declared =
+    typeof source.mimeType === "string" ? source.mimeType : undefined;
+  let format: string | null = null;
+  if (declared) {
+    format = mimeToFormat(declared, allowed, log, where);
+    if (!format) return { drop: DROP_UNSUPPORTED_TYPE };
+  }
+
+  const resolved = await resolveSource(source, log, options, where);
+  if (!resolved) {
+    // resolveSource names this item on every path it refuses itself. Only a
+    // fetch failure does not: that logs against the URL's digest, deeper down,
+    // so it is the one case still missing a line naming the attachment.
+    if (source.type === "url") {
+      log.warn(
+        `${LOG_PREFIX} Skipping content (${where}): ${DROP_UNRESOLVABLE}`,
+      );
+    }
+    return { drop: DROP_UNRESOLVABLE };
+  }
+  if (resolved.bytes.length === 0) {
+    // A zero-length array is truthy, so this needs its own check: an empty
+    // block is not a smaller attachment, it is one the provider rejects for
+    // the whole request.
+    log.warn(
+      `${LOG_PREFIX} Skipping content with an empty body (${where}): a zero-byte block is rejected by the provider`,
+    );
+    return { drop: DROP_EMPTY };
+  }
+
+  if (!format) {
+    // Only reached when the source declared nothing, so this type is entirely
+    // the remote server's word, and only this path is checked against the
+    // family. A DECLARED `text/png` on an image is still accepted, because a
+    // client naming its own attachment is not the case being defended
+    // against. Requiring the top-level type to match the kind
+    // of attachment asked for stops a server relabelling a payload across
+    // families, e.g. serving `text/png` for an image, which the subtype check
+    // below would accept on its own.
+    //
+    // It does NOT make an untyped document URL safe: an error page served as
+    // `text/html` is a legitimate document type, and nothing in a 200 response
+    // distinguishes it from the document that was asked for. Declaring a type
+    // on the attachment is what avoids that.
+    const served = resolved.contentType;
+    if (!served) {
+      log.warn(
+        `${LOG_PREFIX} No MIME type provided by the source or the response (${where}), cannot determine format`,
+      );
+      return { drop: DROP_UNTYPED };
+    }
+    const parsedServed = parseMime(served);
+    if (!parsedServed || !topLevel.has(parsedServed.topLevel)) {
+      log.warn(
+        `${LOG_PREFIX} Response type '${forLog(served)}' (${where}) is not one of ${JSON.stringify([...topLevel].sort())} for this attachment`,
+      );
+      return { drop: DROP_UNSUPPORTED_TYPE };
+    }
+    format = mimeToFormat(served, allowed, log, where, parsedServed);
+    if (!format) return { drop: DROP_UNSUPPORTED_TYPE };
+  }
+  return { bytes: resolved.bytes, format };
+}
+
+/**
+ * A Bedrock document name that is unique within a request and stable across
+ * replays of the same content.
+ *
+ * Bedrock requires document names to be unique across the whole request, so a
+ * fixed name makes any message carrying two documents unsendable. Three things
+ * separate the names, and each is load-bearing:
+ *
+ *  - the message id, because one request converts each message separately, so
+ *    a per-conversion counter alone would give byte-identical documents in two
+ *    different messages the same name;
+ *  - the index within that message, which separates byte-identical copies
+ *    attached to the same message;
+ *  - the content digest, which separates two different documents that land at
+ *    the same index of the same message. Replay stability comes from the
+ *    message id and the index, which are what stay the same across replays;
+ *    the digest is what stops two different payloads colliding.
+ *
+ * The name is model-visible, so nothing user-controlled is copied into it; the
+ * message id is hashed rather than interpolated.
+ *
+ * Close to the Python sibling's `_document_name` but not identical: Python
+ * keys a URL-sourced document on the URL string, so its name survives the
+ * remote content changing, while this keys on the bytes actually fetched, so a
+ * changed remote yields a changed name. Both are unique within a request,
+ * which is what the provider requires.
+ */
+function documentName(
+  bytes: Uint8Array,
+  index: number,
+  messageId: string | undefined,
+): string {
+  // `loadCrypto()` is awaited before every call and throws rather than leaving
+  // the module unset, so there is no unloaded case to fall back for.
+  const hash = cryptoModule!.createHash("sha256");
+  const utf8 = new TextEncoder();
+  for (const part of [messageId ?? "direct", String(index)]) {
+    const encoded = utf8.encode(part);
+    // Length-prefixed so two different component splits cannot collide.
+    const length = new Uint8Array(4);
+    new DataView(length.buffer).setUint32(0, encoded.length);
+    hash.update(length);
+    hash.update(encoded);
+  }
+  hash.update(bytes);
+  return `document-${hash.digest("hex").slice(0, 32)}`;
+}
+
+/**
+ * Convert an AG-UI `InputContent` list to Strands `ContentBlock` values,
+ * reporting what could not be converted.
  *
  * Supported types:
  *  - `TextInputContent` -> `TextBlock`
  *  - `ImageInputContent` -> `ImageBlock` (png, jpeg, gif, webp)
  *  - `DocumentInputContent` -> `DocumentBlock` (pdf, csv, doc, docx, xls, xlsx, html, txt, md)
- *  - `VideoInputContent` -> `VideoBlock` (flv, mkv, mov, mpeg, mpg, mp4, three_gp, webm, wmv)
- *  - `AudioInputContent` — skipped (Strands has no audio support).
- *  - Unresolvable items (bad MIME, fetch failure) — skipped.
+ *  - `VideoInputContent` -> `VideoBlock` (flv, mkv, mov, mpeg, mpg, mp4, 3gp, webm, wmv)
+ *  - `AudioInputContent`: skipped (Strands has no audio support).
+ *  - Deprecated `binary` content: mapped to an `ImageBlock`, taking inline
+ *    `data` when present and fetching `url` only when it is absent.
+ *  - Unresolvable items (bad MIME, fetch failure, empty body): skipped and
+ *    reported in `dropped`.
+ *
+ * A result carrying document blocks and no usable text block gains a leading
+ * `TextBlock(" ")`, because Bedrock rejects the request otherwise.
+ *
+ * Pass the same `options.fetchCache` to every conversion made for one request
+ * so a remote attachment is fetched once rather than once per conversion, and
+ * `options.messageId` so document names stay unique across the request.
+ *
+ * @internal not part of the package's public API; `convertAguiContentToStrands`
+ * is the exported entry point.
  */
-export async function convertAguiContentToStrands(
+export async function convertAguiContentToStrandsDetailed(
   content: InputContent[],
   log: Logger = DEFAULT_LOGGER,
-): Promise<ContentBlock[]> {
+  options?: MediaConversionOptions,
+): Promise<MediaConversionResult> {
   const blocks: ContentBlock[] = [];
+  const dropped: DroppedMedia[] = [];
+  let documentIndex = 0;
 
-  for (const item of content) {
+  for (const [itemIndex, item] of content.entries()) {
+    // Two dropped attachments in one conversion are otherwise
+    // indistinguishable in the log.
+    const where = `item ${itemIndex}${options?.messageId ? ` of message ${forLog(options.messageId)}` : ""}`;
+
+    if (!item || typeof item !== "object") {
+      // Logged but not reported, for the same reason a malformed text item is
+      // not: `dropped` is the media report and reaches a client beside a count
+      // of media delivered.
+      log.warn(`${LOG_PREFIX} Skipping content (${where}): not an object`);
+      continue;
+    }
+
+    // A bare `{ text }` with no discriminant is what the SDK's serialized
+    // blocks look like, and `flattenContentToText` already reads them as text.
+    // Falling through to the unknown-type branch reported one to the client as
+    // a lost attachment.
+    if (
+      item.type === undefined &&
+      typeof (item as { text?: unknown }).text === "string"
+    ) {
+      const bare = (item as unknown as { text: string }).text;
+      if (bare.length > 0) blocks.push(new TextBlock(bare));
+      continue;
+    }
+
     if (item.type === "text") {
-      blocks.push(new TextBlock((item as TextInputContent).text));
+      // `text` is typed as a string but arrives off the wire, so a malformed
+      // item must be dropped like any other rather than throwing out of the
+      // whole conversion and taking the other attachments with it. An empty
+      // one is dropped too: the provider rejects an empty block on its own
+      // account, and it carries nothing to lose.
+      const text = (item as TextInputContent).text;
+      if (typeof text === "string" && text.length > 0) {
+        blocks.push(new TextBlock(text));
+      } else if (typeof text !== "string") {
+        // Logged but not reported: `dropped` is the media report, and it
+        // reaches a client next to a count of media blocks delivered. A text
+        // item in it would read as a lost attachment.
+        log.warn(
+          `${LOG_PREFIX} Skipping text (${where}): no usable text field`,
+        );
+      }
       continue;
     }
 
     if (item.type === "image") {
-      const imageItem = item as ImageInputContent;
-      const bytes = await resolveSourceBytes(imageItem.source, log);
-      if (!bytes) continue;
-      const fmt = mimeToFormat(imageItem.source.mimeType, IMAGE_FORMATS, log);
-      if (!fmt) continue;
+      const resolved = await resolveMedia(
+        (item as ImageInputContent).source,
+        IMAGE_FORMATS,
+        IMAGE_TOP_LEVEL,
+        log,
+        options,
+        where,
+      );
+      if ("drop" in resolved) {
+        // resolveMedia has already logged the reason with this item's
+        // context; a second line here would report one drop twice.
+        dropped.push({ type: "image", reason: resolved.drop });
+        continue;
+      }
       blocks.push(
-        new ImageBlock({ format: fmt as ImageFormat, source: { bytes } }),
+        new ImageBlock({
+          format: resolved.format as ImageFormat,
+          source: { bytes: resolved.bytes },
+        }),
       );
       continue;
     }
 
     if (item.type === "document") {
-      const docItem = item as DocumentInputContent;
-      const bytes = await resolveSourceBytes(docItem.source, log);
-      if (!bytes) continue;
-      const fmt = mimeToFormat(docItem.source.mimeType, DOCUMENT_FORMATS, log);
-      if (!fmt) continue;
+      const index = documentIndex++;
+      // Names the digest below. A failure here would otherwise throw out of
+      // the whole conversion, which is the one outcome the drop-and-report
+      // design exists to avoid, so this document is dropped instead.
+      try {
+        await loadCrypto();
+      } catch (e) {
+        log.warn(
+          `${LOG_PREFIX} Skipping document (${where}): the hash used to name it is unavailable`,
+          e,
+        );
+        dropped.push({ type: "document", reason: DROP_UNRESOLVABLE });
+        continue;
+      }
+      const resolved = await resolveMedia(
+        (item as DocumentInputContent).source,
+        DOCUMENT_FORMATS,
+        DOCUMENT_TOP_LEVEL,
+        log,
+        options,
+        where,
+      );
+      if ("drop" in resolved) {
+        // resolveMedia has already logged the reason with this item's
+        // context; a second line here would report one drop twice.
+        dropped.push({ type: "document", reason: resolved.drop });
+        continue;
+      }
       blocks.push(
         new DocumentBlock({
-          format: fmt as DocumentFormat,
-          name: "document",
-          source: { bytes },
+          format: resolved.format as DocumentFormat,
+          name: documentName(resolved.bytes, index, options?.messageId),
+          source: { bytes: resolved.bytes },
         }),
       );
       continue;
     }
 
     if (item.type === "video") {
-      const vidItem = item as VideoInputContent;
-      const bytes = await resolveSourceBytes(vidItem.source, log);
-      if (!bytes) continue;
-      const fmt = mimeToFormat(vidItem.source.mimeType, VIDEO_FORMATS, log);
-      if (!fmt) continue;
+      const resolved = await resolveMedia(
+        (item as VideoInputContent).source,
+        VIDEO_FORMATS,
+        VIDEO_TOP_LEVEL,
+        log,
+        options,
+        where,
+      );
+      if ("drop" in resolved) {
+        // resolveMedia has already logged the reason with this item's
+        // context; a second line here would report one drop twice.
+        dropped.push({ type: "video", reason: resolved.drop });
+        continue;
+      }
       blocks.push(
-        new VideoBlock({ format: fmt as VideoFormat, source: { bytes } }),
+        new VideoBlock({
+          format: resolved.format as VideoFormat,
+          source: { bytes: resolved.bytes },
+        }),
       );
       continue;
     }
 
     if (item.type === "audio") {
       log.warn(
-        `${LOG_PREFIX} Skipping audio content: Strands has no audio support`,
+        `${LOG_PREFIX} Skipping audio (${where}): Strands has no audio support`,
       );
+      dropped.push({ type: "audio", reason: "Strands has no audio support" });
       continue;
     }
 
@@ -1413,23 +1913,59 @@ export async function convertAguiContentToStrands(
         url?: string;
         data?: string;
       };
+      const fmt = mimeToFormat(
+        typeof bin.mimeType === "string" ? bin.mimeType : undefined,
+        IMAGE_FORMATS,
+        log,
+        where,
+      );
+      if (!fmt) {
+        // mimeToFormat has already said why, with this item's context; a
+        // second line here would log one dropped item twice.
+        dropped.push({
+          type: "binary",
+          reason:
+            typeof bin.mimeType === "string" && bin.mimeType
+              ? DROP_UNSUPPORTED_TYPE
+              : DROP_UNTYPED,
+        });
+        continue;
+      }
+      // `data` present but empty, or present and malformed, is a caller
+      // sending nothing rather than a caller asking for the URL. Falling
+      // through would spend a request the message never asked for and then
+      // report the wrong reason, so any present `data` claims the item.
+      const hasInlineData = bin.data !== undefined && bin.data !== null;
       let bytes: Uint8Array | null = null;
-      if (bin.data) {
-        bytes = decodeBase64(bin.data, log);
-      } else if (bin.url) {
-        bytes = await fetchUrlBytes(bin.url, log);
+      let inlineMalformed = false;
+      if (hasInlineData) {
+        if (typeof bin.data !== "string") {
+          inlineMalformed = true;
+        } else if (bin.data) {
+          bytes = decodeBase64(bin.data, log, where);
+          if (!bytes) inlineMalformed = true;
+        } else {
+          bytes = new Uint8Array(0);
+        }
+      } else if (typeof bin.url === "string" && bin.url) {
+        bytes =
+          (await fetchUrlContentCached(bin.url, log, options))?.bytes ?? null;
+      }
+      if (inlineMalformed) {
+        log.warn(`${LOG_PREFIX} Skipping binary (${where}): ${DROP_MALFORMED}`);
+        dropped.push({ type: "binary", reason: DROP_MALFORMED });
+        continue;
       }
       if (!bytes) {
         log.warn(
-          `${LOG_PREFIX} Skipping binary content: could not resolve bytes`,
+          `${LOG_PREFIX} Skipping binary (${where}): ${DROP_UNRESOLVABLE}`,
         );
+        dropped.push({ type: "binary", reason: DROP_UNRESOLVABLE });
         continue;
       }
-      const fmt = mimeToFormat(bin.mimeType, IMAGE_FORMATS, log);
-      if (!fmt) {
-        log.warn(
-          `${LOG_PREFIX} Skipping binary content: unsupported MIME type '${forLog(bin.mimeType)}'`,
-        );
+      if (bytes.length === 0) {
+        log.warn(`${LOG_PREFIX} Skipping binary (${where}): ${DROP_EMPTY}`);
+        dropped.push({ type: "binary", reason: DROP_EMPTY });
         continue;
       }
       blocks.push(
@@ -1439,11 +1975,41 @@ export async function convertAguiContentToStrands(
     }
 
     log.warn(
-      `${LOG_PREFIX} Skipping unknown content type: ${forLog((item as { type?: string }).type)}`,
+      `${LOG_PREFIX} Skipping unknown content type (${where}): ${forLog((item as { type?: string }).type)}`,
     );
+    dropped.push({
+      type: forLog((item as { type?: string }).type, 40),
+      reason: "unknown content type",
+    });
   }
 
-  return blocks;
+  // Bedrock rejects a message that carries document blocks but no text block,
+  // which makes a document-only message unsendable on the live turn and on
+  // every replay of the thread afterwards. The Python sibling inserts the same
+  // single space.
+  if (
+    blocks.some((b) => b instanceof DocumentBlock) &&
+    !blocks.some((b) => b instanceof TextBlock)
+  ) {
+    blocks.unshift(new TextBlock(" "));
+  }
+
+  return { blocks, dropped };
+}
+
+/**
+ * Convert an AG-UI `InputContent` list to Strands `ContentBlock` values.
+ *
+ * See {@link convertAguiContentToStrandsDetailed}, which additionally reports
+ * the items it could not convert.
+ */
+export async function convertAguiContentToStrands(
+  content: InputContent[],
+  log: Logger = DEFAULT_LOGGER,
+  options?: MediaConversionOptions,
+): Promise<ContentBlock[]> {
+  return (await convertAguiContentToStrandsDetailed(content, log, options))
+    .blocks;
 }
 
 /** Extract plain text from AG-UI message content or Strands content blocks. */
@@ -1458,17 +2024,26 @@ export function flattenContentToText(content: unknown): string {
     const parts: string[] = [];
     for (const item of content) {
       if (!item || typeof item !== "object") continue;
-      const typed = item as { type?: string; text?: string };
-      // AG-UI TextInputContent
-      if (typed.type === "text" && typeof typed.text === "string") {
-        parts.push(typed.text);
-      }
-      // Strands TextBlock
-      if (typed.type === "textBlock" && typeof typed.text === "string") {
+      const typed = item as { type?: string; text?: unknown };
+      if (typeof typed.text !== "string") continue;
+      // Three shapes carry text: AG-UI `TextInputContent` (`type: "text"`), a
+      // Strands `TextBlock` instance (`type: "textBlock"`), and the SDK's
+      // SERIALIZED block, which is a bare `{ text }` with no discriminant at
+      // all. `_buildStrandsHistory` emits that third form, so omitting it made
+      // a replayed turn flatten to nothing.
+      if (
+        typed.type === undefined ||
+        typed.type === "text" ||
+        typed.type === "textBlock"
+      ) {
         parts.push(typed.text);
       }
     }
     return parts.join(" ");
+  }
+  // A single block rather than a list: same rules, one element.
+  if (typeof content === "object") {
+    return flattenContentToText([content]);
   }
   return "";
 }


### PR DESCRIPTION
Fixes the seven defects on PNI-382 and the hygiene tail carried across from the
cancelled PNI-380. They land as one change because they all live in
`convertAguiContentToStrands` and its callers, and fixing them separately would
have meant reordering the same function four times.

## User-visible

**An attachment sent as a URL with no declared type was always dropped.**
`mimeType` is optional on the wire, but it was the only thing the converter
read; the response's own `Content-Type` was never consulted. When that
attachment was a message's only content, the run ended in
`MEDIA_RESOLUTION_FAILED`. The converter now falls back to the response content
type. A declared type still wins.

Because that fallback trusts a remote server, the served type's top-level
family must also match the attachment being resolved, so a server cannot hand
back `text/png` for an image and have the subtype check accept it. This does
not make an untyped document URL safe: an error page served as `text/html` is a
legitimate document type, and nothing in a 200 response separates it from the
document that was asked for. Declaring a type on the attachment is what avoids
that, and the code says so rather than implying more than it delivers.

**A message whose only content was a document was refused by the provider.**
The converter returned document blocks with no accompanying text block, which
Bedrock rejects for the whole request, so the turn failed live and again on
every replay. A single space is now inserted, as the Python sibling does. Empty
text items are dropped rather than emitted, since an empty block is itself
rejected and would otherwise satisfy the guard without satisfying the provider.

**Most of the formats the converter claimed to support were unreachable.** The
format was the last slash-separated segment of the MIME type, lowercased, with
no alias table and no parameter stripping. `text/plain` parsed to `plain`, not
`txt`; `application/msword` does not match `doc`; and any type carrying a
`charset` parameter failed outright. There is now an alias table, parameters
are stripped, and a MIME type must be exactly one type/subtype pair, so a value
carrying two of them cannot satisfy the family check with one and supply its
format from the other.

The format sets were also wrong against the SDK. `three_gp` is not in the SDK's
`VideoFormat` union; `3gp` is, and the SDK's own Bedrock provider translates it
to Bedrock's spelling on the way out, so emitting `three_gp` skipped that
translation and handed every other provider a format it does not know. The sets
now match the SDK for video. They deliberately do **not** match it for
documents: the SDK's `DocumentFormat` also carries `json` and `xml`, but
document formats reach Bedrock untranslated and Bedrock's enum has neither, so
accepting them would turn one unsupported attachment into a rejected request.
A test pins that refusal with the reason next to it.

**An empty body produced a zero-byte block** that the provider rejects for the
whole request, because the guard was `if (!bytes)` and a zero-length
`Uint8Array` is truthy. Reachable from a bodyless response or an empty inline
value.

## Efficiency

**Every URL attachment downloaded twice on a cold run.** A cold run converts
the same turns more than once: once building the construction-time seed, and
again reconciling the replayed history. Both resolved the same URLs.

What a deployment's egress does, measured against the parent commit rather than
reasoned about:

| Thread | Requests before | Requests after |
|---|---|---|
| One URL attachment, one cold run | 2 | 1 |
| Same URL in two turns, one cold run | 4 | 1 |

Before, outbound requests scaled with the number of attachment *references* in
the thread, at two requests each, so a long thread re-downloaded its whole
attachment history on every cold run. After, they scale with the number of
*distinct URLs*, at one request each. For an operator this is attachment egress
per cold run falling by at least half, and by more on any thread that
references the same asset more than once.

**Bytes were fetched before the format check**, so an attachment that could
never be delivered was downloaded first. The declared type is now checked
before anything is fetched or decoded. A URL source that declares no type is
the one case that still has to be fetched first, because the response is then
the only place its type can come from.

**A partial media loss was unsignalled**: a caller could not tell a refusal
from no attachment having been sent. The converter now reports what it could
not convert, and the adapter emits a `MediaDropped` custom event carrying the
dropped items with reasons and the count of media delivered. It is emitted
before the model runs, and before the refusal on a total failure, which is the
case where the reasons matter most and the one where they previously never
arrived. A turn with no attachments and a turn whose attachments all arrived
both stay silent. The report covers the live turn only; re-announcing an old
drop on every replay would say nothing new.

## Carried across from PNI-380

**Bedrock document names were hardcoded**, so any message carrying two
documents was unsendable. Names now derive from the message id, the document's
index within that message, and a digest of its content: unique across a
request, stable across replays, with nothing user-controlled in the
model-visible name.

**`flattenContentToText` missed the SDK's serialized block shape**, a bare
`{ text }` with no discriminant, which is what history replay stores. The text
fallback silently produced nothing; the A2UI tool already carried a hand-rolled
workaround for it.

**Drop diagnostics named no item**, so two dropped attachments in one
conversion were indistinguishable. Each drop now logs one line carrying the
reason, the item's index and the message id. One line, not two: the deprecated
binary path used to log twice per drop, and now no path does.

Also from that list: the logger's "Not exported" comment contradicted the
export on the next line.

**Cancellation is only partly done, and this PR should not claim otherwise.**
The run's `AbortController` was created beside `agent.stream()`, long after
conversion. It is now created before the fetches, covers the whole run, and its
signal reaches the transport, so an abort mid-flight does cancel a download.
What it does not do is cancel on client disconnect. The endpoint signals a
disconnect by calling `return()` on the run generator, and an async generator
parked inside an `await` cannot be interrupted that way: the call queues behind
whatever is in flight, and every media fetch happens inside such an await. This
was found by writing a test that asserted the abort arrives during the download
(it timed out) and then a weaker one (it also failed). Closing it needs a
cancellation channel independent of generator abandonment, which is a public
API change and wants its own ticket. A test and a code comment pin the current
limit so the controller's presence does not imply more than it delivers.

Deliberately closed rather than fixed, each with a reason:

- The A2UI tool's direct `DEFAULT_LOGGER` calls. Different file and subject.
- The missing `engines` field. The ticket frames this as a question of whether
  the repo wants the convention, and sibling integrations do not declare one.
- Type-checking `examples/`. Adding it surfaces five pre-existing errors caused
  by the package tsconfig's `moduleResolution: "node"` not resolving the SDK's
  subpath exports. Closing the gap needs either a resolution change affecting
  how the shipped package's types resolve for every consumer, or a separate
  tsconfig wired into the typecheck target. The errors were verified
  pre-existing, then the change reverted.

## Found while fixing the above

Two classes turned up repeatedly and were fixed as classes rather than
one report at a time.

**A message could be made unsendable in six shapes**, each fix revealing the
next: a blank text block, an empty content array, broken user/assistant
alternation on replay, the same on the seed path, an empty assistant turn, and
the document-only case. Tests now assert the sequence of roles, not just each
message's shape, because per-message assertions could not see the ordering
ones.

**Malformed wire data crashed the whole conversion from seven dereferences**:
a text item with no `text`, a media source that is missing or null, a
non-object element in the content array, a non-string `mimeType` on the
deprecated binary path, a non-string `source.value` on both the data and URL
branches, and the two agent-side gates that decide whether a message carries
media. The URL one threw from inside the fetch's own error handler, escaping
the containment written for it. All are typed as present but arrive off the
wire; each now drops the item rather than taking the message's other
attachments with it.

**The deprecated binary branch was unreachable.** All three gates that decide
whether a message carries media omitted that type, so the attachment was
discarded before the converter saw it, with no report, and on the live turn the
prompt became the empty string that flattening a binary-only message produces.
The three gates are now one guarded predicate.

## Deliberate test changes

`seed-concurrency.test.ts` reached its latch through the old ordering: its
fixture declared no type, and the converter fetched bytes before checking the
format. With the format check moved ahead of the fetch, an attachment that
declares an undeliverable type no longer reaches the network, so the fixture
now declares `image/png`. This is deliberate. Without it the test would still
pass, but only because the mock response happens to set no `Content-Type`,
which is a far more fragile reason than the one it now states.

The same test was also genuinely flaky, which review caught by observing it
fail: its 1500ms watchdog lost to a cold-cache thread B and reported the wrong
cause. It now pays module-load and JIT cost in a warm-up run before anything is
timed, the watchdog sits far above B's steady-state cost, and its assertions
are reordered so the watchdog firing is reported as the watchdog firing.

The unsoundness the ticket describes, the test passing while the runs it drove
failed inside the adapter, was already fixed upstream in 445f3f6ff, which added
`expectCompletedRun` on both threads and an assertion on the model call count.
It did not reproduce and needed no further work.

## Testing

Every fix has a test asserting observable behaviour, and every fix was
mutation-tested: reverted in place, the suite confirmed red, then restored.

Reported honestly, because it did not pass first time. Mutation testing was run
after each review round, and the first pass of each round routinely caught only
part of the set: 11 of 17, then 2 of 4, then 3 of 5, then 1 of 3. Every gap was
a test that asserted less than its name claimed, and each was rewritten until
the mutation went red. It also caught three tests that were vacuous for
subtler reasons, including one whose cache-isolation fixture varied the thread
as well as the run, and one check whose only test case could not distinguish
the fix from its absence.

Review across six rounds found two fixes of mine that had regressed something
else and one that had never landed at all, which is why the rounds continued
past the first clean-looking one.

## Not weakened

The URL validation policy is untouched. The only change inside the fetch is its
return statement, which now carries the response content type alongside the
bytes, plus an optional caller signal that can only abort sooner than the
existing timeout. The scheme allowlist, address checks, redirect handling and
size cap are unchanged, and all 326 `url-fetch-policy` tests pass.
`fetchUrlBytes` keeps its original signature as a thin wrapper.

## Follow-ups this review surfaced

None are fixed here; all are pre-existing or outside this subject.

- **A security finding in the address policy**, verified by execution, that
  wants a maintainer's eyes before this ships anywhere it matters. Reported
  separately rather than in this PR.
- Roughly 35 distinct pre-existing defects in `agent.ts`, several corroborated
  by four independent reviewers.
- Orchestrator mode flattens content to text, so it drops every attachment with
  no log and no report, and an attachment-only turn sends an empty prompt. That
  is this PR's bug class in a path that has never had media support; adding it
  is a feature.
- Python parity: Python has the same zero-byte-block bug (its guard is
  `if raw is None`, which an empty `bytes` passes) and no video MIME aliases.
