### PR TITLE
feat(langgraph-py): populate terminal-event token usage from provider metadata

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -85,6 +85,9 @@ from ag_ui.core import (
     SubagentFinishedEvent,
     SubagentFinishedSuspendedOutcome,
     SubagentErrorEvent,
+    TokenUsage,
+    aggregate_token_usage,
+    token_usage_from_langchain_metadata,
 )
 from .interrupts import lg_interrupts_to_agui, DEFAULT_RESUME_SENTINEL_CANCELLED, DEFAULT_RESUME_SENTINEL_MAP
 from ag_ui.encoder import EventEncoder
@@ -1619,6 +1622,10 @@ class LangGraphAgent:
             # out of the graph input in run(). Re-emitted in the snapshot so
             # they persist in the display without entering graph state.
             "inbound_subagent_messages": getattr(self, "_inbound_subagent_messages", []) or [],
+            # Per-model-call provider usage, appended during the run and folded
+            # into the terminal event by _collect_run_usage. Seeded per run, so
+            # one run's counts can never be attributed to the next.
+            "usage": [],
         }
         self.active_run = INITIAL_ACTIVE_RUN
         # Seed the public-id registry from the run's INPUT (client-echoed
@@ -1836,7 +1843,16 @@ class LangGraphAgent:
                     for ev in self.handle_node_change(None):
                         yield ev
                     yield self._dispatch_event(
-                        RunErrorEvent(type=EventType.RUN_ERROR, message=error_message, raw_event=event)
+                        RunErrorEvent(
+                            type=EventType.RUN_ERROR,
+                            message=error_message,
+                            raw_event=event,
+                            # Partial usage: a run that failed after one or more
+                            # model calls completed still spent those tokens, so
+                            # report them. Omitted (None) when the run died
+                            # before any call reported usage.
+                            usage=self._collect_run_usage(),
+                        )
                     )
                     # RUN_ERROR is terminal: the clients reject EVERY event after
                     # it ("The run has already errored with 'RUN_ERROR'"). `break`
@@ -2984,9 +3000,55 @@ class LangGraphAgent:
                 thread_id=thread_id,
                 run_id=run_id,
                 outcome=outcome,
+                # An interrupted run is a finished run for usage purposes: the
+                # model calls it already made were paid for and are reported.
+                # The short-circuit replay path in prepare_stream reaches this
+                # with no model calls at all, where _collect_run_usage returns
+                # None and the field is simply omitted.
+                usage=self._collect_run_usage(),
             )
         )
         return events
+
+    def _record_chunk_usage(self, event: Any, usage_metadata: Any) -> None:
+        """Accumulate one usage entry per model call from a chunk's
+        ``usage_metadata``.
+
+        Kept per-call and folded together at the terminal event by
+        ``_collect_run_usage``, mirroring the TypeScript producer. The mapper is
+        the shared SDK one, so a malformed provider count (string, ``None``,
+        ``NaN``, negative, fractional) is dropped rather than forwarded: the
+        alternative is a ValidationError raised while BUILDING the terminal
+        event, which would cost the user the whole run over a token count.
+
+        A chunk with no ``usage_metadata``, or with nothing usable in it, adds
+        nothing at all — the field is then omitted from the terminal event
+        rather than reported as zeros, so "the provider reported no usage" stays
+        distinct from "the provider reported zero".
+        """
+        if not usage_metadata:
+            return
+        metadata = (event.get("metadata") or {}) if isinstance(event, dict) else {}
+        entry = token_usage_from_langchain_metadata(
+            usage_metadata,
+            # LangChain's standard run metadata. Absent for some providers, in
+            # which case the entry carries counts with no labels — still usable,
+            # and aggregation groups all unlabelled calls together.
+            provider=metadata.get("ls_provider"),
+            model=metadata.get("ls_model_name"),
+        )
+        if entry is not None:
+            self.active_run.setdefault("usage", []).append(entry)
+
+    def _collect_run_usage(self) -> Optional[List[TokenUsage]]:
+        """Aggregate this run's accumulated per-call usage for a terminal event.
+
+        Returns ``None`` (an omitted field) when no provider usage was
+        reported, so consumers read missing usage as "not measured" rather than
+        as zero.
+        """
+        aggregated = aggregate_token_usage((self.active_run or {}).get("usage") or [])
+        return aggregated or None
 
     def _emit_success_finish(
         self, *, thread_id: str, run_id: str
@@ -2996,6 +3058,7 @@ class LangGraphAgent:
             type=EventType.RUN_FINISHED,
             thread_id=thread_id,
             run_id=run_id,
+            usage=self._collect_run_usage(),
         )
 
     def _build_command_from_agui_resume(
@@ -3086,6 +3149,13 @@ class LangGraphAgent:
 
             response_metadata = _chunk_get(chunk_raw, "response_metadata", None) or {}
             tool_call_chunks_list = _chunk_get(chunk_raw, "tool_call_chunks", None) or []
+
+            # Capture provider-reported token usage. LangChain attaches
+            # `usage_metadata` to the FINAL streamed chunk — the one that also
+            # carries `finish_reason` — so this must run BEFORE the
+            # finish-reason early return below or the usage of every model call
+            # would be dropped.
+            self._record_chunk_usage(event, _chunk_get(chunk_raw, "usage_metadata", None))
 
             if response_metadata.get('finish_reason', None):
                 return

--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -1626,6 +1626,10 @@ class LangGraphAgent:
             # into the terminal event by _collect_run_usage. Seeded per run, so
             # one run's counts can never be attributed to the next.
             "usage": [],
+            # Model-call run ids already counted, so the OnChatModelEnd fallback
+            # does not re-count what the stream already reported. Per run for
+            # the same reason as "usage" above.
+            "usage_run_ids": set(),
         }
         self.active_run = INITIAL_ACTIVE_RUN
         # Seed the public-id registry from the run's INPUT (client-echoed
@@ -3010,25 +3014,51 @@ class LangGraphAgent:
         )
         return events
 
-    def _record_chunk_usage(self, event: Any, usage_metadata: Any) -> None:
-        """Accumulate one usage entry per model call from a chunk's
-        ``usage_metadata``.
+    def _record_usage(self, event: Any, usage_metadata: Any, *, streamed: bool) -> None:
+        """Accumulate one usage entry per model call.
+
+        Usage reaches us on two channels, and which one a call uses is the
+        provider's choice, not ours:
+
+        * ``OnChatModelStream`` — the final streamed chunk, alongside
+          ``finish_reason``. This is the streaming case.
+        * ``OnChatModelEnd`` — the aggregated output message. This is the ONLY
+          channel when the model does not stream at all (streaming disabled, or
+          a tool call answered without streaming): no ``OnChatModelStream``
+          event is emitted for such a call, so a stream-only producer reports
+          nothing for it. Verified against this package's locked dependencies:
+          a non-streaming model reporting 3/2/5 produced no stream event and a
+          model-end output carrying the counts.
+
+        A streaming provider reports the SAME usage on BOTH channels under the
+        same run id, so the model-end read is a fallback, not an addition:
+        ``usage_run_ids`` records which calls the stream already covered and the
+        fallback skips those. The streaming path never consults the set, only
+        adds to it — two streamed chunks that each carry usage for one call are
+        still summed, matching the TypeScript producer.
 
         Kept per-call and folded together at the terminal event by
-        ``_collect_run_usage``, mirroring the TypeScript producer. The mapper is
-        the shared SDK one, so a malformed provider count (string, ``None``,
-        ``NaN``, negative, fractional) is dropped rather than forwarded: the
-        alternative is a ValidationError raised while BUILDING the terminal
-        event, which would cost the user the whole run over a token count.
+        ``_collect_run_usage``. The mapper is the shared SDK one, so a malformed
+        provider count (string, ``None``, ``NaN``, negative, fractional,
+        wider-than-int64) is dropped rather than forwarded: the alternative is a
+        ValidationError raised while BUILDING the terminal event, which would
+        cost the user the whole run over a token count.
 
-        A chunk with no ``usage_metadata``, or with nothing usable in it, adds
-        nothing at all — the field is then omitted from the terminal event
-        rather than reported as zeros, so "the provider reported no usage" stays
-        distinct from "the provider reported zero".
+        Nothing usable adds nothing at all — the field is then omitted from the
+        terminal event rather than reported as zeros, so "the provider reported
+        no usage" stays distinct from "the provider reported zero".
         """
         if not usage_metadata:
             return
-        metadata = (event.get("metadata") or {}) if isinstance(event, dict) else {}
+        is_dict = isinstance(event, dict)
+        run_id = event.get("run_id") if is_dict else None
+        covered = self.active_run.setdefault("usage_run_ids", set())
+        if not streamed and run_id in covered:
+            # The stream already reported this exact call. Counting the
+            # aggregated model-end copy as well would double every streamed
+            # call's tokens.
+            return
+        metadata = (event.get("metadata") or {}) if is_dict else {}
         entry = token_usage_from_langchain_metadata(
             usage_metadata,
             # LangChain's standard run metadata. Absent for some providers, in
@@ -3039,6 +3069,7 @@ class LangGraphAgent:
         )
         if entry is not None:
             self.active_run.setdefault("usage", []).append(entry)
+            covered.add(run_id)
 
     def _collect_run_usage(self) -> Optional[List[TokenUsage]]:
         """Aggregate this run's accumulated per-call usage for a terminal event.
@@ -3154,8 +3185,10 @@ class LangGraphAgent:
             # `usage_metadata` to the FINAL streamed chunk — the one that also
             # carries `finish_reason` — so this must run BEFORE the
             # finish-reason early return below or the usage of every model call
-            # would be dropped.
-            self._record_chunk_usage(event, _chunk_get(chunk_raw, "usage_metadata", None))
+            # would be dropped. OnChatModelEnd covers the non-streaming case.
+            self._record_usage(
+                event, _chunk_get(chunk_raw, "usage_metadata", None), streamed=True
+            )
 
             if response_metadata.get('finish_reason', None):
                 return
@@ -3489,6 +3522,25 @@ class LangGraphAgent:
                 return
 
         elif event_type == LangGraphEventTypes.OnChatModelEnd:
+            # The non-streaming channel for token usage, and the ONLY one for a
+            # model call that never streamed — such a call emits no
+            # OnChatModelStream event at all, so the streamed capture above
+            # never sees it. `data.output` is the aggregated message
+            # (AIMessage when the model did not stream, AIMessageChunk when it
+            # did); dual-path access because some upstream paths deliver it as
+            # a plain dict. Deduped by run id inside _record_usage, since a
+            # streaming provider reports the same counts on both channels.
+            output_message = (event.get("data") or {}).get("output")
+            self._record_usage(
+                event,
+                (
+                    output_message.get("usage_metadata")
+                    if isinstance(output_message, dict)
+                    else getattr(output_message, "usage_metadata", None)
+                ),
+                streamed=False,
+            )
+
             if self.get_message_in_progress(self.active_run["id"]) and self.get_message_in_progress(self.active_run["id"]).get("tool_call_id"):
                 resolved = self._dispatch_event(
                     ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=self.get_message_in_progress(self.active_run["id"])["tool_call_id"], raw_event=event)

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -2,6 +2,8 @@ from typing import TypedDict, Optional, List, Any, Dict, Set, Union, Literal
 from typing_extensions import NotRequired
 from enum import Enum
 
+from ag_ui.core import TokenUsage
+
 class LangGraphEventTypes(str, Enum):
     OnChainStart = "on_chain_start"
     OnChainStream = "on_chain_stream"
@@ -235,6 +237,14 @@ RunMetadata = TypedDict("RunMetadata", {
     # only tool_call_id, no parent_message_id/subagent_run_id) back to the owning
     # assistant entry in subagent_messages. Maps tool_call_id -> message id.
     "subagent_tool_call_owner": NotRequired[Dict[str, str]],
+    # Provider-reported token usage, ONE ENTRY PER MODEL CALL, in the order the
+    # calls reported it. Appended from each OnChatModelStream chunk that carries
+    # `usage_metadata`, and folded into one entry per (provider, model) by
+    # LangGraphAgent._collect_run_usage at the terminal event. Kept per-call
+    # rather than pre-summed so a run invoking several models keeps them
+    # separate — aggregation is the SDK's job (aggregate_token_usage), shared
+    # with the TypeScript producer so both languages emit the same shape.
+    "usage": NotRequired[List[TokenUsage]],
 })
 
 # run_id -> lane -> in-flight message/tool-call record. The inner "lane" key is

--- a/integrations/langgraph/python/ag_ui_langgraph/types.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/types.py
@@ -245,6 +245,13 @@ RunMetadata = TypedDict("RunMetadata", {
     # separate — aggregation is the SDK's job (aggregate_token_usage), shared
     # with the TypeScript producer so both languages emit the same shape.
     "usage": NotRequired[List[TokenUsage]],
+    # LangGraph run ids of the model calls that already contributed a usage
+    # entry. Usage arrives on TWO channels and a call can use either or both:
+    # the final OnChatModelStream chunk, and the aggregated OnChatModelEnd
+    # output. A streaming provider reports it on both, under the SAME run id —
+    # so without this set, every streamed call would be counted twice. The
+    # model-end fallback consults it; the streaming path only populates it.
+    "usage_run_ids": NotRequired[Set[Optional[str]]],
 })
 
 # run_id -> lane -> in-flight message/tool-call record. The inner "lane" key is

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -10,13 +10,36 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "ag-ui-protocol>=0.1.21",
+    "ag-ui-protocol>=0.1.22",
     "ag-ui-a2ui-toolkit>=0.0.4",
     "langchain>=1.2.0",
     "langchain-core>=0.3.0",
     "langgraph>=0.6.0,<2",
     "pydantic>=2.0.0",
 ]
+
+# TEMPORARY, MUST BE REMOVED BEFORE THE NEXT ag-ui-langgraph RELEASE.
+#
+# Terminal-event token usage needs `ag_ui.core.token_usage`
+# (token_usage_from_langchain_metadata / aggregate_token_usage), which lives in
+# this repo's sdks/python but is not in any published ag-ui-protocol wheel
+# (latest on PyPI is 0.1.21). Without this override the package does not import
+# at all — `from ag_ui.core import aggregate_token_usage` raises ImportError —
+# so every test here fails on a clean checkout.
+#
+# `[tool.uv.sources]` is a development-only override: uv applies it for local
+# `uv sync` and CI, and it is NOT written into the built wheel's metadata, so
+# installed users still resolve `ag-ui-protocol>=0.1.22` from PyPI. That is
+# exactly why it is unsafe to leave here — a release cut while this points at a
+# local path ships a wheel whose declared floor cannot be satisfied.
+#
+# The sequence, same as PNI-274: release ag-ui-protocol 0.1.22 with the token
+# usage helpers, delete this block, relock, then release ag-ui-langgraph. Until
+# 0.1.22 is on PyPI the `langgraph-python-declared-floor` lane cannot pass —
+# that lane installs the declared floor from PyPI, and this floor does not
+# exist there yet. See OSS-886.
+[tool.uv.sources]
+ag-ui-protocol = { path = "../../../sdks/python" }
 
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.115.12"]

--- a/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
+++ b/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
@@ -27,7 +27,9 @@ import unittest
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from langchain_core.messages import AIMessageChunk
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
 from ag_ui.core import EventType, RunAgentInput
 
@@ -76,6 +78,106 @@ def _chunk_event(
         "parent_ids": [],
         "tags": [],
     }
+
+
+def _model_end_event(
+    *,
+    usage_metadata: Any = None,
+    run_id: str = "run1",
+    provider: Optional[str] = "openai",
+    model: Optional[str] = "gpt-4o",
+    node: str = "model",
+    output_as_dict: bool = False,
+):
+    """An ``on_chat_model_end`` event carrying the aggregated output message.
+
+    This is the only channel a non-streaming model uses — it emits no
+    ``on_chat_model_stream`` event at all.
+    """
+    if output_as_dict:
+        output: Any = {"usage_metadata": usage_metadata}
+    else:
+        output = AIMessage(content="hi")
+        output.usage_metadata = usage_metadata
+
+    metadata = {"langgraph_node": node}
+    if provider is not None:
+        metadata["ls_provider"] = provider
+    if model is not None:
+        metadata["ls_model_name"] = model
+
+    return {
+        "event": "on_chat_model_end",
+        "run_id": run_id,
+        "metadata": metadata,
+        "data": {"output": output},
+        "name": node,
+        "parent_ids": [],
+        "tags": [],
+    }
+
+
+class _NonStreamingModel(BaseChatModel):
+    """A model with no ``_astream``, so LangChain emits no stream events for it
+    — the shape a real provider takes when streaming is disabled, or when a
+    tool call is answered without streaming."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "test-non-streaming"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        message = AIMessage(
+            content="hi",
+            usage_metadata={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+class _StreamingModel(BaseChatModel):
+    """A model that streams and reports usage on its final chunk, as real
+    streaming providers do."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "test-streaming"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="hi"))])
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        yield ChatGenerationChunk(message=AIMessageChunk(content="h"))
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="i",
+                usage_metadata={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+                response_metadata={"finish_reason": "stop"},
+            )
+        )
+
+
+async def _events_from_real_model(model, *, node="model", provider="openai",
+                                  model_name="gpt-4o"):
+    """Capture what LangChain ACTUALLY emits for a model call, rather than
+    assuming the event shape.
+
+    The model-call events are taken verbatim and only have the LangGraph run
+    metadata merged in (which LangGraph, not LangChain, supplies). If a future
+    LangChain changes where usage lives, these fixtures change with it and the
+    tests fail loudly — which is the point.
+    """
+    captured = []
+    async for event in model.astream_events([HumanMessage("q")], version="v2"):
+        if event["event"] not in ("on_chat_model_stream", "on_chat_model_end"):
+            continue
+        event["metadata"] = {
+            **(event.get("metadata") or {}),
+            "langgraph_node": node,
+            "ls_provider": provider,
+            "ls_model_name": model_name,
+        }
+        captured.append(event)
+    return captured
 
 
 def _error_event(message: str = "boom", node: str = "model"):
