### PR TITLE
fix(aws-strands): read the parked tool batch through both checkpoint shapes

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/interrupt_checkpoint.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/interrupt_checkpoint.py
@@ -1,0 +1,132 @@
+"""Read and write the tool batch a Strands interrupt checkpoint parks.
+
+When a tool raises an interrupt, Strands checkpoints the whole batch it was
+dispatching: the assistant message holding every ``toolUse`` of that turn, plus
+the results of the calls that already finished. The resume re-dispatches that
+message and answers the finished calls from the checkpoint rather than running
+them again, so the adapter has to read the batch (to know which tools must stay
+registered) and correct results inside it (so a frontend tool's real answer,
+which only arrives on the next request, replaces the proxy placeholder before
+the model ever sees it).
+
+Where that batch lives is private to Strands and has already moved once:
+
+* Up to 1.54 it sat on ``_InterruptState.context`` under the string keys
+  ``"tool_results"`` and ``"tool_use_message"``.
+* From 1.55 it sits on ``_InterruptState.pending_tool_execution``, an object
+  with ``assistant_message`` and ``completed_tool_results``, and the legacy
+  keys are migrated out of ``context`` on load.
+
+Reading either shape directly from the call sites is what broke on 1.55: every
+read returned nothing, so a corrected frontend result silently stopped reaching
+the model. This module is the single place that knows both shapes. It reads the
+new one when the installed release has it and the legacy one otherwise, so the
+adapter keeps working across the whole supported range rather than tracking one
+release's private layout.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+# The keys Strands used before the batch became a typed field.
+_LEGACY_RESULTS_KEY = "tool_results"
+_LEGACY_MESSAGE_KEY = "tool_use_message"
+
+
+class _CheckpointSignal:
+    """A distinguishable answer for a checkpoint that carries no message."""
+
+    def __init__(self, label: str) -> None:
+        self._label = label
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return self._label
+
+
+#: No tool batch is parked at all. An interrupt raised before any tool ran
+#: checkpoints exactly this way, and it has no batch to protect or correct.
+NO_PARKED_BATCH = _CheckpointSignal("NO_PARKED_BATCH")
+
+#: A checkpoint is carrying something, but this adapter cannot get at it. The
+#: caller must assume a batch is parked and behave conservatively, because the
+#: alternative is breaking a resume that is already in flight.
+UNREADABLE_CHECKPOINT = _CheckpointSignal("UNREADABLE_CHECKPOINT")
+
+
+def _pending_tool_execution(interrupt_state: Any) -> Any:
+    """Return the release's typed parked-batch field, or None when it has none.
+
+    ``None`` covers both "this release predates the field" and "this release
+    has it but nothing is parked", because both mean the same thing to every
+    caller: look at the legacy ``context`` keys instead.
+    """
+    return getattr(interrupt_state, "pending_tool_execution", None)
+
+
+def parked_tool_results(interrupt_state: Any) -> list | None:
+    """Return the live list of completed results parked by *interrupt_state*.
+
+    The list is returned as-is rather than copied: correcting a result in place
+    is how the adapter gets the client's real answer into the batch Strands is
+    about to replay, and a copy would correct nothing. Callers that mutate it
+    must still publish it through :func:`publish_parked_tool_results` so the
+    session manager learns the state changed.
+
+    Returns ``None`` when nothing is parked or when what is parked is not a
+    list of results.
+    """
+    pending = _pending_tool_execution(interrupt_state)
+    if pending is not None:
+        results = getattr(pending, "completed_tool_results", None)
+        return results if isinstance(results, list) else None
+
+    context = getattr(interrupt_state, "context", None)
+    if not isinstance(context, Mapping):
+        return None
+    results = context.get(_LEGACY_RESULTS_KEY)
+    return results if isinstance(results, list) else None
+
+
+def parked_assistant_message(interrupt_state: Any) -> Any:
+    """Return the assistant message whose tool batch *interrupt_state* parked.
+
+    Three answers, which callers must tell apart:
+
+    * :data:`NO_PARKED_BATCH` when the checkpoint holds no batch.
+    * :data:`UNREADABLE_CHECKPOINT` when the checkpoint holds state this
+      adapter cannot inspect at all.
+    * Otherwise the parked message itself, which is usually a mapping but is
+      whatever the checkpoint holds; the caller decides what it can do with it.
+    """
+    pending = _pending_tool_execution(interrupt_state)
+    if pending is not None:
+        return getattr(pending, "assistant_message", None)
+
+    context = getattr(interrupt_state, "context", None)
+    if not isinstance(context, Mapping):
+        return UNREADABLE_CHECKPOINT
+    if _LEGACY_MESSAGE_KEY not in context:
+        return NO_PARKED_BATCH
+    return context[_LEGACY_MESSAGE_KEY]
+
+
+def publish_parked_tool_results(interrupt_state: Any, tool_results: list) -> None:
+    """Republish corrected parked results so the session manager persists them.
+
+    Correcting the results in place is enough for the run in flight, but not
+    for the next process: ``RepositorySessionManager.sync_agent`` only writes
+    interrupt state back when the state's own version counter has moved, and an
+    in-place edit of the parked list moves nothing. ``set_pending_tool_results``
+    bumps that counter, so routing the corrected list back through it is what
+    makes a correction survive a rebuilt agent.
+
+    On a release with no such method the in-place edit is all there is, and this
+    is a no-op.
+    """
+    if _pending_tool_execution(interrupt_state) is None:
+        return
+    setter = getattr(interrupt_state, "set_pending_tool_results", None)
+    if not callable(setter):
+        return
+    setter(tool_results)

--- a/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/session_reconcile.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any, Iterable, Mapping, Tuple
 
 from .client_proxy_tool import PROXY_RESULT_PLACEHOLDER
+from .interrupt_checkpoint import parked_tool_results, publish_parked_tool_results
 
 # Key under which the adapter stores the ids of the frontend tool calls it has
 # emitted, as a JSON list on the Strands agent's session state. Namespaced to
@@ -138,9 +139,17 @@ def reconcile_frontend_tool_results(
     # reach the adapter so it can stop before Strands consumes the checkpoint.
     interrupt_state = getattr(agent, "_interrupt_state", None)
     if interrupt_state is not None and getattr(interrupt_state, "activated", False):
-        tool_results = interrupt_state.context.get("tool_results")
+        tool_results = parked_tool_results(interrupt_state)
         if tool_results:
-            corrected |= _correct_all_tools(tool_results, pending_results)
+            mutated: set[str] = set()
+            corrected |= _correct_all_tools(
+                tool_results, pending_results, mutated_ids=mutated
+            )
+            if mutated:
+                # The edit above already reaches the run in flight. This is
+                # what makes it reach the next process: see the writer's own
+                # note on the session manager's version check.
+                publish_parked_tool_results(interrupt_state, tool_results)
 
     return corrected
 
@@ -179,11 +188,8 @@ def active_proxy_placeholder_ids(agent: Any) -> set[str]:
     interrupt_state = getattr(agent, "_interrupt_state", None)
     if interrupt_state is None or not getattr(interrupt_state, "activated", False):
         return set()
-    context = getattr(interrupt_state, "context", None)
-    if not isinstance(context, Mapping):
-        return set()
-    tool_results = context.get("tool_results")
-    if not isinstance(tool_results, list):
+    tool_results = parked_tool_results(interrupt_state)
+    if tool_results is None:
         return set()
 
     return {
@@ -229,12 +235,23 @@ def _correct_single_tool(
 
 
 def _correct_all_tools(
-    tool_results, pending_results: Mapping[str, Tuple[str, bool]]
+    tool_results,
+    pending_results: Mapping[str, Tuple[str, bool]],
+    *,
+    mutated_ids: set[str] | None = None,
 ) -> set[str]:
-    """Reconcile matching ToolResult dicts in *tool_results* in place."""
+    """Reconcile matching ToolResult dicts in *tool_results* in place.
+
+    Returns every id that is now carrying its real result. ``mutated_ids``, when
+    given, collects the narrower set this call actually rewrote, so a caller can
+    tell "corrected here" from "already correct" and skip republishing a batch
+    nothing changed.
+    """
     changed: set[str] = set()
     for tool_result in tool_results:
-        tool_use_id = _correct_single_tool(tool_result, pending_results)
+        tool_use_id = _correct_single_tool(
+            tool_result, pending_results, mutated_ids=mutated_ids
+        )
         if tool_use_id:
             changed.add(tool_use_id)
     return changed

--- a/integrations/aws-strands/python/src/ag_ui_strands/template_tools.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/template_tools.py
@@ -25,6 +25,11 @@ from strands.tools.registry import ToolRegistry
 
 from .a2ui_tool import is_auto_injected_a2ui_tool
 from .client_proxy_tool import _is_proxy
+from .interrupt_checkpoint import (
+    NO_PARKED_BATCH,
+    UNREADABLE_CHECKPOINT,
+    parked_assistant_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -166,32 +171,35 @@ def parked_batch_tool_names(agent: Any) -> "Set[str] | _ExemptEveryTemplateTool"
     through the approval hook, through an interrupt of its own, or not at all,
     and the batch answers all three at once.
 
+    Where the batch lives on the checkpoint differs by Strands release, so it is
+    read through :mod:`~ag_ui_strands.interrupt_checkpoint` rather than off a
+    key this function names itself.
+
     Returns:
         The names to hold registered; an empty set when nothing is parked; or
         :data:`EXEMPT_EVERY_TEMPLATE_TOOL` for a checkpoint that is carrying a
         tool batch this function cannot read, where holding everything costs
         one unfiltered turn and the alternative breaks a resume. An activated
-        checkpoint with no ``tool_use_message`` at all is not that case: an
+        checkpoint carrying no parked batch at all is not that case: an
         interrupt raised before any tool ran parks exactly that way, and it has
         no batch to protect.
     """
     state = getattr(agent, "_interrupt_state", None)
     if state is None or getattr(state, "activated", False) is not True:
         return set()
