### PR TITLE
fix(client): bound HTTP error response previews

### DIFF
--- a/sdks/typescript/packages/client/README.md
+++ b/sdks/typescript/packages/client/README.md
@@ -76,3 +76,18 @@ Bug reports and pull requests are welcome! Please read our [contributing guide](
 ## License
 
 MIT © 2025 AG-UI Protocol Contributors
+
+## HTTP error response limits
+
+For non-success HTTP responses, the client streams at most 64 KiB of body bytes
+into a diagnostic preview before UTF-8 decoding. Once the budget is reached it
+cancels the reader without waiting for another chunk or EOF; an incomplete UTF-8
+character at the boundary is omitted. The payload remains a string with a
+` [truncated]` suffix, including when the body is exactly 64 KiB. Complete JSON
+bodies below the limit retain their structured `error.payload` behavior. The
+HTTP status remains available as `error.status`.
+
+The body detail embedded in `error.message` is independently limited to 4,096
+characters plus a truncation marker. Large error responses previously retained
+in full are now previews. The byte budget bounds retained content; a single
+chunk supplied by the underlying stream can already exceed that budget.

--- a/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
+++ b/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
@@ -20,7 +20,7 @@ describe("runHttpRequest", () => {
       body: {
         getReader: vi.fn().mockReturnValue({
           read: vi.fn().mockResolvedValue({ done: true }),
-          cancel: vi.fn(),
+          cancel: vi.fn().mockResolvedValue(undefined),
         }),
       },
     };
@@ -59,7 +59,7 @@ describe("runHttpRequest", () => {
         .mockResolvedValueOnce({ done: false, value: chunk1 })
         .mockResolvedValueOnce({ done: false, value: chunk2 })
         .mockResolvedValueOnce({ done: true }),
-      cancel: vi.fn(),
+      cancel: vi.fn().mockResolvedValue(undefined),
     };
 
     // Mock response with our custom reader and headers
@@ -120,13 +120,8 @@ describe("runHttpRequest", () => {
 
     const mockText = '{"message":"User not found"}';
 
-    const mockResponse = {
-      ok: false,
-      status: 404,
-      headers: mockHeaders,
-      // our error-path reads .text() (not streaming)
-      text: vi.fn().mockResolvedValue(mockText),
-    } as unknown as Response;
+    const mockResponse = new Response(mockText, { status: 404, headers: mockHeaders });
+    const textSpy = vi.spyOn(mockResponse, "text");
 
     // Override fetch for this test
     fetchMock.mockResolvedValue(mockResponse);
@@ -158,7 +153,114 @@ describe("runHttpRequest", () => {
     // Should not have emitted any data events on error short-circuit
     expect(nextSpy).not.toHaveBeenCalled();
 
-    // Ensure we read the error body exactly once
-    expect((mockResponse as any).text).toHaveBeenCalledTimes(1);
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("bounded HTTP error bodies", () => {
+  const cap = 64 * 1024;
+  const encoder = new TextEncoder();
+  const errorFrom = (response: Response) => new Promise<Error & { status: number; payload: unknown }>((resolve, reject) => {
+    runHttpRequest(async () => response).subscribe({
+      next: () => reject(new Error("Unexpected event")),
+      complete: () => reject(new Error("Unexpected completion")),
+      error: resolve,
+    });
+  });
+
+  function streamingError(chunks: Uint8Array[], contentType = "text/plain", cancel = vi.fn()) {
+    let index = 0;
+    const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+      if (index < chunks.length) controller.enqueue(chunks[index++]);
+      else controller.close();
+    });
+    const body = new ReadableStream({ pull, cancel }, { highWaterMark: 0 });
+    return { response: new Response(body, { status: 500, headers: { "content-type": contentType } }), pull, cancel };
+  }
+
+  it("caps an oversized chunk and retains bounded payload and message previews", async () => {
+    const { response, pull, cancel } = streamingError([encoder.encode("x".repeat(cap * 4)), encoder.encode("never read")]);
+    const error = await errorFrom(response);
+    expect(error.status).toBe(500);
+    expect(error.payload).toBe("x".repeat(cap) + " [truncated]");
+    expect(error.message).toBe("HTTP 500: " + "x".repeat(4096) + " [truncated]");
+    expect(pull).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  it("stops pulling an unbounded stream once the byte budget is reached", async () => {
+    const cancel = vi.fn();
+    const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+      controller.enqueue(encoder.encode("x".repeat(1024)));
+    });
+    const response = new Response(new ReadableStream({ pull, cancel }, { highWaterMark: 0 }), { status: 503 });
+    const error = await errorFrom(response);
+    expect(error.status).toBe(503);
+    expect(pull).toHaveBeenCalledTimes(64);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(String(error.payload).length).toBe(cap + " [truncated]".length);
+  });
+
+  it("decodes multibyte UTF-8 split across chunks", async () => {
+    const bytes = encoder.encode("你😀");
+    const { response } = streamingError([bytes.subarray(0, 1), bytes.subarray(1, 5), bytes.subarray(5)]);
+    expect((await errorFrom(response)).payload).toBe("你😀");
+  });
+
+  it("does not emit half a UTF-8 character at the cap", async () => {
+    const { response } = streamingError([encoder.encode("x".repeat(cap - 1) + "你")]);
+    expect((await errorFrom(response)).payload).toBe("x".repeat(cap - 1) + " [truncated]");
+  });
+
+  it("keeps oversized JSON as a marked string rather than parsing a partial document", async () => {
+    const { response } = streamingError([encoder.encode(JSON.stringify({ message: "x".repeat(cap) }))], "application/json");
+    const error = await errorFrom(response);
+    expect(typeof error.payload).toBe("string");
+    expect(String(error.payload)).toHaveLength(cap + " [truncated]".length);
+    expect(error.status).toBe(500);
+  });
+
+  it.each(["plain failure", "{invalid json", "", "x".repeat(cap - 1)])("preserves complete bodies below the cap (%#)", async (text) => {
+    const { response, cancel } = streamingError([encoder.encode(text)], "application/json");
+    expect((await errorFrom(response)).payload).toBe(text);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("marks an exact-cap body without waiting for another read", async () => {
+    const { response, pull, cancel } = streamingError([encoder.encode("x".repeat(cap))]);
+    expect((await errorFrom(response)).payload).toBe("x".repeat(cap) + " [truncated]");
+    expect(pull).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("reports the HTTP status for a missing body", async () => {
+    const error = await errorFrom(new Response(null, { status: 502 }));
+    expect(error.status).toBe(502);
+    expect(error.payload).toBe("");
+    expect(error.message).toBe("HTTP 502: ");
+  });
+
+  it("does not replace an HTTP error when cancellation rejects", async () => {
+    const cancel = vi.fn().mockRejectedValue(new Error("Cancel failed"));
+    const { response } = streamingError([new Uint8Array(cap)], "text/plain", cancel);
+    const error = await errorFrom(response);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(error.status).toBe(500);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a pending error body when unsubscribed", async () => {
+    const cancel = vi.fn();
+    const pull = vi.fn();
+    const response = new Response(new ReadableStream({ pull, cancel }, { highWaterMark: 0 }), { status: 500 });
+    const onError = vi.fn();
+    const subscription = runHttpRequest(async () => response).subscribe({ error: onError });
+    await vi.waitFor(() => expect(pull).toHaveBeenCalledOnce());
+    subscription.unsubscribe();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+    expect(response.body?.locked).toBe(false);
   });
 });

--- a/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
+++ b/sdks/typescript/packages/client/src/run/__tests__/http-request.test.ts
@@ -241,13 +241,31 @@ describe("bounded HTTP error bodies", () => {
     expect(error.message).toBe("HTTP 502: ");
   });
 
-  it("does not replace an HTTP error when cancellation rejects", async () => {
-    const cancel = vi.fn().mockRejectedValue(new Error("Cancel failed"));
-    const { response } = streamingError([new Uint8Array(cap)], "text/plain", cancel);
-    const error = await errorFrom(response);
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    expect(error.status).toBe(500);
-    expect(cancel).toHaveBeenCalledOnce();
+  it.each([
+    [new DOMException("Aborted", "AbortError"), false],
+    [new Error("Cancel failed"), true],
+  ])("preserves HTTP errors and diagnoses cancellation appropriately: %s", async (failure, shouldWarn) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      const cancel = vi.fn().mockRejectedValue(failure);
+      const { response } = streamingError([new Uint8Array(cap)], "text/plain", cancel);
+      const error = await errorFrom(response);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(error.status).toBe(500);
+      expect(String(error.payload)).toHaveLength(cap + " [truncated]".length);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(unhandled).not.toHaveBeenCalled();
+      if (shouldWarn) {
+        expect(warn).toHaveBeenCalledExactlyOnceWith("Failed to cancel HTTP response reader:", failure);
+      } else {
+        expect(warn).not.toHaveBeenCalled();
+      }
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      warn.mockRestore();
+    }
   });
 
   it("cancels a pending error body when unsubscribed", async () => {

--- a/sdks/typescript/packages/client/src/run/http-request.ts
+++ b/sdks/typescript/packages/client/src/run/http-request.ts
@@ -1,5 +1,5 @@
 import { Observable, from, defer, throwError } from "rxjs";
-import { mergeMap, switchMap } from "rxjs/operators";
+import { switchMap } from "rxjs/operators";
 
 export enum HttpEventType {
   HEADERS = "headers",
@@ -26,22 +26,7 @@ export const runHttpRequest = (
   return defer(() => from(fetchResponse())).pipe(
     switchMap((response) => {
       if (!response.ok) {
-        const contentType = response.headers.get("content-type") || "";
-        // Read the (small) error body once, then error the stream
-        return from(response.text()).pipe(
-          mergeMap((text) => {
-            let payload: unknown = text;
-            if (contentType.includes("application/json")) {
-              try { payload = JSON.parse(text); } catch {/* keep raw text */}
-            }
-            const err: Error & { status?: number; payload?: unknown } = new Error(
-              `HTTP ${response.status}: ${typeof payload === "string" ? payload : JSON.stringify(payload)}`
-            );
-            err.status = response.status;
-            err.payload = payload;
-            return throwError(() => err);
-          })
-        );
+        return readHttpError(response);
       }
       // Emit headers event first
       const headersEvent: HttpHeadersEvent = {
@@ -90,3 +75,80 @@ export const runHttpRequest = (
     }),
   );
 };
+
+// Bound both the decoded payload and the diagnostic copied into the message.
+const MAX_ERROR_BODY_BYTES = 64 * 1024;
+const MAX_ERROR_MESSAGE_CHARS = 4 * 1024;
+const TRUNCATED = " [truncated]";
+
+function readHttpError(response: Response): Observable<never> {
+  return new Observable((subscriber) => {
+    const reader = response.body?.getReader();
+    let finished = false;
+    let cancelled = false;
+    const cancel = () => {
+      if (reader && !finished && !cancelled) {
+        cancelled = true;
+        // Cleanup must not replace the HTTP error or produce an unhandled rejection.
+        void reader.cancel().catch(() => {});
+      }
+    };
+
+    void (async () => {
+      let text = "";
+      let truncated = false;
+      const decoder = new TextDecoder();
+      try {
+        let bytes = 0;
+        if (reader) {
+          while (!subscriber.closed) {
+            const { done, value } = await reader.read();
+            if (subscriber.closed) return;
+            if (done) {
+              finished = true;
+              text += decoder.decode();
+              break;
+            }
+            const accepted = value.subarray(0, MAX_ERROR_BODY_BYTES - bytes);
+            text += decoder.decode(accepted, { stream: true });
+            bytes += accepted.byteLength;
+            if (bytes === MAX_ERROR_BODY_BYTES) {
+              // Do not fetch another chunk to probe for EOF, or flush an
+              // incomplete UTF-8 character at the preview boundary.
+              truncated = true;
+              cancel();
+              break;
+            }
+          }
+        }
+        if (subscriber.closed) return;
+        let payload: unknown = text;
+        if (truncated) {
+          payload = text + TRUNCATED;
+        } else if (response.headers.get("content-type")?.includes("application/json")) {
+          try {
+            payload = JSON.parse(text);
+          } catch {
+            // Preserve the readable text for non-JSON error responses.
+          }
+        }
+        const detail = typeof payload === "string" ? payload : JSON.stringify(payload);
+        const excerpt = detail.length > MAX_ERROR_MESSAGE_CHARS
+          ? detail.slice(0, MAX_ERROR_MESSAGE_CHARS) + TRUNCATED
+          : detail;
+        const error: Error & { status?: number; payload?: unknown } = new Error(
+          `HTTP ${response.status}: ${excerpt}`,
+        );
+        error.status = response.status;
+        error.payload = payload;
+        subscriber.error(error);
+      } catch (error) {
+        subscriber.error(error);
+      } finally {
+        cancel();
+        reader?.releaseLock();
+      }
+    })();
+    return cancel;
+  });
+}

--- a/sdks/typescript/packages/client/src/run/http-request.ts
+++ b/sdks/typescript/packages/client/src/run/http-request.ts
@@ -90,7 +90,12 @@ function readHttpError(response: Response): Observable<never> {
       if (reader && !finished && !cancelled) {
         cancelled = true;
         // Cleanup must not replace the HTTP error or produce an unhandled rejection.
-        void reader.cancel().catch(() => {});
+        void reader.cancel().catch((error) => {
+          if ((error as DOMException)?.name === "AbortError") {
+            return;
+          }
+          console.warn("Failed to cancel HTTP response reader:", error);
+        });
       }
     };
 


### PR DESCRIPTION
Fixes #2521.

The non-OK HTTP path previously buffered response.text() without a limit and retained the full response in both the Error message and payload. It now streams a UTF-8 preview under a 64 KiB byte budget and independently caps the message detail at 4,096 characters. Small complete JSON errors retain structured payloads and the HTTP status remains available.

At the byte limit, cancel immediately without reading another chunk or waiting for EOF. The payload is a string with a truncation marker, including at exactly 64 KiB; incomplete UTF-8 at that cutoff is omitted and partial JSON is never parsed. Reader cancellation on unsubscribe is supported, locks are released, and cancellation rejection cannot mask the HTTP error. Expected AbortError cancellations remain silent; unexpected cancellation failures emit a warning, matching the cleanup policy in #2697. A chunk already supplied by the transport can exceed the budget; the limit bounds the retained preview and prevents further pulls, not the transport's allocation of that chunk. README documents these limits and compatibility details.

Scope approved by @NathanTarbert in https://github.com/ag-ui-protocol/ag-ui/issues/2521#issuecomment-5592533716.

Tests cover oversized chunks, an endless producer and exact pull count, split multibyte text, UTF-8 cutoff, oversized JSON, small JSON/text, exact/under-limit bodies, null bodies, failed cancellation, and unsubscribe during a pending read. The existing HTTP regression suite is extended.

Validation on Node 22.23.2: `pnpm nx run-many -t test,typecheck,lint --projects=@ag-ui/client --parallel=1` passed: 759 tests in 69 files, plus build/typecheck/lint and dependencies. `git diff --check` passed.

AI assistance: Codex prepared the patch and ran the reported checks.

