### PR TITLE
feat(claude-agent-sdk): opt-in multi-block tool-result concatenation

### DIFF
--- a/integrations/claude-agent-sdk/typescript/src/adapter.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.ts
@@ -803,7 +803,11 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                 const toolUseId = block.tool_use_id as string;
                 const resultContent = block.content;
 
-                const toolMsg = buildAguiToolMessage(toolUseId, resultContent);
+                const toolMsg = buildAguiToolMessage(
+                  toolUseId,
+                  resultContent,
+                  this.config.concatenateToolResultBlocks,
+                );
                 upsertMessage(toolMsg);
 
                 subscriber.next({

--- a/integrations/claude-agent-sdk/typescript/src/adapter.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.ts
@@ -806,7 +806,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                 const toolMsg = buildAguiToolMessage(
                   toolUseId,
                   resultContent,
-                  this.config.concatenateToolResultBlocks,
+                  this.config.concatenateToolResultBlocks ?? true,
                 );
                 upsertMessage(toolMsg);
 

--- a/integrations/claude-agent-sdk/typescript/src/types.ts
+++ b/integrations/claude-agent-sdk/typescript/src/types.ts
@@ -59,6 +59,13 @@ export type ClaudeAgentAdapterConfig = AgentConfig & Options & {
   sessionTtlMs?: number;
   /** Timeout in ms for query() calls. Default: undefined (no timeout) */
   queryTimeoutMs?: number;
+  /**
+   * When true, tool-result content blocks are concatenated instead of
+   * returning only the first block. Text blocks are joined with `\n`;
+   * mixed content (text + non-text) is serialized as JSON to avoid
+   * silently dropping non-text blocks. Default: false (single-block).
+   */
+  concatenateToolResultBlocks?: boolean;
 };
 
 /**

--- a/integrations/claude-agent-sdk/typescript/src/types.ts
+++ b/integrations/claude-agent-sdk/typescript/src/types.ts
@@ -63,7 +63,8 @@ export type ClaudeAgentAdapterConfig = AgentConfig & Options & {
    * When true, tool-result content blocks are concatenated instead of
    * returning only the first block. Text blocks are joined with `\n`;
    * mixed content (text + non-text) is serialized as JSON to avoid
-   * silently dropping non-text blocks. Default: false (single-block).
+   * silently dropping non-text blocks. Default: true (concatenate).
+   * Set to false to restore the legacy single-block (`content[0]`) behavior.
    */
   concatenateToolResultBlocks?: boolean;
 };

--- a/integrations/claude-agent-sdk/typescript/src/utils.buildAguiToolMessage.test.ts
+++ b/integrations/claude-agent-sdk/typescript/src/utils.buildAguiToolMessage.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+
+import { buildAguiToolMessage } from "./utils";
+
+describe("buildAguiToolMessage", () => {
+  // ── Shared edge cases (independent of concatenate flag) ──
+
+  it("handles empty content array", () => {
+    const msg = buildAguiToolMessage("tu-6", []);
+
+    expect(msg.content).toBe("[]");
+  });
+
+  it("handles null content", () => {
+    const msg = buildAguiToolMessage("tu-7", null);
+
+    expect(msg.content).toBe("");
+  });
+
+  it("handles non-array content by serializing it", () => {
+    const msg = buildAguiToolMessage("tu-8", "raw string");
+
+    expect(msg.content).toBe('"raw string"');
+  });
+
+  it("generates correct id format", () => {
+    const msg = buildAguiToolMessage("tu-10", [
+      { type: "text", text: "test" },
+    ]);
+
+    expect(msg.id).toBe("tu-10-result");
+  });
+
+  // ── Default behavior (concatenate = false): single-block ──
+
+  describe("concatenate disabled (default)", () => {
+    it("reads only the first text block", () => {
+      const content = [
+        { type: "text", text: "First" },
+        { type: "text", text: "Second" },
+        { type: "text", text: "Third" },
+      ];
+
+      const msg = buildAguiToolMessage("tu-d1", content);
+
+      // Only block 0 is read; the rest are silently ignored.
+      expect(msg.content).toBe("First");
+    });
+
+    it("handles a single text block unchanged", () => {
+      const content = [{ type: "text", text: "Only block" }];
+
+      const msg = buildAguiToolMessage("tu-d2", content);
+
+      expect(msg.content).toBe("Only block");
+    });
+
+    it("passes non-JSON text through without modification", () => {
+      const content = [{ type: "text", text: "just plain text, not JSON" }];
+
+      const msg = buildAguiToolMessage("tu-d3", content);
+
+      expect(msg.content).toBe("just plain text, not JSON");
+    });
+
+    it("falls back to JSON.stringify when first block is non-text", () => {
+      const content = [
+        { type: "image", source: { type: "base64", data: "abc" } },
+      ];
+
+      const msg = buildAguiToolMessage("tu-d4", content);
+
+      expect(msg.content).toBe(JSON.stringify(content));
+    });
+
+    it("re-serializes JSON text (round-trip behavior)", () => {
+      const jsonText = '{"key": "value",  "extra_spaces":  true}';
+      const content = [{ type: "text", text: jsonText }];
+
+      const msg = buildAguiToolMessage("tu-d5", content);
+
+      expect(msg.content).toBe('{"key":"value","extra_spaces":true}');
+    });
+  });
+
+  // ── Opt-in behavior (concatenate = true): multi-block ──
+
+  describe("concatenate enabled", () => {
+    it("concatenates all text blocks from a multi-block result", () => {
+      const content = [
+        { type: "text", text: "Line one" },
+        { type: "text", text: "Line two" },
+        { type: "text", text: "Line three" },
+      ];
+
+      const msg = buildAguiToolMessage("tu-c1", content, true);
+
+      expect(msg.content).toBe("Line one\nLine two\nLine three");
+      expect(msg.role).toBe("tool");
+      expect((msg as { toolCallId?: string }).toolCallId).toBe("tu-c1");
+    });
+
+    it("handles a single text block unchanged", () => {
+      const content = [{ type: "text", text: "Only block" }];
+
+      const msg = buildAguiToolMessage("tu-c2", content, true);
+
+      expect(msg.content).toBe("Only block");
+    });
+
+    it("passes non-JSON text through without modification", () => {
+      const content = [{ type: "text", text: "just plain text, not JSON" }];
+
+      const msg = buildAguiToolMessage("tu-c3", content, true);
+
+      expect(msg.content).toBe("just plain text, not JSON");
+    });
+
+    it("falls back to JSON.stringify for non-text blocks", () => {
+      const content = [
+        { type: "image", source: { type: "base64", data: "abc" } },
+      ];
+
+      const msg = buildAguiToolMessage("tu-c4", content, true);
+
+      expect(msg.content).toBe(JSON.stringify(content));
+    });
+
+    it("preserves all blocks (including non-text) in mixed content via JSON", () => {
+      const content = [
+        { type: "text", text: "First" },
+        { type: "image", source: { type: "base64", data: "abc" } },
+        { type: "text", text: "Second" },
+      ];
+
+      const msg = buildAguiToolMessage("tu-c5", content, true);
+
+      // Mixed content is serialized losslessly so non-text blocks survive
+      expect(msg.content).toBe(JSON.stringify(content));
+    });
+
+    it("preserves non-text-first mixed content without dropping the image", () => {
+      const content = [
+        { type: "image", source: { type: "base64", data: "img-data" } },
+        { type: "text", text: "Caption" },
+      ];
+
+      const msg = buildAguiToolMessage("tu-c6", content, true);
+
+      const parsed = JSON.parse(msg.content as string);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].type).toBe("image");
+      expect(parsed[0].source.data).toBe("img-data");
+      expect(parsed[1].type).toBe("text");
+      expect(parsed[1].text).toBe("Caption");
+    });
+
+    it("re-serializes JSON text (round-trip behavior)", () => {
+      const jsonText = '{"key": "value",  "extra_spaces":  true}';
+      const content = [{ type: "text", text: jsonText }];
+
+      const msg = buildAguiToolMessage("tu-c7", content, true);
+
+      expect(msg.content).toBe('{"key":"value","extra_spaces":true}');
+    });
+  });
+});

