### PR TITLE
feat(claude-agent-sdk): surface raw MCP tool name via metadata

### DIFF
--- a/integrations/claude-agent-sdk/typescript/src/adapter.raw-tool-name.test.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.raw-tool-name.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock workspace packages that aren't built in worktree isolation
+vi.mock("@ag-ui/client", () => {
+  class AbstractAgent {
+    constructor(_config?: Record<string, unknown>) {}
+    clone() {
+      return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+    }
+  }
+  return {
+    AbstractAgent,
+    EventType: {
+      RUN_STARTED: "RUN_STARTED",
+      RUN_FINISHED: "RUN_FINISHED",
+      RUN_ERROR: "RUN_ERROR",
+      TEXT_MESSAGE_START: "TEXT_MESSAGE_START",
+      TEXT_MESSAGE_CONTENT: "TEXT_MESSAGE_CONTENT",
+      TEXT_MESSAGE_END: "TEXT_MESSAGE_END",
+      TOOL_CALL_START: "TOOL_CALL_START",
+      TOOL_CALL_ARGS: "TOOL_CALL_ARGS",
+      TOOL_CALL_END: "TOOL_CALL_END",
+      TOOL_CALL_RESULT: "TOOL_CALL_RESULT",
+      STATE_SNAPSHOT: "STATE_SNAPSHOT",
+      MESSAGES_SNAPSHOT: "MESSAGES_SNAPSHOT",
+      CUSTOM: "CUSTOM",
+      REASONING_START: "REASONING_START",
+      REASONING_MESSAGE_START: "REASONING_MESSAGE_START",
+      REASONING_MESSAGE_CONTENT: "REASONING_MESSAGE_CONTENT",
+      REASONING_MESSAGE_END: "REASONING_MESSAGE_END",
+      REASONING_END: "REASONING_END",
+      REASONING_ENCRYPTED_VALUE: "REASONING_ENCRYPTED_VALUE",
+    },
+    randomUUID: () => crypto.randomUUID(),
+  };
+});
+
+vi.mock("@ag-ui/core", () => ({}));
+
+// Track the query mock so we can swap the stream per test
+let mockStreamMessages: Array<Record<string, unknown>> = [];
+
+// Mock the Claude Agent SDK so we don't need real API credentials
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(() => {
+    let idx = 0;
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: vi.fn(async () => {
+          if (idx < mockStreamMessages.length) {
+            return { value: mockStreamMessages[idx++], done: false };
+          }
+          return { value: undefined, done: true };
+        }),
+      }),
+      interrupt: vi.fn(),
+    };
+  }),
+  createSdkMcpServer: vi.fn(() => ({})),
+}));
+
+// Mock the SDK types import
+vi.mock("@anthropic-ai/sdk/resources/beta/messages/messages", () => ({}));
+
+import { ClaudeAgentAdapter } from "./adapter";
+
+function collectEvents(
+  adapter: ClaudeAgentAdapter,
+  input: Record<string, unknown>,
+): Promise<Record<string, unknown>[]> {
+  const events: Record<string, unknown>[] = [];
+  return new Promise((resolve, reject) => {
+    adapter.run(input as never).subscribe({
+      next: (event: unknown) => events.push(event as Record<string, unknown>),
+      error: reject,
+      complete: () => resolve(events),
+    });
+  });
+}
+
+describe("raw MCP tool name exposure", () => {
+  beforeEach(() => {
+    mockStreamMessages = [];
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("streaming path (TOOL_CALL_START via content_block_start)", () => {
+    it("emits metadata.rawName with the MCP-prefixed name for MCP tools", async () => {
+      mockStreamMessages = [
+        {
+          type: "stream_event",
+          event: { type: "message_start" },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: {
+              type: "tool_use",
+              id: "tool-1",
+              name: "mcp__example_sandbox__Bash",
+            },
+          },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_stop",
+          },
+        },
+        {
+          type: "stream_event",
+          event: { type: "message_stop" },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t1",
+        runId: "r1",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const toolCallStart = events.find((e) => e.type === "TOOL_CALL_START");
+      expect(toolCallStart).toBeDefined();
+      expect(toolCallStart!.toolCallName).toBe("Bash");
+      const meta = toolCallStart!.metadata as Record<string, unknown>;
+      expect(meta).toBeDefined();
+      expect(meta.rawName).toBe("mcp__example_sandbox__Bash");
+    });
+
+    it("emits metadata.rawName equal to the display name for built-in tools", async () => {
+      mockStreamMessages = [
+        {
+          type: "stream_event",
+          event: { type: "message_start" },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: {
+              type: "tool_use",
+              id: "tool-2",
+              name: "Bash",
+            },
+          },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_stop",
+          },
+        },
+        {
+          type: "stream_event",
+          event: { type: "message_stop" },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t2",
+        runId: "r2",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const toolCallStart = events.find((e) => e.type === "TOOL_CALL_START");
+      expect(toolCallStart).toBeDefined();
+      expect(toolCallStart!.toolCallName).toBe("Bash");
+      const meta = toolCallStart!.metadata as Record<string, unknown>;
+      expect(meta).toBeDefined();
+      expect(meta.rawName).toBe("Bash");
+    });
+  });
+
+  describe("non-streaming path (complete assistant message)", () => {
+    it("emits metadata.rawName with MCP prefix on TOOL_CALL_START for non-streamed tool blocks", async () => {
+      mockStreamMessages = [
+        {
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-3",
+                name: "mcp__server__MyTool",
+                input: { arg: "value" },
+              },
+            ],
+          },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t3",
+        runId: "r3",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const toolCallStart = events.find((e) => e.type === "TOOL_CALL_START");
+      expect(toolCallStart).toBeDefined();
+      expect(toolCallStart!.toolCallName).toBe("MyTool");
+      const meta = toolCallStart!.metadata as Record<string, unknown>;
+      expect(meta).toBeDefined();
+      expect(meta.rawName).toBe("mcp__server__MyTool");
+    });
+  });
+
+  describe("assistant message tool calls carry rawName in metadata", () => {
+    it("includes rawName metadata on MCP tool calls in MESSAGES_SNAPSHOT", async () => {
+      mockStreamMessages = [
+        {
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-4",
+                name: "mcp__sandbox__Read",
+                input: { path: "/tmp/test" },
+              },
+            ],
+          },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t4",
+        runId: "r4",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const snapshot = events.find((e) => e.type === "MESSAGES_SNAPSHOT") as
+        | { messages: Array<Record<string, unknown>> }
+        | undefined;
+      expect(snapshot).toBeDefined();
+
+      const assistantMsg = snapshot!.messages.find(
+        (m: Record<string, unknown>) => m.role === "assistant",
+      ) as { toolCalls?: Array<Record<string, unknown>> } | undefined;
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.toolCalls).toBeDefined();
+      expect(assistantMsg!.toolCalls!.length).toBeGreaterThan(0);
+
+      const toolCall = assistantMsg!.toolCalls![0];
+      const fn = toolCall.function as { name: string };
+      expect(fn.name).toBe("Read");
+      expect(toolCall.metadata).toEqual({ rawName: "mcp__sandbox__Read" });
+    });
+
+    it("includes rawName metadata equal to display name for built-in tool calls", async () => {
+      mockStreamMessages = [
+        {
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-5",
+                name: "Read",
+                input: { path: "/tmp/test" },
+              },
+            ],
+          },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t5",
+        runId: "r5",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const snapshot = events.find((e) => e.type === "MESSAGES_SNAPSHOT") as
+        | { messages: Array<Record<string, unknown>> }
+        | undefined;
+      expect(snapshot).toBeDefined();
+
+      const assistantMsg = snapshot!.messages.find(
+        (m: Record<string, unknown>) => m.role === "assistant",
+      ) as { toolCalls?: Array<Record<string, unknown>> } | undefined;
+      expect(assistantMsg).toBeDefined();
+
+      const toolCall = assistantMsg!.toolCalls![0];
+      const fn = toolCall.function as { name: string };
+      expect(fn.name).toBe("Read");
+      expect(toolCall.metadata).toEqual({ rawName: "Read" });
+    });
+  });
+
+  describe("streaming path also carries rawName metadata in MESSAGES_SNAPSHOT", () => {
+    it("includes rawName metadata on streamed MCP tool calls", async () => {
+      mockStreamMessages = [
+        {
+          type: "stream_event",
+          event: { type: "message_start" },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: {
+              type: "tool_use",
+              id: "tool-6",
+              name: "mcp__srv__Write",
+            },
+          },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"path":"/tmp/out"}',
+            },
+          },
+        },
+        {
+          type: "stream_event",
+          event: {
+            type: "content_block_stop",
+          },
+        },
+        {
+          type: "stream_event",
+          event: { type: "message_stop" },
+        },
+        {
+          type: "result",
+          result: "",
+          is_error: false,
+        },
+      ];
+
+      const adapter = new ClaudeAgentAdapter({ model: "claude-haiku-4-5" });
+      const events = await collectEvents(adapter, {
+        threadId: "t6",
+        runId: "r6",
+        messages: [],
+        tools: [],
+        context: [],
+      });
+
+      const snapshot = events.find((e) => e.type === "MESSAGES_SNAPSHOT") as
+        | { messages: Array<Record<string, unknown>> }
+        | undefined;
+      expect(snapshot).toBeDefined();
+
+      const assistantMsg = snapshot!.messages.find(
+        (m: Record<string, unknown>) => m.role === "assistant",
+      ) as { toolCalls?: Array<Record<string, unknown>> } | undefined;
+      expect(assistantMsg).toBeDefined();
+
+      const toolCall = assistantMsg!.toolCalls![0];
+      const fn = toolCall.function as { name: string };
+      expect(fn.name).toBe("Write");
+      expect(toolCall.metadata).toEqual({ rawName: "mcp__srv__Write" });
+    });
+  });
+});

