### PR TITLE
Give every docs page a real social card

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -264,9 +264,6 @@
     }
   },
   "seo": {
-    "metatags": {
-      "og:image": "https://raw.githubusercontent.com/ag-ui-protocol/docs/logo/light.png"
-    },
     "indexing": "navigable"
   },
   "integrations": {


### PR DESCRIPTION
![Rendered AG-UI social cards](https://raw.githubusercontent.com/jerelvelarde/ag-ui/pr-media/images/contact-sheet.png)

> **These four images are not produced by this PR.** This PR deletes three lines and hands card
> generation back to Mintlify; the cards above were rendered locally to show what the page-level
> layout can look like, and they illustrate a possible follow-up using `thumbnails.background` or
> per-page `og:image`. Nothing here is a claim about what merging this will output.
>
> Clockwise from top left: a concept page, a two-line title with a two-line description, an empty
> background of the kind `thumbnails.background` takes, and the same layout in light appearance.
> Individually: [subagents](https://raw.githubusercontent.com/jerelvelarde/ag-ui/pr-media/images/card-subagents.png), [versioning](https://raw.githubusercontent.com/jerelvelarde/ag-ui/pr-media/images/card-versioning.png),
> [light](https://raw.githubusercontent.com/jerelvelarde/ag-ui/pr-media/images/card-light-architecture.png), [background](https://raw.githubusercontent.com/jerelvelarde/ag-ui/pr-media/images/background.png).

## The problem

Every page on docs.ag-ui.com currently advertises a broken image to Slack, X, LinkedIn and Discord. Sharing https://docs.ag-ui.com/concepts/subagents produces a card with correct title and description text next to a grey placeholder box, because `docs.json` declares:

```json
"seo": {
  "metatags": {
    "og:image": "https://raw.githubusercontent.com/ag-ui-protocol/docs/logo/light.png"
  }
}
```

That URL cannot resolve. A `raw.githubusercontent.com` path needs `/owner/repo/<branch>/path`, and this one has no branch segment; there is also no `ag-ui-protocol/docs` repository. It answers `404` with 14 bytes of `text/plain`. Because the value is a site-wide default rather than a per-page one, the failure is not isolated to one page — the same dead URL is emitted in `og:image` and `twitter:image` on all 141 pages.

The second cost is less visible. Setting `seo.metatags.og:image` does not merely supply a fallback; it switches off Mintlify's per-page card generation for the whole site. So the protocol's most shareable surface, the spec and concept pages, cannot show what page a link actually points to.

## The approach

Delete the override. Nothing replaces it, and that is the point: with no `og:image` in `docs.json`, Mintlify generates a card per page from that page's own division, title and description, served from `/_mintlify/api/og`. The generated card also inherits the site's configured `colors` and `logo`, so it stays visually consistent with the docs without a separate asset to keep in sync.

The alternative was to point the override at a real 1200×630 asset. It was rejected because one static card for 141 pages loses exactly the information that makes a docs link worth clicking — the reader learns they are being sent to "Agent User Interaction Protocol" and not to "Subagents". A committed image is also a second thing to update whenever the logo or palette changes, and this one already rotted once.

The cost of relying on generation is that the card's appearance is Mintlify's to define, not this repository's. If a branded card is wanted later, restoring an override is a three-line change back.

`description` frontmatter is what fills the card's second line. Of the 84 pages in the navigation tree, 81 have one and three do not: `introduction`, `sdk/js/encoder` and `sdk/js/proto`. Those three render with a title and no second line. `introduction` is worth fixing on its own merits, since it is the page most likely to be shared — it declares `description:` with an empty value. The other three files in the repo that lack the key entirely are `snippets/spec-draft-banner.mdx` and `snippets/snippet-intro.mdx`, which are includes rather than pages, and `sdk/js/overview.mdx`, a zero-byte file absent from `navigation`. None of that blocks this change, so no frontmatter sweep is bundled in here.

## What is not covered

- **The generated card cannot be seen before merge, and this PR does not prove it renders.** Card generation happens in the hosted build, keyed to a deployment-scoped theme revision; `mint dev` does not perform it, and the `Mintlify Deployment` check reports `skipping` on every docs PR in this repository, internal branches included. What is proven below is that the dead URL stops being emitted, plus strong evidence that generation is provisioned for this deployment. The gap between those two is real.
- If generation does not engage for some reason not visible from outside, pages fall back to a text-only summary card rather than a generated image. That is better than the current broken box but is not the goal, and would want a static 1200×630 asset instead.
- The card will render against the configured `#09090b` primary. Worth an eyeball on production right after merge.
- Platforms cache what they already scraped. Existing links in Slack and on X keep the broken box until re-scraped — X via the Card Validator, Slack on its own cache expiry.
- `seo.indexing: "navigable"` and all other metatags are untouched.

## Verification

**The override is what emits the dead URL** — `mint dev` on this branch, against `docs/`, with and without the change:

```
before (override present), /concepts/subagents:
  <meta property="og:image"    content=".../ag-ui-protocol/docs/logo/light.png"/>
  <meta name="twitter:image"   content=".../ag-ui-protocol/docs/logo/light.png"/>

after (this branch), /concepts/subagents:
  og:title, og:description, og:site_name, og:type   present
  twitter:card=summary_large_image, twitter:title, twitter:description   present
  og:image, twitter:image                            absent
```

**The URL is dead**, and it is live on production today:

```
$ curl -sSLo /dev/null -w '%{http_code} %{content_type} %{size_download}\n' \
    https://raw.githubusercontent.com/ag-ui-protocol/docs/logo/light.png
404 text/plain; charset=utf-8 14

$ curl -sSL https://docs.ag-ui.com/concepts/subagents | grep -oE '<meta[^>]*image[^>]*>'
og:image / twitter:image  ->  .../ag-ui-protocol/docs/logo/light.png
```

**Generation is provisioned for this deployment.** The endpoint is reachable on docs.ag-ui.com and rejects a foreign theme revision with a 409 naming the current deployment, rather than 404 or a not-enabled error:

```
$ curl -sSL 'https://docs.ag-ui.com/_mintlify/api/og?division=Concepts&title=Subagents'
OG theme revision is required

$ curl -sSL 'https://docs.ag-ui.com/_mintlify/api/og?...&theme=<another+site+revision>'
OG theme revision does not match the current deployment      # HTTP 409
```

For a baseline of the same endpoint doing the work on a site with no override:

```
$ curl -sSLo /dev/null -w '%{http_code} %{content_type} %{size_download}\n' \
    'https://trigger.mintlify.app/_mintlify/api/og?division=Getting+Started&title=Introduction&theme=<its+revision>'
200 image/png 120666
```

`docs.json` parses after the edit, and the diff is a deletion only:

```
$ python3 -c "import json;print(json.load(open('docs/docs.json'))['seo'])"
{'indexing': 'navigable'}

$ git diff --stat upstream/main
 docs/docs.json | 3 ---
```

No test file accompanies this; the repository has no harness that asserts on rendered metatags, and adding one for a single config key would outweigh the change. The check that matters is one curl against production after merge:

```
curl -sSL https://docs.ag-ui.com/concepts/subagents | grep -oE '<meta property="og:image"[^>]*>'
```

It should return a `/_mintlify/api/og?...&title=Subagents...` URL that answers `200 image/png`.