-    context = getattr(state, "context", None)
-    if not isinstance(context, Mapping):
+    message = parked_assistant_message(state)
+    if message is UNREADABLE_CHECKPOINT:
         logger.warning(
             "An activated interrupt checkpoint carries no readable context; "
             "holding every template tool registered rather than risk removing "
             "one this thread's resume is about to re-dispatch."
         )
         return EXEMPT_EVERY_TEMPLATE_TOOL
-    if "tool_use_message" not in context:
+    if message is NO_PARKED_BATCH:
         # A pause raised before any tool ran. Nothing is mid-dispatch, so
         # nothing needs holding.
         return set()
 
-    message = context["tool_use_message"]
     names: Set[str] = set()
     if isinstance(message, Mapping):
         for block in message.get("content") or []:

--- a/integrations/aws-strands/python/tests/interrupt_state_stub.py
+++ b/integrations/aws-strands/python/tests/interrupt_state_stub.py
@@ -1,8 +1,9 @@
 """Test-local stand-in for Strands' interrupt state.
 
 The adapter never imports Strands' interrupt-state class. It reads the state
-structurally off the agent (``activated``, ``interrupts``, ``context``), so a
-test that needs a paused agent only needs an object exposing that surface.
+structurally off the agent (``activated``, ``interrupts``, ``context`` and the
+parked tool batch), so a test that needs a paused agent only needs an object
+exposing that surface.
 
 Importing the real private class instead pins the suite to one Strands
 release: it moved from ``strands.agent.interrupt.InterruptState`` to
@@ -18,12 +19,30 @@ from typing import Any
 
 
 @dataclass
+class PendingToolExecutionStub:
+    """The typed parked-tool-batch field Strands grew in 1.55.
+
+    Before it, a checkpoint kept the batch it stopped inside on ``context``
+    under ``"tool_use_message"`` and ``"tool_results"``; from 1.55 it keeps the
+    same two things here and migrates the legacy keys out of ``context`` on
+    load. The adapter reads whichever shape the installed release writes, so
+    the suite has to be able to build both on any release, which is why this is
+    a local paraphrase rather than an import.
+    """
+
+    assistant_message: Any = None
+    completed_tool_results: list[Any] = field(default_factory=list)
+
+
+@dataclass
 class InterruptStateStub:
     """The interrupt-state surface the adapter observes."""
 
     interrupts: dict[str, Any] = field(default_factory=dict)
     context: dict[str, Any] = field(default_factory=dict)
     activated: bool = False
+    pending_tool_execution: PendingToolExecutionStub | None = None
+    _version: int = field(default=0, compare=False, repr=False)
 
     def activate(self, context: dict[str, Any] | None = None) -> None:
         """Mark the state paused, replacing the context only when one is given."""
@@ -67,11 +86,26 @@ class InterruptStateStub:
             ]
         self.context["responses"] = prompt
 
+    def set_pending_tool_results(self, completed_tool_results: list[Any]) -> None:
+        """Replace the parked results and bump the version, as Strands does.
+
+        The bump is the load-bearing half. ``RepositorySessionManager`` only
+        writes interrupt state back when this counter has moved, so a result
+        corrected in place but never published through here reaches the run in
+        flight and nothing after it.
+        """
+        if self.pending_tool_execution is None:
+            return
+        self.pending_tool_execution.completed_tool_results = completed_tool_results
+        self._version += 1
+
     def deactivate(self) -> None:
         """Clear the pause, dropping interrupts and context as Strands does."""
         self.interrupts = {}
         self.context = {}
         self.activated = False
+        self.pending_tool_execution = None
+        self._version += 1
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the way Strands does, so checkpoint snapshots compare."""

