### PR TITLE
feat(neuron-ai): add Neuron AI to the list of supported agent frameworks

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -272,6 +272,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangChain and Crew
 | [Langroid](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/langroid) | Supported | [Demos](https://dojo.ag-ui.com/langroid/feature/shared_state) |
 | [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/) | In Progress | – |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | In Progress | – |
+| [Neuron AI](https://docs.neuron-ai.dev/agent/streaming#ag-ui-adapter) | Supported | [Demos](https://github.com/lussoluca/webinar_neuron_2026) |
 
 ### Agent Interaction Protocols
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -272,7 +272,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangChain and Crew
 | [Langroid](https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/langroid) | Supported | [Demos](https://dojo.ag-ui.com/langroid/feature/shared_state) |
 | [OpenAI Agent SDK](https://openai.github.io/openai-agents-python/) | In Progress | – |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | In Progress | – |
-| [Neuron AI](https://docs.neuron-ai.dev/agent/streaming#ag-ui-adapter) | Supported | [Demos](https://github.com/lussoluca/webinar_neuron_2026) |
+| [Neuron AI](https://docs.neuron-ai.dev/) | Supported | [Integration](https://docs.neuron-ai.dev/agent/streaming#ag-ui-adapter) [Demos](https://github.com/lussoluca/webinar_neuron_2026) |
 
 ### Agent Interaction Protocols
 


### PR DESCRIPTION
Added [Neuron AI](http://neuron-ai.dev) to the list "Agent Framework - Community" supporting the AG-UI protocol. Close #2136 