@@ -359,6 +461,40 @@ class TestMalformedProviderCounts(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(entry.input_tokens)
         self.assertEqual(entry.output_tokens, 3)
 
+    async def test_an_integer_too_large_to_be_a_float_does_not_abort_the_run(self):
+        """Regression: the count guard called ``math.isfinite`` first, which
+        coerces to float and raises ``OverflowError`` on a large int. The
+        exception escaped mid-stream, so the run died with no terminal event —
+        the guard killing the run it exists to protect."""
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=10**1000, output_tokens=4),
+                         finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "outputTokens": 4}],
+        )
+
+    async def test_a_huge_integer_on_the_model_end_path_does_not_abort_the_run(self):
+        emitted = await _run([
+            _model_end_event(usage_metadata=_usage(input_tokens=10**1000)),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertIsNone(finished.usage)
+
+    async def test_counts_beyond_the_int64_wire_range_are_dropped(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=2**63, output_tokens=6),
+                         finish_reason="stop"),
+        ])
+
+        entry = _terminal(emitted, EventType.RUN_FINISHED).usage[0]
+        self.assertIsNone(entry.input_tokens)
+        self.assertEqual(entry.output_tokens, 6)
+
     async def test_a_wholly_malformed_payload_does_not_fail_the_run(self):
         """The regression this guards: an unguarded count raises a
         ValidationError while BUILDING RUN_FINISHED, so the run ends with no
@@ -372,6 +508,153 @@ class TestMalformedProviderCounts(unittest.IsolatedAsyncioTestCase):
 
         finished = _terminal(emitted, EventType.RUN_FINISHED)
         self.assertIsNone(finished.usage)
+
+
+class TestNonStreamingModelUsage(unittest.IsolatedAsyncioTestCase):
+    """A model call that does not stream reports its usage ONLY on
+    ``on_chat_model_end``. Capturing from ``on_chat_model_stream`` alone missed
+    every such call — streaming disabled, or a tool call answered without
+    streaming — and those runs finished with no usage at all."""
+
+    async def test_a_real_non_streaming_model_reports_usage(self):
+        """Driven by what LangChain actually emits, not a hand-built event."""
+        events = await _events_from_real_model(_NonStreamingModel())
+
+        # Guard the fixture: if LangChain ever starts emitting stream events for
+        # a model with no _astream, this test would silently stop covering the
+        # non-streaming path.
+        self.assertEqual(
+            [e["event"] for e in events], ["on_chat_model_end"],
+            "fixture must exercise the non-streaming path (no stream events)",
+        )
+
+        finished = _terminal(await _run(events), EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{
+                "provider": "openai",
+                "model": "gpt-4o",
+                "inputTokens": 3,
+                "outputTokens": 2,
+                "totalTokens": 5,
+            }],
+        )
+
+    async def test_model_end_usage_is_recorded(self):
+        emitted = await _run([
+            _model_end_event(usage_metadata=_usage(input_tokens=3, output_tokens=2,
+                                                   total_tokens=5)),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "inputTokens": 3,
+              "outputTokens": 2, "totalTokens": 5}],
+        )
+
+    async def test_model_end_output_delivered_as_a_dict_still_works(self):
+        emitted = await _run([
+            _model_end_event(usage_metadata=_usage(input_tokens=8),
+                             output_as_dict=True),
+        ])
+
+        self.assertEqual(
+            [u.input_tokens for u in _terminal(emitted, EventType.RUN_FINISHED).usage],
+            [8],
+        )
+
+    async def test_model_end_without_usage_changes_nothing(self):
+        emitted = await _run([_chunk_event(finish_reason="stop"), _model_end_event()])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertIsNone(finished.usage)
+        self.assertNotIn("usage", _wire(finished))
+
+
+class TestStreamedCallsAreNotDoubleCounted(unittest.IsolatedAsyncioTestCase):
+    """A streaming provider reports the same counts TWICE — once on the final
+    stream chunk, once on the aggregated model-end output — under the same run
+    id. The model-end read is a fallback, not an addition."""
+
+    async def test_a_real_streaming_model_is_counted_once(self):
+        events = await _events_from_real_model(_StreamingModel())
+
+        # Guard the fixture: this test is only meaningful if LangChain really
+        # does report the same usage on both channels.
+        with_usage = [
+            e for e in events
+            if getattr(
+                (e["data"].get("chunk") or e["data"].get("output")),
+                "usage_metadata", None,
+            )
+        ]
+        self.assertEqual(
+            [e["event"] for e in with_usage],
+            ["on_chat_model_stream", "on_chat_model_end"],
+            "fixture must report usage on BOTH channels for one call",
+        )
+        self.assertEqual(
+            len({e["run_id"] for e in with_usage}), 1,
+            "both reports must belong to the same model call",
+        )
+
+        finished = _terminal(await _run(events), EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "inputTokens": 3,
+              "outputTokens": 2, "totalTokens": 5}],
+            "the streamed call's tokens must be reported once, not doubled",
+        )
+
+    async def test_model_end_repeating_a_streamed_call_is_ignored(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=3, output_tokens=2),
+                         finish_reason="stop"),
+            _model_end_event(usage_metadata=_usage(input_tokens=3, output_tokens=2)),
+        ])
+
+        entry = _terminal(emitted, EventType.RUN_FINISHED).usage[0]
+        self.assertEqual((entry.input_tokens, entry.output_tokens), (3, 2))
+
+    async def test_a_streamed_call_and_a_separate_non_streamed_call_both_count(self):
+        """Dedup is per model call, not per run: a second call that never
+        streamed must still be counted."""
+        streamed = _chunk_event(usage_metadata=_usage(input_tokens=3),
+                                finish_reason="stop")
+        streamed["run_id"] = "call-a"
+
+        emitted = await _run([
+            streamed,
+            _model_end_event(usage_metadata=_usage(input_tokens=3), run_id="call-a"),
+            _model_end_event(usage_metadata=_usage(input_tokens=10), run_id="call-b"),
+        ])
+
+        self.assertEqual(
+            [u.input_tokens for u in _terminal(emitted, EventType.RUN_FINISHED).usage],
+            [13],
+        )
+
+    async def test_dedup_state_does_not_leak_between_runs(self):
+        agent = make_agent(emit_raw_events=False)
+
+        first = await _drive(agent, [
+            _model_end_event(usage_metadata=_usage(input_tokens=5), run_id="call-a"),
+        ])
+        self.assertEqual(
+            [u.input_tokens for u in _terminal(first, EventType.RUN_FINISHED).usage],
+            [5],
+        )
+
+        # Same model-call run id in the next run: a set that survived the run
+        # boundary would swallow this entirely.
+        second = await _drive(agent, [
+            _model_end_event(usage_metadata=_usage(input_tokens=7), run_id="call-a"),
+        ])
+        self.assertEqual(
+            [u.input_tokens for u in _terminal(second, EventType.RUN_FINISHED).usage],
+            [7],
+        )
 
 
 class TestUsageCarriesNoContent(unittest.IsolatedAsyncioTestCase):

--- a/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
+++ b/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
@@ -485,9 +485,9 @@ class TestMalformedProviderCounts(unittest.IsolatedAsyncioTestCase):
         finished = _terminal(emitted, EventType.RUN_FINISHED)
         self.assertIsNone(finished.usage)
 
-    async def test_counts_beyond_the_int64_wire_range_are_dropped(self):
+    async def test_counts_beyond_the_safe_integer_wire_range_are_dropped(self):
         emitted = await _run([
-            _chunk_event(usage_metadata=_usage(input_tokens=2**63, output_tokens=6),
+            _chunk_event(usage_metadata=_usage(input_tokens=2**53, output_tokens=6),
                          finish_reason="stop"),
         ])
 

--- a/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
+++ b/integrations/langgraph/python/tests/test_terminal_event_token_usage.py
@@ -1,0 +1,472 @@
+"""Terminal-event token usage (OSS-886).
+
+``RUN_FINISHED.usage`` and ``RUN_ERROR.usage`` are documented on the protocol
+but were never populated by the Python producer — only by the TypeScript one.
+These tests pin the Python side to the same behaviour: per-model-call
+``usage_metadata`` is accumulated during the run and folded into one entry per
+``(provider, model)`` at the terminal event.
+
+Two rules carry most of the weight and are asserted from both directions:
+
+* **omit vs zero** — a provider that reported nothing leaves ``usage`` absent,
+  never present-with-zeros. "Not measured" and "measured zero" are different
+  answers, and a consumer showing 0 tokens for an unreported run is wrong.
+* **numeric-only** — ``TokenUsage`` feeds anonymous usage telemetry, so no
+  content-bearing provider field may be copied into it, whatever else the
+  provider attaches next to the counts.
+
+Like ``test_exit_custom_event.py``, these drive the real pipeline
+(``_handle_stream_events`` -> ``_handle_single_event`` -> ``_dispatch_event``)
+over a synthetic LangGraph event stream, rather than calling the emit helpers
+directly — the capture point is inside the streaming path and its ORDER
+relative to the finish-reason early return is the thing most likely to break.
+"""
+
+import math
+import unittest
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessageChunk
+
+from ag_ui.core import EventType, RunAgentInput
+
+from tests._helpers import make_agent
+
+
+def _chunk_event(
+    *,
+    usage_metadata: Any = None,
+    finish_reason: Optional[str] = None,
+    content: str = "",
+    provider: Optional[str] = "openai",
+    model: Optional[str] = "gpt-4o",
+    node: str = "model",
+    message_id: str = "run--msg1",
+):
+    """An ``on_chat_model_stream`` event, optionally carrying usage metadata.
+
+    ``usage_metadata`` is assigned after construction on purpose: LangChain
+    validates the field against its ``UsageMetadata`` TypedDict at construction,
+    which would reject exactly the malformed payloads these tests must feed in.
+    Real providers deliver those payloads regardless — the metadata comes off
+    the wire, not out of a constructor.
+
+    ``provider`` / ``model`` become the standard LangChain run metadata keys
+    (``ls_provider`` / ``ls_model_name``); ``None`` omits the key entirely, which
+    is what providers that report no labels look like.
+    """
+    chunk = AIMessageChunk(content=content, id=message_id)
+    chunk.response_metadata = {"finish_reason": finish_reason} if finish_reason else {}
+    chunk.tool_call_chunks = []
+    chunk.usage_metadata = usage_metadata
+
+    metadata = {"langgraph_node": node}
+    if provider is not None:
+        metadata["ls_provider"] = provider
+    if model is not None:
+        metadata["ls_model_name"] = model
+
+    return {
+        "event": "on_chat_model_stream",
+        "run_id": "run1",
+        "metadata": metadata,
+        "data": {"chunk": chunk},
+        "name": node,
+        "parent_ids": [],
+        "tags": [],
+    }
+
+
+def _error_event(message: str = "boom", node: str = "model"):
+    return {
+        "event": "error",
+        "run_id": "run1",
+        "metadata": {"langgraph_node": node},
+        "data": {"message": message},
+        "name": node,
+        "parent_ids": [],
+        "tags": [],
+    }
+
+
+def _usage(input_tokens=None, output_tokens=None, total_tokens=None,
+           reasoning=None, cache_read=None, **extra):
+    """A LangChain-shaped ``usage_metadata`` payload.
+
+    ``extra`` keys land at the top level, which is how a provider smuggles
+    content-bearing fields in next to the counts.
+    """
+    payload = {}
+    if input_tokens is not None:
+        payload["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        payload["output_tokens"] = output_tokens
+    if total_tokens is not None:
+        payload["total_tokens"] = total_tokens
+    if reasoning is not None:
+        payload["output_token_details"] = {"reasoning": reasoning}
+    if cache_read is not None:
+        payload["input_token_details"] = {"cache_read": cache_read}
+    payload.update(extra)
+    return payload
+
+
+async def _drive(agent, stream_events, interrupts=None):
+    """Drive the real streaming pipeline over ``stream_events``.
+
+    Takes the agent rather than building one, so a test can drive the SAME
+    agent twice and check that per-run state does not leak between runs.
+    """
+
+    async def fake_stream():
+        for ev in stream_events:
+            yield ev
+
+    final_state = MagicMock()
+    final_state.values = {"messages": []}
+    if interrupts:
+        task = MagicMock()
+        task.interrupts = list(interrupts)
+        final_state.tasks = [task]
+        final_state.next = ("model",)
+    else:
+        final_state.tasks = []
+        final_state.next = []
+    final_state.metadata = {"writes": {}}
+
+    mock_prepared = {
+        "state": {"messages": []},
+        "stream": fake_stream(),
+        "config": {"configurable": {"thread_id": "t1"}},
+    }
+
+    def fake_get_state_snapshot(state):
+        if isinstance(state, dict):
+            return state
+        return getattr(state, "values", {}) or {}
+
+    with patch.object(agent, "prepare_stream", AsyncMock(return_value=mock_prepared)), \
+         patch.object(agent.graph, "aget_state", AsyncMock(return_value=final_state)), \
+         patch.object(agent, "get_state_snapshot", side_effect=fake_get_state_snapshot):
+        input_data = RunAgentInput(
+            thread_id="t1",
+            run_id="run1",
+            messages=[],
+            state={},
+            tools=[],
+            context=[],
+            forwarded_props={},
+        )
+        return [ev async for ev in agent._handle_stream_events(input_data)]
+
+
+async def _run(stream_events, interrupts=None, **agent_kwargs):
+    agent = make_agent(**{"emit_raw_events": False, **agent_kwargs})
+    return await _drive(agent, stream_events, interrupts=interrupts)
+
+
+def _terminal(emitted, event_type):
+    matches = [
+        ev for ev in emitted
+        if ev is not None and getattr(ev, "type", None) == event_type
+    ]
+    types = [None if ev is None else getattr(ev, "type", None) for ev in emitted]
+    assert len(matches) == 1, f"expected exactly one {event_type}; got {types!r}"
+    return matches[0]
+
+
+def _wire(event):
+    """The event as it reaches the client. Absent counts must be absent, not
+    ``null`` — which is what distinguishes "not measured" from zero on the
+    wire."""
+    return event.model_dump(by_alias=True, exclude_none=True)
+
+
+class TestRunFinishedUsage(unittest.IsolatedAsyncioTestCase):
+    async def test_a_single_model_call_reports_its_usage(self):
+        emitted = await _run([
+            _chunk_event(content="hi"),
+            _chunk_event(
+                usage_metadata=_usage(
+                    input_tokens=100, output_tokens=50, total_tokens=150,
+                    reasoning=20, cache_read=10,
+                ),
+                finish_reason="stop",
+            ),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{
+                "provider": "openai",
+                "model": "gpt-4o",
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+                "reasoningTokens": 20,
+                "cachedInputTokens": 10,
+            }],
+        )
+
+    async def test_usage_on_the_finish_reason_chunk_is_not_dropped(self):
+        """LangChain attaches ``usage_metadata`` to the FINAL chunk — the same
+        one that carries ``finish_reason`` and makes the handler return early.
+        Capture therefore has to happen before that return, so this is the
+        whole feature in one assertion: the only chunk carrying usage here is
+        the one that returns early."""
+        emitted = await _run([
+            _chunk_event(content="hi"),
+            _chunk_event(usage_metadata=_usage(input_tokens=7), finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual([u.input_tokens for u in finished.usage], [7])
+
+    async def test_repeated_calls_to_one_model_are_summed(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=100, output_tokens=20,
+                                               total_tokens=120), finish_reason="stop"),
+            _chunk_event(usage_metadata=_usage(input_tokens=10, output_tokens=5,
+                                               total_tokens=15), finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual(len(finished.usage), 1)
+        self.assertEqual(
+            (finished.usage[0].input_tokens,
+             finished.usage[0].output_tokens,
+             finished.usage[0].total_tokens),
+            (110, 25, 135),
+        )
+
+    async def test_distinct_models_stay_separate_in_first_seen_order(self):
+        emitted = await _run([
+            _chunk_event(model="gpt-4o", usage_metadata=_usage(input_tokens=1),
+                         finish_reason="stop"),
+            _chunk_event(model="gpt-4o-mini", usage_metadata=_usage(input_tokens=2),
+                         finish_reason="stop"),
+            _chunk_event(model="gpt-4o", usage_metadata=_usage(input_tokens=3),
+                         finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual([u.model for u in finished.usage], ["gpt-4o", "gpt-4o-mini"])
+        self.assertEqual([u.input_tokens for u in finished.usage], [4, 2])
+
+    async def test_a_field_only_some_calls_report_is_summed_over_those_calls(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=1, reasoning=7),
+                         finish_reason="stop"),
+            _chunk_event(usage_metadata=_usage(input_tokens=2), finish_reason="stop"),
+            _chunk_event(usage_metadata=_usage(input_tokens=3, reasoning=5),
+                         finish_reason="stop"),
+        ])
+
+        entry = _terminal(emitted, EventType.RUN_FINISHED).usage[0]
+        self.assertEqual(entry.input_tokens, 6)
+        self.assertEqual(entry.reasoning_tokens, 12)
+        # No call reported these, so they must not appear at all.
+        self.assertIsNone(entry.output_tokens)
+        self.assertNotIn("outputTokens", _wire(_terminal(emitted, EventType.RUN_FINISHED))["usage"][0])
+
+    async def test_unlabelled_usage_is_still_reported(self):
+        """Some providers attach no ``ls_provider`` / ``ls_model_name``. The
+        counts are still real; only the labels are missing."""
+        emitted = await _run([
+            _chunk_event(provider=None, model=None,
+                         usage_metadata=_usage(input_tokens=5), finish_reason="stop"),
+        ])
+
+        self.assertEqual(
+            _wire(_terminal(emitted, EventType.RUN_FINISHED))["usage"],
+            [{"inputTokens": 5}],
+        )
+
+
+class TestUsageIsOmittedNotZeroed(unittest.IsolatedAsyncioTestCase):
+    """"Not reported" must stay distinguishable from "reported as zero"."""
+
+    async def test_a_run_with_no_provider_usage_omits_the_field_entirely(self):
+        emitted = await _run([
+            _chunk_event(content="hi"),
+            _chunk_event(finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertIsNone(finished.usage)
+        self.assertNotIn("usage", _wire(finished))
+
+    async def test_usage_with_no_usable_count_omits_the_field_entirely(self):
+        """A labels-only or zeroed entry would claim a measurement that never
+        happened, so nothing is emitted at all."""
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens="nope"), finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertIsNone(finished.usage)
+        self.assertNotIn("usage", _wire(finished))
+
+    async def test_a_measured_zero_is_reported_as_zero(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=4, output_tokens=0),
+                         finish_reason="stop"),
+        ])
+
+        self.assertEqual(
+            _wire(_terminal(emitted, EventType.RUN_FINISHED))["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "inputTokens": 4, "outputTokens": 0}],
+        )
+
+
+class TestMalformedProviderCounts(unittest.IsolatedAsyncioTestCase):
+    """A bad count must never reach the wire. Consumers validate every event and
+    raise on failure, so one malformed count would fail an otherwise-successful
+    run at its FINAL event — and on the Python side the ``TokenUsage``
+    constructor would raise inside the producer's own terminal path. Either way
+    the user loses the answer, not just the token count."""
+
+    async def test_malformed_counts_are_dropped_and_the_run_still_finishes(self):
+        emitted = await _run([
+            _chunk_event(
+                usage_metadata={
+                    "input_tokens": "100",          # string
+                    "output_tokens": None,          # not reported
+                    "total_tokens": float("nan"),   # NaN
+                    "input_token_details": {"cache_read": -1},      # negative
+                    "output_token_details": {"reasoning": 1.5},     # fractional
+                },
+                finish_reason="stop",
+            ),
+            _chunk_event(usage_metadata=_usage(output_tokens=9), finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "outputTokens": 9}],
+        )
+
+    async def test_infinite_counts_are_dropped(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=math.inf, output_tokens=3),
+                         finish_reason="stop"),
+        ])
+
+        entry = _terminal(emitted, EventType.RUN_FINISHED).usage[0]
+        self.assertIsNone(entry.input_tokens)
+        self.assertEqual(entry.output_tokens, 3)
+
+    async def test_a_wholly_malformed_payload_does_not_fail_the_run(self):
+        """The regression this guards: an unguarded count raises a
+        ValidationError while BUILDING RUN_FINISHED, so the run ends with no
+        terminal event at all."""
+        emitted = await _run([
+            _chunk_event(usage_metadata="not a mapping at all", finish_reason="stop"),
+            _chunk_event(usage_metadata=[1, 2, 3], finish_reason="stop"),
+            _chunk_event(usage_metadata={"input_tokens": {"nested": "object"}},
+                         finish_reason="stop"),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertIsNone(finished.usage)
+
+
+class TestUsageCarriesNoContent(unittest.IsolatedAsyncioTestCase):
+    """``TokenUsage`` feeds anonymous usage telemetry. Nothing content-bearing
+    or identifying may ride along, however the provider labels it."""
+
+    SECRETS = {
+        "prompt": "what is the capital of France?",
+        "completion": "Paris",
+        "messages": [{"role": "user", "content": "SECRET-CONTENT"}],
+        "text": "SECRET-CONTENT",
+        "content": "SECRET-CONTENT",
+        "thread_id": "SECRET-THREAD",
+        "user_id": "SECRET-USER",
+        "api_key": "sk-live-SECRET",
+    }
+
+    async def test_no_content_bearing_provider_field_is_copied_into_usage(self):
+        emitted = await _run([
+            _chunk_event(
+                usage_metadata=_usage(input_tokens=3, output_tokens=4, **self.SECRETS),
+                finish_reason="stop",
+            ),
+        ])
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        usage_json = finished.usage[0].model_dump_json()
+        for key, value in self.SECRETS.items():
+            self.assertNotIn(key, usage_json)
+            if isinstance(value, str):
+                self.assertNotIn(value, usage_json)
+        self.assertEqual(
+            _wire(finished)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "inputTokens": 3, "outputTokens": 4}],
+        )
+
+
+class TestRunErrorUsage(unittest.IsolatedAsyncioTestCase):
+    async def test_a_run_that_fails_after_a_model_call_reports_partial_usage(self):
+        emitted = await _run([
+            _chunk_event(usage_metadata=_usage(input_tokens=100, output_tokens=12),
+                         finish_reason="stop"),
+            _error_event("boom"),
+        ])
+
+        errored = _terminal(emitted, EventType.RUN_ERROR)
+        self.assertEqual(errored.message, "boom")
+        self.assertEqual(
+            _wire(errored)["usage"],
+            [{"provider": "openai", "model": "gpt-4o", "inputTokens": 100, "outputTokens": 12}],
+        )
+
+    async def test_a_run_that_fails_before_any_model_call_omits_usage(self):
+        emitted = await _run([_error_event("boom")])
+
+        errored = _terminal(emitted, EventType.RUN_ERROR)
+        self.assertIsNone(errored.usage)
+        self.assertNotIn("usage", _wire(errored))
+
+
+class TestInterruptedRunUsage(unittest.IsolatedAsyncioTestCase):
+    async def test_an_interrupted_run_reports_the_usage_it_already_spent(self):
+        """An interrupt ends the run with RUN_FINISHED. The model calls made
+        before the pause were paid for, so they are reported."""
+        interrupt = MagicMock()
+        interrupt.value = "approve?"
+        interrupt.id = "int-1"
+
+        emitted = await _run(
+            [_chunk_event(usage_metadata=_usage(input_tokens=42), finish_reason="stop")],
+            interrupts=[interrupt],
+        )
+
+        finished = _terminal(emitted, EventType.RUN_FINISHED)
+        self.assertEqual([u.input_tokens for u in finished.usage], [42])
+
+
+class TestUsageDoesNotLeakBetweenRuns(unittest.IsolatedAsyncioTestCase):
+    async def test_a_second_run_on_the_same_agent_starts_from_nothing(self):
+        agent = make_agent(emit_raw_events=False)
+
+        first = await _drive(agent, [
+            _chunk_event(usage_metadata=_usage(input_tokens=11), finish_reason="stop"),
+        ])
+        self.assertEqual(
+            [u.input_tokens for u in _terminal(first, EventType.RUN_FINISHED).usage],
+            [11],
+        )
+
+        second = await _drive(agent, [_chunk_event(finish_reason="stop")])
+        self.assertIsNone(
+            _terminal(second, EventType.RUN_FINISHED).usage,
+            "the first run's counts must not be re-reported by the second",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/integrations/langgraph/python/uv.lock
+++ b/integrations/langgraph/python/uv.lock
@@ -40,7 +40,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ag-ui-a2ui-toolkit", specifier = ">=0.0.4" },
-    { name = "ag-ui-protocol", specifier = ">=0.1.21" },
+    { name = "ag-ui-protocol", directory = "../../../sdks/python" },
     { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.12" },
     { name = "langchain", specifier = ">=1.2.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
@@ -59,15 +59,14 @@ dev = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.21"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.22"
+source = { directory = "../../../sdks/python" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/a8/86e3dec527a47a798f4aba5cddc68deedacd78dcf0f638d0cf7c9ac21525/ag_ui_protocol-0.1.21.tar.gz", hash = "sha256:42f6fb809399cd2ced5417ed928f821feda2534f4e55aebeada170823a6b1a5f", size = 15102, upload-time = "2026-08-27T11:48:28.235Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/e5/4229590a6c0561ef9979e251d12962b85df5c5e88685c6dd2fbdf221ba7d/ag_ui_protocol-0.1.21-py3-none-any.whl", hash = "sha256:628203b9decd66eb98995f86edca5536de330ecdfbcb809809863e4408ddeb57", size = 18527, upload-time = "2026-08-27T11:48:27.343Z" },
-]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.11.2" }]
 
 [[package]]
 name = "annotated-doc"

--- a/sdks/python/ag_ui/core/__init__.py
+++ b/sdks/python/ag_ui/core/__init__.py
@@ -93,6 +93,11 @@ from ag_ui.core.types import (
     InputContentPart,
 )
 
+from ag_ui.core.token_usage import (
+    token_usage_from_langchain_metadata,
+    aggregate_token_usage,
+)
+
 from ag_ui.core.capabilities import (
     SubAgentInfo,
     IdentityCapabilities,
@@ -155,6 +160,9 @@ __all__ = [
     "RunFinishedOutcome",
     "RunFinishedSuccessOutcome",
     "TokenUsage",
+    # Token usage mapping / aggregation
+    "token_usage_from_langchain_metadata",
+    "aggregate_token_usage",
     "RunFinishedInterruptOutcome",
     "SubagentStartedEvent",
     "SubagentFinishedEvent",

--- a/sdks/python/ag_ui/core/token_usage.py
+++ b/sdks/python/ag_ui/core/token_usage.py
@@ -34,12 +34,13 @@ _COUNT_KEYS: Tuple[str, ...] = (
 )
 
 
-# The largest count that survives every binding's wire representation: proto
-# `int64` and C# `long?`. Python ints are unbounded, so a provider (or a bad
-# cast upstream of one) can hand over a number that simply cannot be encoded;
-# it is rejected here, at the producer, rather than becoming an encoder crash
-# mid-stream.
-_MAX_TOKEN_COUNT = 2**63 - 1
+# The largest count that survives every binding's wire representation. Proto
+# `int64` and C# `long?` reach 2**63 - 1, but the TypeScript protobuf decoder
+# stops at `Number.MAX_SAFE_INTEGER`, so that is the real ceiling across the
+# bindings. Python ints are unbounded, so a provider (or a bad cast upstream of
+# one) can hand over a number that simply cannot be encoded; it is rejected
+# here, at the producer, rather than becoming an encoder crash mid-stream.
+_MAX_TOKEN_COUNT = 2**53 - 1
 
 
 def _normalize_number(value: Any) -> Optional[int]:

--- a/sdks/python/ag_ui/core/token_usage.py
+++ b/sdks/python/ag_ui/core/token_usage.py
@@ -34,9 +34,18 @@ _COUNT_KEYS: Tuple[str, ...] = (
 )
 
 
-def _num(value: Any) -> Optional[int]:
+# The largest count that survives every binding's wire representation: proto
+# `int64` and C# `long?`. Python ints are unbounded, so a provider (or a bad
+# cast upstream of one) can hand over a number that simply cannot be encoded;
+# it is rejected here, at the producer, rather than becoming an encoder crash
+# mid-stream.
+_MAX_TOKEN_COUNT = 2**63 - 1
+
+
+def _normalize_number(value: Any) -> Optional[int]:
     """