--- a/integrations/aws-strands/python/tests/test_session_reconcile.py
+++ b/integrations/aws-strands/python/tests/test_session_reconcile.py
@@ -16,11 +16,16 @@ from strands.session.file_session_manager import FileSessionManager
 from strands.types.session import SessionAgent, SessionMessage
 
 from ag_ui_strands import session_reconcile
+from ag_ui_strands.interrupt_checkpoint import (
+    parked_tool_results,
+    publish_parked_tool_results,
+)
 from ag_ui_strands.session_reconcile import (
     AG_UI_FRONTEND_CALL_IDS_STATE_KEY,
     has_placeholder_results,
     reconcile_frontend_tool_results,
 )
+from tests.interrupt_state_stub import InterruptStateStub, PendingToolExecutionStub
 
 PLACEHOLDER = "Forwarded to client"
 
@@ -535,3 +540,222 @@ def test_recorded_call_ids_accepts_only_ids_this_adapter_wrote(stored):
     assert session_reconcile.recorded_frontend_call_ids(agent) == (
         ["native-1"] if isinstance(stored, list) else []
     )
+
+
+# ---------------------------------------------------------------------------
+# The parked tool batch, across the two shapes Strands has kept it in
+# ---------------------------------------------------------------------------
+#
+# A checkpoint parks the tool batch it stopped inside. Up to strands-agents
+# 1.54 it lived on ``_interrupt_state.context`` under ``"tool_results"``; from
+# 1.55 it lives on ``_interrupt_state.pending_tool_execution`` and the legacy
+# key is migrated out of ``context``. Reading only the older shape is how a
+# frontend tool's real answer silently stopped reaching the model on 1.55: the
+# parked placeholder was never corrected and the model was handed "Forwarded to
+# client" in place of the user's answer. Both shapes are driven here, on every
+# release, because only one of them exists on the installed SDK at a time.
+
+
+def _typed_checkpoint(*results):
+    """An activated checkpoint parking *results* the way 1.55 and later do."""
+    return InterruptStateStub(
+        activated=True,
+        pending_tool_execution=PendingToolExecutionStub(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=list(results),
+        ),
+    )
+
+
+def _legacy_checkpoint(*results):
+    """An activated checkpoint parking *results* the way 1.54 and earlier did."""
+    return InterruptStateStub(
+        activated=True, context={"tool_results": list(results)}
+    )
+
+
+@pytest.mark.parametrize(
+    "build_checkpoint",
+    [
+        pytest.param(_typed_checkpoint, id="pending-tool-execution"),
+        pytest.param(_legacy_checkpoint, id="legacy-context"),
+    ],
+)
+def test_the_parked_results_reader_hands_back_the_list_the_sdk_will_replay(
+    build_checkpoint,
+):
+    """The reader must return the live list, not a copy of it.
+
+    Correcting a parked placeholder is done in place, so a reader that copied
+    would correct a list nobody replays. Identity is therefore the property
+    worth pinning, not equality.
+    """
+    parked = {
+        "toolUseId": "native-proxy",
+        "status": "success",
+        "content": [{"text": PLACEHOLDER}],
+    }
+    checkpoint = build_checkpoint(parked)
+
+    results = parked_tool_results(checkpoint)
+
+    assert results is not None
+    assert results[0] is parked
+    results[0]["content"] = [{"text": '{"approved": true}'}]
+    assert session_reconcile.active_proxy_placeholder_ids(
+        SimpleNamespace(_interrupt_state=checkpoint)
+    ) == set()
+
+
+@pytest.mark.parametrize(
+    "build_checkpoint",
+    [
+        pytest.param(_typed_checkpoint, id="pending-tool-execution"),
+        pytest.param(_legacy_checkpoint, id="legacy-context"),
+    ],
+)
+def test_a_parked_proxy_placeholder_is_seen_in_either_checkpoint_shape(
+    build_checkpoint,
+):
+    """The gate that stops an uncorrected resume has to see the placeholder.
+
+    ``active_proxy_placeholder_ids`` is what tells the adapter a checkpoint is
+    still carrying a placeholder the client's answer never replaced. Reading it
+    off one shape means that gate silently guards nothing on the other, and the
+    run continues into Strands with the stub result.
+    """
+    agent = SimpleNamespace(
+        _interrupt_state=build_checkpoint(
+            {
+                "toolUseId": "native-proxy",
+                "status": "success",
+                "content": [{"text": PLACEHOLDER}],
+            }
+        )
+    )
+
+    assert session_reconcile.active_proxy_placeholder_ids(agent) == {"native-proxy"}
+
+
+def test_a_checkpoint_parking_no_batch_at_all_reads_as_nothing_parked():
+    """A pause raised before any tool ran parks no batch, in either shape."""
+    assert parked_tool_results(InterruptStateStub(activated=True)) is None
+    assert (
+        session_reconcile.active_proxy_placeholder_ids(
+            SimpleNamespace(_interrupt_state=InterruptStateStub(activated=True))
+        )
+        == set()
+    )
+
+
+@pytest.mark.parametrize(
+    "build_checkpoint",
+    [
+        pytest.param(_typed_checkpoint, id="pending-tool-execution"),
+        pytest.param(_legacy_checkpoint, id="legacy-context"),
+    ],
+)
+def test_reconcile_corrects_the_parked_batch_in_either_checkpoint_shape(
+    tmp_path, build_checkpoint
+):
+    """The correction has to land where the resume will read it.
+
+    This is the user-visible defect the shape change caused: an approved
+    frontend tool whose parked result still says "Forwarded to client" is what
+    the model is handed on the resume, so the human's answer never reaches it.
+    """
+    sm = _make_session(tmp_path)
+    parked = _tool_result_block("native-proxy", PLACEHOLDER)["toolResult"]
+    checkpoint = build_checkpoint(parked)
+    agent = SimpleNamespace(
+        agent_id="default", messages=[], _interrupt_state=checkpoint
+    )
+
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"native-proxy": ('{"approved": true}', False)}
+    )
+
+    assert corrected == {"native-proxy"}
+    assert parked_tool_results(checkpoint)[0]["content"] == [
+        {"text": '{"approved": true}'}
+    ]
+    assert parked["status"] == "success"
+
+
+def test_a_corrected_batch_is_republished_so_the_session_persists_it(tmp_path):
+    """An in-place edit alone does not survive the process.
+
+    ``RepositorySessionManager.sync_agent`` only writes interrupt state back
+    when the state's own version counter has moved, and mutating a parked
+    result moves nothing. Routing the corrected list through
+    ``set_pending_tool_results`` is what bumps that counter, so a rebuilt agent
+    reads the client's answer instead of the placeholder it replaced.
+    """
+    sm = _make_session(tmp_path)
+    checkpoint = _typed_checkpoint(
+        _tool_result_block("native-proxy", PLACEHOLDER)["toolResult"]
+    )
+    agent = SimpleNamespace(
+        agent_id="default", messages=[], _interrupt_state=checkpoint
+    )
+    version_before = checkpoint._version
+
+    reconcile_frontend_tool_results(
+        sm, agent, {"native-proxy": ('{"approved": true}', False)}
+    )
+
+    assert checkpoint._version > version_before
+    assert checkpoint.pending_tool_execution.completed_tool_results[0]["content"] == [
+        {"text": '{"approved": true}'}
+    ]
+
+
+def test_a_batch_that_needed_no_correction_is_not_republished(tmp_path):
+    """A version bump means "persist me", so it must not be spent on a no-op.
+
+    Every bump costs the session manager a write of the whole checkpoint. A
+    reconciliation pass that found every parked result already carrying its
+    real value changed nothing, and saying otherwise would make each turn
+    rewrite state that is already correct.
+    """
+    sm = _make_session(tmp_path)
+    checkpoint = _typed_checkpoint(
+        {
+            "toolUseId": "native-proxy",
+            "status": "success",
+            "content": [{"text": '{"approved": true}'}],
+        }
+    )
+    agent = SimpleNamespace(
+        agent_id="default", messages=[], _interrupt_state=checkpoint
+    )
+    version_before = checkpoint._version
+
+    corrected = reconcile_frontend_tool_results(
+        sm, agent, {"native-proxy": ('{"approved": true}', False)}
+    )
+
+    assert corrected == {"native-proxy"}
+    assert checkpoint._version == version_before
+
+
+def test_republishing_is_a_no_op_on_a_release_that_offers_no_setter():
+    """The declared floor has no ``set_pending_tool_results`` to call.
+
+    On those releases the in-place correction is the whole mechanism, and the
+    writer has to stay silent rather than fail the run trying to reach an API
+    that does not exist.
+    """
+    parked = {
+        "toolUseId": "native-proxy",
+        "status": "success",
+        "content": [{"text": '{"approved": true}'}],
+    }
+    older_sdk_state = SimpleNamespace(
+        activated=True, context={"tool_results": [parked]}
+    )
+    assert not hasattr(older_sdk_state, "set_pending_tool_results")
+
+    publish_parked_tool_results(older_sdk_state, parked_tool_results(older_sdk_state))
+
+    assert older_sdk_state.context["tool_results"] == [parked]

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -16,8 +16,10 @@ Two rules keep this suite honest, both learned the hard way:
 
 from __future__ import annotations
 
