### PR TITLE
fix(java): bound transport payloads and terminate decoder failures

### DIFF
--- a/sdks/community/java/ag-ui/README.md
+++ b/sdks/community/java/ag-ui/README.md
@@ -14,11 +14,11 @@ dependencies**.
 
 ## Modules
 
-| Module | Description |
-|--------|-------------|
-| [`core`](core) | Core types and protocol primitives — messages, events, agent abstraction, and a pluggable `Serializer`. No external runtime dependencies. |
+| Module             | Description                                                                                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`core`](core)     | Core types and protocol primitives — messages, events, agent abstraction, and a pluggable `Serializer`. No external runtime dependencies.                                           |
 | [`client`](client) | Client implementation. `HttpAgent` runs against a remote AG-UI endpoint over HTTP, decoding the Server-Sent Events response into a stream of events. Built on the JDK `HttpClient`. |
-| [`server`](server) | Server-side support for exposing an `Agent` over the AG-UI protocol. |
+| [`server`](server) | Server-side support for exposing an `Agent` over the AG-UI protocol.                                                                                                                |
 
 ## Requirements
 
@@ -44,6 +44,8 @@ mvn test
 `HttpAgent` POSTs a `RunAgentInput` to an AG-UI endpoint and exposes the
 Server-Sent Events response as a `Flow.Publisher<Event>`. You supply a
 `Serializer` (the library is agnostic to the concrete JSON implementation).
+By default, the client bounds each SSE wire line to 1 MiB and each decoded event
+`data` payload to 8 MiB. Pass an `SseLimits` overload to customize those caps.
 
 ```java
 import com.agui.community.client.HttpAgent;
@@ -74,6 +76,17 @@ Each subscription triggers a fresh run: the request is sent on subscribe, events
 are emitted in order, and the publisher completes when the stream ends (or
 signals `onError` on failure).
 
+The SSE limits count UTF-8 bytes, not Java characters. Line limits exclude the
+wire line terminator but still apply to comments and fields the AG-UI parser
+ignores. Event payload limits include the newlines inserted between multiple
+`data:` fields. Limits apply per line and per event; there is no lifetime byte
+budget for a long-running stream.
+
+`Serializer` is an interface, not a bundled JSON binding. This repository does
+not provide a concrete JSON `Serializer` implementation. Applications should
+configure parser constraints appropriate to their JSON library, such as nesting,
+token, and string limits, and wrap library failures in `SerializationException`.
+
 ### Implementing an agent
 
 `Agent` is a functional interface — implement `run` to emit your own event
@@ -84,6 +97,11 @@ Agent agent = input -> {
     // produce a Flow.Publisher<Event> describing the run
 };
 ```
+
+The included JDK HTTP server adapter rejects request bodies larger than 8 MiB by
+default. Use a `JdkAgentHttpHandler` constructor that accepts
+`maxRequestBodyBytes` to provide a positive custom cap. Oversized requests
+receive `413 Payload Too Large` before the body is parsed or the agent is run.
 
 ## Using as a dependency
 

--- a/sdks/community/java/ag-ui/client/README.md
+++ b/sdks/community/java/ag-ui/client/README.md
@@ -9,11 +9,12 @@ agnostic to the concrete JSON library you use.
 
 ## What's inside
 
-| Type | Purpose |
-|------|---------|
-| [`HttpAgent`](src/main/java/com/agui/community/client/HttpAgent.java) | An `Agent` that serializes a `RunAgentInput` to JSON, POSTs it to a remote endpoint, and decodes the Server-Sent Events response into a `Flow.Publisher<Event>`. |
-| [`SseEventParser`](src/main/java/com/agui/community/client/SseEventParser.java) | Parses a Server-Sent Events byte/line stream into AG-UI events. |
-| [`HttpAgentException`](src/main/java/com/agui/community/client/HttpAgentException.java) | Raised (via `onError`) when a request fails or returns an error status. |
+| Type                                                                                    | Purpose                                                                                                                                                          |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`HttpAgent`](src/main/java/com/agui/community/client/HttpAgent.java)                   | An `Agent` that serializes a `RunAgentInput` to JSON, POSTs it to a remote endpoint, and decodes the Server-Sent Events response into a `Flow.Publisher<Event>`. |
+| [`SseLimits`](src/main/java/com/agui/community/client/SseLimits.java)                   | Positive per-line and per-event byte caps for an SSE response. Defaults are 1 MiB per line and 8 MiB per event data payload.                                     |
+| [`SseEventParser`](src/main/java/com/agui/community/client/SseEventParser.java)         | Parses a Server-Sent Events byte/line stream into AG-UI events.                                                                                                  |
+| [`HttpAgentException`](src/main/java/com/agui/community/client/HttpAgentException.java) | Raised (via `onError`) when a request fails or returns an error status.                                                                                          |
 
 ## Usage
 
@@ -45,10 +46,22 @@ are emitted in order, and the publisher completes when the stream ends.
 
 ### Customizing the transport
 
-The default constructor uses `HttpClient.newHttpClient()`, the common
-`ForkJoinPool`, and a 5-minute request timeout. Use the full constructor to
-control the `HttpClient`, the `Executor` on which the response stream is
-consumed, and the per-request timeout:
+The default constructor uses `HttpClient.newHttpClient()`, a cached thread pool
+for stream processing, a 5-minute request timeout, and `SseLimits.DEFAULT`.
+`SseLimits.DEFAULT` allows up to 1 MiB per SSE line and 8 MiB per decoded event
+`data` payload.
+
+Use the `SseLimits` overload when you only need custom response limits:
+
+```java
+Agent agent = new HttpAgent(
+        URI.create("https://example.com/agent"),
+        serializer,
+        new SseLimits(256 * 1024, 2 * 1024 * 1024));
+```
+
+Use the full constructor to control the `HttpClient`, the `Executor` on which
+the response stream is consumed, the per-request timeout, and the SSE limits:
 
 ```java
 Agent agent = new HttpAgent(
@@ -56,8 +69,16 @@ Agent agent = new HttpAgent(
         serializer,
         myHttpClient,
         myExecutor,
-        Duration.ofSeconds(30));
+        Duration.ofSeconds(30),
+        new SseLimits(256 * 1024, 2 * 1024 * 1024));
 ```
+
+Both limits count UTF-8 bytes, not Java characters. The line limit excludes the
+CR/LF terminator, but applies to every wire line, including comments and fields
+that the AG-UI client ignores. The event limit applies to the combined decoded
+`data` payload, including the newline bytes inserted between multiple `data:`
+fields. These caps are per line and per event; there is no lifetime byte budget
+for a long-running stream.
 
 ## Dependency
 

