### PR TITLE
docs(aws-strands): correct the concurrent-run comment on _activeRunsByThread

### DIFF
--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -2136,9 +2136,12 @@ export class StrandsAgent {
    * Threads with an in-flight run. Strands `Agent.stream()` throws if a
    * second invocation is started on a busy agent; we detect the collision
    * up front and emit a protocol-shaped RUN_ERROR/THREAD_BUSY instead.
-   * Python guards the same collision with the same code and the same text,
-   * but only around an orchestrator, and keyed by thread only when a factory
-   * builds one per run; its single-agent path has no guard of its own.
+   * Python refuses the same per-thread collision before entering its own run
+   * body, with the same code and the same message text. It additionally
+   * guards a shared orchestrator instance across every thread, since such an
+   * instance cannot be multiplexed at all; that arm narrows back to per-thread
+   * when a callable builds a fresh orchestrator per run. It also refuses a run
+   * against an orchestrator parked at an interrupt.
    */
   private readonly _activeRunsByThread = new Set<string>();
   /** Outstanding AG-UI interrupt objects per thread, used to validate


### PR DESCRIPTION
## What

The doc comment on `_activeRunsByThread` in `integrations/aws-strands/typescript/src/agent.ts` claimed that Python guarded the per-thread run collision only around an orchestrator, and that its single-agent path had no guard of its own.

That stopped being true in 6b09f47ee, "fix(aws-strands): refuse a second concurrent run on one thread in Python". Python now has its own `_active_runs_by_thread` set and refuses an overlapping run in `run` before the body is entered, emitting `THREAD_BUSY` with the same message template TypeScript uses, via `_busy_scope`.

## Change

The comment now describes what both bridges actually do:

- both refuse a per-thread collision before the run body, with the same code and the same message text;
- Python additionally guards a shared orchestrator instance across every thread, since such an instance cannot be multiplexed at all, and that arm narrows back to per-thread when a callable builds a fresh orchestrator per run;
- Python also refuses a run against an orchestrator parked at an interrupt.

`integrations/aws-strands/ARCHITECTURE.md` already documented this behaviour correctly, so the comment was the only thing out of date and no doc change was needed.

Comment only. No runtime strings and no behaviour changed.

## Verification

`pnpm exec vitest run` in `integrations/aws-strands/typescript`: 76 test files passed, 1611 tests passed, 0 failed.