--- a/integrations/claude-agent-sdk/typescript/src/adapter.ts
+++ b/integrations/claude-agent-sdk/typescript/src/adapter.ts
@@ -434,6 +434,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
       id: string;
       type: "function";
       function: { name: string; arguments: string };
+      metadata?: Record<string, unknown>;
     };
     let pendingMsg: {
       id: string;
@@ -563,6 +564,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                   runId,
                   toolCallId: currentToolCallId,
                   toolCallName: currentToolDisplayName, // Use unprefixed name for frontend matching!
+                  metadata: { rawName: currentToolCallName }, // Original name including any mcp__ prefix
                   parentMessageId: currentMessageId ?? undefined, // Link to parent message
                 });
               }
@@ -659,6 +661,7 @@ export class ClaudeAgentAdapter extends AbstractAgent {
                     name: currentToolDisplayName,
                     arguments: accumulatedToolJson,
                   },
+                  metadata: { rawName: currentToolCallName },
                 });
               }
 

--- a/integrations/claude-agent-sdk/typescript/src/handlers.ts
+++ b/integrations/claude-agent-sdk/typescript/src/handlers.ts
@@ -108,6 +108,7 @@ export function handleToolUseBlock(
     runId,
     toolCallId: toolId,
     toolCallName: toolDisplayName, // Use unprefixed name
+    metadata: { rawName: toolName }, // Original name including any mcp__ prefix
     parentMessageId: parentToolUseId,
   });
 

