### PR TITLE
feat(mastra): convert stored Mastra messages back to AG-UI messages

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/message-conversion-from-mastra.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-conversion-from-mastra.test.ts
@@ -1,0 +1,349 @@
+import type { MastraDBMessage, MastraMessagePart } from "@mastra/core/agent";
+import type { AssistantMessage, ToolMessage } from "@ag-ui/client";
+import { convertMastraMessagesToAGUI, convertAGUIMessagesToMastra } from "../utils";
+import { continuationMessageId, toolResultMessageId } from "../message-ids";
+
+/**
+ * `convertMastraMessagesToAGUI` is the inverse of `convertAGUIMessagesToMastra`:
+ * it turns the messages Mastra Memory hands back (`memory.recall()` on a local
+ * agent, `getMemoryThread().listMessages()` against a server — both
+ * `MastraDBMessage[]`) into AG-UI messages, so a thread Mastra already owns can
+ * be rehydrated after a reload.
+ */
+
+const CREATED_AT = new Date("2026-01-01T00:00:00.000Z");
+
+function storedMessage(
+  id: string,
+  role: MastraDBMessage["role"],
+  parts: MastraMessagePart[],
+  content: Partial<MastraDBMessage["content"]> = {},
+): MastraDBMessage {
+  return {
+    id,
+    role,
+    createdAt: CREATED_AT,
+    threadId: "thread-1",
+    content: { format: 2, parts, ...content },
+  };
+}
+
+function toolInvocationPart(
+  overrides: Partial<{
+    state: string;
+    toolCallId: string;
+    toolName: string;
+    args: unknown;
+    result: unknown;
+    errorText: string;
+  }> = {},
+): MastraMessagePart {
+  return {
+    type: "tool-invocation",
+    toolInvocation: {
+      state: "result",
+      step: 0,
+      toolCallId: "call_1",
+      toolName: "getWeather",
+      args: { city: "Paris" },
+      result: { tempC: 19 },
+      ...overrides,
+    },
+  } as MastraMessagePart;
+}
+
+describe("convertMastraMessagesToAGUI", () => {
+  it("converts a plain user turn to a string-content user message", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("u1", "user", [{ type: "text", text: "weather in Paris?" }]),
+    ]);
+
+    expect(result).toEqual([
+      { id: "u1", role: "user", content: "weather in Paris?" },
+    ]);
+  });
+
+  it("converts a plain assistant turn", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "step-start" },
+        { type: "text", text: "It is sunny." },
+      ]),
+    ]);
+
+    expect(result).toEqual([
+      { id: "a1", role: "assistant", content: "It is sunny." },
+    ]);
+  });
+
+  it("splits a text -> tool -> text turn into assistant / tool / assistant", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "step-start" },
+        { type: "text", text: "Let me check." },
+        toolInvocationPart(),
+        { type: "text", text: "It is 19C in Paris." },
+      ]),
+    ]);
+
+    expect(result).toHaveLength(3);
+
+    const [assistant, tool, continuation] = result as [
+      AssistantMessage,
+      ToolMessage,
+      AssistantMessage,
+    ];
+
+    expect(assistant).toEqual({
+      id: "a1",
+      role: "assistant",
+      content: "Let me check.",
+      toolCalls: [
+        {
+          id: "call_1",
+          type: "function",
+          function: { name: "getWeather", arguments: '{"city":"Paris"}' },
+        },
+      ],
+    });
+    expect(tool).toEqual({
+      id: toolResultMessageId("call_1"),
+      role: "tool",
+      toolCallId: "call_1",
+      content: '{"tempC":19}',
+    });
+    // The trailing text must NOT ride on the base id, or the client renders it
+    // above the tool card it was written after.
+    expect(continuation).toEqual({
+      id: continuationMessageId("a1"),
+      role: "assistant",
+      content: "It is 19C in Paris.",
+    });
+  });
+
+  it("gives each text run after a tool call its own continuation index", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "text", text: "first" },
+        toolInvocationPart({ toolCallId: "call_1" }),
+        { type: "text", text: "second" },
+        toolInvocationPart({ toolCallId: "call_2" }),
+        { type: "text", text: "third" },
+      ]),
+    ]);
+
+    expect(result.map((m) => m.id)).toEqual([
+      "a1",
+      toolResultMessageId("call_1"),
+      continuationMessageId("a1"),
+      toolResultMessageId("call_2"),
+      continuationMessageId("a1", 2),
+    ]);
+  });
+
+  it("keeps parallel tool calls on one assistant message and emits both results", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "text", text: "checking both" },
+        toolInvocationPart({ toolCallId: "call_1", toolName: "getWeather" }),
+        toolInvocationPart({ toolCallId: "call_2", toolName: "getTime" }),
+      ]),
+    ]);
+
+    const [assistant, ...tools] = result;
+    expect((assistant as AssistantMessage).toolCalls?.map((c) => c.id)).toEqual([
+      "call_1",
+      "call_2",
+    ]);
+    expect(tools.map((m) => (m as ToolMessage).toolCallId)).toEqual([
+      "call_1",
+      "call_2",
+    ]);
+  });
+
+  it("emits a tool-call with no tool message while the call is unsettled", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        toolInvocationPart({ state: "call", result: undefined }),
+      ]),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as AssistantMessage).toolCalls).toHaveLength(1);
+  });
+
+  it("carries a failed tool call onto the AG-UI error field", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        toolInvocationPart({
+          state: "output-error",
+          result: undefined,
+          errorText: "upstream 500",
+        }),
+      ]),
+    ]);
+
+    const tool = result.find((m) => m.role === "tool") as ToolMessage;
+    expect(tool.error).toBe("upstream 500");
+  });
+
+  it("labels a denied tool call instead of reporting it as a success", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        toolInvocationPart({ state: "output-denied", result: undefined }),
+      ]),
+    ]);
+
+    const tool = result.find((m) => m.role === "tool") as ToolMessage;
+    expect(tool.error).toBe("tool call denied");
+  });
+
+  it("passes a string tool result through unstringified", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        toolInvocationPart({ result: "19C and sunny" }),
+      ]),
+    ]);
+
+    const tool = result.find((m) => m.role === "tool") as ToolMessage;
+    expect(tool.content).toBe("19C and sunny");
+  });
+
+  it("converts a user file part to AG-UI input content", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("u1", "user", [
+        { type: "text", text: "what is this?" },
+        { type: "file", mimeType: "image/png", data: "aGk=" },
+      ]),
+    ]);
+
+    expect(result[0]!.content).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "image",
+        source: { type: "data", mimeType: "image/png", value: "aGk=" },
+      },
+    ]);
+  });
+
+  it("emits reasoning as its own message before the text it produced", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "reasoning", reasoning: "thinking hard", details: [] },
+        { type: "text", text: "the answer" },
+      ]),
+    ]);
+
+    expect(result.map((m) => m.role)).toEqual(["reasoning", "assistant"]);
+    expect(result[0]!.content).toBe("thinking hard");
+    expect(result[0]!.id).toBe("a1-reasoning-1");
+    // Reasoning must not consume a continuation index: the assistant text keeps
+    // the stored turn id so it still dedups against Mastra storage.
+    expect(result[1]!.id).toBe("a1");
+  });
+
+  it("keeps one assistant message when reasoning interleaves with text", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "text", text: "part one " },
+        { type: "reasoning", reasoning: "second thoughts", details: [] },
+        { type: "text", text: "part two" },
+      ]),
+    ]);
+
+    // Reasoning leads the segment, and the surrounding text stays ONE assistant
+    // message: emitting it inline would either reorder the text or split it
+    // across two messages sharing the stored turn id.
+    expect(result).toEqual([
+      { id: "a1-reasoning-1", role: "reasoning", content: "second thoughts" },
+      { id: "a1", role: "assistant", content: "part one part two" },
+    ]);
+    expect(new Set(result.map((m) => m.id)).size).toBe(result.length);
+  });
+
+  it("keeps reasoning that follows a tool call below that call's result", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("a1", "assistant", [
+        { type: "text", text: "checking" },
+        toolInvocationPart(),
+        { type: "reasoning", reasoning: "the result means X", details: [] },
+        { type: "text", text: "it is 19C" },
+      ]),
+    ]);
+
+    // The reasoning was written after the call, so it must not be hoisted above
+    // the assistant message that made the call.
+    expect(result.map((m) => [m.role, m.id])).toEqual([
+      ["assistant", "a1"],
+      ["tool", toolResultMessageId("call_1")],
+      ["reasoning", "a1-reasoning-1"],
+      ["assistant", continuationMessageId("a1")],
+    ]);
+  });
+
+  it("drops parts with no AG-UI equivalent and skips signal messages", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("s1", "signal", [{ type: "text", text: "internal" }]),
+      storedMessage("a1", "assistant", [
+        { type: "step-start" },
+        {
+          type: "source",
+          source: { sourceType: "url", id: "s", url: "https://example.com" },
+        } as MastraMessagePart,
+        { type: "text", text: "answer" },
+      ]),
+    ]);
+
+    expect(result).toEqual([{ id: "a1", role: "assistant", content: "answer" }]);
+  });
+
+  it("skips empty messages instead of emitting blank bubbles", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("u1", "user", []),
+      storedMessage("a1", "assistant", [{ type: "step-start" }]),
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("converts a system message, falling back to legacy string content", () => {
+    const result = convertMastraMessagesToAGUI([
+      storedMessage("sys1", "system", [], { content: "be terse" }),
+    ]);
+
+    expect(result).toEqual([
+      { id: "sys1", role: "system", content: "be terse" },
+    ]);
+  });
+
+  it("preserves stored ids through a Mastra -> AG-UI -> Mastra round trip", () => {
+    const stored = [
+      storedMessage("u1", "user", [{ type: "text", text: "hi" }]),
+      storedMessage("a1", "assistant", [
+        { type: "text", text: "one moment" },
+        toolInvocationPart(),
+        { type: "text", text: "done" },
+      ]),
+    ];
+
+    const agui = convertMastraMessagesToAGUI(stored);
+    const backToMastra = convertAGUIMessagesToMastra(agui);
+
+    // Every id Mastra actually stored survives the round trip, so re-sending
+    // restored history upserts by id rather than creating new rows.
+    expect(backToMastra.map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      toolResultMessageId("call_1"),
+      continuationMessageId("a1"),
+    ]);
+    // And the tool result resolves back to its original tool name.
+    expect(backToMastra[2]!.content).toEqual([
+      expect.objectContaining({ toolName: "getWeather", toolCallId: "call_1" }),
+    ]);
+  });
+
+  it("returns an empty list for an empty thread", () => {
+    expect(convertMastraMessagesToAGUI([])).toEqual([]);
+  });
+});

