### PR TITLE
feat(integrations-py): forward FastAPI route kwargs from the endpoint helpers

### DIFF
--- a/integrations/adk-middleware/python/CHANGELOG.md
+++ b/integrations/adk-middleware/python/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `add_adk_fastapi_endpoint()` and `create_adk_app()` accept extra keyword
+  arguments and forward them to `app.post` for the agent route (`name`,
+  `tags`, `operation_id`, `summary`, `dependencies`, `include_in_schema`,
+  ...), so an application can give the route the same metadata, OpenAPI
+  identity and dependencies as the rest of its API. The derived
+  `<path>/capabilities` and `/agents/state` routes keep their own identity,
+  because FastAPI requires a unique `operation_id` and `name` per operation.
+
 ## [0.7.0] - 2026-06-22
 
 ### Added

--- a/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/endpoint.py
@@ -316,6 +316,7 @@ def add_adk_fastapi_endpoint(
     extract_headers: Optional[List[str]] = None,
     extract_state_from_request: Optional[Callable[[Request, RunAgentInput], Coroutine[dict[str,Any], Any, Any]]] = None,
     agent_resolver: Optional[AgentResolver] = None,
+    **kwargs: Any,
 ):
     """Add ADK middleware endpoint to FastAPI app.
 
@@ -331,6 +332,11 @@ def add_adk_fastapi_endpoint(
         agent_resolver: Optional async function that can select an ``ADKAgent``
             for the request after state extraction. Returning ``None`` uses
             the default agent.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
 
     Note:
         This function also adds an experimental POST /agents/state endpoint for
@@ -385,7 +391,7 @@ def add_adk_fastapi_endpoint(
 
     default_agent = agent
 
-    @app.post(path)
+    @app.post(path, **kwargs)
     async def adk_endpoint(input_data: RunAgentInput, request: Request):
         """ADK middleware endpoint.
 
@@ -653,6 +659,7 @@ def create_adk_app(
     extract_headers: Optional[List[str]] = None,
     extract_state_from_request: Optional[Callable[[Request, RunAgentInput], Coroutine[dict[str,Any], Any, Any]]] = None,
     agent_resolver: Optional[AgentResolver] = None,
+    **kwargs: Any,
 ) -> FastAPI:
     """Create a FastAPI app with ADK middleware endpoint.
 
@@ -667,6 +674,11 @@ def create_adk_app(
         agent_resolver: Optional async function that can select an ``ADKAgent``
             for the request after state extraction. Returning ``None`` uses
             the default agent.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
 
     Returns:
         FastAPI application instance
@@ -679,5 +691,6 @@ def create_adk_app(
         extract_headers=extract_headers,
         extract_state_from_request=extract_state_from_request,
         agent_resolver=agent_resolver,
+        **kwargs,
     )
     return app

--- a/integrations/adk-middleware/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/adk-middleware/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the middleware could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only: the capabilities
+and ``/agents/state`` routes keep their own identity, because FastAPI
+requires a unique ``operation_id`` and ``name`` per operation.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_adk.endpoint import add_adk_fastapi_endpoint, create_adk_app
+from ag_ui_adk.adk_agent import ADKAgent
+
+
+@pytest.fixture
+def mock_agent():
+    return MagicMock(spec=ADKAgent)
+
+
+class TestEndpointRouteKwargs:
+    def test_metadata_lands_on_the_agent_route(self, mock_agent):
+        app = FastAPI()
+        add_adk_fastapi_endpoint(
+            app,
+            mock_agent,
+            path="/",
+            name="adk_agent",
+            tags=["ADK"],
+            summary="ADK middleware endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/"]["post"]
+        assert operation["tags"] == ["ADK"]
+        assert operation["summary"] == "ADK middleware endpoint"
+        assert operation["operationId"] == "run_agent"
+        assert app.url_path_for("adk_agent") == "/"
+
+    def test_other_routes_keep_their_own_identity(self, mock_agent):
+        """A duplicated ``operation_id`` is what breaks OpenAPI client
+        generators, so the helper's other routes stay untouched."""
+        app = FastAPI()
+        add_adk_fastapi_endpoint(
+            app, mock_agent, path="/", tags=["ADK"], operation_id="run_agent"
+        )
+
+        paths = app.openapi()["paths"]
+        others = [paths[p][m] for p, m in (("/capabilities", "get"), ("/agents/state", "post"))]
+        for operation in others:
+            assert operation["operationId"] != "run_agent"
+            assert "tags" not in operation
+
+    def test_dependencies_guard_the_agent_route_only(self, mock_agent):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        add_adk_fastapi_endpoint(
+            app, mock_agent, path="/", dependencies=[Depends(deny)]
+        )
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        assert client.post("/", json={}).status_code == 401
+
+        # The helper's other routes are left unguarded.
+        routes = {r.path: r for r in app.routes if hasattr(r, "dependencies")}
+        assert routes["/capabilities"].dependencies == []
+        assert routes["/agents/state"].dependencies == []
+
+    def test_create_adk_app_forwards_route_kwargs(self, mock_agent):
+        app = create_adk_app(mock_agent, path="/", tags=["ADK"], name="adk_agent")
+
+        assert app.openapi()["paths"]["/"]["post"]["tags"] == ["ADK"]
+        assert app.url_path_for("adk_agent") == "/"
+
+    def test_default_registration_is_unchanged(self, mock_agent):
+        app = FastAPI()
+        add_adk_fastapi_endpoint(app, mock_agent, path="/")
+
+        assert "tags" not in app.openapi()["paths"]["/"]["post"]