+import ast
 import enum
 import functools
+import importlib
 import inspect
 import logging
 import types
@@ -135,10 +137,107 @@ def _is_declared_dict_shape(annotation: typing.Any) -> bool:
     )
 
 
+def _type_checking_names(module: types.ModuleType) -> dict:
+    """Names *module* imports only under ``TYPE_CHECKING``.
+
+    A quoted annotation may reference a name that exists nowhere at runtime,
+    because the SDK imports it behind ``if TYPE_CHECKING:`` to avoid a cycle.
+    Rather than hardcode the ones we have met, read the module's own
+    ``TYPE_CHECKING`` block and import exactly what it declares, so a release
+    that quotes a different name resolves without editing this file.
+    """
+    try:
+        tree = ast.parse(inspect.getsource(module))
+    except (OSError, TypeError, SyntaxError):
+        return {}
+
+    names: dict = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        guard = node.test
+        guard_name = (
+            guard.id
+            if isinstance(guard, ast.Name)
+            else guard.attr if isinstance(guard, ast.Attribute) else None
+        )
+        if guard_name != "TYPE_CHECKING":
+            continue
+        for statement in node.body:
+            if isinstance(statement, ast.ImportFrom):
+                source = "." * statement.level + (statement.module or "")
+                try:
+                    imported = importlib.import_module(source, module.__package__)
+                except ImportError:
+                    continue
+                for alias in statement.names:
+                    if hasattr(imported, alias.name):
+                        names[alias.asname or alias.name] = getattr(
+                            imported, alias.name
+                        )
+            elif isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    try:
+                        imported = importlib.import_module(alias.name)
+                    except ImportError:
+                        continue
+                    names[alias.asname or alias.name.split(".")[0]] = imported
+    return names
+
+
+@functools.lru_cache(maxsize=1)
+def _annotation_namespace() -> dict:
+    """The namespace a quoted ``Agent.__init__`` annotation is written against.
+
+    Module globals win, with ``typing`` and the module's ``TYPE_CHECKING``-only
+    imports filling the gaps those globals leave.
+    """
+    module = inspect.getmodule(Agent.__init__)
+    if module is None:
+        return dict(vars(typing))
+    return {
+        **vars(typing),
+        **_type_checking_names(module),
+        **vars(module),
+    }
+
+
+def _resolve_forward_reference(annotation: typing.Any, label: str) -> typing.Any:
+    """Evaluate a quoted annotation into the object it names.
+
+    Strands quotes an annotation whenever its names are ``TYPE_CHECKING``-only,
+    and ``_annotations`` hands those through unresolved because
+    ``get_type_hints`` refuses the whole signature over one unrelated name. A
+    string reaching ``_synthesize`` is therefore an ordinary annotation the
+    suite has to evaluate itself, not a param it may decline to cover.
+    """
+    expression = (
+        annotation.__forward_arg__
+        if isinstance(annotation, typing.ForwardRef)
+        else annotation
+    )
+    try:
+        # The expression is an annotation written in the installed SDK's own
+        # source, evaluated against that module's namespace. This is what
+        # ``typing.get_type_hints`` does with the same input; it is only done
+        # by hand here because that call refuses the whole signature over one
+        # unrelated unresolvable name.
+        return eval(expression, dict(_annotation_namespace()))  # noqa: S307
+    except Exception as e:  # noqa: BLE001 - any failure leaves the param uncovered
+        raise _Unsynthesizable(
+            f"could not resolve the quoted annotation {expression!r} for {label} "
+            f"({type(e).__name__}: {e}); it names something neither the declaring "
+            f"module's globals nor its TYPE_CHECKING imports provide"
+        ) from e
+
+
 def _synthesize(annotation: typing.Any, label: str) -> typing.Any:
     """Build a value satisfying ``annotation``, tagged with ``label``."""
     if annotation is inspect.Parameter.empty or annotation is typing.Any:
         return MagicMock(name=f"sentinel-{label}")