--- a/integrations/mastra/typescript/src/__tests__/message-id-alignment.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/message-id-alignment.test.ts
@@ -1,5 +1,6 @@
 import { EventType } from "@ag-ui/client";
 import { MastraAgent } from "../mastra";
+import { continuationMessageId } from "../message-ids";
 import {
   makeLocalMastraAgent,
   makeRemoteMastraAgent,
@@ -114,8 +115,7 @@ describe("assistant message id alignment", () => {
  */
 describe("assistant text ordering vs backend tool calls", () => {
   const TURN_ID = "mastra-turn-1";
-  // Keep in sync with MastraAgent.continuationMessageId (private).
-  const CONTINUATION_ID = `${TURN_ID}-agui-text`;
+  const CONTINUATION_ID = continuationMessageId(TURN_ID);
 
   it("splits trailing text onto a distinct continuation id when Mastra reuses the turn id across the tool call", async () => {
     // The exact real-world shape: one messageId re-announced on both step-starts.
@@ -240,9 +240,8 @@ describe("assistant text ordering vs backend tool calls", () => {
  */
 describe("assistant text segments across multiple tool calls", () => {
   const TURN_ID = "mastra-turn-multi";
-  // Keep in sync with MastraAgent.continuationMessageId (private).
-  const SEGMENT_2_ID = `${TURN_ID}-agui-text`;
-  const SEGMENT_3_ID = `${TURN_ID}-agui-text-2`;
+  const SEGMENT_2_ID = continuationMessageId(TURN_ID);
+  const SEGMENT_3_ID = continuationMessageId(TURN_ID, 2);
 
   const alternatingChunks = [
     { type: "step-start", payload: { messageId: TURN_ID } },

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -48,6 +48,7 @@ import {
   getNetwork,
 } from "./utils";
 import { planA2UIInjection, type A2UIInjectConfig } from "./a2ui-tool";
+import { continuationBaseId, continuationMessageId } from "./message-ids";
 
 const { compare } = jsonpatch;
 
@@ -602,50 +603,12 @@ export class MastraAgent extends AbstractAgent {
   private readonly abortControllers = new Set<AbortController>();
 
   /**
-   * Suffix appended to a turn's base (Mastra-stored) messageId to key the
-   * SEPARATE AG-UI message that carries assistant text streamed AFTER a tool
-   * call in the same turn. See {@link continuationMessageId} and the ordering
-   * note in {@link makeStreamCallbacks}.
+   * The continuation-id scheme for assistant text streamed AFTER a tool call in
+   * the same turn lives in `./message-ids`, shared with the stored-history
+   * converter (`convertMastraMessagesToAGUI`) so both directions split a Mastra
+   * turn into the same AG-UI message ids. See the ordering note in
+   * {@link makeStreamCallbacks}.
    */
-  private static readonly ASSISTANT_TEXT_CONTINUATION_SUFFIX = "-agui-text";
-
-  /**
-   * Matches any id produced by {@link continuationMessageId}, capturing the base
-   * id it was derived from. Used by `selectNewMessages` to recognise the whole
-   * continuation family of a stored turn without knowing how many segments the
-   * turn had.
-   */
-  private static readonly CONTINUATION_ID_PATTERN = new RegExp(
-    `^(.+)${MastraAgent.ASSISTANT_TEXT_CONTINUATION_SUFFIX}(?:-\\d+)?$`,
-  );
-
-  /**
-   * Deterministic id for the `index`-th "trailing text" continuation message
-   * split off a turn whose tool call already rendered under `baseId`. A turn can
-   * alternate text -> tool -> text more than once, so each contiguous run of
-   * text after a tool call gets its own index and therefore its own AG-UI
-   * message (reusing one id makes the client append later segments onto the
-   * message at its original index — run-on text above the cards it followed).
-   *
-   * Index 1 is the bare suffix, so single-boundary turns keep the exact id they
-   * had before. Deterministic (a pure function of the stored turn id and the
-   * segment index) so re-sent history dedups: `selectNewMessages` recognises the
-   * whole family from each stored id and filters the continuation messages out,
-   * so split text is never re-forwarded (and duplicated) on later turns.
-   */
-  private static continuationMessageId(baseId: string, index = 1): string {
-    const suffix = MastraAgent.ASSISTANT_TEXT_CONTINUATION_SUFFIX;
-    return index <= 1 ? `${baseId}${suffix}` : `${baseId}${suffix}-${index}`;
-  }
-
-  /**
-   * The base id a continuation id was derived from, or null if `id` is not a
-   * continuation id at all. Callers must still check the result against the ids
-   * Mastra actually stored — the suffix shape alone does not make an id ours.
-   */
-  private static continuationBaseId(id: string): string | null {
-    return MastraAgent.CONTINUATION_ID_PATTERN.exec(id)?.[1] ?? null;
-  }
 
   constructor(private config: MastraAgentConfig) {
     const {
@@ -1410,7 +1373,7 @@ export class MastraAgent extends AbstractAgent {
       const segmentIndex = continuationIndexByParentId.get(currentId) ?? 0;
       return segmentIndex === 0
         ? currentId
-        : MastraAgent.continuationMessageId(currentId, segmentIndex);
+        : continuationMessageId(currentId, segmentIndex);
     };
 
     const closeReasoning = () => {
@@ -2677,7 +2640,7 @@ export class MastraAgent extends AbstractAgent {
       // (and duplicated) each turn.
       const isStored = (id: string): boolean => {
         if (storedIds.has(id)) return true;
-        const base = MastraAgent.continuationBaseId(id);
+        const base = continuationBaseId(id);
         return base !== null && storedIds.has(base);
       };
       const fresh = messages.filter((m) => !(m.id && isStored(m.id)));

--- a/integrations/mastra/typescript/src/message-ids.ts
+++ b/integrations/mastra/typescript/src/message-ids.ts
@@ -1,0 +1,72 @@
+/**
+ * The AG-UI message-id scheme for a Mastra turn, shared by the live bridge
+ * ({@link MastraAgent}) and the stored-history converter
+ * ({@link convertMastraMessagesToAGUI}).
+ *
+ * Mastra stores a whole turn — text, tool calls, tool results, further text —
+ * as ordered parts of ONE stored message, while AG-UI models the same turn as
+ * assistant -> tool -> assistant. Both directions therefore have to split the
+ * turn into several AG-UI messages, and both must derive the same ids for the
+ * pieces: `selectNewMessages` recognises a stored turn's whole continuation
+ * family from its stored base id and filters it out of the next run, so
+ * re-sent history (live) and restored history (after a reload) are both
+ * dropped instead of being persisted a second time.
+ */
+
+/**
+ * Suffix appended to a turn's base (Mastra-stored) messageId to key the
+ * SEPARATE AG-UI message that carries assistant text streamed AFTER a tool
+ * call in the same turn.
+ */
+export const ASSISTANT_TEXT_CONTINUATION_SUFFIX = "-agui-text";
+
+/**
+ * Matches any id produced by {@link continuationMessageId}, capturing the base
+ * id it was derived from. Lets a caller recognise the whole continuation family
+ * of a stored turn without knowing how many segments the turn had.
+ */
+const CONTINUATION_ID_PATTERN = new RegExp(
+  `^(.+)${ASSISTANT_TEXT_CONTINUATION_SUFFIX}(?:-\\d+)?$`,
+);
+
+/**
+ * Deterministic id for the `index`-th "trailing text" continuation message
+ * split off a turn whose tool call already rendered under `baseId`. A turn can
+ * alternate text -> tool -> text more than once, so each contiguous run of
+ * text after a tool call gets its own index and therefore its own AG-UI
+ * message (reusing one id makes the client append later segments onto the
+ * message at its original index — run-on text above the cards it followed).
+ *
+ * Index 1 is the bare suffix, so single-boundary turns keep the exact id they
+ * had before.
+ */
+export function continuationMessageId(baseId: string, index = 1): string {
+  return index <= 1
+    ? `${baseId}${ASSISTANT_TEXT_CONTINUATION_SUFFIX}`
+    : `${baseId}${ASSISTANT_TEXT_CONTINUATION_SUFFIX}-${index}`;
+}
+
+/**
+ * The base id a continuation id was derived from, or null if `id` is not a
+ * continuation id at all. Callers must still check the result against the ids
+ * Mastra actually stored — the suffix shape alone does not make an id ours.
+ */
+export function continuationBaseId(id: string): string | null {
+  return CONTINUATION_ID_PATTERN.exec(id)?.[1] ?? null;
+}
+
+/**
+ * Deterministic id for the AG-UI `tool` message that carries a stored tool
+ * result. Mastra keeps the result inside the assistant turn's parts, so there
+ * is no stored id to reuse: deriving it from the (unique) toolCallId keeps the
+ * id stable across reloads, so restoring a thread twice does not produce two
+ * different tool messages for the same call.
+ *
+ * NOTE: the live stream still mints a random id for TOOL_CALL_RESULT, so a
+ * live turn and the same turn after a reload do not share tool-message ids.
+ * That is invisible in the UI (only one of the two exists at a time) but it
+ * does mean a restored tool result is persisted once as its own Mastra row.
+ */
+export function toolResultMessageId(toolCallId: string): string {
+  return `${toolCallId}-result`;
+}

--- a/integrations/mastra/typescript/src/utils.ts
+++ b/integrations/mastra/typescript/src/utils.ts
@@ -1,16 +1,24 @@
 import type {
+  AssistantMessage,
   InputContent,
   InputContentDataSource,
   InputContentUrlSource,
   Message,
+  ToolCall,
+  ToolMessage,
 } from "@ag-ui/client";
 import { AbstractAgent } from "@ag-ui/client";
 import { MastraClient } from "@mastra/client-js";
 import type { Mastra } from "@mastra/core";
 import type { CoreMessage } from "@mastra/core/llm";
+import type {
+  MastraDBMessage,
+  MastraMessagePart,
+} from "@mastra/core/agent";
 import { Agent as LocalMastraAgent } from "@mastra/core/agent";
 import { RequestContext } from "@mastra/core/request-context";
 import { MastraAgent, MastraTracingOptions } from "./mastra";
+import { continuationMessageId, toolResultMessageId } from "./message-ids";
 
 /**
  * CoreMessage extended with an optional `id` field.
@@ -217,6 +225,209 @@ export function convertAGUIMessagesToMastra(
         ],
       } as CoreMessage);
     }
+  }
+
+  return result;
+}
+
+/**
+ * Turns the ordered parts of a stored Mastra USER message into AG-UI user
+ * content. A single text part collapses to a plain string (the shape the live
+ * bridge and every AG-UI client produce for typed input); anything richer
+ * becomes an InputContent array.
+ */
+function mastraPartsToAGUIUserContent(
+  parts: MastraMessagePart[],
+): string | InputContent[] {
+  const content: InputContent[] = [];
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text) content.push({ type: "text", text: part.text });
+    } else if (part.type === "file") {
+      const mimeType = part.mimeType || "application/octet-stream";
+      const kind = mimeType.startsWith("image/")
+        ? ("image" as const)
+        : mimeType.startsWith("audio/")
+          ? ("audio" as const)
+          : mimeType.startsWith("video/")
+            ? ("video" as const)
+            : ("document" as const);
+      content.push({
+        type: kind,
+        source: { type: "data", mimeType, value: part.data },
+      } as InputContent);
+    }
+    // `source`, `source-document`, `step-start`, `data-*`: no AG-UI input
+    // equivalent, so they are dropped rather than guessed at.
+  }
+  if (content.length === 1 && content[0]!.type === "text") {
+    return (content[0] as Extract<InputContent, { type: "text" }>).text;
+  }
+  return content;
+}
+
+/** Concatenated text of a stored message's text parts. */
+function mastraPartsToText(parts: MastraMessagePart[]): string {
+  return parts
+    .filter(
+      (part): part is Extract<MastraMessagePart, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+/** Stored tool-invocation states that carry a settled result. */
+const SETTLED_TOOL_STATES = new Set(["result", "output-error", "output-denied"]);
+
+/**
+ * Converts stored Mastra messages into AG-UI messages — the inverse of
+ * {@link convertAGUIMessagesToMastra}.
+ *
+ * The input is what Mastra's own history APIs return: `memory.recall()` on a
+ * local agent, or `MastraClient.getMemoryThread(...).listMessages()` against a
+ * Mastra server. Both hand back `MastraDBMessage[]`. Use it to rehydrate a
+ * thread that Mastra Memory already owns (e.g. after a page reload on a
+ * self-hosted runtime, where there is no CopilotKit-side event store to replay
+ * from) by seeding the client with the returned messages, or by emitting them
+ * as a MESSAGES_SNAPSHOT.
+ *
+ * A Mastra assistant turn stores text, tool calls, tool results and further
+ * text as ordered parts of ONE message, while AG-UI models the same turn as
+ * assistant -> tool -> assistant. The turn is therefore split at each tool
+ * boundary, reusing the live bridge's continuation ids (see `./message-ids`) so
+ * the restored history dedups against Mastra's stored ids on the next run
+ * instead of being persisted again.
+ *
+ * Parts with no AG-UI equivalent (`step-start`, `source`, `source-document`,
+ * `data-*`) are dropped. `signal` messages are Mastra-internal and skipped.
+ */
+export function convertMastraMessagesToAGUI(
+  messages: MastraDBMessage[],
+): Message[] {
+  const result: Message[] = [];
+
+  for (const message of messages) {
+    const parts = message.content?.parts ?? [];
+
+    if (message.role === "signal") continue;
+
+    if (message.role === "system") {
+      const text = mastraPartsToText(parts) || message.content?.content || "";
+      if (text) {
+        result.push({ id: message.id, role: "system", content: text });
+      }
+      continue;
+    }
+
+    if (message.role === "user") {
+      const content = mastraPartsToAGUIUserContent(parts);
+      const isEmpty = typeof content === "string" ? !content : !content.length;
+      if (!isEmpty) {
+        result.push({ id: message.id, role: "user", content });
+      }
+      continue;
+    }
+
+    // assistant: walk the parts in order, flushing a segment at every
+    // tool -> text boundary so the transcript keeps call -> result -> text.
+    let text = "";
+    let toolCalls: ToolCall[] = [];
+    let toolResults: ToolMessage[] = [];
+    // Reasoning for the segment being built, and reasoning that arrived after
+    // its tool call and therefore belongs to the NEXT segment (the trailing
+    // text), kept apart so a flush cannot hoist it above the tool result.
+    let reasoning: Message[] = [];
+    let carriedReasoning: Message[] = [];
+    let reasoningCount = 0;
+    let segment = 0;
+
+    const flush = () => {
+      // Reasoning leads its segment: the model reasons, then answers.
+      result.push(...reasoning);
+      if (text || toolCalls.length > 0) {
+        const assistant: AssistantMessage = {
+          id:
+            segment === 0
+              ? message.id
+              : continuationMessageId(message.id, segment),
+          role: "assistant",
+          ...(text ? { content: text } : {}),
+          ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        };
+        result.push(assistant);
+      }
+      result.push(...toolResults);
+      text = "";
+      toolCalls = [];
+      toolResults = [];
+      reasoning = carriedReasoning;
+      carriedReasoning = [];
+      segment += 1;
+    };
+
+    for (const part of parts) {
+      if (part.type === "text") {
+        // Text that follows a tool call belongs to the next AG-UI message.
+        if (toolCalls.length > 0) flush();
+        text += part.text;
+        continue;
+      }
+
+      if (part.type === "tool-invocation") {
+        const invocation = part.toolInvocation;
+        toolCalls.push({
+          id: invocation.toolCallId,
+          type: "function",
+          function: {
+            name: invocation.toolName,
+            arguments: JSON.stringify(invocation.args ?? {}),
+          },
+        });
+        if (SETTLED_TOOL_STATES.has(invocation.state)) {
+          const raw = invocation.result ?? "";
+          const failed = invocation.state !== "result";
+          const toolMessage: ToolMessage = {
+            id: toolResultMessageId(invocation.toolCallId),
+            role: "tool",
+            toolCallId: invocation.toolCallId,
+            content: typeof raw === "string" ? raw : JSON.stringify(raw),
+            ...(failed
+              ? {
+                  error:
+                    invocation.errorText ??
+                    (invocation.state === "output-denied"
+                      ? "tool call denied"
+                      : "tool call failed"),
+                }
+              : {}),
+          };
+          toolResults.push(toolMessage);
+        }
+        continue;
+      }
+
+      if (part.type === "reasoning") {
+        // Held until the segment flushes rather than emitted inline: flushing
+        // here would either reorder the segment's text or split it across two
+        // messages sharing one id. Only a tool boundary opens a new segment,
+        // matching the live bridge's id scheme.
+        if (part.reasoning) {
+          reasoningCount += 1;
+          const reasoningMessage: Message = {
+            id: `${message.id}-reasoning-${reasoningCount}`,
+            role: "reasoning",
+            content: part.reasoning,
+          };
+          // After a tool call, hold it for the next segment so it renders below
+          // the tool result rather than above the call that produced it.
+          if (toolCalls.length > 0) carriedReasoning.push(reasoningMessage);
+          else reasoning.push(reasoningMessage);
+        }
+        continue;
+      }
+    }
+    flush();
   }
 
   return result;


### PR DESCRIPTION
## Summary

`@ag-ui/mastra` exports `convertAGUIMessagesToMastra` and nothing that converts the other way, so a self-hosted runtime cannot rehydrate a thread Mastra Memory already owns. After a page reload the chat comes back blank while the agent keeps reading the stored history — the "AI sees the conversation, the user does not" report in [CopilotKit#1881](https://github.com/CopilotKit/CopilotKit/issues/1881) (open since 2025-05, 31 comments, several people forking or leaving over it).

This adds the inverse converter. It is deliberately the small half of that issue: a documented `connect()` fallback that reads Memory server-side is a separate change, and this is the piece every manual workaround has had to hand-write.

```ts
import { convertMastraMessagesToAGUI } from "@ag-ui/mastra";

// local agent
const { messages } = await memory.recall({ threadId, resourceId, perPage: false });
// or a Mastra server
const { messages } = await client.getMemoryThread({ threadId, agentId }).listMessages();

agent.setMessages(convertMastraMessagesToAGUI(messages));
```

Both history APIs return `MastraDBMessage[]`, so one input type covers the local and remote paths.

## The part that is not just field mapping

A Mastra assistant turn stores text, tool calls, tool results and further text as ordered parts of **one** message. AG-UI models the same turn as `assistant -> tool -> assistant`. So the converter splits a turn at each tool boundary — and the pieces have to carry the ids the live bridge would have minted:

```
stored: a1 [text "Let me check." | tool-invocation call_1 (result) | text "It is 19C."]

emitted: a1             assistant  "Let me check." + toolCalls[call_1]
         call_1-result  tool       {"tempC":19}
         a1-agui-text   assistant  "It is 19C."
```

`selectNewMessages` recognises a stored turn's whole continuation family from its stored base id, so restored history dedups on the next run instead of being persisted a second time. Getting those ids wrong means every reload re-writes the thread into Mastra storage — which is exactly the failure mode of #2054 / OSS-105, in the other direction.

That id scheme therefore moves out of `MastraAgent`'s private statics into `src/message-ids.ts`, shared by the live bridge and the converter. `message-id-alignment.test.ts` had hand-duplicated the `-agui-text` suffix behind a "Keep in sync with MastraAgent.continuationMessageId (private)" comment; it now imports the real helper.

## Behavior notes

- `reasoning` parts lead their segment, and reasoning written *after* a tool call is held for the next segment so it renders below the result rather than above the call that produced it.
- Reasoning never opens a new segment, so the assistant text keeps the stored turn id and stays dedupable.
- A failed (`output-error`) or denied (`output-denied`) invocation sets AG-UI's `error` field, so a failure is not replayed to the model as a success.
- `step-start`, `source`, `source-document` and `data-*` parts are dropped (no AG-UI equivalent); `signal` messages are Mastra-internal and skipped. Empty messages are skipped rather than emitted as blank bubbles.
- Tool-result messages get a deterministic `${toolCallId}-result` id, because Mastra keeps the result inside the assistant turn and there is no stored id to reuse. The live path still mints `randomUUID()` for `TOOL_CALL_RESULT`, so a restored tool result is persisted once as its own Mastra row. Aligning the live path is a follow-up, not this PR.

## Testing

All commands run in `integrations/mastra/typescript` after building the workspace deps (`pnpm --filter @ag-ui/core --filter @ag-ui/client --filter @ag-ui/encoder --filter @ag-ui/proto --filter @ag-ui/a2ui-toolkit run build`).

**1. New tests — 18 cases in `src/__tests__/message-conversion-from-mastra.test.ts`**

```
$ pnpm vitest run src/__tests__/message-conversion-from-mastra.test.ts
 ✓ src/__tests__/message-conversion-from-mastra.test.ts (18 tests) 3ms
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Coverage: plain user/assistant/system turns, the text→tool→text split, multiple segments (`-agui-text`, `-agui-text-2`), parallel tool calls on one assistant message, an unsettled call with no result, `output-error` and `output-denied`, string vs object results, a user `file` part, reasoning before text, reasoning interleaved with text (one assistant message, no duplicate ids), reasoning after a tool call, dropped parts, skipped `signal`/empty messages, an empty thread, and a Mastra → AG-UI → Mastra round trip asserting every stored id survives and the tool result resolves back to `getWeather`.

**2. Mutation checks — each mechanism was broken to confirm the tests catch it**

| Mutation | Result |
|---|---|
| assistant segments always use `message.id` (no continuation ids) | 3 failed, incl. the round trip |
| `toolResultMessageId` made non-deterministic (`+ Math.random()`) | 3 failed |
| reasoning emitted inline instead of carried past a tool call | 1 failed ("keeps reasoning that follows a tool call below that call's result") |

**3. No regression from moving the id helpers out of `MastraAgent`**

```
$ pnpm vitest run
 Test Files  24 passed (24)
      Tests  356 passed (356)
```

**4. Typecheck and build**

```
$ pnpm tsc --noEmit        # exit 0
$ pnpm run build           # ✔ Build complete in 1602ms (16 ESM files, 308.18 kB)
```

## Notes for review

- No public API is removed. `convertMastraMessagesToAGUI` is additive; `src/message-ids.ts` is internal (not re-exported from `index.ts`).
- Touches `src/utils.ts` alongside open PR #2576, which hardens `JSON.parse` inside `convertAGUIMessagesToMastra`. Different function, different region — but whichever lands second may want a look.
- Docs for the rehydration recipe are not in this PR; happy to add a page if you would rather ship them together.
