### PR TITLE
fix(client): bind public agent methods

### DIFF
--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-clone.test.ts
@@ -41,6 +41,45 @@ describe("AbstractAgent cloning", () => {
     expect(cloned.state).toEqual(agent.state);
     expect(cloned.state).not.toBe(agent.state);
   });
+
+  it("keeps public methods bound on new and cloned agents", () => {
+    const agent = new CloneableTestAgent();
+
+    for (const target of [agent, agent.clone()]) {
+      const { subscribe, use, addMessage, addMessages, setMessages, setState } = target;
+      const subscription = subscribe({});
+
+      expect(use((input: RunAgentInput, next: AbstractAgent) => next.run(input))).toBe(target);
+      addMessage({ id: "msg-2", role: "user", content: "Second" });
+      addMessages([{ id: "msg-3", role: "user", content: "Third" }]);
+      setMessages([{ id: "msg-4", role: "user", content: "Fourth" }]);
+      setState({ stage: "updated" });
+
+      expect(target.messages).toHaveLength(1);
+      expect(target.messages[0].id).toBe("msg-4");
+      expect(target.state).toEqual({ stage: "updated" });
+      subscription.unsubscribe();
+    }
+  });
+
+  it("binds subclass overrides", () => {
+    class OverridingAgent extends CloneableTestAgent {
+      calls = 0;
+
+      override addMessage(message: Message) {
+        this.calls++;
+        super.addMessage(message);
+      }
+    }
+
+    const agent = new OverridingAgent();
+    const { addMessage } = agent;
+
+    addMessage({ id: "msg-2", role: "user", content: "Second" });
+
+    expect(agent.calls).toBe(1);
+    expect(agent.messages).toHaveLength(2);
+  });
 });
 
 describe("HttpAgent cloning", () => {

--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -112,6 +112,7 @@ export abstract class AbstractAgent {
     this.state = structuredClone_(initialState ?? {});
     this._debug = resolveAgentDebugConfig(debug);
     this._debugLogger = createDebugLogger(this._debug);
+    this.bindPublicMethods();
 
     if (compareVersions(this.maxVersion, "0.0.39") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_39());
@@ -134,6 +135,15 @@ export abstract class AbstractAgent {
     if (compareVersions(this.maxVersion, "0.0.57") <= 0) {
       this.middlewares.unshift(new BackwardCompatibility_0_0_57());
     }
+  }
+
+  private bindPublicMethods() {
+    this.subscribe = this.subscribe.bind(this);
+    this.use = this.use.bind(this);
+    this.addMessage = this.addMessage.bind(this);
+    this.addMessages = this.addMessages.bind(this);
+    this.setMessages = this.setMessages.bind(this);
+    this.setState = this.setState.bind(this);
   }
 
   public subscribe(subscriber: AgentSubscriber) {
@@ -592,6 +602,7 @@ export abstract class AbstractAgent {
     cloned.subscribers = [...this.subscribers];
     cloned.middlewares = [...this.middlewares];
     cloned.pendingInterrupts = structuredClone_(this.pendingInterrupts);
+    cloned.bindPublicMethods();
 
     return cloned;
   }


### PR DESCRIPTION
## Summary

- bind `subscribe`, `use`, and the four public state/message mutators so they remain usable when destructured or passed as callbacks
- rebind those methods on clones, whose constructors are intentionally skipped
- cover constructed agents, cloned agents, and subclass overrides

Fixes #2650

## Validation

- `nx run @ag-ui/client:test` (69 files, 743 tests)
- `nx run @ag-ui/client:typecheck`
- `nx run @ag-ui/client:lint`