### PR TITLE
fix(aws-strands): state the disposition for the SDK's backgroundTasks field

### DIFF
--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -577,6 +577,16 @@ const NEWER_SDK_FIELD_PLAN = {
   // then does not keep, so there is nothing to read back. Its effect travels
   // through those two instead.
   contextManager: "notForwarded",
+  // Declared as `boolean | BackgroundTasksConfig`, but the Agent consumes it
+  // into a BackgroundTasks plugin bound to that agent and registered in its
+  // plugin registry, and keeps nothing under this name except that plugin.
+  // Forwarding what is readable would hand a plugin to a field that expects a
+  // config: every real setting (`never`, `maxConcurrency`, `timeout`) would
+  // read back as undefined and fall back to its default while background
+  // execution stayed switched on, so a tool the template excluded would become
+  // eligible for it again. The config is plain data, so per-thread background
+  // execution is set through threadAgentConfig instead.
+  backgroundTasks: "notForwarded",
   // Both hold conversation-scoped data. Handing one instance to every thread
   // is the same hazard as sharing the conversation manager, so they are
   // dropped and recorded rather than cross-wired.


### PR DESCRIPTION
## What

Strands SDK 1.16.0 (published 2026-08-31, resolved by the `latest` dist-tag) adds `backgroundTasks` to `AgentConfig`. That breaks the `aws-strands-typescript-latest` CI lane's typecheck:

```
src/agent.ts(626,7): error TS2741: Property 'backgroundTasks' is missing in type
'{ model: "copy"; ... }' but required in type 'Record<keyof AgentConfig, FieldDisposition>'.
```

This is the field plan working as designed. `THREAD_FIELD_PLAN` is an exhaustive mapping over `keyof AgentConfig`, so a field the SDK adds fails the build until someone states what happens to it when the adapter builds a per-thread agent. It refuses to default because sharing something per-thread that should be isolated, or isolating something that should be shared, is a real behaviour bug.

No open PR causes this. Verified by checking out `main` at `32f838c35` into a throwaway worktree, installing 1.16.0, and running `pnpm exec tsc --noEmit`: the same error appears at `src/agent.ts(599,7)`.

## What `backgroundTasks` is

Declared as `boolean | BackgroundTasksConfig`. The config selects which tools may run in the background rather than blocking the turn (`agentic` / `always` / `never`), how many run at once (`maxConcurrency`), their per-execution `timeout`, and whether an invocation waits for them (`waitForCompletion`). It is plain data: flags plus tool references.

The Agent does not keep it. At construction it does:

```js
this._backgroundTasks = config?.backgroundTasks
  ? new BackgroundTasks(config.backgroundTasks === true ? {} : config.backgroundTasks, ...)
  : undefined;
```

and registers that `BackgroundTasks` plugin into its own plugin registry. There is no public `backgroundTasks` accessor, so what a template read recovers under this name is the plugin instance, not the config it was built from.

## Why `notForwarded`

Copying is wrong on two counts. The plugin would be handed to a field that expects a config, so `new BackgroundTasks(plugin, ...)` on the per-thread agent would read every real setting as `undefined` and fall back to its default, while background execution itself stayed switched on because the value is truthy. A tool the template had explicitly excluded via `never` would become eligible for background execution again in every thread. The plugin also holds conversation-scoped task state and an `_agent` reference bound to the template.

The original config does survive on the plugin's private `_config`, but recovering it that way is the same reach-into-internals guess that produced wrong answers for `traceAttributes` and was deliberately rejected there. `_readTemplateField` probes two conventions on purpose.

`unsafeToShare` is the wrong bucket by the table's own criterion: it reports at debug level because Strands populates those fields on every Agent whether or not the caller asked. `_backgroundTasks` is `undefined` unless the caller enabled the feature, so readability is an exact proxy for "the caller set this". That maps to `notForwarded`, which reports into `_uncarriedSetFields` and therefore fires for exactly the callers who set it and never for those who did not.

Since the config is plain data, `threadAgentConfig` carries it properly: it runs once per `threadId` and each thread constructs its own `BackgroundTasks`.

The entry goes in `NEWER_SDK_FIELD_PLAN`, which exists for fields released after the version this package pins, so the pin does not move.

## Verification

Installed `@strands-agents/sdk@1.16.0` in `integrations/aws-strands/typescript` via pnpm, then restored `package.json` and `pnpm-lock.yaml` with `git checkout --`, so no SDK bump ships.

| | typecheck | tests |
|---|---|---|
| SDK 1.16.0 | clean | 1209/1209 pass |
| SDK 1.1.0 (pinned, restored) | clean | 1209/1209 pass |

The whole suite already passed on 1.16.0 before this change; only the typecheck tripwire failed.
