### PR TITLE
fix(langgraph): let forwardedProps hydrate graph state on every run

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/agent.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/agent.py
@@ -33,6 +33,7 @@ from .types import (
     LangGraphReasoning
 )
 from .utils import (
+    ADAPTER_OWNED_FORWARDED_PROPS,
     agui_messages_to_langchain,
     DEFAULT_SCHEMA_KEYS,
     filter_object_by_schema_keys,
@@ -2374,7 +2375,25 @@ class LangGraphAgent:
                 state=state,
                 schema_keys=self.active_run["schema_keys"],
             )
-            stream_input = {**forwarded_props, **payload_input} if payload_input else None
+            # forwardedProps are an explicit per-run instruction, so they win
+            # over the client's synced state. The previous order
+            # ({**forwarded_props, **payload_input}) lost every collision to
+            # that state: on the first run of a thread the client holds no
+            # graph keys, so a forwarded value came through, but from the
+            # second run onward the client echoes back the STATE_SNAPSHOT the
+            # graph wrote and its stale value silently replaced the forwarded
+            # one (CopilotKit#3168).
+            #
+            # ADAPTER_OWNED_FORWARDED_PROPS stay out of the graph input
+            # entirely. They are run controls or merge-built channels, never
+            # graph state, and leaking them in is what made #3168 look like it
+            # worked on run 1.
+            forwarded_state = {
+                key: value
+                for key, value in forwarded_props.items()
+                if key not in ADAPTER_OWNED_FORWARDED_PROPS
+            }
+            stream_input = {**payload_input, **forwarded_state} if payload_input else None
 
 
         subgraphs_stream_enabled = input.forwarded_props.get('stream_subgraphs', True) if input.forwarded_props else True