--- a/integrations/claude-agent-sdk/typescript/src/schema-survival.test.ts
+++ b/integrations/claude-agent-sdk/typescript/src/schema-survival.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Proves that rawName survives real @ag-ui/core schema parsing.
+ *
+ * This file intentionally does NOT mock @ag-ui/core -- it imports the real
+ * ToolCallSchema, ToolCallStartEventSchema, and EventType so the assertions
+ * exercise the actual Zod schemas from the upstream package.
+ *
+ * - On events: rawName lives inside event `metadata` (a z.record(z.any()) field
+ *   declared on BaseEventSchema, inherited by ToolCallStartEventSchema).
+ * - On messages: rawName lives inside tool-call `metadata` (same z.record type
+ *   declared on ToolCallSchema).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ToolCallSchema,
+  ToolCallStartEventSchema,
+  EventType,
+} from "@ag-ui/core";
+
+describe("schema survival: rawName via metadata (real @ag-ui/core schemas)", () => {
+  describe("ToolCallStartEventSchema (event metadata)", () => {
+    it("preserves metadata.rawName for an MCP tool", () => {
+      const parsed = ToolCallStartEventSchema.parse({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-1",
+        toolCallName: "Bash",
+        metadata: { rawName: "mcp__sandbox__Bash" },
+      });
+      expect(parsed.metadata).toBeDefined();
+      expect(parsed.metadata!.rawName).toBe("mcp__sandbox__Bash");
+    });
+
+    it("preserves metadata.rawName equal to display name for a built-in tool", () => {
+      const parsed = ToolCallStartEventSchema.parse({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-2",
+        toolCallName: "Read",
+        metadata: { rawName: "Read" },
+      });
+      expect(parsed.metadata).toBeDefined();
+      expect(parsed.metadata!.rawName).toBe("Read");
+    });
+
+    it("accepts an event with no metadata", () => {
+      const parsed = ToolCallStartEventSchema.parse({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: "tc-3",
+        toolCallName: "Write",
+      });
+      expect(parsed.metadata).toBeUndefined();
+    });
+  });
+
+  describe("ToolCallSchema (message tool-call metadata)", () => {
+    it("preserves metadata.rawName for an MCP tool call", () => {
+      const parsed = ToolCallSchema.parse({
+        id: "tc-1",
+        type: "function",
+        function: { name: "Read", arguments: "{}" },
+        metadata: { rawName: "mcp__sandbox__Read" },
+      });
+      expect(parsed.metadata).toBeDefined();
+      expect(parsed.metadata!.rawName).toBe("mcp__sandbox__Read");
+    });
+
+    it("preserves metadata.rawName equal to display name for a built-in tool", () => {
+      const parsed = ToolCallSchema.parse({
+        id: "tc-2",
+        type: "function",
+        function: { name: "Write", arguments: "{}" },
+        metadata: { rawName: "Write" },
+      });
+      expect(parsed.metadata).toBeDefined();
+      expect(parsed.metadata!.rawName).toBe("Write");
+    });
+
+    it("accepts a tool call with no metadata", () => {
+      const parsed = ToolCallSchema.parse({
+        id: "tc-3",
+        type: "function",
+        function: { name: "Bash", arguments: "{}" },
+      });
+      expect(parsed.metadata).toBeUndefined();
+    });
+  });
+});

