### PR TITLE
fix(mastra): report remote token usage

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/token-usage.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/token-usage.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { EventType } from "@ag-ui/client";
-import { collectEvents, makeInput, makeLocalMastraAgent } from "./helpers";
+import {
+  collectEvents,
+  makeInput,
+  makeLocalMastraAgent,
+  makeRemoteMastraAgent,
+} from "./helpers";
 
 const finishChunk = { type: "finish", payload: {} };
 
@@ -41,6 +46,35 @@ describe("MastraAgent — RUN_FINISHED token usage", () => {
     const agent = makeLocalMastraAgent({ streamChunks: [finishChunk] });
     const finished = runFinished(await collectEvents(agent, makeInput()));
     expect(finished.usage).toBeUndefined();
+  });
+
+  it("reports terminal usage from a remote stream", async () => {
+    const agent = makeRemoteMastraAgent({
+      streamChunks: [
+        {
+          type: "step-finish",
+          payload: {
+            output: {
+              usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+            },
+          },
+        },
+        {
+          type: "finish",
+          payload: {
+            output: {
+              usage: { inputTokens: 30, outputTokens: 12, totalTokens: 42 },
+            },
+          },
+        },
+      ],
+    });
+
+    const finished = runFinished(await collectEvents(agent, makeInput()));
+
+    expect(finished.usage).toEqual([
+      { inputTokens: 30, outputTokens: 12, totalTokens: 42 },
+    ]);
   });
 });
 
@@ -99,5 +133,26 @@ describe("MastraAgent — RUN_FINISHED token usage on resumed runs", () => {
 
     expect(finished).toBeDefined();
     expect(finished.usage).toBeUndefined();
+  });
+
+  it("reports fallback usage from a remote resumed stream", async () => {
+    const agent = makeRemoteMastraAgent({
+      resumeChunks: [
+        {
+          type: "finish",
+          payload: {
+            usage: { inputTokens: 8, outputTokens: 3, totalTokens: 11 },
+          },
+        },
+      ],
+    });
+
+    const finished = runFinished(
+      await collectEvents(agent, makeResumeInput(resumeInterrupt)),
+    );
+
+    expect(finished.usage).toEqual([
+      { inputTokens: 8, outputTokens: 3, totalTokens: 11 },
+    ]);
   });
 });

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -996,12 +996,13 @@ export class MastraAgent extends AbstractAgent {
               }
 
               let stopped = false;
-              const { handleChunk, flush } = this.createChunkProcessor({
-                ...callbacks,
-                onError: (error) => {
-                  subscriber.error(error);
-                },
-              });
+              const { handleChunk, flush, getUsage } =
+                this.createChunkProcessor({
+                  ...callbacks,
+                  onError: (error) => {
+                    subscriber.error(error);
+                  },
+                });
 
               await response.processDataStream({
                 onChunk: async (chunk: any) => {
@@ -1019,7 +1020,7 @@ export class MastraAgent extends AbstractAgent {
                 flush();
                 await finishResume(
                   await this.resolveTraceId(response),
-                  await this.resolveUsage(response),
+                  await this.resolveUsage(response, getUsage()),
                 );
               }
             }
@@ -1278,9 +1279,12 @@ export class MastraAgent extends AbstractAgent {
    * (no usage, remote agent, rejected promise) yields an empty array so the run
    * still finishes without usage.
    */
-  private async resolveUsage(response: any): Promise<TokenUsage[]> {
+  private async resolveUsage(
+    response: any,
+    streamedUsage?: unknown,
+  ): Promise<TokenUsage[]> {
     try {
-      const raw = await response?.usage;
+      const raw = streamedUsage ?? (await response?.usage);
       const identity = this.getModelIdentity();
       const entry = tokenUsageFromAiSdkUsage(raw, identity);
       return entry ? [entry] : [];
@@ -1623,15 +1627,22 @@ export class MastraAgent extends AbstractAgent {
    * path (processDataStream callback) — single source of truth for chunk
    * handling and buffering logic.
    *
-   * @returns An object with two methods:
+   * @returns An object with three methods:
    *   - `handleChunk`: processes a single chunk; returns `true` if processing should stop (error or malformed chunk).
    *   - `flush`: emits any buffered tool-call (call at end of stream).
+   *   - `getUsage`: returns usage reported by the terminal `finish` chunk.
    */
   private createChunkProcessor(
     callbacks: MastraAgentStreamOptions,
     clientToolNames: Set<string> = new Set(),
     initialState: Record<string, any> = {},
   ) {
+    // Remote processDataStream responses report token usage on the terminal
+    // `finish` chunk rather than on the response object. Keep only that
+    // boundary's value: `step-finish` can repeat usage for each model step and
+    // would double-count the run if included.
+    let usage: unknown;
+
     // Running client-side working-memory state, mapped to AG-UI shared state.
     // Seeded from the run's input.state (the base the client already holds), so
     // the first STATE_DELTA patches from what the UI shows, not from empty.
@@ -2418,6 +2429,7 @@ export class MastraAgent extends AbstractAgent {
         case "finish": {
           flush();
           releaseBufferedText(chunk.payload, true);
+          usage = chunk.payload?.output?.usage ?? chunk.payload?.usage;
           callbacks.onFinishMessagePart?.();
           break;
         }
@@ -2587,7 +2599,7 @@ export class MastraAgent extends AbstractAgent {
       return false;
     };
 
-    return { handleChunk, flush };
+    return { handleChunk, flush, getUsage: () => usage };
   }
 
   /**
@@ -3129,7 +3141,7 @@ export class MastraAgent extends AbstractAgent {
         // Remote agents use processDataStream (callback-based) — share
         // chunk handling logic via createChunkProcessor.
         if (response && typeof response.processDataStream === "function") {
-          const { handleChunk, flush } = this.createChunkProcessor(
+          const { handleChunk, flush, getUsage } = this.createChunkProcessor(
             {
               onMessageId,
               onTextPart,
@@ -3169,7 +3181,7 @@ export class MastraAgent extends AbstractAgent {
           if (!stopped) {
             flush();
             const traceId = await this.resolveTraceId(response);
-            const usage = await this.resolveUsage(response);
+            const usage = await this.resolveUsage(response, getUsage());
             await onRunFinished?.(traceId, usage);
           }
         } else {


### PR DESCRIPTION
## Summary

- Fix the remote Mastra boundary by reading token usage from `finish.payload.output.usage`, with `finish.payload.usage` as a fallback shape.
- Report usage for remote runs and remote resumed runs while ignoring `step-finish` usage to prevent double counting.
- Keep `response.usage` as the fallback for compatible responses.
- No migration or feature flag is required.

Refs ENT-1326.

[Intelligence PR #1028](https://github.com/CopilotKit/Intelligence/pull/1028) owns the UI and closes the ticket. This PR fixes the remote Mastra boundary.

## Validation

- `npm exec --yes pnpm@10.33.4 -- nx test @ag-ui/mastra --skip-nx-cache -- token-usage.test.ts` — passed, 7 tests.
- `npm exec --yes pnpm@10.33.4 -- nx run-many -t test,typecheck --projects=@ag-ui/mastra --skip-nx-cache` — passed, 332 tests; typecheck passed.
- `git diff --check` — passed.