-    Accept a value only if it is a real, finite, non-negative whole number.
+    Accept a value only if it is a real, finite, non-negative whole number that
+    fits the wire, and return it as an ``int``.
 
     Providers do hand over strings, ``None``s and ``NaN``s in their usage
     metadata, and a bad value must not reach the wire: consumers validate every
@@ -58,9 +67,22 @@ def _num(value: Any) -> Optional[int]:
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return None
+
+    # Integers are settled BEFORE any float check, and never converted to one.
+    # ``math.isfinite`` coerces its argument to a float and raises
+    # ``OverflowError`` on a large int — ``math.isfinite(10**1000)`` does — so
+    # checking finiteness first would abort the run from inside the very guard
+    # whose job is to render bad metadata harmless. An int is finite by
+    # construction; the only questions are sign and range.
+    if isinstance(value, int):
+        return value if 0 <= value <= _MAX_TOKEN_COUNT else None
+
     if not math.isfinite(value):  # NaN, +Infinity, -Infinity
         return None
-    if value < 0 or int(value) != value:
+    # Range before ``int()``: bounding first keeps the conversion cheap and
+    # keeps a 1e300 from being materialised as a 300-digit integer just to be
+    # thrown away.
+    if value < 0 or value > _MAX_TOKEN_COUNT or int(value) != value:
         return None
     return int(value)
 
