### PR TITLE
fix(adk-middleware): don't close plugins the caller's App owns

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -41,6 +41,22 @@ from google.adk.agents import BaseAgent, LlmAgent, RunConfig as ADKRunConfig
 # pre-appended to the session as its own event, and new_message becomes a
 # minimal placeholder that short-circuits _resolve_invocation_id.
 _ADK_OVERRIDES_INVOCATION_ID = hasattr(Runner, "_resolve_invocation_id")
+
+# Feature detect ADK's guard for plugins a Runner does not own.
+#
+# PluginManager.set_skip_closing_plugins() was added in google-adk 2.2.0 and is
+# absent on 1.x. Without it a per-request Runner closes the caller's App-owned
+# plugins on every request; with it that half of Runner.close() is skipped,
+# leaving toolset cleanup and the session flush intact. ADK itself uses it for
+# the nested Runner in tools/agent_tool.py.
+try:  # pragma: no cover - import shape varies across ADK versions
+    from google.adk.plugins.plugin_manager import PluginManager as _PluginManager
+
+    _ADK_SKIPS_CLOSING_PLUGINS = hasattr(
+        _PluginManager, "set_skip_closing_plugins"
+    )
+except Exception:  # pragma: no cover - defensive
+    _ADK_SKIPS_CLOSING_PLUGINS = False
 from google.adk.agents.run_config import StreamingMode
 from google.adk.agents.llm_agent import InstructionProvider, ToolUnion
 from google.adk.sessions import BaseSessionService, InMemorySessionService
@@ -1093,6 +1109,31 @@ class ADKAgent:
         return 'plugin_close_timeout' in sig.parameters
 
     @staticmethod
+    def _mark_plugins_externally_owned(runner: Runner) -> None:
+        """Stop a per-request Runner from closing plugins the caller owns.
+
+        ``Runner.close()`` closes every registered plugin. Plugins reached
+        through a caller-supplied ``App`` are the caller's own instances and
+        hold process-lifetime state -- clients, pools, background batch
+        writers -- so closing one per request forces a full re-initialization
+        on the next one.
+
+        ``set_skip_closing_plugins`` is ADK's guard for exactly this; ADK
+        (>= 2.2) uses it itself for the nested runner in
+        ``google/adk/tools/agent_tool.py``. It was added in google-adk 2.2.0
+        and is absent on 1.x, where this is a no-op and the previous
+        per-request close behaviour stands.
+        """
+        if not _ADK_SKIPS_CLOSING_PLUGINS:
+            return
+        plugin_manager = getattr(runner, 'plugin_manager', None)
+        # The module flag says the ADK we imported has the API; this says the
+        # object in hand does. Both, so an unexpected manager degrades to the
+        # old behaviour instead of raising inside a request.
+        if hasattr(plugin_manager, 'set_skip_closing_plugins'):
+            plugin_manager.set_skip_closing_plugins(True)
+
+    @staticmethod
     def _adk_supports_streaming_fc_args() -> bool:
         """Check if google-adk supports reliable streaming function call arguments.
 
@@ -1141,7 +1182,11 @@ class ADKAgent:
         if self._app is not None:
             # Create per-request App copy with modified agent (preserves all App configs)
             request_app = self._app.model_copy(update={'root_agent': adk_agent})
-            return Runner(app=request_app, **service_kwargs)
+            runner = Runner(app=request_app, **service_kwargs)
+            # model_copy is shallow: request_app.plugins holds the caller's own
+            # objects, and this runner is closed at the end of the request.
+            self._mark_plugins_externally_owned(runner)
+            return runner
         else:
             # Old style: component-based (no plugins support - use from_app() for that)
             return Runner(

--- a/integrations/adk-middleware/python/tests/test_app_owned_plugin_lifecycle.py
+++ b/integrations/adk-middleware/python/tests/test_app_owned_plugin_lifecycle.py
@@ -1,0 +1,86 @@
+"""Plugins supplied through an App must outlive the per-request Runner.
+
+`_create_runner` builds one Runner per request from a shallow copy of the
+caller's App, and that Runner is closed when the request finishes. Closing a
+Runner also closes its plugins, so without the ownership marker every request
+tore down the caller's own plugin instances and the next request paid a full
+re-initialization.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from google.adk.agents import LlmAgent
+from google.adk.apps import App
+from google.adk.plugins.base_plugin import BasePlugin
+
+from ag_ui_adk import ADKAgent
+from ag_ui_adk.adk_agent import _ADK_SKIPS_CLOSING_PLUGINS
+from ag_ui_adk.session_manager import SessionManager
+from tests.constants import LIVE_TEST_MODEL
+
+
+class RecordingPlugin(BasePlugin):
+    """A plugin that records whether anything closed it."""
+
+    def __init__(self):
+        super().__init__(name="recording_plugin")
+        self.close_count = 0
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_session_manager():
+    SessionManager.reset_default()
+    yield
+    SessionManager.reset_default()
+
+
+@pytest.fixture
+def plugin():
+    return RecordingPlugin()
+
+
+@pytest.fixture
+def agent_with_plugin(plugin):
+    app = App(
+        name="plugin_lifecycle_app",
+        root_agent=LlmAgent(name="test_agent", model=LIVE_TEST_MODEL),
+        plugins=[plugin],
+    )
+    return ADKAgent.from_app(app, user_id="test_user", use_in_memory_services=True)
+
+
+@pytest.mark.skipif(
+    not _ADK_SKIPS_CLOSING_PLUGINS,
+    reason="PluginManager.set_skip_closing_plugins was added in google-adk 2.2",
+)
+@pytest.mark.asyncio
+async def test_app_owned_plugin_survives_repeated_requests(
+    agent_with_plugin, plugin
+):
+    """The real failure mode: one shared plugin, many short-lived runners."""
+    for _ in range(5):
+        runner = agent_with_plugin._create_runner(
+            adk_agent=agent_with_plugin._adk_agent,
+            user_id="test_user",
+            app_name="plugin_lifecycle_app",
+        )
+        await runner.close()
+
+    assert plugin.close_count == 0
+
+
+@pytest.mark.parametrize(
+    "runner",
+    [
+        object(),
+        SimpleNamespace(plugin_manager=None),
+        SimpleNamespace(plugin_manager=object()),
+    ],
+)
+def test_marking_is_a_no_op_when_adk_lacks_the_api(runner):
+    """Older ADK has no set_skip_closing_plugins; marking must not raise."""
+    ADKAgent._mark_plugins_externally_owned(runner)


