### PR TITLE
test(dojo): assert terminal run events in the strands fixed-schema suites

### DIFF
--- a/apps/dojo/e2e/tests/awsStrandsTests/a2uiFixedSchema.spec.ts
+++ b/apps/dojo/e2e/tests/awsStrandsTests/a2uiFixedSchema.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../test-isolation-helper";
 import { A2UIPage } from "../../featurePages/A2UIPage";
+import { captureRuntimeSSE, expectRunFinished } from "../../utils/runtime-sse";
+
+const INTEGRATION_ID = "aws-strands";
 
 // OSS-158 — AWS Strands (Python) A2UI fixed schema. The agent exposes two plain
 // backend tools (search_flights / search_hotels); the LLM supplies the row data
@@ -16,12 +19,18 @@ test("[AWS Strands] A2UI Fixed Schema renders flight search surface", async ({
 
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
+  const sse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "flights from SFO to JFK",
+  );
   await a2ui.sendMessage("Find flights from SFO to JFK for next Tuesday.");
 
   await a2ui.assertUserMessageVisible("Find flights from SFO to JFK");
   await a2ui.assertSurfaceWithIdVisible("flight-search-results");
   // Flight data is bound via the fixed schema template — assert key data fields.
   await a2ui.assertSurfaceContainsAll(["UA 123", "DL 456", "$289", "$315"]);
+  expectRunFinished(await sse, "flight search run");
 });
 
 test("[AWS Strands] A2UI Fixed Schema renders hotel search with StarRating", async ({
@@ -31,6 +40,11 @@ test("[AWS Strands] A2UI Fixed Schema renders hotel search with StarRating", asy
 
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
+  const sse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "hotels in downtown Manhattan",
+  );
   await a2ui.sendMessage("Find hotels in downtown Manhattan for next weekend.");
 
   await a2ui.assertUserMessageVisible("Find hotels in downtown Manhattan");
@@ -43,6 +57,7 @@ test("[AWS Strands] A2UI Fixed Schema renders hotel search with StarRating", asy
   // Verify StarRating custom component rendered (numeric rating value).
   const surface = a2ui.surface("hotel-search-results");
   await expect(surface.getByText("4.5").first()).toBeVisible();
+  expectRunFinished(await sse, "hotel search run");
 });
 
 test("[AWS Strands] A2UI Fixed Schema renders multiple surfaces in sequence", async ({
@@ -53,13 +68,30 @@ test("[AWS Strands] A2UI Fixed Schema renders multiple surfaces in sequence", as
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
 
+  // Terminal events are captured per run, because a painted surface does not
+  // establish that its run completed: this very case once passed while two
+  // runs emitted RUN_ERROR.
+  const flightsSse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "flights from SFO to JFK",
+  );
+
   // First surface: flights
   await a2ui.sendMessage("Find flights from SFO to JFK.");
   await a2ui.assertSurfaceWithIdVisible("flight-search-results");
+  expectRunFinished(await flightsSse, "flight surface run");
+
+  const hotelsSse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "hotels in downtown Manhattan",
+  );
 
   // Second surface: hotels
   await a2ui.sendMessage("Find hotels in downtown Manhattan.");
   await a2ui.assertSurfaceWithIdVisible("hotel-search-results");
+  expectRunFinished(await hotelsSse, "hotel surface run");
 
   // Both surfaces should be present
   const count = await a2ui.getSurfaceCount();

--- a/apps/dojo/e2e/tests/awsStrandsTypescriptTests/a2uiFixedSchema.spec.ts
+++ b/apps/dojo/e2e/tests/awsStrandsTypescriptTests/a2uiFixedSchema.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../test-isolation-helper";
 import { A2UIPage } from "../../featurePages/A2UIPage";
+import { captureRuntimeSSE, expectRunFinished } from "../../utils/runtime-sse";
+
+const INTEGRATION_ID = "aws-strands-typescript";
 
 // OSS-158 — AWS Strands (TypeScript) A2UI fixed schema. The agent exposes two
 // plain backend tools (search_flights / search_hotels); the LLM supplies the row
@@ -16,12 +19,18 @@ test("[AWS Strands TS] A2UI Fixed Schema renders flight search surface", async (
 
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
+  const sse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "flights from SFO to JFK",
+  );
   await a2ui.sendMessage("Find flights from SFO to JFK for next Tuesday.");
 
   await a2ui.assertUserMessageVisible("Find flights from SFO to JFK");
   await a2ui.assertSurfaceWithIdVisible("flight-search-results");
   // Flight data is bound via the fixed schema template — assert key data fields.
   await a2ui.assertSurfaceContainsAll(["UA 123", "DL 456", "$289", "$315"]);
+  expectRunFinished(await sse, "flight search run");
 });
 
 test("[AWS Strands TS] A2UI Fixed Schema renders hotel search with StarRating", async ({
@@ -31,6 +40,11 @@ test("[AWS Strands TS] A2UI Fixed Schema renders hotel search with StarRating", 
 
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
+  const sse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "hotels in downtown Manhattan",
+  );
   await a2ui.sendMessage("Find hotels in downtown Manhattan for next weekend.");
 
   await a2ui.assertUserMessageVisible("Find hotels in downtown Manhattan");
@@ -43,6 +57,7 @@ test("[AWS Strands TS] A2UI Fixed Schema renders hotel search with StarRating", 
   // Verify StarRating custom component rendered (numeric rating value).
   const surface = a2ui.surface("hotel-search-results");
   await expect(surface.getByText("4.5").first()).toBeVisible();
+  expectRunFinished(await sse, "hotel search run");
 });
 
 test("[AWS Strands TS] A2UI Fixed Schema renders multiple surfaces in sequence", async ({
@@ -53,13 +68,30 @@ test("[AWS Strands TS] A2UI Fixed Schema renders multiple surfaces in sequence",
   const a2ui = new A2UIPage(page);
   await a2ui.openChat();
 
+  // Terminal events are captured per run, because a painted surface does not
+  // establish that its run completed: this very case once passed while two
+  // runs emitted RUN_ERROR.
+  const flightsSse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "flights from SFO to JFK",
+  );
+
   // First surface: flights
   await a2ui.sendMessage("Find flights from SFO to JFK.");
   await a2ui.assertSurfaceWithIdVisible("flight-search-results");
+  expectRunFinished(await flightsSse, "flight surface run");
+
+  const hotelsSse = captureRuntimeSSE(
+    page,
+    INTEGRATION_ID,
+    "hotels in downtown Manhattan",
+  );
 
   // Second surface: hotels
   await a2ui.sendMessage("Find hotels in downtown Manhattan.");
   await a2ui.assertSurfaceWithIdVisible("hotel-search-results");
+  expectRunFinished(await hotelsSse, "hotel surface run");
 
   // Both surfaces should be present
   const count = await a2ui.getSurfaceCount();

--- a/apps/dojo/e2e/utils/runtime-sse.ts
+++ b/apps/dojo/e2e/utils/runtime-sse.ts
@@ -1,8 +1,34 @@
-import type { Page, Response } from "@playwright/test";
+import { expect, type Page, type Response } from "@playwright/test";
 
 /** Escape a value taken off the wire before interpolating it into a RegExp. */
 export function escapeForRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Assert a captured run reached `RUN_FINISHED` and never emitted `RUN_ERROR`.
+ *
+ * Rendering is not success. A tool call and its result are on the wire before
+ * the model continuation happens, so a surface can paint from a run that then
+ * dies at the provider: that is how a context-ordering defect shipped past a
+ * suite whose fixed-schema tests only asserted that cards appeared. Terminal
+ * events are the only thing that separates the two.
+ */
+export function expectRunFinished(sse: string, label: string): void {
+  const types = [...sse.matchAll(/"type":"([A-Z_]+)"/g)].map(
+    (match) => match[1]!,
+  );
+  expect(types, `${label}: the run produced no protocol events`).not.toEqual(
+    [],
+  );
+  expect(
+    types.filter((type) => type === "RUN_ERROR"),
+    `${label}: run errored. Events: ${types.join(" -> ")}`,
+  ).toEqual([]);
+  expect(
+    types.at(-1),
+    `${label}: run did not end on RUN_FINISHED. Events: ${types.join(" -> ")}`,
+  ).toBe("RUN_FINISHED");
 }
 
 /**


### PR DESCRIPTION
## What

The AWS Strands A2UI fixed-schema e2e suites, in both languages, now assert the
terminal protocol events of every run they exercise, instead of asserting only
that a surface painted with the right data.

`expectRunFinished` joins `captureRuntimeSSE` in `apps/dojo/e2e/utils/runtime-sse.ts`.
It reads the captured runtime SSE body and requires the run to have produced
protocol events, emitted no `RUN_ERROR`, and ended on `RUN_FINISHED`. When it
fails, it names the event sequence it actually saw.

## Why

Rendering is not completion. A tool call and its result reach the browser before
the model continuation happens, so a surface can paint from a run that then dies
at the provider, and a suite that only checks the surface stays green.

That is how a real defect shipped. Forwarding `RunAgentInput.context` used to
fold a text block into whichever user turn was latest, and on a tool
continuation that turn is the one carrying the tool result. Every
OpenAI-compatible formatter emits a turn's plain text ahead of the tool messages
it appends, so the provider-bound request became
`assistant(tool_calls) -> user(text) -> tool(result)`, and OpenAI answers that
with HTTP 400 "An assistant message with 'tool_calls' must be followed by tool
messages responding to each 'tool_call_id'". The bridge wrapped it as a terminal
`RUN_ERROR`. The cards were already on screen, so these very tests passed
against a dead run.

The bridge-side defect itself is fixed on main by #2676, which places forwarded
context where every provider formatter accepts it. This PR closes the coverage
hole that let it through: the browser tests could not tell a completed run from
a failed one.

## Scope

Three files, tests only. No production code, no CI configuration.

- `apps/dojo/e2e/utils/runtime-sse.ts` gains `expectRunFinished`.
- `apps/dojo/e2e/tests/awsStrandsTests/a2uiFixedSchema.spec.ts`
- `apps/dojo/e2e/tests/awsStrandsTypescriptTests/a2uiFixedSchema.spec.ts`

All three cases in each suite are covered, and the multi-surface case captures
per run, so a second turn cannot hide behind a first that succeeded.

The helper lives in the shared utility rather than in either suite, because the
same gap exists wherever a test treats rendering as proof of completion.

## Verification

- The assertion was proven able to fail before being trusted. Fed a stream that
  paints a tool result and then emits `RUN_ERROR` (the exact shape of the
  shipped defect), a stream cut before any terminal event, and a stream with no
  protocol events at all, it fails on each and passes only the healthy run.
- Both suites compile and enumerate under `playwright test --list` (6 tests).
- `tsc --noEmit --strict` clean on the three touched files.
- Prettier clean.
- The suites themselves run in CI against the aimock fixtures.

## Tickets

PNI-419, PNI-421, PNI-422. The bridge fixes those tickets asked for landed in
#2676; the browser-coverage criterion is what remained, and this delivers it.
