### PR TITLE
chore(python): add Changelog URLs to published packages

### DIFF
--- a/integrations/adk-middleware/python/pyproject.toml
+++ b/integrations/adk-middleware/python/pyproject.toml
@@ -85,6 +85,7 @@ build-backend = "uv_build"
 [project.urls]
 Homepage = "https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/adk-middleware/python"
 Issues = "https://github.com/ag-ui-protocol/ag-ui/issues"
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/CHANGELOG.md"
 
 
 [dependency-groups]

--- a/integrations/agent-spec/python/pyproject.toml
+++ b/integrations/agent-spec/python/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 ]
 authors = [{ name = "Agent Spec team" }]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [dependency-groups]
 dev = [
   "pytest>=7.4.0",

--- a/integrations/aws-strands/python/pyproject.toml
+++ b/integrations/aws-strands/python/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "strands-agents>=1.15.0",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/integrations/claude-agent-sdk/python/pyproject.toml
+++ b/integrations/claude-agent-sdk/python/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
   "pydantic>=2.0.0",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [dependency-groups]
 dev = [
   "pytest>=7.4.0",

--- a/integrations/claude-managed-agents/python/pyproject.toml
+++ b/integrations/claude-managed-agents/python/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
   "fastapi>=0.100.0",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [dependency-groups]
 dev = [
   "pytest>=7.4.0",

--- a/integrations/crew-ai/python/pyproject.toml
+++ b/integrations/crew-ai/python/pyproject.toml
@@ -80,6 +80,9 @@ dependencies = [
     "ag-ui-a2ui-toolkit>=0.0.4",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [project.optional-dependencies]
 # Opt-in: the crewai-tools package and its heavy transitive tree. The bridge
 # never imports it (see the note above, CPK-7721 review #6).

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
 [tool.uv.sources]
 ag-ui-protocol = { path = "../../../sdks/python" }
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.115.12"]
 

--- a/integrations/langroid/python/pyproject.toml
+++ b/integrations/langroid/python/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/ag-ui-protocol/ag-ui"
 Homepage = "https://github.com/ag-ui-protocol/ag-ui"
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
 
 [tool.ag-ui.scripts]
 test = "python -m unittest discover tests"

--- a/integrations/watsonx/python/pyproject.toml
+++ b/integrations/watsonx/python/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "httpx>=0.27",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.115.12"]
 

--- a/sdks/python/a2ui_toolkit/pyproject.toml
+++ b/sdks/python/a2ui_toolkit/pyproject.toml
@@ -11,6 +11,9 @@ license = "MIT"
 requires-python = ">=3.10,<3.15"
 dependencies = []
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [build-system]
 requires = ["uv_build>=0.8.0,<0.9"]
 build-backend = "uv_build"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "pydantic>=2.11.2",
 ]
 
+[project.urls]
+Changelog = "https://github.com/ag-ui-protocol/ag-ui/releases"
+
 [tool.ag-ui.scripts]
 test = "python -m unittest discover tests"
 


### PR DESCRIPTION
Adds a `Changelog` entry to `[project.urls]` for all 11 Python packages enrolled in `scripts/release/release.config.json`. Ten packages link to [GitHub Releases](https://github.com/ag-ui-protocol/ag-ui/releases); `ag_ui_adk` links to its [package changelog on `main`](https://github.com/ag-ui-protocol/ag-ui/blob/main/integrations/adk-middleware/python/CHANGELOG.md).

The links are included automatically in future builds and will appear on PyPI with each package's next release. No package versions or dependencies change.

Validation on Python 3.12:

- Parsed all 27 tracked Python manifests and confirmed the 11 changed manifests differ only by their Changelog entries.
- Built an sdist and wheel for each of the 11 packages with `uv build --no-sources`, covering uv_build, Hatchling, and setuptools. Confirmed the correct Changelog URL appears exactly once in all 22 artifacts, with package names, versions, and existing URLs preserved.
- Both link targets returned HTTP 200; `git diff --check` passed.
