### PR TITLE
fix(client): retire only the interrupts a run was started to answer

### DIFF
--- a/sdks/typescript/packages/client/src/agent/agent.ts
+++ b/sdks/typescript/packages/client/src/agent/agent.ts
@@ -63,7 +63,8 @@ export abstract class AbstractAgent {
   public isRunning: boolean = false;
   /** Interrupts emitted by the most recent run that have not yet been resolved.
    *  Populated when RUN_FINISHED arrives with outcome.type === "interrupt".
-   *  Cleared when a subsequent run completes successfully. */
+   *  An entry is cleared when a run that carried a `resume` for it completes
+   *  without a further interrupt; interrupts no run has answered stay put. */
   public pendingInterrupts: Interrupt[] = [];
   private middlewares: Middleware[] = [];
   // Emits to immediately detach from the active run (stop processing its stream)

--- a/sdks/typescript/packages/client/src/apply/__tests__/default.interrupts.test.ts
+++ b/sdks/typescript/packages/client/src/apply/__tests__/default.interrupts.test.ts
@@ -1,0 +1,92 @@
+import { AbstractAgent } from "../../agent/agent";
+import {
+  BaseEvent,
+  EventType,
+  RunAgentInput,
+  RunFinishedEvent,
+  RunStartedEvent,
+} from "@ag-ui/core";
+import { Observable, of } from "rxjs";
+
+class TestAgent extends AbstractAgent {
+  private events: BaseEvent[] = [];
+
+  setEvents(events: BaseEvent[]) {
+    this.events = events;
+  }
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return of(...this.events);
+  }
+}
+
+const runStarted = (runId: string): RunStartedEvent =>
+  ({ type: EventType.RUN_STARTED, threadId: "t", runId }) as RunStartedEvent;
+
+const interruptFinished = (runId: string, interruptId: string): RunFinishedEvent =>
+  ({
+    type: EventType.RUN_FINISHED,
+    threadId: "t",
+    runId,
+    outcome: { type: "interrupt", interrupts: [{ id: interruptId, reason: "tool_call" }] },
+  }) as unknown as RunFinishedEvent;
+
+const successFinished = (runId: string): RunFinishedEvent =>
+  ({ type: EventType.RUN_FINISHED, threadId: "t", runId, result: "ok" }) as RunFinishedEvent;
+
+describe("RUN_FINISHED and pendingInterrupts", () => {
+  it("keeps the interrupt pending when the same stream finishes a later run successfully", async () => {
+    // Reporter's sequence (issue #2437, part 3): the server emits an interrupt
+    // outcome and then, without the client ever resuming, starts a second run
+    // in the same stream and finishes it plainly. The interrupt gate must hold.
+    const agent = new TestAgent({ threadId: "t", initialMessages: [] });
+    agent.setEvents([
+      runStarted("run-1"),
+      interruptFinished("run-1", "int-1"),
+      runStarted("run-2"),
+      successFinished("run-2"),
+    ]);
+
+    await agent.runAgent({ runId: "run-1" });
+
+    expect(agent.pendingInterrupts.map((i) => i.id)).toEqual(["int-1"]);
+
+    // And the gate in onInitialize is still armed for the next client run.
+    await expect(agent.runAgent({ runId: "run-3" })).rejects.toThrow(
+      /pending interrupt\(s\) not addressed by resume: int-1/,
+    );
+  });
+
+  it("clears the interrupt when the run that resumed it finishes successfully", async () => {
+    const agent = new TestAgent({ threadId: "t", initialMessages: [] });
+    agent.setEvents([runStarted("run-1"), interruptFinished("run-1", "int-1")]);
+    await agent.runAgent({ runId: "run-1" });
+    expect(agent.pendingInterrupts.map((i) => i.id)).toEqual(["int-1"]);
+
+    agent.setEvents([runStarted("run-2"), successFinished("run-2")]);
+    await agent.runAgent({
+      runId: "run-2",
+      resume: [{ interruptId: "int-1", status: "resolved" }],
+    });
+
+    expect(agent.pendingInterrupts).toEqual([]);
+
+    // Gate released: a plain run is allowed again.
+    agent.setEvents([runStarted("run-3"), successFinished("run-3")]);
+    await expect(agent.runAgent({ runId: "run-3" })).resolves.toBeDefined();
+  });
+
+  it("clears the interrupt when the resume entry cancelled it", async () => {
+    const agent = new TestAgent({ threadId: "t", initialMessages: [] });
+    agent.setEvents([runStarted("run-1"), interruptFinished("run-1", "int-1")]);
+    await agent.runAgent({ runId: "run-1" });
+
+    agent.setEvents([runStarted("run-2"), successFinished("run-2")]);
+    await agent.runAgent({
+      runId: "run-2",
+      resume: [{ interruptId: "int-1", status: "cancelled" }],
+    });
+
+    expect(agent.pendingInterrupts).toEqual([]);
+  });
+});

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -1091,19 +1091,32 @@ export const defaultApplyEvents = (
           // interrupt list so consumers that hold the original event payload
           // can't mutate the agent's tracked state through array aliasing.
           if (mutation.stopPropagation !== true) {
-            agent.pendingInterrupts =
-              finishedParams.outcome === "interrupt"
-                ? finishedParams.interrupts.map((interrupt) => {
-                    if ((interrupt as { subagentRunId?: string | null }).subagentRunId !== null) {
-                      return interrupt;
-                    }
-                    const copy = { ...interrupt } as typeof interrupt & {
-                      subagentRunId?: string | null;
-                    };
-                    delete copy.subagentRunId;
-                    return copy as typeof interrupt;
-                  })
-                : [];
+            if (finishedParams.outcome === "interrupt") {
+              agent.pendingInterrupts = finishedParams.interrupts.map((interrupt) => {
+                if ((interrupt as { subagentRunId?: string | null }).subagentRunId !== null) {
+                  return interrupt;
+                }
+                const copy = { ...interrupt } as typeof interrupt & {
+                  subagentRunId?: string | null;
+                };
+                delete copy.subagentRunId;
+                return copy as typeof interrupt;
+              });
+            } else {
+              // A plain finish only retires the interrupts this run was started
+              // to answer, and `input.resume` is the client's own record of
+              // which those are. Clearing the whole list instead would let a
+              // stream that emits an interrupt outcome and then opens a second
+              // run of its own release the gate onInitialize is holding, so the
+              // next client run would go out with the interrupt unanswered.
+              // `?? []` because the reducer also runs against agents whose
+              // list was never initialized — a partial stand-in, or a clone
+              // that came back without the field.
+              const answered = new Set((input.resume ?? []).map((entry) => entry.interruptId));
+              agent.pendingInterrupts = (agent.pendingInterrupts ?? []).filter(
+                (interrupt) => !answered.has(interrupt.id),
+              );
+            }
           }
 
           return emitUpdates();


### PR DESCRIPTION
Addresses part 3 of #2437. Parts 1 and 2 are not touched here — see the bottom.

A plain `RUN_FINISHED` now retires only the interrupts the run carried a `resume` for. Interrupts no run has answered stay pending.

@ez-lbz's part 3 is accurate: `apply/default.ts:1093-1107` assigned `agent.pendingInterrupts = []` on any `RUN_FINISHED` whose outcome was not `interrupt`, which defeats the guard at `agent/agent.ts:419-434` — the one that throws `Thread has N pending interrupt(s) not addressed by resume`.

One refinement on how it is reached, because it sharpens the fix: `verify.ts:232` rejects two bare `RUN_FINISHED` in a row, so the sequence is not one run finishing twice. `verify.ts:244` permits `RUN_STARTED` after `RUN_FINISHED`, so the reachable version is two runs in one stream — the server emits an interrupt outcome, then opens and plainly finishes a second run of its own, while the client's single `RunAgentInput` covers the whole stream.

## The clearing condition

@dawNotPoi asked on the issue whether a pending interrupt should remain until an explicit client resume, and that question is what this fix answers: yes, and the client already has the record it needs to tell the difference. `RunAgentInput.resume` is `ResumeEntry[]` (`core/src/types.ts:227-234`), each entry carrying `interruptId` — the client's own statement of which interrupts it launched this run to answer. `input` is in scope in the reducer at `default.ts:135`.

So the plain-finish branch filters the pending list by those ids. Two properties make that right rather than merely narrower:

- **It is not weaker for genuine resumes.** `onInitialize` already refuses to start a run unless every pending interrupt is covered by `resume`, so on a legitimate resume the filter clears the whole list — identical to the previous behaviour.
- **A server-fabricated second run has no `resume` of its own**, so the filter removes nothing and the gate holds.

A `status: "cancelled"` resume counts as answered — filtering is by `interruptId` regardless of status, since a cancelled interrupt has been addressed and must release the gate. Covered by a test.

`agent.ts`'s doc comment said "Cleared when a subsequent run completes successfully", which was the defect restated as documentation; it now states the actual rule.

The `?? []` on the pending list is load-bearing, not defensive noise: the reducer legitimately runs against agents whose list was never initialised — partial stand-ins, and a clone that came back without the field, which `interrupts-lifecycle.test.ts:82-88` documents. The previous unconditional assignment happened to satisfy that; a filter does not.

## Tests

`sdks/typescript/packages/client/src/apply/__tests__/default.interrupts.test.ts`, three cases driving `agent.runAgent()` rather than `defaultApplyEvents` in isolation, following the pattern in the neighbouring `run-started-input.test.ts`:

1. the reporter's sequence — gate held, and the follow-up `runAgent()` still rejects with `not addressed by resume: int-1`
2. a resolved resume — clears, and a plain run is allowed again afterwards
3. a cancelled resume — clears

On base: `expected [] to deeply equal [ 'int-1' ]`.

Mutations, both against the final fix: reverting the branch to `= []` fails case 1 while cases 2 and 3 still pass, confirming they do not pin the old behaviour; deleting the clear entirely fails cases 2 and 3, so a fix that only ever held the gate would not survive either.

`npx nx run @ag-ui/client:test`: **748 passed** across 70 files, against **745** across 69 on base `c358c999e`. `npx tsc --noEmit -p tsconfig.json` exit 0. pnpm 10.33.4, node v20.19.0, vitest 4.0.18, tsc 5.8.2.

- [x] Failing test written and confirmed failing before the fix
- [x] Fix applied, tests pass
- [x] Package suite passes on branch and base, versions stated
- [x] Typecheck clean
- [x] Mutation-tested, including against over-correction

`prettier --check` flags `agent.ts`, identically on `origin/main` — the two hunks it wants are the `_debugLogger` setter and `uncovered`, neither touched here. The edited region matches prettier's output, so the file was not swept.

## Parts 1 and 2

Left alone deliberately. They are the client trusting server-asserted message roles: `TEXT_MESSAGE_START` stores the role verbatim, `prepareRunAgentInput` (`agent.ts:391-416`) replays it, and `MESSAGES_SNAPSHOT` merges entries of any role. Telling a role the client asserted from one the server did needs a message-provenance concept the protocol does not have, so it is a spec decision rather than a client patch, and it should get its own issue rather than sitting behind this.

@dawNotPoi — you offered to take both halves of this and asked for scope confirmation first, which was the right instinct and went unanswered too long; apologies for that. Your question is what settled the clearing rule above. Reviews very welcome here, and parts 1-2 are yours if you want them once the provenance question has an answer.