+
+    if isinstance(annotation, (str, typing.ForwardRef)):
+        return _synthesize(_resolve_forward_reference(annotation, label), label)
 
     origin = typing.get_origin(annotation)
     args = typing.get_args(annotation)

--- a/integrations/aws-strands/python/tests/test_template_tool_filtering.py
+++ b/integrations/aws-strands/python/tests/test_template_tool_filtering.py
@@ -34,7 +34,7 @@ from ag_ui_strands.template_tools import (
     resolve_template_tool_selection,
     sync_template_tools,
 )
-from tests.interrupt_state_stub import InterruptStateStub
+from tests.interrupt_state_stub import InterruptStateStub, PendingToolExecutionStub
 
 
 THREAD_ID = "template-filter-thread"
@@ -1145,3 +1145,60 @@ class TestParkedBatchToolNames:
         state = InterruptStateStub()
         state.activate({"tool_results": []})
         assert parked_batch_tool_names(self._agent(state)) == set()
+
+    # Where a checkpoint keeps its parked batch is private to Strands and has
+    # already moved: up to 1.54 it sat on ``context`` under
+    # ``"tool_use_message"``, from 1.55 on a ``pending_tool_execution`` field
+    # with the legacy key migrated out. The three cases above drive the older
+    # shape; the three below drive the newer one, because whichever the
+    # installed SDK does not write is the one this filter would quietly stop
+    # reading. Getting it wrong here unregisters a template tool the resume is
+    # about to re-dispatch, which turns the human's answer into a "tool not
+    # found" the model then re-fires.
+
+    def test_every_tool_in_a_typed_parked_batch_is_named(self):
+        state = InterruptStateStub(
+            interrupts={"i1": StrandsInterrupt("i1", "ag_ui:tool_call:delete_record")},
+            activated=True,
+            pending_tool_execution=PendingToolExecutionStub(
+                assistant_message={
+                    "role": "assistant",
+                    "content": [
+                        {"toolUse": {"toolUseId": "a", "name": "delete_record"}},
+                        {"toolUse": {"toolUseId": "b", "name": "read_docs"}},
+                        {"text": "thinking"},
+                    ],
+                },
+                completed_tool_results=[],
+            ),
+        )
+        assert parked_batch_tool_names(self._agent(state)) == {
+            "delete_record",
+            "read_docs",
+        }
+
+    def test_a_typed_checkpoint_parking_no_execution_names_nothing(self):
+        """How a 1.55 pause raised before any tool ran actually looks.
+
+        The typed field is unset and ``context`` no longer carries the legacy
+        key, so nothing is mid-dispatch and nothing needs holding. Reading that
+        as an unreadable batch would leave every template tool registered for a
+        turn the filter was asked to narrow.
+        """
+        state = InterruptStateStub(activated=True, context={"responses": []})
+        assert parked_batch_tool_names(self._agent(state)) == set()
+
+    def test_an_unreadable_typed_parked_batch_holds_every_template_tool(self):
+        """A batch that is present but does not decode still gets protected.
+
+        The conservative direction has to survive the shape change too: a
+        checkpoint carrying an execution whose message this adapter cannot read
+        is not the same as one carrying no execution at all.
+        """
+        state = InterruptStateStub(
+            activated=True,
+            pending_tool_execution=PendingToolExecutionStub(
+                assistant_message="not a message"
+            ),
+        )
+        assert parked_batch_tool_names(self._agent(state)) is EXEMPT_EVERY_TEMPLATE_TOOL


