### PR TITLE
fix(go): bound the SSE frame and line the reader will hold

### DIFF
--- a/sdks/community/go/pkg/client/sse/client.go
+++ b/sdks/community/go/pkg/client/sse/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// DefaultMaxFrameBytes is the default cap on what a single SSE frame may hold
+// while the reader waits for the blank line that dispatches it, and on the
+// length of a single line within that frame.
+//
+// Mirrors the Dart SDK's kSseDefaultMaxDataCodeUnits (8 MiB) so the community
+// SDKs bound an unterminated stream at the same point. Dart counts UTF-16 code
+// units; this counts bytes, so the two admit slightly different amounts of
+// non-ASCII text. Override it per client via Config.MaxFrameBytes when a
+// use-case legitimately needs larger payloads.
+const DefaultMaxFrameBytes = 8 * 1024 * 1024
+
 type Config struct {
 	Endpoint       string
 	APIKey         string
@@ -23,7 +35,10 @@ type Config struct {
 	ConnectTimeout time.Duration
 	ReadTimeout    time.Duration
 	BufferSize     int
-	Logger         *logrus.Logger
+	// MaxFrameBytes caps the bytes a single frame may accumulate, and the
+	// length of a single line. Zero selects DefaultMaxFrameBytes.
+	MaxFrameBytes int
+	Logger        *logrus.Logger
 }
 
 type Client struct {
@@ -58,6 +73,12 @@ func NewClient(config Config) *Client {
 
 	if config.BufferSize == 0 {
 		config.BufferSize = 100
+	}
+
+	// A negative cap would refuse every frame, so it falls back here too rather
+	// than reaching the reader.
+	if config.MaxFrameBytes <= 0 {
+		config.MaxFrameBytes = DefaultMaxFrameBytes
 	}
 
 	transport := &http.Transport{
@@ -178,6 +199,40 @@ func (c *Client) stream(opts StreamOptions) (<-chan Frame, <-chan error, error) 
 	return frames, errors, nil
 }
 
+// errLineTooLong reports that a single line grew past the line budget derived
+// from Config.MaxFrameBytes.
+var errLineTooLong = stderrors.New("SSE line exceeded the maximum frame size")
+
+// isLineTooLong exists as a function because readStream names its error channel
+// "errors", which shadows the package of the same name.
+func isLineTooLong(err error) bool {
+	return stderrors.Is(err, errLineTooLong)
+}
+
+// readLine reads one line, its trailing delimiter included, and refuses to hold
+// more than limit bytes.
+//
+// bufio.Reader.ReadBytes grows a buffer until it finds the delimiter, so a peer
+// that never sends one grows it for as long as the connection lasts. ReadSlice
+// returns bufio.ErrBufferFull rather than growing, which gives this loop
+// somewhere to check the running total before appending.
+func readLine(reader *bufio.Reader, limit int) ([]byte, error) {
+	var line []byte
+	for {
+		chunk, err := reader.ReadSlice('\n')
+		if len(line)+len(chunk) > limit {
+			return nil, errLineTooLong
+		}
+		// ReadSlice hands back the reader's own buffer, so append's copy is what
+		// keeps the bytes valid across iterations.
+		line = append(line, chunk...)
+		if stderrors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return line, err
+	}
+}
+
 func (c *Client) readStream(ctx context.Context, resp *http.Response, frames chan<- Frame, errors chan<- error) {
 	defer func() {
 		_ = resp.Body.Close()
@@ -189,6 +244,13 @@ func (c *Client) readStream(ctx context.Context, resp *http.Response, frames cha
 	}()
 
 	reader := bufio.NewReader(resp.Body)
+	maxFrameBytes := c.config.MaxFrameBytes
+	// The longest line the reader will hold: a "data: " line carrying a whole
+	// frame's budget, plus its terminator. A line longer than this cannot belong
+	// to a frame the accumulation cap below would accept, and a line with any
+	// other field name — "event:", "id:" — is bounded by the same figure, which
+	// is the only thing bounding it since those are not accumulated.
+	maxLineBytes := maxFrameBytes + len("data: ") + 1
 	var buffer bytes.Buffer
 	var frameCount int64
 	var byteCount int64
@@ -213,7 +275,7 @@ func (c *Client) readStream(ctx context.Context, resp *http.Response, frames cha
 
 		// Start async read
 		go func() {
-			line, err := reader.ReadBytes('\n')
+			line, err := readLine(reader, maxLineBytes)
 			select {
 			case readCh <- readResult{line: line, err: err}:
 			case <-ctx.Done():
@@ -246,6 +308,13 @@ func (c *Client) readStream(ctx context.Context, resp *http.Response, frames cha
 		}
 
 		if result.err != nil {
+			if isLineTooLong(result.err) {
+				select {
+				case errors <- fmt.Errorf("SSE line exceeded %d bytes; ending the stream", maxLineBytes):
+				case <-ctx.Done():
+				}
+				return
+			}
 			if result.err == io.EOF {
 				if c.logger != nil {
 					c.logger.WithFields(logrus.Fields{
@@ -296,7 +365,29 @@ func (c *Client) readStream(ctx context.Context, resp *http.Response, frames cha
 
 		if bytes.HasPrefix(line, []byte("data: ")) {
 			data := bytes.TrimPrefix(line, []byte("data: "))
+			separator := 0
 			if buffer.Len() > 0 {
+				separator = 1
+			}
+			if buffer.Len()+separator+len(data) > maxFrameBytes {
+				/*
+				 * Decided before the frame is dispatched, and the stream ends here
+				 * rather than resuming.
+				 *
+				 * Resetting the buffer and carrying on would forget that the reader
+				 * is part-way through a frame it refused. The lines that follow are
+				 * the tail of that frame, not a new one, so a sender could put
+				 * anything it liked past the cap and have it dispatched as an event.
+				 * No later offset is known to be a frame boundary, so there is
+				 * nothing safe to resume from.
+				 */
+				select {
+				case errors <- fmt.Errorf("SSE frame exceeded %d bytes; ending the stream", maxFrameBytes):
+				case <-ctx.Done():
+				}
+				return
+			}
+			if separator == 1 {
 				buffer.WriteByte('\n')
 			}
 			buffer.Write(data)

--- a/sdks/community/go/pkg/client/sse/client_stream_test.go
+++ b/sdks/community/go/pkg/client/sse/client_stream_test.go
@@ -750,3 +750,152 @@ func BenchmarkReadStream(b *testing.B) {
 		}
 	}
 }
+
+// holdingReader serves data and then blocks instead of reporting EOF, the way a
+// server that keeps a connection open but stops sending does. Nothing about the
+// stream tells the reader to stop, so a reader that only stops at EOF never
+// stops here.
+type holdingReader struct {
+	data    []byte
+	pos     int
+	release chan struct{}
+}
+
+func newHoldingReader(t *testing.T, data []byte) *holdingReader {
+	t.Helper()
+	r := &holdingReader{data: data, release: make(chan struct{})}
+	t.Cleanup(func() { close(r.release) })
+	return r
+}
+
+func (r *holdingReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		<-r.release
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// collectReadStream runs readStream over body and reports the frames it
+// dispatched and the error it ended with. It fails the test if readStream never
+// returns, which is what an unbounded accumulator looks like from the outside.
+func collectReadStream(t *testing.T, client *Client, body io.Reader) ([]Frame, error) {
+	t.Helper()
+
+	resp := &http.Response{Body: io.NopCloser(body)}
+	frames := make(chan Frame, 16)
+	errCh := make(chan error, 1)
+
+	go client.readStream(context.Background(), resp, frames, errCh)
+
+	var collected []Frame
+	deadline := time.After(10 * time.Second)
+loop:
+	for {
+		select {
+		case frame, ok := <-frames:
+			if !ok {
+				break loop
+			}
+			collected = append(collected, frame)
+		case <-deadline:
+			require.FailNow(t, "readStream never returned; the reader is still accumulating")
+		}
+	}
+
+	var err error
+	select {
+	case err = <-errCh:
+	default:
+	}
+	return collected, err
+}
+
+// dataLines returns count `data:` lines of payload bytes each, with no blank
+// line, so they accumulate into one frame that is never dispatched.
+func dataLines(count, payload int) []byte {
+	var b bytes.Buffer
+	for i := 0; i < count; i++ {
+		b.WriteString("data: ")
+		b.Write(bytes.Repeat([]byte("x"), payload))
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+func TestReadStreamBounds(t *testing.T) {
+	const cap = 4096
+
+	newCappedClient := func() *Client {
+		return NewClient(Config{MaxFrameBytes: cap, BufferSize: 16})
+	}
+
+	t.Run("refuses a line that never ends", func(t *testing.T) {
+		// No delimiter anywhere. bufio.Reader.ReadBytes grows its buffer until it
+		// finds one, so before the per-line limit this read never returned.
+		body := newHoldingReader(t, append([]byte("data: "), bytes.Repeat([]byte("x"), 8*cap)...))
+
+		frames, err := collectReadStream(t, newCappedClient(), body)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded")
+		assert.Empty(t, frames, "an unterminated line must not be dispatched")
+	})
+
+	t.Run("refuses a frame accumulated across many lines", func(t *testing.T) {
+		// Every line is well under the per-line limit, so only a cap on the
+		// accumulated frame stops this one.
+		body := newHoldingReader(t, dataLines(200, 100))
+
+		frames, err := collectReadStream(t, newCappedClient(), body)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded")
+		assert.Empty(t, frames, "a frame over the cap must not be dispatched")
+	})
+
+	t.Run("dispatches nothing after an overflow", func(t *testing.T) {
+		/*
+		 * There is no offset after a refused frame that is known to be a frame
+		 * boundary. Resetting the buffer and carrying on reads the tail of the
+		 * refused frame as a frame of its own, which lets a sender put anything it
+		 * likes past the cap and have it dispatched.
+		 */
+		var body bytes.Buffer
+		body.WriteString("data: good\n\n")
+		body.Write(dataLines(200, 100))
+		body.WriteString("\n")
+		body.WriteString("data: forged\n\n")
+
+		frames, err := collectReadStream(t, newCappedClient(), newHoldingReader(t, body.Bytes()))
+
+		require.Error(t, err)
+		require.Len(t, frames, 1, "only the frame that completed before the overflow may be dispatched")
+		assert.Equal(t, "good", string(frames[0].Data))
+	})
+
+	t.Run("still dispatches a frame at the cap", func(t *testing.T) {
+		// The boundary is inclusive: a frame whose data is exactly MaxFrameBytes
+		// long is legitimate and has to get through.
+		payload := bytes.Repeat([]byte("y"), cap)
+		body := append(append([]byte("data: "), payload...), '\n', '\n')
+
+		frames, err := collectReadStream(t, newCappedClient(), bytes.NewReader(body))
+
+		assert.NoError(t, err)
+		require.Len(t, frames, 1)
+		assert.Equal(t, payload, frames[0].Data)
+	})
+
+	t.Run("defaults to the cap the Dart SDK uses", func(t *testing.T) {
+		// kSseDefaultMaxDataCodeUnits in sdks/community/dart/lib/src/internal/
+		// sse_constants.dart. Kept equal so the community SDKs bound an
+		// unterminated stream at the same point.
+		assert.Equal(t, 8*1024*1024, DefaultMaxFrameBytes)
+		assert.Equal(t, DefaultMaxFrameBytes, NewClient(Config{}).config.MaxFrameBytes)
+		// A negative cap would otherwise reach the reader and refuse every frame.
+		assert.Equal(t, DefaultMaxFrameBytes, NewClient(Config{MaxFrameBytes: -1}).config.MaxFrameBytes)
+	})
+}


### PR DESCRIPTION
Fixes #2438

The Go SSE reader now refuses a frame, or a single line, larger than a configurable cap, and ends the stream when one arrives.

@ez-lbz's report is accurate on both paths. `pkg/client/sse/client.go:192` declared `var buffer bytes.Buffer` and only reset it when a blank line dispatched a frame, so a peer that sends `data:` lines and never a blank line grew it for the life of the connection. `:216` called `reader.ReadBytes('\n')`, and `bufio.Reader.ReadBytes` grows its own buffer until it finds the delimiter — so a peer that never sends one grew that too, and the read never returned.

Their note that this SDK has no CRLF defect also holds: `bytes.TrimSuffix(line, []byte("\r"))` already strips CR, so this is bounds only.

## The fix

`readLine` replaces `ReadBytes`. It loops `ReadSlice('\n')`, which returns `bufio.ErrBufferFull` rather than growing, which is what gives the loop somewhere to check the running total before appending. The frame guard runs before `buffer.Write(data)`.

Two decisions match the sibling fixes in #2500 (Rust) and #2502 (Kotlin), so the community SDKs behave the same way under the same attack:

- **The cap is decided before the frame is dispatched, and on overflow the stream ends rather than resynchronizing.** The reader is part-way through a frame it refused; the lines that follow are that frame's tail, not a new frame. Resetting the buffer and continuing would let a sender place anything it liked past the cap and have it dispatched as a legitimate event, and no later offset is known to be a frame boundary.
- **The per-line budget is derived from the frame cap** (`maxFrameBytes + len("data: ") + 1`) rather than being an independent number. A flat cap on the line rejected a legitimate frame sitting exactly at the frame cap, since the line also carries its field prefix and terminator. Derived this way, the line guard can never fire before the frame guard for a `data:` line, while remaining the only bound on an `event:` or `id:` line.

`DefaultMaxFrameBytes` is 8 MiB, mirroring the Dart SDK's `kSseDefaultMaxDataCodeUnits` so the community SDKs bound an unterminated stream at the same point, and overridable per client through `Config.MaxFrameBytes`. Dart counts UTF-16 code units and this counts bytes, so the two admit slightly different amounts of non-ASCII text; the doc comment says so. A zero or negative value falls back to the default rather than reaching the reader, where a negative cap would refuse every frame.

## Tests

`TestReadStreamBounds` in `client_stream_test.go`, five subtests at `MaxFrameBytes: 4096` so they run in milliseconds. The assertions rest on a `holdingReader` that serves its bytes and then blocks instead of returning EOF — a server that holds the connection open and stops sending. Nothing in that stream tells the reader to stop, so a reader that only stops at EOF never stops, which is what makes "the reader stops rather than growing" a real assertion rather than an artefact of a finite fixture. A helper fails the test if `readStream` never returns.

- refuses a line that never ends: no delimiter anywhere, error naming the cap, zero frames
- refuses a frame accumulated across many lines: 200 lines of 100 bytes, each far under the line cap
- dispatches nothing after an overflow: `data: good\n\n` then overflowing lines then `data: forged\n\n` yields exactly one frame, `"good"` — the frame that legitimately completed is still delivered, and nothing past the cap is
- still dispatches a frame at the cap: the boundary is inclusive, so the guards are not over-eager
- defaults to the cap the Dart SDK uses, with zero and negative values both resolving to it

Before the fix, the three bounds subtests fail with `readStream never returned; the reader is still accumulating`.

Mutations run, all killed: removing the line check (hangs to the deadline), removing the frame guard, `buffer.Reset(); continue` instead of ending the stream (the forged tail gets dispatched), the frame boundary `>` → `>=`, and `<= 0` → `== 0` in `NewClient`.

## Verification

`.github/workflows/unit-go-sdk.yml` pins `go-version: "1.24.4"`, matching `go 1.24.4` in `go.mod`; run on exactly that (`go version go1.24.4 darwin/arm64`). From `sdks/community/go`:

```
go mod download
go test ./... -v
go vet ./...
gofmt -l .
```

**370 passing on this branch against 364 on base** `c358c999e`, all packages ok on both. `go vet` reports the same 4 findings at identical lines on both sides (`client_stream_test.go` cancel-function warnings, which sit after my additions so the line numbers are unchanged), and `gofmt -l` lists the same 5 pre-existing files on both. Neither is currently gating — the CI lane runs only `go test`.

- [x] Failing tests written and confirmed failing before the fix
- [x] Fix applied, tests pass
- [x] Package suite passes on branch and base, toolchain version stated
- [x] Mutation-tested

## Two things for the codeowner

@mattsp1290, flagging these rather than deciding them:

The issue also asks for a per-`id` cap like Dart's `maxIdCodeUnits` (1024). This client never accumulates `event:` or `id:` fields — only `data:` lines reach the buffer — so they are bounded by the line budget alone. That is a real bound but looser than Dart's. Tightening it means parsing fields this client currently ignores, which is more than bounds, so it is left as a follow-up if you want parity.

The `case <-ctx.Done():` arms on the two new error sends mirror what every other send in `readStream` already does, and exist so an overflow on a cancelled context cannot block, but no test drives that race.