### PR TITLE
fix(java): bound agent HTTP request bodies

### DIFF
--- a/sdks/community/java/ag-ui/server/README.md
+++ b/sdks/community/java/ag-ui/server/README.md
@@ -71,6 +71,32 @@ server.createContext("/agent", new JdkAgentHttpHandler(registry, serializer));
 The single-agent constructor above is shorthand for a one-entry registry: it is
 served on the base path (the alias) and on `/agent/default`.
 
+### Request body size limit
+
+Both existing two-argument `JdkAgentHttpHandler` constructors use
+`DEFAULT_MAX_REQUEST_BODY_BYTES`: **8 MiB (8,388,608 bytes)**. Bodies are measured
+in bytes before UTF-8 decoding, not in characters. A body exactly at the limit
+is accepted; a larger body receives **413 Request Entity Too Large** without
+calling the serializer or agent.
+
+Override the limit with the third constructor argument for either a single
+agent or an `AgentRegistry`:
+
+```java
+int maxRequestBodyBytes = 16 * 1024 * 1024; // 16 MiB
+new JdkAgentHttpHandler(agent, serializer, maxRequestBodyBytes);
+new JdkAgentHttpHandler(registry, serializer, maxRequestBodyBytes);
+```
+
+The limit must be between `1` and `Integer.MAX_VALUE - 1`, inclusive; other
+values throw `IllegalArgumentException`. The handler rejects an oversized
+`Content-Length` before reading the body and otherwise reads at most the limit
+plus one byte, including for chunked requests without `Content-Length`.
+
+**Compatibility:** constructor signatures remain available, but previously
+accepted requests larger than 8 MiB now receive 413 by default. Applications
+that need larger requests must explicitly configure a suitable limit.
+
 ### Bringing your own transport
 
 To integrate with another stack (servlet, WebFlux, …), use the transport-neutral

--- a/sdks/community/java/ag-ui/server/src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java
+++ b/sdks/community/java/ag-ui/server/src/main/java/com/agui/community/server/jdk/JdkAgentHttpHandler.java
@@ -35,6 +35,12 @@ import java.util.concurrent.CompletionException;
  * Request} before streaming begins; non-{@code POST} requests receive
  * {@code 405 Method Not Allowed}.
  *