--- a/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/HttpAgent.java
+++ b/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/HttpAgent.java
@@ -3,7 +3,9 @@ package com.agui.community.client;
 import com.agui.community.core.agent.Agent;
 import com.agui.community.core.agent.RunAgentInput;
 import com.agui.community.core.event.Event;
+import com.agui.community.core.serialization.SerializationException;
 import com.agui.community.core.serialization.Serializer;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -14,7 +16,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.SubmissionPublisher;
-import java.util.stream.Stream;
 
 /**
  * An {@link Agent} that runs against a remote AG-UI endpoint over HTTP. It
@@ -51,6 +52,7 @@ public final class HttpAgent implements Agent {
     private final HttpClient httpClient;
     private final Executor executor;
     private final Duration requestTimeout;
+    private final SseLimits sseLimits;
 
     /**
      * Creates an agent using a default {@link HttpClient} and a cached thread
@@ -60,8 +62,19 @@ public final class HttpAgent implements Agent {
      * @param serializer the serializer used to encode the input and decode events
      */
     public HttpAgent(URI endpoint, Serializer serializer) {
+        this(endpoint, serializer, SseLimits.DEFAULT);
+    }
+
+    /**
+     * Creates an agent with default transport settings and custom SSE limits.
+     *
+     * @param endpoint the URI of the remote AG-UI endpoint
+     * @param serializer the serializer used to encode input and decode events
+     * @param sseLimits the per-line and per-event response size limits
+     */
+    public HttpAgent(URI endpoint, Serializer serializer, SseLimits sseLimits) {
         this(endpoint, serializer, HttpClient.newHttpClient(), DEFAULT_EXECUTOR,
-                DEFAULT_REQUEST_TIMEOUT);
+                DEFAULT_REQUEST_TIMEOUT, sseLimits);
     }
 
     /**
@@ -78,11 +91,30 @@ public final class HttpAgent implements Agent {
      */
     public HttpAgent(URI endpoint, Serializer serializer, HttpClient httpClient, Executor executor,
                      Duration requestTimeout) {
+        this(endpoint, serializer, httpClient, executor, requestTimeout, SseLimits.DEFAULT);
+    }
+
+    /**
+     * Creates an agent with custom transport settings and SSE size limits.
+     * Limit failures close the response and signal {@link HttpAgentException}
+     * through {@code onError}. Limits apply independently to each line/event;
+     * there is no lifetime byte budget for a long-running stream.
+     *
+     * @param endpoint the URI of the remote AG-UI endpoint
+     * @param serializer the serializer used to encode input and decode events
+     * @param httpClient the HTTP client to use
+     * @param executor the executor used for blocking reads and event publication
+     * @param requestTimeout the per-request timeout
+     * @param sseLimits the per-line and per-event response size limits
+     */
+    public HttpAgent(URI endpoint, Serializer serializer, HttpClient httpClient, Executor executor,
+                     Duration requestTimeout, SseLimits sseLimits) {
         this.endpoint = Objects.requireNonNull(endpoint, "endpoint must not be null");
         this.serializer = Objects.requireNonNull(serializer, "serializer must not be null");
         this.httpClient = Objects.requireNonNull(httpClient, "httpClient must not be null");
         this.executor = Objects.requireNonNull(executor, "executor must not be null");
         this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout must not be null");
+        this.sseLimits = Objects.requireNonNull(sseLimits, "sseLimits must not be null");
     }
 
     @Override
