### PR TITLE
fix(langgraph-py): don't crash on malformed tool_call.arguments JSON

### DIFF
--- a/integrations/langgraph/python/ag_ui_langgraph/utils.py
+++ b/integrations/langgraph/python/ag_ui_langgraph/utils.py
@@ -1737,10 +1737,37 @@ def agui_messages_to_langchain(messages: List[AGUIMessage]) -> List[BaseMessage]
             tool_calls = []
             if hasattr(message, "tool_calls") and message.tool_calls:
                 for tc in message.tool_calls:
+                    args = {}
+                    if hasattr(tc, "function") and tc.function.arguments:
+                        try:
+                            args = json.loads(tc.function.arguments)
+                        except (json.JSONDecodeError, TypeError):
+                            # `arguments` is the CLIENT's own locally-accumulated
+                            # string, built up from streamed TOOL_CALL_ARGS
+                            # deltas it received over a prior run — it can
+                            # arrive corrupted here for reasons outside this
+                            # function's control (e.g. a parallel-tool-call
+                            # stream whose deltas got merged under the wrong
+                            # tool_call_id, or a run stopped mid-stream leaving
+                            # a truncated JSON string). Since `messages` is the
+                            # client's full history replayed on every future
+                            # run, raising here used to crash not just the run
+                            # that produced the bad arguments but EVERY
+                            # subsequent run in the same conversation — the
+                            # thread became permanently unusable. Falling back
+                            # to `{}` matches how this same branch already
+                            # treats an empty `arguments` string (see the `and
+                            # tc.function.arguments` guard above); this just
+                            # extends that existing fallback to a
+                            # non-empty-but-invalid one too.
+                            logger.warning(
+                                "Dropping unparseable tool_call arguments for %s (id=%s)",
+                                tc.function.name, tc.id,
+                            )
                     tool_calls.append({
                         "id": tc.id,
                         "name": tc.function.name,
-                        "args": json.loads(tc.function.arguments) if hasattr(tc, "function") and tc.function.arguments else {},
+                        "args": args,
                         "type": "tool_call",
                     })
             # Fold any buffered reasoning blocks onto this assistant message.

--- a/integrations/langgraph/python/tests/test_message_conversion.py
+++ b/integrations/langgraph/python/tests/test_message_conversion.py
@@ -68,6 +68,40 @@ class TestAguiMessagesToLangchain(unittest.TestCase):
         assert ai.tool_calls[0]["name"] == "search"
         assert ai.tool_calls[0]["args"] == {"query": "weather"}
 
+    def test_assistant_message_with_corrupted_tool_call_arguments(self):
+        """A tool call's `arguments` string is the client's own locally-
+        accumulated buffer of streamed TOOL_CALL_ARGS deltas from a prior
+        run — it can arrive here corrupted for reasons outside this
+        function's control (e.g. a parallel-tool-call stream whose deltas
+        got merged under the wrong tool_call_id, or a run stopped mid-
+        stream leaving a truncated JSON string). Since `messages` is the
+        client's full history replayed on every future run, this must not
+        raise: raising here crashes not just the run that produced the bad
+        arguments but every subsequent run in the same conversation."""
+        msg = AGUIAssistantMessage(
+            id="a3",
+            role="assistant",
+            content="",
+            tool_calls=[
+                AGUIToolCall(
+                    id="tc2",
+                    type="function",
+                    function=AGUIFunctionCall(
+                        name="write_file",
+                        arguments='{"path": "a.txt" "content": "x"}',
+                    ),
+                )
+            ],
+        )
+        result = agui_messages_to_langchain([msg])
+        assert len(result) == 1
+        ai = result[0]
+        assert isinstance(ai, AIMessage)
+        assert len(ai.tool_calls) == 1
+        assert ai.tool_calls[0]["id"] == "tc2"
+        assert ai.tool_calls[0]["name"] == "write_file"
+        assert ai.tool_calls[0]["args"] == {}
+
     def test_system_message(self):
         msg = AGUISystemMessage(id="s1", role="system", content="You are helpful")
         result = agui_messages_to_langchain([msg])


### PR DESCRIPTION
Fixes #2680

## Summary

`agui_messages_to_langchain` does a bare `json.loads(tc.function.arguments)` with no error handling. If that string is non-empty but invalid JSON, this raises uncaught — and since `messages` is the client's full conversation history replayed on **every** future run, a single corrupted tool call permanently wedges the whole thread: every subsequent run crashes identically until the conversation is abandoned.

We hit this in production via #1016 (parallel tool calls can get their `TOOL_CALL_ARGS` deltas mismatched to the wrong `tool_call_id`), which left a client with a corrupted `arguments` string for a `write_file` call. That's a much larger streaming fix and out of scope here — this PR is just about not crashing on it, regardless of how the string got corrupted.

## What changed

- Wraps the `json.loads` call in a `try`/`except (json.JSONDecodeError, TypeError)`, falling back to `{}` — the same fallback this line already applies to an *empty* `arguments` string, just extended to a non-empty-but-invalid one.
- Logs a warning (matching this file's existing `logger.warning` conventions) so the underlying corruption stays visible instead of silently swallowed.
- Added a regression test in `tests/test_message_conversion.py` reproducing the exact real-world corrupted-arguments shape we saw in production.

## Test plan

- [x] New test: `test_assistant_message_with_corrupted_tool_call_arguments`
- [x] `uv run pytest tests/` in `integrations/langgraph/python` — 792 passed
- [x] `uv run --locked python -m unittest discover tests -v` (the exact CI command for the `langgraph-python` job) — 780 passed