### PR TITLE
feat(go-sdk): add token usage to RUN_FINISHED and RUN_ERROR

### DIFF
--- a/sdks/community/go/pkg/core/events/run_events.go
+++ b/sdks/community/go/pkg/core/events/run_events.go
@@ -136,6 +136,10 @@ type RunFinishedEvent struct {
 	RunIDValue    string              `json:"runId"`
 	Result        interface{}         `json:"result,omitempty"`
 	Outcome       *RunFinishedOutcome `json:"outcome,omitempty"`
+	// Usage is optional per-(provider, model) token usage for the completed run.
+	// A list so runs that invoke multiple models keep them separate for
+	// downstream display; consumers that only need totals sum across entries.
+	Usage []TokenUsage `json:"usage,omitempty"`
 }
 
 // NewRunFinishedEvent creates a new run finished event
@@ -197,6 +201,13 @@ func WithOutcome(outcome RunFinishedOutcome) RunFinishedOption {
 	}
 }
 
+// WithUsage sets the token usage for the run finished event
+func WithUsage(usage []TokenUsage) RunFinishedOption {
+	return func(e *RunFinishedEvent) {
+		e.Usage = usage
+	}
+}
+
 // WithSuccessOutcome sets the outcome to success for the run finished event
 func WithSuccessOutcome() RunFinishedOption {
 	return func(e *RunFinishedEvent) {
@@ -236,6 +247,10 @@ func (e *RunFinishedEvent) Validate() error {
 		return fmt.Errorf("RunFinishedEvent validation failed: outcome 'interrupt' requires at least one interrupt")
 	}
 
+	if err := validateUsage("RunFinished", e.Usage); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -260,6 +275,9 @@ type RunErrorEvent struct {
 	Code       *string `json:"code,omitempty"`
 	Message    string  `json:"message"`
 	RunIDValue string  `json:"runId,omitempty"`
+	// Usage is optional partial token usage for a run that failed after one or
+	// more model calls completed. Same numeric-only shape as RUN_FINISHED.
+	Usage []TokenUsage `json:"usage,omitempty"`
 }
 
 // NewRunErrorEvent creates a new run error event
@@ -283,6 +301,13 @@ type RunErrorOption func(*RunErrorEvent)
 func WithErrorCode(code string) RunErrorOption {
 	return func(e *RunErrorEvent) {
 		e.Code = &code
+	}
+}
+
+// WithErrorUsage sets the partial token usage for the run error event
+func WithErrorUsage(usage []TokenUsage) RunErrorOption {
+	return func(e *RunErrorEvent) {
+		e.Usage = usage
 	}
 }
 
@@ -310,6 +335,10 @@ func (e *RunErrorEvent) Validate() error {
 
 	if e.Message == "" {
 		return fmt.Errorf("RunErrorEvent validation failed: message field is required")
+	}
+
+	if err := validateUsage("RunError", e.Usage); err != nil {
+		return err
 	}
 
 	return nil

--- a/sdks/community/go/pkg/core/events/token_usage.go
+++ b/sdks/community/go/pkg/core/events/token_usage.go
@@ -1,0 +1,73 @@
+package events
+
+import "fmt"
+
+// TokenUsage is a numeric-only, per-(provider, model) token usage summary.
+//
+// Deliberately carries no content-bearing or identifying fields — no prompts,
+// completions, messages, or thread/run/user IDs — only provider and model
+// labels and numeric counts. Usage feeds anonymous telemetry, so nothing that
+// could carry user content may be added here.
+//
+// Counts are pointers because zero is meaningful data: a call that produced no
+// output tokens is not the same as a call that did not report the figure.
+// int64 matches the protobuf `int64` and the .NET `long?` bindings.
+type TokenUsage struct {
+	// Provider is the model provider label (e.g. "openai", "google").
+	Provider string `json:"provider,omitempty"`
+	// Model is the model label (e.g. "gemini-3.5-flash").
+	Model string `json:"model,omitempty"`
+	// InputTokens is the number of tokens in the prompt.
+	InputTokens *int64 `json:"inputTokens,omitempty"`
+	// OutputTokens is the number of tokens in the completion.
+	OutputTokens *int64 `json:"outputTokens,omitempty"`
+	// TotalTokens is the total across input and output.
+	TotalTokens *int64 `json:"totalTokens,omitempty"`
+	// ReasoningTokens is the number of tokens spent on reasoning.
+	ReasoningTokens *int64 `json:"reasoningTokens,omitempty"`
+	// CachedInputTokens is the number of prompt tokens served from cache.
+	CachedInputTokens *int64 `json:"cachedInputTokens,omitempty"`
+}
+
+// Validate validates a token usage entry.
+//
+// The peer SDKs constrain every count to a non-negative integer — TypeScript
+// with `z.number().int().nonnegative()`, .NET with an unsigned reading of
+// `long?` — and the protobuf transport writes them through an int64 writer.
+// Rejecting a negative here turns a bad producer value into an error at the
+// source rather than a rejected event, or a mid-stream crash, at the receiver.
+func (u TokenUsage) Validate() error {
+	for _, count := range []struct {
+		name  string
+		value *int64
+	}{
+		{"inputTokens", u.InputTokens},
+		{"outputTokens", u.OutputTokens},
+		{"totalTokens", u.TotalTokens},
+		{"reasoningTokens", u.ReasoningTokens},
+		{"cachedInputTokens", u.CachedInputTokens},
+	} {
+		if count.value != nil && *count.value < 0 {
+			return fmt.Errorf("TokenUsage validation failed: %s must not be negative", count.name)
+		}
+	}
+
+	return nil
+}
+
+// validateUsage validates every entry in a usage list, naming the event that
+// carries it so the message matches the rest of the package.
+func validateUsage(eventName string, usage []TokenUsage) error {
+	for i, entry := range usage {
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("%sEvent validation failed: usage[%d]: %w", eventName, i, err)
+		}
+	}
+
+	return nil
+}
+
+// TokenCount returns a pointer to the given count, for populating a TokenUsage.
+func TokenCount(count int64) *int64 {
+	return &count
+}

--- a/sdks/community/go/pkg/core/events/token_usage_test.go
+++ b/sdks/community/go/pkg/core/events/token_usage_test.go
@@ -1,0 +1,110 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunFinishedUsageRoundTrip verifies usage survives a decode with the wire
+// names the peer SDKs use.
+func TestRunFinishedUsageRoundTrip(t *testing.T) {
+	usage := []TokenUsage{
+		{
+			Provider:          "google",
+			Model:             "gemini-3.5-flash",
+			InputTokens:       TokenCount(12),
+			OutputTokens:      TokenCount(4),
+			TotalTokens:       TokenCount(16),
+			CachedInputTokens: TokenCount(0),
+		},
+		{Provider: "openai", Model: "gpt-5", InputTokens: TokenCount(7)},
+	}
+
+	event := NewRunFinishedEventWithOptions("thread-1", "run-1", WithUsage(usage))
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	var wire struct {
+		Usage []map[string]any `json:"usage"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	require.Len(t, wire.Usage, 2)
+	assert.Equal(t, "google", wire.Usage[0]["provider"])
+	assert.Equal(t, float64(12), wire.Usage[0]["inputTokens"])
+	assert.Equal(t, float64(4), wire.Usage[0]["outputTokens"])
+
+	// Zero is meaningful data, so it is written rather than dropped.
+	assert.Equal(t, float64(0), wire.Usage[0]["cachedInputTokens"])
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+	finished, ok := decoded.(*RunFinishedEvent)
+	require.True(t, ok)
+	assert.Equal(t, usage, finished.Usage)
+}
+
+// TestUsageOmittedWhenAbsent verifies a run with no usage writes no key.
+func TestUsageOmittedWhenAbsent(t *testing.T) {
+	encoded, err := NewRunFinishedEvent("thread-1", "run-1").ToJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "usage")
+
+	encoded, err = NewRunErrorEvent("boom").ToJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "usage")
+}
+
+// TestUnreportedCountOmitted verifies an unreported count is absent rather than
+// written as zero, which would claim the model produced none.
+func TestUnreportedCountOmitted(t *testing.T) {
+	event := NewRunFinishedEventWithOptions("thread-1", "run-1",
+		WithUsage([]TokenUsage{{InputTokens: TokenCount(12)}}))
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	var wire struct {
+		Usage []map[string]any `json:"usage"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &wire))
+	require.Len(t, wire.Usage, 1)
+	assert.Contains(t, wire.Usage[0], "inputTokens")
+	assert.NotContains(t, wire.Usage[0], "outputTokens")
+}
+
+// TestRunErrorUsageRoundTrip verifies a failed run can report partial usage.
+func TestRunErrorUsageRoundTrip(t *testing.T) {
+	event := NewRunErrorEvent("boom", WithErrorUsage([]TokenUsage{{Provider: "google", InputTokens: TokenCount(12)}}))
+	require.NoError(t, event.Validate())
+
+	encoded, err := event.ToJSON()
+	require.NoError(t, err)
+
+	decoded, err := EventFromJSON(encoded)
+	require.NoError(t, err)
+	errored, ok := decoded.(*RunErrorEvent)
+	require.True(t, ok)
+	require.Len(t, errored.Usage, 1)
+	require.NotNil(t, errored.Usage[0].InputTokens)
+	assert.Equal(t, int64(12), *errored.Usage[0].InputTokens)
+}
+
+// TestUsageRejectsNegativeCounts verifies a negative count is caught at the
+// source, since the peer SDKs constrain every count to non-negative.
+func TestUsageRejectsNegativeCounts(t *testing.T) {
+	finished := NewRunFinishedEventWithOptions("thread-1", "run-1",
+		WithUsage([]TokenUsage{{InputTokens: TokenCount(1)}, {OutputTokens: TokenCount(-1)}}))
+	err := finished.Validate()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "usage[1]")
+		assert.Contains(t, err.Error(), "outputTokens must not be negative")
+	}
+
+	errored := NewRunErrorEvent("boom", WithErrorUsage([]TokenUsage{{TotalTokens: TokenCount(-5)}}))
+	assert.Error(t, errored.Validate())
+}


