### PR TITLE
fix(go-sdk): stop RunFinished emitting an outcome the peer SDKs reject

### DIFF
--- a/sdks/community/go/pkg/core/events/run_events.go
+++ b/sdks/community/go/pkg/core/events/run_events.go
@@ -111,6 +111,24 @@ type RunFinishedOutcome struct {
 	Interrupts []types.Interrupt `json:"interrupts,omitempty"`
 }
 
+// MarshalJSON implements json.Marshaler.
+//
+// Interrupts belongs only to the interrupt variant. TypeScript parses the
+// outcome as a strict discriminated union and Python models each variant as its
+// own type, so a success outcome carrying the key is rejected by both; dropping
+// it here means a caller that sets both cannot put an unparseable event on the
+// wire.
+func (o RunFinishedOutcome) MarshalJSON() ([]byte, error) {
+	// Alias the type so marshalling does not recurse into this method.
+	type outcome RunFinishedOutcome
+
+	if o.Type != RunFinishedOutcomeTypeInterrupt {
+		o.Interrupts = nil
+	}
+
+	return json.Marshal(outcome(o))
+}
+
 // RunFinishedEvent indicates that an agent run has finished successfully
 type RunFinishedEvent struct {
 	*BaseEvent
@@ -208,6 +226,14 @@ func (e *RunFinishedEvent) Validate() error {
 
 	if e.RunIDValue == "" {
 		return fmt.Errorf("RunFinishedEvent validation failed: runId field is required")
+	}
+
+	// The peer SDKs require at least one interrupt on this variant: TypeScript
+	// with `.min(1)`, Python with a non-empty validator. Go's `omitempty` would
+	// otherwise drop an empty list and emit a bare {"type": "interrupt"}, which
+	// both reject as missing a required field.
+	if e.Outcome != nil && e.Outcome.Type == RunFinishedOutcomeTypeInterrupt && len(e.Outcome.Interrupts) == 0 {
+		return fmt.Errorf("RunFinishedEvent validation failed: outcome 'interrupt' requires at least one interrupt")
 	}
 
 	return nil

--- a/sdks/community/go/pkg/core/events/run_outcome_test.go
+++ b/sdks/community/go/pkg/core/events/run_outcome_test.go
@@ -1,0 +1,84 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
+)
+
+// TestRunFinishedSuccessOutcomeDropsInterrupts verifies a success outcome never
+// carries interrupts, which the peer SDKs reject as an unknown key.
+func TestRunFinishedSuccessOutcomeDropsInterrupts(t *testing.T) {
+	event := NewRunFinishedEvent("thread-1", "run-1")
+	event.Outcome = &RunFinishedOutcome{
+		Type:       RunFinishedOutcomeTypeSuccess,
+		Interrupts: []types.Interrupt{{ID: "int-1", Reason: "tool_call"}},
+	}
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	var wire struct {
+		Outcome map[string]any `json:"outcome"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	assert.Equal(t, "success", wire.Outcome["type"])
+	assert.NotContains(t, wire.Outcome, "interrupts")
+}
+
+// TestRunFinishedInterruptOutcomeKeepsInterrupts verifies the guard leaves the
+// variant that owns the field alone.
+func TestRunFinishedInterruptOutcomeKeepsInterrupts(t *testing.T) {
+	interrupts := []types.Interrupt{{ID: "int-1", Reason: "tool_call"}}
+	event := NewRunFinishedEventWithOptions("thread-1", "run-1", WithInterruptOutcome(interrupts))
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+
+	finished, ok := decoded.(*RunFinishedEvent)
+	require.True(t, ok)
+	require.NotNil(t, finished.Outcome)
+	assert.Equal(t, RunFinishedOutcomeTypeInterrupt, finished.Outcome.Type)
+	require.Len(t, finished.Outcome.Interrupts, 1)
+	assert.Equal(t, "int-1", finished.Outcome.Interrupts[0].ID)
+}
+
+// TestRunFinishedInterruptOutcomeRequiresInterrupts verifies an interrupt outcome
+// with nothing in it is rejected, rather than emitting a bare {"type":"interrupt"}
+// that the peer SDKs read as missing a required field.
+func TestRunFinishedInterruptOutcomeRequiresInterrupts(t *testing.T) {
+	empty := NewRunFinishedEventWithOptions("thread-1", "run-1", WithInterruptOutcome([]types.Interrupt{}))
+	err := empty.Validate()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "outcome 'interrupt' requires at least one interrupt")
+	}
+
+	nilList := NewRunFinishedEventWithOptions("thread-1", "run-1", WithInterruptOutcome(nil))
+	assert.Error(t, nilList.Validate())
+}
+
+// TestRunFinishedOutcomeUnaffectedCases verifies the guards leave every valid
+// shape alone, including an omitted outcome.
+func TestRunFinishedOutcomeUnaffectedCases(t *testing.T) {
+	success := NewRunFinishedEventWithOptions("thread-1", "run-1", WithSuccessOutcome())
+	require.NoError(t, success.Validate())
+
+	encoded, err := success.ToJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"outcome":{"type":"success"}`)
+
+	omitted := NewRunFinishedEvent("thread-1", "run-1")
+	require.NoError(t, omitted.Validate())
+
+	encoded, err = omitted.ToJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "outcome")
+}


