### PR TITLE
fix(aws-strands): carry, refuse, and drop what the Python continuation could not

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1474,6 +1474,34 @@ def _build_snapshot_messages(input_messages: List[Any]) -> List[Any]:
     return out
 
 
+def _continuation_result_line(
+    tool_name: str, result_text: Any, error_text: Any
+) -> str:
+    """One line of the continuation prompt: the tool, and what came back.
+
+    Forwards the ACTUAL result so the model can act on the human's decision
+    (e.g. an approval resolving to ``{"approved": false}``). Announcing a bare
+    success would silently break HITL: the model is told the tool returned
+    nothing and proceeds as though the human had approved. The synthetic
+    acknowledgement is only for a result that is genuinely empty, and a
+    client-reported failure carries its reason with an empty body alongside it,
+    so reading the body alone reports that failure as a success.
+
+    Shared by every place a client answer has to be SAID rather than persisted,
+    so the same answer reaches the model in the same words whichever prompt
+    carries it. The persisted wording of the same answer omits the name, because
+    there a ``toolResult`` block is already attached to the call it answers.
+    """
+    text = result_text if isinstance(result_text, str) else ""
+    if error_text:
+        if text.strip():
+            return f"{tool_name} failed: {error_text} (returned: {text})"
+        return f"{tool_name} failed: {error_text}"
+    if text.strip():
+        return f"{tool_name} returned: {text}"
+    return f"{tool_name} executed successfully with no return value."
+
+
 def _build_strands_history(
     input_messages: List[Any],
     url_fetch_policy: "UrlFetchPolicy | None" = None,
@@ -1490,10 +1518,17 @@ def _build_strands_history(
     Every URL content source in *input_messages* is fetched under
     *url_fetch_policy* and shares one budget, so the ceilings bound the whole
     history rather than each attachment separately.
+
+    Orphan tool results are dropped, as the seed conversion drops them: a
+    ``toolResult`` no ``toolUse`` in the replayed history answers is a history
+    real providers reject, so replaying one turns a turn the continuation prompt
+    could still have carried into a generic provider failure.
     """
     out: List[Dict[str, Any]] = []
     fetch_budget = _FetchBudget(url_fetch_policy)
     pending_tool_results: List[Dict[str, Any]] = []
+    # Every ``toolUse`` id the history built so far offers a result a home.
+    offered_tool_use_ids: set[str] = set()
 
     def flush_tool_results() -> None:
         if not pending_tool_results:
@@ -1504,10 +1539,18 @@ def _build_strands_history(
     for msg in input_messages or []:
         role = getattr(msg, "role", None)
         if role == "tool":
+            tool_call_id = getattr(msg, "tool_call_id", "") or ""
+            if tool_call_id not in offered_tool_use_ids:
+                logger.warning(
+                    "History replay dropped a tool result no replayed tool call "
+                    "answers: tool_call_id=%s",
+                    tool_call_id,
+                )
+                continue
             pending_tool_results.append(
                 {
                     "toolResult": {
-                        "toolUseId": getattr(msg, "tool_call_id", "") or "",
+                        "toolUseId": tool_call_id,
                         "content": [{"text": _coerce_text(msg.content)}],
                         # Carry the AG-UI failure signal onto Bedrock's toolResult status,
                         # so a client-reported tool failure is not asserted to the model as
@@ -1566,6 +1609,8 @@ def _build_strands_history(
                         }
                     }
                 )
+                if tc.id:
+                    offered_tool_use_ids.add(tc.id)
             if not blocks:
                 blocks = [{"text": ""}]
             out.append({"role": "assistant", "content": blocks})
@@ -4041,22 +4086,11 @@ class StrandsAgent:
                             # prompt replaces whenever replay and
                             # reconciliation are both off.
                             error_text = getattr(msg, "error", None)
-                            if error_text:
-                                if result_text and result_text.strip():
-                                    _result_parts.append(
-                                        f"{tool_name} failed: {error_text} "
-                                        f"(returned: {result_text})"
-                                    )
-                                else:
-                                    _result_parts.append(
-                                        f"{tool_name} failed: {error_text}"
-                                    )
-                            elif result_text and result_text.strip():
-                                _result_parts.append(f"{tool_name} returned: {result_text}")
-                            else:
-                                _result_parts.append(
-                                    f"{tool_name} executed successfully with no return value."
+                            _result_parts.append(
+                                _continuation_result_line(
+                                    tool_name, result_text, error_text
                                 )
+                            )
                         elif tool_name:
                             # Named, but neither signal says frontend: not in
                             # the current declarations and no recorded id.
@@ -4273,8 +4307,11 @@ class StrandsAgent:
                         "text": text or "",
                         # Carry the client's failure signal alongside the text so
                         # reconciliation can stamp the persisted toolResult status
-                        # too, not just its content.
+                        # too, not just its content. The reason itself rides
+                        # along for the prompt carry below, which has to SAY the
+                        # failure rather than persist it.
                         "is_error": bool(getattr(msg, "error", None)),
+                        "error": getattr(msg, "error", None),
                     }
                 )
                 last_frontend_result_index = msg_index
@@ -4383,6 +4420,9 @@ class StrandsAgent:
             # below runs unconditionally after the other branches and layers
             # on top, rather than short-circuiting them.
             resume_prompt: str | List[Dict[str, Any]] | list[InterruptResponseContent] | None = user_message
+            # Client answers the native history does not carry, so the prompt
+            # has to. Filled in by whichever branch below settles it.
+            uncarried_result_ids: list[str] = []
             context_block = _format_agui_context(model_context)
             if context_block and not _ensure_transient_context_hook(strands_agent):
                 raise RuntimeError(
@@ -4460,6 +4500,43 @@ class StrandsAgent:
                     )
                     yield _interrupt_reconciliation_error()
                     return
+                # Every admitted result the attempt left alone. An empty set
+                # answers "nothing was declined", not "the history is clean":
+                # nothing admitted means nothing could have been corrected.
+                declined_native_ids = sorted(
+                    native_id
+                    for native_id in resolved_native_results
+                    if native_id not in corrected_native_ids
+                )
+                if declined_native_ids:
+                    # Said out loud. A decline leaves the client's answer where
+                    # only the continuation prompt can reach the model with it,
+                    # and both of the ways that carry can fail are silent
+                    # otherwise.
+                    logger.warning(
+                        "Frontend tool result reconciliation corrected nothing for "
+                        "native ids %s; the client's answer has to reach the model "
+                        "through the continuation prompt instead",
+                        declined_native_ids,
+                    )
+                if resume_submitted:
+                    # A resume drives Strands with its interrupt responses, so it
+                    # has no continuation prompt to fall back on, and a decline
+                    # here leaves the uncorrected placeholder as what the model
+                    # reads for the client's answer. Refused, like the pre-write
+                    # gates above, rather than answered with a stub. Later than
+                    # those gates by necessity: only the attempt itself says a
+                    # correction declined.
+                    if declined_native_ids:
+                        logger.error(
+                            "Active interrupt tool result reconciliation failed: "
+                            "no correction landed for native ids %s",
+                            declined_native_ids,
+                        )
+                        yield _interrupt_reconciliation_error()
+                        return
+                else:
+                    uncarried_result_ids = declined_native_ids
                 # Continue from the corrected native history only when every
                 # NON-EMPTY frontend result this turn was admitted (i.e. its
                 # call id was recorded at emission) AND none of those
@@ -4492,6 +4569,47 @@ class StrandsAgent:
                     if reconciled and not has_newer_user_message
                     else user_message
                 )
+
+            # A user message after the results is this run's prompt, which means
+            # the trailing derivation above produced nothing and the answers
+            # reach the model through neither the history nor the prompt. Carried
+            # ahead of the user's own text rather than dropped: dropping is what
+            # leaves the model to re-fire the call it is already being answered
+            # about. Every result named here is one no correction landed for, so
+            # nothing is told twice.
+            if not resume_submitted and has_newer_user_message and uncarried_result_ids:
+                _carried = set(uncarried_result_ids)
+                _carry_lines: list[str] = []
+                for result in frontend_results:
+                    if result["tool_call_id"] not in _carried:
+                        continue
+                    carried_name = _tool_call_id_to_name.get(result["tool_call_id"])
+                    if not carried_name:
+                        # Nothing names the call, and an answer that has to be
+                        # SAID cannot be phrased without the name. Left out
+                        # rather than guessed at: guessing feeds the model false
+                        # context.
+                        logger.warning(
+                            "Could not resolve tool name for tool_call_id=%s; the "
+                            "client's answer is not carried into the continuation "
+                            "prompt",
+                            result["tool_call_id"],
+                        )
+                        continue
+                    _carry_lines.append(
+                        _continuation_result_line(
+                            carried_name, result["text"], result["error"]
+                        )
+                    )
+                if _carry_lines:
+                    _preamble = "\n".join(_carry_lines)
+                    if isinstance(resume_prompt, str):
+                        resume_prompt = f"{_preamble}\n{resume_prompt}"
+                    else:
+                        resume_prompt = [
+                            {"text": _preamble},
+                            *(resume_prompt or []),
+                        ]
 
             # A client answering to an interrupt sends its responses
             # in ``RunAgentInput.resume`` (as per the AG-UI interrupt round-trip),

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -1505,6 +1505,7 @@ def _continuation_result_line(
 def _build_strands_history(
     input_messages: List[Any],
     url_fetch_policy: "UrlFetchPolicy | None" = None,
+    dropped_tool_result_ids: set[str] | None = None,
 ) -> List[Dict[str, Any]]:
     """Convert ``RunAgentInput.messages`` to Strands native ``Messages``.
 
@@ -1523,6 +1524,11 @@ def _build_strands_history(
     ``toolResult`` no ``toolUse`` in the replayed history answers is a history
     real providers reject, so replaying one turns a turn the continuation prompt
     could still have carried into a generic provider failure.
+
+    A dropped result is also an answer this history no longer carries, so the
+    caller has to know: pass *dropped_tool_result_ids* and it is filled with the
+    ids left out, which is the signal to reach the model some other way rather
+    than to replay a history the client's answer is missing from.
     """
     out: List[Dict[str, Any]] = []
     fetch_budget = _FetchBudget(url_fetch_policy)
@@ -1546,6 +1552,8 @@ def _build_strands_history(
                     "answers: tool_call_id=%s",
                     tool_call_id,
                 )
+                if dropped_tool_result_ids is not None:
+                    dropped_tool_result_ids.add(tool_call_id)
                 continue
             pending_tool_results.append(
                 {
@@ -4428,12 +4436,32 @@ class StrandsAgent:
                 raise RuntimeError(
                     "Strands agent does not expose a hook registry for transient context"
                 )
+            dropped_replay_result_ids: set[str] = set()
             if replay_history:
                 native_history = await asyncio.to_thread(
                     _build_strands_history,
                     input_data.messages,
                     self.config.url_fetch_policy,
+                    dropped_replay_result_ids,
                 )
+            if replay_history and dropped_replay_result_ids:
+                # The rebuilt history has no home for those results, so replaying
+                # it would hand the model a turn the client's answer is missing
+                # from -- and on a delta-only payload, which carries the result
+                # without the assistant message that opened the call, it would
+                # replace the whole cached conversation with what little the
+                # payload rebuilt. The legacy continuation path says the answer
+                # instead, over a history this run leaves alone.
+                logger.warning(
+                    "History replay would drop the client's answer for tool_call_ids "
+                    "%s, so this turn carries it in the continuation prompt and "
+                    "leaves the existing history in place",
+                    sorted(dropped_replay_result_ids),
+                )
+                uncarried_result_ids = [
+                    result["tool_call_id"] for result in frontend_results
+                ]
+            elif replay_history:
                 # Apply ``state_context_builder`` to the last user-text
                 # message in the reconciled history rather than to the
                 # synthetic ``user_message`` string. This matches what the
@@ -4521,17 +4549,34 @@ class StrandsAgent:
                     )
                 if resume_submitted:
                     # A resume drives Strands with its interrupt responses, so it
-                    # has no continuation prompt to fall back on, and a decline
-                    # here leaves the uncorrected placeholder as what the model
-                    # reads for the client's answer. Refused, like the pre-write
-                    # gates above, rather than answered with a stub. Later than
-                    # those gates by necessity: only the attempt itself says a
-                    # correction declined.
-                    if declined_native_ids:
+                    # has no continuation prompt to fall back on, and an
+                    # uncorrected placeholder is then what the model reads for the
+                    # client's answer. Refused, like the pre-write gates above,
+                    # rather than answered with a stub. Later than those gates by
+                    # necessity: only the attempt itself says a correction
+                    # declined.
+                    #
+                    # A decline alone does not mean a stub remains. It also
+                    # describes an id with nothing left to correct anywhere, which
+                    # a long-lived thread accumulates: a recorded id is kept until
+                    # its placeholder is corrected, so one whose placeholder is
+                    # already gone is re-admitted and re-declined on every later
+                    # turn. Refusing on the decline would wedge that thread for
+                    # good. The stub itself is the condition, so that is what is
+                    # read.
+                    stubbed_declined_ids = [
+                        native_id
+                        for native_id in declined_native_ids
+                        if has_placeholder_results(
+                            getattr(strands_agent, "messages", None) or [],
+                            only_ids={native_id},
+                        )
+                    ]
+                    if stubbed_declined_ids:
                         logger.error(
                             "Active interrupt tool result reconciliation failed: "
                             "no correction landed for native ids %s",
-                            declined_native_ids,
+                            stubbed_declined_ids,
                         )
                         yield _interrupt_reconciliation_error()
                         return
@@ -4569,6 +4614,12 @@ class StrandsAgent:
                     if reconciled and not has_newer_user_message
                     else user_message
                 )
+            else:
+                # Neither branch ran, so nothing repaired a history and no answer
+                # is in one. Everything this turn admitted is the prompt's to say.
+                uncarried_result_ids = [
+                    result["tool_call_id"] for result in frontend_results
+                ]
 
             # A user message after the results is this run's prompt, which means
             # the trailing derivation above produced nothing and the answers

--- a/integrations/aws-strands/python/tests/test_history_replay.py
+++ b/integrations/aws-strands/python/tests/test_history_replay.py
@@ -1,0 +1,104 @@
+"""Tests for the native history ``_build_strands_history`` replays to the model.
+
+The history is handed to the provider wholesale, so it has to be a history the
+provider accepts. A ``toolResult`` block that no ``toolUse`` in the same history
+answers is not: real providers reject it, which turns a turn the continuation
+prompt could still have carried into a generic provider failure.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ag_ui.core import (
+    AssistantMessage,
+    FunctionCall,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+from ag_ui_strands.agent import _build_strands_history
+
+
+def _tool_call(call_id: str, name: str = "get_weather") -> ToolCall:
+    return ToolCall(id=call_id, function=FunctionCall(name=name, arguments="{}"))
+
+
+def _tool_results(history: list) -> list:
+    return [
+        block["toolResult"]
+        for message in history
+        for block in message["content"]
+        if "toolResult" in block
+    ]
+
+
+def _tool_use_ids(history: list) -> list:
+    return [
+        block["toolUse"]["toolUseId"]
+        for message in history
+        for block in message["content"]
+        if "toolUse" in block
+    ]
+
+
+class TestOrphanToolResults:
+    def test_answered_result_survives_replay(self):
+        history = _build_strands_history(
+            [
+                UserMessage(id="u1", content="weather?"),
+                AssistantMessage(id="a1", tool_calls=[_tool_call("tc1")]),
+                ToolMessage(id="t1", content="sunny", tool_call_id="tc1"),
+            ]
+        )
+
+        assert _tool_use_ids(history) == ["tc1"]
+        assert [result["toolUseId"] for result in _tool_results(history)] == ["tc1"]
+
+    def test_result_no_replayed_call_answers_is_dropped(self):
+        # A delta-only continuation carries the result without the assistant
+        # message that opened the call, so nothing in the replayed history
+        # answers it.
+        history = _build_strands_history(
+            [ToolMessage(id="t1", content="sunny", tool_call_id="tc1")]
+        )
+
+        assert _tool_results(history) == []
+
+    def test_only_the_unanswered_result_is_dropped(self):
+        history = _build_strands_history(
+            [
+                UserMessage(id="u1", content="weather?"),
+                AssistantMessage(id="a1", tool_calls=[_tool_call("tc1")]),
+                ToolMessage(id="t1", content="sunny", tool_call_id="tc1"),
+                ToolMessage(id="t2", content="stale", tool_call_id="tc-gone"),
+            ]
+        )
+
+        assert [result["toolUseId"] for result in _tool_results(history)] == ["tc1"]
+
+    def test_result_ahead_of_its_call_is_dropped(self):
+        # Nothing offers it a home at the point it arrives, and the forward scan
+        # that pairs calls with results never looks backwards for one.
+        history = _build_strands_history(
+            [
+                ToolMessage(id="t1", content="sunny", tool_call_id="tc1"),
+                AssistantMessage(id="a1", tool_calls=[_tool_call("tc1")]),
+            ]
+        )
+
+        assert _tool_results(history) == []
+        assert _tool_use_ids(history) == ["tc1"]
+
+    def test_a_dropped_result_is_reported(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+            _build_strands_history(
+                [ToolMessage(id="t1", content="sunny", tool_call_id="tc-gone")]
+            )
+
+        reported = [record.getMessage() for record in caplog.records]
+        assert any(
+            "no replayed tool call" in message and "tc-gone" in message
+            for message in reported
+        )

--- a/integrations/aws-strands/python/tests/test_reconciliation_decline.py
+++ b/integrations/aws-strands/python/tests/test_reconciliation_decline.py
@@ -1,0 +1,328 @@
+"""Tests for what happens when frontend-result reconciliation corrects nothing.
+
+Reconciliation rewrites the proxy's ``"Forwarded to client"`` placeholder with
+the client's real answer. It can decline: an admitted id whose placeholder is no
+longer anywhere reconciliation looks has nothing to rewrite. A decline is not a
+failure of the turn, but it does mean the answer is not in the history, so the
+run has to reach the model with it some other way or say why it cannot.
+
+The message path has a continuation prompt to carry the answer in. The resume
+path has none, because it drives Strands with its interrupt responses instead,
+so an uncorrected placeholder is what the model would read as the answer.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ag_ui.core import (
+    AssistantMessage,
+    EventType,
+    FunctionCall,
+    ResumeEntry,
+    RunAgentInput,
+    Tool,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from strands.agent.state import AgentState
+from strands.hooks.registry import HookRegistry
+from strands.interrupt import Interrupt as StrandsInterrupt
+
+from ag_ui_strands.agent import StrandsAgent
+from ag_ui_strands.client_proxy_tool import PROXY_RESULT_PLACEHOLDER
+from ag_ui_strands.config import StrandsAgentConfig
+from ag_ui_strands.session_reconcile import AG_UI_FRONTEND_CALL_IDS_STATE_KEY
+from tests.hook_helpers import invoke_after_model_call, invoke_before_model_call
+from tests.interrupt_state_stub import InterruptStateStub
+
+RECONCILE_LOGGER = "ag_ui_strands.agent"
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+
+def _repository_manager(messages=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        session_id="session-1",
+        session_repository=SimpleNamespace(
+            list_messages=MagicMock(return_value=list(messages or [])),
+            update_message=MagicMock(),
+        ),
+    )
+
+
+class _MockStrandsCore:
+    """The streaming surface the adapter drives, recording its prompt."""
+
+    def __init__(self, session_manager, interrupts=None):
+        self.agent_id = "default"
+        self.tool_registry = MagicMock()
+        self.tool_registry.registry = {}
+        self.state = AgentState()
+        self.model = MagicMock()
+        self.messages = []
+        self.stream_prompts = []
+        self.hooks = HookRegistry()
+        self.session_manager = session_manager
+        self._interrupt_state = InterruptStateStub()
+        for interrupt in interrupts or []:
+            self._interrupt_state.interrupts[interrupt.id] = interrupt
+        if interrupts:
+            self._interrupt_state.activate()
+
+    async def stream_async(self, prompt):
+        self.stream_prompts.append(prompt)
+        self._interrupt_state.resume(prompt)
+        invoke_before_model_call(self.hooks, self)
+        invoke_after_model_call(self.hooks, self)
+        return
+        yield  # pragma: no cover - generator marker
+
+
+def _placeholder_result(tool_use_id: str) -> dict:
+    return {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"text": PROXY_RESULT_PLACEHOLDER}],
+    }
+
+
+def _placeholder_message(tool_use_id: str) -> dict:
+    return {"role": "user", "content": [{"toolResult": _placeholder_result(tool_use_id)}]}
+
+
+def _adapter() -> StrandsAgent:
+    core = MagicMock()
+    core.model = MagicMock()
+    core.system_prompt = "You are a test assistant."
+    core.tool_registry = MagicMock()
+    core.tool_registry.registry = {}
+    core.record_direct_tool_call = True
+    return StrandsAgent(agent=core, name="test_agent", config=StrandsAgentConfig())
+
+
+def _run_input(messages, *, resume=None, tools=None) -> RunAgentInput:
+    return RunAgentInput(
+        thread_id="thread-1",
+        run_id="run-1",
+        state={},
+        messages=messages,
+        tools=tools or [Tool(name="approveTool", description="approve", parameters={})],
+        context=[],
+        forwarded_props={},
+        resume=resume,
+    )
+
+
+async def _collect(agent: StrandsAgent, input_data: RunAgentInput) -> list:
+    return [event async for event in agent.run(input_data)]
+
+
+def _errors(events: list) -> list:
+    return [event for event in events if event.type == EventType.RUN_ERROR]
+
+
+# ---------------------------------------------------------------------------
+# The message path: the prompt carries what the history could not
+# ---------------------------------------------------------------------------
+
+
+def _answered_call_then_new_question() -> list:
+    """A client answer, followed by the user's next turn.
+
+    The newer user message is what puts the answer out of the trailing scan's
+    reach, so the derived continuation prompt is the user's own text.
+    """
+    return [
+        UserMessage(id="u1", content="approve it"),
+        AssistantMessage(
+            id="a1",
+            tool_calls=[
+                ToolCall(
+                    id="fe-1",
+                    function=FunctionCall(name="approveTool", arguments="{}"),
+                )
+            ],
+        ),
+        ToolMessage(id="t1", tool_call_id="fe-1", content='{"approved": false}'),
+        UserMessage(id="u2", content="and now what?"),
+    ]
+
+
+def _declining_core() -> _MockStrandsCore:
+    """Admits ``fe-1`` but holds no placeholder anywhere to correct."""
+    core = _MockStrandsCore(session_manager=_repository_manager())
+    core.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["fe-1"])
+    return core
+
+
+class TestDeclinedCorrectionOnTheMessagePath:
+    @pytest.mark.asyncio
+    async def test_the_answer_is_carried_ahead_of_the_users_text(self):
+        core = _declining_core()
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(
+                _adapter(), _run_input(_answered_call_then_new_question())
+            )
+
+        assert _errors(events) == []
+        assert core.stream_prompts == [
+            'approveTool returned: {"approved": false}\nand now what?'
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_client_reported_failure_carries_its_reason(self):
+        core = _declining_core()
+        messages = _answered_call_then_new_question()
+        messages[2] = ToolMessage(
+            id="t1", tool_call_id="fe-1", content="", error="user cancelled"
+        )
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            await _collect(_adapter(), _run_input(messages))
+
+        assert core.stream_prompts == [
+            "approveTool failed: user cancelled\nand now what?"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_decline_is_reported(self, caplog):
+        core = _declining_core()
+
+        with (
+            patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core),
+            caplog.at_level(logging.WARNING, logger=RECONCILE_LOGGER),
+        ):
+            await _collect(_adapter(), _run_input(_answered_call_then_new_question()))
+
+        reported = [record.getMessage() for record in caplog.records]
+        assert any(
+            "corrected nothing" in message and "fe-1" in message
+            for message in reported
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_corrected_answer_is_not_told_twice(self):
+        # The placeholder is there to rewrite, so the history carries the answer
+        # and the prompt stays the user's own text.
+        core = _declining_core()
+        core.messages = [_placeholder_message("fe-1")]
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(
+                _adapter(), _run_input(_answered_call_then_new_question())
+            )
+
+        assert _errors(events) == []
+        assert core.stream_prompts == ["and now what?"]
+
+    @pytest.mark.asyncio
+    async def test_an_unnameable_answer_is_left_out_rather_than_guessed_at(self):
+        # Nothing names the call, so no line can be phrased for it. The user's
+        # own turn still reaches the model.
+        core = _declining_core()
+        messages = _answered_call_then_new_question()
+        del messages[1]
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(_adapter(), _run_input(messages))
+
+        assert _errors(events) == []
+        assert core.stream_prompts == ["and now what?"]
+
+
+# ---------------------------------------------------------------------------
+# The resume path: nothing carries anything, so the run is refused
+# ---------------------------------------------------------------------------
+
+
+def _resume_core(*, extra_placeholder: bool) -> _MockStrandsCore:
+    """A checkpoint parking one proxy placeholder, admitting two answers.
+
+    ``extra_placeholder`` decides whether ``fe-2`` has anything to correct.
+    """
+    core = _MockStrandsCore(
+        session_manager=_repository_manager(),
+        interrupts=[StrandsInterrupt(id="native-interrupt", name="confirm")],
+    )
+    core._interrupt_state.context["tool_results"] = [_placeholder_result("native-proxy")]
+    core.messages = [_placeholder_message("native-proxy")]
+    if extra_placeholder:
+        core.messages.append(_placeholder_message("fe-2"))
+    core.state.set(AG_UI_FRONTEND_CALL_IDS_STATE_KEY, ["native-proxy", "fe-2"])
+    return core
+
+
+def _resume_input() -> RunAgentInput:
+    return _run_input(
+        [
+            ToolMessage(
+                id="t1", tool_call_id="native-proxy", content='{"approved": true}'
+            ),
+            ToolMessage(id="t2", tool_call_id="fe-2", content='{"picked": "red"}'),
+        ],
+        resume=[
+            ResumeEntry(
+                interrupt_id="native-interrupt", status="resolved", payload=True
+            )
+        ],
+    )
+
+
+class TestDeclinedCorrectionOnTheResumePath:
+    @pytest.mark.asyncio
+    async def test_a_decline_refuses_the_run(self):
+        core = _resume_core(extra_placeholder=False)
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(_adapter(), _resume_input())
+
+        errors = _errors(events)
+        assert len(errors) == 1
+        assert errors[0].code == "INTERRUPT_RECONCILIATION_ERROR"
+        assert errors[0].message == "Active interrupt tool result reconciliation failed"
+        assert not any(event.type == EventType.RUN_FINISHED for event in events)
+        # Unlike the pre-write gates this one cannot leave the turn untouched:
+        # only the attempt itself says a correction declined, so the corrections
+        # that did land are already written. What it does keep from happening is
+        # the model reading the uncorrected placeholder as the client's answer,
+        # and the checkpoint is still there for a retry.
+        assert core.stream_prompts == []
+        assert core._interrupt_state.activated
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_names_the_declined_ids(self, caplog):
+        core = _resume_core(extra_placeholder=False)
+
+        with (
+            patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core),
+            caplog.at_level(logging.ERROR, logger=RECONCILE_LOGGER),
+        ):
+            await _collect(_adapter(), _resume_input())
+
+        reported = [record.getMessage() for record in caplog.records]
+        assert any(
+            "reconciliation failed" in message and "fe-2" in message
+            for message in reported
+        )
+
+    @pytest.mark.asyncio
+    async def test_every_correction_landing_resumes_normally(self):
+        core = _resume_core(extra_placeholder=True)
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(_adapter(), _resume_input())
+
+        assert _errors(events) == []
+        assert len(core.stream_prompts) == 1
+        assert core._interrupt_state.context["tool_results"][0]["content"] == [
+            {"text": '{"approved": true}'}
+        ]

--- a/integrations/aws-strands/python/tests/test_reconciliation_decline.py
+++ b/integrations/aws-strands/python/tests/test_reconciliation_decline.py
@@ -9,10 +9,15 @@ run has to reach the model with it some other way or say why it cannot.
 The message path has a continuation prompt to carry the answer in. The resume
 path has none, because it drives Strands with its interrupt responses instead,
 so an uncorrected placeholder is what the model would read as the answer.
+
+What the resume path refuses on is that remaining placeholder, not the decline
+itself. The two are not the same: an id whose placeholder is already gone
+declines every time it is re-admitted, and a long-lived thread accumulates those.
 """
 
 from __future__ import annotations
 
+import copy
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -46,6 +51,13 @@ RECONCILE_LOGGER = "ag_ui_strands.agent"
 # ---------------------------------------------------------------------------
 # Doubles
 # ---------------------------------------------------------------------------
+
+
+def _no_session_core(history) -> "_MockStrandsCore":
+    """A cached agent with no session manager, so replay owns the history."""
+    core = _MockStrandsCore(session_manager=None)
+    core.messages = list(history)
+    return core
 
 
 def _repository_manager(messages=None) -> SimpleNamespace:
@@ -98,14 +110,16 @@ def _placeholder_message(tool_use_id: str) -> dict:
     return {"role": "user", "content": [{"toolResult": _placeholder_result(tool_use_id)}]}
 
 
-def _adapter() -> StrandsAgent:
+def _adapter(config: StrandsAgentConfig | None = None) -> StrandsAgent:
     core = MagicMock()
     core.model = MagicMock()
     core.system_prompt = "You are a test assistant."
     core.tool_registry = MagicMock()
     core.tool_registry.registry = {}
     core.record_direct_tool_call = True
-    return StrandsAgent(agent=core, name="test_agent", config=StrandsAgentConfig())
+    return StrandsAgent(
+        agent=core, name="test_agent", config=config or StrandsAgentConfig()
+    )
 
 
 def _run_input(messages, *, resume=None, tools=None) -> RunAgentInput:
@@ -247,7 +261,9 @@ class TestDeclinedCorrectionOnTheMessagePath:
 def _resume_core(*, extra_placeholder: bool) -> _MockStrandsCore:
     """A checkpoint parking one proxy placeholder, admitting two answers.
 
-    ``extra_placeholder`` decides whether ``fe-2`` has anything to correct.
+    ``extra_placeholder`` decides whether ``fe-2`` still has a stub in the live
+    history: with one, the model would read it as the client's answer, and
+    without one there is nothing left for a decline to leave behind.
     """
     core = _MockStrandsCore(
         session_manager=_repository_manager(),
@@ -277,12 +293,29 @@ def _resume_input() -> RunAgentInput:
     )
 
 
+def _refusing_rewrite(corrects: set[str]):
+    """A rewriter that corrects only *corrects*, leaving other stubs standing.
+
+    Today's rewriter always corrects a stub it was handed an answer for, so a
+    decline and a remaining stub cannot co-occur through it. The gate is about
+    what the model would read, not about which rewriter left it there, so the
+    refusal is driven from that condition directly.
+    """
+    return patch(
+        "ag_ui_strands.agent.reconcile_frontend_tool_results",
+        return_value=set(corrects),
+    )
+
+
 class TestDeclinedCorrectionOnTheResumePath:
     @pytest.mark.asyncio
-    async def test_a_decline_refuses_the_run(self):
-        core = _resume_core(extra_placeholder=False)
+    async def test_a_remaining_stub_refuses_the_run(self):
+        core = _resume_core(extra_placeholder=True)
 
-        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+        with (
+            patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core),
+            _refusing_rewrite({"native-proxy"}),
+        ):
             events = await _collect(_adapter(), _resume_input())
 
         errors = _errors(events)
@@ -299,11 +332,12 @@ class TestDeclinedCorrectionOnTheResumePath:
         assert core._interrupt_state.activated
 
     @pytest.mark.asyncio
-    async def test_the_refusal_names_the_declined_ids(self, caplog):
-        core = _resume_core(extra_placeholder=False)
+    async def test_the_refusal_names_the_stubbed_ids(self, caplog):
+        core = _resume_core(extra_placeholder=True)
 
         with (
             patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core),
+            _refusing_rewrite({"native-proxy"}),
             caplog.at_level(logging.ERROR, logger=RECONCILE_LOGGER),
         ):
             await _collect(_adapter(), _resume_input())
@@ -315,8 +349,22 @@ class TestDeclinedCorrectionOnTheResumePath:
         )
 
     @pytest.mark.asyncio
+    async def test_a_decline_with_nothing_left_to_correct_resumes(self):
+        # An id kept for retry whose placeholder is already gone. It is
+        # re-admitted and re-declined on every later turn, and it is never
+        # pruned, so refusing on the decline would wedge the thread for good.
+        core = _resume_core(extra_placeholder=False)
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(_adapter(), _resume_input())
+
+        assert _errors(events) == []
+        assert len(core.stream_prompts) == 1
+
+    @pytest.mark.asyncio
     async def test_every_correction_landing_resumes_normally(self):
         core = _resume_core(extra_placeholder=True)
+
 
         with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
             events = await _collect(_adapter(), _resume_input())
@@ -325,4 +373,107 @@ class TestDeclinedCorrectionOnTheResumePath:
         assert len(core.stream_prompts) == 1
         assert core._interrupt_state.context["tool_results"][0]["content"] == [
             {"text": '{"approved": true}'}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# The replay path stands down rather than replay a history missing the answer
+# ---------------------------------------------------------------------------
+
+
+def _cached_history_awaiting_an_answer() -> list:
+    return [
+        {"role": "user", "content": [{"text": "what is the weather"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": "fe-1", "name": "get_weather", "input": {}}}
+            ],
+        },
+        _placeholder_message("fe-1"),
+    ]
+
+
+class TestReplayThatWouldDropTheAnswer:
+    @pytest.mark.asyncio
+    async def test_a_delta_only_turn_keeps_its_history_and_says_the_answer(self):
+        # The payload carries the result without the assistant message that
+        # opened the call, so the rebuilt history has no home for it. Replaying
+        # what little rebuilt would replace the whole conversation with it.
+        core = _no_session_core(_cached_history_awaiting_an_answer())
+        before = copy.deepcopy(core.messages)
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(
+                _adapter(),
+                _run_input(
+                    [ToolMessage(id="t1", tool_call_id="fe-1", content="sunny, 22C")],
+                    tools=[
+                        Tool(name="get_weather", description="w", parameters={})
+                    ],
+                ),
+            )
+
+        assert _errors(events) == []
+        assert core.messages == before
+        assert core.stream_prompts == ["get_weather returned: sunny, 22C"]
+
+    @pytest.mark.asyncio
+    async def test_a_history_that_answers_itself_still_replays(self):
+        core = _no_session_core(_cached_history_awaiting_an_answer())
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(
+                _adapter(),
+                _run_input(
+                    [
+                        UserMessage(id="u1", content="what is the weather"),
+                        AssistantMessage(
+                            id="a1",
+                            tool_calls=[
+                                ToolCall(
+                                    id="fe-1",
+                                    function=FunctionCall(
+                                        name="get_weather", arguments="{}"
+                                    ),
+                                )
+                            ],
+                        ),
+                        ToolMessage(
+                            id="t1", tool_call_id="fe-1", content="sunny, 22C"
+                        ),
+                    ],
+                    tools=[Tool(name="get_weather", description="w", parameters={})],
+                ),
+            )
+
+        assert _errors(events) == []
+        # ``None`` tells Strands to stream from the replaced history as-is.
+        assert core.stream_prompts == [None]
+        assert core.messages[-1]["content"][0]["toolResult"]["content"] == [
+            {"text": "sunny, 22C"}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# The legacy path has no repaired history to rely on either
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationDisabled:
+    @pytest.mark.asyncio
+    async def test_the_answer_is_still_carried(self):
+        # Nothing repairs a history when replay is off, so every admitted answer
+        # is the prompt's to say.
+        core = _declining_core()
+        agent = _adapter(StrandsAgentConfig(replay_history_into_strands=False))
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", return_value=core):
+            events = await _collect(
+                agent, _run_input(_answered_call_then_new_question())
+            )
+
+        assert _errors(events) == []
+        assert core.stream_prompts == [
+            'approveTool returned: {"approved": false}\nand now what?'
         ]

--- a/integrations/aws-strands/python/tests/test_tool_error_status.py
+++ b/integrations/aws-strands/python/tests/test_tool_error_status.py
@@ -1,4 +1,4 @@
-from ag_ui.core import ToolMessage
+from ag_ui.core import AssistantMessage, FunctionCall, ToolCall, ToolMessage
 
 from ag_ui_strands.agent import _build_strands_history, _build_snapshot_messages
 
@@ -14,17 +14,39 @@ def _tool_message(**overrides):
     return ToolMessage(**fields)
 
 
+def _answered_turn(tool_message):
+    """The call the result answers, ahead of the result itself.
+
+    Replay drops a ``toolResult`` no replayed ``toolUse`` answers, so a status
+    assertion needs the pair rather than the result alone.
+    """
+    return [
+        AssistantMessage(
+            id="a1",
+            tool_calls=[
+                ToolCall(
+                    id=tool_message.tool_call_id,
+                    function=FunctionCall(name="do_thing", arguments="{}"),
+                )
+            ],
+        ),
+        tool_message,
+    ]
+
+
 class TestBedrockToolResultStatus:
     def test_error_maps_onto_bedrock_status(self):
         # A client-reported tool failure must reach the model as an error, not a
         # silent success -- AG-UI's ToolMessage.error sets Bedrock's toolResult status.
-        history = _build_strands_history([_tool_message(error="invalid id")])
-        tool_result = history[0]["content"][0]["toolResult"]
+        history = _build_strands_history(
+            _answered_turn(_tool_message(error="invalid id"))
+        )
+        tool_result = history[-1]["content"][0]["toolResult"]
         assert tool_result["status"] == "error"
 
     def test_defaults_to_success_without_error(self):
-        history = _build_strands_history([_tool_message(content="42")])
-        tool_result = history[0]["content"][0]["toolResult"]
+        history = _build_strands_history(_answered_turn(_tool_message(content="42")))
+        tool_result = history[-1]["content"][0]["toolResult"]
         assert tool_result["status"] == "success"
 
 


### PR DESCRIPTION
Ports three behaviours from the TypeScript bridge into the Python adapter. They are the three the architecture notes list as things the TypeScript continuation decision does that Python's does not, and they are the whole of that list. A second commit corrects three problems a review of the first one turned up.

## A declined reconciliation was silent, and could lose the client's answer

`reconcile_frontend_tool_results` can return without correcting a result it was asked to correct: an admitted id whose placeholder is no longer anywhere reconciliation looks has nothing to rewrite. Python logged nothing for that, and when a newer user message followed the tool result the outgoing prompt was that user message, so the client's answer reached the model in neither the corrected history nor the prompt.

The declined ids are now named in a warning, and the answers are carried into the outgoing prompt ahead of the user's own text. The wording is the trailing derivation's own, extracted into `_continuation_result_line` so one answer reaches the model in one form whichever prompt carries it. Every branch that leaves an answer out of the history fills the same list, including the legacy path taken when `replay_history_into_strands` is off, which is a configuration the first commit still dropped the answer on.

## The resume path has no prompt to carry anything

So an uncorrected `"Forwarded to client"` placeholder is what the model would read for the client's answer. That run is refused under the existing `INTERRUPT_RECONCILIATION_ERROR`, with the message the TypeScript bridge already emits, byte for byte.

It is the one reconciliation gate that must run after the first write, since only the attempt itself says a correction declined. The corrections that did land are therefore already persisted when it fires, and the test says that rather than asserting an atomicity this gate cannot offer.

What the gate reads is the remaining stub, not the decline. Those are not the same thing: a decline also describes an id with nothing left to correct anywhere, which a long-lived thread accumulates, because a recorded id is kept until its placeholder is corrected and one whose placeholder is already gone is re-admitted and re-declined on every later turn. Refusing on the decline wedged such a thread permanently, including resumes whose own interrupt reconciled cleanly.

Worth stating plainly: today's rewriter always corrects a stub it was handed an answer for, so a decline and a remaining stub cannot co-occur through it, and this gate is a net rather than a live path in Python. It is driven in the test from the condition itself rather than from a rewriter that cannot produce it.

## The replayed history kept tool results nothing answered

`_build_strands_history` emitted a `toolResult` even when no `toolUse` in the replayed history answered it. Real providers reject that history, so replaying one turned a turn the continuation prompt could still have carried into a generic provider failure. It now tracks the ids it has emitted and drops a result matching none, the way the seed conversion already did.

Dropping is only half of it. A delta-only continuation carries the result without the assistant message that opened the call, so the rebuilt history loses the answer, and since replay replaces the agent's history wholesale it loses the whole conversation with it. The first commit handed the model an empty history and no prompt, with the run still reporting success, which is the re-fire loop this derivation exists to prevent, on the default configuration. `_build_strands_history` now reports the ids it left out, and a turn that would drop one keeps the history it has and says the answer in the continuation prompt instead.

## Tests

New tests are organised by behaviour rather than one file per fix:

- `tests/test_history_replay.py` covers what the replayed history keeps and drops.
- `tests/test_reconciliation_decline.py` covers what happens when reconciliation corrects nothing, split into the message path that carries, the resume path that refuses, the replay path that stands down, and the disabled-reconciliation path.

Eleven of the nineteen fail against the code they were written for; the rest are control cases whose behaviour is unchanged.

Two existing tests in `tests/test_tool_error_status.py` pinned the old shape by handing `_build_strands_history` a lone tool message. They were testing the error-to-status mapping either way, so they now pair the result with the call it answers.

`python -m pytest tests` reports 993 passed, up from 976.

## Not included

TypeScript also fails the run closed when a carried answer cannot be named. Python logs and leaves that answer out of the prompt instead. Worth closing separately if the two bridges should be identical here.

The architecture notes still describe all three of these as TypeScript-only. That entry lives on the branch carrying the TypeScript change and is not in this diff; it needs striking wherever the two meet.
