### PR TITLE
fix(aws-strands): make the template MCP-client warning able to fire

### DIFF
--- a/integrations/aws-strands/typescript/README.md
+++ b/integrations/aws-strands/typescript/README.md
@@ -391,6 +391,11 @@ const agent = new Agent({
 const aguiAgent = new StrandsAgent({ agent, name: "MyAgent" });
 ```
 
+The adapter checks for this at construction time: a template `Agent` still
+holding `McpClient` entries gets a warning naming how many, because their tools
+cannot reach a per-thread clone. Spreading the resolved tools in silences it,
+once the client itself is out of `tools`.
+
 `McpClient` comes from the package root. `@strands-agents/sdk` publishes an
 `exports` map with no `./mcp` entry, so a subpath import of it does not
 resolve. Any `Transport` from `@modelcontextprotocol/sdk` works in its place;

--- a/integrations/aws-strands/typescript/src/__tests__/agent-config-forwarded-real-sdk.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/agent-config-forwarded-real-sdk.test.ts
@@ -12,9 +12,10 @@
  * can actually fail.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   Agent,
+  McpClient,
   SlidingWindowConversationManager,
   tool,
   type AgentConfig,
@@ -140,6 +141,52 @@ describe("template forwarding against the real Strands SDK", () => {
 
     expect(first.id).toBe("wizard-001");
     expect(second.id).toBe(first.id);
+  });
+
+  it("warns when the template Agent holds an unresolved McpClient", () => {
+    // The SDK routes an `McpClient` out of `tools` into a private client list
+    // and registers its tools only in `Agent.initialize()`, which the template
+    // Agent never runs. So `agent.tools` stays empty, the per-thread clones
+    // inherit nothing, and the model silently loses every MCP tool. Reading
+    // the resolved tool list cannot see this, which is why the client list is
+    // what gets probed.
+    const client = new McpClient({
+      // Never touched: `McpClient`'s constructor stores the transport and
+      // connects only on demand, so the suite needs no live MCP server.
+      transport: {} as never,
+    });
+    const template = realTemplate({ tools: [client] });
+
+    // Pinned so the assertion below is about the warning and not about a
+    // client that happened to resolve.
+    expect(template.tools).toHaveLength(0);
+
+    const warn = vi.fn();
+    new StrandsAgent({
+      agent: template,
+      name: "adapter-name",
+      config: { logger: { debug: vi.fn(), warn, error: vi.fn() } },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("McpClient");
+  });
+
+  it("stays quiet when the caller spread the resolved MCP tools in", () => {
+    const echo = tool({
+      name: "echo",
+      description: "echo",
+      inputSchema: z.object({ v: z.string() }),
+      callback: (input) => ({ echoed: input.v }),
+    });
+    const warn = vi.fn();
+    new StrandsAgent({
+      agent: realTemplate({ tools: [echo] }),
+      name: "adapter-name",
+      config: { logger: { debug: vi.fn(), warn, error: vi.fn() } },
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("builds a working Agent from the forwarded config", () => {

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -2219,25 +2219,31 @@ export class StrandsAgent {
       );
     }
 
-    // Detect unconnected MCP clients passed directly into `tools: [...]`.
-    // Strands resolves a connected `McpClient`'s tools into `agent.tools` at
-    // construction time; an unconnected one stays as the bare client and the
-    // resolved tool list never appears here. The fix is on the caller's
-    // side: `await client.connect()` and spread `await client.listTools()`
-    // into the `tools` array.
-    for (const tool of this._templateFields.tools ?? []) {
-      if (
-        tool != null &&
-        typeof (tool as { connect?: unknown }).connect === "function" &&
-        typeof (tool as { name?: unknown }).name !== "string"
-      ) {
-        this._log.warn(
-          `${LOG_PREFIX} an entry in the template Agent's \`tools\` looks like ` +
-            "an unconnected McpClient — its tools will not be available to the " +
-            "model. Call `await client.connect()` and spread the resolved tool " +
-            "list into `tools: [...]` before constructing the Agent.",
-        );
-      }
+    // Detect MCP clients passed directly into `tools: [...]`, whose tools are
+    // therefore absent from the resolved list this adapter clones.
+    //
+    // Strands routes an `McpClient` out of `tools` into an internal client
+    // list rather than into the tool registry, and registers its tools only
+    // inside `Agent.initialize()`, which runs on the first invocation. The
+    // template Agent is never invoked, so the `agent.tools` list cloned onto
+    // every per-thread agent never gains them. Connecting the client first
+    // changes nothing, because `listTools()` connects lazily; the distinction
+    // is resolved-versus-unresolved, not connected-versus-unconnected.
+    //
+    // The client list is private, so it is read through `_readTemplateField`,
+    // which tries the public name before the underscore one and returns
+    // `undefined` rather than throwing when neither is there.
+    const templateMcpClients = _readTemplateField(agentCore, "mcpClients");
+    if (Array.isArray(templateMcpClients) && templateMcpClients.length > 0) {
+      this._log.warn(
+        `${LOG_PREFIX} the template Agent's \`tools\` holds ` +
+          `${templateMcpClients.length} McpClient ` +
+          `${templateMcpClients.length === 1 ? "entry" : "entries"} whose ` +
+          "tools are not in `agent.tools`, so they will not be available to " +
+          "the model. Resolve them yourself and spread the result in: " +
+          "`await client.connect()`, then `tools: [...(await " +
+          "client.listTools())]`. Drop the client from `tools` once you do.",
+      );
     }
   }
 


