### PR TITLE
feat(aws-strands): forward RunAgentInput.context to the model in the TypeScript bridge

### DIFF
--- a/integrations/aws-strands/ARCHITECTURE.md
+++ b/integrations/aws-strands/ARCHITECTURE.md
@@ -93,6 +93,8 @@ This document explains how the AWS Strands integration inside `integrations/aws-
 - **State priming**
   - If `RunAgentInput.state` is provided, it immediately publishes a `StateSnapshotEvent`, filtering out any `messages` field so the frontend remains the source of truth for the timeline.
   - Optionally rewrites the outgoing user prompt via `StrandsAgentConfig.state_context_builder`.
+- **Model context (`RunAgentInput.context`)**
+  - The application's context entries are rendered as one text block (`Context provided by the application:` followed by one `- description: value` line per entry, the A2UI component-schema entry excluded through the shared toolkit split) and shown to the model for exactly one call: a `BeforeModelCallEvent` hook splices the block into `agent.messages` immediately before the latest user turn (into that turn's content when it carries a tool result, appended when there is no user turn at all) and the paired `AfterModelCallEvent` hook splices it back out, with the stream teardown as a second restore for cancellation. The block never reaches `agent.messages` after the call, a `MessagesSnapshotEvent`, or the session store. The block is request-scoped (a `ContextVar` in Python, `AsyncLocalStorage` in TypeScript, both set around each pull of the Strands stream) so concurrent runs cannot see each other's context. A non-empty block on an agent with no hook registry ends the run with a `RunErrorEvent`. On the orchestrator path the hook goes on every reachable leaf agent; an orchestrator with no reachable leaf gets the block prefixed onto its prompt instead. Python additionally refuses that prompt fallback during an interrupt resume; the TypeScript orchestrator path has no resume arm, so that refusal has no counterpart there. Both bridges also drop the middleware's usage guide for a render tool that A2UI auto-injection replaced, from the model block and from the recovery subagent's context alike. Tools and hooks keep reading the unnarrowed context through `agui_context` state (Python) and `buildContextExtras` (TypeScript).
 - **History reconciliation**
   - When the cached per-thread `StrandsAgentCore` has no `session_manager`, the adapter rebuilds Strands' internal `messages` list from `RunAgentInput.messages` before each `stream_async` call. Tool calls are rendered as `toolUse` ContentBlocks on assistant turns and tool results as `toolResult` blocks on user turns, matching Strands' native shape.
   - For legacy placeholder frontend tools, this fixes the "frontend tool loops forever" symptom: without reconciliation, Strands re-fires the same tool every turn because the result the frontend produced never reaches the LLM context. Explicit native waits resume from Strands' checkpoint instead.
@@ -235,6 +237,7 @@ typescript/src/
 ├── config.ts             ← StrandsAgentConfig, ToolBehavior, helpers
 ├── endpoint.ts           ← Express route registration + capabilities endpoint
 ├── logger.ts             ← injectable Logger interface + internal default
+├── model-context.ts      ← RunAgentInput.context shown to the model for one call only
 ├── server.ts             ← createStrandsApp factory + CORS/auth wiring
 ├── session-reconcile.ts  ← port of session_reconcile.py, snapshot-shaped
 ├── types.ts              ← internal SeenToolCall bookkeeping

--- a/integrations/aws-strands/typescript/src/__tests__/context-forwarding.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/context-forwarding.test.ts
@@ -1,0 +1,671 @@
+/**
+ * `RunAgentInput.context` must reach the model for one call and nowhere else.
+ *
+ * The block the application's context renders to is shown to the model from a
+ * before-model-call hook and withdrawn from the after-hook, so these tests sit
+ * at the real model boundary: a `ScriptedModel` records exactly the history the
+ * SDK handed it, and the durable history, the `MESSAGES_SNAPSHOT` and the
+ * session store are read back afterwards to prove the block stayed out of all
+ * three. Mirrors the Python bridge's `tests/test_context_forwarding.py` case
+ * for case, then covers the arms that file leaves to other suites: the
+ * tool-result turn, cancellation, concurrent runs, orchestrators, the refusal
+ * on an agent with no hook registry, and the A2UI render-guide exclusion.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  AfterInvocationEvent,
+  Agent,
+  FileStorage,
+  Graph,
+  SessionManager,
+  tool,
+} from "@strands-agents/sdk";
+import { A2UI_SCHEMA_CONTEXT_DESCRIPTION } from "@ag-ui/a2ui-toolkit";
+import {
+  EventType,
+  type InputContent,
+  type Message as AguiMessage,
+  type RunAgentInput,
+} from "@ag-ui/core";
+import { z } from "zod";
+
+import { StrandsAgent } from "../agent";
+import {
+  a2uiRenderGuideDescription,
+  buildA2UISubagentState,
+  withoutA2UIRenderGuides,
+} from "../a2ui-tool";
+import {
+  MODEL_CONTEXT_HEADER,
+  formatAguiContext,
+  normalizeAguiContext,
+} from "../model-context";
+import {
+  ScriptedModel,
+  collect,
+  errorCodes,
+  expectCompletedRun,
+  historyShape,
+  historyTexts,
+  minimalRunInput,
+  modelSawShape,
+  modelSawTexts,
+  modelTurn,
+  persistedSnapshot,
+  realStrandsAgent,
+  scriptedStrandsAgent,
+  snapshotsOf,
+  threadAgent,
+} from "./helpers";
+
+/** Pinned as a literal so a drift in the header is a failing test, not a rename. */
+const HEADER = "Context provided by the application:";
+
+/** The block for the given lines, in the shape both bridges emit. */
+function blockOf(...lines: string[]): string {
+  return `${HEADER}\n${lines.join("\n")}`;
+}
+
+type ContextEntry = RunAgentInput["context"][number];
+
+/** One user turn plus the given context, the shape every case starts from. */
+function contextRun(
+  context: ContextEntry[],
+  options: {
+    threadId?: string;
+    content?: string | InputContent[];
+    messages?: AguiMessage[];
+    forwardedProps?: Record<string, unknown>;
+  } = {},
+): RunAgentInput {
+  return minimalRunInput({
+    threadId: options.threadId,
+    context,
+    messages: options.messages ?? [
+      {
+        id: "u1",
+        role: "user",
+        content: options.content ?? "hello",
+      } as AguiMessage,
+    ],
+    ...(options.forwardedProps
+      ? { forwardedProps: options.forwardedProps }
+      : {}),
+  });
+}
+
+/** A logger that swallows the injection warning a Graph run prints. */
+const quiet = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("model context block rendering", () => {
+  it("pins the header the Python bridge emits", () => {
+    expect(MODEL_CONTEXT_HEADER).toBe(HEADER);
+  });
+
+  it("renders one line per entry, with the description dropped when blank", () => {
+    const block = formatAguiContext(
+      normalizeAguiContext([
+        { description: "account", value: "premium" },
+        { description: "   ", value: "no description" },
+        { value: "missing description" },
+      ]),
+    );
+    expect(block).toBe(
+      blockOf(
+        "- account: premium",
+        "- no description",
+        "- missing description",
+      ),
+    );
+  });
+
+  it("JSON-serializes non-string values the way json.dumps does for scalars", () => {
+    // Integers, booleans and null serialize identically on both bridges; the
+    // shapes that do not (objects, arrays, integral floats, non-ASCII) are
+    // documented on `formatAguiContext` rather than emulated.
+    const block = formatAguiContext(
+      normalizeAguiContext([
+        { description: "count", value: 42 },
+        { description: "enabled", value: true },
+        { description: "nothing", value: null },
+      ]),
+    );
+    expect(block).toBe(
+      blockOf("- count: 42", "- enabled: true", "- nothing: null"),
+    );
+  });
+
+  it("renders nothing for an empty or schema-only context", () => {
+    expect(formatAguiContext(normalizeAguiContext([]))).toBe("");
+    expect(formatAguiContext(normalizeAguiContext(undefined))).toBe("");
+    expect(
+      formatAguiContext(
+        normalizeAguiContext([
+          { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "catalog" },
+        ]),
+      ),
+    ).toBe("");
+  });
+});
+
+describe("context forwarding to the model", () => {
+  it("shows the context to the model immediately before the latest user turn and excludes the A2UI schema entry", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")]);
+    const lookalike = "A2UI Component Schema for customer preferences";
+
+    const events = await collect(
+      agent,
+      contextRun([
+        { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "raw catalog" },
+        { description: lookalike, value: "keep me" },
+        { description: "user_id", value: "u-42" },
+      ]),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf(`- ${lookalike}: keep me`, "- user_id: u-42"),
+      "hello",
+    ]);
+    expect(modelSawShape(model, 0)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+      { role: "user", blocks: ["textBlock"] },
+    ]);
+    // The block was for the model only: the durable history holds the turn
+    // and the answer, and no snapshot the client received carries it.
+    expect(historyTexts(threadAgent(agent)!.messages)).toEqual(["hello", "ok"]);
+    for (const snapshot of snapshotsOf(events)) {
+      expect(JSON.stringify(snapshot)).not.toContain(HEADER);
+    }
+  });
+
+  it("changes nothing when the context is empty", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events = await collect(agent, contextRun([]));
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual(["hello"]);
+    expect(JSON.stringify(model.seenMessages[0])).not.toContain(HEADER);
+  });
+
+  it("is transient when history replay is disabled", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")], {
+      config: { replayHistoryIntoStrands: false },
+    });
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "account", value: "premium" }]),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf("- account: premium"),
+      "hello",
+    ]);
+    expect(historyTexts(threadAgent(agent)!.messages)).toEqual(["hello", "ok"]);
+  });
+
+  it("is transient for a multimodal direct prompt", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")], {
+      config: { replayHistoryIntoStrands: false },
+    });
+    const content: InputContent[] = [
+      { type: "text", text: "hello" },
+      {
+        type: "image",
+        source: {
+          type: "data",
+          value: Buffer.from("fake-image").toString("base64"),
+          mimeType: "image/png",
+        },
+      },
+    ];
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "locale", value: "nl-NL" }], { content }),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawShape(model, 0)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+      { role: "user", blocks: ["textBlock", "imageBlock"] },
+    ]);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf("- locale: nl-NL"),
+      "hello",
+    ]);
+    expect(historyShape(threadAgent(agent)!.messages)).toEqual([
+      { role: "user", blocks: ["textBlock", "imageBlock"] },
+      { role: "assistant", blocks: ["textBlock"] },
+    ]);
+  });
+
+  it("leaves the prompt alone when the only entry is the A2UI schema", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")], {
+      config: { replayHistoryIntoStrands: false },
+    });
+
+    const events = await collect(
+      agent,
+      contextRun([
+        { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "raw catalog" },
+      ]),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual(["hello"]);
+    expect(modelSawShape(model, 0)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+    ]);
+  });
+
+  it("follows stale history but keeps the latest user turn byte-identical", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "selected invoice", value: "123" }], {
+        messages: [
+          { id: "u1", role: "user", content: "selected invoice 456" },
+          { id: "a1", role: "assistant", content: "noted" },
+          { id: "u2", role: "user", content: "which invoice is selected?" },
+        ],
+      }),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      "selected invoice 456",
+      "noted",
+      blockOf("- selected invoice: 123"),
+      "which invoice is selected?",
+    ]);
+    // The turn the model routed on is the turn the client sent, unchanged.
+    // Read from the model-call-time copy: the live array has since grown by
+    // the answer. Only the role and the content are compared, because that is
+    // all a provider is sent; the SDK is free to add bookkeeping fields to a
+    // serialized message and does across releases.
+    const seen = model.seenMessages[0]!;
+    const latest = seen[seen.length - 1]!;
+    expect(latest.role).toBe("user");
+    expect(latest.toJSON().content).toEqual([
+      { text: "which invoice is selected?" },
+    ]);
+    expect(historyTexts(threadAgent(agent)!.messages)).toEqual([
+      "selected invoice 456",
+      "noted",
+      "which invoice is selected?",
+      "ok",
+    ]);
+  });
+
+  it("rides inside the latest user turn when that turn carries a tool result", async () => {
+    const lookup = tool({
+      name: "lookup",
+      description: "d",
+      inputSchema: z.object({}).passthrough(),
+      callback: async () => ({ invoice: 42 }),
+    });
+    const { agent, model } = realStrandsAgent(
+      [
+        modelTurn.toolUse({ toolUseId: "t1", name: "lookup", input: {} }),
+        modelTurn.text("done"),
+      ],
+      { tools: [lookup] },
+    );
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "selected invoice", value: "123" }]),
+    );
+
+    expectCompletedRun(events);
+    // First call: the usual separate turn before the question.
+    expect(modelSawShape(model, 0)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+      { role: "user", blocks: ["textBlock"] },
+    ]);
+    // Second call: the latest user turn is the tool result, and a user
+    // message between a toolUse and its toolResult is a shape providers
+    // reject, so the block is prepended into that same turn instead.
+    expect(modelSawShape(model, 1)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+      { role: "assistant", blocks: ["toolUseBlock"] },
+      { role: "user", blocks: ["textBlock", "toolResultBlock"] },
+    ]);
+    expect(modelSawTexts(model, 1)[1]).toBe(blockOf("- selected invoice: 123"));
+    // Withdrawn again: the durable tool-result turn is only the tool result.
+    expect(historyShape(threadAgent(agent)!.messages)).toEqual([
+      { role: "user", blocks: ["textBlock"] },
+      { role: "assistant", blocks: ["toolUseBlock"] },
+      { role: "user", blocks: ["toolResultBlock"] },
+      { role: "assistant", blocks: ["textBlock"] },
+    ]);
+    expect(JSON.stringify(threadAgent(agent)!.messages)).not.toContain(HEADER);
+  });
+
+  it("is withdrawn when the consumer abandons the run mid-model-call", async () => {
+    const { agent } = realStrandsAgent([modelTurn.text("a long answer")]);
+
+    // Break out on the first token: the model call is still in flight, so the
+    // after-hook has not run and only the run-loop teardown can restore.
+    for await (const event of agent.run(
+      contextRun([{ description: "account", value: "premium" }]),
+    )) {
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) break;
+    }
+
+    expect(JSON.stringify(threadAgent(agent)!.messages)).not.toContain(HEADER);
+  });
+
+  it("keeps two in-flight runs' context apart", async () => {
+    const { agent, model } = realStrandsAgent([
+      modelTurn.text("one"),
+      modelTurn.text("two"),
+    ]);
+
+    await Promise.all([
+      collect(
+        agent,
+        contextRun([{ description: "thread", value: "A" }], {
+          threadId: "thread-A",
+          content: "question A",
+        }),
+      ),
+      collect(
+        agent,
+        contextRun([{ description: "thread", value: "B" }], {
+          threadId: "thread-B",
+          content: "question B",
+        }),
+      ),
+    ]);
+
+    expect(model.seenMessages).toHaveLength(2);
+    for (const seen of model.seenMessages) {
+      const texts = historyTexts(seen);
+      expect(texts).toHaveLength(2);
+      const which = texts[1]!.endsWith("A") ? "A" : "B";
+      expect(texts).toEqual([
+        blockOf(`- thread: ${which}`),
+        `question ${which}`,
+      ]);
+    }
+  });
+
+  it("refuses a run with context on an agent that exposes no hook registry", async () => {
+    const agent = scriptedStrandsAgent([], {
+      stubOverrides: { addHook: undefined },
+    });
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "account", value: "premium" }]),
+    );
+
+    expect(errorCodes(events)).toEqual(["STRANDS_ERROR"]);
+    const error = events.find((e) => e.type === EventType.RUN_ERROR) as
+      | { message?: string }
+      | undefined;
+    expect(error?.message).toBe(
+      "Strands agent does not expose a hook registry for transient context",
+    );
+  });
+
+  it("does not need a hook registry when there is no context to show", async () => {
+    const agent = scriptedStrandsAgent([], {
+      stubOverrides: { addHook: undefined },
+    });
+
+    const events = await collect(agent, contextRun([]));
+
+    expect(errorCodes(events)).toEqual([]);
+  });
+});
+
+describe("context forwarding with a session manager", () => {
+  it("is visible for one model call but never persisted", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agui-strands-context-"));
+    dirs.push(dir);
+    const threadId = "context-session";
+    const { agent, model } = realStrandsAgent(
+      [modelTurn.text("ok"), modelTurn.text("ok again")],
+      {
+        config: {
+          sessionManagerProvider: () =>
+            new SessionManager({
+              sessionId: threadId,
+              storage: { snapshot: new FileStorage(dir) },
+            }),
+        },
+      },
+    );
+
+    const first = await collect(
+      agent,
+      contextRun([{ description: "token", value: "secret-value" }], {
+        threadId,
+        content: "first question",
+      }),
+    );
+    expectCompletedRun(first);
+
+    const instance = threadAgent(agent, threadId)!;
+    expect(JSON.stringify(model.seenMessages[0])).toContain("secret-value");
+    expect(JSON.stringify(instance.messages)).not.toContain("secret-value");
+    expect(JSON.stringify(persistedSnapshot(dir))).not.toContain(
+      "secret-value",
+    );
+
+    const second = await collect(
+      agent,
+      contextRun([], { threadId, content: "second question" }),
+    );
+    expectCompletedRun(second);
+
+    expect(JSON.stringify(model.seenMessages[1])).toContain("second question");
+    expect(JSON.stringify(model.seenMessages[1])).not.toContain("secret-value");
+    expect(JSON.stringify(instance.messages)).not.toContain("secret-value");
+    expect(JSON.stringify(persistedSnapshot(dir))).not.toContain(
+      "secret-value",
+    );
+  });
+
+  it("is not persisted when the consumer abandons the run mid-model-call", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agui-strands-context-"));
+    dirs.push(dir);
+    const threadId = "context-cancel-session";
+    const { agent } = realStrandsAgent([modelTurn.text("a long answer")], {
+      config: {
+        sessionManagerProvider: () =>
+          new SessionManager({
+            sessionId: threadId,
+            storage: { snapshot: new FileStorage(dir) },
+          }),
+      },
+    });
+
+    // Returning the Strands stream is not a silent close: its own cleanup
+    // runs the after-invocation hooks, and the session manager saves
+    // `agent.messages` from there. Record what those hooks see at that
+    // moment, then break with the model call still in flight.
+    const messagesAtAfterInvocation: string[] = [];
+    for await (const event of agent.run(
+      contextRun([{ description: "token", value: "secret-value" }], {
+        threadId,
+        content: "first question",
+      }),
+    )) {
+      if (event.type === EventType.TEXT_MESSAGE_START) {
+        threadAgent(agent, threadId)!.addHook(
+          AfterInvocationEvent,
+          (hookEvent: AfterInvocationEvent) => {
+            messagesAtAfterInvocation.push(
+              JSON.stringify(hookEvent.agent.messages),
+            );
+          },
+        );
+      }
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) break;
+    }
+
+    expect(messagesAtAfterInvocation).toHaveLength(1);
+    expect(messagesAtAfterInvocation[0]).not.toContain("secret-value");
+    expect(
+      JSON.stringify(threadAgent(agent, threadId)!.messages),
+    ).not.toContain("secret-value");
+    expect(JSON.stringify(persistedSnapshot(dir))).not.toContain(
+      "secret-value",
+    );
+  });
+});
+
+describe("context forwarding through an orchestrator", () => {
+  it("shows the context to each leaf agent's model and withdraws it again", async () => {
+    const model = new ScriptedModel([modelTurn.text("short answer")]);
+    const leaf = new Agent({ id: "writer", model, printer: false });
+    const graph = new Graph({ nodes: [leaf], edges: [] });
+    const agent = new StrandsAgent({
+      agent: graph as never,
+      name: "graph",
+      config: { logger: quiet },
+    });
+
+    const events = await collect(
+      agent,
+      contextRun([{ description: "selected invoice", value: "123" }], {
+        content: "which invoice?",
+      }),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf("- selected invoice: 123"),
+      "which invoice?",
+    ]);
+    expect(JSON.stringify(leaf.messages)).not.toContain(HEADER);
+  });
+
+  it("prefixes the prompt when the orchestrator exposes no leaf to hook", async () => {
+    const prompts: string[] = [];
+    const bare = {
+      id: "bare",
+      // No `model` field: this is the orchestrator code path. No `nodes`
+      // either, so there is nothing to install a hook on.
+      async *stream(input: string) {
+        prompts.push(input);
+      },
+    };
+    const agent = new StrandsAgent({ agent: bare as never, name: "bare" });
+
+    await collect(
+      agent,
+      contextRun([{ description: "account", value: "premium" }]),
+    );
+    await collect(agent, contextRun([]));
+
+    expect(prompts).toEqual([
+      `${blockOf("- account: premium")}\n\nhello`,
+      "hello",
+    ]);
+  });
+});
+
+describe("A2UI render-guide exclusion", () => {
+  const renderGuide = a2uiRenderGuideDescription("render_a2ui");
+
+  it("spells the middleware's marker exactly as the Python bridge does", () => {
+    expect(renderGuide).toBe(
+      "A2UI render tool usage guide — how to call render_a2ui with valid arguments.",
+    );
+  });
+
+  it("drops only the guides for the tools that were replaced", () => {
+    const kept = withoutA2UIRenderGuides(
+      [
+        { description: renderGuide, value: "stale" },
+        { description: "user_id", value: "u-42" },
+        {
+          description: a2uiRenderGuideDescription("other_tool"),
+          value: "keep",
+        },
+      ],
+      ["render_a2ui"],
+    );
+    expect(kept.map((entry) => entry.value)).toEqual(["u-42", "keep"]);
+  });
+
+  it("narrows the subagent's context the same way", () => {
+    const state = buildA2UISubagentState(
+      minimalRunInput({
+        state: { plan: "x" },
+        context: [
+          { description: A2UI_SCHEMA_CONTEXT_DESCRIPTION, value: "schema" },
+          { description: renderGuide, value: "stale" },
+          { description: "user_id", value: "u-42" },
+        ],
+      }),
+      ["render_a2ui"],
+    );
+    expect(state).toEqual({
+      plan: "x",
+      "ag-ui": {
+        context: [{ description: "user_id", value: "u-42" }],
+        a2ui_schema: "schema",
+      },
+    });
+  });
+
+  it("keeps the guide out of the model block once generate_a2ui is injected", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")], {
+      config: { logger: quiet },
+    });
+
+    const events = await collect(
+      agent,
+      contextRun(
+        [
+          { description: renderGuide, value: "stale guide" },
+          { description: "user_id", value: "u-42" },
+        ],
+        { forwardedProps: { injectA2UITool: true } },
+      ),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf("- user_id: u-42"),
+      "hello",
+    ]);
+  });
+
+  it("keeps the guide in the model block when nothing was injected", async () => {
+    const { agent, model } = realStrandsAgent([modelTurn.text("ok")]);
+
+    const events = await collect(
+      agent,
+      contextRun([
+        { description: renderGuide, value: "live guide" },
+        { description: "user_id", value: "u-42" },
+      ]),
+    );
+
+    expectCompletedRun(events);
+    expect(modelSawTexts(model, 0)).toEqual([
+      blockOf(`- ${renderGuide}: live guide`, "- user_id: u-42"),
+      "hello",
+    ]);
+  });
+});

--- a/integrations/aws-strands/typescript/src/__tests__/helpers.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/helpers.ts
@@ -104,6 +104,12 @@ export function scriptedAgent(
     model: { name: "stub-model", modelId: "stub-model" },
     tools: [],
     toolRegistry: registry,
+    // An inert hook registry, so a stub can take a run that carries
+    // `context[]`: the adapter refuses such a run on an agent with no
+    // `addHook`, because the context reaches the model only through a hook.
+    // Python's `_CapturingCore` carries a real `HookRegistry` for the same
+    // reason. Override with `addHook: undefined` to drive the refusal.
+    addHook: () => () => {},
     async *stream(_args: unknown) {
       for (const e of events) yield e;
     },

--- a/integrations/aws-strands/typescript/src/a2ui-tool.ts
+++ b/integrations/aws-strands/typescript/src/a2ui-tool.ts
@@ -704,6 +704,71 @@ export function strandsToolResultsToAgui(
 // Auto-inject decision
 // ---------------------------------------------------------------------------
 
+/**
+ * Exact description `@ag-ui/a2ui-middleware` stamps on the usage guide it
+ * injects for a render tool. A wire-format marker, not prose: it must stay
+ * byte-identical to the middleware's string and to the Python bridge's
+ * `_a2ui_render_guide_description`, em dash included.
+ */
+export function a2uiRenderGuideDescription(toolName: string): string {
+  return (
+    "A2UI render tool usage guide — how to call " +
+    `${toolName} with valid arguments.`
+  );
+}
+
+/**
+ * Drop only the usage guides for render tools this adapter replaced.
+ *
+ * Once auto-injection swaps the middleware's `render_a2ui` proxy for
+ * `generate_a2ui`, the guide that taught the model how to call the proxy is
+ * stale and must reach neither the outer model nor the recovery subagent.
+ * Everything else in the context stays. Python's `_without_a2ui_render_guides`
+ * is the same filter.
+ */
+export function withoutA2UIRenderGuides<T extends { description?: unknown }>(
+  context: readonly T[],
+  toolNames: readonly string[],
+): T[] {
+  const guides = new Set(toolNames.map(a2uiRenderGuideDescription));
+  return context.filter(
+    (entry) =>
+      typeof entry?.description !== "string" || !guides.has(entry.description),
+  );
+}
+
+/**
+ * The run state the recovery subagent is given.
+ *
+ * Lifts the A2UI schema and the remaining context under `state["ag-ui"]` so
+ * the subagent prompt carries the component schema plus context, the same way
+ * the LangGraph adapter routes context into graph state. Uses the shared
+ * toolkit split so both adapters agree on the schema-context description, and
+ * drops the usage guides for the render tools in `dropToolNames`, since those
+ * tools are the ones this injection replaces. Python builds `a2ui_ag_ui` the
+ * same way.
+ */
+export function buildA2UISubagentState(
+  input: RunAgentInput,
+  dropToolNames: readonly string[],
+): Record<string, unknown> {
+  const [schemaValue, regularContext] = splitA2UISchemaContext(
+    input.context as Array<Record<string, unknown>> | undefined,
+  );
+  const baseState: Record<string, unknown> =
+    input.state &&
+    typeof input.state === "object" &&
+    !Array.isArray(input.state)
+      ? { ...(input.state as Record<string, unknown>) }
+      : {};
+  const agUi: Record<string, unknown> = {
+    context: withoutA2UIRenderGuides(regularContext, dropToolNames),
+  };
+  if (schemaValue !== undefined) agUi.a2ui_schema = schemaValue;
+  baseState["ag-ui"] = agUi;
+  return baseState;
+}
+
 /** Backend override knobs (mirrors the runtime `injectA2UITool` flag). */
 export interface A2UIInjectConfig {
   /**
@@ -822,20 +887,7 @@ export function planA2UIInjection<TModel = Model>(
 
   const renderToolName = typeof flag === "string" ? flag : RENDER_A2UI_TOOL_NAME;
 
-  // Lift the A2UI schema + remaining context under state["ag-ui"] so the
-  // sub-agent prompt carries the component schema + context, same as the
-  // LangGraph adapter routes context into graph state. Uses the shared toolkit
-  // split so both adapters agree on the schema-context description.
-  const [schemaValue, regularContext] = splitA2UISchemaContext(
-    input.context as Array<Record<string, unknown>> | undefined,
-  );
-  const baseState: Record<string, unknown> =
-    input.state && typeof input.state === "object" && !Array.isArray(input.state)
-      ? { ...(input.state as Record<string, unknown>) }
-      : {};
-  const agUi: Record<string, unknown> = { context: regularContext };
-  if (schemaValue !== undefined) agUi.a2ui_schema = schemaValue;
-  baseState["ag-ui"] = agUi;
+  const baseState = buildA2UISubagentState(input, [renderToolName]);
 
   // Resolve the frontend-registered catalog from run state (native a2ui_schema
   // or an "A2UI catalog" context entry) so surfaces bind to the host's catalog

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -57,8 +57,18 @@ import { isProxyTool, syncProxyTools } from "./client-proxy-tool";
 import {
   planA2UIInjection,
   isAutoInjectedA2UITool,
+  withoutA2UIRenderGuides,
   A2UI_STREAM_KEY,
 } from "./a2ui-tool";
+import {
+  ensureTransientContextHook,
+  formatAguiContext,
+  installOrchestratorContextHooks,
+  normalizeAguiContext,
+  pullWithModelContext,
+  restoreOrchestratorContext,
+  restoreTransientModelContext,
+} from "./model-context";
 import {
   _buildToolResultContent,
   _coerceText,
@@ -1012,25 +1022,30 @@ function _terminalErrorCode(e: unknown): string {
 }
 
 /**
- * Re-yield `source`, reporting anything it throws as a `_ForeignFault`.
+ * Re-yield `source`, reporting anything it throws as a `_ForeignFault`, with
+ * `contextBlock` in scope for each pull.
  *
  * The orchestrator pulls its stream through a `for await`, which leaves no
  * boundary between what the SDK raised and what this adapter's translation of
  * an event raised. This restores one, as Python's
  * `_stream_with_model_context` does for both of its loops. The single-agent
- * loop needs no equivalent: it reports every failure out of its own `next()`
- * as the forced stop, which never reaches the classifier at all. Teardown
- * stays with the caller, which already returns the underlying stream in its
- * own `finally`.
+ * loop needs no equivalent for faults: it reports every failure out of its own
+ * `next()` as the forced stop, which never reaches the classifier at all. The
+ * other half of Python's wrapper, scoping the request's model context to one
+ * pull at a time, is shared with that loop through `pullWithModelContext`, so
+ * an orchestrator's leaf agents see the block on the same terms a single
+ * agent does. Teardown stays with the caller, which already returns the
+ * underlying stream in its own `finally`.
  */
 async function* _foreignStreamFaults<T>(
   source: AsyncIterable<T>,
+  contextBlock = "",
 ): AsyncGenerator<T, void, void> {
   const iterator = source[Symbol.asyncIterator]();
   while (true) {
     let next: IteratorResult<T, unknown>;
     try {
-      next = await iterator.next();
+      next = await pullWithModelContext(iterator, contextBlock);
     } catch (e) {
       throw new _ForeignFault(e);
     }
@@ -2802,6 +2817,13 @@ export class StrandsAgent {
     // terminal RUN_ERROR (this block runs before the main try/catch below).
     // Auto-injection is best-effort: if it throws, log and run without A2UI
     // rather than crashing the turn.
+    //
+    // What the model will be told about the application's context this run.
+    // Starts as the whole of `RunAgentInput.context` and is narrowed below
+    // when A2UI auto-injection actually happens, the way Python narrows
+    // `model_context` from `agui_context`. Tools and hooks keep reading the
+    // unnarrowed context through `buildContextExtras`.
+    let modelContext = normalizeAguiContext(inputData.context);
     try {
       const registry = strandsAgent.toolRegistry;
       // Auto-inject requires enumerating the registry to (a) remove our OWN
@@ -2835,6 +2857,14 @@ export class StrandsAgent {
         if (plan) {
           for (const name of plan.dropToolNames) registry.remove(name);
           registry.add(plan.tool);
+          // The middleware also supplies a usage guide for the render proxy.
+          // Once that proxy is replaced with `generate_a2ui`, the guide is
+          // stale and must reach neither the outer model nor the recovery
+          // subagent (which `planA2UIInjection` narrows for itself).
+          modelContext = withoutA2UIRenderGuides(
+            modelContext,
+            plan.dropToolNames,
+          );
         }
       }
     } catch (e) {
@@ -3669,6 +3699,20 @@ export class StrandsAgent {
         persistInterruptBookkeeping(strandsAgent, null, null, this._log);
       }
 
+      // The application's context, rendered once for the model. It is shown
+      // from a before-model-call hook and withdrawn from the paired after-hook
+      // (see `model-context.ts`), so it needs a hook registry to ride on. A
+      // real `Agent` always has one; an agent that does not cannot honour a
+      // non-empty block, and pretending otherwise would silently drop what
+      // the app asked the model to know. Python raises the same way at the
+      // same point, after RUN_STARTED, so the client sees a RUN_ERROR.
+      const contextBlock = formatAguiContext(modelContext);
+      if (contextBlock && !ensureTransientContextHook(strandsAgent)) {
+        throw new Error(
+          "Strands agent does not expose a hook registry for transient context",
+        );
+      }
+
       // AbortController wired into Strands's `cancelSignal` so that abandoning
       // the outer generator (HTTP client disconnect) stops the underlying
       // Bedrock streaming call rather than silently burning tokens.
@@ -3692,7 +3736,10 @@ export class StrandsAgent {
         while (true) {
           let next: IteratorResult<AgentStreamEvent, unknown>;
           try {
-            next = await agentStream.next();
+            // The one pull site, so the one place the request's context block
+            // is in scope for the SDK. Python scopes its ContextVar around
+            // each `__anext__` for the same reason.
+            next = await pullWithModelContext(agentStream, contextBlock);
           } catch (streamErr) {
             // Strands throws "Stream ended without completing a message" when
             // a frontend tool call halts the agent before the model emits a
@@ -4755,6 +4802,14 @@ export class StrandsAgent {
         } catch {
           // ignore
         }
+        // A model call abandoned mid-flight never reaches its after-hook, so
+        // the block it was shown is still in `agent.messages`. Take it out
+        // before the drain: returning the stream runs the after-invocation
+        // hooks, and a session manager snapshots `agent.messages` from there,
+        // so a restore that ran afterwards would come too late for the store.
+        // Idempotent when the hook already ran. Python restores from the same
+        // teardown `finally`.
+        restoreTransientModelContext(strandsAgent);
         try {
           await agentStream.return(undefined as never);
         } catch {
@@ -5293,6 +5348,26 @@ export class StrandsAgent {
       // anything citations introduce.
       const citations = new CitationAccumulator(this._log);
 
+      // The application's context, shown to each leaf agent's model for one
+      // call and withdrawn again, as on the single-agent path. Hooks go on the
+      // leaves because that is where the model calls are; the orchestrator
+      // itself makes none. An orchestrator with no reachable leaf (a
+      // hand-rolled one, a remote node) can only receive context in its task
+      // input, so the block is prefixed onto the prompt instead and cleared,
+      // which is Python's fallback too. Python additionally refuses that
+      // fallback during an interrupt resume; this path has no resume arm, so
+      // there is nothing here to refuse.
+      let contextBlock = formatAguiContext(
+        normalizeAguiContext(inputData.context),
+      );
+      const installedHooks = installOrchestratorContextHooks(
+        this._orchestrator,
+      );
+      if (contextBlock && installedHooks === 0) {
+        prompt = `${contextBlock}\n\n${prompt}`;
+        contextBlock = "";
+      }
+
       const orchestratorStream = this._orchestrator!.stream(prompt);
       // A throw out of this stream reaches the outer handler below and is
       // reported as STRANDS_ERROR, not under the forced-stop code the
@@ -5325,7 +5400,10 @@ export class StrandsAgent {
       // another is FAILED too. What a partially failed Graph owes a client is a
       // design question, not missing plumbing. See `ARCHITECTURE.md`.
       try {
-        for await (const rawEvent of _foreignStreamFaults(orchestratorStream)) {
+        for await (const rawEvent of _foreignStreamFaults(
+          orchestratorStream,
+          contextBlock,
+        )) {
           const event = unwrapStrandsEvent(rawEvent);
           const kind = getEventKind(event);
 
@@ -5484,6 +5562,12 @@ export class StrandsAgent {
           }
         }
       } finally {
+        // A leaf abandoned mid-model-call never reached its after-hook; take
+        // the block back off every hooked leaf before the drain, because
+        // returning the stream runs each leaf's after-invocation hooks and a
+        // session manager snapshots the leaf's `messages` from there. Python's
+        // `_restore_orchestrator_context` runs from the same teardown.
+        restoreOrchestratorContext(this._orchestrator);
         try {
           await orchestratorStream.return(undefined as never);
         } catch {

--- a/integrations/aws-strands/typescript/src/model-context.ts
+++ b/integrations/aws-strands/typescript/src/model-context.ts
@@ -1,0 +1,398 @@
+/**
+ * Request-scoped model context for the AWS Strands bridge.
+ *
+ * `RunAgentInput.context` is what the application knew at the moment the user
+ * asked: the selected record, the locale, whatever `useCopilotReadable`
+ * published. The bridge already hands it to tools and hooks through
+ * `buildContextExtras` and to the A2UI subagent through `planA2UIInjection`,
+ * but nothing put it in front of the model itself, so context the app
+ * injected was invisible to the LLM. This module renders it as one text block
+ * and shows that block to the model for exactly one call, never persisting
+ * it. It is the counterpart of the Python bridge's `_format_agui_context`,
+ * `_MODEL_CONTEXT_BLOCK` and `_TransientModelContextHook`, and every
+ * observable choice below (block wording, placement, restore) is kept in step
+ * with that side so both bridges send the same prompt for the same input.
+ *
+ * Two constraints shape the design:
+ *
+ * 1. The block is request-scoped, and two threads can be in flight in one
+ *    process, so nothing module-level and mutable may carry it. Python uses a
+ *    `ContextVar`; the direct Node analogue is `AsyncLocalStorage`, which
+ *    follows the async continuation chain rather than the module. The store
+ *    is set around each pull of the Strands stream, exactly as Python's
+ *    `_stream_with_model_context` sets and resets its token around each
+ *    `__anext__`, so every continuation the SDK schedules while serving that
+ *    pull (the model call, the hooks around it) inherits the run's block and
+ *    nothing outside the pull does.
+ *
+ * 2. The block must reach the model without reaching the durable
+ *    conversation: not `agent.messages` after the call, not a
+ *    `MESSAGES_SNAPSHOT`, not the session store. So it is spliced into
+ *    `agent.messages` from a `BeforeModelCallEvent` hook and spliced back out
+ *    from the paired `AfterModelCallEvent` hook, with the run-loop teardown as
+ *    a second restore for the cancellation path where the after-hook never
+ *    fires. The mutation is recorded per agent in a `WeakMap`, the TS
+ *    counterpart of the marker attribute Python sets on the agent instance.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import {
+  AfterModelCallEvent,
+  BeforeModelCallEvent,
+  Message as StrandsMessage,
+  TextBlock,
+} from "@strands-agents/sdk";
+import { splitA2UISchemaContext } from "@ag-ui/a2ui-toolkit";
+
+/** One `RunAgentInput.context` entry, flattened to the two fields the block reads. */
+export interface AguiContextEntry {
+  description: unknown;
+  value: unknown;
+}
+
+/**
+ * First line of the block, matched literally by the Python bridge's tests and
+ * by anyone diffing the two bridges' prompts. Changing it is a parity change.
+ */
+export const MODEL_CONTEXT_HEADER = "Context provided by the application:";
+
+/**
+ * Upper bound on orchestrator nesting the hook installer will descend, the
+ * same cap as Python's `_MAX_MULTIAGENT_NESTING`. A `Graph` can hold a
+ * `Graph`, and a cycle built by hand would otherwise recurse without end.
+ */
+export const MAX_MULTIAGENT_NESTING = 10;
+
+/**
+ * Flatten wire context into `{description, value}` pairs, defaulting both to
+ * `""`, as Python's `_normalize_agui_context` does for the dict shape the
+ * wire carries. A field that is present but `null` stays `null` so the block
+ * renders it the way `json.dumps(None)` would.
+ */
+export function normalizeAguiContext(context: unknown): AguiContextEntry[] {
+  if (!Array.isArray(context)) return [];
+  const normalized: AguiContextEntry[] = [];
+  for (const entry of context) {
+    const record =
+      entry !== null && typeof entry === "object"
+        ? (entry as Record<string, unknown>)
+        : {};
+    normalized.push({
+      description: "description" in record ? record.description : "",
+      value: "value" in record ? record.value : "",
+    });
+  }
+  return normalized;
+}
+
+/**
+ * Render context as the text block the model sees, byte for byte what the
+ * Python bridge's `_format_agui_context` renders: one `- description: value`
+ * line per entry (`- value` when the description is blank), non-string values
+ * JSON-serialized, and `""` when nothing is left to say.
+ *
+ * The A2UI component-schema entry is excluded through the shared toolkit's
+ * `splitA2UISchemaContext`, so both bridges agree on which entry that is: it
+ * feeds the `generate_a2ui` path and would only bloat the prompt here.
+ *
+ * `JSON.stringify` and `json.dumps` agree on strings, integers, booleans and
+ * `null`, which is what a lax caller can realistically send in a field the
+ * wire types as a string. They disagree on the shapes the wire never carries:
+ * objects and arrays (`json.dumps` puts a space after `,` and `:`), integral
+ * floats (`1.0` against `1`) and non-ASCII text (`json.dumps` escapes it).
+ * Those are left to differ rather than papered over with a Python emulation.
+ */
+export function formatAguiContext(context: AguiContextEntry[]): string {
+  const [, regularContext] = splitA2UISchemaContext(
+    context as unknown as Array<Record<string, unknown>>,
+  );
+  const lines: string[] = [];
+  for (const entry of regularContext) {
+    const rawDescription = entry.description;
+    const description =
+      rawDescription === null || rawDescription === undefined
+        ? ""
+        : String(rawDescription).trim();
+    const value = entry.value;
+    const valueText =
+      typeof value === "string"
+        ? value
+        : JSON.stringify(value === undefined ? "" : value);
+    lines.push(
+      description ? `- ${description}: ${valueText}` : `- ${valueText}`,
+    );
+  }
+  if (lines.length === 0) return "";
+  return `${MODEL_CONTEXT_HEADER}\n${lines.join("\n")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Request-scoped carrier
+// ---------------------------------------------------------------------------
+
+/**
+ * The block for the run currently pulling the Strands stream, or `undefined`
+ * outside any pull. Read only by the before-model-call hook below.
+ */
+const modelContextBlock = new AsyncLocalStorage<string>();
+
+/**
+ * Pull one event from a Strands stream with `contextBlock` in scope.
+ *
+ * This is the TS `_stream_with_model_context`: the store is entered for the
+ * duration of one `next()` and left again before the event is handed back to
+ * the run loop, so the block is visible to the SDK while it serves the pull
+ * and to nothing that runs between pulls. Both run loops pull through here.
+ * An empty block skips the store entirely so a run with no context costs
+ * nothing and, more to the point, cannot see a block another run set.
+ */
+export function pullWithModelContext<T, R>(
+  iterator: AsyncIterator<T, R>,
+  contextBlock: string,
+): Promise<IteratorResult<T, R>> {
+  if (!contextBlock) return iterator.next();
+  return modelContextBlock.run(contextBlock, () => iterator.next());
+}
+
+// ---------------------------------------------------------------------------
+// Model-call-only injection
+// ---------------------------------------------------------------------------
+
+/**
+ * What the before-hook did to `agent.messages`, so the after-hook and the
+ * teardown can undo exactly that. `insert` added a whole user message at
+ * `index`; `prepend` added one text block to the front of an existing user
+ * turn's `content`. Both hold the inserted object so the restore removes by
+ * identity rather than by position, in case the SDK moved things meanwhile.
+ */
+type ContextMutation =
+  | {
+      kind: "insert";
+      messages: unknown[];
+      index: number;
+      inserted: StrandsMessage;
+    }
+  | { kind: "prepend"; content: unknown[]; inserted: TextBlock };
+
+/** Agents that already carry the hook pair, so a re-run installs nothing. */
+const hookedAgents = new WeakSet<object>();
+
+/** The in-flight mutation per agent; absent between model calls. */
+const mutations = new WeakMap<object, ContextMutation>();
+
+type MessagesOwner = { messages?: unknown };
+
+/**
+ * Whether a content block is a tool result. Seeded history reaches the agent
+ * as ContentBlock instances, which carry a `type` discriminant; the
+ * plain-object form carries the `toolResult` key itself. Both shapes occur,
+ * and the run loop's own tail check reads them the same way.
+ */
+function isToolResultBlock(block: unknown): boolean {
+  if (block === null || typeof block !== "object") return false;
+  const record = block as { toolResult?: unknown; type?: unknown };
+  return record.toolResult !== undefined || record.type === "toolResultBlock";
+}
+
+/**
+ * Place the run's block in front of the model, mirroring Python's
+ * `_TransientModelContextHook._before_model_call` case for case:
+ *
+ * - No user message at all: append the block as a new user turn.
+ * - The latest user turn carries a tool result: prepend the block into that
+ *   same turn. A separate user message between an assistant `toolUse` and its
+ *   `toolResult` is a shape providers reject, so the block rides inside.
+ * - Otherwise: insert the block as its own user message immediately BEFORE
+ *   the latest user turn. The actual latest turn stays byte-identical for
+ *   model routers and fixtures that key off it, while live UI context lands
+ *   next to the question it belongs to rather than at the head of stale
+ *   history.
+ */
+function injectModelContext(event: BeforeModelCallEvent): void {
+  const contextBlock = modelContextBlock.getStore();
+  if (!contextBlock) return;
+  const agent = event.agent as unknown as MessagesOwner;
+  if (mutations.has(agent)) {
+    // A second before-hook with the first still in place means an after-hook
+    // or a teardown was skipped. Persisting that would leak the block into the
+    // durable conversation, which is the one thing this module exists to
+    // prevent, so it fails loudly instead. Same message as Python.
+    throw new Error("Transient AG-UI model context was not restored");
+  }
+  const messages = agent.messages;
+  if (!Array.isArray(messages)) return;
+
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if ((messages[index] as { role?: unknown } | undefined)?.role === "user") {
+      latestUserIndex = index;
+      break;
+    }
+  }
+  const contextMessage = new StrandsMessage({
+    role: "user",
+    content: [new TextBlock(contextBlock)],
+  });
+
+  if (latestUserIndex < 0) {
+    messages.push(contextMessage);
+    mutations.set(agent, {
+      kind: "insert",
+      messages,
+      index: messages.length - 1,
+      inserted: contextMessage,
+    });
+    return;
+  }
+
+  const latestUser = messages[latestUserIndex] as { content?: unknown };
+  const content = latestUser.content;
+  if (Array.isArray(content) && content.some(isToolResultBlock)) {
+    const inserted = new TextBlock(contextBlock);
+    content.unshift(inserted);
+    mutations.set(agent, { kind: "prepend", content, inserted });
+    return;
+  }
+
+  messages.splice(latestUserIndex, 0, contextMessage);
+  mutations.set(agent, {
+    kind: "insert",
+    messages,
+    index: latestUserIndex,
+    inserted: contextMessage,
+  });
+}
+
+/** Remove `target` from `list` by identity, trying `hint` first. */
+function removeByIdentity(
+  list: unknown[],
+  target: unknown,
+  hint: number,
+): void {
+  const at = list[hint] === target ? hint : list.indexOf(target);
+  if (at >= 0) list.splice(at, 1);
+}
+
+/**
+ * Undo an in-flight context mutation on `agent`, if there is one.
+ *
+ * Called from the after-model-call hook on the normal path and from the run
+ * loop's teardown on the cancellation path, where the model call was
+ * abandoned and the after-hook never fired. Idempotent, so both may run.
+ * The recorded array is searched first; the agent's live `messages` is
+ * searched as well in case the SDK swapped the array in between, so the
+ * inserted turn cannot survive in a copy the record does not know about.
+ */
+export function restoreTransientModelContext(agent: unknown): void {
+  if (agent === null || typeof agent !== "object") return;
+  const mutation = mutations.get(agent);
+  if (!mutation) return;
+  mutations.delete(agent);
+  if (mutation.kind === "prepend") {
+    removeByIdentity(mutation.content, mutation.inserted, 0);
+    return;
+  }
+  removeByIdentity(mutation.messages, mutation.inserted, mutation.index);
+  const live = (agent as MessagesOwner).messages;
+  if (Array.isArray(live) && live !== mutation.messages) {
+    removeByIdentity(live, mutation.inserted, mutation.index);
+  }
+}
+
+type AddHook = (
+  eventType: unknown,
+  callback: (event: never) => void,
+) => unknown;
+
+/**
+ * Install the model-only context hook pair once on a Strands agent.
+ *
+ * Returns `false` when `agent` exposes no `addHook`, which is the TS shape of
+ * Python's "no `hooks.add_hook`" answer: a real `Agent` always has one, a
+ * remote or hand-rolled `InvokableAgent` may not. The caller decides what a
+ * `false` means; with a non-empty block it is a run the bridge cannot honour.
+ */
+export function ensureTransientContextHook(agent: unknown): boolean {
+  if (agent === null || typeof agent !== "object") return false;
+  if (hookedAgents.has(agent)) return true;
+  const addHook = (agent as { addHook?: unknown }).addHook;
+  if (typeof addHook !== "function") return false;
+  (addHook as AddHook).call(agent, BeforeModelCallEvent, injectModelContext);
+  (addHook as AddHook).call(
+    agent,
+    AfterModelCallEvent,
+    (event: AfterModelCallEvent) => restoreTransientModelContext(event.agent),
+  );
+  hookedAgents.add(agent);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrators
+// ---------------------------------------------------------------------------
+
+/**
+ * The node map of a `Graph` or `Swarm`, or `undefined` for anything that does
+ * not expose one. `ReadonlyMap` is a `Map` at runtime; Python's `dict` check
+ * is the same gate.
+ */
+function orchestratorNodes(
+  orchestrator: unknown,
+): Iterable<unknown> | undefined {
+  const nodes = (orchestrator as { nodes?: unknown } | null)?.nodes;
+  return nodes instanceof Map ? nodes.values() : undefined;
+}
+
+/**
+ * Install the hook pair on every leaf agent an orchestrator exposes, and
+ * return how many took it. The Python SDK hangs both an agent and a nested
+ * orchestrator off `node.executor`; the TS SDK gives `AgentNode` an `.agent`
+ * and `MultiAgentNode` an `.orchestrator`, so both are read. A leaf that
+ * refuses the hook is not counted, which lets the caller fall back to the
+ * prompt when nothing at all could take it.
+ */
+export function installOrchestratorContextHooks(
+  orchestrator: unknown,
+  depth = 0,
+): number {
+  if (depth > MAX_MULTIAGENT_NESTING) return 0;
+  const nodes = orchestratorNodes(orchestrator);
+  if (!nodes) return 0;
+  let installed = 0;
+  for (const node of nodes) {
+    const record = node as { agent?: unknown; orchestrator?: unknown } | null;
+    if (ensureTransientContextHook(record?.agent)) {
+      installed += 1;
+    } else {
+      installed += installOrchestratorContextHooks(
+        record?.orchestrator,
+        depth + 1,
+      );
+    }
+  }
+  return installed;
+}
+
+/**
+ * Restore transient context on every hooked leaf under an orchestrator. The
+ * orchestrator teardown calls this so a run abandoned mid-model-call leaves
+ * no leaf carrying the block.
+ */
+export function restoreOrchestratorContext(
+  orchestrator: unknown,
+  depth = 0,
+): void {
+  if (depth > MAX_MULTIAGENT_NESTING) return;
+  const nodes = orchestratorNodes(orchestrator);
+  if (!nodes) return;
+  for (const node of nodes) {
+    const record = node as { agent?: unknown; orchestrator?: unknown } | null;
+    const leaf = record?.agent;
+    if (leaf !== null && typeof leaf === "object" && hookedAgents.has(leaf)) {
+      restoreTransientModelContext(leaf);
+    } else {
+      restoreOrchestratorContext(record?.orchestrator, depth + 1);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Brings the TypeScript AWS Strands bridge to parity with the Python bridge on forwarding `RunAgentInput.context` to the model.

Until now the TypeScript bridge handed context to tools and hooks (`buildContextExtras`) and to the A2UI subagent, but nothing put it in front of the model, so whatever the application published through `useCopilotReadable` was invisible to the LLM. Python has done this for a while; this PR implements the same contract in TypeScript, matching Python's observable behaviour rather than its plumbing.

## What the model sees

The context entries are rendered as one text block:

```
Context provided by the application:
- description: value
- description: value
```

The A2UI component-schema entry is excluded through the shared toolkit's `splitA2UISchemaContext`, because the `generate_a2ui` path already carries it. The block is shown to the model for exactly one call and is never persisted: it does not reach `agent.messages` after the call, a `MESSAGES_SNAPSHOT`, or the session store.

Placement mirrors Python case for case:

- normally, the block is inserted as its own user message immediately before the latest user turn, so that turn stays byte-identical for model routers and fixtures that key off it;
- when the latest user turn carries a tool result, the block is prepended into that turn's content (a separate user message between a `toolUse` and its `toolResult` is a shape providers reject);
- when there is no user turn at all, the block is appended.

## How it is carried

- `model-context.ts` (new): block rendering, the request-scoped carrier, the `BeforeModelCallEvent` / `AfterModelCallEvent` hook pair, restore, and the orchestrator walkers.
- The carrier is `AsyncLocalStorage`, the Node analogue of Python's `ContextVar`. It is entered around each pull of the Strands stream (`pullWithModelContext`), exactly as Python's `_stream_with_model_context` sets and resets its token around each `__anext__`, so two runs in flight in one process cannot see each other's block. Covered by an interleaved two-thread test.
- The mutation is recorded per agent in a `WeakMap` and undone from the after-hook on the normal path and from both run loops' teardown `finally` on the cancellation path, where the after-hook never fires. The teardown restore runs before the stream is returned, because returning the Strands stream runs the after-invocation hooks and a session manager snapshots `agent.messages` from there; a restore after the drain would come too late for the store. A session-manager cancellation test covers that ordering. The restore runs before the session manager can save: the SDK runs `AfterModelCallEvent` callbacks in reverse registration order, the bridge registers its pair after the session manager (at first run rather than at construction), and the assistant message is only appended, and so only persisted, after the after-hooks have returned.
- Single-agent loop: the hook pair is installed once per agent; a non-empty block on an agent with no hook registry ends the run with a `RUN_ERROR`, as in Python.
- Orchestrator loop: the hook pair goes on every reachable leaf agent (`AgentNode.agent`, recursing through `MultiAgentNode.orchestrator`, depth-capped like `_MAX_MULTIAGENT_NESTING`). An orchestrator with no reachable leaf gets the block prefixed onto its prompt instead, which is Python's fallback too.

## Also ported: A2UI render-guide exclusion

While comparing prompts I found a pre-existing drift in the same area. Once A2UI auto-injection replaces the middleware's `render_a2ui` proxy with `generate_a2ui`, Python drops the middleware's usage guide for that proxy from both the model context and the recovery subagent's context (`_without_a2ui_render_guides`). TypeScript had no equivalent. This PR adds `withoutA2UIRenderGuides` and applies it at both sites, so the two bridges produce the same prompt with A2UI on as well as off. The `planA2UIInjection` state build is extracted into `buildA2UISubagentState` for that.

## Where the two bridges still cannot produce the same prompt

1. **Non-string context values.** The wire types `Context.value` as a string, so these only arrive from lax callers. `JSON.stringify` and `json.dumps` agree on strings, integers, booleans and `null`. They disagree on objects and arrays (`json.dumps` inserts a space after `,` and `:`), integral floats (`1.0` against `1`) and non-ASCII text (`json.dumps` escapes it). Left to differ rather than emulating Python's serializer in TypeScript; noted on `formatAguiContext`.
2. **Orchestrator resume refusal.** Python refuses the prompt-prefix fallback during an interrupt resume. The TypeScript orchestrator path has no resume arm at all (pre-existing), so there is no path on which to refuse.
3. **Tool-result-turn mutation shape (not prompt-visible).** Python swaps the turn's `content` list and swaps the original back; TypeScript unshifts a `TextBlock` into the existing array and removes it by identity. The model sees the same bytes.

## Tests

`context-forwarding.test.ts` (24 tests) mirrors `tests/test_context_forwarding.py` case for case at the real model boundary (a scripted model records the exact history the SDK handed it), then covers the arms Python leaves to other suites: the tool-result turn, cancellation mid-model-call (in memory and at the session manager's save point), two interleaved runs, the orchestrator leaf path and its prompt fallback, the refusal on an agent with no hook registry, and the render-guide exclusion.

- `integrations/aws-strands/typescript`: `pnpm test` 77 files, 1635 tests passed; `pnpm typecheck` clean; `pnpm build` clean.
- `integrations/aws-strands/python`: `pytest tests/ -q` 1270 passed, no Python file touched.

`ARCHITECTURE.md` gains a "Model context" bullet that applies to both bridges and records divergence 2.
