### PR TITLE
fix(mastra): seed thread-scoped working memory on a new thread

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/helpers.ts
+++ b/integrations/mastra/typescript/src/__tests__/helpers.ts
@@ -24,6 +24,16 @@ export class FakeMemory {
     this.threads.set(thread.id, thread);
   }
 
+  /** Records every createThread call (the first-turn thread-scope sync). */
+  createThreadCalls: Array<{ threadId?: string; resourceId: string }> = [];
+
+  async createThread(args: { threadId?: string; resourceId: string }) {
+    this.createThreadCalls.push(args);
+    const thread = { id: args.threadId, resourceId: args.resourceId };
+    this.threads.set(thread.id!, thread);
+    return thread;
+  }
+
   async getWorkingMemory(_opts: any): Promise<string | undefined> {
     return this.workingMemoryValue;
   }

--- a/integrations/mastra/typescript/src/__tests__/working-memory-sync.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/working-memory-sync.test.ts
@@ -1,0 +1,79 @@
+import { EventType } from "@ag-ui/client";
+import {
+  FakeMemory,
+  makeLocalMastraAgent,
+  makeInput,
+  collectEvents,
+  collectError,
+} from "./helpers";
+
+const SIMPLE_STREAM_CHUNKS = [
+  { type: "text-delta", payload: { text: "ok" } },
+  { type: "finish", payload: {} },
+];
+
+/**
+ * Memory with thread-scoped working memory: Mastra stores the value in
+ * thread.metadata and rejects an update for a thread that does not exist.
+ */
+class ThreadScopedMemory extends FakeMemory {
+  async updateWorkingMemory(args: {
+    resourceId?: string;
+    threadId?: string;
+    workingMemory: string;
+    memoryConfig?: any;
+  }): Promise<void> {
+    if (!this.threads.has(args.threadId!)) {
+      throw new Error(`Thread ${args.threadId} not found`);
+    }
+    await super.updateWorkingMemory(args);
+  }
+}
+
+describe("input.state -> working memory sync (local agent)", () => {
+  it("creates the thread and retries when thread-scoped memory rejects the first turn", async () => {
+    const memory = new ThreadScopedMemory();
+    const agent = makeLocalMastraAgent({ memory, streamChunks: SIMPLE_STREAM_CHUNKS });
+
+    const events = await collectEvents(
+      agent,
+      makeInput({ threadId: "thread-1", state: { plan: "draft" } }),
+    );
+
+    expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+    expect(memory.createThreadCalls).toEqual([
+      { threadId: "thread-1", resourceId: "resource-1" },
+    ]);
+    expect(memory.updateWorkingMemoryCalls).toHaveLength(1);
+    expect(JSON.parse(memory.updateWorkingMemoryCalls[0].workingMemory)).toEqual({
+      plan: "draft",
+    });
+  });
+
+  it("does not create a thread when the update succeeds", async () => {
+    const memory = new FakeMemory();
+    const agent = makeLocalMastraAgent({ memory, streamChunks: SIMPLE_STREAM_CHUNKS });
+
+    await collectEvents(agent, makeInput({ state: { plan: "draft" } }));
+
+    expect(memory.createThreadCalls).toEqual([]);
+    expect(memory.updateWorkingMemoryCalls).toHaveLength(1);
+  });
+
+  it("still fails the run when the update is rejected for an existing thread", async () => {
+    const memory = new FakeMemory();
+    memory.threads.set("thread-1", { id: "thread-1", resourceId: "resource-1" });
+    memory.updateWorkingMemory = async () => {
+      throw new Error("storage unavailable");
+    };
+    const agent = makeLocalMastraAgent({ memory, streamChunks: SIMPLE_STREAM_CHUNKS });
+
+    const { error } = await collectError(
+      agent,
+      makeInput({ threadId: "thread-1", state: { plan: "draft" } }),
+    );
+
+    expect(error.message).toBe("storage unavailable");
+    expect(memory.createThreadCalls).toEqual([]);
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -2810,12 +2810,29 @@ export class MastraAgent extends AbstractAgent {
         // No/invalid existing working memory — start from the client state.
       }
 
-      await memory.updateWorkingMemory({
-        resourceId,
-        threadId: input.threadId,
-        workingMemory: JSON.stringify({ ...existing, ...rest }),
-        memoryConfig,
-      });
+      const write = () =>
+        memory.updateWorkingMemory({
+          resourceId,
+          threadId: input.threadId,
+          workingMemory: JSON.stringify({ ...existing, ...rest }),
+          memoryConfig,
+        });
+
+      try {
+        await write();
+      } catch (error) {
+        // Thread-scoped working memory lives in thread.metadata, so Mastra
+        // refuses the update until the thread exists — and on the first turn
+        // it does not yet (the stream creates it). Create it and retry once;
+        // anything else is a real failure and still fails the run.
+        if (await memory.getThreadById(
+          { threadId: input.threadId, resourceId } as { threadId: string },
+        )) {
+          throw error;
+        }
+        await memory.createThread({ threadId: input.threadId, resourceId });
+        await write();
+      }
       return;
     }
 
@@ -2851,10 +2868,9 @@ export class MastraAgent extends AbstractAgent {
       await write();
     } catch {
       // The remote working-memory HTTP route requires the thread to exist. On
-      // the first turn it may not yet (unlike local Memory, which upserts). So
-      // create the thread and retry once. Best-effort: if it still fails, skip
-      // rather than fail the run — the stream creates the thread, and later
-      // turns will sync.
+      // the first turn it may not yet. So create the thread and retry once.
+      // Best-effort: if it still fails, skip rather than fail the run — the
+      // stream creates the thread, and later turns will sync.
       try {
         await client.createMemoryThread({
           agentId,


### PR DESCRIPTION
`syncInputStateToWorkingMemory` writes `input.state` before the first `agent.stream()`. With `workingMemory.scope: 'thread'` the value lives in `thread.metadata`, and the thread is only created by the stream, so `Memory.updateWorkingMemory` throws `Thread <id> not found` on the first turn and the run errors before it starts.

The remote path already creates the thread and retries; the local path lost that in ba4de183 when the sync moved from `saveThread` to `updateWorkingMemory`.

Fix: if the update fails and the thread does not exist, create it and retry once. Other failures still fail the run. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)