### PR TITLE
fix(client): handle response cancellation failures during teardown

### DIFF
--- a/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
+++ b/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
@@ -1,11 +1,71 @@
 import { runHttpRequest, HttpEventType } from "../http-request";
-import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from "vitest";
 
 describe("runHttpRequest", () => {
   let fetchMock: Mock;
 
   beforeEach(() => {
     fetchMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    [new DOMException("Aborted", "AbortError"), false],
+    [new Error("Socket closed"), true],
+  ])("handles cancellation rejection during unsubscribe: %s", async (failure, shouldWarn) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const reader = {
+      read: vi.fn(() => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {})),
+      cancel: vi.fn().mockRejectedValue(failure),
+    };
+    const response = {
+      ok: true, status: 200, headers: new Headers(),
+      body: { getReader: () => reader },
+    } as unknown as Response;
+    const onError = vi.fn();
+    const subscription = runHttpRequest(async () => response).subscribe({ error: onError });
+    try {
+      await vi.waitFor(() => expect(reader.read).toHaveBeenCalledOnce());
+      subscription.unsubscribe();
+      // Let the cancellation rejection and Node's unhandled-rejection checkpoint run.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(reader.cancel).toHaveBeenCalledOnce();
+      expect(onError).not.toHaveBeenCalled();
+      expect(unhandled).not.toHaveBeenCalled();
+      if (shouldWarn) {
+        expect(warn).toHaveBeenCalledExactlyOnceWith("Failed to cancel HTTP response reader:", failure);
+      } else {
+        expect(warn).not.toHaveBeenCalled();
+      }
+    } finally {
+      subscription.unsubscribe();
+      process.off("unhandledRejection", unhandled);
+    }
+  });
+
+  it("preserves the original read error when cancellation also fails", async () => {
+    const readError = new Error("Connection terminated");
+    const cancelError = new Error("Reader already errored");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const reader = {
+      read: vi.fn().mockRejectedValue(readError),
+      cancel: vi.fn().mockRejectedValue(cancelError),
+    };
+    const response = {
+      ok: true, status: 200, headers: new Headers(),
+      body: { getReader: () => reader },
+    } as unknown as Response;
+    const error = await new Promise((resolve) => {
+      runHttpRequest(async () => response).subscribe({ error: resolve });
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(error).toBe(readError);
+    expect(warn).toHaveBeenCalledExactlyOnceWith("Failed to cancel HTTP response reader:", cancelError);
   });
 
   it("should call the provided fetch thunk", async () => {
@@ -20,7 +80,7 @@ describe("runHttpRequest", () => {
       body: {
         getReader: vi.fn().mockReturnValue({
           read: vi.fn().mockResolvedValue({ done: true }),
-          cancel: vi.fn(),
+          cancel: vi.fn().mockResolvedValue(undefined),
         }),
       },
     };
@@ -59,7 +119,7 @@ describe("runHttpRequest", () => {
         .mockResolvedValueOnce({ done: false, value: chunk1 })
         .mockResolvedValueOnce({ done: false, value: chunk2 })
         .mockResolvedValueOnce({ done: true }),
-      cancel: vi.fn(),
+      cancel: vi.fn().mockResolvedValue(undefined),
     };
 
     // Mock response with our custom reader and headers

--- a/sdks/typescript/packages/client/src/run/http-request.ts
+++ b/sdks/typescript/packages/client/src/run/http-request.ts
@@ -83,7 +83,8 @@ export const runHttpRequest = (
               return;
             }
 
-            throw error;
+            // Teardown has no subscriber left to receive this error.
+            console.warn("Failed to cancel HTTP response reader:", error);
           });
         };
       });


### PR DESCRIPTION
Fixes #2510.

Unsubscribing from a response whose reader rejects cancellation used to rethrow inside a detached Promise rejection handler, allowing a disconnected server to produce an unhandled rejection. Keep AbortError silent as expected teardown, and report other cancellation errors through console.warn instead of throwing after the subscriber has closed. The existing read-loop error still reaches the subscriber unchanged.

Scope approved by @NathanTarbert in https://github.com/ag-ui-protocol/ag-ui/issues/2510#issuecomment-5592533920. This preserves the requested distinction between ordinary aborts and unexpected cancellation failures.

Regression coverage tests both cancellation error types during unsubscribe, checks the unhandled-rejection checkpoint, and confirms a read error is not replaced by a subsequent cancellation failure. Existing reader mocks now return the Promise required by the real cancellation API.

Validation on Node 22.23.2:
- `pnpm nx run-many -t test,typecheck,lint --projects=@ag-ui/client --parallel=1 --skip-nx-cache` passed (748 tests in 69 files, plus build and dependent tasks).
- `git diff --check` passed.

AI assistance: Codex prepared the patch and ran the reported checks.