### PR DESCRIPTION
## The problem

The TypeScript bridge's constructor carried a warning meant to catch an `McpClient` handed straight into the template `Agent`'s `tools` array. It could never fire, and its comment gave the wrong reason for the behaviour it was warning about.

**The check was unreachable.** It scanned `this._templateFields.tools`, which is `agent.tools.slice()` off the template Agent, for an entry with a `connect` method and no `name`. Measured against the installed `@strands-agents/sdk` 1.1.0, that list cannot hold a client: `flattenTools` (`dist/src/agent/agent.js`) routes an `McpClient` into a separate `_mcpClients` array and passes only the rest into the `ToolRegistry` that `Agent.tools` reads from. Probed directly, `new Agent({ systemPrompt: "x", tools: [new McpClient({ transport })] })` gives `agent.tools.length === 0` and `agent._mcpClients.length === 1`.

**The comment was wrong.** It said Strands resolves a *connected* client's tools into `agent.tools` at construction time, so only an unconnected one would show up as a bare client. The SDK does no such thing at construction. `Agent.initialize()`, which is async and runs on the first invocation, is what calls `client.listTools()` and registers the result; `McpClient.listTools()` connects lazily on its own. Connected versus unconnected makes no difference. The real distinction is that the adapter clones the resolved registry before `initialize()` has ever run, which is what this package's README already explains.

## The change

The warning is kept, because the failure it names is real and silent: MCP tools missing from every per-thread agent, with nothing at construction time to say so. It now reads the template's MCP client list instead of its tool list, through the existing `_readTemplateField` helper, which tries the public name before the underscore one and returns `undefined` rather than throwing when neither is there.

The message drops the connected-versus-unconnected framing, says how many client entries are in play, and tells the caller to resolve the tools and then drop the client from `tools`. That last part matters for a caller who passed both the client and its resolved tools, who would otherwise be warned on every construction with nothing left to fix.

The comment now states the actual mechanism.

## Tests

Both directions, in `agent-config-forwarded-real-sdk.test.ts` alongside the rest of the template-forwarding coverage, against a genuine `Agent` (the routing is an `instanceof McpClient` check, so a fabricated template could not exercise it):

- An `McpClient` in `tools` produces exactly one warning naming `McpClient`. The same test pins `template.tools` as empty first, so the assertion is about the warning firing and not about a client that happened to resolve. This test fails on `main` and passes with the change.
- A template carrying an ordinary resolved tool stays quiet.

The client is constructed with a stub transport cast to `never`: `McpClient`'s constructor only stores the transport, so the suite needs no live MCP server.

## Verification

- `pnpm exec vitest run` in `integrations/aws-strands/typescript`: 76 files, 1613 tests, all passing.
- Same suite with `src/agent.ts` reverted to `main`: the new warning test fails, the other 1612 pass.
- `pnpm exec tsc --noEmit` clean; `prettier --check` clean on the three touched files.

## Docs

`README.md` gained a short paragraph pointing out that the adapter warns at construction time, placed in the existing "Passing tools to the Agent" section right after the resolve-and-spread example. That section's resolved-versus-unresolved explanation landed in #2611 and needed no correction here.