### PR DESCRIPTION
Fixes #2682

Follow-up to #2678, which added the same guard to `SubagentFinishedOutcome` and flagged that its older twin lacked one.

`RunFinishedOutcome` is a single flat struct standing in for what TypeScript and Python model as two separate variants, so it can hold combinations neither variant allows. Two of those serialize to JSON the peer SDKs reject, and both passed Go's own `Validate()` — the failure only surfaced at the receiving client.

### The two cases need opposite fixes

**A success outcome carrying interrupts** emits `{"type": "success", "interrupts": [...]}`. TypeScript parses the outcome as a `.strict()` discriminated union and rejects the extra key; Python's `RunFinishedSuccessOutcome` has no such field. `interrupts` simply does not belong on that variant, so `MarshalJSON` drops it — the same guard `SubagentFinishedOutcome` already carries.

**An interrupt outcome carrying nothing** was the opposite problem: `omitempty` dropped an empty list and the event went out as a bare `{"type": "interrupt"}`, which TypeScript rejects as `Required` (the field is `.min(1)`) and Python rejects via its non-empty validator. Dropping a key cannot fix this one — the required data is genuinely absent — so `Validate()` rejects it instead, mirroring both peers. An interrupt outcome with no interrupt is a producer bug worth reporting, not something the marshaller can repair.

That asymmetry is why #2678's guard doesn't transfer unchanged. It's also why the subagent twin only needed one direction: `SubagentFinishedSuspendedOutcome.interruptIds` is declared optional with no minimum, because an ancestor subagent suspended by a descendant legitimately owns no interrupt. `RunFinishedInterruptOutcome.interrupts` is required and non-empty.

### Testing

`go test ./...` passes and `gofmt`/`go vet` are clean on both touched files. Four unit tests cover the guard, the untouched valid variants, and the rejected empty case.

Wire behaviour was checked against the real peer parsers rather than by inspection — the TypeScript zod schemas in `sdks/typescript/packages/core/src` and the Python pydantic models in `ag_ui.core`, run over the exact bytes Go emits. Both agree in all four cases:

| shape | before | after |
|---|---|---|
| `success` | accepted | accepted |
| `interrupt` with one interrupt | accepted | accepted |
| `success` + `interrupts` | **rejected** | accepted |
| `interrupt` + empty list | **rejected** | never reaches the wire (`Validate` fails) |

No public API changes: both guards sit behind existing methods, and every valid shape serializes exactly as before.