--- a/integrations/agent-spec/python/ag_ui_agentspec/endpoint.py
+++ b/integrations/agent-spec/python/ag_ui_agentspec/endpoint.py
@@ -1,6 +1,8 @@
 import asyncio
 
-from fastapi import FastAPI, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
 from ag_ui.encoder import EventEncoder
@@ -14,11 +16,23 @@ from ag_ui_agentspec.agent import AgentSpecAgent
 from ag_ui_agentspec.agentspec_tracing_exporter import EVENT_QUEUE
 
 
-def add_agentspec_fastapi_endpoint(app: FastAPI, agentspec_agent: AgentSpecAgent, path: str = "/"):
-    """Adds an Agent Spec endpoint to the FastAPI app."""
-    
+def add_agentspec_fastapi_endpoint(
+    app: FastAPI | APIRouter,
+    agentspec_agent: AgentSpecAgent,
+    path: str = "/",
+    **kwargs: Any,
+):
+    """Adds an Agent Spec endpoint to the FastAPI app.
 
-    @app.post(path)
+    Args:
+        app: FastAPI application or APIRouter to register the route on.
+        agentspec_agent: Agent Spec agent to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` (``name``, ``tags``,
+            ``operation_id``, ``dependencies``, ``include_in_schema``, ...).
+    """
+
+    @app.post(path, **kwargs)
     async def agentic_chat_endpoint(input_data: RunAgentInput, request: Request):
         """Agentic chat endpoint"""
 

