### PR TITLE
ci(python): run the agent-spec and claude-agent-sdk test suites

### DIFF
--- a/.github/workflows/unit-python-sdk.yml
+++ b/.github/workflows/unit-python-sdk.yml
@@ -16,8 +16,6 @@ on:
       - "integrations/langroid/python/**"
       - "integrations/crew-ai/python/**"
       - "integrations/claude-managed-agents/python/**"
-      # agent-spec and claude-agent-sdk have no test lane, but they ship
-      # committed lockfiles that the `lockfiles` job below verifies.
       - "integrations/agent-spec/python/**"
       - "integrations/claude-agent-sdk/python/**"
       # Globs, not another hand-maintained list: the lockfiles job discovers locks
@@ -1119,6 +1117,132 @@ jobs:
   # in CI. Five of the 13 are stale today, which is why closing this needs its own
   # change: freezing them as-is turns dojo-e2e red, and relocking all 13
   # pulls in dependency churn well beyond a toolchain pin.
+  agent-spec-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        # id so the lockfile assertion below can gate on this step's outcome — see
+        # the comment there for why !cancelled() alone is not enough.
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect fork PR
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
+            echo "prefix=fork-" >> "$GITHUB_OUTPUT"
+          else
+            echo "prefix=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Load cached venv
+        id: cached-uv-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: integrations/agent-spec/python/.venv
+          key: ${{ steps.fork-check.outputs.prefix }}venv-${{ runner.os }}-agent-spec-py${{ env.PYTHON_VERSION }}-uv${{ env.UV_VERSION }}-${{ hashFiles('integrations/agent-spec/python/uv.lock') }}
+
+      - name: Install dependencies
+        working-directory: integrations/agent-spec/python
+        run: uv sync --locked
+
+      - name: Run tests
+        working-directory: integrations/agent-spec/python
+        run: uv run --locked python -m pytest tests/ -v
+
+      - name: Assert no lockfile was rewritten
+        # Must run when the tests FAIL: a job that rewrote a lockfile and then failed
+        # its tests would otherwise skip this step and report only the test failure,
+        # losing the signal this guard exists to produce.
+        #
+        # !cancelled() rather than always(), because always() also fires on
+        # cancellation, and concurrency cancels supersede runs constantly here — each
+        # one would otherwise spend a step re-checking a job nobody is waiting on.
+        #
+        # The checkout gate is NOT redundant with !cancelled(). !cancelled() is TRUE
+        # when an earlier step failed, including `Checkout code` — and this step is a
+        # local `uses:`, so with no repo on disk it dies with "Can't find 'action.yml'
+        # under .../assert-lockfiles-unchanged". That lands AFTER the real error and
+        # reads as though the guard itself is broken, which is precisely the misleading
+        # signal action.yml's header argues against.
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        uses: ./.github/actions/assert-lockfiles-unchanged
+
+  claude-agent-sdk-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        # id so the lockfile assertion below can gate on this step's outcome — see
+        # the comment there for why !cancelled() alone is not enough.
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Detect fork PR
+        id: fork-check
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME}" != "${{ github.repository }}" ]]; then
+            echo "prefix=fork-" >> "$GITHUB_OUTPUT"
+          else
+            echo "prefix=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Load cached venv
+        id: cached-uv-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: integrations/claude-agent-sdk/python/.venv
+          key: ${{ steps.fork-check.outputs.prefix }}venv-${{ runner.os }}-claude-agent-sdk-py${{ env.PYTHON_VERSION }}-uv${{ env.UV_VERSION }}-${{ hashFiles('integrations/claude-agent-sdk/python/uv.lock') }}
+
+      - name: Install dependencies
+        working-directory: integrations/claude-agent-sdk/python
+        run: uv sync --locked
+
+      - name: Run tests
+        working-directory: integrations/claude-agent-sdk/python
+        run: uv run --locked python -m pytest tests/ -v
+
+      - name: Assert no lockfile was rewritten
+        # Must run when the tests FAIL: a job that rewrote a lockfile and then failed
+        # its tests would otherwise skip this step and report only the test failure,
+        # losing the signal this guard exists to produce.
+        #
+        # !cancelled() rather than always(), because always() also fires on
+        # cancellation, and concurrency cancels supersede runs constantly here — each
+        # one would otherwise spend a step re-checking a job nobody is waiting on.
+        #
+        # The checkout gate is NOT redundant with !cancelled(). !cancelled() is TRUE
+        # when an earlier step failed, including `Checkout code` — and this step is a
+        # local `uses:`, so with no repo on disk it dies with "Can't find 'action.yml'
+        # under .../assert-lockfiles-unchanged". That lands AFTER the real error and
+        # reads as though the guard itself is broken, which is precisely the misleading
+        # signal action.yml's header argues against.
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
+        uses: ./.github/actions/assert-lockfiles-unchanged
+
   lockfiles:
     name: lockfiles
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the CI coverage note in #2645.

## Problem

`unit-python-sdk.yml` has a lane per python integration — langgraph, watsonx, adk-middleware, aws-strands, langroid, crew-ai, claude-managed-agents — except two. `integrations/agent-spec/python` and `integrations/claude-agent-sdk/python` ship a `tests/` directory (49 and 110 tests today) and declare `[tool.ag-ui.scripts] test = "python -m pytest"`, but nothing ran them:

- the generic `python` job only runs `sdks/python`;
- both packages appeared in `paths:` solely so the `lockfiles` job would verify their committed locks, which the comment there recorded: *"agent-spec and claude-agent-sdk have no test lane, but they ship committed lockfiles that the `lockfiles` job below verifies."*

So a change to either package could go green with none of its tests executing.

## Change

One lane per package, copied verbatim from the `langroid-python` lane — same pinned `actions/checkout`, `setup-uv` and `actions/cache` refs, same fork-PR cache-key prefix, same `uv sync --locked`, same `assert-lockfiles-unchanged` guard. The runner is `python -m pytest tests/ -v` rather than `unittest discover`, because both suites use pytest fixtures and `pytest-asyncio`; this matches the `crewai-python` and `claude-managed-agents-python` lanes.

The `paths:` comment recording the gap is removed. The two path entries stay, so the new lanes trigger on changes to either package.

## Testing

Ran the exact CI commands locally in a clean worktree at `origin/main`:

```
integrations/agent-spec/python        uv sync --locked  →  ok
                                     uv run --locked python -m pytest tests/ -q  →  49 passed
integrations/claude-agent-sdk/python  uv sync --locked  →  ok
                                     uv run --locked python -m pytest tests/ -q  →  110 passed
```

`--locked` (not `--frozen`) is what the other lanes use, and it passes for both, so neither lock is stale. `git status` stayed clean afterwards, so neither install rewrites a lockfile and the `assert-lockfiles-unchanged` guard has nothing to trip on.

Workflow checks that cover this file, run locally:

```
actionlint .github/workflows/unit-python-sdk.yml               →  clean
bash scripts/release/verify-python-toolchain-pins.sh
  All 17 pin declaration(s) match .github/python-toolchain.env (uv 0.12.1, CPython 3.12).
  All 24 setup-uv invocation(s) resolve their version from it.
```

The pin script's counts include the two invocations this PR adds.

## Note for a maintainer

The two new checks, `agent-spec-python` and `claude-agent-sdk-python`, are not in branch protection's required list. They will report on PRs but not block until someone adds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
