### PR TITLE
feat(go-sdk): add metadata and subagent events

### DIFF
--- a/sdks/community/go/pkg/core/events/activity_events.go
+++ b/sdks/community/go/pkg/core/events/activity_events.go
@@ -12,6 +12,9 @@ type ActivitySnapshotEvent struct {
 	ActivityType string `json:"activityType"`
 	Content      any    `json:"content"`
 	Replace      *bool  `json:"replace,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewActivitySnapshotEvent creates a new activity snapshot event.
@@ -64,6 +67,9 @@ type ActivityDeltaEvent struct {
 	MessageID    string               `json:"messageId"`
 	ActivityType string               `json:"activityType"`
 	Patch        []JSONPatchOperation `json:"patch"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewActivityDeltaEvent creates a new activity delta event.

--- a/sdks/community/go/pkg/core/events/custom_events.go
+++ b/sdks/community/go/pkg/core/events/custom_events.go
@@ -10,6 +10,9 @@ type RawEvent struct {
 	*BaseEvent
 	Event  any     `json:"event"`
 	Source *string `json:"source,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewRawEvent creates a new raw event
@@ -59,6 +62,9 @@ type CustomEvent struct {
 	*BaseEvent
 	Name  string `json:"name"`
 	Value any    `json:"value,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewCustomEvent creates a new custom event

--- a/sdks/community/go/pkg/core/events/events.go
+++ b/sdks/community/go/pkg/core/events/events.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 )
 
 // EventType represents the type of AG-UI event.
@@ -140,6 +142,10 @@ type BaseEvent struct {
 	EventType   EventType `json:"type"`
 	TimestampMs *int64    `json:"timestamp,omitempty"`
 	RawEvent    any       `json:"rawEvent,omitempty"`
+	// Metadata is declared here rather than per event, so every event type
+	// carries it. Reach it through GetBaseEvent on the Event interface, which
+	// stays unchanged so existing implementations keep compiling.
+	Metadata types.Metadata `json:"metadata,omitempty"`
 }
 
 // Type returns the event type
@@ -178,6 +184,10 @@ func (b *BaseEvent) ToJSON() ([]byte, error) {
 
 	if b.RawEvent != nil {
 		eventData["data"] = b.RawEvent
+	}
+
+	if len(b.Metadata) > 0 {
+		eventData["metadata"] = b.Metadata
 	}
 
 	return json.Marshal(eventData)

--- a/sdks/community/go/pkg/core/events/events.go
+++ b/sdks/community/go/pkg/core/events/events.go
@@ -69,6 +69,14 @@ const (
 	// EventTypeReasoningEncryptedValue attaches an encrypted reasoning value.
 	EventTypeReasoningEncryptedValue     EventType = "REASONING_ENCRYPTED_VALUE"
 
+	// Subagent events attribute a segment of the stream to a nested agent.
+	// EventTypeSubagentStarted indicates a subagent has started within the run.
+	EventTypeSubagentStarted EventType = "SUBAGENT_STARTED"
+	// EventTypeSubagentFinished indicates a subagent has finished.
+	EventTypeSubagentFinished EventType = "SUBAGENT_FINISHED"
+	// EventTypeSubagentError indicates a subagent has errored, independent of the run.
+	EventTypeSubagentError EventType = "SUBAGENT_ERROR"
+
 	// EventTypeUnknown represents an unrecognized event type
 	EventTypeUnknown EventType = "UNKNOWN"
 )
@@ -108,6 +116,9 @@ var validEventTypes = map[EventType]bool{
 	EventTypeReasoningMessageChunk:      true,
 	EventTypeReasoningEnd:               true,
 	EventTypeReasoningEncryptedValue:    true,
+	EventTypeSubagentStarted:            true,
+	EventTypeSubagentFinished:           true,
+	EventTypeSubagentError:              true,
 }
 
 // Event defines the common interface for all AG-UI events
@@ -247,6 +258,7 @@ func ValidateSequence(events []Event) error {
 	activeReasoningMessages := make(map[string]bool)
 	activeToolCalls := make(map[string]bool)
 	activeSteps := make(map[string]bool)
+	activeSubagents := make(map[string]bool)
 	finishedRuns := make(map[string]bool)
 
 	for i, event := range events {
@@ -398,6 +410,29 @@ func ValidateSequence(events []Event) error {
 		case EventTypeReasoningEnd:
 			// Reasoning events are always valid in sequence context.
 
+		case EventTypeSubagentStarted:
+			if subagentEvent, ok := event.(*SubagentStartedEvent); ok {
+				if activeSubagents[subagentEvent.SubagentRunID] {
+					return fmt.Errorf("subagent %s already started", subagentEvent.SubagentRunID)
+				}
+				activeSubagents[subagentEvent.SubagentRunID] = true
+			}
+
+		case EventTypeSubagentFinished:
+			if subagentEvent, ok := event.(*SubagentFinishedEvent); ok {
+				if !activeSubagents[subagentEvent.SubagentRunID] {
+					return fmt.Errorf("cannot finish subagent %s that was not started", subagentEvent.SubagentRunID)
+				}
+				delete(activeSubagents, subagentEvent.SubagentRunID)
+			}
+
+		case EventTypeSubagentError:
+			// A subagent can error without having been announced, so this ends
+			// the invocation without requiring a prior SUBAGENT_STARTED.
+			if subagentEvent, ok := event.(*SubagentErrorEvent); ok {
+				delete(activeSubagents, subagentEvent.SubagentRunID)
+			}
+
 		case EventTypeStateSnapshot:
 			// State snapshot events are always valid in sequence context
 			// They represent complete state at any point in time
@@ -508,6 +543,12 @@ func EventFromJSON(data []byte) (Event, error) {
 		event = &ReasoningEndEvent{}
 	case EventTypeReasoningEncryptedValue:
 		event = &ReasoningEncryptedValueEvent{}
+	case EventTypeSubagentStarted:
+		event = &SubagentStartedEvent{}
+	case EventTypeSubagentFinished:
+		event = &SubagentFinishedEvent{}
+	case EventTypeSubagentError:
+		event = &SubagentErrorEvent{}
 	default:
 		return nil, fmt.Errorf("unknown event type: %s", base.Type)
 	}

--- a/sdks/community/go/pkg/core/events/message_events.go
+++ b/sdks/community/go/pkg/core/events/message_events.go
@@ -11,6 +11,9 @@ type TextMessageStartEvent struct {
 	MessageID string  `json:"messageId"`
 	Role      *string `json:"role,omitempty"`
 	Name      string  `json:"name,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewTextMessageStartEvent creates a new text message start event
@@ -76,6 +79,9 @@ type TextMessageContentEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
 	Delta     string `json:"delta"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewTextMessageContentEvent creates a new text message content event
@@ -140,6 +146,9 @@ func (e *TextMessageContentEvent) ToJSON() ([]byte, error) {
 type TextMessageEndEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewTextMessageEndEvent creates a new text message end event
@@ -201,6 +210,9 @@ type TextMessageChunkEvent struct {
 	Role      *string `json:"role,omitempty"`
 	Delta     *string `json:"delta,omitempty"`
 	Name      *string `json:"name,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewTextMessageChunkEvent creates a new text message chunk event

--- a/sdks/community/go/pkg/core/events/metadata_test.go
+++ b/sdks/community/go/pkg/core/events/metadata_test.go
@@ -1,0 +1,82 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+)
+
+// TestEventMetadataRoundTrip verifies metadata declared on BaseEvent survives a
+// marshal/unmarshal cycle on a concrete event.
+func TestEventMetadataRoundTrip(t *testing.T) {
+	event := NewTextMessageStartEvent("msg-1")
+	event.Metadata = types.Metadata{
+		types.AGUIMetadataKey: map[string]any{"nodePath": "root/child"},
+		"tokenUsage":          map[string]any{"input": float64(12)},
+	}
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, event.Metadata, decoded.GetBaseEvent().Metadata)
+}
+
+// TestEventUnmarshalMetadataNullAndAbsent verifies an explicit null metadata object
+// decodes the same as an absent one, and neither is written back out.
+func TestEventUnmarshalMetadataNullAndAbsent(t *testing.T) {
+	for name, payload := range map[string]string{
+		"null":   `{"type": "TEXT_MESSAGE_START", "messageId": "msg-1", "metadata": null}`,
+		"absent": `{"type": "TEXT_MESSAGE_START", "messageId": "msg-1"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoded, err := EventFromJSON([]byte(payload))
+			require.NoError(t, err)
+			assert.Nil(t, decoded.GetBaseEvent().Metadata)
+
+			encoded, err := decoded.ToJSON()
+			require.NoError(t, err)
+			assert.NotContains(t, string(encoded), "metadata")
+		})
+	}
+}
+
+// TestEventMetadataPreservesNullValues verifies a null under a key is data, unlike a
+// null in place of the whole object.
+func TestEventMetadataPreservesNullValues(t *testing.T) {
+	payload := []byte(`{
+		"type": "RUN_FINISHED",
+		"threadId": "thread-1",
+		"runId": "run-1",
+		"metadata": {"finishReason": null}
+	}`)
+
+	decoded, err := EventFromJSON(payload)
+	require.NoError(t, err)
+
+	metadata := decoded.GetBaseEvent().Metadata
+	require.NotNil(t, metadata)
+	value, ok := metadata["finishReason"]
+	assert.True(t, ok)
+	assert.Nil(t, value)
+}
+
+// TestBaseEventToJSONIncludesMetadata verifies the hand-rolled BaseEvent serializer
+// carries metadata, since it does not go through the struct tags.
+func TestBaseEventToJSONIncludesMetadata(t *testing.T) {
+	base := NewBaseEvent(EventTypeCustom)
+	base.Metadata = types.Metadata{"traceId": "abc"}
+
+	encoded, err := base.ToJSON()
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, map[string]any{"traceId": "abc"}, decoded["metadata"])
+}

--- a/sdks/community/go/pkg/core/events/reasoning_events.go
+++ b/sdks/community/go/pkg/core/events/reasoning_events.go
@@ -9,6 +9,9 @@ import (
 type ReasoningStartEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningStartEvent creates a new reasoning start event.
@@ -39,6 +42,9 @@ func (e *ReasoningStartEvent) ToJSON() ([]byte, error) {
 type ReasoningEndEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningEndEvent creates a new reasoning end event.
@@ -70,6 +76,9 @@ type ReasoningMessageStartEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
 	Role      string `json:"role"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningMessageStartEvent creates a new reasoning message start event.
@@ -105,6 +114,9 @@ type ReasoningMessageContentEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
 	Delta     string `json:"delta"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningMessageContentEvent creates a new reasoning message content event.
@@ -139,6 +151,9 @@ func (e *ReasoningMessageContentEvent) ToJSON() ([]byte, error) {
 type ReasoningMessageEndEvent struct {
 	*BaseEvent
 	MessageID string `json:"messageId"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningMessageEndEvent creates a new reasoning message end event.
@@ -170,6 +185,9 @@ type ReasoningMessageChunkEvent struct {
 	*BaseEvent
 	MessageID *string `json:"messageId,omitempty"`
 	Delta     *string `json:"delta,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningMessageChunkEvent creates a new reasoning message chunk event.
@@ -231,6 +249,9 @@ type ReasoningEncryptedValueEvent struct {
 	Subtype        ReasoningEncryptedValueSubtype `json:"subtype"`
 	EntityID       string                         `json:"entityId"`
 	EncryptedValue string                         `json:"encryptedValue"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewReasoningEncryptedValueEvent creates a new reasoning encrypted value event.

--- a/sdks/community/go/pkg/core/events/run_events.go
+++ b/sdks/community/go/pkg/core/events/run_events.go
@@ -303,6 +303,9 @@ func (e *RunErrorEvent) ToJSON() ([]byte, error) {
 type StepStartedEvent struct {
 	*BaseEvent
 	StepName string `json:"stepName"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewStepStartedEvent creates a new step started event
@@ -361,6 +364,9 @@ func (e *StepStartedEvent) ToJSON() ([]byte, error) {
 type StepFinishedEvent struct {
 	*BaseEvent
 	StepName string `json:"stepName"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewStepFinishedEvent creates a new step finished event

--- a/sdks/community/go/pkg/core/events/state_events.go
+++ b/sdks/community/go/pkg/core/events/state_events.go
@@ -30,6 +30,9 @@ type Function = coretypes.FunctionCall
 type StateSnapshotEvent struct {
 	*BaseEvent
 	Snapshot any `json:"snapshot"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewStateSnapshotEvent creates a new state snapshot event
@@ -70,6 +73,9 @@ type JSONPatchOperation struct {
 type StateDeltaEvent struct {
 	*BaseEvent
 	Delta []JSONPatchOperation `json:"delta"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewStateDeltaEvent creates a new state delta event

--- a/sdks/community/go/pkg/core/events/subagent_events.go
+++ b/sdks/community/go/pkg/core/events/subagent_events.go
@@ -1,0 +1,254 @@
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SubagentStartedEvent indicates a subagent has started within the run
+type SubagentStartedEvent struct {
+	*BaseEvent
+	SubagentRunID string `json:"subagentRunId"`
+	Name          string `json:"name"`
+	Description   string `json:"description,omitempty"`
+	// ParentSubagentRunID is the subagent that spawned this one, for nesting.
+	ParentSubagentRunID string `json:"parentSubagentRunId,omitempty"`
+	// ParentToolCallID links back to the tool call that spawned this subagent,
+	// for the agents-as-tools pattern. It lets a consumer correlate the
+	// subagent to its spawning call without inspecting the raw event.
+	ParentToolCallID string `json:"parentToolCallId,omitempty"`
+	// ParentMessageID is the message that held the spawning tool call.
+	ParentMessageID string `json:"parentMessageId,omitempty"`
+}
+
+// NewSubagentStartedEvent creates a new subagent started event
+func NewSubagentStartedEvent(subagentRunID, name string, options ...SubagentStartedOption) *SubagentStartedEvent {
+	event := &SubagentStartedEvent{
+		BaseEvent:     NewBaseEvent(EventTypeSubagentStarted),
+		SubagentRunID: subagentRunID,
+		Name:          name,
+	}
+
+	for _, opt := range options {
+		opt(event)
+	}
+
+	return event
+}
+
+// SubagentStartedOption defines options for creating subagent started events
+type SubagentStartedOption func(*SubagentStartedEvent)
+
+// WithSubagentDescription sets the description for the subagent
+func WithSubagentDescription(description string) SubagentStartedOption {
+	return func(e *SubagentStartedEvent) {
+		e.Description = description
+	}
+}
+
+// WithParentSubagentRunID sets the subagent that spawned this one
+func WithParentSubagentRunID(parentSubagentRunID string) SubagentStartedOption {
+	return func(e *SubagentStartedEvent) {
+		e.ParentSubagentRunID = parentSubagentRunID
+	}
+}
+
+// WithParentToolCall sets the tool call, and the message that held it, that spawned this subagent
+func WithParentToolCall(parentToolCallID, parentMessageID string) SubagentStartedOption {
+	return func(e *SubagentStartedEvent) {
+		e.ParentToolCallID = parentToolCallID
+		e.ParentMessageID = parentMessageID
+	}
+}
+
+// Validate validates the subagent started event
+func (e *SubagentStartedEvent) Validate() error {
+	if err := e.BaseEvent.Validate(); err != nil {
+		return err
+	}
+
+	if e.SubagentRunID == "" {
+		return fmt.Errorf("SubagentStartedEvent validation failed: subagentRunId field is required")
+	}
+
+	if e.Name == "" {
+		return fmt.Errorf("SubagentStartedEvent validation failed: name field is required")
+	}
+
+	return nil
+}
+
+// ToJSON serializes the event to JSON
+func (e *SubagentStartedEvent) ToJSON() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// SubagentFinishedOutcomeType discriminates between outcome variants.
+type SubagentFinishedOutcomeType string
+
+const (
+	// SubagentFinishedOutcomeTypeSuccess indicates the subagent completed its work.
+	SubagentFinishedOutcomeTypeSuccess SubagentFinishedOutcomeType = "success"
+	// SubagentFinishedOutcomeTypeSuspended indicates the subagent is paused awaiting outside input.
+	SubagentFinishedOutcomeTypeSuspended SubagentFinishedOutcomeType = "suspended"
+)
+
+// SubagentFinishedOutcome represents the outcome of a finished subagent.
+// Type discriminates between success and suspended variants.
+//
+// This mirrors RunFinishedOutcome one level down: a subagent's terminal event
+// closes its stream segment for THIS run either because the work completed
+// ("success") or because the workflow is paused awaiting outside input
+// ("suspended" — the run ends with an interrupt outcome, and on resume the same
+// subagentRunId is re-announced as a continuation of the suspended invocation).
+// An omitted outcome means legacy success. Without this, a paused subagent was
+// indistinguishable from a completed one.
+type SubagentFinishedOutcome struct {
+	// Type is the outcome discriminator ("success" or "suspended").
+	Type SubagentFinishedOutcomeType `json:"type"`
+	// InterruptIDs names the run-level interrupts this subagent directly owns.
+	// Only populated when Type is "suspended", and it may be empty even then:
+	// an ancestor subagent suspended because a descendant interrupted owns no
+	// interrupt itself.
+	InterruptIDs []string `json:"interruptIds,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler.
+//
+// InterruptIDs belongs only to the suspended variant. TypeScript parses the
+// outcome as a strict discriminated union, so a success outcome carrying the
+// key is rejected outright; dropping it here means a caller that sets both
+// cannot put an unparseable event on the wire.
+func (o SubagentFinishedOutcome) MarshalJSON() ([]byte, error) {
+	// Alias the type so marshalling does not recurse into this method.
+	type outcome SubagentFinishedOutcome
+
+	if o.Type != SubagentFinishedOutcomeTypeSuspended {
+		o.InterruptIDs = nil
+	}
+
+	return json.Marshal(outcome(o))
+}
+
+// SubagentFinishedEvent indicates a subagent has finished
+type SubagentFinishedEvent struct {
+	*BaseEvent
+	SubagentRunID string `json:"subagentRunId"`
+	// Result is the subagent's completion payload, mirroring RunFinishedEvent.Result.
+	Result  any                      `json:"result,omitempty"`
+	Outcome *SubagentFinishedOutcome `json:"outcome,omitempty"`
+}
+
+// NewSubagentFinishedEvent creates a new subagent finished event
+func NewSubagentFinishedEvent(subagentRunID string, options ...SubagentFinishedOption) *SubagentFinishedEvent {
+	event := &SubagentFinishedEvent{
+		BaseEvent:     NewBaseEvent(EventTypeSubagentFinished),
+		SubagentRunID: subagentRunID,
+	}
+
+	for _, opt := range options {
+		opt(event)
+	}
+
+	return event
+}
+
+// SubagentFinishedOption defines options for creating subagent finished events
+type SubagentFinishedOption func(*SubagentFinishedEvent)
+
+// WithSubagentResult sets the completion payload for the subagent
+func WithSubagentResult(result any) SubagentFinishedOption {
+	return func(e *SubagentFinishedEvent) {
+		e.Result = result
+	}
+}
+
+// WithSubagentSuccessOutcome sets the outcome to success for the subagent finished event
+func WithSubagentSuccessOutcome() SubagentFinishedOption {
+	return func(e *SubagentFinishedEvent) {
+		e.Outcome = &SubagentFinishedOutcome{Type: SubagentFinishedOutcomeTypeSuccess}
+	}
+}
+
+// WithSubagentSuspendedOutcome sets the outcome to suspended with the interrupts the subagent owns
+func WithSubagentSuspendedOutcome(interruptIDs []string) SubagentFinishedOption {
+	return func(e *SubagentFinishedEvent) {
+		e.Outcome = &SubagentFinishedOutcome{
+			Type:         SubagentFinishedOutcomeTypeSuspended,
+			InterruptIDs: interruptIDs,
+		}
+	}
+}
+
+// Validate validates the subagent finished event
+func (e *SubagentFinishedEvent) Validate() error {
+	if err := e.BaseEvent.Validate(); err != nil {
+		return err
+	}
+
+	if e.SubagentRunID == "" {
+		return fmt.Errorf("SubagentFinishedEvent validation failed: subagentRunId field is required")
+	}
+
+	return nil
+}
+
+// ToJSON serializes the event to JSON
+func (e *SubagentFinishedEvent) ToJSON() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// SubagentErrorEvent indicates a subagent has errored, independent of the run
+type SubagentErrorEvent struct {
+	*BaseEvent
+	SubagentRunID string  `json:"subagentRunId"`
+	Message       string  `json:"message"`
+	Code          *string `json:"code,omitempty"`
+}
+
+// NewSubagentErrorEvent creates a new subagent error event
+func NewSubagentErrorEvent(subagentRunID, message string, options ...SubagentErrorOption) *SubagentErrorEvent {
+	event := &SubagentErrorEvent{
+		BaseEvent:     NewBaseEvent(EventTypeSubagentError),
+		SubagentRunID: subagentRunID,
+		Message:       message,
+	}
+
+	for _, opt := range options {
+		opt(event)
+	}
+
+	return event
+}
+
+// SubagentErrorOption defines options for creating subagent error events
+type SubagentErrorOption func(*SubagentErrorEvent)
+
+// WithSubagentErrorCode sets the error code for the subagent error event
+func WithSubagentErrorCode(code string) SubagentErrorOption {
+	return func(e *SubagentErrorEvent) {
+		e.Code = &code
+	}
+}
+
+// Validate validates the subagent error event
+func (e *SubagentErrorEvent) Validate() error {
+	if err := e.BaseEvent.Validate(); err != nil {
+		return err
+	}
+
+	if e.SubagentRunID == "" {
+		return fmt.Errorf("SubagentErrorEvent validation failed: subagentRunId field is required")
+	}
+
+	if e.Message == "" {
+		return fmt.Errorf("SubagentErrorEvent validation failed: message field is required")
+	}
+
+	return nil
+}
+
+// ToJSON serializes the event to JSON
+func (e *SubagentErrorEvent) ToJSON() ([]byte, error) {
+	return json.Marshal(e)
+}

--- a/sdks/community/go/pkg/core/events/subagent_events_test.go
+++ b/sdks/community/go/pkg/core/events/subagent_events_test.go
@@ -1,0 +1,213 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubagentStartedEventRoundTrip verifies the spawning links survive a decode.
+func TestSubagentStartedEventRoundTrip(t *testing.T) {
+	event := NewSubagentStartedEvent(
+		"sub-1",
+		"researcher",
+		WithSubagentDescription("looks things up"),
+		WithParentSubagentRunID("sub-0"),
+		WithParentToolCall("tc-1", "msg-1"),
+	)
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	assert.Equal(t, "SUBAGENT_STARTED", wire["type"])
+	assert.Equal(t, "sub-1", wire["subagentRunId"])
+	assert.Equal(t, "researcher", wire["name"])
+	assert.Equal(t, "looks things up", wire["description"])
+	assert.Equal(t, "sub-0", wire["parentSubagentRunId"])
+	assert.Equal(t, "tc-1", wire["parentToolCallId"])
+	assert.Equal(t, "msg-1", wire["parentMessageId"])
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+	require.IsType(t, &SubagentStartedEvent{}, decoded)
+	assert.Equal(t, event.ParentToolCallID, decoded.(*SubagentStartedEvent).ParentToolCallID)
+}
+
+// TestSubagentStartedEventValidation verifies the two required fields.
+func TestSubagentStartedEventValidation(t *testing.T) {
+	event := NewSubagentStartedEvent("", "researcher")
+	assertErrorContains(t, event.Validate(), "subagentRunId field is required")
+
+	event = NewSubagentStartedEvent("sub-1", "")
+	assertErrorContains(t, event.Validate(), "name field is required")
+}
+
+// TestSubagentStartedEventOptionalFieldsOmitted verifies absent is the only spelling
+// for a field with no value, since the subagent surface tolerates no nulls.
+func TestSubagentStartedEventOptionalFieldsOmitted(t *testing.T) {
+	encoded, err := NewSubagentStartedEvent("sub-1", "researcher").ToJSON()
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	for _, key := range []string{"description", "parentSubagentRunId", "parentToolCallId", "parentMessageId"} {
+		assert.NotContains(t, wire, key)
+	}
+}
+
+// TestSubagentFinishedEventSuspendedOutcome verifies the suspended variant carries
+// the interrupts the subagent owns.
+func TestSubagentFinishedEventSuspendedOutcome(t *testing.T) {
+	event := NewSubagentFinishedEvent("sub-1", WithSubagentSuspendedOutcome([]string{"int-1"}))
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+
+	finished, ok := decoded.(*SubagentFinishedEvent)
+	require.True(t, ok)
+	require.NotNil(t, finished.Outcome)
+	assert.Equal(t, SubagentFinishedOutcomeTypeSuspended, finished.Outcome.Type)
+	assert.Equal(t, []string{"int-1"}, finished.Outcome.InterruptIDs)
+}
+
+// TestSubagentFinishedEventSuccessOutcomeDropsInterruptIDs verifies a success outcome
+// never carries interruptIds, which the TypeScript schema rejects outright.
+func TestSubagentFinishedEventSuccessOutcomeDropsInterruptIDs(t *testing.T) {
+	event := NewSubagentFinishedEvent("sub-1", WithSubagentResult(map[string]any{"answer": 42}))
+	event.Outcome = &SubagentFinishedOutcome{
+		Type:         SubagentFinishedOutcomeTypeSuccess,
+		InterruptIDs: []string{"int-1"},
+	}
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	var wire struct {
+		Outcome map[string]any `json:"outcome"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	assert.Equal(t, "success", wire.Outcome["type"])
+	assert.NotContains(t, wire.Outcome, "interruptIds")
+}
+
+// TestSubagentFinishedEventOmittedOutcome verifies an absent outcome stays absent,
+// which reads as legacy success.
+func TestSubagentFinishedEventOmittedOutcome(t *testing.T) {
+	encoded, err := NewSubagentFinishedEvent("sub-1").ToJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "outcome")
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+	assert.Nil(t, decoded.(*SubagentFinishedEvent).Outcome)
+}
+
+// TestSubagentErrorEvent verifies the error event round-trips and validates.
+func TestSubagentErrorEvent(t *testing.T) {
+	event := NewSubagentErrorEvent("sub-1", "boom", WithSubagentErrorCode("E_TOOL"))
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+
+	errored, ok := decoded.(*SubagentErrorEvent)
+	require.True(t, ok)
+	assert.Equal(t, "sub-1", errored.SubagentRunID)
+	assert.Equal(t, "boom", errored.Message)
+	require.NotNil(t, errored.Code)
+	assert.Equal(t, "E_TOOL", *errored.Code)
+
+	assertErrorContains(t, NewSubagentErrorEvent("sub-1", "").Validate(), "message field is required")
+	assertErrorContains(t, NewSubagentErrorEvent("", "boom").Validate(), "subagentRunId field is required")
+}
+
+// TestSubagentRunIDAttribution verifies an ordinary event can be attributed to a
+// subagent, and stays unattributed when it comes from the root agent.
+func TestSubagentRunIDAttribution(t *testing.T) {
+	event := NewTextMessageStartEvent("msg-1")
+	event.SubagentRunID = "sub-1"
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "sub-1", decoded.(*TextMessageStartEvent).SubagentRunID)
+
+	rootEncoded, err := NewTextMessageStartEvent("msg-2").ToJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rootEncoded), "subagentRunId")
+}
+
+// TestSubagentEventTypesAreValid verifies the three types are registered, so
+// BaseEvent.Validate accepts them.
+func TestSubagentEventTypesAreValid(t *testing.T) {
+	for _, eventType := range []EventType{EventTypeSubagentStarted, EventTypeSubagentFinished, EventTypeSubagentError} {
+		assert.True(t, isValidEventType(eventType), string(eventType))
+	}
+}
+
+// TestValidateSequenceSubagentLifecycle verifies a subagent must start before it
+// finishes, and cannot start twice.
+func TestValidateSequenceSubagentLifecycle(t *testing.T) {
+	valid := []Event{
+		NewRunStartedEvent("thread-1", "run-1"),
+		NewSubagentStartedEvent("sub-1", "researcher"),
+		NewSubagentFinishedEvent("sub-1", WithSubagentSuccessOutcome()),
+		NewRunFinishedEvent("thread-1", "run-1"),
+	}
+	assert.NoError(t, ValidateSequence(valid))
+
+	finishWithoutStart := []Event{
+		NewRunStartedEvent("thread-1", "run-1"),
+		NewSubagentFinishedEvent("sub-1"),
+	}
+	assertErrorContains(t, ValidateSequence(finishWithoutStart), "cannot finish subagent sub-1 that was not started")
+
+	startedTwice := []Event{
+		NewRunStartedEvent("thread-1", "run-1"),
+		NewSubagentStartedEvent("sub-1", "researcher"),
+		NewSubagentStartedEvent("sub-1", "researcher"),
+	}
+	assertErrorContains(t, ValidateSequence(startedTwice), "subagent sub-1 already started")
+}
+
+// TestValidateSequenceSubagentErrorEndsInvocation verifies a subagent can error
+// without having been announced, and that the error closes the invocation.
+func TestValidateSequenceSubagentErrorEndsInvocation(t *testing.T) {
+	unannounced := []Event{
+		NewRunStartedEvent("thread-1", "run-1"),
+		NewSubagentErrorEvent("sub-1", "boom"),
+	}
+	assert.NoError(t, ValidateSequence(unannounced))
+
+	reused := []Event{
+		NewRunStartedEvent("thread-1", "run-1"),
+		NewSubagentStartedEvent("sub-1", "researcher"),
+		NewSubagentErrorEvent("sub-1", "boom"),
+		NewSubagentStartedEvent("sub-1", "researcher"),
+	}
+	assert.NoError(t, ValidateSequence(reused))
+}
+
+// assertErrorContains asserts err is non-nil and its message contains want. The
+// module's testify version predates assert.ErrorContains.
+func assertErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), want)
+	}
+}

--- a/sdks/community/go/pkg/core/events/tool_events.go
+++ b/sdks/community/go/pkg/core/events/tool_events.go
@@ -11,6 +11,9 @@ type ToolCallStartEvent struct {
 	ToolCallID      string  `json:"toolCallId"`
 	ToolCallName    string  `json:"toolCallName"`
 	ParentMessageID *string `json:"parentMessageId,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewToolCallStartEvent creates a new tool call start event
@@ -74,6 +77,9 @@ type ToolCallArgsEvent struct {
 	*BaseEvent
 	ToolCallID string `json:"toolCallId"`
 	Delta      string `json:"delta"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewToolCallArgsEvent creates a new tool call args event
@@ -138,6 +144,9 @@ func (e *ToolCallArgsEvent) ToJSON() ([]byte, error) {
 type ToolCallEndEvent struct {
 	*BaseEvent
 	ToolCallID string `json:"toolCallId"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewToolCallEndEvent creates a new tool call end event
@@ -199,6 +208,9 @@ type ToolCallResultEvent struct {
 	ToolCallID string  `json:"toolCallId"`
 	Content    string  `json:"content"`
 	Role       *string `json:"role,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewToolCallResultEvent creates a new tool call result event
@@ -246,6 +258,9 @@ type ToolCallChunkEvent struct {
 	ToolCallName    *string `json:"toolCallName,omitempty"`
 	ParentMessageID *string `json:"parentMessageId,omitempty"`
 	Delta           *string `json:"delta,omitempty"`
+	// SubagentRunID attributes this event to a subagent invocation.
+	// Empty when the event comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // NewToolCallChunkEvent creates a new tool call chunk event

--- a/sdks/community/go/pkg/core/types/metadata.go
+++ b/sdks/community/go/pkg/core/types/metadata.go
@@ -1,0 +1,56 @@
+package types
+
+import "maps"
+
+// AGUIMetadataKey is the key reserved for AG-UI's own use inside a metadata
+// object. Every other key is user space.
+//
+// Reservation is by convention: nothing rejects a write to this key at runtime,
+// because metadata is open by key and validating its shape would contradict
+// that.
+const AGUIMetadataKey = "ag-ui"
+
+// Metadata is extra information attached to an event, a message, or a tool call.
+//
+// Open by key — any JSON value is allowed under a key, including nil. A nil
+// value under a key is meaningful data and is preserved.
+//
+// Deliberately map[string]any rather than a recursive JSON-value type. Every
+// dynamic payload in the protocol already uses the permissive form — State,
+// RawEvent, CustomEvent.Value, InputContent.Metadata, Interrupt.Metadata — so
+// tightening this one field would make it the sole outlier while fixing nothing
+// elsewhere. A recursive validation would also walk every value on every event,
+// on the streaming hot path, to catch a mistake that already fails loudly at
+// encode time.
+//
+// The object itself is absent or a mapping. Go collapses an explicit JSON null
+// into the same nil map as an absent field, and omitempty drops it again on the
+// way out, so a null never survives a round trip. That matches Python and .NET;
+// the TypeScript client is stricter and rejects a null metadata object outright.
+type Metadata map[string]any
+
+// MergeMetadata folds incoming into existing, key by key, with the last write
+// winning.
+//
+// A message is assembled from a sequence of events, and the interesting values
+// — token usage and finish reason among them — are only known at the end. So
+// metadata accumulates as the sequence arrives rather than being fixed at the
+// start.
+//
+// A key's value is replaced outright. This never recurses, so a slice or map
+// under any key — including AGUIMetadataKey — is replaced wholesale rather than
+// blended with what was there before.
+//
+// Returns a new map rather than mutating either argument. A nil incoming
+// returns existing untouched; an empty incoming changes nothing.
+func MergeMetadata(existing, incoming Metadata) Metadata {
+	if incoming == nil {
+		return existing
+	}
+
+	merged := make(Metadata, len(existing)+len(incoming))
+	maps.Copy(merged, existing)
+	maps.Copy(merged, incoming)
+
+	return merged
+}

--- a/sdks/community/go/pkg/core/types/metadata_test.go
+++ b/sdks/community/go/pkg/core/types/metadata_test.go
@@ -187,3 +187,38 @@ func TestMergeMetadataEmptyInputs(t *testing.T) {
 	assert.Equal(t, Metadata{"attempt": 1}, MergeMetadata(nil, existing))
 	assert.Nil(t, MergeMetadata(nil, nil))
 }
+
+// TestMessageUnmarshalSubagentRunID verifies subagent attribution decodes in both
+// the camelCase and snake_case spellings.
+func TestMessageUnmarshalSubagentRunID(t *testing.T) {
+	for name, payload := range map[string]string{
+		"camelCase":  `{"id": "msg-1", "role": "assistant", "subagentRunId": "sub-1"}`,
+		"snake_case": `{"id": "msg-1", "role": "assistant", "subagent_run_id": "sub-1"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var message Message
+			require.NoError(t, json.Unmarshal([]byte(payload), &message))
+			assert.Equal(t, "sub-1", message.SubagentRunID)
+		})
+	}
+}
+
+// TestInterruptUnmarshalSubagentRunID verifies the interrupt names the subagent that
+// raised it, and stays unattributed when the root agent raised it.
+func TestInterruptUnmarshalSubagentRunID(t *testing.T) {
+	var interrupt Interrupt
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "int-1",
+		"reason": "tool_call",
+		"subagent_run_id": "sub-1"
+	}`), &interrupt))
+	assert.Equal(t, "sub-1", interrupt.SubagentRunID)
+
+	var rootRaised Interrupt
+	require.NoError(t, json.Unmarshal([]byte(`{"id": "int-2", "reason": "tool_call"}`), &rootRaised))
+	assert.Empty(t, rootRaised.SubagentRunID)
+
+	encoded, err := json.Marshal(rootRaised)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "subagentRunId")
+}

--- a/sdks/community/go/pkg/core/types/metadata_test.go
+++ b/sdks/community/go/pkg/core/types/metadata_test.go
@@ -1,0 +1,189 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessageUnmarshalMetadata verifies a message carries metadata through a decode.
+func TestMessageUnmarshalMetadata(t *testing.T) {
+	payload := []byte(`{
+		"id": "msg-1",
+		"role": "assistant",
+		"content": "hi",
+		"metadata": {
+			"ag-ui": {"source": "adk"},
+			"tokenUsage": {"input": 12, "output": 4},
+			"finishReason": null
+		},
+		"toolCalls": [
+			{
+				"id": "tc-1",
+				"type": "function",
+				"function": {"name": "tool", "arguments": "{}"},
+				"metadata": {"traceId": "abc"}
+			}
+		]
+	}`)
+
+	var message Message
+	require.NoError(t, json.Unmarshal(payload, &message))
+
+	require.NotNil(t, message.Metadata)
+	assert.Equal(t, map[string]any{"source": "adk"}, message.Metadata[AGUIMetadataKey])
+	assert.Equal(t, map[string]any{"input": float64(12), "output": float64(4)}, message.Metadata["tokenUsage"])
+
+	// A null value under a key is meaningful data and is preserved, unlike a
+	// null in place of the whole object.
+	value, ok := message.Metadata["finishReason"]
+	assert.True(t, ok)
+	assert.Nil(t, value)
+
+	require.Len(t, message.ToolCalls, 1)
+	assert.Equal(t, Metadata{"traceId": "abc"}, message.ToolCalls[0].Metadata)
+}
+
+// TestMessageUnmarshalMetadataNullAndAbsent verifies an explicit null metadata object
+// decodes the same as an absent one, and neither is written back out.
+func TestMessageUnmarshalMetadataNullAndAbsent(t *testing.T) {
+	for name, payload := range map[string]string{
+		"null":   `{"id": "msg-1", "role": "user", "content": "hi", "metadata": null}`,
+		"absent": `{"id": "msg-1", "role": "user", "content": "hi"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var message Message
+			require.NoError(t, json.Unmarshal([]byte(payload), &message))
+			assert.Nil(t, message.Metadata)
+
+			encoded, err := json.Marshal(message)
+			require.NoError(t, err)
+			assert.NotContains(t, string(encoded), "metadata")
+		})
+	}
+}
+
+// TestMessageMetadataRoundTrip verifies metadata survives a marshal/unmarshal cycle.
+func TestMessageMetadataRoundTrip(t *testing.T) {
+	original := Message{
+		ID:       "msg-1",
+		Role:     RoleAssistant,
+		Content:  "hi",
+		Metadata: Metadata{AGUIMetadataKey: map[string]any{"nodePath": "root/child"}, "attempt": float64(2)},
+		ToolCalls: []ToolCall{{
+			ID:       "tc-1",
+			Type:     ToolCallTypeFunction,
+			Function: FunctionCall{Name: "tool", Arguments: "{}"},
+			Metadata: Metadata{"traceId": "abc"},
+		}},
+	}
+
+	encoded, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded Message
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	assert.Equal(t, original.Metadata, decoded.Metadata)
+	require.Len(t, decoded.ToolCalls, 1)
+	assert.Equal(t, original.ToolCalls[0].Metadata, decoded.ToolCalls[0].Metadata)
+}
+
+// TestRunAgentInputUnmarshalMetadataSnakeCase verifies metadata decodes alongside
+// snake_case field names on the types that accept both spellings.
+func TestRunAgentInputUnmarshalMetadataSnakeCase(t *testing.T) {
+	payload := []byte(`{
+		"thread_id": "thread-1",
+		"run_id": "run-1",
+		"state": {},
+		"messages": [
+			{
+				"id": "msg-1",
+				"role": "tool",
+				"content": "done",
+				"tool_call_id": "tc-1",
+				"metadata": {"latencyMs": 12}
+			}
+		],
+		"tools": [
+			{
+				"name": "tool",
+				"description": "desc",
+				"parameters": {"type": "object"},
+				"metadata": {"a2ui": {"schema": "v1"}}
+			}
+		],
+		"context": [],
+		"forwarded_props": {},
+		"resume": [
+			{
+				"interrupt_id": "int-1",
+				"status": "resolved",
+				"payload": {"approved": true},
+				"metadata": {"signature": "sig-1"}
+			}
+		]
+	}`)
+
+	var input RunAgentInput
+	require.NoError(t, json.Unmarshal(payload, &input))
+
+	require.Len(t, input.Messages, 1)
+	assert.Equal(t, Metadata{"latencyMs": float64(12)}, input.Messages[0].Metadata)
+
+	require.Len(t, input.Tools, 1)
+	assert.Equal(t, Metadata{"a2ui": map[string]any{"schema": "v1"}}, input.Tools[0].Metadata)
+
+	require.Len(t, input.Resume, 1)
+	assert.Equal(t, Metadata{"signature": "sig-1"}, input.Resume[0].Metadata)
+}
+
+// TestInterruptUnmarshalMetadata verifies interrupt metadata still decodes as a
+// Metadata map after the named type replaced the inline map.
+func TestInterruptUnmarshalMetadata(t *testing.T) {
+	payload := []byte(`{
+		"id": "int-1",
+		"reason": "tool_call",
+		"metadata": {"toolName": "search"}
+	}`)
+
+	var interrupt Interrupt
+	require.NoError(t, json.Unmarshal(payload, &interrupt))
+	assert.Equal(t, Metadata{"toolName": "search"}, interrupt.Metadata)
+}
+
+// TestMergeMetadata verifies the fold is last-write-wins and non-recursive.
+func TestMergeMetadata(t *testing.T) {
+	existing := Metadata{
+		AGUIMetadataKey: map[string]any{"nodePath": "root"},
+		"attempt":       1,
+	}
+	incoming := Metadata{
+		AGUIMetadataKey: map[string]any{"tokenUsage": 12},
+		"finishReason":  "stop",
+	}
+
+	merged := MergeMetadata(existing, incoming)
+
+	// A key's value is replaced outright, so the reserved key is not blended.
+	assert.Equal(t, map[string]any{"tokenUsage": 12}, merged[AGUIMetadataKey])
+	assert.Equal(t, 1, merged["attempt"])
+	assert.Equal(t, "stop", merged["finishReason"])
+
+	// Neither argument is mutated.
+	assert.Equal(t, map[string]any{"nodePath": "root"}, existing[AGUIMetadataKey])
+	assert.Len(t, existing, 2)
+	assert.Len(t, incoming, 2)
+}
+
+// TestMergeMetadataEmptyInputs verifies the absent and empty cases.
+func TestMergeMetadataEmptyInputs(t *testing.T) {
+	existing := Metadata{"attempt": 1}
+
+	assert.Equal(t, existing, MergeMetadata(existing, nil))
+	assert.Equal(t, existing, MergeMetadata(existing, Metadata{}))
+	assert.Equal(t, Metadata{"attempt": 1}, MergeMetadata(nil, existing))
+	assert.Nil(t, MergeMetadata(nil, nil))
+}

--- a/sdks/community/go/pkg/core/types/types.go
+++ b/sdks/community/go/pkg/core/types/types.go
@@ -45,6 +45,13 @@ type ToolCall struct {
 	Type string `json:"type"`
 	// Function is the function call payload.
 	Function FunctionCall `json:"function"`
+	// Metadata is optional extra information about the tool call.
+	//
+	// A tool call is not a message, so it carries its own metadata rather than
+	// folding into the assistant message that owns it. Several tool calls can
+	// share one parent, and merging them all into it would make the result
+	// depend on their relative order.
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 const (
@@ -188,6 +195,8 @@ type Message struct {
 	Error string `json:"error,omitempty"`
 	// ActivityType is an optional activity discriminator for activity messages.
 	ActivityType string `json:"activityType,omitempty"`
+	// Metadata is optional extra information attached to the message.
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler and supports snake_case compatibility.
@@ -227,6 +236,9 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	if err := unmarshalField(raw, &m.ActivityType, "activityType", "activity_type"); err != nil {
 		return err
 	}
+	if err := unmarshalField(raw, &m.Metadata, "metadata"); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -247,6 +259,8 @@ type Tool struct {
 	Description string `json:"description"`
 	// Parameters contains the JSON Schema for the tool parameters.
 	Parameters any `json:"parameters"`
+	// Metadata is optional arbitrary tool metadata (e.g. an A2UI schema).
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // Interrupt represents a pause point requiring user input before the agent can continue.
@@ -264,7 +278,7 @@ type Interrupt struct {
 	// ExpiresAt is an optional ISO 8601 timestamp after which the interrupt is no longer valid.
 	ExpiresAt string `json:"expiresAt,omitempty"`
 	// Metadata is optional arbitrary metadata associated with the interrupt.
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler and supports snake_case compatibility.
@@ -317,6 +331,10 @@ type ResumeEntry struct {
 	Status ResumeStatus `json:"status"`
 	// Payload is an optional response payload for the interrupt.
 	Payload any `json:"payload,omitempty"`
+	// Metadata is optional envelope data about the response — signatures,
+	// routing keys — as opposed to Payload, which is the answer the agent asked
+	// for and will act on.
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler and supports snake_case compatibility.
@@ -333,6 +351,9 @@ func (e *ResumeEntry) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if err := unmarshalField(raw, &e.Payload, "payload"); err != nil {
+		return err
+	}
+	if err := unmarshalField(raw, &e.Metadata, "metadata"); err != nil {
 		return err
 	}
 

--- a/sdks/community/go/pkg/core/types/types.go
+++ b/sdks/community/go/pkg/core/types/types.go
@@ -197,6 +197,9 @@ type Message struct {
 	ActivityType string `json:"activityType,omitempty"`
 	// Metadata is optional extra information attached to the message.
 	Metadata Metadata `json:"metadata,omitempty"`
+	// SubagentRunID attributes this message to a subagent invocation.
+	// Empty when the message comes from the root agent.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler and supports snake_case compatibility.
@@ -239,6 +242,9 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	if err := unmarshalField(raw, &m.Metadata, "metadata"); err != nil {
 		return err
 	}
+	if err := unmarshalField(raw, &m.SubagentRunID, "subagentRunId", "subagent_run_id"); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -279,6 +285,13 @@ type Interrupt struct {
 	ExpiresAt string `json:"expiresAt,omitempty"`
 	// Metadata is optional arbitrary metadata associated with the interrupt.
 	Metadata Metadata `json:"metadata,omitempty"`
+	// SubagentRunID is the subagent whose work raised this interrupt, when it
+	// was raised inside one. Empty for a root-raised interrupt.
+	//
+	// Attribution lives on each interrupt rather than on RUN_FINISHED because
+	// one run can carry interrupts from several subagents. It lets a client
+	// render the approval request inside that subagent's group.
+	SubagentRunID string `json:"subagentRunId,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler and supports snake_case compatibility.
@@ -307,6 +320,9 @@ func (i *Interrupt) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if err := unmarshalField(raw, &i.Metadata, "metadata"); err != nil {
+		return err
+	}
+	if err := unmarshalField(raw, &i.SubagentRunID, "subagentRunId", "subagent_run_id"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Relates to #2677

Brings the Go community SDK up to the metadata and subagent surface that TypeScript, Python and .NET already ship. Nothing here is new design — it is a port of the existing SDKs, and where they disagree I followed the two that agree and said so in the code.

Two commits, so this can be split if only one half is wanted:

**1. `metadata`** — declared once on `BaseEvent`, so every event type carries it, plus `Message`, `ToolCall`, `Tool` and `ResumeEntry` alongside the `Interrupt.metadata` that was already there. Adds a `Metadata` type, the reserved `ag-ui` key constant, and `MergeMetadata`, which mirrors the TypeScript fold helper (a message is assembled from a sequence of events, and token usage and finish reason are only known at the end).

**2. Subagents** — `SUBAGENT_STARTED` / `SUBAGENT_FINISHED` / `SUBAGENT_ERROR`, registered in `validEventTypes`, `EventFromJSON` and `ValidateSequence`, plus `subagentRunId` on the same 24 events Python attributes, and on `Message` and `Interrupt`. `SubagentFinishedOutcome` mirrors `RunFinishedOutcome` one level down, following the existing flat-struct-with-discriminator shape in `run_events.go`.

### Decisions worth a reviewer's eye

- **The attribution table follows Python, not .NET.** .NET has no chunk events at all, so its list is 22; Python and TypeScript both attribute `TEXT_MESSAGE_CHUNK` and `TOOL_CALL_CHUNK`, and Go has both, so they are included. `MESSAGES_SNAPSHOT`, the `RUN_*` family and the deprecated `THINKING_*` family are excluded, matching all three.
- **`subagentRunId` is a plain `string` with `omitempty`, not a `*string`.** Empty and absent mean the same thing for this field, and one spelling across all 24 events beats matching each struct's local pointer convention.
- **A null `metadata` object decodes as absent rather than erroring.** Go collapses the two into a nil map and `omitempty` drops it again on the way out, so a null never survives a round trip. This matches Python and .NET; TypeScript is stricter and rejects it outright. Enforcing the TypeScript reading in Go would mean a custom unmarshaller on every carrier to reject something no official producer emits. A null *value under a key* is meaningful data and is preserved everywhere.
- **`SubagentFinishedOutcome.MarshalJSON` drops `interruptIds` from a success outcome.** TypeScript parses the outcome as a `.strict()` discriminated union, so `{"type": "success", "interruptIds": [...]}` is rejected. The flat Go struct can express that combination, so the marshaller makes it unrepresentable on the wire. Worth flagging that the pre-existing `RunFinishedOutcome` has the same latent shape and no such guard — happy to fix that here or separately, whichever you prefer.
- **`Tool.metadata` is ahead of Python.** TypeScript and .NET both have it; Python's `Tool` does not. Python's models allow extra keys, so this is forward-compatible rather than a break.
- **The `Event` interface is unchanged**, so existing implementations keep compiling. Metadata is reached through `GetBaseEvent()`.

### Testing

`go test ./...` passes, and `gofmt`/`go vet` are clean on every touched file. (`events.go` and `reasoning_events.go` had pre-existing `gofmt` drift in a const block; I left it alone rather than mixing an unrelated reformat into the diff.)

Beyond the Go unit tests, wire compatibility was checked in both directions against the real peer SDKs rather than by inspection:

- Go-produced payloads for every new and changed shape parse against the TypeScript zod schemas in `sdks/typescript/packages/core/src` (including through the `EventSchemas` discriminated union) and against the Python pydantic models in `ag_ui.core`.
- Python-produced payloads decode back into the Go types with metadata, the reserved key, null-under-key values, subagent attribution and the outcome discriminator all intact.
- The strict-union guard is covered by a negative case: TypeScript does reject a success outcome carrying `interruptIds`, and Go never emits one.