--- a/integrations/agent-spec/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/agent-spec/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,82 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the agent could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_agentspec.agent import AgentSpecAgent
+from ag_ui_agentspec.endpoint import add_agentspec_fastapi_endpoint
+
+
+def _make_agent():
+    return MagicMock(spec=AgentSpecAgent)
+
+
+def _register(app, **kwargs):
+    return add_agentspec_fastapi_endpoint(app, _make_agent(), "/agent", **kwargs)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        _register(
+            app,
+            name="agent_run",
+            tags=["Agent"],
+            summary="AG-UI agent endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/agent"]["post"]
+        self.assertEqual(operation["tags"], ["Agent"])
+        self.assertEqual(operation["summary"], "AG-UI agent endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("agent_run"), "/agent")
+
+    def test_include_in_schema_hides_the_agent_route(self):
+        app = FastAPI()
+        _register(app, include_in_schema=False)
+
+        self.assertNotIn("/agent", app.openapi()["paths"])
+
+    def test_dependencies_guard_the_agent_route(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        _register(app, dependencies=[Depends(deny)])
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(
+            TestClient(app).post("/agent", json={}).status_code, 401
+        )
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        _register(router, name="agent_run")
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("agent_run"), "/v1/agent")
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        _register(app)
+
+        self.assertNotIn("tags", app.openapi()["paths"]["/agent"]["post"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/endpoint.py
+++ b/integrations/claude-agent-sdk/python/ag_ui_claude_sdk/endpoint.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
 from ag_ui.core.types import RunAgentInput
@@ -7,10 +9,26 @@ from ag_ui.encoder import EventEncoder
 from .adapter import ClaudeAgentAdapter
 
 
-def add_claude_fastapi_endpoint(app: FastAPI, adapter: ClaudeAgentAdapter, path: str = "/"):
-    """Adds a Claude Agent SDK endpoint to the FastAPI app."""
+def add_claude_fastapi_endpoint(
+    app: FastAPI | APIRouter,
+    adapter: ClaudeAgentAdapter,
+    path: str = "/",
+    **kwargs: Any,
+):
+    """Adds a Claude Agent SDK endpoint to the FastAPI app.
 
-    @app.post(path)
+    Args:
+        app: FastAPI application or APIRouter to register the routes on.
+        adapter: Claude Agent SDK adapter to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
+    """
+
+    @app.post(path, **kwargs)
     async def claude_agent_endpoint(input_data: RunAgentInput, request: Request):
         accept_header = request.headers.get("accept")
         encoder = EventEncoder(accept=accept_header)

--- a/integrations/claude-agent-sdk/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/claude-agent-sdk/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,97 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the agent could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only: the health route keeps its own
+identity, because FastAPI requires a unique ``operation_id`` and ``name``
+per operation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_claude_sdk.adapter import ClaudeAgentAdapter
+from ag_ui_claude_sdk.endpoint import add_claude_fastapi_endpoint
+
+
+def _make_agent():
+    adapter = MagicMock(spec=ClaudeAgentAdapter)
+    adapter.name = "test"
+    return adapter
+
+
+def _register(app, **kwargs):
+    return add_claude_fastapi_endpoint(app, _make_agent(), "/agent", **kwargs)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        _register(
+            app,
+            name="agent_run",
+            tags=["Agent"],
+            summary="AG-UI agent endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/agent"]["post"]
+        self.assertEqual(operation["tags"], ["Agent"])
+        self.assertEqual(operation["summary"], "AG-UI agent endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("agent_run"), "/agent")
+
+    def test_include_in_schema_hides_the_agent_route(self):
+        app = FastAPI()
+        _register(app, include_in_schema=False)
+
+        self.assertNotIn("/agent", app.openapi()["paths"])
+
+    def test_health_route_keeps_its_own_identity(self):
+        """Metadata must not be copied onto the second route: a duplicated
+        ``operation_id`` is what breaks OpenAPI client generators."""
+        app = FastAPI()
+        _register(app, tags=["Agent"], operation_id="run_agent")
+
+        health = app.openapi()["paths"]["/agent/health"]["get"]
+        self.assertNotEqual(health["operationId"], "run_agent")
+        self.assertNotIn("tags", health)
+
+    def test_dependencies_guard_the_agent_route_only(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        _register(app, dependencies=[Depends(deny)])
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(client.post("/agent", json={}).status_code, 401)
+        # A health probe stays reachable without the dependency.
+        self.assertEqual(client.get("/agent/health").status_code, 200)
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        _register(router, name="agent_run")
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("agent_run"), "/v1/agent")
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        _register(app)
+
+        self.assertNotIn("tags", app.openapi()["paths"]["/agent"]["post"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/claude-managed-agents/python/ag_ui_claude_managed_agents/endpoint.py
+++ b/integrations/claude-managed-agents/python/ag_ui_claude_managed_agents/endpoint.py
@@ -1,6 +1,8 @@
 """FastAPI endpoint helper."""
 
-from fastapi import FastAPI, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
 from ag_ui.core.types import RunAgentInput
@@ -10,7 +12,10 @@ from .agent import ManagedAgentsAgent
 
 
 def add_managed_agents_fastapi_endpoint(
-    app: FastAPI, agent: ManagedAgentsAgent, path: str = "/"
+    app: FastAPI | APIRouter,
+    agent: ManagedAgentsAgent,
+    path: str = "/",
+    **kwargs: Any,
 ) -> None:
     """Add a Managed Agents endpoint to the FastAPI app.
 
@@ -20,9 +25,19 @@ def add_managed_agents_fastapi_endpoint(
     says nothing else: it is reachable by whoever can reach the endpoint, and
     the managed agent id it used to return is an internal identifier probes have
     no use for.
+
+    Args:
+        app: FastAPI application or APIRouter to register the routes on.
+        agent: Managed Agents agent to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
     """
 
-    @app.post(path)
+    @app.post(path, **kwargs)
     async def managed_agents_endpoint(input_data: RunAgentInput, request: Request):
         accept_header = request.headers.get("accept")
         encoder = EventEncoder(accept=accept_header)

--- a/integrations/claude-managed-agents/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/claude-managed-agents/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,97 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the agent could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only: the health route keeps its own
+identity, because FastAPI requires a unique ``operation_id`` and ``name``
+per operation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_claude_managed_agents import (
+    ManagedAgentsAgent,
+    add_managed_agents_fastapi_endpoint,
+)
+
+
+def _make_agent():
+    return MagicMock(spec=ManagedAgentsAgent)
+
+
+def _register(app, **kwargs):
+    return add_managed_agents_fastapi_endpoint(app, _make_agent(), "/agent", **kwargs)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        _register(
+            app,
+            name="agent_run",
+            tags=["Agent"],
+            summary="AG-UI agent endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/agent"]["post"]
+        self.assertEqual(operation["tags"], ["Agent"])
+        self.assertEqual(operation["summary"], "AG-UI agent endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("agent_run"), "/agent")
+
+    def test_include_in_schema_hides_the_agent_route(self):
+        app = FastAPI()
+        _register(app, include_in_schema=False)
+
+        self.assertNotIn("/agent", app.openapi()["paths"])
+
+    def test_health_route_keeps_its_own_identity(self):
+        """Metadata must not be copied onto the second route: a duplicated
+        ``operation_id`` is what breaks OpenAPI client generators."""
+        app = FastAPI()
+        _register(app, tags=["Agent"], operation_id="run_agent")
+
+        health = app.openapi()["paths"]["/agent/health"]["get"]
+        self.assertNotEqual(health["operationId"], "run_agent")
+        self.assertNotIn("tags", health)
+
+    def test_dependencies_guard_the_agent_route_only(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        _register(app, dependencies=[Depends(deny)])
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(client.post("/agent", json={}).status_code, 401)
+        # A health probe stays reachable without the dependency.
+        self.assertEqual(client.get("/agent/health").status_code, 200)
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        _register(router, name="agent_run")
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("agent_run"), "/v1/agent")
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        _register(app)
+
+        self.assertNotIn("tags", app.openapi()["paths"]["/agent"]["post"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
+++ b/integrations/crew-ai/python/ag_ui_crewai/endpoint.py
@@ -9,7 +9,7 @@ import threading
 import time
 import uuid
 from typing import Any
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
 from ._env import _parse_env_float
@@ -3349,7 +3349,7 @@ async def _run_flow_resume_stream(
 
 
 def add_crewai_flow_fastapi_endpoint(
-    app: FastAPI,
+    app: FastAPI | APIRouter,
     flow: Flow,
     path: str = "/",
     *,
@@ -3358,6 +3358,7 @@ def add_crewai_flow_fastapi_endpoint(
     emit_raw_events: bool | None = None,
     emission_shape: str | None = None,
     conversational: bool = False,
+    **kwargs: Any,
 ):
     """Adds a CrewAI endpoint to the FastAPI app.
 
@@ -3394,6 +3395,9 @@ def add_crewai_flow_fastapi_endpoint(
     back, so the run re-kicks off and re-pauses in a loop. Pass
     ``emit_interrupt_outcome=True`` (or ``enable_legacy_on_interrupt_event=False``)
     for those clients.
+
+    ``**kwargs`` are forwarded to ``app.post`` (``name``, ``tags``,
+    ``operation_id``, ``dependencies``, ``include_in_schema``, ...).
     """
     global GLOBAL_EVENT_LISTENER # pylint: disable=global-statement
     hitl_options = HITLOptions(
@@ -3424,7 +3428,7 @@ def add_crewai_flow_fastapi_endpoint(
     resolved_emit_raw_events = resolve_emit_raw_events(emit_raw_events)
     resolved_emission_shape = resolve_emission_shape(emission_shape)
 
-    @app.post(path)
+    @app.post(path, **kwargs)
     async def agentic_chat_endpoint(input_data: RunAgentInput, request: Request):
         """Agentic chat endpoint"""
 
@@ -3507,12 +3511,13 @@ def add_crewai_flow_fastapi_endpoint(
 
 
 def add_crewai_crew_fastapi_endpoint(
-    app: FastAPI,
+    app: FastAPI | APIRouter,
     crew: CrewBaseInstance,
     path: str = "/",
     *,
     emit_raw_events: bool | None = None,
     emission_shape: str | None = None,
+    **kwargs: Any,
 ):
     """Adds a CrewAI crew endpoint to the FastAPI app.
 
@@ -3526,6 +3531,9 @@ def add_crewai_crew_fastapi_endpoint(
     ChatWithCrewFlow construction is deferred to first request because the
     constructor calls crew_chat_generate_crew_chat_inputs which makes an LLM
     call. At import time the LLM mock server may not be running yet.
+
+    ``**kwargs`` are forwarded to ``app.post`` (``name``, ``tags``,
+    ``operation_id``, ``dependencies``, ``include_in_schema``, ...).
     """
     global GLOBAL_EVENT_LISTENER # pylint: disable=global-statement
     # Skip the legacy bus listener on the StreamFrame path (see the rationale
@@ -3553,7 +3561,7 @@ def add_crewai_crew_fastapi_endpoint(
                 _cached_flow = ChatWithCrewFlow(crew=crew)
             return _cached_flow
 
-    @app.post(path)
+    @app.post(path, **kwargs)
     async def crew_endpoint(input_data: RunAgentInput, request: Request):
         """Crew chat endpoint with deferred initialization."""
         accept_header = request.headers.get("accept")

--- a/integrations/crew-ai/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/crew-ai/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,91 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helpers.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding a flow or a crew could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post``.
+"""
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import ag_ui_crewai.endpoint as ep
+
+
+class _Flow:
+    def kickoff_async(self, inputs=None):  # pragma: no cover - never called
+        raise AssertionError
+
+
+class _Crew:
+    def crew(self):  # pragma: no cover - construction is deferred to a request
+        raise AssertionError
+
+
+def _register_flow(app, **kwargs):
+    ep.add_crewai_flow_fastapi_endpoint(app, _Flow(), "/agent", **kwargs)
+
+
+def test_metadata_lands_on_the_flow_route():
+    app = FastAPI()
+    _register_flow(
+        app,
+        name="agent_run",
+        tags=["Agent"],
+        summary="AG-UI agent endpoint",
+        operation_id="run_agent",
+    )
+
+    operation = app.openapi()["paths"]["/agent"]["post"]
+    assert operation["tags"] == ["Agent"]
+    assert operation["summary"] == "AG-UI agent endpoint"
+    assert operation["operationId"] == "run_agent"
+
+    # ``name`` makes the route reachable by reverse lookup.
+    assert app.url_path_for("agent_run") == "/agent"
+
+
+def test_include_in_schema_hides_the_flow_route():
+    app = FastAPI()
+    _register_flow(app, include_in_schema=False)
+
+    assert "/agent" not in app.openapi()["paths"]
+
+
+def test_dependencies_guard_the_flow_route():
+    def deny():
+        raise HTTPException(status_code=401, detail="nope")
+
+    app = FastAPI()
+    _register_flow(app, dependencies=[Depends(deny)])
+
+    # The dependency runs before the body is parsed, so the flow is never
+    # kicked off.
+    assert TestClient(app).post("/agent", json={}).status_code == 401
+
+
+def test_registers_on_an_api_router():
+    router = APIRouter()
+    _register_flow(router, name="agent_run")
+
+    app = FastAPI()
+    app.include_router(router, prefix="/v1")
+
+    assert app.url_path_for("agent_run") == "/v1/agent"
+
+
+def test_default_registration_is_unchanged():
+    app = FastAPI()
+    _register_flow(app)
+
+    assert "tags" not in app.openapi()["paths"]["/agent"]["post"]
+
+
+def test_metadata_lands_on_the_crew_route():
+    app = FastAPI()
+    ep.add_crewai_crew_fastapi_endpoint(
+        app, _Crew(), "/agent", tags=["Agent"], name="crew_run"
+    )
+
+    assert app.openapi()["paths"]["/agent"]["post"]["tags"] == ["Agent"]
+    assert app.url_path_for("crew_run") == "/agent"

--- a/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/endpoint.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, HTTPException, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from ag_ui.core.types import RunAgentInput
@@ -6,10 +8,26 @@ from ag_ui.encoder import EventEncoder
 
 from .agent import LangGraphAgent
 
-def add_langgraph_fastapi_endpoint(app: FastAPI, agent: LangGraphAgent, path: str = "/"):
-    """Adds an endpoint to the FastAPI app."""
+def add_langgraph_fastapi_endpoint(
+    app: FastAPI | APIRouter,
+    agent: LangGraphAgent,
+    path: str = "/",
+    **kwargs: Any,
+):
+    """Adds an endpoint to the FastAPI app.
 
-    @app.post(path)
+    Args:
+        app: FastAPI application or APIRouter to register the routes on.
+        agent: LangGraph agent to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
+    """
+
+    @app.post(path, **kwargs)
     async def langgraph_agent_endpoint(input_data: RunAgentInput, request: Request):
         # Get the accept header from the request
         accept_header = request.headers.get("accept")

--- a/integrations/langgraph/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/langgraph/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,114 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+``add_langgraph_fastapi_endpoint`` used to register the agent route with a
+bare decorator, so an application embedding the agent could not set the
+route's ``name``, ``tags``, ``operation_id``, ``dependencies`` or
+``include_in_schema``. Extra keyword arguments now reach ``app.post`` for the
+agent route only: the health route keeps its own identity, because FastAPI
+requires a unique ``operation_id`` and ``name`` per operation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from langgraph.graph.state import CompiledStateGraph
+
+from ag_ui_langgraph import LangGraphAgent
+from ag_ui_langgraph.endpoint import add_langgraph_fastapi_endpoint
+
+
+def _make_agent() -> LangGraphAgent:
+    graph = MagicMock(spec=CompiledStateGraph)
+    graph.config_specs = []
+    graph.nodes = {}
+    return LangGraphAgent(name="test", graph=graph)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        add_langgraph_fastapi_endpoint(
+            app,
+            _make_agent(),
+            path="/",
+            name="copilotkit",
+            tags=["CopilotKit"],
+            summary="CopilotKit runtime endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/"]["post"]
+        self.assertEqual(operation["tags"], ["CopilotKit"])
+        self.assertEqual(operation["summary"], "CopilotKit runtime endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("copilotkit"), "/")
+
+    def test_health_route_keeps_its_own_identity(self):
+        """Metadata must not be copied onto the second route: a duplicated
+        ``operation_id`` is what breaks OpenAPI client generators."""
+        app = FastAPI()
+        add_langgraph_fastapi_endpoint(
+            app,
+            _make_agent(),
+            path="/",
+            tags=["CopilotKit"],
+            operation_id="run_agent",
+        )
+
+        health = app.openapi()["paths"]["/health"]["get"]
+        self.assertNotEqual(health["operationId"], "run_agent")
+        self.assertNotIn("tags", health)
+
+    def test_include_in_schema_hides_the_agent_route_only(self):
+        app = FastAPI()
+        add_langgraph_fastapi_endpoint(
+            app, _make_agent(), path="/", include_in_schema=False
+        )
+
+        paths = app.openapi()["paths"]
+        self.assertNotIn("/", paths)
+        self.assertIn("/health", paths)
+
+    def test_dependencies_guard_the_agent_route_only(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        add_langgraph_fastapi_endpoint(
+            app, _make_agent(), path="/", dependencies=[Depends(deny)]
+        )
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(client.post("/", json={}).status_code, 401)
+        # A health probe stays reachable without the dependency.
+        self.assertEqual(client.get("/health").status_code, 200)
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        add_langgraph_fastapi_endpoint(
+            router, _make_agent(), path="/agent", name="copilotkit"
+        )
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("copilotkit"), "/v1/agent")
+        self.assertEqual(TestClient(app).get("/v1/agent/health").status_code, 200)
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        add_langgraph_fastapi_endpoint(app, _make_agent(), path="/")
+
+        operation = app.openapi()["paths"]["/"]["post"]
+        self.assertNotIn("tags", operation)
+        self.assertEqual(app.url_path_for("langgraph_agent_endpoint"), "/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
+++ b/integrations/langroid/python/src/ag_ui_langroid/endpoint.py
@@ -1,6 +1,8 @@
 """FastAPI endpoint utilities for Langroid integration."""
 
-from fastapi import FastAPI, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from ag_ui.core import RunAgentInput
@@ -9,14 +11,25 @@ from .agent import LangroidAgent
 
 
 def add_langroid_fastapi_endpoint(
-    app: FastAPI,
+    app: FastAPI | APIRouter,
     agent: LangroidAgent,
     path: str,
-    **kwargs
+    **kwargs: Any,
 ) -> None:
-    """Add a Langroid agent endpoint to FastAPI app."""
-    
-    @app.post(path)
+    """Add a Langroid agent endpoint to FastAPI app.
+
+    Args:
+        app: FastAPI application or APIRouter to register the routes on.
+        agent: Langroid agent to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
+    """
+
+    @app.post(path, **kwargs)
     async def langroid_endpoint(input_data: RunAgentInput, request: Request):
         """Langroid agent endpoint."""
         accept_header = request.headers.get("accept")
@@ -60,6 +73,7 @@ def create_langroid_app(
     agent: LangroidAgent,
     path: str = "/",
     origins: list[str] | None = None,
+    **kwargs: Any,
 ) -> FastAPI:
     """Create a FastAPI app with a single Langroid agent endpoint.
 
@@ -70,6 +84,7 @@ def create_langroid_app(
             development. Credentials are only enabled when explicit, non-wildcard
             origins are supplied — a wildcard origin can never be combined with
             ``allow_credentials=True``.
+        **kwargs: Forwarded to :func:`add_langroid_fastapi_endpoint`.
     """
     app = FastAPI(title=f"Langroid - {agent.name}")
 
@@ -85,7 +100,7 @@ def create_langroid_app(
     )
     
     # Add the agent endpoint
-    add_langroid_fastapi_endpoint(app, agent, path)
+    add_langroid_fastapi_endpoint(app, agent, path, **kwargs)
     
     return app
 

--- a/integrations/langroid/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/langroid/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,98 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the agent could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only: the health route keeps its own
+identity, because FastAPI requires a unique ``operation_id`` and ``name``
+per operation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_langroid.agent import LangroidAgent
+from ag_ui_langroid.endpoint import add_langroid_fastapi_endpoint
+
+
+def _make_agent():
+    agent = MagicMock(spec=LangroidAgent)
+    agent.name = "test"
+    agent.description = "test"
+    return agent
+
+
+def _register(app, **kwargs):
+    return add_langroid_fastapi_endpoint(app, _make_agent(), "/agent", **kwargs)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        _register(
+            app,
+            name="agent_run",
+            tags=["Agent"],
+            summary="AG-UI agent endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/agent"]["post"]
+        self.assertEqual(operation["tags"], ["Agent"])
+        self.assertEqual(operation["summary"], "AG-UI agent endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("agent_run"), "/agent")
+
+    def test_include_in_schema_hides_the_agent_route(self):
+        app = FastAPI()
+        _register(app, include_in_schema=False)
+
+        self.assertNotIn("/agent", app.openapi()["paths"])
+
+    def test_health_route_keeps_its_own_identity(self):
+        """Metadata must not be copied onto the second route: a duplicated
+        ``operation_id`` is what breaks OpenAPI client generators."""
+        app = FastAPI()
+        _register(app, tags=["Agent"], operation_id="run_agent")
+
+        health = app.openapi()["paths"]["/agent/health"]["get"]
+        self.assertNotEqual(health["operationId"], "run_agent")
+        self.assertNotIn("tags", health)
+
+    def test_dependencies_guard_the_agent_route_only(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        _register(app, dependencies=[Depends(deny)])
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(client.post("/agent", json={}).status_code, 401)
+        # A health probe stays reachable without the dependency.
+        self.assertEqual(client.get("/agent/health").status_code, 200)
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        _register(router, name="agent_run")
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("agent_run"), "/v1/agent")
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        _register(app)
+
+        self.assertNotIn("tags", app.openapi()["paths"]["/agent"]["post"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/watsonx/python/src/ag_ui_watsonx/endpoint.py
+++ b/integrations/watsonx/python/src/ag_ui_watsonx/endpoint.py
@@ -1,6 +1,8 @@
 """FastAPI endpoint utilities for IBM watsonx orchestrate integration."""
 
-from fastapi import FastAPI, Request
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
 from ag_ui.core.types import RunAgentInput
@@ -10,13 +12,25 @@ from .agent import WatsonxAgent
 
 
 def add_watsonx_fastapi_endpoint(
-    app: FastAPI,
+    app: FastAPI | APIRouter,
     agent: WatsonxAgent,
     path: str = "/",
+    **kwargs: Any,
 ) -> None:
-    """Adds an endpoint to the FastAPI app."""
+    """Adds an endpoint to the FastAPI app.
 
-    @app.post(path)
+    Args:
+        app: FastAPI application or APIRouter to register the routes on.
+        agent: watsonx orchestrate agent to serve.
+        path: Path of the agent route.
+        **kwargs: Forwarded to ``app.post`` for the agent route (``name``,
+            ``tags``, ``operation_id``, ``dependencies``, ``include_in_schema``,
+            ...). They do not apply to the other routes this helper registers,
+            because values such as ``operation_id`` and ``name`` must stay
+            unique per operation.
+    """
+
+    @app.post(path, **kwargs)
     async def watsonx_endpoint(input_data: RunAgentInput, request: Request):
         # Get the accept header from the request
         accept_header = request.headers.get("accept")

--- a/integrations/watsonx/python/tests/test_endpoint_route_kwargs.py
+++ b/integrations/watsonx/python/tests/test_endpoint_route_kwargs.py
@@ -1,0 +1,98 @@
+"""Tests for route metadata passthrough on the FastAPI endpoint helper.
+
+The agent route used to be registered with a bare decorator, so an
+application embedding the agent could not set its ``name``, ``tags``,
+``operation_id``, ``dependencies`` or ``include_in_schema``. Extra keyword
+arguments now reach ``app.post`` for the agent route only: the health route keeps its own
+identity, because FastAPI requires a unique ``operation_id`` and ``name``
+per operation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from ag_ui_watsonx.agent import WatsonxAgent
+from ag_ui_watsonx.endpoint import add_watsonx_fastapi_endpoint
+
+
+def _make_agent():
+    agent = MagicMock(spec=WatsonxAgent)
+    agent.name = "test"
+    agent.description = "test"
+    return agent
+
+
+def _register(app, **kwargs):
+    return add_watsonx_fastapi_endpoint(app, _make_agent(), "/agent", **kwargs)
+
+
+class TestEndpointRouteKwargs(unittest.TestCase):
+    def test_metadata_lands_on_the_agent_route(self):
+        app = FastAPI()
+        _register(
+            app,
+            name="agent_run",
+            tags=["Agent"],
+            summary="AG-UI agent endpoint",
+            operation_id="run_agent",
+        )
+
+        operation = app.openapi()["paths"]["/agent"]["post"]
+        self.assertEqual(operation["tags"], ["Agent"])
+        self.assertEqual(operation["summary"], "AG-UI agent endpoint")
+        self.assertEqual(operation["operationId"], "run_agent")
+
+        # ``name`` makes the route reachable by reverse lookup.
+        self.assertEqual(app.url_path_for("agent_run"), "/agent")
+
+    def test_include_in_schema_hides_the_agent_route(self):
+        app = FastAPI()
+        _register(app, include_in_schema=False)
+
+        self.assertNotIn("/agent", app.openapi()["paths"])
+
+    def test_health_route_keeps_its_own_identity(self):
+        """Metadata must not be copied onto the second route: a duplicated
+        ``operation_id`` is what breaks OpenAPI client generators."""
+        app = FastAPI()
+        _register(app, tags=["Agent"], operation_id="run_agent")
+
+        health = app.openapi()["paths"]["/agent/health"]["get"]
+        self.assertNotEqual(health["operationId"], "run_agent")
+        self.assertNotIn("tags", health)
+
+    def test_dependencies_guard_the_agent_route_only(self):
+        def deny():
+            raise HTTPException(status_code=401, detail="nope")
+
+        app = FastAPI()
+        _register(app, dependencies=[Depends(deny)])
+        client = TestClient(app)
+
+        # The dependency runs before the body is parsed, so the agent is
+        # never invoked.
+        self.assertEqual(client.post("/agent", json={}).status_code, 401)
+        # A health probe stays reachable without the dependency.
+        self.assertEqual(client.get("/agent/health").status_code, 200)
+
+    def test_registers_on_an_api_router(self):
+        router = APIRouter()
+        _register(router, name="agent_run")
+
+        app = FastAPI()
+        app.include_router(router, prefix="/v1")
+
+        self.assertEqual(app.url_path_for("agent_run"), "/v1/agent")
+
+    def test_default_registration_is_unchanged(self):
+        app = FastAPI()
+        _register(app)
+
+        self.assertNotIn("tags", app.openapi()["paths"]["/agent"]["post"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2644. Reported downstream as CopilotKit/CopilotKit#1270 (Jan 2025, second reporter Jun 2025); the duplicate-`operationId` half was reported separately as CopilotKit/CopilotKit#2672 and closed with a codegen workaround.

## Problem

Every Python endpoint helper except `add_strands_fastapi_endpoint` registered its agent route with a bare decorator:

```python
@app.post(path)
async def langgraph_agent_endpoint(input_data: RunAgentInput, request: Request):
```

An application that mounts an agent route inside an existing API could not set:

- `operation_id` — FastAPI derives it from the handler name and path, so it is unstable and two agent routes in one app collide. OpenAPI client generators break on it.
- `dependencies` — the app's own auth or rate-limit dependency could not be attached. The only workaround was global middleware, which then also covers routes that must stay open.
- `include_in_schema` — the agent route could not be hidden from a public `/docs`.
- `name` — no `app.url_path_for(...)` reverse lookup.
- `tags`, `summary`, `description` — no grouping in `/docs`, and an API governance lint gate that requires a tag on every operation could not pass.

## Change

Each helper takes `**kwargs: Any` and forwards it to `app.post` **for the agent route only**:

| Helper | Package |
| --- | --- |
| `add_langgraph_fastapi_endpoint` | `ag-ui-langgraph` |
| `add_crewai_flow_fastapi_endpoint`, `add_crewai_crew_fastapi_endpoint` | `ag-ui-crewai` |
| `add_adk_fastapi_endpoint`, `create_adk_app` | `ag-ui-adk` |
| `add_agentspec_fastapi_endpoint` | `ag-ui-agent-spec` |
| `add_claude_fastapi_endpoint` | `ag-ui-claude-sdk` |
| `add_managed_agents_fastapi_endpoint` | `ag-ui-claude-managed-agents` |
| `add_watsonx_fastapi_endpoint` | `ag-ui-watsonx` |
| `add_langroid_fastapi_endpoint`, `create_langroid_app` | `ag_ui_langroid` |

Also in this PR:

- Every helper annotates `app` as `FastAPI | APIRouter`, which `ag-ui-adk` already did. Mounting on a router is how an existing app gives the agent route a prefix.
- `create_adk_app` and `create_langroid_app` forward `**kwargs` to the helper they wrap.
- `add_langroid_fastapi_endpoint` already accepted `**kwargs` and silently dropped them. They now reach the route.
- `ag-ui-strands` is untouched: it already forwards route kwargs, and this PR follows its precedent.

Defaults are unchanged, so the change is additive for current callers.

### Design note: the agent route only

Metadata is not copied onto the other routes a helper registers (`<path>/health`, `<path>/capabilities`, `/agents/state`), for two reasons:

1. FastAPI requires a unique `operation_id` and `name` per operation. Copying them would recreate the duplicate-`operationId` bug this PR is meant to fix.
2. A health probe usually has to stay reachable without the agent route's `dependencies`.

Both are asserted by tests, so the decision is pinned rather than implied.

## Testing

New test module per package (`tests/test_endpoint_route_kwargs.py`), each covering: metadata on the agent route, `include_in_schema`, `dependencies` on the agent route only, registration on an `APIRouter`, an unchanged default registration, and — where a second route exists — that the health route keeps its own `operationId` and tags.

Every suite run locally from a clean worktree at `origin/main` (`uv sync --frozen`, then `uv run pytest`):

```
langgraph              791 passed, 733 subtests passed   (1 pre-existing failure, see below)
adk-middleware         943 passed, 8 skipped
crew-ai                884 passed, 3 skipped, 30 deselected
claude-managed-agents  147 passed
claude-agent-sdk       116 passed
agent-spec              54 passed
langroid                53 passed
watsonx                 41 passed
```

New tests only:

```
langgraph              6 passed      adk-middleware  5 passed
crew-ai                6 passed      langroid        6 passed
watsonx                6 passed      claude-agent-sdk 6 passed
claude-managed-agents  6 passed      agent-spec      5 passed
```

**Mutation-checked**, so the tests fail for the intended reason:

- Reverting `@app.post(path, **kwargs)` to `@app.post(path)`: langgraph 4 failed / 2 passed, adk 3 failed / 2 passed, langroid 4/2, watsonx 4/2, claude-agent-sdk 4/2, claude-managed-agents 4/2, agent-spec 4/1, crew-ai 5/1.
- Copying the kwargs onto the health route as well (langgraph): 3 failed, including `test_health_route_keeps_its_own_identity`.
- Dropping the `**kwargs` forwarding from `create_adk_app`: `test_create_adk_app_forwards_route_kwargs` failed.
- Restoring each file: all green again.

**Pre-existing failure**, unrelated to this change: `integrations/langgraph/python/examples/tests/test_deepagents_subagents_contract.py::test_deepagents_subagents_graph_imports_without_openai_key`. Verified on a pristine `origin/main` checkout with this PR's files reverted — it fails there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI coverage note

`unit-python-sdk.yml` has no job for `integrations/agent-spec/python` or `integrations/claude-agent-sdk/python`, so the test modules those two packages already carry — and the two added here — never run in CI. The runs above are the only verification for them. Worth a follow-up; I did not add the jobs in this PR.
