### PR TITLE
fix(mastra): offer a resumed run the tools of the run it continues

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/resume-run-options.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/resume-run-options.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { EventType } from "@ag-ui/client";
+import { Agent } from "@mastra/core/agent";
+import { MockMemory } from "@mastra/core/memory";
+import { MastraLanguageModelV2Mock } from "@mastra/core/test-utils/llm-mock";
+import { GENERATE_A2UI_TOOL_NAME } from "@ag-ui/a2ui-toolkit";
+import { MastraAgent } from "../mastra";
+import { makeInput, collectEvents } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// #2667: the resumed run has to be offered the same tools and run options as
+// the initial run. `run()` used to build `resumeOptions` from `toolCallId` /
+// `runId` / `memory` / `requestContext` alone, so `clientTools` (the frontend
+// tools from `RunAgentInput.tools`), the auto-injected A2UI `toolsets` and
+// `untilIdle` were all dropped on resume. An agent that answers exclusively
+// through frontend tools then ended the resumed run with nothing on the wire.
+//
+// The model stand-in below is what makes that observable: it can only call a
+// tool it was actually OFFERED, exactly like a real model. A resume that drops
+// `clientTools` therefore yields no tool call and no text.
+// ---------------------------------------------------------------------------
+
+const FRONTEND_TOOL = {
+  name: "show_expense_card",
+  description: "Renders the expense decision card in the UI",
+  parameters: {
+    type: "object",
+    properties: { amount: { type: "number" } },
+    required: ["amount"],
+  },
+};
+
+/** Chunk names the stand-in "model" emits for the resumed turn. */
+function resumedTurnChunks(opts: any): any[] {
+  const offered = Object.keys(opts?.clientTools ?? {});
+  const chunks: any[] = [];
+  if (offered.includes(FRONTEND_TOOL.name)) {
+    chunks.push({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tc-2",
+        toolName: FRONTEND_TOOL.name,
+        args: { amount: 250 },
+      },
+    });
+  }
+  chunks.push({ type: "finish", payload: {} });
+  return chunks;
+}
+
+function resumeInput(
+  forwardedExtras: Record<string, unknown> = {},
+  tools: any[] = [FRONTEND_TOOL],
+) {
+  return makeInput({
+    tools: tools as any,
+    messages: [{ id: "1", role: "user", content: "Approve it" }] as any,
+    forwardedProps: {
+      command: {
+        resume: { approved: true },
+        interruptEvent: { toolCallId: "tc-1", runId: "mastra-run-1" },
+      },
+      ...forwardedExtras,
+    },
+  });
+}
+
+/**
+ * A real `@mastra/core` Agent (real `listTools`, real `model`, real option
+ * surface) with only `resumeStream` stubbed, since driving a genuine suspended
+ * snapshot needs a configured storage backend. The stub replays whatever the
+ * stand-in model would produce for the options it was handed.
+ */
+function realLocalAgent() {
+  return new Agent({
+    id: "resume-agent",
+    name: "resume-agent",
+    instructions: "Answer only by calling frontend tools.",
+    model: new MastraLanguageModelV2Mock({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        request: { body: {} },
+        response: undefined,
+      }),
+    }) as any,
+    memory: new MockMemory() as any,
+  });
+}
+
+function stubLocalResume(agent: Agent) {
+  const calls: Array<{ resumeData: unknown; opts: any }> = [];
+  vi.spyOn(agent, "resumeStream").mockImplementation((async (
+    resumeData: any,
+    opts: any,
+  ) => {
+    calls.push({ resumeData, opts });
+    const chunks = resumedTurnChunks(opts);
+    return {
+      fullStream: (async function* () {
+        for (const chunk of chunks) yield chunk;
+      })(),
+    };
+  }) as any);
+  return calls;
+}
+
+/** Remote analogue: @mastra/client-js replays the resumed run via callbacks. */
+function remoteAgentWithResume() {
+  const calls: Array<{ resumeData: unknown; opts: any }> = [];
+  const agent = {
+    async stream() {
+      return { processDataStream: async () => {} };
+    },
+    async resumeStream(resumeData: any, opts: any) {
+      calls.push({ resumeData, opts });
+      const chunks = resumedTurnChunks(opts);
+      return {
+        processDataStream: async ({
+          onChunk,
+        }: {
+          onChunk: (chunk: any) => Promise<void>;
+        }) => {
+          for (const chunk of chunks) await onChunk(chunk);
+        },
+      };
+    },
+  };
+  return { agent, calls };
+}
+
+function wrap(agent: unknown, config: Record<string, unknown> = {}) {
+  return new MastraAgent({
+    agentId: "resume-agent",
+    agent: agent as any,
+    resourceId: "resource-1",
+    ...config,
+  } as any);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resume run options (#2667)", () => {
+  describe("local agent", () => {
+    it("still produces output when the agent answers only through frontend tools", async () => {
+      const agent = realLocalAgent();
+      stubLocalResume(agent);
+
+      const events = await collectEvents(wrap(agent), resumeInput());
+
+      const toolCallStarts = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_START,
+      );
+      expect(toolCallStarts).toHaveLength(1);
+      expect((toolCallStarts[0] as any).toolCallName).toBe(FRONTEND_TOOL.name);
+      expect(events[events.length - 1].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("offers the frontend tools to resumeStream as clientTools", async () => {
+      const agent = realLocalAgent();
+      const calls = stubLocalResume(agent);
+
+      await collectEvents(wrap(agent), resumeInput());
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].opts.clientTools).toEqual({
+        [FRONTEND_TOOL.name]: {
+          id: FRONTEND_TOOL.name,
+          description: FRONTEND_TOOL.description,
+          inputSchema: FRONTEND_TOOL.parameters,
+        },
+      });
+      // The resume keys the suspended snapshot — unchanged by this fix.
+      expect(calls[0].opts.toolCallId).toBe("tc-1");
+      expect(calls[0].opts.runId).toBe("mastra-run-1");
+    });
+
+    it("forwards untilIdle on resume when the bridge is configured with it", async () => {
+      const agent = realLocalAgent();
+      const calls = stubLocalResume(agent);
+
+      await collectEvents(
+        wrap(agent, { untilIdle: { maxIdleMs: 1234 } }),
+        resumeInput(),
+      );
+
+      expect(calls[0].opts.untilIdle).toEqual({ maxIdleMs: 1234 });
+    });
+
+    it("omits untilIdle on resume when the bridge is not configured with it", async () => {
+      const agent = realLocalAgent();
+      const calls = stubLocalResume(agent);
+
+      await collectEvents(wrap(agent), resumeInput());
+
+      expect("untilIdle" in calls[0].opts).toBe(false);
+    });
+
+    it("forwards the auto-injected A2UI toolset on resume", async () => {
+      const agent = realLocalAgent();
+      const calls = stubLocalResume(agent);
+
+      await collectEvents(
+        wrap(agent),
+        resumeInput({ injectA2UITool: true }, []),
+      );
+
+      const toolsets = calls[0].opts.toolsets as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      expect(toolsets?.a2ui?.[GENERATE_A2UI_TOOL_NAME]).toBeDefined();
+    });
+
+    it("omits toolsets on resume when A2UI is not injected", async () => {
+      const agent = realLocalAgent();
+      const calls = stubLocalResume(agent);
+
+      await collectEvents(wrap(agent), resumeInput());
+
+      expect("toolsets" in calls[0].opts).toBe(false);
+    });
+  });
+
+  describe("remote agent", () => {
+    it("still produces output when the agent answers only through frontend tools", async () => {
+      const { agent } = remoteAgentWithResume();
+
+      const events = await collectEvents(wrap(agent), resumeInput());
+
+      const toolCallStarts = events.filter(
+        (e) => e.type === EventType.TOOL_CALL_START,
+      );
+      expect(toolCallStarts).toHaveLength(1);
+      expect((toolCallStarts[0] as any).toolCallName).toBe(FRONTEND_TOOL.name);
+      expect(events[events.length - 1].type).toBe(EventType.RUN_FINISHED);
+    });
+
+    it("offers the frontend tools to the remote resumeStream as clientTools", async () => {
+      const { agent, calls } = remoteAgentWithResume();
+
+      await collectEvents(wrap(agent), resumeInput());
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].opts.clientTools).toEqual({
+        [FRONTEND_TOOL.name]: {
+          id: FRONTEND_TOOL.name,
+          description: FRONTEND_TOOL.description,
+          inputSchema: FRONTEND_TOOL.parameters,
+        },
+      });
+    });
+
+    it("does not send untilIdle or an A2UI toolset to a remote resume", async () => {
+      // Mirrors the remote INITIAL stream path: `untilIdle` is local-only and
+      // the A2UI toolset carries in-process `execute`s that cannot cross the
+      // wire, so neither belongs on a remote resume.
+      const { agent, calls } = remoteAgentWithResume();
+
+      await collectEvents(
+        wrap(agent, { untilIdle: true }),
+        resumeInput({ injectA2UITool: true }),
+      );
+
+      expect("untilIdle" in calls[0].opts).toBe(false);
+      expect("toolsets" in calls[0].opts).toBe(false);
+    });
+
+    it("does not attempt A2UI planning against a remote agent", async () => {
+      // @mastra/client-js's Agent resource has no `listTools`, so planning
+      // against it would only ever throw into the best-effort warn — noise on
+      // every remote resume.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { agent } = remoteAgentWithResume();
+
+      await collectEvents(wrap(agent), resumeInput({ injectA2UITool: true }));
+
+      expect(
+        warn.mock.calls.filter((args) =>
+          String(args[0]).includes("A2UI auto-injection skipped"),
+        ),
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -859,6 +859,24 @@ export class MastraAgent extends AbstractAgent {
           // with "No snapshot found for this workflow run". The remote instance
           // loads that snapshot from configured storage, so `memory` must point
           // at the same thread/resource the suspended run used.
+          //
+          // The resumed run has to be offered the same tools as the run it
+          // continues (#2667): the frontend tools from `RunAgentInput.tools`,
+          // and — local only — the auto-injected A2UI toolset. Without them
+          // the model sees no frontend tool after the suspended tool returns,
+          // so an agent that answers exclusively through frontend tools ends
+          // the resumed run with nothing on the wire. Both `clientTools` and
+          // `toolsets` are part of the resume option surface: local
+          // `Agent.resumeStream` takes `AgentExecutionOptionsBase`, and
+          // @mastra/client-js `resumeStream` runs `clientTools` through
+          // `processClientTools` like its `stream` does.
+          const clientTools = this.buildClientTools(input.tools);
+          const a2uiToolsets = await this.planA2UIToolsets(
+            input,
+            clientTools,
+            resumeRequestContext,
+          );
+
           const resumeOptions: Record<string, unknown> = {
             toolCallId: interruptEvent.toolCallId,
             runId: interruptEvent.runId,
@@ -867,8 +885,16 @@ export class MastraAgent extends AbstractAgent {
               resource: this.resourceId ?? input.threadId,
             },
             requestContext: resumeRequestContext,
+            clientTools,
+            ...(a2uiToolsets ? { toolsets: a2uiToolsets } : {}),
           };
           if (this.isLocalMastraAgent(this.agent)) {
+            // LOCAL ONLY, mirroring the initial stream path: `untilIdle` pipes
+            // the background-task lifecycle into this run's stream, which only
+            // the in-process agent can do.
+            if (this.untilIdle) {
+              resumeOptions.untilIdle = this.untilIdle;
+            }
             // LOCAL ONLY (#2288). @mastra/client-js excludes `abortSignal`
             // from its stream params (StreamParamsBase Omits it) and takes the
             // fetch signal from construction-time ClientOptions.abortSignal,
@@ -2899,6 +2925,75 @@ export class MastraAgent extends AbstractAgent {
   }
 
   /**
+   * The frontend tools from `RunAgentInput.tools`, in the `clientTools` shape
+   * Mastra expects. Shared by the initial `agent.stream(...)` and the resumed
+   * `agent.resumeStream(...)` call so a resumed run is offered the same tools
+   * as the run it continues (#2667) — without it, an agent that answers only
+   * through frontend tools ends the resumed run with nothing on the wire.
+   */
+  private buildClientTools(tools: RunAgentInput["tools"]): Record<string, any> {
+    return (tools ?? []).reduce(
+      (acc, tool) => {
+        acc[tool.name as string] = {
+          id: tool.name,
+          description: tool.description,
+          inputSchema: tool.parameters,
+        };
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+  }
+
+  /**
+   * Auto-inject the backend-owned `generate_a2ui` tool (pillar 1: easy devex)
+   * when the runtime/middleware forwarded `injectA2UITool`. The dev wires NO
+   * tool; recovery + subagent ride along. Injected per-run as a server toolset
+   * so its execute runs in-process (where the loop lives); the
+   * middleware-injected `render_a2ui` client tool is dropped from
+   * `clientTools` (mutated in place) so the model calls `generate_a2ui`. Opt
+   * out via `injectA2UITool:false`; customize via the `a2ui` config.
+   * USER-PREVAILS if the agent already wires `generate_a2ui`. Best-effort: a
+   * failure degrades to no A2UI, the turn still runs.
+   *
+   * LOCAL ONLY — the injected tool carries an in-process `execute`, so it
+   * cannot cross the @mastra/client-js wire. Callers gate on
+   * `isLocalMastraAgent`.
+   *
+   * Shared by the initial stream and the resume path, so a resumed run keeps
+   * the A2UI toolset the interrupted run had (#2667).
+   */
+  private async planA2UIToolsets(
+    input: RunAgentInput,
+    clientTools: Record<string, any>,
+    requestContext: RequestContext,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (!this.isLocalMastraAgent(this.agent)) return undefined;
+    try {
+      const existing = await this.agent.listTools({ requestContext });
+      const existingToolNames = [
+        ...Object.keys(existing ?? {}),
+        ...Object.keys(clientTools),
+      ];
+      const plan = planA2UIInjection({
+        model: this.a2ui?.model ?? (this.agent as { model?: unknown }).model,
+        input,
+        existingToolNames,
+        config: this.a2ui,
+      });
+      if (!plan) return undefined;
+      for (const drop of plan.dropToolNames) delete clientTools[drop];
+      return { a2ui: { [plan.toolName]: plan.tool } };
+    } catch (error) {
+      console.warn(
+        "[MastraAgent] A2UI auto-injection skipped (continuing without A2UI):",
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  /**
    * Streams a local or remote Mastra agent, emitting AG-UI events via callbacks.
    * For local agents, iterates fullStream with processFullStream.
    * For remote agents, uses processDataStream with createChunkProcessor.
@@ -2937,17 +3032,7 @@ export class MastraAgent extends AbstractAgent {
     }: MastraAgentStreamOptions,
     abortSignal: AbortSignal,
   ): Promise<void> {
-    const clientTools = tools.reduce(
-      (acc, tool) => {
-        acc[tool.name as string] = {
-          id: tool.name,
-          description: tool.description,
-          inputSchema: tool.parameters,
-        };
-        return acc;
-      },
-      {} as Record<string, any>,
-    );
+    const clientTools = this.buildClientTools(tools);
     // Names of the frontend tools — only these stream their args live (see
     // createChunkProcessor). Server tools (on the Mastra agent) are absent here.
     const clientToolNames = new Set<string>(
@@ -2985,45 +3070,17 @@ export class MastraAgent extends AbstractAgent {
 
     if (this.isLocalMastraAgent(this.agent)) {
       try {
-        // Auto-inject the backend-owned `generate_a2ui` tool (pillar 1: easy
-        // devex) when the runtime/middleware forwarded `injectA2UITool`. The dev
-        // wires NO tool; recovery + subagent ride along. Injected per-run as a
-        // server toolset so its execute runs in-process (where the loop lives);
-        // the middleware-injected `render_a2ui` client tool is dropped so the
-        // model calls `generate_a2ui`. Opt out via `injectA2UITool:false`;
-        // customize via the `a2ui` config. USER-PREVAILS if the agent already
-        // wires `generate_a2ui`. Best-effort: a failure degrades to no A2UI, the
-        // turn still runs.
-        let a2uiToolsets: Record<string, unknown> | undefined;
-        try {
-          const existing = await this.agent.listTools({ requestContext });
-          const existingToolNames = [
-            ...Object.keys(existing ?? {}),
-            ...clientToolNames,
-          ];
-          const plan = planA2UIInjection({
-            model:
-              this.a2ui?.model ?? (this.agent as { model?: unknown }).model,
-            input: {
-              forwardedProps,
-              context: inputContext,
-              messages,
-              threadId,
-              runId,
-            } as RunAgentInput,
-            existingToolNames,
-            config: this.a2ui,
-          });
-          if (plan) {
-            a2uiToolsets = { a2ui: { [plan.toolName]: plan.tool } };
-            for (const drop of plan.dropToolNames) delete clientTools[drop];
-          }
-        } catch (error) {
-          console.warn(
-            "[MastraAgent] A2UI auto-injection skipped (continuing without A2UI):",
-            error,
-          );
-        }
+        const a2uiToolsets = await this.planA2UIToolsets(
+          {
+            forwardedProps,
+            context: inputContext,
+            messages,
+            threadId,
+            runId,
+          } as RunAgentInput,
+          clientTools,
+          requestContext,
+        );
 
         const streamOptions: Record<string, unknown> = {
           memory: {


### PR DESCRIPTION
Fixes #2667

A resumed run now reaches `agent.resumeStream` with the same tools as the run it continues: the frontend tools from `RunAgentInput.tools`, and — local only — the auto-injected A2UI toolset and `untilIdle`.

@manfredsteyer's report is exact about the shape of this. `clientTools` was built only inside `streamMastraAgent` (`mastra.ts:2940`), which the resume branch never enters; the A2UI `toolsets` only in the local initial-stream branch (`mastra.ts:2987-3010`); `untilIdle` only at `mastra.ts:3045-3047`. The resume options at `mastra.ts:862-889` carried `toolCallId`, `runId`, `memory` and `requestContext` and nothing else. So after a suspended tool returned, the model was offered no frontend tool at all, and an agent that answers exclusively through frontend tools ended the resumed run with nothing on the wire.

## The fix

Their suggested direction — one shared option set — is what this does. `buildClientTools(tools)` and `planA2UIToolsets(input, clientTools, requestContext)` come out of the inline blocks in `streamMastraAgent` and now serve both paths. The resume path builds `clientTools` from `input.tools`, spreads `toolsets` when a plan exists, and sets `untilIdle` inside the existing `isLocalMastraAgent` branch.

`toolsets` and `untilIdle` stay local-only, mirroring the initial path rather than introducing a new asymmetry:

- the injected A2UI tool carries an in-process `execute`, so it cannot cross the `@mastra/client-js` wire, and the remote initial path does not send it either
- `untilIdle` pipes the background-task lifecycle into the run's stream, which only the in-process agent can do (documented at `mastra.ts:368-387`)

`clientTools` **is** sent remotely: `@mastra/client-js@1.28.0` declares it on `StreamParamsBase` and runs it through `processClientTools` in `resumeStream` exactly as its `stream` does. Locally, `@mastra/core@1.47.0`'s `AgentExecutionOptionsBase` declares all three, and the deprecation note on `resumeStreamUntilIdle` points at `resumeStream(resumeData, { untilIdle: true, … })`.

No protocol change and no public API change.

## Tests

`integrations/mastra/typescript/src/__tests__/resume-run-options.test.ts`, 10 tests. Fixtures use the real `@mastra/core` `Agent`, `MockMemory` and `MastraLanguageModelV2Mock`, with only `resumeStream` stubbed — a genuine suspended snapshot needs a configured storage backend this package does not dev-depend on.

The assertions do not spot-check the option object. The stand-in model can only call a tool it was offered: `resumedTurnChunks(opts)` emits a `tool-call` for the frontend tool only when `opts.clientTools` contains it, so the empty resumed run from the issue reproduces as real absent output. Coverage includes the negative controls — `untilIdle` and `toolsets` absent when not configured, and neither sent to a remote resume — and a remote resume asserting the A2UI planner is not attempted.

On base: 6 failed / 3 passed, the failures being both "still produces output when the agent answers only through frontend tools" (local and remote), both `clientTools` assertions, `untilIdle` forwarding, and A2UI toolset forwarding.

Mutations run, all detected: dropping `clientTools` from `resumeOptions` (4 tests), dropping the `toolsets` spread (1), dropping the `untilIdle` assignment (1), hoisting `untilIdle` out of the local guard (1), and dropping the local-only guard in `planA2UIToolsets` (1).

`npx nx run @ag-ui/mastra:test`: **348 passed** across 24 files, against **338** across 23 on base `87e9d964d`. `npx tsc --noEmit -p tsconfig.json` exit 0 on both. Node v20.19.0, pnpm 10.33.4, vitest 4.0.18, tsc 5.9.3, `@mastra/core` 1.47.0, `@mastra/client-js` 1.28.0.

- [x] Failing test written and confirmed failing before the fix
- [x] Fix applied, tests pass
- [x] Package suite passes on branch and base, versions stated
- [x] Typecheck clean
- [x] Mutation-tested

`src/mastra.ts` is flagged by prettier, but identically on `origin/main` — the same 3 spots (a blank line, `finishResume`'s params, `provider`/`modelId`), none of them from this change. The file was not reformatted, and no repo-root `pnpm format` was run.

## Adjacent, deliberately left alone

The resume path calls `processFullStream(...)` without `clientToolNames`, where the initial path passes it. A frontend tool call in a resumed run therefore takes the buffered path rather than streaming its args live — `flush()` still emits `TOOL_CALL_START/ARGS/END` at end of stream, which is what these tests assert, so it is a fidelity gap rather than the reported outage. It sits next to #2403 and is better handled there or on its own.

Local resume now makes one in-process `listTools()` call even when A2UI is off, matching the initial path. Real `@mastra/core` agents always have `listTools`; hand-rolled test fakes without it hit the pre-existing best-effort warn.