### PR TITLE
fix(a2ui): use canonical v0.9 basic catalog ID

### DIFF
--- a/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/__init__.py
+++ b/sdks/python/a2ui_toolkit/ag_ui_a2ui_toolkit/__init__.py
@@ -76,7 +76,8 @@ from .recovery import (  # noqa: E402
 A2UI_OPERATIONS_KEY = "a2ui_operations"
 """Container key the A2UI middleware looks for in tool results."""
 
-BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json"
+# Canonical $id declared by the A2UI v0.9 basic catalog specification.
+BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
 """Default catalog id used when the subagent does not specify one."""
 
 A2UI_SCHEMA_CONTEXT_DESCRIPTION = (

--- a/sdks/python/a2ui_toolkit/tests/test_toolkit.py
+++ b/sdks/python/a2ui_toolkit/tests/test_toolkit.py
@@ -43,7 +43,7 @@ class TestConstants(unittest.TestCase):
     def test_basic_catalog_id(self):
         self.assertEqual(
             BASIC_CATALOG_ID,
-            "https://a2ui.org/specification/v0_9/basic_catalog.json",
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
         )
 
 

--- a/sdks/typescript/packages/a2ui-toolkit/src/__tests__/toolkit.test.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/__tests__/toolkit.test.ts
@@ -31,7 +31,7 @@ describe("constants", () => {
   });
 
   it("BASIC_CATALOG_ID points at the v0.9 basic catalog", () => {
-    expect(BASIC_CATALOG_ID).toBe("https://a2ui.org/specification/v0_9/basic_catalog.json");
+    expect(BASIC_CATALOG_ID).toBe("https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json");
   });
 });
 

--- a/sdks/typescript/packages/a2ui-toolkit/src/index.ts
+++ b/sdks/typescript/packages/a2ui-toolkit/src/index.ts
@@ -14,7 +14,8 @@ import type { A2UIValidationCatalog } from "./validate";
 export const A2UI_OPERATIONS_KEY = "a2ui_operations";
 
 /** Default catalog id used when the subagent does not specify one. */
-export const BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json";
+// Canonical $id declared by the A2UI v0.9 basic catalog specification.
+export const BASIC_CATALOG_ID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json";
 
 /** A single A2UI v0.9 server-to-client operation. */
 export type A2UIOperation = Record<string, unknown>;


### PR DESCRIPTION
Fixes #2572.

Both first-party A2UI toolkits used a catalog ID that the reference renderer does not register. Update the Python and TypeScript constants together and pin their existing assertions to the canonical value.

Verified directly against the A2UI v0.9 specification document on 2026-09-09: https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json declares `$id` (and `catalogId`) as `https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json`. This value was checked against the spec itself, not inferred from either SDK copy. Caller overrides are unchanged.

Scope approved by @NathanTarbert in https://github.com/ag-ui-protocol/ag-ui/issues/2572#issuecomment-5592534079; the subsequent comment explicitly reserves the issue despite the assignee-field limitation.

Validation:
- Node 22.23.2: `pnpm nx run-many -t test,typecheck,lint --projects=@ag-ui/a2ui-toolkit --parallel=1 --skip-nx-cache` passed, including build and 100 TypeScript tests.
- From `sdks/python/a2ui_toolkit`: `python -m unittest discover tests` passed, 100 Python tests. This package has no Nx target.
- `git diff --check` passed.

AI assistance: Codex prepared the patch and ran the reported checks.
