### PR TITLE
fix(mastra): surface a tripwire instead of ending the run silently

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/tripwire.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/tripwire.test.ts
@@ -1,0 +1,62 @@
+import { vi } from "vitest";
+import { EventType, type TextMessageChunkEvent } from "@ag-ui/client";
+import { makeLocalMastraAgent, makeInput, collectEvents } from "./helpers";
+
+function joinedText(events: Awaited<ReturnType<typeof collectEvents>>): string {
+  return events
+    .filter(
+      (e): e is TextMessageChunkEvent => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    )
+    .map((e) => e.delta ?? "")
+    .join("");
+}
+
+/**
+ * A Mastra input/output processor that aborts the run emits a `tripwire`
+ * chunk and closes the stream. Without a mapping the client saw
+ * RUN_STARTED … RUN_FINISHED with no output at all.
+ */
+describe("tripwire chunks", () => {
+  it("surfaces a blocking tripwire as assistant text", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = makeLocalMastraAgent({
+      streamChunks: [
+        {
+          type: "tripwire",
+          payload: { reason: "Prompt injection detected", processorId: "guard" },
+        },
+      ],
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    expect(joinedText(events)).toBe("Prompt injection detected");
+    expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("Unrecognized stream chunk type")),
+    ).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("ignores a retry tripwire because Mastra answers again on the same stream", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = makeLocalMastraAgent({
+      streamChunks: [
+        { type: "text-delta", payload: { text: "first try" } },
+        { type: "tripwire", payload: { reason: "Too long", retry: true } },
+        { type: "text-delta", payload: { text: "second try" } },
+        { type: "finish", payload: { finishReason: "stop" } },
+      ],
+    });
+
+    const events = await collectEvents(agent, makeInput());
+
+    expect(joinedText(events)).toBe("first trysecond try");
+    expect(joinedText(events)).not.toContain("Too long");
+    expect(events.some((e) => e.type === EventType.RUN_FINISHED)).toBe(true);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("Unrecognized stream chunk type")),
+    ).toBe(false);
+    warn.mockRestore();
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -2575,6 +2575,20 @@ export class MastraAgent extends AbstractAgent {
           ]);
           break;
         }
+        case "tripwire": {
+          // A processor blocked the run. With `retry: true` Mastra retries
+          // internally and produces a new response on this same stream, so
+          // there is nothing to surface. Otherwise the stream ends here: emit
+          // the reason as assistant text so the run does not finish as an
+          // empty success. (Mastra's own channel adapter posts a non-retry
+          // tripwire as a user-visible message the same way.)
+          if (chunk.payload.retry) break;
+          flush();
+          callbacks.onTextPart?.(
+            chunk.payload.reason || "The response was blocked by a processor.",
+          );
+          break;
+        }
         case "abort": {
           // @mastra/core emits a first-class `abort` chunk (payload `{}`) when
           // a run is cancelled via abortSignal, and closes the stream straight


### PR DESCRIPTION
Mastra processor tripwires were treated as unrecognized chunks, leaving clients with `RUN_STARTED … RUN_FINISHED` and no explanation when a processor blocked the run.

This change surfaces non-retry tripwire reasons as assistant text. A `retry: true` flag requests a retry but does not guarantee another response: real Mastra input processors can emit it and close the stream. The adapter retains that reason until new text, processed final text, or a tool call arrives; if the stream ends first, it surfaces the reason before `RUN_FINISHED`.

Rejected buffered text is discarded so it cannot leak into a later successful retry. Already-streamed text remains visible. Both local and remote streams use the same handling.

Validation executed locally with Mastra 1.47.0:
- All 355 Mastra tests pass through Nx, including a real input-processor regression that aborts before model execution.
- Regression coverage includes terminal retry requests, successful retries, processed-final-text buffering, tool responses, repeated rejection, and stream errors on local and remote paths.
- Mastra build and typecheck pass through Nx.
