### PR TITLE
fix(watsonx): persist the orchestrate-issued thread_id for conversation continuity

### DIFF
--- a/integrations/watsonx/python/README.md
+++ b/integrations/watsonx/python/README.md
@@ -28,3 +28,26 @@ Run with:
 ```bash
 uvicorn main:app --port 8000
 ```
+
+## Conversation Continuity
+
+watsonx orchestrate stores conversation history server-side, keyed by a
+`thread_id` it issues in the SSE stream. The adapter captures that ID, maps it
+to the AG-UI `thread_id`, and sends it back as the `X-IBM-THREAD-ID` header on
+subsequent turns (the header is omitted on the first turn so watsonx creates
+the thread).
+
+The mapping lives in an in-memory store by default, which works as long as the
+`WatsonxAgent` instance outlives the conversation. When agent instances are
+created per-request, pass a custom store (any object with `get(thread_id)` and
+`set(thread_id, watsonx_thread_id)`, sync or async):
+
+```python
+agent = WatsonxAgent(
+    region="au-syd",
+    instance_id="your-instance-id",
+    agent_id="your-watsonx-agent-id",
+    api_key="YOUR_API_KEY",
+    thread_id_store=MyDatabaseThreadIdStore(),
+)
+```

--- a/integrations/watsonx/python/src/ag_ui_watsonx/__init__.py
+++ b/integrations/watsonx/python/src/ag_ui_watsonx/__init__.py
@@ -1,10 +1,12 @@
 """AG-UI integration for IBM watsonx orchestrate agents."""
 
