### PR TITLE
test(aws-strands): bind the test servers to the address the probes dial

### DIFF
--- a/integrations/aws-strands/typescript/src/__tests__/disconnect-unhandled-rejection.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/disconnect-unhandled-rejection.test.ts
@@ -42,7 +42,7 @@ describe("endpoint disconnect + throwing generator finally", () => {
     app.use(express.json({ limit: "1mb" }));
     addStrandsExpressEndpoint(app, agent, { path: "/" });
     const server = await new Promise<import("http").Server>((resolve) => {
-      const s = app.listen(0, () => resolve(s));
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
     });
     const port = (server.address() as AddressInfo).port;
 

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-accept.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-accept.test.ts
@@ -49,7 +49,7 @@ async function startApp(): Promise<{
     { path: "/" },
   );
   const server = await new Promise<import("http").Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port;
   return {

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-capabilities.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-capabilities.test.ts
@@ -17,7 +17,7 @@ async function startApp(configure: (app: express.Express) => void): Promise<{
   app.use(express.json({ limit: "1mb" }));
   configure(app);
   const server = await new Promise<import("http").Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port;
   return {

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-disconnect.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-disconnect.test.ts
@@ -59,7 +59,7 @@ async function startApp(agent: StrandsAgent): Promise<{
   app.use(express.json({ limit: "1mb" }));
   addStrandsExpressEndpoint(app, agent, { path: "/" });
   const server = await new Promise<import("http").Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port;
   return {

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint-validation.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint-validation.test.ts
@@ -62,7 +62,7 @@ async function startApp(): Promise<{
   const agent = new RecordingStrandsAgent();
   addStrandsExpressEndpoint(app, agent, { path: "/" });
   const server = await new Promise<import("http").Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port;
   return {

--- a/integrations/aws-strands/typescript/src/__tests__/endpoint.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/endpoint.test.ts
@@ -50,7 +50,7 @@ async function startApp(agent: StrandsAgent): Promise<{
   addStrandsExpressEndpoint(app, agent, { path: "/" });
   addPing(app, "/ping");
   const server = await new Promise<import("http").Server>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
   });
   const port = (server.address() as AddressInfo).port;
   return {

--- a/integrations/aws-strands/typescript/src/__tests__/terminal-error-paths.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/terminal-error-paths.test.ts
@@ -439,7 +439,7 @@ describe("terminal error paths", () => {
       app.use(express.json({ limit: "10mb" }));
       addStrandsExpressEndpoint(app, new UnencodableAgent(), { path: "/" });
       const server = await new Promise<import("http").Server>((resolve) => {
-        const s = app.listen(0, () => resolve(s));
+        const s = app.listen(0, "127.0.0.1", () => resolve(s));
       });
       const port = (server.address() as AddressInfo).port;
 

--- a/integrations/aws-strands/typescript/src/__tests__/transport-harness.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/transport-harness.test.ts
@@ -27,16 +27,32 @@ function appThatFailsToBind(failure: Error): Express {
   } as unknown as Express;
 }
 
-/** An app that binds successfully, exposing the emitter the harness wires up. */
-function appThatBinds(): { app: Express; emitter: EventEmitter } {
+/**
+ * An app that binds successfully, exposing the emitter the harness wires up
+ * and the arguments it was asked to bind with.
+ */
+function appThatBinds(): {
+  app: Express;
+  emitter: EventEmitter;
+  boundTo: () => { port: number; host: string };
+} {
   const emitter = new EventEmitter();
+  let bound: { port: number; host: string } | undefined;
   const app = {
-    listen: (_port: number, onListening: () => void) => {
+    listen: (port: number, host: string, onListening: () => void) => {
+      bound = { port, host };
       setImmediate(onListening);
       return emitter;
     },
   } as unknown as Express;
-  return { app, emitter };
+  return {
+    app,
+    emitter,
+    boundTo: () => {
+      if (!bound) throw new Error("listen was never called");
+      return bound;
+    },
+  };
 }
 
 describe("listen reports a bind failure instead of hanging", () => {
@@ -59,6 +75,17 @@ describe("listen reports a bind failure instead of hanging", () => {
       new Promise((resolve) => setTimeout(() => resolve("still pending"), 500)),
     ]);
     expect(settled).toBe(failure);
+  });
+
+  // The probes all dial `127.0.0.1`, and an unspecified host binds the IPv6
+  // wildcard instead. A process already holding the IPv4 wildcard on the port
+  // the kernel hands out then answers those probes in this server's place, so
+  // dropping the host does not fail here or anywhere obvious: it hands a
+  // stranger's reply to whichever suite drew the colliding number.
+  it("binds the loopback address the probes dial, not the wildcard", async () => {
+    const { app, boundTo } = appThatBinds();
+    await listen(app);
+    expect(boundTo()).toEqual({ port: 0, host: "127.0.0.1" });
   });
 
   it("does not absorb a post-bind server error into the settled promise", async () => {

--- a/integrations/aws-strands/typescript/src/__tests__/transport-harness.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/transport-harness.ts
@@ -53,7 +53,17 @@ export interface StartedApp {
 }
 
 /**
- * Bind an app to an ephemeral port.
+ * Bind an app to an ephemeral port on the IPv4 loopback.
+ *
+ * The address is pinned because every probe below dials `127.0.0.1`, and an
+ * unspecified host binds the IPv6 wildcard instead. That pair is not the same
+ * port: an unrelated process already holding the IPv4 wildcard on the number
+ * the kernel hands out keeps receiving the loopback traffic, so the probe is
+ * answered by that process while this server never sees a connection. It
+ * reaches the suite as whatever that stranger happens to reply -- a foreign
+ * status and body, an HTTP parse error, or a bare close -- on whichever test
+ * drew the colliding number. Binding the loopback explicitly takes precedence
+ * over a wildcard holder, so the probe reaches this app or nothing at all.
  *
  * Two failure modes, and each needs its own handler. A bind failure
  * (EADDRINUSE, a permission denial) arrives before the promise settles, so it
@@ -68,7 +78,7 @@ export function listen(
   app: import("express").Express,
 ): Promise<import("http").Server> {
   return new Promise((resolve, reject) => {
-    const server = app.listen(0, () => {
+    const server = app.listen(0, "127.0.0.1", () => {
       server.removeListener("error", reject);
       // Thrown synchronously out of `emit`, which surfaces it as an uncaught
       // exception and fails the run. Loud beats lost for a server fault the


### PR DESCRIPTION
## The flake

`integrations/aws-strands/typescript/src/__tests__/cors.test.ts` failed roughly one run in six when the machine was under load. The failure moved around between runs, which is why it read as several unrelated problems:

- a CORS header with the wrong value, or absent entirely
- `agent.runs` still `0` after a POST that returned a response
- `HTTPParserError: Response does not match the HTTP/1.1 protocol` whose payload was `{"type":"Tier1","version":"1.0"}`, a body no route in this package emits
- `SocketError: other side closed` with `bytesWritten: 334, bytesRead: 0`

All four are the same defect.

## Root cause

`app.listen(0)` with no host binds the IPv6 wildcard (`::`). Every probe in these suites dials `127.0.0.1`, an IPv4 address. Those are not the same port.

When an unrelated process already holds the IPv4 wildcard on the port number the kernel hands out, that process keeps receiving the loopback traffic and answers the probe. The test's own server never sees a connection, so it emits no `connection` event and its agent never runs. What the suite asserts on is whatever the stranger happened to reply.

`lsof` at the moment of failure, captured by a stress harness:

```
COMMAND   PID USER   FD   TYPE   DEVICE   SIZE/OFF NODE NAME
Spotify   855  ran  214u  IPv4   0xb8e...      0t0  TCP *:52655 (LISTEN)
node    38136  ran   13u  IPv6   0x649...      0t0  TCP *:52655 (LISTEN)
```

Two listeners on one port number, one per address family. The `{"type":"Tier1","version":"1.0"}` body in the parser error is that other process's local API answering, not anything this package serves.

Reproduced deliberately with a stand-in process holding the IPv4 wildcard, which isolates the mechanism from any particular application being installed:

```
--- unspecified host (previous harness behaviour) ---
our bind ok: {"address":"::","family":"IPv6","port":56613}
fetch 127.0.0.1:56613 -> {"type":"Tier1","version":"1.0"}   (our server saw request: false)

--- 127.0.0.1 host ---
our bind ok: {"address":"127.0.0.1","family":"IPv4","port":56616}
fetch 127.0.0.1:56616 -> {"whoami":"ours"}                  (our server saw request: true)
```

This also explains why no listen port was ever duplicated inside the test process, and why the collision rate tracks machine load: the more of the ephemeral range is churning, the likelier a test draws a number some other process is already sitting on.

## The change

Pin the bind address to `127.0.0.1` in the shared transport harness and in the seven sibling suites that bound the same way. A specific bind takes precedence over a wildcard holder, so a probe now reaches its own app or nothing at all.

The harness self-test gains an assertion on the bind address, so dropping the host fails there rather than reappearing silently as a flake in an unrelated suite.

No behaviour under test changes: no assertion is weakened, no retry or timeout is added, and no runtime string, error code, or logged message is touched.

## Verification

- A stress rig cycling the real harness (bind, POST, `/capabilities`, preflight, close) failed 3 times in 2000 cycles before the change and ran 6000 cycles clean after it, both under ten busy cores.
- 35 consecutive green runs of `cors.test.ts` under load, then 32 more after the self-test was added.
- Full package suite green: 76 files, 1612 tests.
- `tsc --noEmit` clean; Prettier clean on every changed file.

Unrelated to the documentation-contract work in #2620.