--- a/integrations/claude-agent-sdk/typescript/src/utils.ts
+++ b/integrations/claude-agent-sdk/typescript/src/utils.ts
@@ -370,6 +370,7 @@ export function buildAguiAssistantMessage(
           name: stripMcpPrefix(rawName),
           arguments: JSON.stringify(toolBlock.input ?? {}),
         },
+        metadata: { rawName },
       });
     }
     // Reasoning/ThinkingBlocks are intentionally skipped — not conversation history


### PR DESCRIPTION
Fixes #2633

### Problem

`stripMcpPrefix` removes the `mcp__<server>__` prefix from tool names before
the adapter emits `TOOL_CALL_START` events and before it builds assistant
message tool calls. This makes built-in and MCP tool calls indistinguishable
in the event stream and message history.

### Changes (integration package only -- no `@ag-ui/core` change)

- Emit `metadata: { rawName }` on `TOOL_CALL_START` in both the streaming path
  (`adapter.ts`) and the non-streaming path (`handlers.ts`), carrying the raw
  prefixed name while `toolCallName` stays the stripped display name.
- Carry `metadata: { rawName }` on tool calls built by `buildAguiAssistantMessage`
  (`utils.ts`) and on the in-flight message accumulator (`adapter.ts`).
- For built-in tools, `metadata.rawName` equals the display name.

The raw name uses the `metadata` map that both `BaseEventSchema` (events) and
`ToolCallSchema` (messages) already declare, so no shared-schema edit is
required and the field survives `.parse()` on both surfaces.

### Tests (new `adapter.raw-tool-name.test.ts` + `schema-survival.test.ts`)

- MCP tool emits `metadata.rawName` with the full prefix on the streaming path;
  built-in tool emits `metadata.rawName` equal to the display name.
- Non-streaming (complete assistant message) path emits `metadata.rawName`.
- MCP and built-in tool calls in `MESSAGES_SNAPSHOT` carry `metadata.rawName`.
- `schema-survival.test.ts` parses through the **real** `ToolCallStartEventSchema`
  and `ToolCallSchema` from `@ag-ui/core` and asserts `metadata.rawName`
  survives `.parse()` on both -- proving the design premise against the real
  schemas rather than a mock.