-from .agent import WatsonxAgent
+from .agent import InMemoryThreadIdStore, ThreadIdStore, WatsonxAgent
 from .endpoint import add_watsonx_fastapi_endpoint
 from .utils import create_watsonx_app
 
 __all__ = [
+    "InMemoryThreadIdStore",
+    "ThreadIdStore",
     "WatsonxAgent",
     "add_watsonx_fastapi_endpoint",
     "create_watsonx_app",

--- a/integrations/watsonx/python/src/ag_ui_watsonx/agent.py
+++ b/integrations/watsonx/python/src/ag_ui_watsonx/agent.py
@@ -1,7 +1,8 @@
 """Translates between IBM watsonx orchestrate SSE and AG-UI events."""
 
-from typing import AsyncGenerator, List
+from typing import Any, AsyncGenerator, List, Protocol
 import asyncio
+import inspect
 import logging
 import time
 import uuid
@@ -37,6 +38,47 @@ logger = logging.getLogger(__name__)
 _IAM_TOKEN_URL = "https://iam.cloud.ibm.com/identity/token"
 
 
+class ThreadIdStore(Protocol):
+    """Persistence for the mapping of AG-UI thread_id to the watsonx-managed
+    thread_id. ``get``/``set`` may be sync or async."""
+
+    def get(self, thread_id: str) -> Any: ...
+
+    def set(self, thread_id: str, watsonx_thread_id: str) -> Any: ...
+
+
+class InMemoryThreadIdStore:
+    """Default store; sufficient when the agent instance lives as long as the
+    conversation. Provide a custom store (e.g. database-backed) when agent
+    instances are created per-request on a server."""
+
+    def __init__(self) -> None:
+        self._threads: dict[str, str] = {}
+
+    def get(self, thread_id: str) -> str | None:
+        return self._threads.get(thread_id)
+
+    def set(self, thread_id: str, watsonx_thread_id: str) -> None:
+        self._threads[thread_id] = watsonx_thread_id
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _messages_since_last_user(messages: list) -> list:
+    """When continuing a watsonx-managed thread, only the messages from the
+    last user message onward are new to the server (earlier context lives in
+    the thread). Keeps trailing assistant/tool messages so tool results still
+    reach watsonx."""
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].role == "user":
+            return messages[i:]
+    return messages
+
+
 class WatsonxAgent:
     def __init__(
         self,
@@ -47,6 +89,7 @@ class WatsonxAgent:
         api_key: str | None = None,
         bearer_token: str | None = None,
         name: str = "watsonx",
+        thread_id_store: ThreadIdStore | None = None,
     ):
         if not api_key and not bearer_token:
             raise ValueError(
@@ -60,6 +103,7 @@ class WatsonxAgent:
         self._token_expires_at = time.time() + 55 * 60 if bearer_token else 0
         self.name = name
         self._token_lock = asyncio.Lock()
+        self._thread_id_store: ThreadIdStore = thread_id_store or InMemoryThreadIdStore()
 
     def clone(self):
         """Create a new WatsonxAgent with the same config but fresh state.
@@ -73,6 +117,8 @@ class WatsonxAgent:
             api_key=self.api_key,
             bearer_token=self._cached_token,
             name=self.name,
+            # Share the store so the clone continues existing watsonx threads.
+            thread_id_store=self._thread_id_store,
         )
         cloned._token_expires_at = self._token_expires_at
         return cloned
@@ -131,8 +177,21 @@ class WatsonxAgent:
                     role="tool",
                 )
 
+        # watsonx orchestrate manages conversation state server-side, keyed by
+        # a thread_id it issues in the SSE stream. It ignores client-invented
+        # IDs (creating a fresh thread instead) and only acts on the last user
+        # message in the payload. So: reuse the watsonx thread_id captured
+        # from a previous run of this AG-UI thread, and when continuing, send
+        # only the messages since the last user message.
+        watsonx_thread_id = await _maybe_await(self._thread_id_store.get(thread_id))
+        request_messages = (
+            _messages_since_last_user(input_data.messages)
+            if watsonx_thread_id
+            else input_data.messages
+        )
+
         messages = []
-        for msg in input_data.messages:
+        for msg in request_messages:
             content = msg.content if isinstance(msg.content, str) else json.dumps(msg.content)
             entry: dict = {"role": msg.role, "content": content}
             if hasattr(msg, "tool_call_id") and msg.tool_call_id:
@@ -181,16 +240,22 @@ class WatsonxAgent:
             # STEP_STARTED wraps the watsonx API call
             yield StepStartedEvent(type=EventType.STEP_STARTED, step_name=step_name)
 
+            # On the first turn the header is omitted so watsonx creates the
+            # thread; its thread_id is captured from the stream and reused on
+            # later turns.
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            }
+            if watsonx_thread_id:
+                headers["X-IBM-THREAD-ID"] = watsonx_thread_id
+
             async with httpx.AsyncClient(timeout=httpx.Timeout(connect=30, read=120, write=30, pool=30)) as client:
                 async with client.stream(
                     "POST",
                     f"{self.base_url}/v1/orchestrate/{self.agent_id}/chat/completions",
                     json=body,
-                    headers={
-                        "Authorization": f"Bearer {token}",
-                        "Content-Type": "application/json",
-                        "X-IBM-THREAD-ID": thread_id,
-                    },
+                    headers=headers,
                 ) as response:
                     response.raise_for_status()
 
@@ -212,6 +277,20 @@ class WatsonxAgent:
                             event=chunk,
                             source="watsonx",
                         )
+
+                        # Persist the watsonx-managed thread_id so the next
+                        # turn continues the same server-side thread. Chunks
+                        # may carry it even when they have no choices.
+                        wx_thread_id = chunk.get("thread_id")
+                        if (
+                            isinstance(wx_thread_id, str)
+                            and wx_thread_id
+                            and wx_thread_id != watsonx_thread_id
+                        ):
+                            watsonx_thread_id = wx_thread_id
+                            await _maybe_await(
+                                self._thread_id_store.set(thread_id, wx_thread_id)
+                            )
 
                         choices = chunk.get("choices") or []
                         if not choices:

--- a/integrations/watsonx/python/tests/test_agent.py
+++ b/integrations/watsonx/python/tests/test_agent.py
@@ -6,8 +6,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ag_ui.core import EventType, RunAgentInput, UserMessage, ToolMessage as AGUIToolMessage
-from ag_ui_watsonx.agent import WatsonxAgent, _IAM_TOKEN_URL
+from ag_ui.core import (
+    AssistantMessage,
+    EventType,
+    FunctionCall,
+    RunAgentInput,
+    ToolCall,
+    ToolMessage as AGUIToolMessage,
+    UserMessage,
+)
+from ag_ui_watsonx.agent import InMemoryThreadIdStore, WatsonxAgent, _IAM_TOKEN_URL
 
 
 # ---------------------------------------------------------------------------
@@ -454,7 +462,10 @@ class TestErrorHandling:
 
 class TestRequestConstruction:
     @pytest.mark.asyncio
-    async def test_sends_thread_id_header(self):
+    async def test_omits_thread_id_header_on_first_turn(self):
+        """watsonx ignores client-invented thread IDs; the header is omitted
+        so watsonx creates the thread, and the returned thread_id is reused
+        later (see TestThreadPersistence)."""
         agent = _make_agent()
         response = _mock_stream_response(_sse_lines(_text_chunk("Hi")))
         client_ctx = _mock_httpx_client(response)
@@ -464,7 +475,7 @@ class TestRequestConstruction:
 
         mock_client = client_ctx._value
         call_kwargs = mock_client.stream.call_args[1]
-        assert call_kwargs["headers"]["X-IBM-THREAD-ID"] == "my-thread"
+        assert "X-IBM-THREAD-ID" not in call_kwargs["headers"]
         assert "Bearer " in call_kwargs["headers"]["Authorization"]
 
     @pytest.mark.asyncio
@@ -704,3 +715,161 @@ class TestToolCallResult:
 
         types = [e.type for e in events]
         assert EventType.TOOL_CALL_RESULT not in types
+
+
+# ---------------------------------------------------------------------------
+# watsonx thread persistence
+# ---------------------------------------------------------------------------
+
+def _text_chunk_with_thread(content: str, watsonx_thread_id: str) -> dict:
+    chunk = _text_chunk(content)
+    chunk["thread_id"] = watsonx_thread_id
+    return chunk
+
+
+class TestThreadPersistence:
+    async def _run(self, agent, input_data, chunks):
+        """Run the agent against a fresh mocked stream, returning call kwargs."""
+        response = _mock_stream_response(_sse_lines(*chunks))
+        client_ctx = _mock_httpx_client(response)
+        with patch("ag_ui_watsonx.agent.httpx.AsyncClient", return_value=client_ctx):
+            await _collect_events(agent, input_data)
+        return client_ctx._value.stream.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_reuses_watsonx_thread_id_on_next_run(self):
+        agent = _make_agent()
+
+        first = await self._run(
+            agent, _make_input(run_id="r-1"), [_text_chunk_with_thread("Hi", "wx-abc")]
+        )
+        second = await self._run(
+            agent, _make_input(run_id="r-2"), [_text_chunk_with_thread("More", "wx-abc")]
+        )
+
+        assert "X-IBM-THREAD-ID" not in first["headers"]
+        assert second["headers"]["X-IBM-THREAD-ID"] == "wx-abc"
+
+    @pytest.mark.asyncio
+    async def test_tracks_watsonx_thread_ids_per_agui_thread(self):
+        agent = _make_agent()
+
+        await self._run(
+            agent,
+            _make_input(thread_id="t-1"),
+            [_text_chunk_with_thread("Hi", "wx-1")],
+        )
+        second = await self._run(
+            agent, _make_input(thread_id="t-2"), [_text_chunk("Hi")]
+        )
+
+        # Second AG-UI thread is new to watsonx, so no header yet.
+        assert "X-IBM-THREAD-ID" not in second["headers"]
+
+    @pytest.mark.asyncio
+    async def test_captures_thread_id_from_chunk_without_choices(self):
+        agent = _make_agent()
+
+        await self._run(
+            agent,
+            _make_input(run_id="r-1"),
+            [{"thread_id": "wx-only"}, _text_chunk("Hi")],
+        )
+        second = await self._run(agent, _make_input(run_id="r-2"), [_text_chunk("Hi")])
+
+        assert second["headers"]["X-IBM-THREAD-ID"] == "wx-only"
+
+    @pytest.mark.asyncio
+    async def test_sends_only_messages_since_last_user_when_continuing(self):
+        agent = _make_agent()
+
+        first = await self._run(
+            agent, _make_input(run_id="r-1"), [_text_chunk_with_thread("Hi", "wx-1")]
+        )
+
+        history = [
+            UserMessage(id="m-1", role="user", content="Hello"),
+            AssistantMessage(id="a-1", role="assistant", content="Hi"),
+            UserMessage(id="m-2", role="user", content="Follow-up"),
+        ]
+        second = await self._run(
+            agent,
+            _make_input(run_id="r-2", messages=history),
+            [_text_chunk("More")],
+        )
+
+        assert len(first["json"]["messages"]) == 1
+        assert len(second["json"]["messages"]) == 1
+        assert second["json"]["messages"][0]["content"] == "Follow-up"
+
+    @pytest.mark.asyncio
+    async def test_keeps_trailing_tool_messages_when_continuing(self):
+        agent = _make_agent()
+
+        await self._run(
+            agent, _make_input(run_id="r-1"), [_text_chunk_with_thread("Hi", "wx-1")]
+        )
+
+        history = [
+            UserMessage(id="m-1", role="user", content="Weather?"),
+            AssistantMessage(
+                id="a-1",
+                role="assistant",
+                tool_calls=[
+                    ToolCall(
+                        id="tc-1",
+                        type="function",
+                        function=FunctionCall(name="get_weather", arguments="{}"),
+                    )
+                ],
+            ),
+            AGUIToolMessage(id="t-1", role="tool", content="Sunny", tool_call_id="tc-1"),
+        ]
+        second = await self._run(
+            agent,
+            _make_input(run_id="r-2", messages=history),
+            [_text_chunk("It's sunny")],
+        )
+
+        roles = [m["role"] for m in second["json"]["messages"]]
+        assert roles == ["user", "assistant", "tool"]
+
+    @pytest.mark.asyncio
+    async def test_custom_thread_id_store(self):
+        store = InMemoryThreadIdStore()
+        store.set("t-1", "wx-stored")
+        agent = _make_agent(thread_id_store=store)
+
+        first = await self._run(
+            agent, _make_input(), [_text_chunk_with_thread("Hi", "wx-new")]
+        )
+
+        assert first["headers"]["X-IBM-THREAD-ID"] == "wx-stored"
+        assert store.get("t-1") == "wx-new"
+
+    @pytest.mark.asyncio
+    async def test_async_thread_id_store(self):
+        class AsyncStore:
+            def __init__(self):
+                self.data = {"t-1": "wx-async"}
+
+            async def get(self, thread_id):
+                return self.data.get(thread_id)
+
+            async def set(self, thread_id, watsonx_thread_id):
+                self.data[thread_id] = watsonx_thread_id
+
+        store = AsyncStore()
+        agent = _make_agent(thread_id_store=store)
+
+        first = await self._run(
+            agent, _make_input(), [_text_chunk_with_thread("Hi", "wx-updated")]
+        )
+
+        assert first["headers"]["X-IBM-THREAD-ID"] == "wx-async"
+        assert store.data["t-1"] == "wx-updated"
+
+    def test_clone_shares_thread_id_store(self):
+        agent = _make_agent()
+        cloned = agent.clone()
+        assert cloned._thread_id_store is agent._thread_id_store

--- a/integrations/watsonx/typescript/README.md
+++ b/integrations/watsonx/typescript/README.md
@@ -102,6 +102,6 @@ This adapter translates between that format and the AG-UI event protocol:
 
 - `choices[0].delta.content` → `TEXT_MESSAGE_START` / `TEXT_MESSAGE_CONTENT` / `TEXT_MESSAGE_END`
 - `choices[0].delta.tool_calls` → `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END`
-- `X-IBM-THREAD-ID` header is mapped from AG-UI's `threadId` for conversation continuity
+- watsonx orchestrate manages conversation history server-side, keyed by a `thread_id` it issues in the SSE stream. The adapter captures that ID, maps it to AG-UI's `threadId`, and sends it back as the `X-IBM-THREAD-ID` header on subsequent turns (the header is omitted on the first turn so watsonx creates the thread). The mapping lives in an in-memory store by default; pass `threadIdStore` (an object with `get`/`set`, sync or async) to persist it externally when agent instances are created per-request on a server.
 
 Authentication is handled via IBM Cloud IAM. Pass an `apiKey` and the adapter exchanges it for a bearer token automatically, refreshing before expiry.

--- a/integrations/watsonx/typescript/src/__tests__/message-mapping.test.ts
+++ b/integrations/watsonx/typescript/src/__tests__/message-mapping.test.ts
@@ -298,7 +298,7 @@ describe("Message mapping", () => {
     expect(body.tools).toBeUndefined();
   });
 
-  it("sends correct headers including X-IBM-THREAD-ID and Authorization", async () => {
+  it("sends Authorization and omits X-IBM-THREAD-ID on the first turn", async () => {
     let capturedHeaders: Record<string, string> | null = null;
 
     globalThis.fetch = vi.fn().mockImplementation((url: string, opts?: any) => {
@@ -328,7 +328,10 @@ describe("Message mapping", () => {
     await collectEvents(makeAgent(), input);
 
     expect(capturedHeaders).toBeDefined();
-    expect(capturedHeaders!["X-IBM-THREAD-ID"]).toBe("my-thread-42");
+    // watsonx ignores client-invented thread IDs; the header is omitted so
+    // watsonx creates the thread, and the returned thread_id is reused later
+    // (see thread-persistence.test.ts).
+    expect(capturedHeaders!["X-IBM-THREAD-ID"]).toBeUndefined();
     expect(capturedHeaders!["Authorization"]).toBe("Bearer tok");
     expect(capturedHeaders!["Content-Type"]).toBe("application/json");
   });

--- a/integrations/watsonx/typescript/src/__tests__/thread-persistence.test.ts
+++ b/integrations/watsonx/typescript/src/__tests__/thread-persistence.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for watsonx thread lifecycle handling: capturing the watsonx-managed
+ * thread_id from the SSE stream and reusing it on subsequent runs.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { WatsonxAgent, type WatsonxThreadIdStore } from "../index";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import { firstValueFrom, toArray } from "rxjs";
+import type { RunAgentInput, Message } from "@ag-ui/core";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAgent(threadIdStore?: WatsonxThreadIdStore) {
+  return new WatsonxAgent({
+    region: "us-south",
+    instanceId: "inst-1",
+    agentId: "agent-1",
+    bearerToken: "tok",
+    threadIdStore,
+  });
+}
+
+function makeInput(overrides: Partial<RunAgentInput> = {}): RunAgentInput {
+  return {
+    threadId: "t-1",
+    runId: "r-1",
+    messages: [{ id: "m-1", role: "user", content: "Hello" } as Message],
+    state: null,
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+function textChunk(content: string, extra: Record<string, unknown> = {}) {
+  return {
+    ...extra,
+    choices: [{ delta: { content }, finish_reason: null }],
+  };
+}
+
+function sseResponse(chunks: (object | string)[]): Response {
+  const lines = chunks.map((c) =>
+    typeof c === "string" ? c : `data: ${JSON.stringify(c)}`,
+  );
+  lines.push("data: [DONE]");
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines.join("\n") + "\n"));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/**
+ * Mock fetch so every chat request gets a fresh SSE response built from
+ * `chunks`, recording headers and bodies of each chat request.
+ */
+function mockFetch(chunks: (object | string)[]) {
+  const requests: { headers: Record<string, string>; body: any }[] = [];
+  globalThis.fetch = vi.fn().mockImplementation((url: string, opts?: any) => {
+    if (typeof url === "string" && url.includes("iam.cloud.ibm.com")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          access_token: "tok",
+          expiration: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      });
+    }
+    requests.push({
+      headers: opts?.headers ?? {},
+      body: JSON.parse(opts?.body ?? "{}"),
+    });
+    return Promise.resolve(sseResponse(chunks));
+  });
+  return requests;
+}
+
+async function collectEvents(
+  agent: WatsonxAgent,
+  input: RunAgentInput,
+): Promise<BaseEvent[]> {
+  return firstValueFrom(agent.run(input).pipe(toArray()));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("watsonx thread persistence", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("omits X-IBM-THREAD-ID on the first turn of a thread", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-1" })]);
+    await collectEvents(makeAgent(), makeInput());
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers["X-IBM-THREAD-ID"]).toBeUndefined();
+  });
+
+  it("reuses the watsonx thread_id from the stream on the next run", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-abc" })]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ runId: "r-1" }));
+    await collectEvents(agent, makeInput({ runId: "r-2" }));
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].headers["X-IBM-THREAD-ID"]).toBeUndefined();
+    expect(requests[1].headers["X-IBM-THREAD-ID"]).toBe("wx-abc");
+  });
+
+  it("tracks watsonx thread IDs per AG-UI thread", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-1" })]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ threadId: "t-1" }));
+    await collectEvents(agent, makeInput({ threadId: "t-2" }));
+
+    // Second AG-UI thread is new to watsonx, so no header yet.
+    expect(requests[1].headers["X-IBM-THREAD-ID"]).toBeUndefined();
+  });
+
+  it("captures thread_id from chunks without choices", async () => {
+    const requests = mockFetch([
+      { thread_id: "wx-only" },
+      textChunk("Hi"),
+    ]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ runId: "r-1" }));
+    await collectEvents(agent, makeInput({ runId: "r-2" }));
+
+    expect(requests[1].headers["X-IBM-THREAD-ID"]).toBe("wx-only");
+  });
+
+  it("sends only messages since the last user message when continuing", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-1" })]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ runId: "r-1" }));
+
+    const history: Message[] = [
+      { id: "m-1", role: "user", content: "Hello" } as Message,
+      { id: "a-1", role: "assistant", content: "Hi" } as Message,
+      { id: "m-2", role: "user", content: "Follow-up" } as Message,
+    ];
+    await collectEvents(agent, makeInput({ runId: "r-2", messages: history }));
+
+    // First turn sends full history; continuation sends only the new suffix.
+    expect(requests[0].body.messages).toHaveLength(1);
+    expect(requests[1].body.messages).toHaveLength(1);
+    expect(requests[1].body.messages[0].content).toBe("Follow-up");
+  });
+
+  it("keeps trailing assistant/tool messages after the last user message", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-1" })]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ runId: "r-1" }));
+
+    const history: Message[] = [
+      { id: "m-1", role: "user", content: "Weather?" } as Message,
+      {
+        id: "a-1",
+        role: "assistant",
+        toolCalls: [
+          {
+            id: "tc-1",
+            type: "function",
+            function: { name: "get_weather", arguments: "{}" },
+          },
+        ],
+      } as unknown as Message,
+      {
+        id: "t-1",
+        role: "tool",
+        content: "Sunny",
+        toolCallId: "tc-1",
+      } as unknown as Message,
+    ];
+    await collectEvents(agent, makeInput({ runId: "r-2", messages: history }));
+
+    const sent = requests[1].body.messages;
+    expect(sent.map((m: any) => m.role)).toEqual(["user", "assistant", "tool"]);
+  });
+
+  it("uses a custom threadIdStore when provided", async () => {
+    const backing = new Map<string, string>([["t-1", "wx-stored"]]);
+    const store: WatsonxThreadIdStore = {
+      get: async (id) => backing.get(id),
+      set: async (id, wxId) => {
+        backing.set(id, wxId);
+      },
+    };
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-new" })]);
+
+    await collectEvents(makeAgent(store), makeInput());
+
+    expect(requests[0].headers["X-IBM-THREAD-ID"]).toBe("wx-stored");
+    expect(backing.get("t-1")).toBe("wx-new");
+  });
+
+  it("clone() shares the thread-id store", async () => {
+    const requests = mockFetch([textChunk("Hi", { thread_id: "wx-clone" })]);
+    const agent = makeAgent();
+
+    await collectEvents(agent, makeInput({ runId: "r-1" }));
+    const cloned = agent.clone();
+    await collectEvents(cloned, makeInput({ runId: "r-2" }));
+
+    expect(requests[1].headers["X-IBM-THREAD-ID"]).toBe("wx-clone");
+  });
+
+  it("still emits a normal event lifecycle when thread_id is present", async () => {
+    mockFetch([textChunk("Hi", { thread_id: "wx-1" })]);
+    const events = await collectEvents(makeAgent(), makeInput());
+
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe(EventType.RUN_STARTED);
+    expect(types[types.length - 1]).toBe(EventType.RUN_FINISHED);
+    expect(types).toContain(EventType.TEXT_MESSAGE_CONTENT);
+  });
+});

--- a/integrations/watsonx/typescript/src/index.ts
+++ b/integrations/watsonx/typescript/src/index.ts
@@ -33,6 +33,19 @@ export interface WatsonxAgentConfig {
   agentId: string;
   apiKey?: string;
   bearerToken?: string;
+  /**
+   * Optional persistence for the mapping of AG-UI threadId to the
+   * watsonx-managed thread_id. Defaults to an in-memory Map, which is
+   * sufficient when the agent instance lives as long as the conversation.
+   * Provide a custom store (e.g. backed by a database) when agent
+   * instances are created per-request on a server.
+   */
+  threadIdStore?: WatsonxThreadIdStore;
+}
+
+export interface WatsonxThreadIdStore {
+  get(threadId: string): string | undefined | Promise<string | undefined>;
+  set(threadId: string, watsonxThreadId: string): unknown | Promise<unknown>;
 }
 
 export class WatsonxAgent extends AbstractAgent {
@@ -45,6 +58,7 @@ export class WatsonxAgent extends AbstractAgent {
   private tokenRefreshPromise?: Promise<string>;
   private activeAbortController?: AbortController;
   private stepInProgress = false;
+  private threadIdStore: WatsonxThreadIdStore;
 
   constructor(config: WatsonxAgentConfig) {
     super({ agentId: config.agentId });
@@ -55,6 +69,7 @@ export class WatsonxAgent extends AbstractAgent {
     this.instanceId = config.instanceId;
     this.watsonxAgentId = config.agentId;
     this.apiKey = config.apiKey;
+    this.threadIdStore = config.threadIdStore ?? new Map<string, string>();
     this.cachedToken = config.bearerToken;
     if (config.bearerToken) {
       this.tokenExpiresAt = Date.now() + 55 * 60 * 1000;
@@ -174,7 +189,16 @@ export class WatsonxAgent extends AbstractAgent {
       }
     }
 
-    const watsonxMessages = this.mapMessages(messages);
+    // watsonx orchestrate manages conversation state server-side, keyed by a
+    // thread_id it issues in the SSE stream. It ignores client-invented IDs
+    // (creating a fresh thread instead) and only acts on the last user
+    // message in the payload. So: reuse the watsonx thread_id captured from
+    // a previous run of this AG-UI thread, and when continuing, send only
+    // the messages since the last user message.
+    const watsonxThreadId = await this.threadIdStore.get(threadId);
+    const watsonxMessages = this.mapMessages(
+      watsonxThreadId ? messagesSinceLastUser(messages) : messages,
+    );
 
     const token = await this.getToken();
 
@@ -208,15 +232,21 @@ export class WatsonxAgent extends AbstractAgent {
     subscriber.next(stepStarted);
     this.stepInProgress = true;
 
+    // On the first turn the header is omitted so watsonx creates the thread;
+    // its thread_id is captured from the stream and reused on later turns.
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    };
+    if (watsonxThreadId) {
+      headers["X-IBM-THREAD-ID"] = watsonxThreadId;
+    }
+
     const response = await fetch(
       `${this.baseUrl}/v1/orchestrate/${this.watsonxAgentId}/chat/completions`,
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          "X-IBM-THREAD-ID": threadId,
-        },
+        headers,
         body: JSON.stringify(requestBody),
         signal: combinedSignal,
       },
@@ -233,11 +263,39 @@ export class WatsonxAgent extends AbstractAgent {
     let msgId: string | null = null;
     let msgStarted = false;
     let accumulatedContent = "";
+    let capturedThreadId: string | null = null;
     const activeToolCalls = new Map<
       number,
       { id: string; name: string; ended: boolean }
     >();
     let buffer = "";
+
+    const state = {
+      get msgId() {
+        return msgId;
+      },
+      set msgId(v: string | null) {
+        msgId = v;
+      },
+      get msgStarted() {
+        return msgStarted;
+      },
+      set msgStarted(v: boolean) {
+        msgStarted = v;
+      },
+      get accumulatedContent() {
+        return accumulatedContent;
+      },
+      set accumulatedContent(v: string) {
+        accumulatedContent = v;
+      },
+      get watsonxThreadId() {
+        return capturedThreadId;
+      },
+      set watsonxThreadId(v: string | null) {
+        capturedThreadId = v;
+      },
+    };
 
     try {
       while (true) {
@@ -252,26 +310,7 @@ export class WatsonxAgent extends AbstractAgent {
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
-          this.processSSELine(line, subscriber, activeToolCalls, {
-            get msgId() {
-              return msgId;
-            },
-            set msgId(v: string | null) {
-              msgId = v;
-            },
-            get msgStarted() {
-              return msgStarted;
-            },
-            set msgStarted(v: boolean) {
-              msgStarted = v;
-            },
-            get accumulatedContent() {
-              return accumulatedContent;
-            },
-            set accumulatedContent(v: string) {
-              accumulatedContent = v;
-            },
-          });
+          this.processSSELine(line, subscriber, activeToolCalls, state);
         }
       }
 
@@ -283,26 +322,7 @@ export class WatsonxAgent extends AbstractAgent {
           : trimmed.slice(5).trim();
         if (data && data !== "[DONE]") {
           try {
-            this.processSSELine(trimmed, subscriber, activeToolCalls, {
-              get msgId() {
-                return msgId;
-              },
-              set msgId(v: string | null) {
-                msgId = v;
-              },
-              get msgStarted() {
-                return msgStarted;
-              },
-              set msgStarted(v: boolean) {
-                msgStarted = v;
-              },
-              get accumulatedContent() {
-                return accumulatedContent;
-              },
-              set accumulatedContent(v: string) {
-                accumulatedContent = v;
-              },
-            });
+            this.processSSELine(trimmed, subscriber, activeToolCalls, state);
           } catch (e) {
             if (!(e instanceof SyntaxError)) throw e;
           }
@@ -310,6 +330,11 @@ export class WatsonxAgent extends AbstractAgent {
       }
     } finally {
       reader.releaseLock();
+      // Persist the watsonx-issued thread_id even if the stream errored
+      // mid-way, so the next turn continues the same server-side thread.
+      if (capturedThreadId && capturedThreadId !== watsonxThreadId) {
+        await this.threadIdStore.set(threadId, capturedThreadId);
+      }
     }
 
     for (const [, tc] of activeToolCalls) {
@@ -390,7 +415,12 @@ export class WatsonxAgent extends AbstractAgent {
     line: string,
     subscriber: import("rxjs").Subscriber<BaseEvent>,
     activeToolCalls: Map<number, { id: string; name: string; ended: boolean }>,
-    state: { msgId: string | null; msgStarted: boolean; accumulatedContent: string },
+    state: {
+      msgId: string | null;
+      msgStarted: boolean;
+      accumulatedContent: string;
+      watsonxThreadId: string | null;
+    },
   ): void {
     // Handle both "data: " and "data:" (without trailing space)
     if (!line.startsWith("data:")) return;
@@ -414,6 +444,12 @@ export class WatsonxAgent extends AbstractAgent {
       source: "watsonx",
     };
     subscriber.next(rawEvent);
+
+    // Chunks carry the watsonx-managed thread_id (also on chunks that have
+    // no choices, so this must run before the early return below).
+    if (typeof chunk.thread_id === "string" && chunk.thread_id) {
+      state.watsonxThreadId = chunk.thread_id;
+    }
 
     const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
     const choice = choices?.[0];
@@ -523,6 +559,23 @@ export class WatsonxAgent extends AbstractAgent {
     cloned.cachedToken = this.cachedToken;
     cloned.tokenExpiresAt = this.tokenExpiresAt;
     cloned.stepInProgress = false;
+    // Share the store so the clone continues existing watsonx threads.
+    cloned.threadIdStore = this.threadIdStore;
     return cloned;
   }
+}
+
+/**
+ * When continuing a watsonx-managed thread, only the messages from the last
+ * user message onward are new to the server (earlier context lives in the
+ * thread). This keeps trailing assistant/tool messages so tool results still
+ * reach watsonx.
+ */
+function messagesSinceLastUser(messages: Message[]): Message[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      return messages.slice(i);
+    }
+  }
+  return messages;
 }


### PR DESCRIPTION
## Problem

watsonx Orchestrate's `/chat/completions` endpoint is stateful: conversation history is stored server-side, keyed by a `thread_id` that watsonx issues and returns in the SSE stream. It ignores client-invented thread IDs (creating a fresh thread instead) and only acts on the last user message in the payload.

Both watsonx adapters (TypeScript and Python) sent the AG-UI `threadId` as the `X-IBM-THREAD-ID` header and discarded the `thread_id` returned in the stream. As a result, every turn started a brand-new orchestrate conversation and the agent lost all prior context — multi-turn memory was completely broken.

Reported by a user of `@ag-ui/watsonx@0.0.1` with CopilotKit chat, who confirmed that extracting the `thread_id` from the RAW SSE events and replaying it as `X-IBM-THREAD-ID` restores conversation memory.

## Fix

Both adapters now natively support the watsonx Orchestrate conversation model:

- **Omit** `X-IBM-THREAD-ID` on the first turn of a thread so orchestrate creates the thread (sending a client-invented ID just produced orphan threads).
- **Capture** the watsonx-issued `thread_id` from SSE chunks — including chunks that carry no `choices`, which is where it can first appear. The TypeScript adapter persists it in the stream's `finally` so a mid-stream error doesn't lose it; Python persists eagerly as chunks arrive.
- **Store** the AG-UI `threadId` → watsonx `thread_id` mapping in a thread-ID store on the agent: in-memory by default, pluggable via `threadIdStore` (TS) / `thread_id_store` (Python) with sync-or-async `get`/`set` for server deployments where agent instances are created per-request. `clone()` shares the store so clones continue existing threads.
- **Reuse** the stored watsonx ID as `X-IBM-THREAD-ID` on subsequent turns.
- **Trim the payload** when continuing a known thread: only messages from the last user message onward are sent (trailing assistant/tool messages are kept so tool results still reach watsonx), since earlier context lives server-side and orchestrate ignores the rest.

Existing workarounds that consume the RAW events keep working — RAW emission is unchanged.

## Testing

- TypeScript: 65 tests pass, including 9 new ones in `thread-persistence.test.ts` covering first-turn header omission, capture/reuse, per-thread tracking, choice-less chunks, payload trimming, custom/async stores, and `clone()`. `tsc --noEmit` and `tsdown` build clean.
- Python: 43 tests pass, including 8 new ones in `TestThreadPersistence` mirroring the TypeScript coverage.
- One pre-existing test per language asserted the old header behavior and was updated to assert the new contract.