### PR TITLE
fix(aws-strands): forward plugins per-thread and warn on agent-bound params

### DIFF
--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -75,6 +75,41 @@ The integration has three main layers:
 
 See [ARCHITECTURE.md](../ARCHITECTURE.md) for diagrams and a deeper dive.
 
+## Per-thread agents: hooks and plugins
+
+The wrapper does not run the agent you hand it. That one is a template: the
+adapter reads its constructor settings back off the instance and builds a fresh
+`strands.Agent` per `thread_id`, so one conversation cannot see another's
+history. Most settings survive that rebuild automatically.
+
+Two do not, because Strands consumes them during construction rather than
+keeping the list you passed. Hooks become a `HookRegistry`, and plugins are run
+against the agent that received them and recorded in a registry bound to it.
+Neither can be read back or handed to a second agent, so a template is the one
+place they will not work. Pass them to the wrapper instead and every per-thread
+agent gets its own:
+
+```python
+agui_agent = StrandsAgent(
+    agent=strands_agent,
+    name="my_agent",
+    hooks=[MyHookProvider()],
+    plugins=[AgentSkills(skills="./skills/")],
+)
+```
+
+Set either on the template and the adapter logs a warning naming the setting
+the first time a thread is built, rather than dropping it in silence. For a
+value that has to differ per thread, build it in
+`StrandsAgentConfig.thread_agent_kwargs`, which runs per request and wins over
+both routes above.
+
+| Scenario                                                | Support boundary                                                                                                                                                        |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hooks=[...]`                                           | Supported on every release this package supports.                                                                                                                        |
+| `plugins=[...]`                                         | Requires `strands-agents >= 1.28.0`, the release that added `plugins` to `Agent`. On an older release the wrapper raises `TypeError` when it is constructed, not on the first request. |
+| `hooks` / `plugins` with a multi-agent orchestrator     | Ignored. An orchestrator is invoked directly, so there is no per-thread agent to attach them to.                                                                          |
+
 ## Key Files
 
 | File                            | Description                                                                     |

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -176,6 +176,17 @@ def _registry_contents(holder: Any) -> Any:
     return _MISSING
 
 
+# Whether the installed Strands takes ``plugins`` on its Agent constructor.
+# The plugin system arrived after this package's declared strands-agents floor,
+# so the adapter's own ``plugins=`` kwarg can be handed a release with nowhere
+# to put it. Probed off the signature rather than compared against a version,
+# for the same reason the forwarding probe is: what matters is the parameter
+# being there, not which release put it there.
+_STRANDS_ACCEPTS_PLUGINS = (
+    "plugins" in inspect.signature(StrandsAgentCore.__init__).parameters
+)
+
+
 # Strands namespaces the plugins it registers on every Agent itself, and
 # registers them whether or not the caller passed any. Anything under this
 # prefix is therefore the SDK's, not a setting to report as dropped.
@@ -3170,6 +3181,29 @@ class StrandsAgent:
         # nothing. Taking them from the caller instead lets every per-thread
         # agent build its own.
         self._plugins = list(plugins) if plugins else []
+        # Refused at wrap time rather than on the first request. Without this
+        # the kwarg reaches a constructor with no parameter for it and Strands
+        # raises a bare TypeError from inside per-thread construction, which
+        # escapes the run generator: the caller sees a traceback pointing at
+        # the SDK rather than at the argument they passed, and only once a
+        # request arrives. This is a static misconfiguration, knowable the
+        # moment the wrapper is built, so it is answered there.
+        # Not raised for an orchestrator, which never builds a per-thread agent
+        # and so ignores plugins on every release. Refusing only the old ones
+        # there would report a version problem for something the new ones do
+        # not do either.
+        if (
+            self._plugins
+            and self._orchestrator is None
+            and not _STRANDS_ACCEPTS_PLUGINS
+        ):
+            raise TypeError(
+                "plugins= was supplied, but the installed strands-agents "
+                f"({distribution_version('strands-agents')}) has no `plugins` "
+                "parameter on Agent, so they cannot be forwarded to per-thread "
+                "agents. Upgrade strands-agents to a release that supports "
+                "plugins, or drop the argument."
+            )
 
         self.name = name
         self.description = description

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -44,6 +44,10 @@ from strands.types.interrupt import InterruptResponseContent
 # "session_manager" is excluded: it is supplied per-thread via
 # StrandsAgentConfig.session_manager_provider (see run()). Forwarding a
 # template-level session_manager would make every thread share one session_id.
+# "plugins" is excluded: Agent consumes the list during init, registering each
+# plugin's hooks and tools into its own registries and keeping only a registry
+# bound to that agent, so there is no list to read back. Callers supply them
+# per-thread through the explicit StrandsAgent(plugins=...) kwarg.
 _AGUI_EXPLICIT_PARAMS = {
     "self",
     "model",
@@ -52,6 +56,7 @@ _AGUI_EXPLICIT_PARAMS = {
     "messages",
     "hooks",
     "session_manager",
+    "plugins",
 }
 
 
@@ -169,6 +174,52 @@ def _registry_contents(holder: Any) -> Any:
             if isinstance(value, (list, tuple)):
                 return list(value)
     return _MISSING
+
+
+# Strands namespaces the plugins it registers on every Agent itself, and
+# registers them whether or not the caller passed any. Anything under this
+# prefix is therefore the SDK's, not a setting to report as dropped.
+_SDK_PLUGIN_NAME_PREFIX = "strands:"
+
+
+def _template_plugin_names(agent: Any) -> List[str]:
+    """Names of the plugins the caller put on the template.
+
+    ``plugins`` is handled through an explicit kwarg, so the generic probe
+    skips it and would never report it. Reading the registry here is what
+    lets a caller who set plugins on the template be told they do not carry,
+    instead of getting silence.
+
+    Strands' own plugins are filtered out by name. Every Agent is built with
+    at least one of them, so counting them would warn every caller about a
+    setting nobody made. A caller plugin that borrowed the SDK's prefix would
+    be missed by this, which is the harmless direction: the cost is one
+    warning not said, against a warning said to everyone.
+    """
+    for attr in _candidate_attributes("plugins"):
+        try:
+            holder = getattr(agent, attr, None)
+        except Exception:  # noqa: BLE001 - a raising property is not a plugin list
+            continue
+        if holder is None:
+            continue
+        if isinstance(holder, (list, tuple)):
+            contents: Any = holder
+        else:
+            contents = _registry_contents(holder)
+        if contents is _MISSING or not contents:
+            continue
+        names = []
+        for plugin in contents:
+            name = getattr(plugin, "name", None)
+            # An entry with no readable name cannot be attributed to the SDK,
+            # so it counts as the caller's rather than being dropped silently.
+            label = name if isinstance(name, str) else type(plugin).__name__
+            if not label.startswith(_SDK_PLUGIN_NAME_PREFIX):
+                names.append(label)
+        if names:
+            return names
+    return []
 
 
 def _element_type(annotation: Any) -> Any:
@@ -2997,6 +3048,7 @@ class StrandsAgent:
         description: str = "",
         config: "StrandsAgentConfig | None" = None,
         hooks: "list | None" = None,
+        plugins: "list | None" = None,
         agents_by_thread: "Dict[str, Any] | None" = None,
     ):
         # Detect a multi-agent orchestrator structurally. A Graph or Swarm has
@@ -3065,9 +3117,18 @@ class StrandsAgent:
             self._unreadable_params = []
             self._template_owned_params = []
 
-        # Params wired to the template are a known structural limit, not a
-        # surprise, so they are recorded without a warning. Params this adapter
-        # could not read at all are the ones worth interrupting for.
+        # ``plugins`` is handled explicitly, so the generic probe above skips
+        # it and cannot report it. A template built with plugins is still a
+        # dropped setting, so record it here and let it be reported through the
+        # same route as every other param that will not carry.
+        if self._orchestrator is None and _template_plugin_names(agent):
+            self._template_owned_params.append("plugins")
+
+        # Both kinds of param will fail to reach per-thread agents, and both
+        # are reported when a thread is built. They are kept apart because they
+        # ask for different reading: an unreadable param is a gap in this
+        # adapter that a later release may close, while one the SDK wired to
+        # the agent that received it will never carry.
         self._unforwardable_params = [
             *self._unreadable_params,
             *self._template_owned_params,
@@ -3095,6 +3156,20 @@ class StrandsAgent:
         # the caller and forward them to every per-thread instance so any
         # observability / loop-cap / policy-enforcement hook actually fires.
         self._hooks = list(hooks) if hooks else []
+
+        # Plugins forwarded to each per-thread StrandsAgentCore.
+        #
+        # A dedicated kwarg for the same reason ``hooks`` has one, one step
+        # further along. Strands consumes the plugin list during init: it calls
+        # each plugin's ``init_agent`` and registers its hooks and tools into
+        # that agent's registries, keeping only a registry bound to that agent.
+        # There is no list left to read back, and the registry cannot be handed
+        # to a second agent. Since the template never serves a request, a
+        # plugin registered there never runs against the agents that do, and a
+        # plugin whose whole behaviour lives in ``init_agent`` silently does
+        # nothing. Taking them from the caller instead lets every per-thread
+        # agent build its own.
+        self._plugins = list(plugins) if plugins else []
 
         self.name = name
         self.description = description
@@ -3580,25 +3655,57 @@ class StrandsAgent:
         Said once per param, and only about params this thread's kwargs did not
         supply, so acting on it makes it stop without the first thread becoming
         the policy for every later one.
+
+        The two kinds get their own message. An unreadable param is a gap in
+        this adapter, and a caller reading that can reasonably wait for a later
+        release to close it. A param the SDK wired to the agent that received
+        it is a structural limit rather than a gap: no adapter release will
+        carry it, so the per-thread route is the whole answer rather than a
+        stopgap. One sentence for both would send half the readers after a fix
+        that is not coming.
         """
-        still_missing = sorted(
-            name
-            for name in self._unreadable_params
-            if name not in core_kwargs and name not in self._reported_uncarried
-        )
-        if not still_missing:
-            return
-        self._reported_uncarried.update(still_missing)
-        # Phrased as a capability, not an accusation: an unreadable param is
-        # unreadable whether or not the caller set one, so this cannot say that
-        # anything was actually lost.
-        logger.warning(
-            "this Strands release stores these Agent constructor params where the "
-            "adapter cannot read them back, so a value set on the template through "
-            "them will not reach per-thread agents: %s. Supply them per thread "
-            "with StrandsAgentConfig.thread_agent_kwargs.",
-            ", ".join(still_missing),
-        )
+
+        def _unreported(names: List[str]) -> List[str]:
+            return sorted(
+                name
+                for name in names
+                if name not in core_kwargs and name not in self._reported_uncarried
+            )
+
+        unreadable = _unreported(self._unreadable_params)
+        template_owned = _unreported(self._template_owned_params)
+        self._reported_uncarried.update(unreadable)
+        self._reported_uncarried.update(template_owned)
+
+        if unreadable:
+            # Phrased as a capability, not an accusation: an unreadable param
+            # is unreadable whether or not the caller set one, so this cannot
+            # say that anything was actually lost.
+            logger.warning(
+                "this Strands release stores these Agent constructor params where the "
+                "adapter cannot read them back, so a value set on the template through "
+                "them will not reach per-thread agents: %s. Supply them per thread "
+                "with StrandsAgentConfig.thread_agent_kwargs.",
+                ", ".join(unreadable),
+            )
+        if template_owned:
+            # ``plugins`` is the one of these with a dedicated kwarg, so point
+            # at it rather than making every caller write a hook for the case
+            # the adapter already has an answer to.
+            route = (
+                "Pass them to StrandsAgent(plugins=[...])"
+                if template_owned == ["plugins"]
+                else "Supply them per thread with "
+                "StrandsAgentConfig.thread_agent_kwargs"
+            )
+            logger.warning(
+                "these Agent constructor params are consumed by the Strands Agent "
+                "that received them and cannot be handed to another agent, so a "
+                "value set on the template will not reach per-thread agents: %s. "
+                "%s.",
+                ", ".join(template_owned),
+                route,
+            )
 
     async def run(
         self,
@@ -3825,6 +3932,12 @@ class StrandsAgent:
                     core_kwargs = dict(self._agent_kwargs)
                     if self._hooks:
                         core_kwargs["hooks"] = list(self._hooks)
+                    # Same falsy-omission rule as hooks, for the same reason:
+                    # ``plugins=[]`` is a value a future StrandsAgentCore could
+                    # read as "disable the defaults", which is not what an
+                    # absent setting means.
+                    if self._plugins:
+                        core_kwargs["plugins"] = list(self._plugins)
                     # The caller's per-thread kwargs go on last, so they can
                     # supply what the template cannot carry and override what
                     # it can. See StrandsAgentConfig.thread_agent_kwargs.
@@ -3854,8 +3967,6 @@ class StrandsAgent:
                             return
                         core_kwargs.update(dict(extra or {}))
                     self._report_uncarried_params(core_kwargs)
-                    if self.config.thread_agent_kwargs is None:
-                        self._report_uncarried_params(core_kwargs)
                     # Re-asserted after the caller: these keep threads apart
                     # and a run coherent, so they stay the adapter's to set.
                     for owned in ("model", "system_prompt", "tools", "session_manager"):

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -23,6 +23,7 @@ import logging
 import types
 import typing
 import warnings
+import weakref
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,6 +33,8 @@ from strands.tools.registry import ToolRegistry
 from ag_ui_strands.agent import (
     StrandsAgent,
     _AGUI_EXPLICIT_PARAMS,
+    _STRANDS_ACCEPTS_PLUGINS,
+    _template_plugin_names,
     _extract_agent_kwargs,
     _forwardable_parameters,
     _references_agent,
@@ -42,29 +45,23 @@ from ag_ui_strands.agent import (
 )
 
 
-# The plugin system arrived after the declared strands-agents floor, and the
-# floor is one of the lanes this suite runs in. Probed as a capability rather
-# than a version so the gate tracks the feature itself.
-#
-# This is not the skip the module docstring rules out. That one is about a
-# param the installed SDK has and this suite finds awkward; here the SDK has no
-# plugins at all, so there is no setting to carry and nothing to be silent
-# about.
+# Only the one test below that drives a real ``strands.Agent`` with a real
+# plugin needs the SDK's plugin system. Everything else here exercises the
+# adapter's own reading, reporting and forwarding, which are the adapter's
+# code on every release, so those tests run at the declared strands-agents
+# floor too. Keeping the gate that narrow is deliberate: a skip at the floor
+# is a version of this package nobody checked.
 try:
     from strands.plugins import Plugin as _StrandsPlugin
 except ImportError:  # pragma: no cover - depends on the installed SDK
     _StrandsPlugin = None
 
-_NO_PLUGIN_SUPPORT = (
-    _StrandsPlugin is None
-    or "plugins" not in inspect.signature(Agent.__init__).parameters
+_needs_sdk_plugins = pytest.mark.skipif(
+    _StrandsPlugin is None or not _STRANDS_ACCEPTS_PLUGINS,
+    reason="this strands-agents release has no plugin system to drive",
 )
-_needs_plugins = pytest.mark.skipif(
-    _NO_PLUGIN_SUPPORT,
-    reason="this strands-agents release has no plugin system to carry",
-)
-# Subclassable stand-in so the plugin classes below still import on a release
-# without them. Every test that touches one is skipped there.
+# Subclassable stand-in so the plugin class below still imports on a release
+# without them. The single test that touches it is skipped there.
 _PluginBase = _StrandsPlugin if _StrandsPlugin is not None else object
 
 
@@ -978,26 +975,59 @@ async def test_no_warning_for_a_param_the_hook_supplies(caplog):
 # second agent, so a plugin set on the template never runs against the agents
 # that serve requests. The adapter answers that with a dedicated kwarg, and
 # tells anyone who used the template instead.
+#
+# Most of what follows is the adapter reading, reporting and forwarding, none
+# of which needs a real plugin. Those tests use a synthetic registry and plain
+# sentinels, the way the resolver tests above already do, so they run on every
+# supported release rather than only the ones new enough to have plugins.
 
 
-class _CountingPlugin(_PluginBase):
-    """Records how many agents it was initialized against."""
+class _FakePluginRegistry:
+    """A plugin registry in the shape the adapter reads.
 
-    name = "counting-plugin"
+    Bound to its agent by weak reference and keyed by plugin name, which is
+    what a real ``_PluginRegistry`` is. Built here rather than by constructing
+    a real Agent with plugins so these tests still run at the declared
+    strands-agents floor, which has no plugin system at all.
+    """
 
-    def __init__(self):
-        super().__init__()
-        self.agents: list = []
+    def __init__(self, owner, plugins: dict):
+        self._agent_ref = weakref.ref(owner)
+        self._plugins = dict(plugins)
 
-    def init_agent(self, agent):
-        self.agents.append(agent)
+
+class _NamedPlugin:
+    """The only thing the adapter reads off a plugin is its name."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
+def _template_with_plugins(*names: str):
+    """A real Agent carrying a registry of caller plugins under those names."""
+    agent = Agent(model=_mock_model())
+    agent._plugin_registry = _FakePluginRegistry(
+        agent, {name: _NamedPlugin(name) for name in names}
+    )
+    return agent
 
 
 def _plugin_warnings(messages: list[str]) -> list[str]:
     return [m for m in messages if "plugins" in m]
 
 
-@_needs_plugins
+def _as_if_sdk_took_plugins():
+    """Assert the forwarding on a release whose real Agent would refuse it.
+
+    The per-thread core is a stub in these tests, and a stub takes any kwarg.
+    What stands between them and running at the declared floor is the wrap-time
+    capability check, so declaring the capability is the whole adaptation. It
+    says out loud what the stub already assumes, which is better than skipping
+    and leaving the adapter's own forwarding logic unasserted on that release.
+    """
+    return patch("ag_ui_strands.agent._STRANDS_ACCEPTS_PLUGINS", True)
+
+
 @pytest.mark.asyncio
 async def test_template_plugins_are_named_when_a_thread_is_built(caplog):
     """The silence this closes: plugins on the template, and no plugins anywhere.
@@ -1007,8 +1037,7 @@ async def test_template_plugins_are_named_when_a_thread_is_built(caplog):
     the worst of the two failure modes: nothing to notice and nothing to
     search for.
     """
-    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
-    ag = StrandsAgent(template, name="test")
+    ag = StrandsAgent(_template_with_plugins("mine"), name="test")
 
     with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
         with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
@@ -1020,7 +1049,6 @@ async def test_template_plugins_are_named_when_a_thread_is_built(caplog):
     )
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_an_agent_with_no_caller_plugins_says_nothing(caplog):
     """Strands registers plugins of its own on every Agent.
@@ -1042,7 +1070,23 @@ async def test_an_agent_with_no_caller_plugins_says_nothing(caplog):
     )
 
 
-@_needs_plugins
+def test_the_sdks_own_plugins_are_not_read_as_the_callers():
+    """The filter that keeps the warning off every caller, asserted directly.
+
+    Driven against a synthetic registry so it states the rule rather than
+    whichever built-ins the installed release happens to register.
+    """
+    agent = Agent(model=_mock_model())
+    agent._plugin_registry = _FakePluginRegistry(
+        agent,
+        {"strands:model": _NamedPlugin("strands:model"), "mine": _NamedPlugin("mine")},
+    )
+
+    assert _template_plugin_names(agent) == ["mine"], (
+        "expected only the caller's plugin to be reported as uncarried"
+    )
+
+
 @pytest.mark.asyncio
 async def test_no_plugins_warning_when_the_explicit_kwarg_supplies_them(caplog):
     """Acting on the warning has to make it stop.
@@ -1050,12 +1094,14 @@ async def test_no_plugins_warning_when_the_explicit_kwarg_supplies_them(caplog):
     The kwarg is what the message asks for, so a caller who has already used
     it must not keep hearing about the template.
     """
-    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
-    ag = StrandsAgent(template, name="test", plugins=[_CountingPlugin()])
+    with _as_if_sdk_took_plugins():
+        ag = StrandsAgent(
+            _template_with_plugins("on-template"), name="test", plugins=[object()]
+        )
 
-    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
-        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
-            await _trigger_thread_creation(ag, "t1")
+        with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+            with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+                await _trigger_thread_creation(ag, "t1")
 
     assert not _plugin_warnings(caplog.messages), (
         f"warned about plugins the caller had already supplied; "
@@ -1063,12 +1109,10 @@ async def test_no_plugins_warning_when_the_explicit_kwarg_supplies_them(caplog):
     )
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_plugins_are_only_warned_about_once(caplog):
     """One thread's message must not become every thread's message."""
-    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
-    ag = StrandsAgent(template, name="test")
+    ag = StrandsAgent(_template_with_plugins("mine"), name="test")
 
     with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
         with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
@@ -1084,12 +1128,10 @@ async def test_plugins_are_only_warned_about_once(caplog):
     )
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_the_plugins_warning_points_at_the_kwarg_that_fixes_it():
     """A message naming the problem and not the route is half a message."""
-    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
-    ag = StrandsAgent(template, name="test")
+    ag = StrandsAgent(_template_with_plugins("mine"), name="test")
 
     with patch.object(logging.getLogger("ag_ui_strands.agent"), "warning") as warn:
         with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
@@ -1103,16 +1145,20 @@ async def test_the_plugins_warning_points_at_the_kwarg_that_fixes_it():
     )
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_plugins_kwarg_reaches_the_per_thread_agent():
-    """The forwarding half: what the caller passes is what the thread gets."""
-    plugin = _CountingPlugin()
-    template = Agent(model=_mock_model())
-    ag = StrandsAgent(template, name="test", plugins=[plugin])
+    """The forwarding half: what the caller passes is what the thread gets.
 
-    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
-        instance = await _trigger_thread_creation(ag, "t1")
+    A sentinel rather than a real plugin, because the adapter's job here is to
+    hand the list on unexamined. What a real plugin then does with a real
+    Agent is asserted separately below.
+    """
+    plugin = object()
+    with _as_if_sdk_took_plugins():
+        ag = StrandsAgent(Agent(model=_mock_model()), name="test", plugins=[plugin])
+
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            instance = await _trigger_thread_creation(ag, "t1")
 
     assert "plugins" in instance.init_kwargs, (
         f"plugins kwarg never reached the per-thread constructor; "
@@ -1124,7 +1170,6 @@ async def test_plugins_kwarg_reaches_the_per_thread_agent():
     )
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "plugins_value",
@@ -1149,13 +1194,49 @@ async def test_a_falsy_plugins_value_omits_the_kwarg(plugins_value):
     )
 
 
-@_needs_plugins
+def test_plugins_on_a_release_without_them_is_refused_at_wrap_time():
+    """A release below the plugin system gets an answer, not a traceback.
+
+    The declared strands-agents floor has no ``plugins`` parameter at all.
+    Left alone, the kwarg reached that constructor and Strands raised a bare
+    TypeError from inside per-thread construction, which escapes the run
+    generator: the caller saw an SDK traceback on their first request rather
+    than a sentence about the argument they passed. Refusing while the wrapper
+    is being built says it once, at the point the mistake was made.
+    """
+    template = Agent(model=_mock_model())
+
+    with patch("ag_ui_strands.agent._STRANDS_ACCEPTS_PLUGINS", False):
+        with pytest.raises(TypeError, match="plugins"):
+            StrandsAgent(template, name="test", plugins=[object()])
+
+        # Not asking for the feature is not a misconfiguration, so the same
+        # release must still build a wrapper that never mentions plugins.
+        StrandsAgent(template, name="test")
+        StrandsAgent(template, name="test", plugins=[])
+
+
+class _CountingPlugin(_PluginBase):
+    """Records which agents it was initialized against."""
+
+    name = "counting-plugin"
+
+    def __init__(self):
+        super().__init__()
+        self.agents: list = []
+
+    def init_agent(self, agent):
+        self.agents.append(agent)
+
+
+@_needs_sdk_plugins
 @pytest.mark.asyncio
 async def test_a_forwarded_plugin_is_initialized_once_per_thread():
     """The assertion that outranks the kwarg plumbing.
 
-    Run against the real ``strands.Agent``: what a plugin is for is the work
-    it does in ``init_agent``, and that has to happen against each agent that
+    The one test here that needs the SDK's real plugin system, and the reason
+    it is worth a skip on older releases: what a plugin is for is the work it
+    does in ``init_agent``, and that has to happen against each agent that
     serves requests. Once per thread and against that thread's own agent is
     the whole contract; the kwarg is only how it gets there.
     """

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -42,6 +42,32 @@ from ag_ui_strands.agent import (
 )
 
 
+# The plugin system arrived after the declared strands-agents floor, and the
+# floor is one of the lanes this suite runs in. Probed as a capability rather
+# than a version so the gate tracks the feature itself.
+#
+# This is not the skip the module docstring rules out. That one is about a
+# param the installed SDK has and this suite finds awkward; here the SDK has no
+# plugins at all, so there is no setting to carry and nothing to be silent
+# about.
+try:
+    from strands.plugins import Plugin as _StrandsPlugin
+except ImportError:  # pragma: no cover - depends on the installed SDK
+    _StrandsPlugin = None
+
+_NO_PLUGIN_SUPPORT = (
+    _StrandsPlugin is None
+    or "plugins" not in inspect.signature(Agent.__init__).parameters
+)
+_needs_plugins = pytest.mark.skipif(
+    _NO_PLUGIN_SUPPORT,
+    reason="this strands-agents release has no plugin system to carry",
+)
+# Subclassable stand-in so the plugin classes below still import on a release
+# without them. Every test that touches one is skipped there.
+_PluginBase = _StrandsPlugin if _StrandsPlugin is not None else object
+
+
 def _mock_model():
     m = MagicMock()
     m.stateful = False
@@ -496,10 +522,10 @@ async def test_no_constructor_param_is_dropped_silently(caplog):
         f"nor reported: {still_present}."
     )
 
-    # A param this adapter cannot read is a gap worth interrupting for, so it
-    # must be named in a warning. A param wired to the template is a structural
-    # property of the SDK present on every agent; warning about it on every
-    # construction would be noise, so it only has to be recorded.
+    # Both kinds have to be named in a warning: either way the setting does
+    # not reach the agents that serve requests, and silence is the defect this
+    # suite exists to catch. They are still kept apart, because they point the
+    # caller at different fixes.
     for param in ag._unreadable_params:
         assert any(param in m for m in caplog.messages), (
             f"{param} could not be read off the template but was never named in "
@@ -508,6 +534,10 @@ async def test_no_constructor_param_is_dropped_silently(caplog):
     for param in ag._template_owned_params:
         assert param in ag._unforwardable_params, (
             f"{param} is owned by the template but is not recorded as unforwardable"
+        )
+        assert any(param in m for m in caplog.messages), (
+            f"{param} is wired to the template and cannot be carried, but the "
+            f"caller was never told; got {caplog.messages}"
         )
     assert not set(ag._template_owned_params) & set(ag._unreadable_params), (
         "a param cannot be both unreadable and read-but-template-owned"
@@ -933,4 +963,210 @@ async def test_no_warning_for_a_param_the_hook_supplies(caplog):
     # The one it did not supply is still named.
     assert "another_param" in said, (
         f"expected the unsupplied param to be named; got {caplog.messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# plugins
+# ---------------------------------------------------------------------------
+#
+# ``plugins`` is the param that motivated splitting the two warnings. Strands
+# consumes the list during construction: it runs each plugin's ``init_agent``
+# against the agent that received it and registers the plugin's hooks and
+# tools into that agent's registries, keeping only a registry bound back to
+# it. Nothing can be read off the template and nothing can be handed to a
+# second agent, so a plugin set on the template never runs against the agents
+# that serve requests. The adapter answers that with a dedicated kwarg, and
+# tells anyone who used the template instead.
+
+
+class _CountingPlugin(_PluginBase):
+    """Records how many agents it was initialized against."""
+
+    name = "counting-plugin"
+
+    def __init__(self):
+        super().__init__()
+        self.agents: list = []
+
+    def init_agent(self, agent):
+        self.agents.append(agent)
+
+
+def _plugin_warnings(messages: list[str]) -> list[str]:
+    return [m for m in messages if "plugins" in m]
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_template_plugins_are_named_when_a_thread_is_built(caplog):
+    """The silence this closes: plugins on the template, and no plugins anywhere.
+
+    The template never serves a request, so its plugins never run. Before this
+    the caller got neither the behaviour nor a word about losing it, which is
+    the worst of the two failure modes: nothing to notice and nothing to
+    search for.
+    """
+    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
+    ag = StrandsAgent(template, name="test")
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            await _trigger_thread_creation(ag, "t1")
+
+    assert _plugin_warnings(caplog.messages), (
+        f"plugins were set on the template and dropped without a word; "
+        f"got {caplog.messages}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_an_agent_with_no_caller_plugins_says_nothing(caplog):
+    """Strands registers plugins of its own on every Agent.
+
+    Counting those would warn every caller about a setting nobody made, and a
+    warning everybody gets is one nobody reads. This is the assertion that
+    keeps the message rare enough to be worth reading.
+    """
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test")
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            await _trigger_thread_creation(ag, "t1")
+
+    assert not _plugin_warnings(caplog.messages), (
+        f"warned about plugins on an agent the caller gave none; "
+        f"got {caplog.messages}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_no_plugins_warning_when_the_explicit_kwarg_supplies_them(caplog):
+    """Acting on the warning has to make it stop.
+
+    The kwarg is what the message asks for, so a caller who has already used
+    it must not keep hearing about the template.
+    """
+    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
+    ag = StrandsAgent(template, name="test", plugins=[_CountingPlugin()])
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            await _trigger_thread_creation(ag, "t1")
+
+    assert not _plugin_warnings(caplog.messages), (
+        f"warned about plugins the caller had already supplied; "
+        f"got {caplog.messages}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_plugins_are_only_warned_about_once(caplog):
+    """One thread's message must not become every thread's message."""
+    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
+    ag = StrandsAgent(template, name="test")
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            await _trigger_thread_creation(ag, "first")
+            after_first = len(_plugin_warnings(caplog.messages))
+            await _trigger_thread_creation(ag, "second")
+
+    assert after_first == 1, (
+        f"expected the first thread to be told once; got {caplog.messages}"
+    )
+    assert len(_plugin_warnings(caplog.messages)) == after_first, (
+        f"warned twice about the same param; got {caplog.messages}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_the_plugins_warning_points_at_the_kwarg_that_fixes_it():
+    """A message naming the problem and not the route is half a message."""
+    template = Agent(model=_mock_model(), plugins=[_CountingPlugin()])
+    ag = StrandsAgent(template, name="test")
+
+    with patch.object(logging.getLogger("ag_ui_strands.agent"), "warning") as warn:
+        with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+            await _trigger_thread_creation(ag, "t1")
+
+    # Rendered rather than read off the format string: the route is chosen at
+    # call time, so the format string alone would not show which one was said.
+    said = [call.args[0] % call.args[1:] for call in warn.call_args_list]
+    assert any("StrandsAgent(plugins=" in m for m in said), (
+        f"the warning never named the kwarg that carries plugins; got {said}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_plugins_kwarg_reaches_the_per_thread_agent():
+    """The forwarding half: what the caller passes is what the thread gets."""
+    plugin = _CountingPlugin()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" in instance.init_kwargs, (
+        f"plugins kwarg never reached the per-thread constructor; "
+        f"got kwargs={list(instance.init_kwargs)}"
+    )
+    assert plugin in instance.init_kwargs["plugins"], (
+        f"expected the caller's plugin to be forwarded; "
+        f"got {instance.init_kwargs['plugins']!r}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "plugins_value",
+    [None, []],
+    ids=["omitted", "explicit-empty-list"],
+)
+async def test_a_falsy_plugins_value_omits_the_kwarg(plugins_value):
+    """"No plugins" is said by not passing the kwarg at all.
+
+    ``plugins=[]`` is a value, and a future Strands could read it as "register
+    none of the defaults either", which is not what an unset option means.
+    """
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=plugins_value)
+
+    with patch("ag_ui_strands.agent.StrandsAgentCore", _CapturingCore):
+        instance = await _trigger_thread_creation(ag, "t1")
+
+    assert "plugins" not in instance.init_kwargs, (
+        f"expected the plugins kwarg to be omitted, but it was forwarded as "
+        f"{instance.init_kwargs.get('plugins')!r}"
+    )
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_a_forwarded_plugin_is_initialized_once_per_thread():
+    """The assertion that outranks the kwarg plumbing.
+
+    Run against the real ``strands.Agent``: what a plugin is for is the work
+    it does in ``init_agent``, and that has to happen against each agent that
+    serves requests. Once per thread and against that thread's own agent is
+    the whole contract; the kwarg is only how it gets there.
+    """
+    plugin = _CountingPlugin()
+    template = Agent(model=_mock_model())
+    ag = StrandsAgent(template, name="test", plugins=[plugin])
+
+    first = await _trigger_thread_creation(ag, "thread-a")
+    second = await _trigger_thread_creation(ag, "thread-b")
+
+    assert plugin.agents == [first, second], (
+        f"expected init_agent to run once against each thread's own agent; "
+        f"got {plugin.agents!r}"
     )

--- a/integrations/aws-strands/python/tests/test_thread_agent_kwargs.py
+++ b/integrations/aws-strands/python/tests/test_thread_agent_kwargs.py
@@ -11,8 +11,9 @@ Mirrors the TypeScript ``threadAgentConfig`` suite.
 
 from __future__ import annotations
 
-import inspect
 import logging
+import weakref
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -189,35 +190,37 @@ async def test_hook_failure_ends_the_run_and_leaves_the_thread_uncached():
 # the template.
 
 
-# Gated on the SDK having a plugin system at all: it arrived after the declared
-# strands-agents floor, and the floor is one of the lanes this suite runs in.
-try:
-    from strands.plugins import Plugin as _StrandsPlugin
-except ImportError:  # pragma: no cover - depends on the installed SDK
-    _StrandsPlugin = None
-
-_needs_plugins = pytest.mark.skipif(
-    _StrandsPlugin is None
-    or "plugins" not in inspect.signature(Agent.__init__).parameters,
-    reason="this strands-agents release has no plugin system to carry",
-)
-_PluginBase = _StrandsPlugin if _StrandsPlugin is not None else object
+# Plain sentinels rather than real plugins: the adapter hands this list to the
+# per-thread constructor unexamined, and the stub below is what receives it.
+# That keeps these running at the declared strands-agents floor, which has no
+# plugin system at all.
 
 
-class _NamedPlugin(_PluginBase):
-    def __init__(self, name: str):
-        self._name = name
-        super().__init__()
+class _FakePluginRegistry:
+    """A plugin registry in the shape the adapter reads."""
 
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def init_agent(self, agent):
-        pass
+    def __init__(self, owner, names):
+        self._agent_ref = weakref.ref(owner)
+        self._plugins = {name: SimpleNamespace(name=name) for name in names}
 
 
-@_needs_plugins
+def _template_with_plugins(*names: str):
+    agent = Agent(model=_mock_model())
+    agent._plugin_registry = _FakePluginRegistry(agent, names)
+    return agent
+
+
+def _as_if_sdk_took_plugins():
+    """Declare the capability the stub core already assumes.
+
+    The wrap-time check refuses ``plugins=`` on a release whose Agent has no
+    such parameter. The per-thread core here is a stub that takes any kwarg, so
+    declaring the capability is what lets the precedence rule be asserted at
+    the declared floor instead of skipped there.
+    """
+    return patch("ag_ui_strands.agent._STRANDS_ACCEPTS_PLUGINS", True)
+
+
 @pytest.mark.asyncio
 async def test_the_hook_can_supply_plugins():
     """The general route still works for the param that gained a kwarg.
@@ -225,7 +228,7 @@ async def test_the_hook_can_supply_plugins():
     A caller who wants a plugin built per thread, rather than one instance
     shared by every thread, has nowhere else to do it.
     """
-    plugin = _NamedPlugin("from-hook")
+    plugin = object()
     template = Agent(model=_mock_model())
     config = StrandsAgentConfig(thread_agent_kwargs=lambda _input: {"plugins": [plugin]})
     ag = StrandsAgent(template, name="test", config=config)
@@ -235,7 +238,6 @@ async def test_the_hook_can_supply_plugins():
     assert _CapturingCore.instances[-1].init_kwargs["plugins"] == [plugin]
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_hook_plugins_win_over_the_adapter_kwarg():
     """Same precedence every other param has, and for the same reason.
@@ -244,20 +246,19 @@ async def test_hook_plugins_win_over_the_adapter_kwarg():
     startup. Whichever knows more about this thread should be the one that
     decides, so the later writer wins.
     """
-    from_ctor = _NamedPlugin("from-ctor")
-    from_hook = _NamedPlugin("from-hook")
+    from_ctor = object()
+    from_hook = object()
     template = Agent(model=_mock_model())
     config = StrandsAgentConfig(
         thread_agent_kwargs=lambda _input: {"plugins": [from_hook]}
     )
-    ag = StrandsAgent(template, name="test", plugins=[from_ctor], config=config)
-
-    await _build(ag)
+    with _as_if_sdk_took_plugins():
+        ag = StrandsAgent(template, name="test", plugins=[from_ctor], config=config)
+        await _build(ag)
 
     assert _CapturingCore.instances[-1].init_kwargs["plugins"] == [from_hook]
 
 
-@_needs_plugins
 @pytest.mark.asyncio
 async def test_no_warning_about_template_plugins_the_hook_supplies(caplog):
     """Acting on the warning through this route has to make it stop too.
@@ -265,9 +266,9 @@ async def test_no_warning_about_template_plugins_the_hook_supplies(caplog):
     The message names the constructor kwarg, but the hook answers it just as
     completely, and a caller who took that route has lost nothing.
     """
-    template = Agent(model=_mock_model(), plugins=[_NamedPlugin("on-template")])
+    template = _template_with_plugins("on-template")
     config = StrandsAgentConfig(
-        thread_agent_kwargs=lambda _input: {"plugins": [_NamedPlugin("from-hook")]}
+        thread_agent_kwargs=lambda _input: {"plugins": [object()]}
     )
     ag = StrandsAgent(template, name="test", config=config)
 

--- a/integrations/aws-strands/python/tests/test_thread_agent_kwargs.py
+++ b/integrations/aws-strands/python/tests/test_thread_agent_kwargs.py
@@ -11,6 +11,8 @@ Mirrors the TypeScript ``threadAgentConfig`` suite.
 
 from __future__ import annotations
 
+import inspect
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -174,3 +176,104 @@ async def test_hook_failure_ends_the_run_and_leaves_the_thread_uncached():
         async for _ in ag.run(_run_input()):
             pass
     assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# plugins
+# ---------------------------------------------------------------------------
+#
+# ``plugins`` has a dedicated kwarg on the adapter, so it reaches this hook
+# with something already in the box. Three sources can name it at once: the
+# template, which cannot carry; the kwarg; and this hook. These fix the order
+# between them, and fix that using either route silences the warning about
+# the template.
+
+
+# Gated on the SDK having a plugin system at all: it arrived after the declared
+# strands-agents floor, and the floor is one of the lanes this suite runs in.
+try:
+    from strands.plugins import Plugin as _StrandsPlugin
+except ImportError:  # pragma: no cover - depends on the installed SDK
+    _StrandsPlugin = None
+
+_needs_plugins = pytest.mark.skipif(
+    _StrandsPlugin is None
+    or "plugins" not in inspect.signature(Agent.__init__).parameters,
+    reason="this strands-agents release has no plugin system to carry",
+)
+_PluginBase = _StrandsPlugin if _StrandsPlugin is not None else object
+
+
+class _NamedPlugin(_PluginBase):
+    def __init__(self, name: str):
+        self._name = name
+        super().__init__()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def init_agent(self, agent):
+        pass
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_the_hook_can_supply_plugins():
+    """The general route still works for the param that gained a kwarg.
+
+    A caller who wants a plugin built per thread, rather than one instance
+    shared by every thread, has nowhere else to do it.
+    """
+    plugin = _NamedPlugin("from-hook")
+    template = Agent(model=_mock_model())
+    config = StrandsAgentConfig(thread_agent_kwargs=lambda _input: {"plugins": [plugin]})
+    ag = StrandsAgent(template, name="test", config=config)
+
+    await _build(ag)
+
+    assert _CapturingCore.instances[-1].init_kwargs["plugins"] == [plugin]
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_hook_plugins_win_over_the_adapter_kwarg():
+    """Same precedence every other param has, and for the same reason.
+
+    The hook sees the request; the constructor kwarg was fixed once at
+    startup. Whichever knows more about this thread should be the one that
+    decides, so the later writer wins.
+    """
+    from_ctor = _NamedPlugin("from-ctor")
+    from_hook = _NamedPlugin("from-hook")
+    template = Agent(model=_mock_model())
+    config = StrandsAgentConfig(
+        thread_agent_kwargs=lambda _input: {"plugins": [from_hook]}
+    )
+    ag = StrandsAgent(template, name="test", plugins=[from_ctor], config=config)
+
+    await _build(ag)
+
+    assert _CapturingCore.instances[-1].init_kwargs["plugins"] == [from_hook]
+
+
+@_needs_plugins
+@pytest.mark.asyncio
+async def test_no_warning_about_template_plugins_the_hook_supplies(caplog):
+    """Acting on the warning through this route has to make it stop too.
+
+    The message names the constructor kwarg, but the hook answers it just as
+    completely, and a caller who took that route has lost nothing.
+    """
+    template = Agent(model=_mock_model(), plugins=[_NamedPlugin("on-template")])
+    config = StrandsAgentConfig(
+        thread_agent_kwargs=lambda _input: {"plugins": [_NamedPlugin("from-hook")]}
+    )
+    ag = StrandsAgent(template, name="test", config=config)
+
+    with caplog.at_level(logging.WARNING, logger="ag_ui_strands.agent"):
+        await _build(ag)
+
+    assert not [m for m in caplog.messages if "plugins" in m], (
+        f"warned about plugins the hook supplied; got {caplog.messages}"
+    )


### PR DESCRIPTION
Closes the still-open half of #2129.

## The bug

`StrandsAgent` builds a fresh `strands.Agent` per `thread_id` from the template Agent, recovering the template's constructor params through `_extract_agent_kwargs`. On strands-agents 1.35.0, `Agent.__init__` accepts `plugins` and consumes the list immediately: it calls each plugin's `init_agent` against the agent that received it, registers that plugin's hooks and tools into that agent's registries, and keeps only a `_PluginRegistry` holding a `weakref` back to the agent.

`_references_agent` sees that weakref and returns `_AGENT_BOUND`, so `plugins` lands in `_template_owned_params`. `_report_uncarried_params` warns only about `_unreadable_params`, and template-owned params were excluded on purpose, on the reasoning that an agent-bound param is a structural property rather than a surprise.

The result is the worst of the two failure modes. A caller who sets `plugins` on the template gets no plugins on the agents that actually serve requests, and no warning that anything was lost. The template never serves a request, so a plugin whose whole behaviour lives in `init_agent` silently does nothing.

Reproduced before the fix:

```python
a = Agent(model=None, system_prompt="BASE.", plugins=[MyPlugin()])
_resolve_template_param(a, "plugins", None)   # -> _AGENT_BOUND
_extract_agent_kwargs(a)                      # -> template_owned == ['plugins']
```

## What changed

**1. An agent-bound param that will not carry now says so.**

`_report_uncarried_params` reports both kinds, each with its own message and both under the existing once-per-param bookkeeping, so neither can nag. They are kept separate because they ask for different reading: an unreadable param is a gap in this adapter that a later release may close, while a param the SDK wired to the agent that received it will never be carryable, so the per-thread route is the whole answer rather than a stopgap.

**2. Python gets the `plugins=` kwarg TypeScript already has.**

`StrandsAgent(plugins=[...])` now forwards to every per-thread `StrandsAgentCore`, next to the existing `hooks` forwarding and under the same falsy-omission rule: an empty list is never passed, because `plugins=[]` is a value a future SDK could read as "register none of the defaults either". `"plugins"` is added to `_AGUI_EXPLICIT_PARAMS` so it is not also probed off the template.

Because that exclusion also takes `plugins` out of the generic probe, a small dedicated read (`_template_plugin_names`) keeps the template case reportable, mirroring the `session_manager` footgun detector already in the constructor. It filters out plugins Strands registers itself: every Agent is built with at least one (`strands:model`), and counting those would warn every caller about a setting nobody made. Plugins a caller opts into are not namespaced that way, including vended ones like `AgentSkills`, whose name is `agent_skills`.

## Precedence

Three sources can name `plugins` at once, and all three can be present together:

1. `thread_agent_kwargs` wins. It goes on last at the merge site, which is the existing rule for every param and is unchanged here.
2. The `plugins=` kwarg is next.
3. The template never carries.

The warning stays quiet whenever either of the first two supplied the param for that thread, so acting on the message makes it stop. It is still said per param and per thread, so one thread supplying everything does not buy silence for the next thread that supplies nothing.

## Version floor

`plugins` arrived on the Strands `Agent` constructor in strands-agents 1.28.0. This package declares a 1.15.0 floor and runs a CI lane against it, so the new kwarg can be handed a release with nowhere to put it. Left alone it reached that constructor and Strands raised a bare `TypeError` from inside per-thread construction, which escapes the run generator rather than becoming a run error: the caller's first request died with an SDK traceback naming neither the argument they passed nor the version that could not take it.

Raising the floor would drop support for 1.15 through 1.27, so instead the capability is probed off the constructor signature and a caller who supplies `plugins=` on a release without it is refused while the wrapper is being built. That is where the mistake is knowable, and it is said once rather than on every request. The message names the installed version and what to do.

This follows the pattern the adapter already uses for session reconciliation, which probes for the exact repository methods it needs, fails in a defined way when they are absent, and documents the boundary in the README support table.

Not raised for a multi-agent orchestrator. An orchestrator builds no per-thread agent and so ignores both `hooks` and `plugins` on every release; reporting a version problem there would describe something the newer releases do not do either.

## Credit

PR #2141 by @hiepcs proposed exactly the shape of part 2, including the `_AGUI_EXPLICIT_PARAMS` entry and the falsy-omission rule, and diagnosed the `AgentSkills` symptom. That PR was written against a much older tree and no longer applies, so this is written fresh, but the design of the forwarding half is theirs.

## Tests

Extended the two suites that already own this behaviour.

`tests/test_template_agent_propagation.py`:
- the warning fires when the template carries plugins and nothing else supplies them
- it stays quiet on an agent whose only plugins are Strands' own, which is what keeps the message rare enough to read
- the SDK-plugin name filter is also asserted directly
- it stays quiet when the `plugins=` kwarg supplies them
- it is said once, not once per thread
- it names the kwarg that fixes it
- the kwarg reaches the per-thread constructor
- a falsy value omits the kwarg entirely (parametrized over `None` and `[]`)
- a release without the plugin system refuses the kwarg at wrap time, and still builds a wrapper when the kwarg is absent or empty
- against the real `strands.Agent`, a forwarded plugin's `init_agent` runs once per thread and against that thread's own agent

`tests/test_thread_agent_kwargs.py`:
- the hook can supply plugins
- hook plugins win over the constructor kwarg
- the warning stays quiet when the hook supplies them

Only the real-`Agent` `init_agent` test needs the SDK's plugin system, so it is the only one skipped at the floor. The rest exercise the adapter's own reading, reporting and forwarding, and use a synthetic plugin registry and plain sentinels, which is how the resolver tests in that file already build their cases. The three that drive the kwarg against a stub core declare the capability explicitly rather than skipping, since a stub takes any kwarg and that is what it already assumes.

`test_no_constructor_param_is_dropped_silently` now also asserts that template-owned params are named in a warning, which is the general form of the defect above.

Each behaviour was checked against a mutated source to confirm the tests fail without it: removing the forwarding, the template detection, the SDK-plugin filter, or the wrap-time refusal each turns the relevant tests red, and moving the kwarg after the hook merge breaks the precedence test.

## Verification

- strands-agents 1.35.0: green, 1289 passed and 1 skipped, against 1277 passed and 1 skipped on main.
- The declared floor, strands-agents 1.15.0, which is a CI lane: green, 1280 passed and 4 skipped. Three of those skips are pre-existing; one is the plugin test above.
- No TypeScript files were touched. The TS package already has this kwarg and its own coverage in `plugins-forwarded.test.ts`.

## Also in this diff

The per-thread build site called `_report_uncarried_params` twice, once unconditionally and again when `thread_agent_kwargs` was `None`. The second call was a no-op given the once-per-param bookkeeping. Removed.

A README section now documents the per-thread rebuild, the `hooks` and `plugins` routes, and the version boundary.