@@ -135,11 +157,11 @@ def token_usage_from_langchain_metadata(
 
     return _build_entry(
         {
-            "input_tokens": _num(_prop(usage_metadata, "input_tokens")),
-            "output_tokens": _num(_prop(usage_metadata, "output_tokens")),
-            "total_tokens": _num(_prop(usage_metadata, "total_tokens")),
-            "reasoning_tokens": _num(_prop(output_details, "reasoning")),
-            "cached_input_tokens": _num(_prop(input_details, "cache_read")),
+            "input_tokens": _normalize_number(_prop(usage_metadata, "input_tokens")),
+            "output_tokens": _normalize_number(_prop(usage_metadata, "output_tokens")),
+            "total_tokens": _normalize_number(_prop(usage_metadata, "total_tokens")),
+            "reasoning_tokens": _normalize_number(_prop(output_details, "reasoning")),
+            "cached_input_tokens": _normalize_number(_prop(input_details, "cache_read")),
         },
         provider,
         model,

--- a/sdks/python/ag_ui/core/token_usage.py
+++ b/sdks/python/ag_ui/core/token_usage.py
@@ -1,0 +1,180 @@
+"""
+Vendor -> :class:`TokenUsage` mappers and aggregation for the Python SDK.
+
+Python twin of ``sdks/typescript/packages/core/src/token-usage.ts``. Producers
+(the LangGraph integration today) accumulate one entry per model call and
+aggregate at the terminal event, so ``RUN_FINISHED.usage`` / ``RUN_ERROR.usage``
+carry one summary per ``(provider, model)``.
+
+Only numeric counts and the optional provider/model labels are ever mapped.
+:class:`TokenUsage` feeds anonymous usage telemetry, so no prompt, completion,
+message or other content-bearing field may be copied into it — see the type's
+own docstring.
+"""
+
+import math
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .events import TokenUsage
+
+__all__ = [
+    "token_usage_from_langchain_metadata",
+    "aggregate_token_usage",
+]
+
+# The snake_case :class:`TokenUsage` count fields, in wire order. Labels
+# (provider/model) are deliberately not here: a labels-only entry is not usage,
+# which is what ``_build_entry`` checks this tuple to decide.
+_COUNT_KEYS: Tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "reasoning_tokens",
+    "cached_input_tokens",
+)
+
+
+def _num(value: Any) -> Optional[int]:
+    """
+    Accept a value only if it is a real, finite, non-negative whole number.
+
+    Providers do hand over strings, ``None``s and ``NaN``s in their usage
+    metadata, and a bad value must not reach the wire: consumers validate every
+    incoming event and raise on failure, so one malformed count would fail an
+    otherwise-successful run at its final event — costing the user the answer,
+    not just the token count.
+
+    This guards harder than the TypeScript ``num()`` it mirrors, which only
+    checks finiteness and leaves the integer/non-negative bound to schema
+    validation. In Python that bound is enforced by :class:`TokenUsage` itself
+    (``Optional[int]`` with ``ge=0``), i.e. by a constructor the *producer*
+    calls — so an unguarded ``-1`` or ``1.5`` would not merely reach the wire,
+    it would raise inside the producer's own terminal-event path and kill the
+    run there. Rejecting the count is strictly better than losing the run.
+
+    ``bool`` is excluded even though it subclasses ``int``: ``True`` is not a
+    token count, and TypeScript's ``typeof v === "number"`` would not have
+    admitted it either.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value):  # NaN, +Infinity, -Infinity
+        return None
+    if value < 0 or int(value) != value:
+        return None
+    return int(value)
+
+
+def _prop(value: Any, key: str) -> Any:
+    """
+    Read a property from a value of unknown shape, yielding ``None`` for
+    anything that carries no such key. Vendor payloads are untrusted, so every
+    access is narrowed rather than assumed.
+
+    Both mapping and attribute access are tried. LangChain's ``usage_metadata``
+    is a ``TypedDict`` (a plain ``dict`` at runtime), but the same dual-path
+    accommodation the LangGraph integration already makes for chunk shapes
+    applies here: an object-shaped payload should lose its usage counts, not be
+    silently reported as "no usage".
+    """
+    if isinstance(value, Mapping):
+        return value.get(key)
+    if isinstance(value, (str, bytes, int, float, bool)) or value is None:
+        return None
+    return getattr(value, key, None)
+
+
+def _build_entry(
+    counts: Mapping[str, Optional[int]],
+    provider: Optional[str],
+    model: Optional[str],
+) -> Optional[TokenUsage]:
+    """
+    Build a :class:`TokenUsage` from already-guarded counts, or ``None`` when no
+    count survived. Returning ``None`` rather than a labels-only entry keeps
+    "the provider reported no usage" distinct from "the provider reported
+    usage", so callers omit the field instead of emitting an entry that claims
+    nothing — and never substitute zeros, which would read as a measured zero.
+    """
+    if all(counts.get(key) is None for key in _COUNT_KEYS):
+        return None
+
+    fields: Dict[str, Any] = {}
+    if provider is not None:
+        fields["provider"] = provider
+    if model is not None:
+        fields["model"] = model
+    for key in _COUNT_KEYS:
+        value = counts.get(key)
+        if value is not None:
+            fields[key] = value
+    return TokenUsage(**fields)
+
+
+def token_usage_from_langchain_metadata(
+    usage_metadata: Any,
+    *,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+) -> Optional[TokenUsage]:
+    """
+    Map a LangChain-family ``usage_metadata`` object into a :class:`TokenUsage`.
+
+    LangChain and LangGraph both attach usage as ``{input_tokens,
+    output_tokens, total_tokens, input_token_details: {cache_read},
+    output_token_details: {reasoning}}``. This maps only those numeric counts
+    plus the optional provider/model labels — never prompt/completion content.
+    Returns ``None`` when no usable count is present, so callers can omit usage
+    rather than report zeros.
+    """
+    if not usage_metadata:
+        return None
+
+    input_details = _prop(usage_metadata, "input_token_details")
+    output_details = _prop(usage_metadata, "output_token_details")
+
+    return _build_entry(
+        {
+            "input_tokens": _num(_prop(usage_metadata, "input_tokens")),
+            "output_tokens": _num(_prop(usage_metadata, "output_tokens")),
+            "total_tokens": _num(_prop(usage_metadata, "total_tokens")),
+            "reasoning_tokens": _num(_prop(output_details, "reasoning")),
+            "cached_input_tokens": _num(_prop(input_details, "cache_read")),
+        },
+        provider,
+        model,
+    )
+
+
+def aggregate_token_usage(entries: Sequence[TokenUsage]) -> List[TokenUsage]:
+    """
+    Sum per-call :class:`TokenUsage` entries into one entry per
+    ``(provider, model)`` pair. Order follows first appearance. A count field
+    stays unset when no member of the group reported it, so "not reported" stays
+    distinct from zero.
+
+    Protocol-agnostic: works on any producer's list of entries, so integrations
+    share it rather than reimplementing aggregation.
+    """
+    grouped: Dict[Tuple[Optional[str], Optional[str]], Dict[str, Optional[int]]] = {}
+
+    for entry in entries:
+        # Keyed on the label pair itself rather than on a joined string (what
+        # the TypeScript version does): a separator inside a label cannot then
+        # collide two distinct pairs into one group.
+        key = (entry.provider, entry.model)
+        target = grouped.setdefault(key, {})
+        for field in _COUNT_KEYS:
+            value = getattr(entry, field)
+            if value is None:
+                continue
+            target[field] = (target.get(field) or 0) + value
+
+    return [
+        TokenUsage(
+            provider=provider,
+            model=model,
+            **{key: value for key, value in counts.items() if value is not None},
+        )
+        for (provider, model), counts in grouped.items()
+    ]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ag-ui-protocol"
-version = "0.1.21"
+version = "0.1.22"
 description = ""
 license-files = ["LICENSE"]
 authors = [

--- a/sdks/python/tests/test_token_usage.py
+++ b/sdks/python/tests/test_token_usage.py
@@ -126,6 +126,51 @@ class TokenUsageGuardTest(unittest.TestCase):
         self.assertEqual(usage.input_tokens, 12)
         self.assertIsInstance(usage.input_tokens, int)
 
+    def test_an_integer_too_large_to_be_a_float_is_dropped_not_raised(self):
+        """Regression: the guard used ``math.isfinite`` first, which coerces to
+        float and raises ``OverflowError`` on a large int
+        (``math.isfinite(10**1000)``). A provider count big enough to trip that
+        aborted the run from inside the guard whose whole job is to make bad
+        metadata harmless — the worst possible failure mode for this code."""
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": 10**1000, "output_tokens": 5}
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertEqual(usage.output_tokens, 5)
+
+    def test_a_huge_integer_in_every_slot_is_dropped_not_raised(self):
+        """Every count field, including the nested detail ones, goes through
+        the same guard — so every one of them must survive the value."""
+        self.assertIsNone(
+            token_usage_from_langchain_metadata(
+                {
+                    "input_tokens": 10**400,
+                    "output_tokens": -(10**400),
+                    "total_tokens": 10**1000,
+                    "output_token_details": {"reasoning": 10**500},
+                    "input_token_details": {"cache_read": 10**600},
+                },
+                provider="openai",
+            )
+        )
+
+    def test_counts_beyond_the_int64_wire_range_are_dropped(self):
+        """Counts are ``int64`` on the proto transport and ``long?`` in C#. A
+        Python int has no such bound, so a value past it is rejected at the
+        producer rather than becoming an encoder crash mid-stream."""
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": 2**63, "output_tokens": 2**63 - 1}
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertEqual(usage.output_tokens, 2**63 - 1)
+
+    def test_a_float_beyond_the_wire_range_is_dropped(self):
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": 1e300, "output_tokens": 2}
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertEqual(usage.output_tokens, 2)
+
     def test_guards_nested_detail_fields(self):
         usage = token_usage_from_langchain_metadata(
             {

--- a/sdks/python/tests/test_token_usage.py
+++ b/sdks/python/tests/test_token_usage.py
@@ -1,0 +1,350 @@
+"""
+Tests for the vendor -> TokenUsage mappers and aggregation.
+
+Mirrors sdks/typescript/packages/core/src/__tests__/token-usage.test.ts, plus
+the Python-specific guard cases (see ``_num``'s docstring: the integer /
+non-negative bound is enforced by the TokenUsage constructor the producer
+itself calls, so an unguarded value raises inside the producer rather than at
+the consumer).
+"""
+
+import math
+import unittest
+
+from ag_ui.core import (
+    TokenUsage,
+    aggregate_token_usage,
+    token_usage_from_langchain_metadata,
+)
+
+
+def _dump(usage):
+    """Serialize the way a producer does, so absent counts are visibly absent
+    rather than present-as-None."""
+    return usage.model_dump(by_alias=True, exclude_none=True)
+
+
+class TokenUsageFromLangChainMetadataTest(unittest.TestCase):
+    def test_maps_core_and_detail_fields(self):
+        usage = token_usage_from_langchain_metadata(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_token_details": {"cache_read": 10},
+                "output_token_details": {"reasoning": 20},
+            },
+            provider="anthropic",
+            model="claude-sonnet-4",
+        )
+        self.assertEqual(
+            _dump(usage),
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4",
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+                "reasoningTokens": 20,
+                "cachedInputTokens": 10,
+            },
+        )
+
+    def test_returns_none_for_missing_or_empty_metadata(self):
+        self.assertIsNone(token_usage_from_langchain_metadata(None))
+        self.assertIsNone(token_usage_from_langchain_metadata({}))
+        self.assertIsNone(token_usage_from_langchain_metadata({}, provider="openai"))
+
+    def test_omits_absent_fields_entirely(self):
+        usage = token_usage_from_langchain_metadata({"input_tokens": 5})
+        self.assertEqual(_dump(usage), {"inputTokens": 5})
+
+    def test_reads_attribute_shaped_metadata(self):
+        """Vendor payloads are dicts in every LangChain version, but an
+        object-shaped one should lose nothing rather than read as "no usage"."""
+
+        class Details:
+            reasoning = 3
+
+        class Meta:
+            input_tokens = 9
+            output_token_details = Details()
+
+        usage = token_usage_from_langchain_metadata(Meta())
+        self.assertEqual(_dump(usage), {"inputTokens": 9, "reasoningTokens": 3})
+
+
+class TokenUsageGuardTest(unittest.TestCase):
+    """Only finite, non-negative whole numbers survive. Everything else is
+    dropped rather than forwarded: consumers validate every event, and the
+    TokenUsage constructor the producer calls would raise on a bad count
+    inside the terminal-event path — failing the whole run at its last event."""
+
+    def test_drops_string_counts(self):
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": "100", "output_tokens": 5}, provider="openai"
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertEqual(usage.output_tokens, 5)
+
+    def test_drops_none_counts(self):
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": None, "output_tokens": 5}
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertEqual(usage.output_tokens, 5)
+
+    def test_drops_nan_and_infinity(self):
+        usage = token_usage_from_langchain_metadata(
+            {
+                "input_tokens": float("nan"),
+                "output_tokens": math.inf,
+                "total_tokens": 7,
+            },
+            provider="openai",
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertIsNone(usage.output_tokens)
+        self.assertEqual(usage.total_tokens, 7)
+
+    def test_drops_negative_and_fractional_counts(self):
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": -1, "output_tokens": 1.5, "total_tokens": 4}
+        )
+        self.assertIsNone(usage.input_tokens)
+        self.assertIsNone(usage.output_tokens)
+        self.assertEqual(usage.total_tokens, 4)
+
+    def test_drops_booleans(self):
+        """``bool`` subclasses ``int`` in Python; ``True`` is not a count."""
+        self.assertIsNone(
+            token_usage_from_langchain_metadata({"input_tokens": True})
+        )
+
+    def test_accepts_integral_float(self):
+        usage = token_usage_from_langchain_metadata({"input_tokens": 12.0})
+        self.assertEqual(usage.input_tokens, 12)
+        self.assertIsInstance(usage.input_tokens, int)
+
+    def test_guards_nested_detail_fields(self):
+        usage = token_usage_from_langchain_metadata(
+            {
+                "input_tokens": 1,
+                "output_token_details": {"reasoning": "12"},
+                "input_token_details": {"cache_read": None},
+            }
+        )
+        self.assertIsNone(usage.reasoning_tokens)
+        self.assertIsNone(usage.cached_input_tokens)
+
+    def test_tolerates_non_object_detail_containers(self):
+        usage = token_usage_from_langchain_metadata(
+            {
+                "input_tokens": 1,
+                "output_token_details": "nope",
+                "input_token_details": 7,
+            }
+        )
+        self.assertEqual(_dump(usage), {"inputTokens": 1})
+
+    def test_returns_none_when_no_usable_count_survives(self):
+        """Not a labels-only entry and not zeros: "not reported" must stay
+        distinct from a measured zero."""
+        self.assertIsNone(
+            token_usage_from_langchain_metadata(
+                {"input_tokens": "nope"}, provider="openai", model="gpt-4o"
+            )
+        )
+        self.assertIsNone(
+            token_usage_from_langchain_metadata(
+                {"input_tokens": float("nan"), "output_token_details": {"reasoning": None}},
+                provider="openai",
+            )
+        )
+
+    def test_reports_a_measured_zero_as_zero(self):
+        usage = token_usage_from_langchain_metadata({"output_tokens": 0})
+        self.assertEqual(_dump(usage), {"outputTokens": 0})
+
+
+class TokenUsageContentSafetyTest(unittest.TestCase):
+    """TokenUsage feeds anonymous usage telemetry. No content-bearing provider
+    field may be copied into it, whatever the provider attaches alongside the
+    counts."""
+
+    CONTENT_BEARING = {
+        "prompt": "what is the capital of France?",
+        "completion": "Paris",
+        "messages": [{"role": "user", "content": "secret"}],
+        "text": "secret",
+        "content": "secret",
+        "input": "secret",
+        "output": "secret",
+        "thread_id": "t-1",
+        "run_id": "r-1",
+        "user_id": "u-1",
+        "api_key": "sk-live-xxx",
+    }
+
+    def test_content_bearing_fields_are_not_copied(self):
+        usage = token_usage_from_langchain_metadata(
+            {"input_tokens": 3, "output_tokens": 4, **self.CONTENT_BEARING},
+            provider="openai",
+            model="gpt-4o",
+        )
+        dumped = _dump(usage)
+        self.assertEqual(
+            dumped,
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "inputTokens": 3,
+                "outputTokens": 4,
+            },
+        )
+        # Belt and braces: nothing anywhere in the serialized entry echoes a
+        # supplied value, under any key spelling.
+        serialized = usage.model_dump_json()
+        for key, value in self.CONTENT_BEARING.items():
+            self.assertNotIn(key, dumped)
+            if isinstance(value, str):
+                self.assertNotIn(value, serialized)
+
+    def test_the_mapper_is_the_guard_because_the_type_allows_extras(self):
+        """``ConfiguredBaseModel`` is ``extra="allow"`` protocol-wide, so the
+        type does NOT refuse a content-bearing field — a direct construction
+        keeps it. The numeric-only guarantee therefore rests on the mapper
+        never passing a vendor payload through, which is what this asserts:
+        whatever keys the payload has, the entry's keys stay inside the
+        allowed set."""
+        smuggled = TokenUsage(input_tokens=1, prompt="secret")
+        self.assertIn("prompt", smuggled.model_dump_json())
+
+        allowed = {
+            "provider",
+            "model",
+            "inputTokens",
+            "outputTokens",
+            "totalTokens",
+            "reasoningTokens",
+            "cachedInputTokens",
+        }
+        mapped = token_usage_from_langchain_metadata(
+            {
+                "input_tokens": 1,
+                "input_token_details": {"cache_read": 2, "prompt": "secret"},
+                "output_token_details": {"reasoning": 3, "completion": "secret"},
+                **self.CONTENT_BEARING,
+            },
+            provider="openai",
+            model="gpt-4o",
+        )
+        self.assertLessEqual(set(_dump(mapped)), allowed)
+
+
+class AggregateTokenUsageTest(unittest.TestCase):
+    def test_returns_empty_for_empty_input(self):
+        self.assertEqual(aggregate_token_usage([]), [])
+
+    def test_sums_entries_for_the_same_provider_and_model(self):
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(
+                    provider="openai",
+                    model="gpt-4o",
+                    input_tokens=100,
+                    output_tokens=20,
+                    total_tokens=120,
+                ),
+                TokenUsage(
+                    provider="openai",
+                    model="gpt-4o",
+                    input_tokens=10,
+                    output_tokens=5,
+                    total_tokens=15,
+                ),
+            ]
+        )
+        self.assertEqual(len(aggregated), 1)
+        self.assertEqual(
+            _dump(aggregated[0]),
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "inputTokens": 110,
+                "outputTokens": 25,
+                "totalTokens": 135,
+            },
+        )
+
+    def test_keeps_distinct_models_separate_in_first_seen_order(self):
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(provider="openai", model="gpt-4o", input_tokens=1),
+                TokenUsage(provider="openai", model="gpt-4o-mini", input_tokens=2),
+                TokenUsage(provider="openai", model="gpt-4o", input_tokens=3),
+            ]
+        )
+        self.assertEqual([u.model for u in aggregated], ["gpt-4o", "gpt-4o-mini"])
+        self.assertEqual(aggregated[0].input_tokens, 4)
+        self.assertEqual(aggregated[1].input_tokens, 2)
+
+    def test_distinct_providers_stay_separate(self):
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(provider="openai", model="m", input_tokens=1),
+                TokenUsage(provider="anthropic", model="m", input_tokens=2),
+            ]
+        )
+        self.assertEqual([u.provider for u in aggregated], ["openai", "anthropic"])
+
+    def test_unlabelled_entries_group_together(self):
+        aggregated = aggregate_token_usage(
+            [TokenUsage(input_tokens=1), TokenUsage(input_tokens=2)]
+        )
+        self.assertEqual(len(aggregated), 1)
+        self.assertEqual(_dump(aggregated[0]), {"inputTokens": 3})
+
+    def test_a_field_only_some_members_report_is_summed_over_those_members(self):
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(provider="p", model="m", input_tokens=1, reasoning_tokens=7),
+                TokenUsage(provider="p", model="m", input_tokens=2),
+                TokenUsage(provider="p", model="m", input_tokens=3, reasoning_tokens=5),
+            ]
+        )
+        self.assertEqual(len(aggregated), 1)
+        self.assertEqual(aggregated[0].input_tokens, 6)
+        self.assertEqual(aggregated[0].reasoning_tokens, 12)
+
+    def test_a_field_no_member_reports_stays_unset(self):
+        """Not zero: "not reported" must stay distinct from a measured zero."""
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(provider="p", model="m", input_tokens=1),
+                TokenUsage(provider="p", model="m", input_tokens=2),
+            ]
+        )
+        self.assertEqual(aggregated[0].input_tokens, 3)
+        self.assertIsNone(aggregated[0].output_tokens)
+        self.assertEqual(_dump(aggregated[0]), {"provider": "p", "model": "m", "inputTokens": 3})
+
+    def test_a_reported_zero_survives_aggregation(self):
+        aggregated = aggregate_token_usage(
+            [
+                TokenUsage(provider="p", model="m", input_tokens=1, output_tokens=0),
+                TokenUsage(provider="p", model="m", input_tokens=2, output_tokens=0),
+            ]
+        )
+        self.assertEqual(aggregated[0].output_tokens, 0)
+
+    def test_does_not_mutate_its_inputs(self):
+        first = TokenUsage(provider="p", model="m", input_tokens=1)
+        second = TokenUsage(provider="p", model="m", input_tokens=2)
+        aggregate_token_usage([first, second])
+        self.assertEqual(first.input_tokens, 1)
+        self.assertEqual(second.input_tokens, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_token_usage.py
+++ b/sdks/python/tests/test_token_usage.py
@@ -154,15 +154,16 @@ class TokenUsageGuardTest(unittest.TestCase):
             )
         )
 
-    def test_counts_beyond_the_int64_wire_range_are_dropped(self):
-        """Counts are ``int64`` on the proto transport and ``long?`` in C#. A
-        Python int has no such bound, so a value past it is rejected at the
-        producer rather than becoming an encoder crash mid-stream."""
+    def test_counts_beyond_the_safe_integer_wire_range_are_dropped(self):
+        """The TypeScript protobuf decoder stops at ``Number.MAX_SAFE_INTEGER``,
+        which is the narrowest ceiling across the bindings. A Python int has no
+        such bound, so a value past it is rejected at the producer rather than
+        becoming an encoder crash mid-stream."""
         usage = token_usage_from_langchain_metadata(
-            {"input_tokens": 2**63, "output_tokens": 2**63 - 1}
+            {"input_tokens": 2**53, "output_tokens": 2**53 - 1}
         )
         self.assertIsNone(usage.input_tokens)
-        self.assertEqual(usage.output_tokens, 2**63 - 1)
+        self.assertEqual(usage.output_tokens, 2**53 - 1)
 
     def test_a_float_beyond_the_wire_range_is_dropped(self):
         usage = token_usage_from_langchain_metadata(

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.9"
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## The gap

`RUN_FINISHED.usage` and `RUN_ERROR.usage` are documented on the protocol and populated by the **TypeScript** LangGraph producer. Nothing in **Python** ever wrote them.

The Python schema already had the field — `TokenUsage` plus `usage: Optional[List[TokenUsage]]` on both terminal events — so from a user's side it reads as supported. What was missing was the producer, and the mapper the producer needs: `sdks/python/ag_ui/core/` had no token-usage helper, and `ag_ui_langgraph/` had no reference to `usage` / `usage_metadata` at all.

This is Python-only. No TypeScript change, no protocol change.

## Customer driver

**S&P Global** reported that `usage` is documented on RUN_FINISHED / RUN_ERROR but never populated in their Python builds. We have already told them this is coming. Linear: **OSS-886**.

## What this adds

### 1. `sdks/python/ag_ui/core/token_usage.py` — twin of `sdks/typescript/packages/core/src/token-usage.ts`

- **`token_usage_from_langchain_metadata(usage_metadata, *, provider=None, model=None)`** — maps the LangChain-family shape (`input_tokens`, `output_tokens`, `total_tokens`, `input_token_details.cache_read`, `output_token_details.reasoning`) plus the optional provider/model labels.
- **`aggregate_token_usage(entries)`** — sums per-call entries into one entry per `(provider, model)`, in first-appearance order.

Both exported from `ag_ui.core`.

**No AI-SDK mapper.** AI-SDK is a TypeScript library with no Python distribution, so `token_usage_from_ai_sdk_usage` would have no callers. Skipped deliberately; if a Python AI-SDK-shaped producer ever appears, the mapper is four lines on top of the shared `_build_entry`.

### 2. `integrations/langgraph/python/ag_ui_langgraph/` — the producer

Mirrors the TypeScript structure: per-call entries accumulate on `active_run["usage"]` during the run, and `_collect_run_usage()` aggregates at the terminal event, returning `None` (an omitted field) when nothing was reported.

Capture sits **before** the finish-reason early return in the `OnChatModelStream` handler — LangChain attaches `usage_metadata` to the same final chunk that carries `finish_reason`, so capturing after the return would drop the usage of every model call. That ordering is the single most breakable thing here and has a dedicated test.

Wired into:
- `RUN_FINISHED` on the success path (`_emit_success_finish`)
- `RUN_FINISHED` on the interrupt path (`_emit_interrupt_finish`) — the calls made before the pause were paid for
- `RUN_ERROR` — partial usage for a run that failed after one or more completed model calls

## The two rules, and why

**Omit, never zero.** A provider that reported nothing leaves `usage` absent — not present-with-zeros, and not a labels-only entry. "Not measured" and "measured zero" are different answers, and a consumer rendering `0 tokens` for an unmeasured run is simply wrong. The same holds field-by-field during aggregation: a count no member of the group reported stays unset rather than summing to 0.

**Numeric-only.** Only the five counts and the two optional labels are ever mapped. `TokenUsage` feeds anonymous usage telemetry, so no prompt, completion, message, thread/run/user id or key may ride along, whatever the provider attaches next to the counts. There is a test that stuffs eight content-bearing fields into `usage_metadata` and asserts none of them — key or value — appear anywhere in the serialized entry.

**Only finite numbers.** Providers hand over strings, `None`s and `NaN`s. A bad value must not reach the wire: consumers validate every incoming event and raise on failure, so one malformed count would fail an otherwise-successful run at its final event — costing the user the answer, not just the token count.

## Two things worth flagging in the TypeScript source

1. **The Python guard is stricter, on purpose.** TS `num()` checks finiteness only and leaves the integer/non-negative bound to `TokenUsageSchema`. That leaves a hole on the TS side: `tokenUsageFromLangChainMetadata({ input_tokens: -1 })` returns `{ inputTokens: -1 }`, the producer emits it, and the consumer's validation throws — the exact failure the guard's own comment says it exists to prevent. In Python that bound lives on the `TokenUsage` constructor **the producer itself calls**, so an unguarded `-1` or `1.5` would raise inside the terminal-event path rather than at the consumer. So `_num` also rejects negative and fractional values. Same observable outcome for well-formed providers; strictly safer for malformed ones. Worth closing the TS hole separately.

2. **Aggregation keys on the label pair, not a joined string.** TS uses `` `${provider ?? ""} ${model ?? ""}` ``, which collides `("a b", "")` with `("a", "b")`. Python keys on the tuple. Behaviour-identical for real labels.

3. **TS does not populate `RUN_ERROR.usage`.** The schema documents it and the Python side now emits it. Python is ahead here rather than divergent; the TS producer should follow, but TS is out of scope for this PR.

## Parity

For an equivalent graph, a customer switching languages sees the same shape: same source field (`usage_metadata` off the streamed chunk), same labels (`ls_provider` / `ls_model_name`), same per-`(provider, model)` grouping in first-appearance order, same omit-when-unreported behaviour, same camelCase wire keys.

## Dependency sequencing — read before merging

The integration imports symbols that are **not in any published `ag-ui-protocol` wheel** (latest on PyPI is 0.1.21). Same shape as PNI-274 (`89c007d1d`) and the a2ui bridge (`b73f77cb7`):

- `sdks/python` bumped 0.1.21 → **0.1.22**
- the integration's declared floor raised to `ag-ui-protocol>=0.1.22`
- the dev-only `[tool.uv.sources]` path override re-added, with a `TEMPORARY, MUST BE REMOVED` block; it is stripped from the built wheel, so installed users still resolve from PyPI
- both `uv.lock`s relocked

The order is: publish `ag-ui-protocol` 0.1.22 → delete the override block → relock → merge → release `ag-ui-langgraph`. If you would rather not carry the override at all, split this into an SDK-only PR and an integration PR gated on the publish; the commit is already cleanly separable along that line.

### `langgraph-python-declared-floor` is green here, and that is not evidence

I expected that lane to go red — it installs the declared floor from PyPI, and 0.1.22 is not there. **It passed, vacuously.** From the job log:

```
AG_UI_PROTOCOL_FLOOR: 0.1.22
Checked 1 package in 45ms
ag-ui-protocol 0.1.22
```

`uv pip install "ag-ui-protocol==0.1.22"` was a **no-op**: it honours this project's `[tool.uv.sources]`, so the requirement was already satisfied by the local-path install from the preceding `uv sync --locked`. It never contacted PyPI. The subsequent `import ag_ui_langgraph` then succeeded against the local tree, not against a published wheel.

This is exactly the blind spot PNI-274's commit message gives as the reason for removing the override in the first place: *"while the override was in place, CI built ag-ui-protocol from the local path, so a wheel declaring `>=0.1.15` stayed green through every lane and only broke on a clean install."* Re-adding the override re-opens it, and the new lane does not close it, because the lane's own downgrade step is subject to the override too.

So **do not read that green tick as "a clean install works"**. Nothing in this PR verifies that, and nothing can until 0.1.22 is on PyPI. Two follow-ups worth considering, both out of scope here:

1. Harden the lane so the override cannot neutralise it — run the downgrade with `--no-sources`, or in a scratch venv outside the project, so it resolves from the registry unconditionally.
2. Or fail the lane outright when `[tool.uv.sources]` names `ag-ui-protocol`: in that state the lane cannot test what it claims to test, and a loud failure beats a misleading pass.

## Deliberately left out

- **Cost fields** — absent by design, separate discussion.
- **Protocol changes** — none; the schema already carried everything.
- **TypeScript changes** — none, per scope, including the two TS issues noted above.
- **AI-SDK mapper** — no Python audience (reasoning above).
- **Non-LangGraph Python integrations** (CrewAI, ADK, Strands, …) — the SDK helper is now available to all of them, but wiring each is its own change.

## Verification

```
$ cd sdks/python && python -m unittest discover tests
Ran 198 tests in 0.027s

OK
```

```
$ cd integrations/langgraph/python && uv run --no-sync python -m unittest discover tests
Ran 762 tests in 10.119s

OK
```

(745 before this change; 17 new. The SDK suite was 173 before; 25 new.)

```
$ cd sdks/python/a2ui_toolkit && python -m unittest discover tests
Ran 100 tests in 0.098s

OK
```

Lockfile gate, all 10 first-party Python packages:

```
./integrations/adk-middleware/python                        OK
./integrations/agent-spec/python                            OK
./integrations/aws-strands/python                           OK
./integrations/claude-agent-sdk/python                       OK
./integrations/claude-managed-agents/python                 OK
./integrations/crew-ai/python                               OK
./integrations/langgraph/python                              OK
./integrations/langroid/python                              OK
./integrations/watsonx/python                                OK
./sdks/python                                                OK
```

**Mutation-checked** — the tests fail when the implementation is wrong, rather than passing on setup:

| mutation | result |
|---|---|
| move the usage capture *after* the finish-reason early return | 13 of 17 new integration tests fail |
| `_collect_run_usage` returns `[]` instead of `None` | 5 fail (the omit-vs-zero set) |
| drop the no-usable-count guard in `_build_entry` | 2 SDK tests fail |

## Test coverage

**SDK (25):** normal mapping; absent fields omitted; attribute-shaped metadata; string / `None` / `NaN` / `Infinity` / negative / fractional / boolean counts rejected; integral floats accepted; nested `reasoning` / `cache_read` guarded; non-object detail containers tolerated; no-usable-count returns `None`; measured zero reported as zero; content-bearing fields not copied (and the entry's key set proven to stay inside the allowed set — `ConfiguredBaseModel` is `extra="allow"` protocol-wide, so the *mapper* is the guard, not the type); aggregation summing, per-model separation, first-seen order, unlabelled grouping, partially-reported field, unreported field stays unset, reported zero survives, inputs not mutated.

**Integration (17):** single call reported; usage on the finish-reason chunk not dropped; repeated calls summed; distinct models separate in first-seen order; partially-reported field; unlabelled usage still reported; no provider usage → field absent; no usable count → field absent; measured zero reported; malformed counts dropped with the run still finishing; infinite counts dropped; wholly malformed payload does not fail the run; no content-bearing field copied; RUN_ERROR partial usage; RUN_ERROR omits usage when nothing was reported; interrupted run reports what it spent; usage does not leak between two runs on the same agent.

Closes OSS-886.