### PR DESCRIPTION
## What this fixes

The `aws-strands-python-latest` CI lane installs the newest published
`strands-agents` at run time. On 1.55.0 six tests fail. They pass on 1.54.0 and on
the pinned 1.18.0, and both failing test files are unchanged from main, so this is
about the SDK, not about a recent change here.

Reproduced before anything was edited:

```
cd integrations/aws-strands/python
uv pip install "strands-agents==1.55.0"
uv run --no-sync python -m pytest tests/ -q
# 6 failed, 1382 passed, 1 skipped
```

## Failure 1: a frontend tool's real result stops reaching the model

`tests/test_interrupt.py::test_mixed_resume_batch_with_falsy_payload_and_tool_behaviors`
(all four parametrisations).

### Upstream

Strands 1.55.0 moved the tool batch an interrupt checkpoint parks. Diffing the
installed 1.54.0 and 1.55.0 packages, in `strands/interrupt.py`:

- added `PendingToolExecution(assistant_message, completed_tool_results)`
- added `_InterruptState.pending_tool_execution: PendingToolExecution | None`
- removed `_InterruptState.has_pending_tool_execution`, which was
  `"tool_use_message" in self.context`
- `from_dict` now migrates the legacy `context["tool_use_message"]` and
  `context["tool_results"]` into the new field and pops them out of `context`