--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -46,6 +46,41 @@ AGUIContentItem = Union[
 
 DEFAULT_SCHEMA_KEYS = ["tools"]
 
+# forwardedProps this adapter owns, and which therefore never become graph
+# state. Two groups:
+#
+#   * props the adapter consumes itself ("command" is the LangGraph-private
+#     resume slot, "node_name"/"stream_subgraphs"/"inject_a2_u_i_tool" steer
+#     the run), plus the camelCase spelling of the A2UI flag, which
+#     langgraph_default_merge_state also accepts;
+#   * channels langgraph_default_merge_state builds ("messages", "tools",
+#     "ag-ui", "copilotkit"), which a forwarded value must never replace.
+#
+# "config", "stream_mode" and "thread_metadata" are consumed by the LangGraph
+# Platform (TypeScript) adapter. They are reserved here too so both adapters
+# agree on the reserved namespace.
+#
+# Every other forwarded prop hydrates graph state. Keys are matched AFTER
+# run() snake-cases them (see camel_to_snake), so list the converted form.
+#
+# Add new adapter-control props here. test_forwarded_props_state_precedence.py
+# reads agent.py and fails when a consumed prop is missing, because an omitted
+# prop is silently written into every graph's state (CopilotKit#3168).
+ADAPTER_OWNED_FORWARDED_PROPS = frozenset({
+    "command",
+    "config",
+    "inject_a2_u_i_tool",
+    "injectA2UITool",
+    "node_name",
+    "stream_mode",
+    "stream_subgraphs",
+    "thread_metadata",
+    "messages",
+    "tools",
+    "ag-ui",
+    "copilotkit",
+})
+
 def filter_object_by_schema_keys(obj: Dict[str, Any], schema_keys: List[str]) -> Dict[str, Any]:
     if not obj:
         return {}

--- a/integrations/langgraph/python/tests/test_forwarded_props_state_precedence.py
+++ b/integrations/langgraph/python/tests/test_forwarded_props_state_precedence.py
@@ -1,0 +1,206 @@
+"""Tests for forwardedProps -> graph-state precedence (CopilotKit#3168).
+
+The bug: ``prepare_stream`` built the graph input as
+``{**forwarded_props, **payload_input}``, so the client's synced state won
+every collision. On the first run of a thread the client state carries no
+graph keys yet, so a forwarded value landed in the input and worked. From the
+second run onward the client echoes back the STATE_SNAPSHOT it received, which
+carries every key the graph wrote, and that stale value silently replaced the
+forwarded one. Identical ``forwardedProps`` therefore produced a different
+graph input on run 1 and run 2.
+
+The fix states one rule: forwardedProps that the adapter does not own itself
+hydrate graph state and win over the synced snapshot, on every run; the
+adapter-owned props never enter graph state at all.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from ag_ui_langgraph.utils import ADAPTER_OWNED_FORWARDED_PROPS
+
+from tests._helpers import make_agent
+
+
+def _make_agent_state():
+    """A checkpoint state with no messages and no open interrupts."""
+    state = MagicMock()
+    state.values = {"messages": []}
+    state.tasks = []
+    state.next = []
+    state.metadata = {"writes": {}}
+    return state
+
+
+def _make_input(state, forwarded_props):
+    inp = MagicMock()
+    inp.thread_id = "t1"
+    inp.run_id = "r1"
+    inp.state = dict(state)
+    inp.messages = []
+    inp.tools = []
+    inp.context = []
+    inp.resume = None
+    inp.forwarded_props = forwarded_props
+    return inp
+
+
+async def _stream_input_for(
+    state, forwarded_props, input_schema_keys=None, mode="start", node_name=None
+):
+    """Drive prepare_stream and return the input handed to the graph."""
+    agent = make_agent()
+    agent_state = _make_agent_state()
+    agent.graph.aget_state = AsyncMock(return_value=agent_state)
+    agent.graph.aupdate_state = AsyncMock(return_value=None)
+    agent.graph.astream_events = MagicMock(return_value=iter([]))
+    agent.active_run = {
+        "id": "r1",
+        "thread_id": "t1",
+        "mode": mode,
+        "node_name": node_name,
+    }
+    keys = ["messages", "tools", "command", "route_cmd"]
+    if input_schema_keys is not None:
+        keys = input_schema_keys
+    agent.get_schema_keys = lambda config: {
+        "input": keys,
+        "output": keys,
+        "config": [],
+        "context": [],
+    }
+
+    await agent.prepare_stream(
+        input=_make_input(state, forwarded_props),
+        agent_state=agent_state,
+        config={"configurable": {}},
+    )
+    return agent.graph.astream_events.call_args.kwargs["input"]
+
+
+class TestForwardedPropsStatePrecedence(unittest.IsolatedAsyncioTestCase):
+
+    async def test_forwarded_prop_hydrates_state_when_client_state_is_empty(self):
+        """First run of a thread: the client has no state yet, so the forwarded
+        value is the only source for the key."""
+        stream_input = await _stream_input_for(
+            state={}, forwarded_props={"route_cmd": "run_tool_call"}
+        )
+        self.assertEqual(stream_input["route_cmd"], "run_tool_call")
+
+    async def test_forwarded_prop_survives_stale_synced_state(self):
+        """The #3168 regression: the client echoes back the snapshot the graph
+        wrote (here the node consumed the value and cleared it). The explicit
+        per-run forwarded value must still reach the graph."""
+        stream_input = await _stream_input_for(
+            state={"route_cmd": None}, forwarded_props={"route_cmd": "run_tool_call"}
+        )
+        self.assertEqual(stream_input["route_cmd"], "run_tool_call")
+
+    async def test_run_one_and_run_two_agree(self):
+        """Identical forwardedProps must produce an identical value for the
+        forwarded key, whatever the client's synced state holds."""
+        forwarded = {"route_cmd": "run_tool_call"}
+        first = await _stream_input_for(state={}, forwarded_props=forwarded)
+        second = await _stream_input_for(
+            state={"route_cmd": None}, forwarded_props=forwarded
+        )
+        self.assertEqual(first["route_cmd"], second["route_cmd"])
+
+    async def test_state_key_without_forwarded_prop_is_untouched(self):
+        """Keys the caller did not forward keep coming from the client state."""
+        stream_input = await _stream_input_for(
+            state={"route_cmd": "from_state"}, forwarded_props={}
+        )
+        self.assertEqual(stream_input["route_cmd"], "from_state")
+
+    async def test_adapter_owned_props_never_enter_graph_state(self):
+        """``command`` is the LangGraph-private resume slot, not graph state.
+        Letting it through wrote a bogus ``command`` key into every graph's
+        state and was the reason #3168 looked like it worked on run 1."""
+        stream_input = await _stream_input_for(
+            state={}, forwarded_props={"command": {"cmd": "run_tool_call"}}
+        )
+        self.assertNotIn("command", stream_input)
+
+    async def test_adapter_owned_props_do_not_override_state(self):
+        """A graph that genuinely declares a state key colliding with an
+        adapter-owned prop keeps its own state value."""
+        stream_input = await _stream_input_for(
+            state={"command": "from_state"},
+            forwarded_props={"command": {"cmd": "run_tool_call"}},
+        )
+        self.assertEqual(stream_input["command"], "from_state")
+
+    async def test_merge_owned_channels_are_not_replaced(self):
+        """``messages``/``tools`` are built by langgraph_default_merge_state.
+        A forwarded prop must never replace them."""
+        stream_input = await _stream_input_for(
+            state={}, forwarded_props={"messages": ["bogus"], "tools": ["bogus"]}
+        )
+        self.assertEqual(stream_input["messages"], [])
+        self.assertNotEqual(stream_input["tools"], ["bogus"])
+
+    async def test_continue_mode_still_sends_no_input(self):
+        """A "continue" run applies its state through aupdate_state and streams
+        with no input, so the graph resumes instead of restarting. A forwarded
+        prop must not turn that into a fresh input."""
+        stream_input = await _stream_input_for(
+            state={"route_cmd": None},
+            forwarded_props={"route_cmd": "run_tool_call"},
+            mode="continue",
+            node_name="router",
+        )
+        self.assertIsNone(stream_input)
+
+
+class TestAdapterOwnedForwardedPropsContract(unittest.TestCase):
+    """Pin the deny-list against the props the adapter actually consumes.
+
+    ``ADAPTER_OWNED_FORWARDED_PROPS`` is hand-maintained. If a new
+    adapter-control prop is added to agent.py and not listed there, it would
+    silently start being written into every graph's state — the exact defect
+    #3168 reported. This test reads the source and fails on that omission.
+    """
+
+    def _adapter_source(self):
+        from pathlib import Path
+
+        import ag_ui_langgraph.agent as agent_module
+
+        return Path(agent_module.__file__).read_text(encoding="utf-8")
+
+    def test_every_consumed_prop_is_declared(self):
+        import re
+
+        source = self._adapter_source()
+        consumed = set(
+            re.findall(
+                r"""forwarded(?:_props)?(?:\.get\(|\[)['"]([A-Za-z_][A-Za-z0-9_]*)['"]""",
+                source,
+            )
+        )
+        consumed |= set(
+            re.findall(
+                r"""['"]([A-Za-z_][A-Za-z0-9_]*)['"]\s+in\s+forwarded(?:_props)?\b""",
+                source,
+            )
+        )
+        self.assertTrue(consumed, "found no forwarded-prop reads; regex is stale")
+        undeclared = consumed - set(ADAPTER_OWNED_FORWARDED_PROPS)
+        self.assertEqual(
+            undeclared,
+            set(),
+            "agent.py consumes these forwardedProps but they are missing from "
+            f"ADAPTER_OWNED_FORWARDED_PROPS: {sorted(undeclared)}",
+        )
+
+    def test_merge_owned_channels_are_declared(self):
+        """langgraph_default_merge_state builds these; forwardedProps must not
+        be able to overwrite them."""
+        for key in ("messages", "tools", "ag-ui", "copilotkit"):
+            self.assertIn(key, ADAPTER_OWNED_FORWARDED_PROPS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`prepare_stream` built the graph input as `{**forwarded_props, **payload_input}`, so the client's synced state won every key collision.

On the **first** run of a thread the client holds no graph keys, so a forwarded value reached the graph and worked. From the **second** run onward the client echoes back the `STATE_SNAPSHOT` the graph wrote, and that stale value silently replaced the forwarded one. Identical `forwardedProps` therefore produced a different graph input on run 1 and run 2.

Reported as CopilotKit/CopilotKit#3168: routing driven by `forwardedProps` works once, then falls back to the default node because the state key reads as `None`.

A second, related leak made the first run look correct. Every forwarded prop was spread into the graph input, including the ones the adapter consumes itself. A caller squatting on the LangGraph-private `command` slot had `command` written into their graph state, which is why run 1 routed and run 2 did not.

## Change

One rule: **forwardedProps that this adapter does not own hydrate graph state, and win over the synced snapshot, on every run. Adapter-owned props never enter graph state.**

`ADAPTER_OWNED_FORWARDED_PROPS` (new, in `utils.py`) covers two groups:

- Run controls the adapter reads: `command`, `node_name`, `stream_subgraphs`, `inject_a2_u_i_tool` (plus the camelCase `injectA2UITool` that `langgraph_default_merge_state` also accepts).
- Channels `langgraph_default_merge_state` builds: `messages`, `tools`, `ag-ui`, `copilotkit`.

`config`, `stream_mode` and `thread_metadata` are reserved too. The Platform (TypeScript) adapter consumes them, so both adapters keep the same reserved namespace.

Keys are matched after `run()` snake-cases them, so a frontend sending `forwardedProps: { routeCmd: "..." }` hydrates the `route_cmd` state key.

### Behavior change

A forwarded prop whose name collides with an adapter-owned prop no longer reaches graph state at all. That is a deliberate break: it was never graph state, and shipping it there is what made #3168 intermittent rather than consistently broken. Callers using `forwardedProps.command` for their own payload should move to a key of their own.

The alternative — dropping the `forwardedProps` → state channel entirely, matching the Platform adapter, which never had it — would break the first run for everyone who relies on it today. That felt like a deprecation, not a bug fix, so it is not in this PR.

### The deny-list is pinned

The list is hand-maintained, and an omitted prop silently regresses into graph state — the exact defect #3168 reported. `TestAdapterOwnedForwardedPropsContract` reads `agent.py`, extracts every `forwarded_props.get("…")` / `"…" in forwarded` read, and fails when one is not declared. This follows the existing `test_camel_to_snake_key_contract` precedent in this package.

## Testing

Branch built on current `origin/main` (`e929f557f`).

**1. New unit tests — `tests/test_forwarded_props_state_precedence.py`, 10 tests**

```
$ uv run --locked python -m unittest tests.test_forwarded_props_state_precedence
Ran 10 tests in 0.011s
OK
```

**2. Full adapter suite, exactly as CI runs it — no regressions**

```
$ uv run --locked python -m unittest discover tests
Ran 783 tests in 2.846s
OK
```

**3. End-to-end against a real compiled graph (`StateGraph` + `MemorySaver`), not mocks**

Two consecutive runs on one thread, identical `forwardedProps: { routeCmd: "run_tool_call", command: {...} }`, with a node that consumes the value and clears it — so run 2's client state carries `None`, reproducing the reporter's setup.

Before:

```
run 1: state.command={'cmd': 'run_tool_call'}
run 2: state.command=None
CLAIM A (forwardedProps clobbered by synced state): REPRODUCED
```

After:

```
client state carried into run 2: {'route_cmd': None, 'command': None}

run 1: routed to tool_call_node  route_cmd='run_tool_call'  command=None
run 2: routed to tool_call_node  route_cmd='run_tool_call'  command=None

FIXED (routing stable across runs): True
reserved `command` kept out of graph state: True
```

**4. Mutation-checked the new tests** — each break is caught, so none of them is self-fulfilling:

| Mutation | Result |
|---|---|
| Restore the old `{**forwarded_props, **payload_input}` order | 3 failed |
| Empty `ADAPTER_OWNED_FORWARDED_PROPS` | 5 failed |
| Drop one consumed prop (`stream_subgraphs`) from the list | 1 failed (contract test) |

**5. Checked for downstream reliance on the old behavior** — every `forwardedProps` in the dojo e2e event traces is `{}`, and no dojo or example agent reads a forwarded prop out of graph state. No version bump here; this package releases through its own `chore: release` commits.

## Out of scope

While tracing this I found that the Python adapter never reads `forwarded_props["config"]` into the `RunnableConfig`; `config["configurable"]` is only ever fed from `self.config`. So `forwardedProps.config.configurable`, which the CopilotKit docs document for this path, does not reach a node's config on the self-hosted Python adapter. Reproduced in the same end-to-end probe (`config.configurable.authToken=None` on both runs). Filed separately rather than mixed in here.
