### PR TITLE
Peer the client in mcp-middleware instead of depending on it

### DIFF
--- a/middlewares/mcp-middleware/package.json
+++ b/middlewares/mcp-middleware/package.json
@@ -27,13 +27,14 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/client": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "peerDependencies": {
+    "@ag-ui/client": ">=0.0.40",
     "rxjs": "7.8.1"
   },
   "devDependencies": {
+    "@ag-ui/client": "workspace:*",
     "@types/node": "^20.11.19",
     "@vitest/coverage-istanbul": "^4.0.18",
     "publint": "^0.3.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1406,9 +1406,6 @@ importers:
 
   middlewares/mcp-middleware:
     dependencies:
-      '@ag-ui/client':
-        specifier: workspace:*
-        version: link:../../sdks/typescript/packages/client
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
@@ -1416,6 +1413,9 @@ importers:
         specifier: 7.8.1
         version: 7.8.1
     devDependencies:
+      '@ag-ui/client':
+        specifier: workspace:*
+        version: link:../../sdks/typescript/packages/client
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
         version: 0.17.4


### PR DESCRIPTION
Fixes #2651

`@ag-ui/mcp-middleware` declared `@ag-ui/client` under `dependencies`, so a consumer that already had the client installed got a second copy nested under the middleware — the 7.3 MB duplicate tree @BenTaylorDev measured, and a second `AbstractAgent`/`EventType` identity alongside the host's.

The sibling package `@ag-ui/mcp-apps-middleware` already has this right, so this is a mirror of what it does rather than a new convention: `@ag-ui/client` moves to `peerDependencies` at `>=0.0.40`, with a `workspace:*` devDependency so the package still builds and tests inside the monorepo.

Worth knowing: the middleware imports two runtime values from the client, `Middleware` (it extends it at `src/index.ts:210`) and `EventType`, not just types. That makes a peer dependency more correct rather than less — those values have to come from the host's copy or the identity checks are against a different class.

## Lockfile

`pnpm-lock.yaml` carries a three-line move: the existing `@ag-ui/client` importer entry for this package goes from `dependencies` to `devDependencies`, matching how the sibling is already recorded. Nothing was re-resolved. A plain `pnpm install --no-frozen-lockfile` wanted 221 insertions of unrelated churn (`@langchain/core` re-resolving under `@copilotkit/runtime` and cascading through peer hashes), so that was reverted in favour of the minimal edit. `pnpm install --frozen-lockfile` passes.

## Overlaps with #2518

@nickcaballero's #2518 edits the same manifest for different lines — `rxjs` in `peerDependencies` (`7.8.1` → `>=7.8.0 <8`) and adding `rxjs` to `devDependencies`. This inserts `@ag-ui/client` into both of those blocks, so whichever lands second needs to keep both lines; the combined result is `{"@ag-ui/client": ">=0.0.40", "rxjs": ">=7.8.0 <8"}`. Both also touch this package's `pnpm-lock.yaml` importer block, so the second one through will need the lockfile regenerated. Happy to rebase behind it.

## Tests

- `pnpm test` — 27/27 passed
- `pnpm build` (tsdown) — CJS + ESM + both `.d.ts` flavours
- `pnpm typecheck` — clean
- `pnpm test:exports` (`publint --strict && attw --pack`) — no problems, all four resolution modes green
- `pnpm install --frozen-lockfile` — clean
- `pnpm pack` and read the tarball manifest: `dependencies` is `@modelcontextprotocol/sdk` only, `peerDependencies` has the client — so there is nothing left for a consumer to nest

node v20.19.0, pnpm 10.33.4, off `main` at 87e9d964d.

- [x] Fix verified against the reported behaviour
- [x] Package test suite passes
- [x] Build succeeds
- [x] Export checks pass
- [x] Lockfile installs frozen

## Not in scope

`mcp-middleware` is also missing `publishConfig.access: public`, which the sibling has. That is not part of this bug and the convention is mixed across `middlewares/` — three packages have it, three don't, and `@ag-ui/a2a-middleware` publishes fine without it. Better as a small consistency sweep than a rider here.

Consumers will need a republish to benefit: the only published version is `0.0.1`, and its `@ag-ui/client: 0.0.54` pin is baked into that tarball. I have not bumped `version`, since that looks like release tooling's job here rather than a fix PR's — say the word if you'd rather it carried the bump.