### PR TITLE
ci(dojo): run the A2UI dojo config test

### DIFF
--- a/.github/workflows/dojo-e2e.yml
+++ b/.github/workflows/dojo-e2e.yml
@@ -88,6 +88,44 @@ jobs:
             exit 1
           fi
 
+  a2ui-config-unit:
+    name: dojo / a2ui-config-unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
+        with:
+          version: 10.33.4
+
+      # This test cannot use the install-free npx form the CrewAI config test
+      # uses next to `check-generated-files`: it loads @ag-ui/a2ui-middleware
+      # and @ag-ui/core from node_modules, so the workspace has to be installed
+      # and those dists built before it can run. Hence its own job rather than
+      # a step on the gate that fans out to the matrix below.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build A2UI middleware
+        run: pnpm exec nx run-many -t build -p @ag-ui/a2ui-middleware
+
+      # Mirrors the `test:a2ui-config` package script. Guards that every dojo
+      # A2UIMiddleware wiring forwards the rendered dynamic catalog, not just
+      # the tool and the catalog id: without the schema the model is asked to
+      # generate A2UI and never told which components exist.
+      - name: Validate A2UI dojo config (dynamic catalog forwarding)
+        working-directory: apps/dojo
+        run: pnpm test:a2ui-config
+
   event-trace-unit:
     name: dojo / event-trace-unit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this adds

A CI job that runs `apps/dojo/src/a2ui-config.test.ts`.

## Why

PR #2372 fixed a real bug: four `A2UIMiddleware` wirings in `apps/dojo/src/agents.ts` passed `injectA2UITool` and a `defaultCatalogId` but no `schema`, and `injectSchemaContext` in the middleware returns the input untouched when `config.schema` is absent. The model was told to generate A2UI and never told which components exist.

That PR shipped a behavioural test for it, plus a `test:a2ui-config` package script. It shipped no CI step, and nothing else picked either of them up:

- No workflow referenced `a2ui-config` or `test:a2ui-config`.
- `apps/dojo/package.json` has no plain `test` script, only the two `test:*` ones, so the repo-wide Nx `test` target has nothing to run for this project. `nx.json`'s `targetDefaults.test` only sets caching and `dependsOn`, and `@nx/js` does not infer a test target from `*.test.ts`.
- There is no vitest or jest config under `apps/dojo`.

The guard existed and nothing pulled the trigger.

## What the test guards

That every dojo `A2UIMiddleware` wiring forwards the rendered dynamic catalog, not just the tool and the catalog id. It runs the middleware against a capturing downstream agent and asserts the A2UI schema context reaches `input.context`, with the catalog id and component keys matching `dynamicSchemaCatalog` and `HotelCard`'s generated properties present.

## Revert check

The test does catch the regression it claims to. With `schema` removed from `DOJO_A2UI_MIDDLEWARE_CONFIG` in `apps/dojo/src/a2ui-config.ts`, leaving the `{ injectA2UITool: true, defaultCatalogId }` shape the call sites had before #2372:

```
# Subtest: Dojo A2UI middleware forwards the rendered dynamic catalog
not ok 1 - Dojo A2UI middleware forwards the rendered dynamic catalog
  ---
  failureType: 'testCodeFailure'
  error: 'dynamic catalog schema must reach downstream agent context'
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  operator: '=='
  ...
# pass 0
# fail 1
```

Restoring `schema` returns it to `# pass 1 / # fail 0`.

## Why a separate job, not a step on `check-generated-files`

The natural place would have been next to the `test:crewai-config` step on `check-generated-files`, which runs `npx tsx --test src/crewai.test.ts` with no install at all. That form does not work for this test.

`src/crewai.test.ts` only imports local modules, so it runs on a bare checkout (verified: 6 passing tests with no `node_modules` present). `src/a2ui-config.test.ts` imports `@ag-ui/client`, `@ag-ui/a2ui-middleware` and `rxjs`. On a bare checkout it dies resolving a transitive runtime dependency:

```
Error: Cannot find module 'uuid'
Require stack:
- sdks/typescript/packages/client/src/utils.ts
```

and with the workspace installed but not built, it dies on the unbuilt dist, because `@ag-ui/client` is path-mapped to source in `apps/dojo/tsconfig.json` while `@ag-ui/core` is not:

```
Error: Cannot find module 'sdks/typescript/packages/client/node_modules/@ag-ui/core/dist/index.js'
```

So it needs an install and a build. `check-generated-files` has no install step, and 24 matrix jobs gate on it via `needs:`, so adding a full workspace install plus a build there would delay all of them. The new job stands alone alongside the existing `event-trace-unit` unit job instead.

Verified sequence, run from clean dists:

```
pnpm install --frozen-lockfile
pnpm exec nx run-many -t build -p @ag-ui/a2ui-middleware   # builds it and 6 dependency tasks
cd apps/dojo && pnpm test:a2ui-config                       # 1 pass, 0 fail
```

`actionlint .github/workflows/dojo-e2e.yml` exits 0, and the file parses with the new job in place.