- added `set_pending_tool_results()`, which bumps the state's `_version`. That
  version is what `RepositorySessionManager.sync_agent` compares to decide
  whether to persist interrupt state at all
  (`repository_session_manager.py:124,139,173`)

Measured on the same scenario with the same adapter source, only the SDK swapped:

| | 1.54.0 | 1.55.0 |
|---|---|---|
| `_interrupt_state.context` keys | `['tool_results', 'tool_use_message']` | `[]` |
| `pending_tool_execution` | attribute absent | populated |
| `active_proxy_placeholder_ids(agent)` | `{'native-approve'}` | `set()` |

### Ours

The adapter read the parked batch by string key from three places:
`session_reconcile.py:141`, `session_reconcile.py:185` and
`template_tools.py:189,194`. On 1.55.0 all three read an empty dict, so:

1. The parked proxy `toolResult` keeps its `{"text": "Forwarded to client"}`
   placeholder. The adapter logs `Frontend tool result reconciliation corrected
   nothing for native ids ['native-approve']` and falls back to the continuation
   prompt, which is not a path this batch shape can take. **User-visible: an
   approved frontend tool reads to the model as "Forwarded to client" instead of
   the user's answer.**
2. `active_proxy_placeholder_ids` returns an empty set, so the gate that should
   stop the run before Strands consumes a still-uncorrected checkpoint has nothing
   to guard.
3. `parked_batch_tool_names` reads "no `tool_use_message`" as "a pause raised
   before any tool ran, nothing is mid-dispatch". On 1.55.0 that is wrong for
   every pause that parks a tool batch, and template tools the resume is about to
   re-dispatch can be unregistered under it. No test covers that combination, so
   it was a latent second symptom of the same cause rather than one of the six
   failures.

Confirmation of the mechanism before writing the fix: with the adapter source
untouched, aliasing the legacy keys onto the new field before the resume run
(`context["tool_results"] = pte.completed_tool_results`) makes the same scenario
put the client's real answer `{"approved": true}` into the messages handed to the
model. Nothing else changed.

### The fix

