### PR TITLE
fix(mastra): stop warning when recall fails on a brand-new thread

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/diff-feed.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/diff-feed.test.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import {
   FakeMemory,
   FakeLocalAgent,
@@ -58,6 +59,49 @@ describe("only-new-messages diff feed", () => {
 
     const ids = (agent.agent as unknown as FakeLocalAgent).lastStreamMessages!.map((m: any) => m.id);
     expect(ids).toEqual(["u1"]);
+  });
+
+  it("sends the full list without warning when the thread does not exist yet", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const memory = new FakeMemory();
+    memory.recall = async () => {
+      throw new Error("No thread found with id thread-1");
+    };
+    const agent = makeLocalMastraAgent({ memory, streamChunks: SIMPLE_STREAM_CHUNKS });
+
+    await collectEvents(
+      agent,
+      makeInput({ messages: [{ id: "u1", role: "user", content: "hi" }] as any }),
+    );
+
+    const ids = (agent.agent as unknown as FakeLocalAgent).lastStreamMessages!.map((m: any) => m.id);
+    expect(ids).toEqual(["u1"]);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("Failed to compute new-message diff")),
+    ).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("still warns when recall fails for an existing thread", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const memory = new FakeMemory();
+    memory.threads.set("thread-1", { id: "thread-1", resourceId: "resource-1" });
+    memory.recall = async () => {
+      throw new Error("storage unavailable");
+    };
+    const agent = makeLocalMastraAgent({ memory, streamChunks: SIMPLE_STREAM_CHUNKS });
+
+    await collectEvents(
+      agent,
+      makeInput({ messages: [{ id: "u1", role: "user", content: "hi" }] as any }),
+    );
+
+    const ids = (agent.agent as unknown as FakeLocalAgent).lastStreamMessages!.map((m: any) => m.id);
+    expect(ids).toEqual(["u1"]);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("Failed to compute new-message diff")),
+    ).toBe(true);
+    warn.mockRestore();
   });
 
   it("falls back to the full list if every message is already stored", async () => {

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -2711,11 +2711,38 @@ export class MastraAgent extends AbstractAgent {
       const keep = new Set([...fresh, ...pairedCalls]);
       return messages.filter((m) => keep.has(m));
     } catch (error) {
+      // recall() throws for a thread that does not exist yet. That is every
+      // first turn, not a failure: nothing is stored, so the full list is the
+      // right thing to send. Only warn when the thread exists (or the lookup
+      // itself fails).
+      if (await this.threadIsMissing(threadId, resourceId)) return messages;
       console.warn(
         `[MastraAgent] Failed to compute new-message diff for thread ${threadId}; sending full history:`,
         error,
       );
       return messages;
+    }
+  }
+
+  private async threadIsMissing(
+    threadId: string,
+    resourceId: string,
+  ): Promise<boolean> {
+    if (!this.isLocalMastraAgent(this.agent)) return false;
+    try {
+      const memory = await this.agent.getMemory({
+        requestContext: this.requestContext,
+      });
+      if (!memory) return false;
+      // Concrete Memory implementations check thread ownership and want the
+      // resourceId alongside the threadId; the abstract signature omits it.
+      const thread = await memory.getThreadById({
+        threadId,
+        resourceId,
+      } as { threadId: string });
+      return thread == null;
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
`selectNewMessages` calls `memory.recall()`, which throws `No thread found with id …` for a thread that does not exist yet. The adapter then logs `[MastraAgent] Failed to compute new-message diff …` on the first turn of every conversation.

Fix: when recall fails, check whether the thread exists. A missing thread means nothing is stored, so the full list is sent without the warning. Other failures still warn. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)