### PR TITLE
chore(dojo): enable Reo enhanced visitor identification

### DIFF
--- a/apps/dojo/src/app/layout.tsx
+++ b/apps/dojo/src/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({
                 e = "${REO_KEY}";
                 t = function() {
                   if (window.Reo) {
-                    window.Reo.init({ clientID: "${REO_KEY}" });
+                    window.Reo.init({ clientID: "${REO_KEY}", enableThirdPartyTracking: true });
                   }
                 };
                 n = document.createElement("script");


### PR DESCRIPTION
Ports [CopilotKit/website#556](https://github.com/CopilotKit/website/pull/556) to the dojo.

## Summary

Adds `enableThirdPartyTracking: true` to the existing `Reo.init()` call in the dojo root layout. This activates Reo's enhanced visitor identification, which uses their data partner network to identify more anonymous visitors.

The Reo dashboard toggle was already enabled on Sep 3. The marketing site half shipped in website#556, and the CopilotKit docs half is in CopilotKit/CopilotKit#6867. This is the dojo half, which keeps the three surfaces at pixel parity (the goal of ENT-507, the commit that added this script stack).

## GTM impact

**Modifies:** the Reo.dev visitor-identification script (`reo-init-script` in `apps/dojo/src/app/layout.tsx`).

- No events renamed or removed
- No other tracking script (PostHog, RB2B, Scarf) is affected
- Adds one configuration property to the existing `Reo.init({})` call
- Reo docs: https://docs.reo.dev/integrations/input-sources/website-visitor-insights/website-visitor-identification/enhanced-website-visitor-identification

## Changes

```diff
- window.Reo.init({ clientID: "${REO_KEY}" });
+ window.Reo.init({ clientID: "${REO_KEY}", enableThirdPartyTracking: true });
```

The script block is gated on `REO_KEY`, so environments without the key are unaffected.

## Testing

- `Reo.init` appears exactly once in the repo, so there is no second call site to update:
  ```
  $ git grep -n "Reo.init" -- .
  apps/dojo/src/app/layout.tsx:78:  window.Reo.init({ clientID: "${REO_KEY}", enableThirdPartyTracking: true });
  ```
- No test asserts the `Reo.init` argument string, so no test needed updating.
- Formatting: the changed line sits inside a template literal, which prettier does not reflow, so the longer line does not affect the format check.
- Visual artifacts: N/A. This is a one-property config change to an inline analytics script, with no visual or layout impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
