### PR TITLE
fix(a2ui-middleware): keep action identities stable across retries

### DIFF
--- a/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
+++ b/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
@@ -189,41 +189,53 @@ describe("A2UIMiddleware", () => {
       expect(toolMsg.content).toContain("restaurant-card");
     });
 
-    it("keeps action identities on retry and gives an identical new click new identities", async () => {
-      const agent = new MockAgent([
-        { type: EventType.RUN_STARTED, runId: "test", threadId: "test" },
-        { type: EventType.RUN_FINISHED, runId: "test", threadId: "test" },
-      ]);
-      const input = createRunAgentInput({
-        runId: "click-1",
-        forwardedProps: {
-          a2uiAction: {
-            userAction: {
-              name: "approve",
-              surfaceId: "form",
-              sourceComponentId: "submit",
-              context: {},
+    it.each([
+      { name: "short", runId: "click-1" },
+      { name: "256-byte ASCII", runId: "a".repeat(256) },
+      { name: "256-byte Unicode", runId: "😀".repeat(64) },
+    ])(
+      "keeps bounded action identities on retry of a $name run ID",
+      async ({ runId }) => {
+        const agent = new MockAgent([
+          { type: EventType.RUN_STARTED, runId: "test", threadId: "test" },
+          { type: EventType.RUN_FINISHED, runId: "test", threadId: "test" },
+        ]);
+        const input = createRunAgentInput({
+          runId,
+          forwardedProps: {
+            a2uiAction: {
+              userAction: {
+                name: "approve",
+                surfaceId: "form",
+                sourceComponentId: "submit",
+                context: {},
+              },
             },
           },
-        },
-      });
-      await collectEvents(new A2UIMiddleware().run(input, agent));
-      await collectEvents(new A2UIMiddleware().run(input, agent));
-      await collectEvents(
-        new A2UIMiddleware().run({ ...input, runId: "click-2" }, agent),
-      );
-      expect(agent.runCalls[1].messages).toEqual(agent.runCalls[0].messages);
-      const firstIds = agent.runCalls[0].messages.map((message) => message.id);
-      expect(
-        agent.runCalls[2].messages.every(
-          (message) => !firstIds.includes(message.id),
-        ),
-      ).toBe(true);
-      const first = agent.runCalls[0].messages[0] as AssistantMessage;
-      const next = agent.runCalls[2].messages[0] as AssistantMessage;
-      expect(next.toolCalls![0].id).not.toBe(first.toolCalls![0].id);
-      expect(input.messages).toEqual([]);
-    });
+        });
+        await collectEvents(new A2UIMiddleware().run(input, agent));
+        await collectEvents(new A2UIMiddleware().run(input, agent));
+        await collectEvents(
+          new A2UIMiddleware().run({ ...input, runId: "click-2" }, agent),
+        );
+        expect(agent.runCalls[1].messages).toEqual(agent.runCalls[0].messages);
+        const firstIds = agent.runCalls[0].messages.map((message) => message.id);
+        expect(
+          agent.runCalls[2].messages.every(
+            (message) => !firstIds.includes(message.id),
+          ),
+        ).toBe(true);
+        const first = agent.runCalls[0].messages[0] as AssistantMessage;
+        const next = agent.runCalls[2].messages[0] as AssistantMessage;
+        expect(next.toolCalls![0].id).not.toBe(first.toolCalls![0].id);
+        const identities = [...firstIds, first.toolCalls![0].id];
+        expect(new Set(identities).size).toBe(3);
+        for (const identity of identities) {
+          expect(Buffer.byteLength(identity, "utf8")).toBeLessThan(128);
+        }
+        expect(input.messages).toEqual([]);
+      },
+    );
 
     it("should not modify messages when no user action present", async () => {
       const middleware = new A2UIMiddleware();

--- a/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
+++ b/middlewares/a2ui-middleware/__tests__/a2ui-middleware.test.ts
@@ -189,6 +189,42 @@ describe("A2UIMiddleware", () => {
       expect(toolMsg.content).toContain("restaurant-card");
     });
 
+    it("keeps action identities on retry and gives an identical new click new identities", async () => {
+      const agent = new MockAgent([
+        { type: EventType.RUN_STARTED, runId: "test", threadId: "test" },
+        { type: EventType.RUN_FINISHED, runId: "test", threadId: "test" },
+      ]);
+      const input = createRunAgentInput({
+        runId: "click-1",
+        forwardedProps: {
+          a2uiAction: {
+            userAction: {
+              name: "approve",
+              surfaceId: "form",
+              sourceComponentId: "submit",
+              context: {},
+            },
+          },
+        },
+      });
+      await collectEvents(new A2UIMiddleware().run(input, agent));
+      await collectEvents(new A2UIMiddleware().run(input, agent));
+      await collectEvents(
+        new A2UIMiddleware().run({ ...input, runId: "click-2" }, agent),
+      );
+      expect(agent.runCalls[1].messages).toEqual(agent.runCalls[0].messages);
+      const firstIds = agent.runCalls[0].messages.map((message) => message.id);
+      expect(
+        agent.runCalls[2].messages.every(
+          (message) => !firstIds.includes(message.id),
+        ),
+      ).toBe(true);
+      const first = agent.runCalls[0].messages[0] as AssistantMessage;
+      const next = agent.runCalls[2].messages[0] as AssistantMessage;
+      expect(next.toolCalls![0].id).not.toBe(first.toolCalls![0].id);
+      expect(input.messages).toEqual([]);
+    });
+
     it("should not modify messages when no user action present", async () => {
       const middleware = new A2UIMiddleware();
       const mockAgent = new MockAgent([

--- a/middlewares/a2ui-middleware/src/index.ts
+++ b/middlewares/a2ui-middleware/src/index.ts
@@ -257,10 +257,11 @@ export class A2UIMiddleware extends Middleware {
       return input;
     }
 
-    // Generate IDs for the synthetic messages
-    const assistantMessageId = randomUUID();
-    const toolCallId = randomUUID();
-    const toolMessageId = randomUUID();
+    // A retry of the same run must carry the same action message identities.
+    // A new click starts a new run, even when its payload is unchanged.
+    const assistantMessageId = `a2ui-action-assistant-${input.runId}`;
+    const toolCallId = `a2ui-action-call-${input.runId}`;
+    const toolMessageId = `a2ui-action-result-${input.runId}`;
 
     // Create synthetic assistant message with tool call
     const syntheticAssistantMessage: AssistantMessage = {

--- a/middlewares/a2ui-middleware/src/index.ts
+++ b/middlewares/a2ui-middleware/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   Middleware,
   RunAgentInput,
@@ -257,11 +257,12 @@ export class A2UIMiddleware extends Middleware {
       return input;
     }
 
-    // A retry of the same run must carry the same action message identities.
+    // Hash the run identity to keep retries stable and synthetic IDs bounded.
     // A new click starts a new run, even when its payload is unchanged.
-    const assistantMessageId = `a2ui-action-assistant-${input.runId}`;
-    const toolCallId = `a2ui-action-call-${input.runId}`;
-    const toolMessageId = `a2ui-action-result-${input.runId}`;
+    const actionId = createHash("sha256").update(input.runId).digest("hex");
+    const assistantMessageId = `a2ui-action-assistant-${actionId}`;
+    const toolCallId = `a2ui-action-call-${actionId}`;
+    const toolMessageId = `a2ui-action-result-${actionId}`;
 
     // Create synthetic assistant message with tool call
     const syntheticAssistantMessage: AssistantMessage = {


### PR DESCRIPTION
Fixes #2711.

A repeated action run currently generates fresh synthetic message and Tool call IDs, so the backend cannot replay the same request. Derive the three bounded IDs from the existing runId.

Retries of one run keep their identities; a new click uses a new runId and remains distinct even with the same payload. No action DTO or additional client state is introduced.

## Validation

Node 22: middleware test, typecheck and build targets passed through Nx (101 tests). The combined history middleware passed 126 tests. Three gateway acceptance tests passed through the built client and middleware, including identical retry with a 256-byte runId and no second native turn. Focused tests cover distinct runs and bounded ASCII/Unicode identities.
