### PR TITLE
fix(aws-strands): advertise RAW in the TypeScript capabilities matrix

### DIFF
--- a/integrations/aws-strands/typescript/README.md
+++ b/integrations/aws-strands/typescript/README.md
@@ -194,13 +194,11 @@ The adapter advertises an event / feature matrix at GET `/capabilities`
 `addCapabilities(app, path, { agent, overrides })` to derive the chunk flags from
 a live agent's `emitChunkEvents` rather than pinning them).
 
-Two flags in that matrix need reading with care. `DEFAULT_CAPABILITIES` reports
-`events.RAW: false`, which predates the adapter emitting `RAW` at all: the
-passthrough described below is live whatever the matrix says, so do not gate a
-client on that flag. `events.STATE_DELTA: false` and `features.stateDelta: false`
-are not a mistake, and mean what they say about the adapter, which emits no delta
-of its own; a `customResultHandler` that emits one is your own addition. Fold an
-override in for either if you serve the matrix to something that reads it.
+One flag in that matrix needs reading with care. `events.STATE_DELTA: false` and
+`features.stateDelta: false` are not a mistake, and mean what they say about the
+adapter, which emits no delta of its own; a `customResultHandler` that emits one
+is your own addition. Fold an override in if you serve the matrix to something
+that reads it.
 
 ## Unmapped Strands events reach the client as `RAW`
 

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-capabilities.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-capabilities.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import express from "express";
 import type { AddressInfo } from "net";
+import { EventType } from "@ag-ui/core";
+import type { AgentStreamEvent } from "@strands-agents/sdk";
 
 import {
   addCapabilities,
@@ -8,6 +10,7 @@ import {
   DEFAULT_CAPABILITIES,
 } from "../endpoint";
 import { StrandsAgent } from "../agent";
+import { collect, scriptedStrandsAgent } from "./helpers";
 
 async function startApp(configure: (app: express.Express) => void): Promise<{
   port: number;
@@ -168,5 +171,63 @@ describe("capabilitiesFor / addCapabilities { agent }", () => {
     } finally {
       await close();
     }
+  });
+});
+
+describe("the advertised matrix against what a run publishes", () => {
+  // An unmapped provider event: real, carries a payload no mapped AG-UI event
+  // conveys, and the adapter has no branch for it. Same guardrail redaction
+  // `raw-fallback.test.ts` uses to pin the fallback itself.
+  const UNMAPPED_EVENT = {
+    type: "modelRedactionEvent",
+    outputRedaction: { text: "[redacted]" },
+  } as unknown as AgentStreamEvent;
+
+  async function runEmitsRaw(): Promise<boolean> {
+    const events = await collect(scriptedStrandsAgent([UNMAPPED_EVENT]));
+    return events.some((e) => e.type === EventType.RAW);
+  }
+
+  it("advertises RAW exactly when a run publishes one", async () => {
+    // Read off a real run rather than hardcoded, so the flag cannot drift away
+    // from the adapter again: the terminal fallback in `agent.ts` forwards
+    // every unmapped Strands event as RAW, unconditionally.
+    const emitsRaw = await runEmitsRaw();
+    expect(
+      emitsRaw,
+      "no RAW event on the wire to compare the flag against",
+    ).toBe(true);
+
+    const { port, close } = await startApp((app) =>
+      addCapabilities(app, "/capabilities"),
+    );
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/capabilities`);
+      const body = await res.json();
+      expect(body.events.RAW).toBe(emitsRaw);
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps RAW advertised in chunk mode", async () => {
+    // The fallback is not gated on `emitChunkEvents`, so neither is the flag.
+    const emitsRaw = await runEmitsRaw();
+    const agent = new StrandsAgent({
+      agent: {
+        model: {},
+        tools: [],
+        toolRegistry: {
+          list: () => [],
+          add() {},
+          get: () => undefined,
+          remove() {},
+        },
+        sessionManager: undefined,
+      } as unknown as import("@strands-agents/sdk").Agent,
+      name: "cap",
+      config: { emitChunkEvents: true },
+    });
+    expect(capabilitiesFor(agent).events.RAW).toBe(emitsRaw);
   });
 });

--- a/integrations/aws-strands/typescript/src/endpoint.ts
+++ b/integrations/aws-strands/typescript/src/endpoint.ts
@@ -490,8 +490,8 @@ export function addPing(app: Express, path: string): void {
 /**
  * Static description of what this adapter actually supports. Every event
  * family here can be observed on the wire; anything missing is either not
- * emitted by this adapter (e.g. `ACTIVITY_*`, `RAW`) or only emitted in
- * specific configurations (the `*_CHUNK` events, gated by
+ * emitted by this adapter (e.g. `ACTIVITY_*`, `SUBAGENT_*`) or only emitted
+ * in specific configurations (the `*_CHUNK` events, gated by
  * `emitChunkEvents` — use {@link capabilitiesFor} to derive the matrix
  * from a concrete agent and pick those flags up automatically).
  *
@@ -596,7 +596,7 @@ export const DEFAULT_CAPABILITIES: StrandsAguiCapabilities = {
     CUSTOM: true,
     ACTIVITY_SNAPSHOT: false,
     ACTIVITY_DELTA: false,
-    RAW: false,
+    RAW: true,
   },
   features: {
     interrupts: true,


### PR DESCRIPTION
## What

`DEFAULT_CAPABILITIES` in `integrations/aws-strands/typescript/src/endpoint.ts` reported `events.RAW: false`, while the run loop's terminal fallback in `agent.ts` forwards every unmapped Strands stream event as `{ type: "RAW", event, source: "strands" }`. A client reading `GET /capabilities` was told the adapter never emits RAW while it does.

- Flip `events.RAW` to `true`.
- `capabilitiesFor` needs no derivation for this flag. The fallback is not gated on `emitChunkEvents` or any other config, so the static default is correct in every configuration. A test pins that.
- Fix the doc comment above `StrandsAguiCapabilities`, which used `RAW` as its example of a family this adapter does not emit. `SUBAGENT_*` replaces it: nothing under `src/` references `SUBAGENT_STARTED`, `SUBAGENT_FINISHED` or `SUBAGENT_ERROR`. The `ACTIVITY_*` example still holds.

## Test

New cases in `src/__tests__/endpoint-capabilities.test.ts`, in the spirit of `docs-contract.test.ts`: rather than hardcoding `true`, they script an unmapped provider event (`modelRedactionEvent`, the same one `raw-fallback.test.ts` uses) through the adapter, read off whether a RAW event actually reached the wire, and assert the served `/capabilities` document agrees. A second case pins the same equality for a chunk-mode agent through `capabilitiesFor`.

Both fail against the old flag (`expected false to be true`), and pass after it.

`pnpm exec vitest run` in `integrations/aws-strands/typescript`: 1613 tests across 76 files, all passing. `tsc --noEmit` clean.

## Python

No equivalent drift. `integrations/aws-strands/python/src/ag_ui_strands/endpoint.py` exposes only the run endpoint and `add_ping` — there is no capabilities endpoint and no capability matrix in the package, so nothing there can be stale about RAW. Python does emit RAW (`agent.py`), it just never advertises anything.

## Note for whoever merges second

The TypeScript README's capabilities section carried a paragraph documenting `events.RAW: false` as a known-wrong flag and telling readers not to gate on it. That caveat landed in #2611, which is already merged into `main`, so this PR deletes it directly rather than leaving it for a follow-up — the surrounding text now flags only `STATE_DELTA` / `stateDelta`, which remain accurate.

If another branch touches that same paragraph, keep this version: the flag it warned about is no longer wrong.
