### PR TITLE
docs: fix CopilotKit quickstart URL

### DIFF
--- a/docs/quickstart/applications.mdx
+++ b/docs/quickstart/applications.mdx
@@ -32,4 +32,4 @@ Once the setup is done, start the server with
 npm run dev
 ```
 
-For the copilotkit example you can head to http://localhost:3000/copilotkit to see the app in action.
+For the CopilotKit example, open [http://localhost:3000](http://localhost:3000) to see the app in action.

--- a/sdks/typescript/packages/cli/src/quickstart-docs.test.ts
+++ b/sdks/typescript/packages/cli/src/quickstart-docs.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "vitest";
+
+test("points CopilotKit users to the generated app's root route", () => {
+  const guide = readFileSync(
+    new URL("../../../../../docs/quickstart/applications.mdx", import.meta.url),
+    "utf8",
+  );
+
+  expect(guide).toContain("[http://localhost:3000](http://localhost:3000)");
+  expect(guide).not.toContain("localhost:3000/copilotkit");
+});


### PR DESCRIPTION
## Summary

- point CopilotKit quickstart users to the generated app root route
- add a focused regression test for the documented URL

## Validation

- `pnpm exec nx test create-ag-ui-app`
- `pnpm exec nx typecheck create-ag-ui-app`
- `git diff --check origin/main...HEAD`

Linear: FAC-123