### PR DESCRIPTION
Fixes #2684

Ports the `TokenUsage` type and the `usage` field that TypeScript, Python and .NET already ship. The Go SDK had zero occurrences of either, so a Go agent could not report what a run cost and usage a peer SDK sent was dropped on decode.

Third in the same series, after #2678 (metadata and subagent events) and #2683 (RunFinished outcome guards). Rebased onto current main, so it applies cleanly on top of both.

### What lands

- **`TokenUsage`** — `provider`, `model`, `inputTokens`, `outputTokens`, `totalTokens`, `reasoningTokens`, `cachedInputTokens`. Numeric counts and labels only, with no content-bearing or identifying fields, matching the peer SDKs' stated reason: usage feeds anonymous telemetry.
- **`usage []TokenUsage`** on `RunFinishedEvent` and `RunErrorEvent`, with `WithUsage` and `WithErrorUsage` options. A list, so a run invoking several models keeps one entry per (provider, model); `RUN_ERROR` carries the partial usage of a run that failed after one or more model calls completed.
- **`Validate()` rejects a negative count**, naming the offending entry and field.

### Decisions worth a reviewer's eye

- **Counts are `*int64`, not plain integers.** Zero is meaningful data: a call that produced no output tokens is not the same as a call that did not report the figure, and `omitempty` on a plain int erases that distinction. `int64` matches the protobuf `int64` and .NET `long?` bindings. There is a `TokenCount(int64) *int64` helper so populating one does not need a temporary variable at every call site.
- **Negative counts are rejected in `Validate()` rather than clamped or ignored.** TypeScript declares every count `z.number().int().nonnegative()`, and the protobuf transport writes them through an int64 writer that throws on a bad value — so catching it at the source beats a rejected event, or a mid-stream crash, at the receiver. This follows the same reasoning as #2683's interrupt-outcome check.
- **`validateUsage` is shared between the two events** rather than duplicated, and names the event in the error so messages match the rest of the package (`RunFinishedEvent validation failed: usage[1]: ...`).
- **No aggregation or vendor mappers.** Python has a whole `token_usage.py` of those; this PR ports only the protocol surface. Mapping helpers can follow if there is appetite for them.

### Testing

`go test ./...` passes, and `gofmt`/`go vet` are clean on every touched file. (`events.go` and `reasoning_events.go` carry pre-existing `gofmt` drift in a const block, untouched here rather than mixing an unrelated reformat into the diff.)

Beyond the unit tests, wire compatibility was verified against the real peer parsers rather than by inspection — the TypeScript zod schemas in `sdks/typescript/packages/core/src` and the Python pydantic models in `ag_ui.core`, run over the exact bytes Go emits:

| shape | TypeScript | Python |
|---|---|---|
| `RUN_FINISHED` with two full usage entries | accepted, nothing stripped | accepted, preserved |
| `RUN_ERROR` with partial usage | accepted, nothing stripped | accepted, preserved |
| `RUN_FINISHED` with no usage | accepted, no `usage` key | accepted, no `usage` key |

"Nothing stripped" is the check that matters here: `TokenUsageSchema` drops unrecognized keys silently, so a near-miss on field names would lose the counts with no error. Comparing what zod returns against what Go sent confirms every field survives.

No breaking changes: `usage` is optional and omitted when absent, so every existing event serializes exactly as before.