@@ -104,21 +136,22 @@ public final class HttpAgent implements Agent {
                     .POST(HttpRequest.BodyPublishers.ofString(serializer.serialize(input)))
                     .build();
 
-            HttpResponse<Stream<String>> response =
-                    httpClient.send(request, HttpResponse.BodyHandlers.ofLines());
+            HttpResponse<InputStream> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
-            if (response.statusCode() >= 400) {
-                publisher.closeExceptionally(new HttpAgentException(
-                        "AG-UI endpoint returned HTTP " + response.statusCode()));
-                return;
-            }
+            try (InputStream body = response.body()) {
+                if (response.statusCode() >= 400) {
+                    throw new HttpAgentException("AG-UI endpoint returned HTTP " + response.statusCode());
+                }
 
-            SseEventParser parser = new SseEventParser();
-            try (Stream<String> lines = response.body()) {
-                lines.forEach(line ->
-                        parser.feed(line).ifPresent(data -> publisher.submit(decode(data))));
+                SseEventParser parser = new SseEventParser(sseLimits.maxEventBytes());
+                SseLineReader lines = new SseLineReader(body, sseLimits.maxLineBytes());
+                String line;
+                while ((line = lines.readLine()) != null) {
+                    parser.feed(line).ifPresent(data -> publisher.submit(decode(data)));
+                }
+                parser.flush().ifPresent(data -> publisher.submit(decode(data)));
             }
-            parser.flush().ifPresent(data -> publisher.submit(decode(data)));
             publisher.close();
         } catch (InterruptedException e) {
             // Restore the interrupt status before surfacing the failure, so callers
@@ -131,6 +164,12 @@ public final class HttpAgent implements Agent {
     }
 
     private Event decode(String data) {
-        return serializer.deserialize(data, Event.class);
+        try {
+            return serializer.deserialize(data, Event.class);
+        } catch (StackOverflowError e) {
+            // A serializer may recurse on untrusted JSON. Terminate this run,
+            // without swallowing other VM errors or attempting to keep parsing.
+            throw new SerializationException("Serializer stack overflow while decoding an AG-UI event", e);
+        }
     }
 }

--- a/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseEventParser.java
+++ b/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseEventParser.java
@@ -1,5 +1,6 @@
 package com.agui.community.client;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 /**
@@ -16,8 +17,18 @@ import java.util.Optional;
  */
 final class SseEventParser {
 
-    private final StringBuilder data = new StringBuilder();
+    private final int maxEventBytes;
+    private StringBuilder data = new StringBuilder();
+    private int dataBytes;
     private boolean hasData;
+
+    SseEventParser() {
+        this(SseLimits.DEFAULT.maxEventBytes());
+    }
+
+    SseEventParser(int maxEventBytes) {
+        this.maxEventBytes = maxEventBytes;
+    }
 
     /**
      * Feeds a single line (without its terminator) into the parser.
@@ -48,10 +59,17 @@ final class SseEventParser {
             }
         }
         if (field.equals("data")) {
+            int valueBytes = value.getBytes(StandardCharsets.UTF_8).length;
+            long combinedBytes = (long) dataBytes + valueBytes + (hasData ? 1 : 0);
+            if (combinedBytes > maxEventBytes) {
+                throw new HttpAgentException(
+                        "SSE event data exceeds maximum size of " + maxEventBytes + " bytes");
+            }
             if (hasData) {
                 data.append('\n');
             }
             data.append(value);
+            dataBytes = (int) combinedBytes;
             hasData = true;
         }
         return Optional.empty();
@@ -73,7 +91,10 @@ final class SseEventParser {
             return Optional.empty();
         }
         String payload = data.toString();
-        data.setLength(0);
+        // Release the backing capacity so a large event is not retained for the
+        // rest of a long-lived stream.
+        data = new StringBuilder();
+        dataBytes = 0;
         hasData = false;
         return Optional.of(payload);
     }

--- a/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseLimits.java
+++ b/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseLimits.java
@@ -1,0 +1,22 @@
+package com.agui.community.client;
+
+/**
+ * Per-line and per-event limits for an SSE response. Both limits count UTF-8
+ * bytes, not Java characters, and must be positive.
+ *
+ * @param maxLineBytes maximum bytes in any line, excluding its CR/LF terminator;
+ *                     applies to comments and ignored fields as well as data
+ * @param maxEventBytes maximum bytes in the combined, decoded event data,
+ *                      including the newlines inserted between data fields
+ */
+public record SseLimits(int maxLineBytes, int maxEventBytes) {
+
+    /** Defaults: 1 MiB per wire line and 8 MiB per event data payload. */
+    public static final SseLimits DEFAULT = new SseLimits(1024 * 1024, 8 * 1024 * 1024);
+
+    public SseLimits {
+        if (maxLineBytes <= 0 || maxEventBytes <= 0) {
+            throw new IllegalArgumentException("SSE size limits must be positive");
+        }
+    }
+}

--- a/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseLineReader.java
+++ b/sdks/community/java/ag-ui/client/src/main/java/com/agui/community/client/SseLineReader.java
@@ -1,0 +1,45 @@
+package com.agui.community.client;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/** Reads bounded UTF-8 lines without materializing an unbounded HTTP body line. */
+final class SseLineReader {
+
+    private final InputStream input;
+    private final int maxLineBytes;
+    private boolean skipLf;
+
+    SseLineReader(InputStream input, int maxLineBytes) {
+        this.input = new BufferedInputStream(input);
+        this.maxLineBytes = maxLineBytes;
+    }
+
+    /** Accepts LF, CRLF and CR; returns a final unterminated line, then null at EOF. */
+    String readLine() throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream(Math.min(1024, maxLineBytes));
+        while (true) {
+            int next = input.read();
+            if (skipLf) {
+                skipLf = false;
+                if (next == '\n') {
+                    continue;
+                }
+            }
+            if (next == -1) {
+                return line.size() == 0 ? null : line.toString(StandardCharsets.UTF_8);
+            }
+            if (next == '\n' || next == '\r') {
+                skipLf = next == '\r';
+                return line.toString(StandardCharsets.UTF_8);
+            }
+            if (line.size() == maxLineBytes) {
+                throw new HttpAgentException("SSE line exceeds maximum size of " + maxLineBytes + " bytes");
+            }
+            line.write(next);
+        }
+    }
+}

--- a/sdks/community/java/ag-ui/client/src/test/java/com/agui/community/client/HttpAgentTest.java
+++ b/sdks/community/java/ag-ui/client/src/test/java/com/agui/community/client/HttpAgentTest.java
@@ -5,25 +5,45 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.sun.net.httpserver.HttpServer;
 import com.agui.community.core.agent.RunAgentInput;
 import com.agui.community.core.event.CustomEvent;
 import com.agui.community.core.event.Event;
+import com.agui.community.core.serialization.SerializationException;
 import com.agui.community.core.serialization.Serializer;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
 import java.net.InetSocketAddress;
+import java.net.ProxySelector;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class HttpAgentTest {
 
@@ -92,12 +112,125 @@ class HttpAgentTest {
         assertInstanceOf(HttpAgentException.class, error);
     }
 
+    @Test
+    void closesResponseBodyAndSignalsErrorOnHttpErrorStatus() throws InterruptedException {
+        CloseObservingInputStream body = new CloseObservingInputStream("boom");
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        newStubbedAgent(new EchoSerializer(), 500, body, SseLimits.DEFAULT).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(1, TimeUnit.SECONDS));
+        assertInstanceOf(HttpAgentException.class, subscriber.error.get());
+        assertTrue(body.closed());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"data: ", ": ", "unknown: ", "id: ", "event: "})
+    void rejectsOversizedLinesIncludingIgnoredFields(String prefix) throws InterruptedException {
+        respondWith(200, prefix + "x".repeat(1024 * 1024));
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+        CountingSerializer serializer = new CountingSerializer();
+
+        new HttpAgent(endpoint, serializer).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(5, TimeUnit.SECONDS));
+        assertInstanceOf(HttpAgentException.class, subscriber.error.get());
+        assertTrue(subscriber.events.isEmpty(), "oversized data must not be decoded");
+        assertEquals(0, serializer.deserializeCalls());
+    }
+
+    @Test
+    void closesResponseBodyAndSignalsErrorOnLineLimitFailure() throws InterruptedException {
+        CloseObservingInputStream body = new CloseObservingInputStream("data: 123456789\n");
+        CountingSerializer serializer = new CountingSerializer();
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        newStubbedAgent(serializer, 200, body, new SseLimits(8, 1024)).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(1, TimeUnit.SECONDS));
+        assertInstanceOf(HttpAgentException.class, subscriber.error.get());
+        assertTrue(body.closed());
+        assertEquals(0, serializer.deserializeCalls());
+    }
+
+    @Test
+    void closesResponseBodyAndSignalsErrorOnEventLimitFailure() throws InterruptedException {
+        CloseObservingInputStream body = new CloseObservingInputStream("data: 1234\ndata: 5678\n\n");
+        CountingSerializer serializer = new CountingSerializer();
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        newStubbedAgent(serializer, 200, body, new SseLimits(1024, 8)).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(1, TimeUnit.SECONDS));
+        assertInstanceOf(HttpAgentException.class, subscriber.error.get());
+        assertTrue(body.closed());
+        assertEquals(0, serializer.deserializeCalls());
+    }
+
+    @Test
+    void closesResponseBodyAndSignalsOrdinarySerializerException() throws InterruptedException {
+        CloseObservingInputStream body = new CloseObservingInputStream("data: {}\n\n");
+        RuntimeException failure = new IllegalArgumentException("bad event");
+        Serializer serializer = new EchoSerializer() {
+            @Override
+            public <T> T deserialize(String json, Class<T> type) {
+                throw failure;
+            }
+        };
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        newStubbedAgent(serializer, 200, body, SseLimits.DEFAULT).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(1, TimeUnit.SECONDS));
+        assertEquals(failure, subscriber.error.get());
+        assertTrue(body.closed());
+    }
+
+    @Test
+    void signalsSerializerStackOverflowAsSerializationFailure() throws InterruptedException {
+        CloseObservingInputStream body = new CloseObservingInputStream("data: {}\n\n");
+        StackOverflowError failure = new StackOverflowError("injected parser overflow");
+        Serializer serializer = new EchoSerializer() {
+            @Override
+            public <T> T deserialize(String json, Class<T> type) {
+                throw failure;
+            }
+        };
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        newStubbedAgent(serializer, 200, body, SseLimits.DEFAULT).run(sampleInput()).subscribe(subscriber);
+
+        assertTrue(subscriber.awaitCompletion(5, TimeUnit.SECONDS), "subscriber was left unterminated");
+        SerializationException error = assertInstanceOf(SerializationException.class, subscriber.error.get());
+        assertEquals(failure, error.getCause());
+        assertTrue(body.closed());
+    }
+
+    @Test
+    void restoresInterruptStatusWhenHttpSendIsInterrupted() {
+        Thread.interrupted();
+        InterruptedException failure = new InterruptedException("interrupted send");
+        CollectingSubscriber subscriber = new CollectingSubscriber();
+
+        try {
+            HttpAgent agent = new HttpAgent(endpoint, new EchoSerializer(), new StubHttpClient(failure),
+                    Runnable::run, Duration.ofSeconds(1), SseLimits.DEFAULT);
+
+            agent.run(sampleInput()).subscribe(subscriber);
+
+            assertEquals(failure, subscriber.error.get());
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
     private static RunAgentInput sampleInput() {
         return new RunAgentInput("thread-1", "run-1", List.of(), List.of());
     }
 
     /** A serializer whose {@code deserialize} turns the SSE payload into a CustomEvent named after it. */
-    private static final class EchoSerializer implements Serializer {
+    private static class EchoSerializer implements Serializer {
         @Override
         public String serialize(Object value) {
             return "{}";
@@ -111,6 +244,182 @@ class HttpAgentTest {
         @Override
         public <T> List<T> deserializeList(String json, Class<T> elementType) {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class CountingSerializer extends EchoSerializer {
+        private final AtomicInteger deserializeCalls = new AtomicInteger();
+
+        @Override
+        public <T> T deserialize(String json, Class<T> type) {
+            deserializeCalls.incrementAndGet();
+            return super.deserialize(json, type);
+        }
+
+        private int deserializeCalls() {
+            return deserializeCalls.get();
+        }
+    }
+
+    private HttpAgent newStubbedAgent(Serializer serializer, int statusCode, InputStream body, SseLimits limits) {
+        return new HttpAgent(endpoint, serializer, new StubHttpClient(new StubHttpResponse(statusCode, body)),
+                Runnable::run, Duration.ofSeconds(1), limits);
+    }
+
+    private static final class CloseObservingInputStream extends InputStream {
+        private final ByteArrayInputStream delegate;
+        private boolean closed;
+
+        private CloseObservingInputStream(String body) {
+            this.delegate = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public int read() {
+            return delegate.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            delegate.close();
+        }
+
+        private boolean closed() {
+            return closed;
+        }
+    }
+
+    private static final class StubHttpClient extends HttpClient {
+        private final HttpResponse<InputStream> response;
+        private final InterruptedException interruption;
+
+        private StubHttpClient(HttpResponse<InputStream> response) {
+            this.response = response;
+            this.interruption = null;
+        }
+
+        private StubHttpClient(InterruptedException interruption) {
+            this.response = null;
+            this.interruption = interruption;
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return null;
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return null;
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public Optional<java.util.concurrent.Executor> executor() {
+            return Optional.empty();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+                throws IOException, InterruptedException {
+            if (interruption != null) {
+                throw interruption;
+            }
+            return (HttpResponse<T>) response;
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+                                                                HttpResponse.BodyHandler<T> responseBodyHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+                                                                HttpResponse.BodyHandler<T> responseBodyHandler,
+                                                                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class StubHttpResponse implements HttpResponse<InputStream> {
+        private final int statusCode;
+        private final InputStream body;
+
+        private StubHttpResponse(int statusCode, InputStream body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public Optional<HttpResponse<InputStream>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public InputStream body() {
+            return body;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create("http://localhost/agent");
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
         }
     }
 

--- a/sdks/community/java/ag-ui/client/src/test/java/com/agui/community/client/SseEventParserTest.java
+++ b/sdks/community/java/ag-ui/client/src/test/java/com/agui/community/client/SseEventParserTest.java
@@ -1,8 +1,13 @@
 package com.agui.community.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +85,153 @@ class SseEventParserTest {
         // A bare "data" line (no colon) contributes an empty data value.
         assertTrue(parser.feed("data").isEmpty());
         assertEquals(Optional.of(""), parser.feed(""));
+    }
+
+    @Test
+    void rejectsAggregateDataBeyondDefaultLimit() {
+        String line = "data: " + "x".repeat(8192);
+        assertThrows(HttpAgentException.class, () -> {
+            for (int i = 0; i < 1024; i++) {
+                parser.feed(line);
+            }
+        });
+    }
+
+    @Test
+    void acceptsAggregateDataAtExactLimitIncludingInsertedNewlinesAndUtf8Bytes() {
+        SseEventParser limited = new SseEventParser(9);
+
+        assertTrue(limited.feed("data: \uD83D\uDE00").isEmpty());
+        assertTrue(limited.feed("data: abcd").isEmpty());
+
+        assertEquals(Optional.of("\uD83D\uDE00\nabcd"), limited.feed(""));
+    }
+
+    @Test
+    void rejectsAggregateDataOneByteOverLimitIncludingInsertedNewline() {
+        SseEventParser limited = new SseEventParser(8);
+
+        assertTrue(limited.feed("data: \u00A2\u20AC").isEmpty());
+
+        HttpAgentException error = assertThrows(HttpAgentException.class, () -> limited.feed("data: xyz"));
+        assertTrue(error.getMessage().contains("8 bytes"));
+    }
+
+    @Test
+    void acceptsLineAtExactByteLimitWithUtf8Characters() throws IOException {
+        SseLineReader reader = reader("a\u00A2\u20AC\n", 6);
+
+        assertEquals("a\u00A2\u20AC", reader.readLine());
+        assertEquals(null, reader.readLine());
+    }
+
+    @Test
+    void rejectsLineOneByteOverLimit() {
+        SseLineReader reader = reader("1234567\n", 6);
+
+        HttpAgentException error = assertThrows(HttpAgentException.class, reader::readLine);
+        assertTrue(error.getMessage().contains("6 bytes"));
+    }
+
+    @Test
+    void readsLinesTerminatedByLfCrCrLfAndFinalEofFlush() throws IOException {
+        SseLineReader reader = reader("lf\ncr\rcrlf\r\nfinal", 64);
+
+        assertEquals("lf", reader.readLine());
+        assertEquals("cr", reader.readLine());
+        assertEquals("crlf", reader.readLine());
+        assertEquals("final", reader.readLine());
+        assertEquals(null, reader.readLine());
+    }
+
+    @Test
+    void preservesUtf8CharactersSplitAcrossSmallInputChunks() throws IOException {
+        SseLineReader reader = new SseLineReader(
+                new OneByteAtATimeInputStream("emoji-\uD83D\uDE00\n".getBytes(StandardCharsets.UTF_8)), 32);
+
+        assertEquals("emoji-\uD83D\uDE00", reader.readLine());
+    }
+
+    @Test
+    void rejectsOversizedUnterminatedLineBeforeConsumingWholeStream() {
+        CountingInputStream input = new CountingInputStream("x".repeat(10_000).getBytes(StandardCharsets.UTF_8));
+        SseLineReader reader = new SseLineReader(input, 8);
+
+        assertThrows(HttpAgentException.class, reader::readLine);
+
+        assertEquals(9, input.bytesRead());
+    }
+
+    @Test
+    void rejectsOversizedIgnoredAndCommentLinesBeforeConsumingWholeStream() {
+        assertRejectedBeforeWholeStream(": " + "x".repeat(10_000), 9);
+        assertRejectedBeforeWholeStream("ignored: " + "x".repeat(10_000), 9);
+    }
+
+    private static SseLineReader reader(String body, int maxLineBytes) {
+        return new SseLineReader(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)), maxLineBytes);
+    }
+
+    private static void assertRejectedBeforeWholeStream(String body, int maxLineBytes) {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        CountingInputStream input = new CountingInputStream(bytes);
+        SseLineReader reader = new SseLineReader(input, maxLineBytes);
+
+        assertThrows(HttpAgentException.class, reader::readLine);
+
+        assertTrue(input.bytesRead() < bytes.length);
+        assertEquals(maxLineBytes + 1, input.bytesRead());
+    }
+
+    private static final class OneByteAtATimeInputStream extends InputStream {
+        private final byte[] bytes;
+        private int offset;
+
+        private OneByteAtATimeInputStream(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public int read() {
+            return offset == bytes.length ? -1 : bytes[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) {
+            int next = read();
+            if (next == -1) {
+                return -1;
+            }
+            buffer[off] = (byte) next;
+            return 1;
+        }
+    }
+
+    private static final class CountingInputStream extends InputStream {
+        private final byte[] bytes;
+        private int offset;
+
+        private CountingInputStream(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public int read() {
+            return offset == bytes.length ? -1 : bytes[offset++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) {
+            int next = read();
+            if (next == -1) {
+                return -1;
+            }
+            buffer[off] = (byte) next;
+            return 1;
+        }
+
+        private int bytesRead() {
+            return offset;
+        }
     }
 }

--- a/sdks/community/java/ag-ui/core/README.md
+++ b/sdks/community/java/ag-ui/core/README.md
@@ -10,13 +10,13 @@ dependencies** — streaming is expressed with the JDK's
 
 ## What's inside
 
-| Package | Contents |
-|---------|----------|
-| [`agent`](src/main/java/com/agui/community/core/agent) | The `Agent` functional interface, plus `RunAgentInput` and `Context` describing a single run. |
-| [`event`](src/main/java/com/agui/community/core/event) | The `Event` model — a `sealed interface` with one record per event variant, discriminated by `EventType`. |
-| [`message`](src/main/java/com/agui/community/core/message) | Conversation messages: `UserMessage`, `AssistantMessage`, `SystemMessage`, `DeveloperMessage`, `ToolMessage`, plus `Role`, `ToolCall`, and `FunctionCall`. |
-| [`tool`](src/main/java/com/agui/community/core/tool) | `Tool` and `ToolParameters` describing tools available to an agent. |
-| [`serialization`](src/main/java/com/agui/community/core/serialization) | The `Serializer` interface (and `SerializationException`) — the JSON binding seam. The core ships no concrete implementation. |
+| Package                                                                | Contents                                                                                                                                                   |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`agent`](src/main/java/com/agui/community/core/agent)                 | The `Agent` functional interface, plus `RunAgentInput` and `Context` describing a single run.                                                              |
+| [`event`](src/main/java/com/agui/community/core/event)                 | The `Event` model — a `sealed interface` with one record per event variant, discriminated by `EventType`.                                                  |
+| [`message`](src/main/java/com/agui/community/core/message)             | Conversation messages: `UserMessage`, `AssistantMessage`, `SystemMessage`, `DeveloperMessage`, `ToolMessage`, plus `Role`, `ToolCall`, and `FunctionCall`. |
+| [`tool`](src/main/java/com/agui/community/core/tool)                   | `Tool` and `ToolParameters` describing tools available to an agent.                                                                                        |
+| [`serialization`](src/main/java/com/agui/community/core/serialization) | The `Serializer` interface (and `SerializationException`) — the JSON binding seam. The core ships no concrete implementation.                              |
 
 ## The event model
 
@@ -58,6 +58,13 @@ order and then completes, or signals `onError` on failure.
 `core` does not bind to any JSON library. Implement `Serializer` to plug in
 Jackson, Gson, or another library; client and server modules accept a
 `Serializer` so the choice stays at the application's edge.
+
+This repository provides the `Serializer` interface and `SerializationException`
+only; it does not ship a concrete JSON `Serializer` implementation.
+Implementations must configure parser constraints appropriate to the chosen JSON
+library, including nesting depth, token count, and string size limits, and must
+wrap serialization or deserialization library failures in
+`SerializationException`.
 
 ## Dependency
 

--- a/sdks/community/java/ag-ui/core/src/main/java/com/agui/community/core/serialization/Serializer.java
+++ b/sdks/community/java/ag-ui/core/src/main/java/com/agui/community/core/serialization/Serializer.java
@@ -15,8 +15,12 @@ import java.util.List;
  * {@code type} discriminator and {@link com.agui.community.core.message.Message}
  * keyed on its {@code role} discriminator.
  *
- * <p>Implementations should be thread-safe and must wrap any underlying failure
- * in a {@link SerializationException}.
+ * <p>This repository provides no concrete JSON {@code Serializer}
+ * implementation; applications or integration modules provide one. Those
+ * implementations should be thread-safe, must configure parser constraints
+ * appropriate to the chosen JSON library (including nesting depth, token count,
+ * and string size limits), and must wrap serialization or deserialization
+ * library failures in a {@link SerializationException}.
  */
 public interface Serializer {
 

--- a/sdks/community/java/ag-ui/server/README.md
+++ b/sdks/community/java/ag-ui/server/README.md
@@ -17,21 +17,21 @@ third-party dependencies.
 
 ### Transport-neutral core (`com.agui.community.server`)
 
-| Type | Purpose |
-|------|---------|
-| [`AgentRunHandler`](src/main/java/com/agui/community/server/AgentRunHandler.java) | Parses a request body into a `RunAgentInput`, runs the `Agent`, and relays its events to an `EventSink`, framing each through an `EventEncoder`. Knows nothing about HTTP or the wire protocol. |
-| [`AgentRegistry`](src/main/java/com/agui/community/server/AgentRegistry.java) | A lookup from agent id to `Agent`, so a transport can route `/agent/{id}` to one of several agents. `single()` exposes the sole agent when exactly one is registered. |
-| [`EventEncoder`](src/main/java/com/agui/community/server/EventEncoder.java) | Frames an `Event` for a particular protocol — the single point of variation between SSE and a future transport such as WebSocket. |
-| [`EventSink`](src/main/java/com/agui/community/server/EventSink.java) | A transport-neutral destination for already-encoded frames; an adapter implements it over its response. |
-| [`SseEventEncoder`](src/main/java/com/agui/community/server/SseEventEncoder.java) | The SSE `EventEncoder`: encodes an `Event` as a `data:` frame using the injected `Serializer`. |
-| [`EventRelaySubscriber`](src/main/java/com/agui/community/server/EventRelaySubscriber.java) | A `Flow.Subscriber<Event>` that writes encoded frames to the sink, requesting one event at a time for backpressure, and surfaces failures in band as a terminal `RUN_ERROR` frame. |
-| [`OutputStreamEventSink`](src/main/java/com/agui/community/server/OutputStreamEventSink.java) | An `EventSink` over a blocking `OutputStream` (flushes per frame). |
+| Type                                                                                          | Purpose                                                                                                                                                                                         |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`AgentRunHandler`](src/main/java/com/agui/community/server/AgentRunHandler.java)             | Parses a request body into a `RunAgentInput`, runs the `Agent`, and relays its events to an `EventSink`, framing each through an `EventEncoder`. Knows nothing about HTTP or the wire protocol. |
+| [`AgentRegistry`](src/main/java/com/agui/community/server/AgentRegistry.java)                 | A lookup from agent id to `Agent`, so a transport can route `/agent/{id}` to one of several agents. `single()` exposes the sole agent when exactly one is registered.                           |
+| [`EventEncoder`](src/main/java/com/agui/community/server/EventEncoder.java)                   | Frames an `Event` for a particular protocol — the single point of variation between SSE and a future transport such as WebSocket.                                                               |
+| [`EventSink`](src/main/java/com/agui/community/server/EventSink.java)                         | A transport-neutral destination for already-encoded frames; an adapter implements it over its response.                                                                                         |
+| [`SseEventEncoder`](src/main/java/com/agui/community/server/SseEventEncoder.java)             | The SSE `EventEncoder`: encodes an `Event` as a `data:` frame using the injected `Serializer`.                                                                                                  |
+| [`EventRelaySubscriber`](src/main/java/com/agui/community/server/EventRelaySubscriber.java)   | A `Flow.Subscriber<Event>` that writes encoded frames to the sink, requesting one event at a time for backpressure, and surfaces failures in band as a terminal `RUN_ERROR` frame.              |
+| [`OutputStreamEventSink`](src/main/java/com/agui/community/server/OutputStreamEventSink.java) | An `EventSink` over a blocking `OutputStream` (flushes per frame).                                                                                                                              |
 
 ### JDK transport (`com.agui.community.server.jdk`)
 
-| Type | Purpose |
-|------|---------|
-| [`JdkAgentHttpHandler`](src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java) | An `HttpHandler` for the JDK's built-in `com.sun.net.httpserver`. Routes `/agent/{id}` to an agent from an `AgentRegistry` (single-agent alias on the base path), streams events as `text/event-stream`, and rejects unknown ids with `404`, malformed input with `400`, and non-`POST` with `405`. No third-party dependencies. |
+| Type                                                                                          | Purpose                                                                                                                                                                                                                                                                                                                                                               |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`JdkAgentHttpHandler`](src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java) | An `HttpHandler` for the JDK's built-in `com.sun.net.httpserver`. Routes `/agent/{id}` to an agent from an `AgentRegistry` (single-agent alias on the base path), streams events as `text/event-stream`, and rejects unknown ids with `404`, malformed input with `400`, oversized request bodies with `413`, and non-`POST` with `405`. No third-party dependencies. |
 
 ## Usage
 
@@ -53,6 +53,10 @@ server.start();
 Point the [`HttpAgent`](../client) client at `http://localhost:8080/agent` to
 drive it.
 
+`JdkAgentHttpHandler` reads at most 8 MiB of request body by default before
+parsing. Oversized requests, including chunked requests, receive
+`413 Payload Too Large` before deserialization or agent invocation.
+
 ### Multiple agents
 
 Pass an [`AgentRegistry`](src/main/java/com/agui/community/server/AgentRegistry.java)
@@ -70,6 +74,16 @@ server.createContext("/agent", new JdkAgentHttpHandler(registry, serializer));
 
 The single-agent constructor above is shorthand for a one-entry registry: it is
 served on the base path (the alias) and on `/agent/default`.
+
+Use the overloads that accept `maxRequestBodyBytes` to set a positive custom
+request body cap:
+
+```java
+server.createContext("/agent", new JdkAgentHttpHandler(
+        registry,
+        serializer,
+        2 * 1024 * 1024));
+```
 
 ### Bringing your own transport
 

--- a/sdks/community/java/ag-ui/server/src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java
+++ b/sdks/community/java/ag-ui/server/src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java
@@ -48,8 +48,12 @@ public final class JdkAgentHttpHandler implements HttpHandler {
     /** Id under which the single-agent convenience constructor registers its agent. */
     static final String DEFAULT_AGENT_ID = "default";
 
+    /** Default maximum request body size, in bytes (8 MiB). */
+    public static final int DEFAULT_MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024;
+
     private final AgentRegistry registry;
     private final Serializer serializer;
+    private final int maxRequestBodyBytes;
 
     /**
      * Creates a handler that serves a single agent. It answers on the base path
@@ -60,8 +64,19 @@ public final class JdkAgentHttpHandler implements HttpHandler {
      *                   (required)
      */
     public JdkAgentHttpHandler(Agent agent, Serializer serializer) {
+        this(agent, serializer, DEFAULT_MAX_REQUEST_BODY_BYTES);
+    }
+
+    /**
+     * Creates a single-agent handler with a custom request body size limit.
+     *
+     * @param agent the agent to run for each request
+     * @param serializer the serializer used to read input and encode events
+     * @param maxRequestBodyBytes the positive maximum body size in bytes
+     */
+    public JdkAgentHttpHandler(Agent agent, Serializer serializer, int maxRequestBodyBytes) {
         this(AgentRegistry.of(Map.of(DEFAULT_AGENT_ID, Objects.requireNonNull(agent, "agent must not be null"))),
-                serializer);
+                serializer, maxRequestBodyBytes);
     }
 
     /**
@@ -73,8 +88,25 @@ public final class JdkAgentHttpHandler implements HttpHandler {
      *                   (required)
      */
     public JdkAgentHttpHandler(AgentRegistry registry, Serializer serializer) {
+        this(registry, serializer, DEFAULT_MAX_REQUEST_BODY_BYTES);
+    }
+
+    /**
+     * Creates a routing handler with a custom request body size limit. Oversized
+     * bodies, including chunked requests, receive {@code 413 Payload Too Large}
+     * before deserialization or agent invocation.
+     *
+     * @param registry the agents addressable by this handler
+     * @param serializer the serializer used to read input and encode events
+     * @param maxRequestBodyBytes the positive maximum body size in bytes
+     */
+    public JdkAgentHttpHandler(AgentRegistry registry, Serializer serializer, int maxRequestBodyBytes) {
         this.registry = Objects.requireNonNull(registry, "registry must not be null");
         this.serializer = Objects.requireNonNull(serializer, "serializer must not be null");
+        if (maxRequestBodyBytes <= 0) {
+            throw new IllegalArgumentException("maxRequestBodyBytes must be positive");
+        }
+        this.maxRequestBodyBytes = maxRequestBodyBytes;
     }
 
     @Override
@@ -92,7 +124,13 @@ public final class JdkAgentHttpHandler implements HttpHandler {
             }
             AgentRunHandler handler = new AgentRunHandler(agent, serializer);
 
-            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            byte[] bytes = exchange.getRequestBody().readNBytes(maxRequestBodyBytes);
+            if (exchange.getRequestBody().read() != -1) {
+                respondPlain(exchange, 413,
+                        "AG-UI request body exceeds maximum size of " + maxRequestBodyBytes + " bytes");
+                return;
+            }
+            String body = new String(bytes, StandardCharsets.UTF_8);
 
             RunAgentInput input;
             try {

--- a/sdks/community/java/ag-ui/server/src/test/java/com/agui/community/server/jdk/JdkAgentHttpHandlerTest.java
+++ b/sdks/community/java/ag-ui/server/src/test/java/com/agui/community/server/jdk/JdkAgentHttpHandlerTest.java
@@ -1,29 +1,46 @@
 package com.agui.community.server.jdk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpPrincipal;
 import com.agui.community.core.agent.Agent;
 import com.agui.community.core.agent.RunAgentInput;
 import com.agui.community.core.event.Event;
 import com.agui.community.core.event.RunFinishedEvent;
 import com.agui.community.core.event.RunStartedEvent;
 import com.agui.community.core.event.TextMessageContentEvent;
+import com.agui.community.core.serialization.Serializer;
 import com.agui.community.server.AgentRegistry;
 import com.agui.community.server.FakeSerializer;
+import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JdkAgentHttpHandlerTest {
 
@@ -108,6 +125,81 @@ class JdkAgentHttpHandlerTest {
         assertEquals(404, postTo("/agent/missing", "{}").statusCode());
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void rejectsOversizedRequestBeforeRunningAgent(boolean chunked) throws Exception {
+        AtomicBoolean invoked = new AtomicBoolean();
+        Agent agent = input -> {
+            invoked.set(true);
+            return agentEmitting(new RunFinishedEvent("t1", "r1")).run(input);
+        };
+        register(new JdkAgentHttpHandler(agent, FakeSerializer.returning(INPUT)));
+        byte[] body = new byte[8 * 1024 * 1024 + 1];
+        HttpRequest.BodyPublisher publisher = chunked
+                ? HttpRequest.BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(body))
+                : HttpRequest.BodyPublishers.ofByteArray(body);
+
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(endpoint).timeout(Duration.ofSeconds(5)).POST(publisher).build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(413, response.statusCode());
+        assertEquals(false, invoked.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void customLimitAcceptsBoundaryAndRejectsOneByteOverBeforeParsingOrRunning(boolean chunked) throws Exception {
+        int maxRequestBodyBytes = 16;
+        AtomicInteger invocations = new AtomicInteger();
+        CountingSerializer serializer = new CountingSerializer(FakeSerializer.returning(INPUT));
+        Agent agent = input -> {
+            invocations.incrementAndGet();
+            return agentEmitting(new RunFinishedEvent("t1", "r1")).run(input);
+        };
+        register(new JdkAgentHttpHandler(agent, serializer, maxRequestBodyBytes));
+
+        HttpResponse<String> boundary = post(bodyOfLength(maxRequestBodyBytes), chunked);
+        HttpResponse<String> oversized = post(bodyOfLength(maxRequestBodyBytes + 1), chunked);
+
+        assertEquals(200, boundary.statusCode());
+        assertEquals(413, oversized.statusCode());
+        assertEquals(1, serializer.deserializeCalls());
+        assertEquals(1, invocations.get());
+    }
+
+    @Test
+    void rejectsNonPositiveCustomLimits() {
+        Agent agent = input -> subscriber -> { };
+        Serializer serializer = FakeSerializer.returning(INPUT);
+        AgentRegistry registry = AgentRegistry.of(Map.of("default", agent));
+
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(agent, serializer, 0));
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(agent, serializer, -1));
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(registry, serializer, 0));
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(registry, serializer, -1));
+    }
+
+    @Test
+    void oversizedDirectExchangeReadsOnlyOneBytePastLimitBeforeRejecting() throws Exception {
+        int maxRequestBodyBytes = 4;
+        CountingInputStream requestBody = new CountingInputStream(bodyOfLength(maxRequestBodyBytes + 10));
+        CountingSerializer serializer = new CountingSerializer(FakeSerializer.returning(INPUT));
+        AtomicBoolean invoked = new AtomicBoolean();
+        JdkAgentHttpHandler handler = new JdkAgentHttpHandler(input -> {
+            invoked.set(true);
+            return agentEmitting(new RunFinishedEvent("t1", "r1")).run(input);
+        }, serializer, maxRequestBodyBytes);
+        TestExchange exchange = new TestExchange(requestBody);
+
+        handler.handle(exchange);
+
+        assertEquals(413, exchange.statusCode());
+        assertEquals(maxRequestBodyBytes + 1, requestBody.bytesRead());
+        assertEquals(0, serializer.deserializeCalls());
+        assertEquals(false, invoked.get());
+    }
+
     private static Agent agentEmitting(Event event) {
         return input -> subscriber -> {
             SubmissionPublisher<Event> publisher = new SubmissionPublisher<>();
@@ -120,6 +212,19 @@ class JdkAgentHttpHandlerTest {
     private void register(JdkAgentHttpHandler handler) {
         server.createContext("/agent", handler);
         server.start();
+    }
+
+    private HttpResponse<String> post(String body, boolean chunked) throws Exception {
+        HttpRequest.BodyPublisher publisher = chunked
+                ? HttpRequest.BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(body.getBytes()))
+                : HttpRequest.BodyPublishers.ofString(body);
+        return HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(endpoint)
+                        .timeout(Duration.ofSeconds(5))
+                        .header("Content-Type", "application/json")
+                        .POST(publisher)
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
     }
 
     private HttpResponse<String> postTo(String path, String body) throws Exception {
@@ -141,5 +246,214 @@ class JdkAgentHttpHandlerTest {
                         .POST(HttpRequest.BodyPublishers.ofString(body))
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static String bodyOfLength(int length) {
+        return "x".repeat(length);
+    }
+
+    private static final class CountingSerializer implements Serializer {
+
+        private final Serializer delegate;
+        private int deserializeCalls;
+
+        private CountingSerializer(Serializer delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String serialize(Object value) {
+            return delegate.serialize(value);
+        }
+
+        @Override
+        public <T> T deserialize(String json, Class<T> type) {
+            deserializeCalls++;
+            return delegate.deserialize(json, type);
+        }
+
+        @Override
+        public <T> List<T> deserializeList(String json, Class<T> elementType) {
+            return delegate.deserializeList(json, elementType);
+        }
+
+        private int deserializeCalls() {
+            return deserializeCalls;
+        }
+    }
+
+    private static final class CountingInputStream extends InputStream {
+
+        private final byte[] bytes;
+        private int position;
+
+        private CountingInputStream(String body) {
+            this.bytes = body.getBytes();
+        }
+
+        @Override
+        public int read() {
+            if (position == bytes.length) {
+                return -1;
+            }
+            return bytes[position++];
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) {
+            if (position == bytes.length) {
+                return -1;
+            }
+            int count = Math.min(length, bytes.length - position);
+            System.arraycopy(bytes, position, buffer, offset, count);
+            position += count;
+            return count;
+        }
+
+        private int bytesRead() {
+            return position;
+        }
+    }
+
+    private static final class TestExchange extends HttpExchange {
+
+        private final InputStream requestBody;
+        private final ByteArrayOutputStream responseBody = new ByteArrayOutputStream();
+        private final com.sun.net.httpserver.Headers responseHeaders = new com.sun.net.httpserver.Headers();
+        private final TestHttpContext context = new TestHttpContext();
+        private int statusCode;
+
+        private TestExchange(InputStream requestBody) {
+            this.requestBody = requestBody;
+        }
+
+        @Override
+        public com.sun.net.httpserver.Headers getRequestHeaders() {
+            return new com.sun.net.httpserver.Headers();
+        }
+
+        @Override
+        public com.sun.net.httpserver.Headers getResponseHeaders() {
+            return responseHeaders;
+        }
+
+        @Override
+        public URI getRequestURI() {
+            return URI.create("http://localhost/agent");
+        }
+
+        @Override
+        public String getRequestMethod() {
+            return "POST";
+        }
+
+        @Override
+        public HttpContext getHttpContext() {
+            return context;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public InputStream getRequestBody() {
+            return requestBody;
+        }
+
+        @Override
+        public OutputStream getResponseBody() {
+            return responseBody;
+        }
+
+        @Override
+        public void sendResponseHeaders(int responseCode, long responseLength) {
+            this.statusCode = responseCode;
+        }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() {
+            return new InetSocketAddress("localhost", 0);
+        }
+
+        @Override
+        public int getResponseCode() {
+            return statusCode;
+        }
+
+        @Override
+        public InetSocketAddress getLocalAddress() {
+            return new InetSocketAddress("localhost", 0);
+        }
+
+        @Override
+        public String getProtocol() {
+            return "HTTP/1.1";
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return null;
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+        }
+
+        @Override
+        public void setStreams(InputStream input, OutputStream output) {
+        }
+
+        @Override
+        public HttpPrincipal getPrincipal() {
+            return null;
+        }
+
+        private int statusCode() {
+            return statusCode;
+        }
+    }
+
+    private static final class TestHttpContext extends HttpContext {
+
+        @Override
+        public HttpHandler getHandler() {
+            return null;
+        }
+
+        @Override
+        public void setHandler(HttpHandler handler) {
+        }
+
+        @Override
+        public String getPath() {
+            return "/agent";
+        }
+
+        @Override
+        public HttpServer getServer() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public List<com.sun.net.httpserver.Filter> getFilters() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public com.sun.net.httpserver.Authenticator setAuthenticator(
+                com.sun.net.httpserver.Authenticator authenticator) {
+            return authenticator;
+        }
+
+        @Override
+        public com.sun.net.httpserver.Authenticator getAuthenticator() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Addresses the Java SDK availability findings associated with #2442.

The Java client previously buffered SSE lines and combined event data without size limits, allowing an oversized response to consume memory before deserialization. A `StackOverflowError` from the event decoder could also escape the worker and leave subscribers without a terminal signal. The JDK server adapter similarly read entire request bodies before checking their contents.

This change adds bounds at the transport's allocation points:

- Read SSE lines incrementally with a configurable 1 MiB default limit, including comments and ignored fields.
- Independently cap combined event data at 8 MiB by default, counting UTF-8 bytes and inserted newlines, and release the accumulation buffer after dispatch.
- Close response bodies on limit, HTTP status, and decoding failures. Translate a decoder's `StackOverflowError` into a `SerializationException` delivered through `onError`.
- Cap JDK server request bodies at 8 MiB by default. Fixed-length and chunked requests exceeding the cap return HTTP 413 before deserialization or agent invocation; rejection requires reading at most the cap plus one byte.

Existing constructors remain available and use the new defaults. Applications requiring larger payloads can configure `SseLimits` and `maxRequestBodyBytes` through the added overloads. Limits apply per line, event, or request, without a lifetime budget on long-running streams.

The SDK remains dependency-free at runtime. JSON nesting, token, and string constraints remain the responsibility of the application's `Serializer`; this repository provides no concrete JSON serializer. The documentation now makes that contract explicit.

Validation: `mvn -B -f sdks/community/java/ag-ui/pom.xml clean verify` passes all 232 tests (177 core, 34 client, 21 server), with no failures, errors, or skipped tests. Regressions cover exact byte boundaries, oversized unterminated and ignored lines, multiline event limits, UTF-8 split across reads, supported line endings, EOF flushing, terminal signals and response cleanup, interrupt restoration, and early server rejection. The initial regressions were confirmed to fail against the original implementation. Scoped Markdown formatting and `git diff --check` also pass.