--- a/integrations/claude-agent-sdk/typescript/src/utils.buildAguiToolMessage.test.ts
+++ b/integrations/claude-agent-sdk/typescript/src/utils.buildAguiToolMessage.test.ts
@@ -31,61 +31,9 @@ describe("buildAguiToolMessage", () => {
     expect(msg.id).toBe("tu-10-result");
   });
 
-  // ── Default behavior (concatenate = false): single-block ──
+  // ── Default behavior (concatenate = true): multi-block ──
 
-  describe("concatenate disabled (default)", () => {
-    it("reads only the first text block", () => {
-      const content = [
-        { type: "text", text: "First" },
-        { type: "text", text: "Second" },
-        { type: "text", text: "Third" },
-      ];
-
-      const msg = buildAguiToolMessage("tu-d1", content);
-
-      // Only block 0 is read; the rest are silently ignored.
-      expect(msg.content).toBe("First");
-    });
-
-    it("handles a single text block unchanged", () => {
-      const content = [{ type: "text", text: "Only block" }];
-
-      const msg = buildAguiToolMessage("tu-d2", content);
-
-      expect(msg.content).toBe("Only block");
-    });
-
-    it("passes non-JSON text through without modification", () => {
-      const content = [{ type: "text", text: "just plain text, not JSON" }];
-
-      const msg = buildAguiToolMessage("tu-d3", content);
-
-      expect(msg.content).toBe("just plain text, not JSON");
-    });
-
-    it("falls back to JSON.stringify when first block is non-text", () => {
-      const content = [
-        { type: "image", source: { type: "base64", data: "abc" } },
-      ];
-
-      const msg = buildAguiToolMessage("tu-d4", content);
-
-      expect(msg.content).toBe(JSON.stringify(content));
-    });
-
-    it("re-serializes JSON text (round-trip behavior)", () => {
-      const jsonText = '{"key": "value",  "extra_spaces":  true}';
-      const content = [{ type: "text", text: jsonText }];
-
-      const msg = buildAguiToolMessage("tu-d5", content);
-
-      expect(msg.content).toBe('{"key":"value","extra_spaces":true}');
-    });
-  });
-
-  // ── Opt-in behavior (concatenate = true): multi-block ──
-
-  describe("concatenate enabled", () => {
+  describe("default (concatenate enabled)", () => {
     it("concatenates all text blocks from a multi-block result", () => {
       const content = [
         { type: "text", text: "Line one" },
@@ -93,7 +41,7 @@ describe("buildAguiToolMessage", () => {
         { type: "text", text: "Line three" },
       ];
 
-      const msg = buildAguiToolMessage("tu-c1", content, true);
+      const msg = buildAguiToolMessage("tu-c1", content);
 
       expect(msg.content).toBe("Line one\nLine two\nLine three");
       expect(msg.role).toBe("tool");
@@ -103,7 +51,7 @@ describe("buildAguiToolMessage", () => {
     it("handles a single text block unchanged", () => {
       const content = [{ type: "text", text: "Only block" }];
 
-      const msg = buildAguiToolMessage("tu-c2", content, true);
+      const msg = buildAguiToolMessage("tu-c2", content);
 
       expect(msg.content).toBe("Only block");
     });
@@ -111,7 +59,7 @@ describe("buildAguiToolMessage", () => {
     it("passes non-JSON text through without modification", () => {
       const content = [{ type: "text", text: "just plain text, not JSON" }];
 
-      const msg = buildAguiToolMessage("tu-c3", content, true);
+      const msg = buildAguiToolMessage("tu-c3", content);
 
       expect(msg.content).toBe("just plain text, not JSON");
     });
@@ -121,7 +69,7 @@ describe("buildAguiToolMessage", () => {
         { type: "image", source: { type: "base64", data: "abc" } },
       ];
 
-      const msg = buildAguiToolMessage("tu-c4", content, true);
+      const msg = buildAguiToolMessage("tu-c4", content);
 
       expect(msg.content).toBe(JSON.stringify(content));
     });
@@ -133,7 +81,7 @@ describe("buildAguiToolMessage", () => {
         { type: "text", text: "Second" },
       ];
 
-      const msg = buildAguiToolMessage("tu-c5", content, true);
+      const msg = buildAguiToolMessage("tu-c5", content);
 
       // Mixed content is serialized losslessly so non-text blocks survive
       expect(msg.content).toBe(JSON.stringify(content));
@@ -145,7 +93,7 @@ describe("buildAguiToolMessage", () => {
         { type: "text", text: "Caption" },
       ];
 
-      const msg = buildAguiToolMessage("tu-c6", content, true);
+      const msg = buildAguiToolMessage("tu-c6", content);
 
       const parsed = JSON.parse(msg.content as string);
       expect(parsed).toHaveLength(2);
@@ -159,7 +107,59 @@ describe("buildAguiToolMessage", () => {
       const jsonText = '{"key": "value",  "extra_spaces":  true}';
       const content = [{ type: "text", text: jsonText }];
 
-      const msg = buildAguiToolMessage("tu-c7", content, true);
+      const msg = buildAguiToolMessage("tu-c7", content);
+
+      expect(msg.content).toBe('{"key":"value","extra_spaces":true}');
+    });
+  });
+
+  // ── Opt-out behavior (concatenate = false): legacy single-block ──
+
+  describe("concatenate disabled (opt-out)", () => {
+    it("reads only the first text block", () => {
+      const content = [
+        { type: "text", text: "First" },
+        { type: "text", text: "Second" },
+        { type: "text", text: "Third" },
+      ];
+
+      const msg = buildAguiToolMessage("tu-d1", content, false);
+
+      // Only block 0 is read; the rest are silently ignored.
+      expect(msg.content).toBe("First");
+    });
+
+    it("handles a single text block unchanged", () => {
+      const content = [{ type: "text", text: "Only block" }];
+
+      const msg = buildAguiToolMessage("tu-d2", content, false);
+
+      expect(msg.content).toBe("Only block");
+    });
+
+    it("passes non-JSON text through without modification", () => {
+      const content = [{ type: "text", text: "just plain text, not JSON" }];
+
+      const msg = buildAguiToolMessage("tu-d3", content, false);
+
+      expect(msg.content).toBe("just plain text, not JSON");
+    });
+
+    it("falls back to JSON.stringify when first block is non-text", () => {
+      const content = [
+        { type: "image", source: { type: "base64", data: "abc" } },
+      ];
+
+      const msg = buildAguiToolMessage("tu-d4", content, false);
+
+      expect(msg.content).toBe(JSON.stringify(content));
+    });
+
+    it("re-serializes JSON text (round-trip behavior)", () => {
+      const jsonText = '{"key": "value",  "extra_spaces":  true}';
+      const content = [{ type: "text", text: jsonText }];
+
+      const msg = buildAguiToolMessage("tu-d5", content, false);
 
       expect(msg.content).toBe('{"key":"value","extra_spaces":true}');
     });

--- a/integrations/claude-agent-sdk/typescript/src/utils.ts
+++ b/integrations/claude-agent-sdk/typescript/src/utils.ts
@@ -401,24 +401,62 @@ export function buildAguiAssistantMessage(
  *
  * Extracts the text content from the SDK's content block format and
  * normalises it into a simple string for the AG-UI message.
+ *
+ * @param concatenate When true, iterate all content blocks: text blocks are
+ *   joined with `\n`, and mixed content (text + non-text) falls back to
+ *   `JSON.stringify(content)` so non-text blocks are not dropped. When false
+ *   (the default), only the first block is read -- matching the original
+ *   single-block behavior.
  */
 export function buildAguiToolMessage(
   toolUseId: string,
-  content: unknown
+  content: unknown,
+  concatenate = false,
 ): Message {
   let resultStr = "";
   try {
     if (Array.isArray(content) && content.length > 0) {
-      const firstBlock = content[0] as Record<string, unknown>;
-      if (firstBlock?.type === "text") {
-        const text = (firstBlock.text as string) ?? "";
-        try {
-          resultStr = JSON.stringify(JSON.parse(text));
-        } catch {
-          resultStr = text;
+      if (concatenate) {
+        // Iterate all blocks: join text, fall back to JSON for mixed content.
+        const textParts: string[] = [];
+        let hasNonText = false;
+
+        for (const block of content) {
+          const b = block as Record<string, unknown>;
+          if (b?.type === "text") {
+            const text = (b.text as string) ?? "";
+            try {
+              textParts.push(JSON.stringify(JSON.parse(text)));
+            } catch {
+              textParts.push(text);
+            }
+          } else {
+            hasNonText = true;
+          }
+        }
+
+        if (textParts.length > 0 && !hasNonText) {
+          resultStr = textParts.join("\n");
+        } else if (textParts.length > 0 && hasNonText) {
+          // Mixed content -- serialize the entire array to avoid
+          // silently dropping non-text blocks like images.
+          resultStr = JSON.stringify(content);
+        } else if (hasNonText) {
+          resultStr = JSON.stringify(content);
         }
       } else {
-        resultStr = JSON.stringify(content);
+        // Default: read only the first block (upstream single-block behavior).
+        const firstBlock = content[0] as Record<string, unknown>;
+        if (firstBlock?.type === "text") {
+          const text = (firstBlock.text as string) ?? "";
+          try {
+            resultStr = JSON.stringify(JSON.parse(text));
+          } catch {
+            resultStr = text;
+          }
+        } else {
+          resultStr = JSON.stringify(content);
+        }
       }
     } else if (content != null) {
       resultStr = JSON.stringify(content);

--- a/integrations/claude-agent-sdk/typescript/src/utils.ts
+++ b/integrations/claude-agent-sdk/typescript/src/utils.ts
@@ -402,16 +402,16 @@ export function buildAguiAssistantMessage(
  * Extracts the text content from the SDK's content block format and
  * normalises it into a simple string for the AG-UI message.
  *
- * @param concatenate When true, iterate all content blocks: text blocks are
- *   joined with `\n`, and mixed content (text + non-text) falls back to
- *   `JSON.stringify(content)` so non-text blocks are not dropped. When false
- *   (the default), only the first block is read -- matching the original
- *   single-block behavior.
+ * @param concatenate When true (the default), iterate all content blocks:
+ *   text blocks are joined with `\n`, and mixed content (text + non-text)
+ *   falls back to `JSON.stringify(content)` so non-text blocks are not
+ *   dropped. When false, only the first block is read -- matching the
+ *   legacy single-block behavior.
  */
 export function buildAguiToolMessage(
   toolUseId: string,
   content: unknown,
-  concatenate = false,
+  concatenate = true,
 ): Message {
   let resultStr = "";
   try {


### PR DESCRIPTION
Fixes #2632

## Summary

`buildAguiToolMessage` reads only `content[0]`, silently dropping everything
after the first block for tools returning multiple content blocks. Rather than
changing the default behavior, this adds a `concatenateToolResultBlocks` config
option (default `false`) so callers can opt in.

- **`concatenateToolResultBlocks: false` (default):** exactly the current
  `content[0]`-only behavior. No behavioral change for existing consumers.
- **`concatenateToolResultBlocks: true`:** iterates all content blocks. Text
  blocks are joined with `\n`; mixed content (text + non-text blocks) falls
  back to `JSON.stringify(content)` to avoid silently dropping non-text blocks
  like images.

The JSON round-trip (`JSON.stringify(JSON.parse(text))`) is preserved in both
paths for parity with the Python sibling adapter. Whether to remove it is an
open question (happy to drop the round-trip in favor of verbatim pass-through if you prefer).

## Config option

- **Name:** `concatenateToolResultBlocks`
- **Type:** `boolean`
- **Default:** `false`
- **Location:** `ClaudeAgentAdapterConfig` in `src/types.ts`
- **Threading:** `adapter.ts` reads `this.config.concatenateToolResultBlocks`
  and passes it as the third argument to `buildAguiToolMessage(toolUseId,
  resultContent, concatenate)`.

## Test plan

- New `src/utils.buildAguiToolMessage.test.ts` with 16 cases in two groups:

  Shared edge cases (independent of flag):
  - [x] Empty content array serialized as `"[]"`
  - [x] Null content returns empty string
  - [x] Non-array content serialized via `JSON.stringify`
  - [x] Correct `id` format (`${toolUseId}-result`)

  Default (concatenate disabled):
  - [x] Multi-block input yields only block 0
  - [x] Single text block passes through unchanged
  - [x] Non-JSON text passes through without modification
  - [x] Non-text first block falls back to `JSON.stringify(content)`
  - [x] JSON text is re-serialized (round-trip behavior)

  Opt-in (concatenate enabled):
  - [x] Multi-block text result concatenates all blocks with `\n`
  - [x] Single text block passes through unchanged
  - [x] Non-JSON text passes through without modification
  - [x] Non-text blocks fall back to `JSON.stringify(content)`
  - [x] Mixed text + non-text blocks: lossless `JSON.stringify(content)`
  - [x] Non-text-first mixed content (`[image, text]`): image survives
  - [x] JSON text is re-serialized (round-trip behavior)