+ * <p><b>Body limit.</b> The two-argument constructors default to
+ * {@value #DEFAULT_MAX_REQUEST_BODY_BYTES} bytes (8 MiB). Use a three-argument
+ * constructor to override this limit. Bodies are counted before UTF-8 decoding;
+ * oversized requests receive HTTP 413 without invoking the serializer or agent.
+ * Previously accepted large requests may therefore be rejected by default.
+ *
  * <pre>{@code
  * AgentRegistry registry = AgentRegistry.of(Map.of("weather", weatherAgent, "support", supportAgent));
  * HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
@@ -45,11 +51,15 @@ import java.util.concurrent.CompletionException;
  */
 public final class JdkAgentHttpHandler implements HttpHandler {
 
+    /** Default maximum request body size: 8 MiB, measured before UTF-8 decoding. */
+    public static final int DEFAULT_MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024;
+
     /** Id under which the single-agent convenience constructor registers its agent. */
     static final String DEFAULT_AGENT_ID = "default";
 
     private final AgentRegistry registry;
     private final Serializer serializer;
+    private final int maxRequestBodyBytes;
 
     /**
      * Creates a handler that serves a single agent. It answers on the base path
@@ -60,8 +70,21 @@ public final class JdkAgentHttpHandler implements HttpHandler {
      *                   (required)
      */
     public JdkAgentHttpHandler(Agent agent, Serializer serializer) {
+        this(agent, serializer, DEFAULT_MAX_REQUEST_BODY_BYTES);
+    }
+
+    /**
+     * Creates a single-agent handler with a request body limit in bytes.
+     *
+     * @param agent the agent to run (required)
+     * @param serializer the serializer (required)
+     * @param maxRequestBodyBytes maximum body size before UTF-8 decoding
+     * @throws IllegalArgumentException if the limit is not between 1 and
+     *         {@code Integer.MAX_VALUE - 1}, inclusive
+     */
+    public JdkAgentHttpHandler(Agent agent, Serializer serializer, int maxRequestBodyBytes) {
         this(AgentRegistry.of(Map.of(DEFAULT_AGENT_ID, Objects.requireNonNull(agent, "agent must not be null"))),
-                serializer);
+                serializer, maxRequestBodyBytes);
     }
 
     /**
@@ -73,8 +96,27 @@ public final class JdkAgentHttpHandler implements HttpHandler {
      *                   (required)
      */
     public JdkAgentHttpHandler(AgentRegistry registry, Serializer serializer) {
+        this(registry, serializer, DEFAULT_MAX_REQUEST_BODY_BYTES);
+    }
+
+    /**
+     * Creates a routing handler with a request body limit in bytes. Oversized
+     * requests receive HTTP 413 without invoking the serializer or agent.
+     *
+     * @param registry the agents addressable by this handler (required)
+     * @param serializer the serializer (required)
+     * @param maxRequestBodyBytes maximum body size before UTF-8 decoding
+     * @throws IllegalArgumentException if the limit is not between 1 and
+     *         {@code Integer.MAX_VALUE - 1}, inclusive
+     */
+    public JdkAgentHttpHandler(AgentRegistry registry, Serializer serializer, int maxRequestBodyBytes) {
         this.registry = Objects.requireNonNull(registry, "registry must not be null");
         this.serializer = Objects.requireNonNull(serializer, "serializer must not be null");
+        // Reserve one byte for detecting an oversized body without integer overflow.
+        if (maxRequestBodyBytes <= 0 || maxRequestBodyBytes == Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("maxRequestBodyBytes must be between 1 and Integer.MAX_VALUE - 1");
+        }
+        this.maxRequestBodyBytes = maxRequestBodyBytes;
     }
 
     @Override
@@ -92,7 +134,23 @@ public final class JdkAgentHttpHandler implements HttpHandler {
             }
             AgentRunHandler handler = new AgentRunHandler(agent, serializer);
 
-            String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            String contentLength = exchange.getRequestHeaders().getFirst("Content-Length");
+            if (contentLength != null) {
+                try {
+                    if (Long.parseLong(contentLength) > maxRequestBodyBytes) {
+                        respondPlain(exchange, 413, "Request body too large");
+                        return;
+                    }
+                } catch (NumberFormatException ignored) {
+                    // The bounded read also protects requests with an invalid length.
+                }
+            }
+            byte[] bytes = exchange.getRequestBody().readNBytes(maxRequestBodyBytes + 1);
+            if (bytes.length > maxRequestBodyBytes) {
+                respondPlain(exchange, 413, "Request body too large");
+                return;
+            }
+            String body = new String(bytes, StandardCharsets.UTF_8);
 
             RunAgentInput input;
             try {

--- a/sdks/community/java/ag-ui/server/src/test/java/com/agui/community/server/jdk/JdkAgentHttpHandlerTest.java
+++ b/sdks/community/java/ag-ui/server/src/test/java/com/agui/community/server/jdk/JdkAgentHttpHandlerTest.java
@@ -2,6 +2,8 @@ package com.agui.community.server.jdk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.sun.net.httpserver.HttpServer;
 import com.agui.community.core.agent.Agent;
@@ -12,18 +14,36 @@ import com.agui.community.core.event.RunStartedEvent;
 import com.agui.community.core.event.TextMessageContentEvent;
 import com.agui.community.server.AgentRegistry;
 import com.agui.community.server.FakeSerializer;
+import com.agui.community.core.serialization.Serializer;
+import java.io.ByteArrayInputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpPrincipal;
+import java.net.Socket;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JdkAgentHttpHandlerTest {
 
@@ -31,6 +51,8 @@ class JdkAgentHttpHandlerTest {
 
     private HttpServer server;
     private URI endpoint;
+    private final AtomicReference<String> requestContentLength = new AtomicReference<>();
+    private final AtomicReference<String> requestTransferEncoding = new AtomicReference<>();
 
     @BeforeEach
     void startServer() throws Exception {
@@ -108,6 +130,204 @@ class JdkAgentHttpHandlerTest {
         assertEquals(404, postTo("/agent/missing", "{}").statusCode());
     }
 
+    @ParameterizedTest
+    @CsvSource({"7, false", "8, false", "9, false", "7, true", "8, true", "9, true"})
+    void enforcesByteLimitWithFixedLengthAndChunkedBodies(int size, boolean chunked) throws Exception {
+        RecordingSerializer serializer = new RecordingSerializer();
+        AtomicInteger runs = new AtomicInteger();
+        register(new JdkAgentHttpHandler(recordingAgent(runs), serializer, 8));
+        String body = " ".repeat(size - 2) + "{}";
+
+        HttpResponse<String> response = postBody(body, chunked);
+
+        boolean accepted = size <= 8;
+        assertEquals(accepted ? 200 : 413, response.statusCode());
+        assertEquals(accepted ? 1 : 0, serializer.reads.get());
+        assertEquals(accepted ? 1 : 0, serializer.writes.get());
+        assertEquals(accepted ? 1 : 0, runs.get());
+        if (accepted) {
+            assertEquals(body, serializer.body.get());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"9, false", "10, false", "9, true", "10, true"})
+    void countsMultibyteUtf8BeforeDecoding(int limit, boolean chunked) throws Exception {
+        RecordingSerializer serializer = new RecordingSerializer();
+        AtomicInteger runs = new AtomicInteger();
+        register(new JdkAgentHttpHandler(recordingAgent(runs), serializer, limit));
+        String body = "[\"你😀\"]";
+        assertEquals(11, body.getBytes(StandardCharsets.UTF_8).length);
+
+        HttpResponse<String> response = postBody(body, chunked);
+
+        assertEquals(413, response.statusCode());
+        assertEquals(0, serializer.reads.get());
+        assertEquals(0, serializer.writes.get());
+        assertEquals(0, runs.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void preservesMultibyteTextAtExactLimit(boolean chunked) throws Exception {
+        RecordingSerializer serializer = new RecordingSerializer();
+        AtomicInteger runs = new AtomicInteger();
+        register(new JdkAgentHttpHandler(recordingAgent(runs), serializer, 11));
+        String body = "[\"你😀\"]";
+
+        assertEquals(200, postBody(body, chunked).statusCode());
+        assertEquals(body, serializer.body.get());
+        assertEquals(1, runs.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void existingConstructorsApplyDefaultLimit(boolean registryConstructor) throws Exception {
+        RecordingSerializer serializer = new RecordingSerializer();
+        AtomicInteger runs = new AtomicInteger();
+        Agent agent = recordingAgent(runs);
+        register(registryConstructor
+                ? new JdkAgentHttpHandler(AgentRegistry.of(Map.of("test", agent)), serializer)
+                : new JdkAgentHttpHandler(agent, serializer));
+        // Send only headers: a response proves rejection precedes any body read.
+        try (Socket socket = new Socket("localhost", server.getAddress().getPort())) {
+            socket.setSoTimeout(5000);
+            String headers = "POST /agent HTTP/1.1\r\nHost: localhost\r\nContent-Length: "
+                    + ((long) JdkAgentHttpHandler.DEFAULT_MAX_REQUEST_BODY_BYTES + 1)
+                    + "\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(headers.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+            String status = new BufferedReader(new InputStreamReader(
+                    socket.getInputStream(), StandardCharsets.US_ASCII)).readLine();
+            assertTrue(status.startsWith("HTTP/1.1 413"), status);
+        }
+        assertEquals(0, serializer.reads.get());
+        assertEquals(0, serializer.writes.get());
+        assertEquals(0, runs.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {Integer.MIN_VALUE, -1, 0, Integer.MAX_VALUE})
+    void rejectsInvalidLimits(int limit) {
+        Agent agent = agentEmitting(new RunFinishedEvent("t1", "r1"));
+        Serializer serializer = FakeSerializer.returning(INPUT);
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(agent, serializer, limit));
+        assertThrows(IllegalArgumentException.class, () -> new JdkAgentHttpHandler(
+                AgentRegistry.of(Map.of("test", agent)), serializer, limit));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, Integer.MAX_VALUE - 1})
+    void acceptsValidLimitExtremes(int limit) {
+        Agent agent = agentEmitting(new RunFinishedEvent("t1", "r1"));
+        Serializer serializer = FakeSerializer.returning(INPUT);
+        assertDoesNotThrow(() -> new JdkAgentHttpHandler(agent, serializer, limit));
+        assertDoesNotThrow(() -> new JdkAgentHttpHandler(
+                AgentRegistry.of(Map.of("test", agent)), serializer, limit));
+    }
+
+    @Test
+    void boundedReadDoesNotTrustUnderstatedContentLength() throws Exception {
+        RecordingSerializer serializer = new RecordingSerializer();
+        AtomicInteger runs = new AtomicInteger();
+        AtomicInteger bytesRead = new AtomicInteger();
+        JdkAgentHttpHandler handler = new JdkAgentHttpHandler(recordingAgent(runs), serializer, 8);
+        HttpContext context = server.createContext("/agent", handler);
+        Headers headers = new Headers();
+        headers.set("Content-Length", "1");
+        AtomicInteger status = new AtomicInteger();
+        InputStream body = new ByteArrayInputStream(new byte[100]) {
+            @Override
+            public synchronized int read(byte[] buffer, int offset, int length) {
+                int count = super.read(buffer, offset, length);
+                if (count > 0) {
+                    bytesRead.addAndGet(count);
+                }
+                return count;
+            }
+        };
+        // A test exchange can expose a misleading length independently of the
+        // real HTTP server's framing rules and immutable request headers.
+        HttpExchange exchange = new HttpExchange() {
+            private final Headers responseHeaders = new Headers();
+            private final OutputStream responseBody = new ByteArrayOutputStream();
+            @Override public Headers getRequestHeaders() { return headers; }
+            @Override public Headers getResponseHeaders() { return responseHeaders; }
+            @Override public URI getRequestURI() { return endpoint; }
+            @Override public String getRequestMethod() { return "POST"; }
+            @Override public HttpContext getHttpContext() { return context; }
+            @Override public void close() { }
+            @Override public InputStream getRequestBody() { return body; }
+            @Override public OutputStream getResponseBody() { return responseBody; }
+            @Override public void sendResponseHeaders(int code, long length) { status.set(code); }
+            @Override public InetSocketAddress getRemoteAddress() { return null; }
+            @Override public int getResponseCode() { return status.get(); }
+            @Override public InetSocketAddress getLocalAddress() { return server.getAddress(); }
+            @Override public String getProtocol() { return "HTTP/1.1"; }
+            @Override public Object getAttribute(String name) { return null; }
+            @Override public void setAttribute(String name, Object value) { }
+            @Override public void setStreams(InputStream input, OutputStream output) { }
+            @Override public HttpPrincipal getPrincipal() { return null; }
+        };
+
+        handler.handle(exchange);
+
+        assertEquals(413, status.get());
+        assertEquals(9, bytesRead.get());
+        assertEquals(0, serializer.reads.get());
+        assertEquals(0, serializer.writes.get());
+        assertEquals(0, runs.get());
+    }
+
+    private static Agent recordingAgent(AtomicInteger runs) {
+        return input -> {
+            runs.incrementAndGet();
+            return agentEmitting(new RunFinishedEvent("t1", "r1")).run(input);
+        };
+    }
+
+    private HttpResponse<String> postBody(String body, boolean chunked) throws Exception {
+        HttpRequest.BodyPublisher publisher = chunked
+                ? HttpRequest.BodyPublishers.ofInputStream(
+                        () -> new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)))
+                : HttpRequest.BodyPublishers.ofString(body);
+        assertEquals(chunked ? -1 : body.getBytes(StandardCharsets.UTF_8).length, publisher.contentLength());
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(endpoint).timeout(Duration.ofSeconds(5))
+                        .header("Content-Type", "application/json").POST(publisher).build(),
+                HttpResponse.BodyHandlers.ofString());
+        if (chunked) {
+            assertEquals(null, requestContentLength.get());
+            assertEquals("chunked", requestTransferEncoding.get());
+        }
+        return response;
+    }
+
+    private static final class RecordingSerializer implements Serializer {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger writes = new AtomicInteger();
+        final AtomicReference<String> body = new AtomicReference<>();
+
+        @Override
+        public String serialize(Object value) {
+            writes.incrementAndGet();
+            return ((Event) value).type().value();
+        }
+
+        @Override
+        public <T> T deserialize(String json, Class<T> type) {
+            reads.incrementAndGet();
+            body.set(json);
+            return type.cast(INPUT);
+        }
+
+        @Override
+        public <T> List<T> deserializeList(String json, Class<T> type) {
+            reads.incrementAndGet();
+            throw new AssertionError("Unexpected deserializeList");
+        }
+    }
+
     private static Agent agentEmitting(Event event) {
         return input -> subscriber -> {
             SubmissionPublisher<Event> publisher = new SubmissionPublisher<>();
@@ -118,7 +338,11 @@ class JdkAgentHttpHandlerTest {
     }
 
     private void register(JdkAgentHttpHandler handler) {
-        server.createContext("/agent", handler);
+        server.createContext("/agent", exchange -> {
+            requestContentLength.set(exchange.getRequestHeaders().getFirst("Content-Length"));
+            requestTransferEncoding.set(exchange.getRequestHeaders().getFirst("Transfer-Encoding"));
+            handler.handle(exchange);
+        });
         server.start();
     }
 


### PR DESCRIPTION
The Java JDK agent handler currently buffers the entire request body before parsing. This adds a configurable byte limit and returns HTTP 413 before invoking either the serializer or agent when it is exceeded.

Fixes #2441. Implements the details requested in https://github.com/ag-ui-protocol/ag-ui/issues/2441#issuecomment-5565720723.

- Preserve both existing constructors with an 8 MiB default; add a third `maxRequestBodyBytes` argument for both single-agent and registry configurations.
- Check `Content-Length` before reading, then read at most `limit + 1` bytes before UTF-8 decoding. Reject nonpositive limits and `Integer.MAX_VALUE` to prevent overflow.
- Document configuration and the compatibility change: previously accepted bodies above 8 MiB now receive 413 unless the limit is overridden.
- Cover fixed-length and real chunked requests at `limit - 1`, `limit`, and `limit + 1`; verify missing `Content-Length` on chunked requests, Chinese/emoji byte boundaries, both existing constructors, invalid limits, early header rejection without sending a body, and bounded reads with an understated length. Rejected requests have zero serializer and agent calls.

Validation: `mvn -B -f sdks/community/java/ag-ui/pom.xml verify` on Temurin 17.0.20.1: **227 tests, 0 failures, 0 errors** across core, client, and server. The handler suite has 26 test cases. `git diff --check` passes.

AI assistance disclosure: Codex assisted with implementation, documentation, and running the reported local checks.