### PR DESCRIPTION
Closes #2642.

## The shape of the bug

`_create_runner` builds one `Runner` per request from `self._app.model_copy(update={'root_agent': adk_agent})`. `model_copy` is shallow, so the copy's `plugins` list holds the caller's own plugin instances. `_run_adk_in_background` then closes that runner in its `finally`, and `Runner.close()` calls `PluginManager.close()`, which closes every registered plugin.

The general shape is *a per-request Runner being closed over a shallow copy of caller-owned state*. This PR fixes the plugin half of that. See "Known sibling" below for the other half.

Plugins are documented as long-lived objects holding clients, pools and background batch writers, so closing one per request means the next request pays a full re-initialization.

## How it showed up

We hit this in production with ADK's `BigQueryAgentAnalyticsPlugin`. Measured over ten minutes on one service:

| Signal | Count |
|---|---|
| Runner closed | 325 |
| Plugin registered into a new manager | 329 |
| Plugin's batch writer drained | 101 |
| Our code constructing the plugin | 0 |

The last row is the point: the plugin is built once at import, and the middleware cycled it 325 times in ten minutes.

That plugin's re-initialisation issues one `CREATE OR REPLACE VIEW` per event type and is awaited from `before_run_callback`, so the DDL landed on the request path. It exhausted a BigQuery per-table daily quota in 2h18m and added about 25 seconds to median latency. The amplification is being fixed on the ADK side in google/adk-python#7020 (our report: google/adk-python#7017), but the per-request teardown that drives it is here.

## The fix

Mark the per-request runner's plugin manager as not owning its plugins. `PluginManager.set_skip_closing_plugins` is ADK's own guard for this, and ADK uses it itself for the nested runner in `tools/agent_tool.py` — which also still calls `runner.close()` afterwards, so this is the established idiom rather than a workaround.

**Version scope, stated plainly:** the API landed in **google-adk 2.2.0** and is absent on 1.x. This package's `uv.lock` pins 1.35.0, so on the blocking `adk-middleware-python` job the change is inert and behaviour is unchanged; it takes effect on the `adk-middleware-python-adk-2x` leg and for anyone running ADK >= 2.2. The `tools/agent_tool.py` precedent is likewise >= 2.2 only. Detection follows the file's existing idiom: a module-level `_ADK_SKIPS_CLOSING_PLUGINS`, alongside `_ADK_OVERRIDES_INVOCATION_ID`.

Applied only on the `self._app is not None` branch: the component-based branch resolves an App with no plugins, so its manager is empty and closing it is already a no-op.

## Testing

`tests/test_app_owned_plugin_lifecycle.py`, two tests:

- `test_app_owned_plugin_survives_repeated_requests` — one shared plugin, five create/close cycles, asserts it is never closed. Reverting just the marker call makes it fail with `close_count == 5`, i.e. exactly once per request. `skipif`-gated on `_ADK_SKIPS_CLOSING_PLUGINS`, matching `test_adk_130_invocation_id_override.py` and `test_lro_tool_response_persistence.py`.
- `test_marking_is_a_no_op_when_adk_lacks_the_api` — parametrized over a runner with no `plugin_manager`, one with `plugin_manager=None`, and one whose manager lacks the setter.

Verified on both legs. Under the locked ADK 1.35.0 (simulated by forcing the flag off): 3 passed, 1 skipped — the blocking job stays green. Under ADK 2.8.0: 4 passed. `tests/test_adk_2_0_compat.py` and `tests/test_capabilities.py` also stay green (21 passed).

## Known sibling, deliberately not in this PR

Toolsets have the same ownership problem through the same `finally`: `_shallow_copy_agent_tree` shares tools by reference on purpose, and `Runner.close()` closes every `BaseToolset` it can reach, so a caller's `McpToolset` is closed on every request. I verified it (`close_count == 3` after three requests) and filed it as #2659 rather than widening this PR, because there is no `skip_closing_toolsets` analogue to mirror — the options all change behaviour and need a maintainer's call. Happy to send that patch once you've picked one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