A new `interrupt_checkpoint` module is the single place that knows both shapes. It
prefers `pending_tool_execution` when the installed release has it and is carrying
something, and falls back to the legacy `context` keys otherwise. It hands back the
live results list rather than a copy, because correcting in place is how the answer
reaches the batch Strands replays. `reconcile_frontend_tool_results` republishes a
batch it actually rewrote through `set_pending_tool_results`, which is what makes a
correction survive into the next process; without the version bump the session
manager never writes it back. `parked_batch_tool_names` now distinguishes "no batch
parked" from "batch I cannot read", so its `EXEMPT_EVERY_TEMPLATE_TOOL` behaviour
and both warnings are unchanged.

Live check after the fix, on 1.55.0: `active_proxy_placeholder_ids` returns
`{'native-approve'}`, the "corrected nothing" warning is gone, and the model
receives `{"approved": true}`.

## Failure 2: the propagation suite could not synthesise a value for `context_manager`

`tests/test_template_agent_propagation.py::test_template_param_round_trips[context_manager]`
and `::test_template_param_reaches_thread_agent_kwargs[context_manager]`, both with
"could not build a value satisfying
`'ContextManagerStrategy | ContextManager | Literal[False] | None'`".

### Upstream

The annotation changed and became a quoted forward reference:

- 1.54.0: `context_manager: Literal['auto', 'agentic'] | None = None`, a real object
  at runtime and a `Literal`, which `_synthesize` already handled
- 1.55.0: `context_manager: 'ContextManagerStrategy | ContextManager | Literal[False] | None' = None`,
  a plain `str` at runtime, because those names are imported under `TYPE_CHECKING`

The suite resolves annotations with `typing.get_type_hints(Agent.__init__)`, which
raises `NameError: name 'ToolProvider' is not defined` on every release we test
against, 1.18.0 and 1.54.0 included. It warns and falls back to raw annotations. On
1.55.0 `context_manager` is the only forwardable parameter whose raw annotation is a
string, so it is the only one that reaches `_synthesize` unresolved.

### Ours

`_synthesize` had no branch for a string. It now resolves one against the declaring
module's globals plus the names that module imports under `if TYPE_CHECKING:`,
discovered by parsing that module's AST rather than hardcoded. A resolution failure
still fails loudly, naming the expression and the namespace it was tried against.
No skip was added; the suite's own rule is that it never skips.

### On whether the adapter carries `context_manager` through the per-thread rebuild

It does not, and it says so. Measured on 1.55.0:

- a built `Agent` stores no trace of the value: none of `context_manager`,
  `_context_manager`, `_default_context_manager` or `_context_manager_registry`
  exists on the instance. It is a facade that `_resolve_context_manager` turns into
  a `conversation_manager`, injected tools, a `ContextOffloader` plugin and a
  token-usage middleware, and the facade value itself is discarded
- `_extract_agent_kwargs` therefore reports it in `unreadable`, and the adapter
  warns on the first per-thread build, pointing at
  `StrandsAgentConfig.thread_agent_kwargs`. It emitted the same warning on 1.54.0
- with `context_manager="agentic"` on the template, the per-thread agent gets the
  injected tools and the conversation manager, both of which arrive through
  parameters the adapter can read, but loses the `ContextOffloader` plugin and one
  middleware handler (template 2, thread 1)
- `thread_agent_kwargs=lambda i: {"context_manager": "agentic"}` produces a
  per-thread agent with the offloader plugin and both middleware handlers present,
  so the documented remedy works

Reconstructing the facade value by guessing it back from a
`SummarizingConversationManager` plus three injected tools would be inventing a
workaround, and could not tell `"auto"` from a hand-built equivalent. So it stays
reported-unreadable, which meets the suite's own bar: a setting either reaches the
per-thread agent or the adapter accounts for it by name. After the fix,
`test_template_param_round_trips[context_manager]` passes by taking the
"reported unreadable" early-return branch, verified directly rather than inferred.

## Tests

New coverage lives in the existing files that fit, organised by behaviour: the
parked-checkpoint reads in `tests/test_session_reconcile.py`, and
`parked_batch_tool_names` in `tests/test_template_tool_filtering.py`. Both shapes
are driven through the shared stub in `tests/interrupt_state_stub.py`, so they run
on every supported release rather than only on the one whose internals they
describe. Covered: reader identity (correcting through it changes what
`active_proxy_placeholder_ids` then sees), placeholder detection and reconciliation
in both shapes, the version bump on publish, no bump when nothing changed, and
publish being inert on a state with no setter.

## Verification

`pyproject.toml`'s `strands-agents>=1.15.0` floor and `uv.lock` are untouched. All
three lanes were run after the change:

- newest published (`strands-agents` 1.55.0, which is what the latest lane installs
  today): `1401 passed, 1 skipped`
- locked pin (`uv sync --locked`, 1.18.0): `1383 passed, 1 skipped`
- declared floor (1.15.0): `1380 passed, 4 skipped`

Baseline at the locked pin before this change was `1370 passed, 1 skipped`; the
difference is the new tests.
