### PR TITLE
feat(agno): reconnect to and resume a background run

### DIFF
--- a/integrations/agno/typescript/README.md
+++ b/integrations/agno/typescript/README.md
@@ -19,7 +19,7 @@ import { AgnoAgent } from "@ag-ui/agno";
 
 // Create an AG-UI compatible agent
 const agent = new AgnoAgent({
-  url: "https://your-agno-server.com/agent",
+  url: "https://your-agno-server.com/agui",
   headers: { Authorization: "Bearer your-token" },
 });
 
@@ -29,8 +29,61 @@ const result = await agent.runAgent({
 });
 ```
 
+## Resumable background runs
+
+By default a run lives and dies with its HTTP connection. Set `background` and
+the server runs the agent detached from the request instead, buffering its
+events; if the connection drops, the agent reconnects to the same run and picks
+up from the last event it received. Its subscriber sees one unbroken sequence,
+however many connections it took.
+
+```ts
+const agent = new AgnoAgent({
+  url: "https://your-agno-server.com/agui",
+  background: true,
+  maxReconnectAttempts: 5, // default
+  reconnectDelayMs: 250, // default
+});
+```
+
+`maxReconnectAttempts` counts reconnects that arrive with nothing new; the
+count resets whenever an attempt delivers an event, so a long run that keeps
+losing its connection keeps going. The delay doubles between fruitless
+attempts, up to ten seconds. Once the budget is spent the observable errors, so
+handle rejection as well as the `RUN_ERROR` a server sends of its own accord.
+
+Each event of a background run carries its resume cursor under
+`metadata.agnoBackground`, and that is also how resumability is detected: when
+no cursor arrives the run streams normally on a single connection and no
+reconnect is attempted. That covers both a server too old to offer background
+runs and a server that has them but cannot apply them to this particular agent.
+The marker is stripped before the event reaches your subscriber, so it never
+becomes part of a message.
+
+Reconnecting stops when the run reaches a terminal event, when `abortRun` is
+called, and when the subscriber unsubscribes. An aborted run ends with a
+`RUN_ERROR` carrying the `abort` code followed by a close, whether the abort
+landed during a request or between two of them; the message and raw event
+differ between those two cases.
+
+A resumed connection whose events arrive without cursors cannot place them, so
+it drops them and ends the run with an error rather than reporting a result it
+had to leave pieces out of.
+
+Background execution requires a server-side database and an agent or team that
+executes in the server's own process. A server that cannot honor the request
+runs it in the foreground instead, and refuses outright if the request is
+trying to resume, since running it in the foreground would execute the whole
+run a second time.
+
+One behavior differs from a plain `HttpAgent` even against a server with no
+background support: a stream that stops part-way through a run, without a
+terminal event, is treated as a dropped connection and surfaces as an error
+rather than as a quiet close.
+
 ## Features
 
 - **HTTP connectivity** – Direct connection to Agno agent servers
 - **Multi-agent support** – Works with Agno's multi-agent system architecture
 - **Streaming responses** – Real-time communication with full AG-UI event support
+- **Resumable background runs** – Survive a dropped connection and resume from a cursor

--- a/integrations/agno/typescript/package.json
+++ b/integrations/agno/typescript/package.json
@@ -32,8 +32,8 @@
     "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
-    "@ag-ui/core": ">=0.0.37",
-    "@ag-ui/client": ">=0.0.37",
+    "@ag-ui/core": ">=0.0.59",
+    "@ag-ui/client": ">=0.0.59",
     "rxjs": "7.8.1"
   },
   "devDependencies": {

--- a/integrations/agno/typescript/src/__tests__/background-resume.test.ts
+++ b/integrations/agno/typescript/src/__tests__/background-resume.test.ts
@@ -1,0 +1,879 @@
+/**
+ * A background AgnoAgent must survive a dropped stream: it reconnects to the
+ * same run, tells the server the last cursor it saw, and hands its subscriber
+ * one unbroken sequence. Against a server that does not support background
+ * runs it must behave exactly like a plain HttpAgent.
+ *
+ * Most cases drive the whole agent through runAgent so the protocol verifier
+ * sees the stitched stream, which is the thing a client actually consumes.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { EventType, type BaseEvent, type RunAgentInput } from "@ag-ui/core";
+import { firstValueFrom, toArray } from "rxjs";
+import { AGNO_BACKGROUND_KEY, AgnoAgent } from "../index";
+
+type Cursor = { eventIndex: number; subIndex: number };
+
+interface StreamEvent {
+  event: Record<string, unknown>;
+  cursor: Cursor;
+}
+
+function marked(
+  event: Record<string, unknown>,
+  eventIndex: number,
+  subIndex = 0,
+): StreamEvent {
+  return {
+    event: {
+      ...event,
+      metadata: { [AGNO_BACKGROUND_KEY]: { eventIndex, subIndex } },
+    },
+    cursor: { eventIndex, subIndex },
+  };
+}
+
+const DELTAS = ["one ", "two ", "three ", "four ", "five"];
+
+function backgroundRun(
+  threadId: string,
+  runId: string,
+  terminal = EventType.RUN_FINISHED,
+) {
+  const events: StreamEvent[] = [
+    marked({ type: EventType.RUN_STARTED, threadId, runId }, -1),
+    marked(
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: "m1",
+        role: "assistant",
+      },
+      0,
+    ),
+  ];
+  DELTAS.forEach((delta, position) => {
+    events.push(
+      marked(
+        { type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta },
+        position + 1,
+      ),
+    );
+  });
+  events.push(
+    marked(
+      { type: EventType.TEXT_MESSAGE_END, messageId: "m1" },
+      DELTAS.length + 1,
+    ),
+  );
+  events.push(
+    terminal === EventType.RUN_FINISHED
+      ? marked(
+          { type: EventType.RUN_FINISHED, threadId, runId },
+          DELTAS.length + 2,
+        )
+      : marked(
+          { type: EventType.RUN_ERROR, message: "the run failed" },
+          DELTAS.length + 2,
+        ),
+  );
+  return events;
+}
+
+function sseBody(events: StreamEvent[]): string {
+  return events
+    .map(({ event }) => `data: ${JSON.stringify(event)}\n\n`)
+    .join("");
+}
+
+function sseResponse(events: StreamEvent[]): Response {
+  return new Response(sseBody(events), {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function requestedCursor(input: RunAgentInput): Cursor | undefined {
+  const props = (input.forwardedProps as Record<string, any> | undefined)?.[
+    AGNO_BACKGROUND_KEY
+  ];
+  if (props?.lastEventIndex === undefined) return undefined;
+  return { eventIndex: props.lastEventIndex, subIndex: props.lastSubIndex };
+}
+
+function after(
+  events: StreamEvent[],
+  cursor: Cursor | undefined,
+): StreamEvent[] {
+  if (cursor === undefined) return events;
+  return events.filter(
+    ({ cursor: c }) =>
+      c.eventIndex > cursor.eventIndex ||
+      (c.eventIndex === cursor.eventIndex && c.subIndex > cursor.subIndex),
+  );
+}
+
+/**
+ * A server that truncates each response after `perAttempt` events until the
+ * run has been served `dropCount` times, then serves the remainder.
+ */
+function createResumingServer(
+  perAttempt: number,
+  dropCount = 1,
+  terminal = EventType.RUN_FINISHED,
+) {
+  const requests: RunAgentInput[] = [];
+  let served = 0;
+  const fetch = async (_url: string, requestInit: RequestInit) => {
+    const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+    requests.push(input);
+    const remaining = after(
+      backgroundRun(input.threadId, input.runId, terminal),
+      requestedCursor(input),
+    );
+    served += 1;
+    return sseResponse(
+      served <= dropCount ? remaining.slice(0, perAttempt) : remaining,
+    );
+  };
+  return { fetch, requests };
+}
+
+/** A server that ignores the background request entirely. */
+function createLegacyServer(truncateAfter?: number) {
+  const requests: RunAgentInput[] = [];
+  const fetch = async (_url: string, requestInit: RequestInit) => {
+    const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+    requests.push(input);
+    const plain = backgroundRun(input.threadId, input.runId).map(
+      ({ event, cursor }) => {
+        const { metadata: _metadata, ...rest } = event;
+        return { event: rest, cursor };
+      },
+    );
+    return sseResponse(
+      truncateAfter === undefined ? plain : plain.slice(0, truncateAfter),
+    );
+  };
+  return { fetch, requests };
+}
+
+function makeAgent(
+  fetch: any,
+  background: boolean,
+  overrides: Record<string, unknown> = {},
+) {
+  return new AgnoAgent({
+    url: "http://agno.invalid/agui",
+    background,
+    reconnectDelayMs: 0,
+    initialMessages: [{ id: "u1", role: "user", content: "count to five" }],
+    fetch,
+    ...overrides,
+  });
+}
+
+function inputFor(runId: string): RunAgentInput {
+  return {
+    threadId: "t1",
+    runId,
+    state: {},
+    messages: [{ id: "u1", role: "user", content: "count to five" }],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  } as RunAgentInput;
+}
+
+async function runToArray(
+  agent: AgnoAgent,
+  input: RunAgentInput,
+): Promise<BaseEvent[]> {
+  return firstValueFrom(agent.run(input).pipe(toArray()));
+}
+
+function backgroundPropsOf(input: RunAgentInput): Record<string, unknown> {
+  return (input.forwardedProps as Record<string, any>)[AGNO_BACKGROUND_KEY];
+}
+
+describe("AgnoAgent background runs", () => {
+  it("does not ask for a background run unless configured for one", async () => {
+    const server = createLegacyServer();
+    const agent = makeAgent(server.fetch, false);
+
+    await agent.runAgent();
+
+    expect(server.requests).toHaveLength(1);
+    expect(
+      (server.requests[0]!.forwardedProps as any)[AGNO_BACKGROUND_KEY],
+    ).toBeUndefined();
+  });
+
+  it("asks for a background run when configured for one", async () => {
+    const server = createResumingServer(99, 0);
+    const agent = makeAgent(server.fetch, true);
+
+    await agent.runAgent();
+
+    expect(backgroundPropsOf(server.requests[0]!)).toEqual({ enabled: true });
+  });
+
+  it("keeps a caller's own background settings when adding the cursor", async () => {
+    const server = createResumingServer(3);
+    const agent = makeAgent(server.fetch, true);
+    const input = inputFor("r1");
+    input.forwardedProps = {
+      user_id: "u9",
+      [AGNO_BACKGROUND_KEY]: { note: "kept" },
+    };
+
+    await runToArray(agent, input);
+
+    expect(server.requests[1]!.forwardedProps).toMatchObject({ user_id: "u9" });
+    expect(backgroundPropsOf(server.requests[1]!)).toEqual({
+      note: "kept",
+      enabled: true,
+      lastEventIndex: 1,
+      lastSubIndex: 0,
+    });
+  });
+
+  it("delivers one unbroken run through the whole agent pipeline", async () => {
+    const server = createResumingServer(3);
+    const agent = makeAgent(server.fetch, true);
+
+    const result = await agent.runAgent();
+
+    expect(server.requests).toHaveLength(2);
+    expect(server.requests[1]!.runId).toBe(server.requests[0]!.runId);
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("resumes from the last cursor it received", async () => {
+    const server = createResumingServer(3);
+    const agent = makeAgent(server.fetch, true);
+
+    await runToArray(agent, inputFor("r1"));
+
+    expect(backgroundPropsOf(server.requests[1]!)).toEqual({
+      enabled: true,
+      lastEventIndex: 1,
+      lastSubIndex: 0,
+    });
+  });
+
+  it("strips the resume marker before handing the event on", async () => {
+    const server = createResumingServer(3);
+    const agent = makeAgent(server.fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(
+        (event.metadata as Record<string, unknown> | undefined)?.[
+          AGNO_BACKGROUND_KEY
+        ],
+      ).toBeUndefined();
+    }
+  });
+
+  it("keeps reconnecting across more drops than its budget, because each one makes progress", async () => {
+    const server = createResumingServer(2, 8);
+    const agent = makeAgent(server.fetch, true, { maxReconnectAttempts: 2 });
+
+    const result = await agent.runAgent();
+
+    expect(server.requests.length).toBeGreaterThan(3);
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("gives up once reconnects stop making progress", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const remaining = after(
+        backgroundRun(input.threadId, input.runId),
+        requestedCursor(input),
+      );
+      served += 1;
+      // The first attempt makes progress; every reconnect after it delivers
+      // nothing, which is what the budget exists to stop.
+      return sseResponse(served === 1 ? remaining.slice(0, 3) : []);
+    };
+    const agent = makeAgent(fetch, true, { maxReconnectAttempts: 2 });
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow(
+      /the stream ended before the run finished/,
+    );
+    expect(requests).toHaveLength(4);
+  });
+
+  it("does not reconnect to a server that ignored the background request", async () => {
+    const server = createLegacyServer(3);
+    const agent = makeAgent(server.fetch, true);
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow(
+      /the stream ended before the run finished/,
+    );
+    expect(server.requests).toHaveLength(1);
+  });
+
+  it("streams a whole run from a server that ignored the background request", async () => {
+    const server = createLegacyServer();
+    const agent = makeAgent(server.fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(server.requests).toHaveLength(1);
+    expect(events[events.length - 1]!.type).toBe(EventType.RUN_FINISHED);
+  });
+
+  it("treats a server error as the end of the run", async () => {
+    const server = createResumingServer(3, 1, EventType.RUN_ERROR);
+    const agent = makeAgent(server.fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(server.requests).toHaveLength(2);
+    expect(events[events.length - 1]).toMatchObject({
+      type: EventType.RUN_ERROR,
+      message: "the run failed",
+    });
+  });
+
+  it("reconnects when the transport reports the connection was cut", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const remaining = after(
+        backgroundRun(input.threadId, input.runId),
+        requestedCursor(input),
+      );
+      served += 1;
+      if (served > 1) {
+        return sseResponse(remaining);
+      }
+      // What the client transport emits for a cancelled fetch: a RUN_ERROR
+      // carrying the abort code, then a clean close.
+      // No metadata on it: that is what marks it as the transport's own report
+      // of a lost socket rather than something the server placed.
+      const cut = {
+        type: EventType.RUN_ERROR,
+        message: "aborted",
+        code: "abort",
+      };
+      return sseResponse([
+        ...remaining.slice(0, 3),
+        { event: cut, cursor: { eventIndex: -1, subIndex: 0 } },
+      ]);
+    };
+    const agent = makeAgent(fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(requests).toHaveLength(2);
+    expect(events[events.length - 1]!.type).toBe(EventType.RUN_FINISHED);
+  });
+
+  it("drops events a server replays inclusively", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      const cursor = requestedCursor(input);
+      served += 1;
+      if (served === 1) {
+        return sseResponse(all.slice(0, 3));
+      }
+      // Inclusive of the cursor rather than after it, so the client has to
+      // recognize the overlap itself.
+      const start = all.findIndex(
+        ({ cursor: c }) =>
+          cursor !== undefined && c.eventIndex === cursor.eventIndex,
+      );
+      if (start < 0) {
+        throw new Error(
+          `no event at the requested cursor ${JSON.stringify(cursor)}`,
+        );
+      }
+      return sseResponse(all.slice(start));
+    };
+    const agent = makeAgent(fetch, true);
+
+    const result = await agent.runAgent();
+
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("ignores a cursor that would rewind the resume point", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      served += 1;
+      if (served === 1) {
+        // A stale marker arrives after a newer one.
+        return sseResponse([
+          ...all.slice(0, 4),
+          marked({ type: EventType.CUSTOM, name: "late", value: 1 }, 0),
+        ]);
+      }
+      return sseResponse(after(all, requestedCursor(input)));
+    };
+    const agent = makeAgent(fetch, true);
+
+    await runToArray(agent, inputFor("r1"));
+
+    expect(backgroundPropsOf(requests[1]!)).toMatchObject({
+      lastEventIndex: 2,
+    });
+  });
+
+  it("does not connect at all once the run is aborted", async () => {
+    const server = createResumingServer(3);
+    const agent = makeAgent(server.fetch, true);
+    agent.abortRun();
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    // The same shape a plain HttpAgent produces for an abort, so one user
+    // action does not settle differently depending on its timing.
+    expect(events).toEqual([
+      expect.objectContaining({ type: EventType.RUN_ERROR, code: "abort" }),
+    ]);
+    expect(server.requests).toHaveLength(0);
+  });
+
+  it("stops reconnecting when the run is aborted during the retry delay", async () => {
+    const server = createResumingServer(3, 99);
+    // Long enough that settling can only come from noticing the abort, not
+    // from the retry timer coming round.
+    const agent = makeAgent(server.fetch, true, { reconnectDelayMs: 5_000 });
+
+    const settled: string[] = [];
+    const seen: BaseEvent[] = [];
+    const subscription = agent.run(inputFor("r1")).subscribe({
+      next: (event) => seen.push(event),
+      error: (error: Error) => settled.push(`error: ${error.message}`),
+      complete: () => settled.push("complete"),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    agent.abortRun();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    subscription.unsubscribe();
+
+    // Settling matters as much as not reconnecting: a run that neither errors
+    // nor completes leaves its caller waiting forever.
+    expect(settled).toEqual(["complete"]);
+    expect(seen[seen.length - 1]).toMatchObject({
+      type: EventType.RUN_ERROR,
+      code: "abort",
+    });
+    expect(server.requests).toHaveLength(1);
+  });
+
+  it("does not hand the transport's dropped-connection error to its subscriber", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const remaining = after(
+        backgroundRun(input.threadId, input.runId),
+        requestedCursor(input),
+      );
+      served += 1;
+      if (served > 1) {
+        return sseResponse(remaining);
+      }
+      // No metadata on it: that is what marks it as the transport's own report
+      // of a lost socket rather than something the server placed.
+      const cut = {
+        type: EventType.RUN_ERROR,
+        message: "aborted",
+        code: "abort",
+      };
+      return sseResponse([
+        ...remaining.slice(0, 3),
+        { event: cut, cursor: { eventIndex: -1, subIndex: 0 } },
+      ]);
+    };
+    const agent = makeAgent(fetch, true);
+
+    // Through runAgent, so the protocol verifier sees the stitched stream and
+    // would reject every resumed event if the cut reached it as a run error.
+    const result = await agent.runAgent();
+
+    expect(requests).toHaveLength(2);
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("refuses rather than report a run whose events it had to drop", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      served += 1;
+      if (served === 1) {
+        return sseResponse(all.slice(0, 3));
+      }
+      // Nothing on this leg carries a cursor, so none of it can be placed.
+      // Reporting the run as finished would stand behind content that was
+      // dropped, and reconnecting would replay the same unplaceable leg
+      // forever, so the run has to stop and say so.
+      return sseResponse(
+        after(all, requestedCursor(input)).map(({ event, cursor }) => {
+          const { metadata: _metadata, ...rest } = event;
+          return { event: rest, cursor };
+        }),
+      );
+    };
+    const agent = makeAgent(fetch, true, { maxReconnectAttempts: 2 });
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow(
+      /stopped placing its events/,
+    );
+    expect(requests).toHaveLength(2);
+  });
+
+  it("drops an event a resumed leg cannot place, wherever it sits", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      served += 1;
+      if (served === 1) {
+        return sseResponse(all.slice(0, 3));
+      }
+      const unmarked = {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "m1",
+        delta: "again ",
+      };
+      // At the head of the leg, before anything stamped: the guard must not
+      // depend on having seen a cursor first.
+      return sseResponse([
+        { event: unmarked, cursor: { eventIndex: 0, subIndex: 0 } },
+        ...after(all, requestedCursor(input)),
+      ]);
+    };
+    const agent = makeAgent(fetch, true, { maxReconnectAttempts: 1 });
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow(
+      /stopped placing its events/,
+    );
+    expect(requests).toHaveLength(2);
+  });
+
+  it("keeps two runs of one agent from disturbing each other", async () => {
+    // Each run gets its own drop count, so one finishing cannot stand in for
+    // the other having been served.
+    const servedPerRun = new Map<string, number>();
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      const served = (servedPerRun.get(input.runId) ?? 0) + 1;
+      servedPerRun.set(input.runId, served);
+      const remaining = after(
+        backgroundRun(input.threadId, input.runId),
+        requestedCursor(input),
+      );
+      return sseResponse(served === 1 ? remaining.slice(0, 3) : remaining);
+    };
+    const agent = makeAgent(fetch, true, { reconnectDelayMs: 30 });
+
+    const first = firstValueFrom(agent.run(inputFor("r1")).pipe(toArray()));
+    const second = firstValueFrom(agent.run(inputFor("r2")).pipe(toArray()));
+
+    const [firstEvents, secondEvents] = await Promise.all([first, second]);
+
+    expect(servedPerRun.get("r1")).toBe(2);
+    expect(servedPerRun.get("r2")).toBe(2);
+    expect(firstEvents[firstEvents.length - 1]!.type).toBe(
+      EventType.RUN_FINISHED,
+    );
+    expect(secondEvents[secondEvents.length - 1]!.type).toBe(
+      EventType.RUN_FINISHED,
+    );
+  });
+
+  it("keeps the caller's own event metadata when it strips the marker", async () => {
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      const all = backgroundRun(input.threadId, input.runId).map(
+        ({ event, cursor }) => ({
+          event: {
+            ...event,
+            metadata: { ...(event.metadata as object), source: "server" },
+          },
+          cursor,
+        }),
+      );
+      return sseResponse(all);
+    };
+    const agent = makeAgent(fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.metadata).toEqual({ source: "server" });
+    }
+  });
+
+  it("ends an abort that lands mid attempt the same way as any other", async () => {
+    let release: (() => void) | undefined;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      const all = backgroundRun(input.threadId, input.runId);
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return sseResponse(all.slice(0, 3));
+    };
+    const agent = makeAgent(fetch, true, { reconnectDelayMs: 5 });
+
+    const settled: string[] = [];
+    const seen: BaseEvent[] = [];
+    const subscription = agent.run(inputFor("r1")).subscribe({
+      next: (event) => seen.push(event),
+      error: (error: Error) => settled.push(`error: ${error.message}`),
+      complete: () => settled.push("complete"),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    agent.abortRun();
+    release?.();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    subscription.unsubscribe();
+
+    expect(settled).toEqual(["complete"]);
+    expect(seen[seen.length - 1]).toMatchObject({
+      type: EventType.RUN_ERROR,
+      code: "abort",
+    });
+  });
+
+  it("stops reconnecting when the subscriber unsubscribes during the retry delay", async () => {
+    const server = createResumingServer(3, 99);
+    const agent = makeAgent(server.fetch, true, { reconnectDelayMs: 50 });
+
+    const subscription = agent
+      .run(inputFor("r1"))
+      .subscribe({ error: () => {} });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    subscription.unsubscribe();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    expect(server.requests).toHaveLength(1);
+  });
+
+  it("does not reconnect at all when the budget is zero", async () => {
+    const server = createResumingServer(3, 99);
+    const agent = makeAgent(server.fetch, true, { maxReconnectAttempts: 0 });
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow();
+    expect(server.requests).toHaveLength(1);
+  });
+
+  it("does not resume from the position a run ended at", async () => {
+    const requests: RunAgentInput[] = [];
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      served += 1;
+      if (served === 1) {
+        // A terminal, then a clean close, then nothing: the run ended, so the
+        // agent has no reason to reconnect and no reason to remember where the
+        // ending sat.
+        return sseResponse(all);
+      }
+      return sseResponse([]);
+    };
+    const agent = makeAgent(fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(requests).toHaveLength(1);
+    expect(events[events.length - 1]!.type).toBe(EventType.RUN_FINISHED);
+  });
+
+  it("drops nothing on a first attempt, whatever the server stamps", async () => {
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      const all = backgroundRun(input.threadId, input.runId);
+      // Two events sharing one position, which a first attempt has no grounds
+      // to call a repeat of anything.
+      return sseResponse(
+        all.map(({ event, cursor }) => ({
+          event: {
+            ...event,
+            metadata: { [AGNO_BACKGROUND_KEY]: { eventIndex: 0, subIndex: 0 } },
+          },
+          cursor,
+        })),
+      );
+    };
+    const agent = makeAgent(fetch, true);
+
+    const result = await agent.runAgent();
+
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("recovers when a later leg places what an earlier one could not", async () => {
+    let served = 0;
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      const all = backgroundRun(input.threadId, input.runId);
+      served += 1;
+      if (served === 1) {
+        return sseResponse(all.slice(0, 3));
+      }
+      if (served === 2) {
+        // One unplaceable event, then a close: this leg loses something, but
+        // the run is not over and the next leg may still deliver it.
+        const unmarked = {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "m1",
+          delta: "again ",
+        };
+        return sseResponse([
+          { event: unmarked, cursor: { eventIndex: 0, subIndex: 0 } },
+        ]);
+      }
+      return sseResponse(after(all, requestedCursor(input)));
+    };
+    const agent = makeAgent(fetch, true);
+
+    const result = await agent.runAgent();
+
+    const assistant = result.newMessages.find(
+      (message) => message.role === "assistant",
+    );
+    expect(assistant?.content).toBe(DELTAS.join(""));
+  });
+
+  it("backs off further after each attempt that gets nowhere", async () => {
+    const at: number[] = [];
+    const started = Date.now();
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      at.push(Date.now() - started);
+      const all = backgroundRun(input.threadId, input.runId);
+      return sseResponse(at.length === 1 ? all.slice(0, 3) : []);
+    };
+    const agent = makeAgent(fetch, true, {
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: 40,
+    });
+
+    await expect(runToArray(agent, inputFor("r1"))).rejects.toThrow(
+      /made no progress/,
+    );
+
+    expect(at).toHaveLength(5);
+    // Each wait doubles the one before it: roughly 40ms, 80ms, 160ms and
+    // 320ms. Compared end to end rather than step by step, so ordinary timer
+    // jitter cannot decide the result.
+    const waits = at.slice(1).map((moment, index) => moment - at[index]!);
+    expect(waits).toHaveLength(4);
+    expect(waits[3]!).toBeGreaterThan(waits[0]! * 4);
+  });
+
+  it("treats a stamped error carrying the abort code as the run's own ending", async () => {
+    const requests: RunAgentInput[] = [];
+    const fetch = async (_url: string, requestInit: RequestInit) => {
+      const input = JSON.parse(requestInit.body as string) as RunAgentInput;
+      requests.push(input);
+      const all = backgroundRun(input.threadId, input.runId);
+      // The server's own cancellation: it carries the abort code but is placed
+      // like every other event this server sends, so it is not a lost socket.
+      const cancelled = {
+        type: EventType.RUN_ERROR,
+        message: "the run was cancelled",
+        code: "abort",
+        metadata: {
+          [AGNO_BACKGROUND_KEY]: { eventIndex: 9, subIndex: 0 },
+        },
+      };
+      return sseResponse([
+        ...all.slice(0, 3),
+        { event: cancelled, cursor: { eventIndex: 9, subIndex: 0 } },
+      ]);
+    };
+    const agent = makeAgent(fetch, true);
+
+    const events = await runToArray(agent, inputFor("r1"));
+
+    expect(requests).toHaveLength(1);
+    expect(events[events.length - 1]).toMatchObject({
+      type: EventType.RUN_ERROR,
+      message: "the run was cancelled",
+    });
+  });
+
+  it("ignores a resume position the caller left in its forwarded props", async () => {
+    const server = createResumingServer(99, 0);
+    const agent = makeAgent(server.fetch, true);
+    const input = inputFor("r1");
+    input.forwardedProps = {
+      [AGNO_BACKGROUND_KEY]: {
+        enabled: false,
+        lastEventIndex: 99,
+        lastSubIndex: 4,
+        note: "kept",
+      },
+    };
+
+    await runToArray(agent, input);
+
+    expect(backgroundPropsOf(server.requests[0]!)).toEqual({
+      note: "kept",
+      enabled: true,
+    });
+  });
+
+  it("carries its background settings through a clone", () => {
+    const agent = new AgnoAgent({
+      url: "http://agno.invalid/agui",
+      background: true,
+      maxReconnectAttempts: 9,
+      reconnectDelayMs: 33,
+      fetch: vi.fn(),
+    });
+
+    const cloned = agent.clone();
+
+    expect(cloned).toBeInstanceOf(AgnoAgent);
+    expect(cloned.background).toBe(true);
+    expect(cloned.maxReconnectAttempts).toBe(9);
+    expect(cloned.reconnectDelayMs).toBe(33);
+  });
+});

--- a/integrations/agno/typescript/src/index.ts
+++ b/integrations/agno/typescript/src/index.ts
@@ -4,5 +4,464 @@
  */
 
 import { HttpAgent } from "@ag-ui/client";
+import type { HttpAgentConfig } from "@ag-ui/client";
+import { BaseEvent, EventType, RunAgentInput } from "@ag-ui/core";
+import { Observable, Subscription } from "rxjs";
 
-export class AgnoAgent extends HttpAgent {}
+/**
+ * The key a background run is requested and answered under.
+ *
+ * It appears twice: in `forwardedProps` on the way out, carrying the opt-in and
+ * the cursor to resume from, and in each event's `metadata` on the way back,
+ * carrying the cursor that event was delivered at.
+ */
+export const AGNO_BACKGROUND_KEY = "agnoBackground";
+
+/** Where an event sat in a background run's stream. */
+export interface AgnoBackgroundCursor {
+  eventIndex: number;
+  subIndex: number;
+}
+
+export interface AgnoAgentConfig extends HttpAgentConfig {
+  /**
+   * Ask the server to run detached from the request that starts it.
+   *
+   * The run then survives a dropped connection, and this agent reconnects to
+   * it automatically, picking up from the last event it received. A server
+   * that does not support background runs streams normally instead and no
+   * reconnect is attempted; note that with `background` set, such a stream
+   * cut short reaches the subscriber as an error rather than a quiet close.
+   */
+  background?: boolean;
+  /**
+   * How many times to reconnect after a drop that made no progress. Resets
+   * whenever an attempt delivers an event, so a long run that keeps losing its
+   * connection keeps going. Zero disables reconnecting. Defaults to 5.
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * Delay before the first reconnect, in milliseconds. Doubles for each
+   * consecutive failure that delivers nothing, up to ten seconds. Defaults
+   * to 250.
+   */
+  reconnectDelayMs?: number;
+}
+
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
+const DEFAULT_RECONNECT_DELAY_MS = 250;
+const MAX_RECONNECT_DELAY_MS = 10_000;
+
+const TERMINAL_EVENT_TYPES: ReadonlySet<string> = new Set([
+  EventType.RUN_FINISHED,
+  EventType.RUN_ERROR,
+]);
+
+/**
+ * The client transport reports a cancelled fetch as a RUN_ERROR carrying this
+ * code rather than as a stream error. Read as-is: it is that layer's wire
+ * value, not one this package defines.
+ */
+const TRANSPORT_ABORT_CODE = "abort";
+
+function wholeNumberOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : fallback;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCursorIndex(value: unknown, floor: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= floor;
+}
+
+function readCursor(event: BaseEvent): AgnoBackgroundCursor | undefined {
+  const metadata = event.metadata as Record<string, unknown> | undefined;
+  const marker = metadata?.[AGNO_BACKGROUND_KEY];
+  if (!isPlainObject(marker)) {
+    return undefined;
+  }
+  const { eventIndex, subIndex } = marker;
+  // The events a run emits before its first buffered one sit at index -1, so
+  // that is the floor there. A position within one event starts at zero.
+  if (!isCursorIndex(eventIndex, -1) || !isCursorIndex(subIndex, 0)) {
+    return undefined;
+  }
+  return { eventIndex, subIndex };
+}
+
+function isAfter(
+  candidate: AgnoBackgroundCursor,
+  held: AgnoBackgroundCursor,
+): boolean {
+  return (
+    candidate.eventIndex > held.eventIndex ||
+    (candidate.eventIndex === held.eventIndex &&
+      candidate.subIndex > held.subIndex)
+  );
+}
+
+/**
+ * Hand the event onward without the resume marker.
+ *
+ * The marker is transport bookkeeping. Left in place it is folded into the
+ * message the event builds and posted back to the server on the next request.
+ */
+function withoutMarker(event: BaseEvent): BaseEvent {
+  const metadata = event.metadata as Record<string, unknown> | undefined | null;
+  if (!isPlainObject(metadata) || !(AGNO_BACKGROUND_KEY in metadata)) {
+    return event;
+  }
+  const { [AGNO_BACKGROUND_KEY]: _marker, ...rest } = metadata;
+  const { metadata: _replaced, ...withoutMetadata } = event;
+  return Object.keys(rest).length > 0
+    ? { ...withoutMetadata, metadata: rest }
+    : (withoutMetadata as BaseEvent);
+}
+
+function withBackgroundProps(
+  input: RunAgentInput,
+  cursor: AgnoBackgroundCursor | undefined,
+): RunAgentInput {
+  const request: Record<string, unknown> = { enabled: true };
+  if (cursor !== undefined) {
+    request.lastEventIndex = cursor.eventIndex;
+    request.lastSubIndex = cursor.subIndex;
+  }
+  const forwardedProps = isPlainObject(input.forwardedProps)
+    ? input.forwardedProps
+    : {};
+  const caller = forwardedProps[AGNO_BACKGROUND_KEY];
+  // A caller's own keys are kept, but every field this agent owns is replaced,
+  // including the resume position: leaving a stale one in place would silently
+  // decide where a first connection starts reading.
+  const carried = isPlainObject(caller) ? { ...caller } : {};
+  delete carried.enabled;
+  delete carried.lastEventIndex;
+  delete carried.lastSubIndex;
+  return {
+    ...input,
+    forwardedProps: {
+      ...forwardedProps,
+      [AGNO_BACKGROUND_KEY]: { ...carried, ...request },
+    },
+  };
+}
+
+/**
+ * Whether an event is the transport reporting a cut connection rather than the
+ * server reporting a failed run.
+ *
+ * The client transport turns a cancelled fetch into a RUN_ERROR carrying the
+ * abort code and then completes. An abort the caller asked for is a real end
+ * to the run; anything else is the connection going away mid-run.
+ */
+function isDroppedConnection(
+  event: BaseEvent,
+  aborted: boolean,
+  resumable: boolean,
+): boolean {
+  if (event.type !== EventType.RUN_ERROR || aborted || !resumable) {
+    return false;
+  }
+  if ((event as { code?: unknown }).code !== TRANSPORT_ABORT_CODE) {
+    return false;
+  }
+  // A server that places its events places this one too, so an unplaced one on
+  // a run that has been getting cursors was made up locally. On a run that has
+  // never seen a cursor the server is not placing anything, and its own error
+  // is the only account of what happened.
+  return readCursor(event) === undefined;
+}
+
+export class AgnoAgent extends HttpAgent {
+  public background: boolean;
+  public maxReconnectAttempts: number;
+  public reconnectDelayMs: number;
+
+  constructor(config: AgnoAgentConfig) {
+    super(config);
+    this.background = config.background ?? false;
+    this.maxReconnectAttempts =
+      config.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    this.reconnectDelayMs =
+      config.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    if (!this.background) {
+      return super.run(input);
+    }
+
+    return new Observable<BaseEvent>((subscriber) => {
+      // The base class swaps its abort controller on each runAgent and reads
+      // the current one when it builds a request, so the current one is read
+      // here too rather than captured. Everything else below belongs to this
+      // subscription alone.
+      const aborted = () => this.abortController.signal.aborted;
+      const attempts = new Subscription();
+      const log = this.debugLogger;
+
+      let cursor: AgnoBackgroundCursor | undefined;
+      // Only a server that answered with a cursor can be reconnected to. Until
+      // one arrives, a dropped stream is indistinguishable from a server that
+      // ignored the request, and reconnecting to such a server would start the
+      // whole run a second time.
+      let resumable = false;
+      let closed = false;
+      let failures = 0;
+      let attemptCount = 0;
+      let deliveredThisAttempt = false;
+      let droppedUnplaceable = false;
+      let retryTimer: ReturnType<typeof setTimeout> | undefined;
+      let cancelWait: (() => void) | undefined;
+
+      const stopWaiting = () => {
+        if (retryTimer !== undefined) {
+          clearTimeout(retryTimer);
+          retryTimer = undefined;
+        }
+        cancelWait?.();
+        cancelWait = undefined;
+      };
+
+      const stop = () => {
+        closed = true;
+        stopWaiting();
+      };
+
+      const finish = () => {
+        stop();
+        subscriber.complete();
+      };
+
+      const giveUp = (reason: string, cause?: unknown) => {
+        stop();
+        subscriber.error(
+          new Error(`Agno background run ${input.runId} stopped: ${reason}`, {
+            cause,
+          }),
+        );
+      };
+
+      /**
+       * End an aborted run the way a plain HttpAgent does.
+       *
+       * An abort landing during a live attempt reaches the subscriber as the
+       * transport's own RUN_ERROR followed by a close. One landing between
+       * attempts has no live stream to produce that, so a matching event is
+       * produced here rather than letting the same user action settle two
+       * different ways. It carries the same type and code; the message and the
+       * raw event are this package's own.
+       */
+      const endAsAborted = () => {
+        stop();
+        subscriber.next({
+          type: EventType.RUN_ERROR,
+          message: "Request aborted",
+          code: TRANSPORT_ABORT_CODE,
+          rawEvent: { reason: "aborted between attempts" },
+        } as BaseEvent);
+        subscriber.complete();
+      };
+
+      const endOfAttempt = (reason: string, cause?: unknown) => {
+        if (closed) {
+          return;
+        }
+        if (aborted()) {
+          endAsAborted();
+          return;
+        }
+        if (!resumable) {
+          // Without a cursor there is no telling a server that never offered
+          // background runs from one that did, and reconnecting to the former
+          // would run the whole thing a second time.
+          giveUp(
+            `${reason}, and the server sent no resume cursor to reconnect with`,
+            cause,
+          );
+          return;
+        }
+        // An attempt that delivered events made progress, so it does not count
+        // against a budget meant to stop a connection that gets nowhere.
+        failures = deliveredThisAttempt ? 0 : failures + 1;
+        if (
+          this.maxReconnectAttempts <= 0 ||
+          failures > this.maxReconnectAttempts
+        ) {
+          giveUp(
+            `${reason}, and ${this.maxReconnectAttempts} reconnect attempts made no progress`,
+          );
+          return;
+        }
+        // Doubling from the base on every consecutive attempt that gets
+        // nowhere, so each wait is longer than the one before it.
+        const delay = Math.min(
+          this.reconnectDelayMs * 2 ** failures,
+          MAX_RECONNECT_DELAY_MS,
+        );
+        log?.lifecycle(
+          "AGNO",
+          `Reconnecting to background run ${input.runId} in ${delay}ms: ${reason}`,
+        );
+        // A live attempt reports an abort through the transport, but one
+        // landing in this wait has nothing to end the run, so the controller
+        // that is current now is watched until the wait is over. A run started
+        // after this one replaces that controller, in which case the abort is
+        // noticed when the timer comes round instead.
+        const waiting = this.abortController.signal;
+        const onAbort = () => {
+          stopWaiting();
+          endAsAborted();
+        };
+        waiting.addEventListener("abort", onAbort, { once: true });
+        cancelWait = () => waiting.removeEventListener("abort", onAbort);
+        retryTimer = setTimeout(() => {
+          stopWaiting();
+          try {
+            attach();
+          } catch (error) {
+            giveUp(error instanceof Error ? error.message : String(error));
+          }
+        }, delay);
+      };
+
+      const attach = () => {
+        if (closed) {
+          return;
+        }
+        if (aborted()) {
+          endAsAborted();
+          return;
+        }
+        attemptCount += 1;
+        const isFirstAttempt = attemptCount === 1;
+        deliveredThisAttempt = false;
+        // Reset per attempt: the cursor never moves past an event that could
+        // not be placed, so the next leg replays from before it and can still
+        // deliver what this one had to drop.
+        droppedUnplaceable = false;
+        // Added to the parent subscription rather than held in a variable: a
+        // synchronous emission that unsubscribes tears the parent down, and a
+        // child added to a torn-down parent is unsubscribed on the spot. That
+        // stops this agent listening; whether the request itself is cancelled
+        // is the transport's business, and today it is not.
+        attempts.add(
+          super.run(withBackgroundProps(input, cursor)).subscribe({
+            next: (event) => {
+              if (closed) {
+                return;
+              }
+              if (isDroppedConnection(event, aborted(), resumable)) {
+                // Not part of the run, so it must not reach the subscriber: the
+                // run verifier would latch it as a failure and reject every
+                // event the reconnect goes on to deliver.
+                log?.lifecycle(
+                  "AGNO",
+                  `Background run ${input.runId} lost its connection`,
+                );
+                return;
+              }
+              // A terminal is how the run ends, so neither guard below may
+              // drop one: a dropped terminal leaves the run reconnecting
+              // against a server that has already said its last word.
+              const terminal = TERMINAL_EVENT_TYPES.has(event.type);
+              const eventCursor = readCursor(event);
+              if (eventCursor !== undefined) {
+                resumable = true;
+                if (
+                  !terminal &&
+                  !isFirstAttempt &&
+                  cursor !== undefined &&
+                  !isAfter(eventCursor, cursor)
+                ) {
+                  log?.lifecycle(
+                    "AGNO",
+                    `Dropped an already delivered event resuming background run ${input.runId}`,
+                  );
+                  // Already delivered on an earlier attempt. A server that
+                  // replays inclusively would otherwise send a second
+                  // RUN_STARTED into a run that is already open. Only from the
+                  // second attempt on: nothing was delivered before the first.
+                  return;
+                }
+                // A terminal ends the run, so its position is never somewhere
+                // to resume from, and the run's last events are the ones a
+                // server has least room to place uniquely.
+                if (
+                  !terminal &&
+                  (cursor === undefined || isAfter(eventCursor, cursor))
+                ) {
+                  cursor = eventCursor;
+                }
+              } else if (!terminal && !isFirstAttempt) {
+                // A resumed leg's event with no cursor cannot be placed, so it
+                // cannot be shown to be new. It is dropped, and the leg is
+                // remembered as having lost something so the run does not go
+                // on to report a success it cannot stand behind.
+                droppedUnplaceable = true;
+                log?.lifecycle(
+                  "AGNO",
+                  `Dropped an unplaceable event resuming background run ${input.runId}`,
+                );
+                return;
+              }
+              if (terminal && droppedUnplaceable) {
+                // The server stopped placing its events part-way through this
+                // leg, so whatever it dropped is gone and this ending cannot
+                // be taken at face value.
+                giveUp(
+                  "the server stopped placing its events, so part of the run was lost",
+                  event,
+                );
+                return;
+              }
+              deliveredThisAttempt = true;
+              subscriber.next(withoutMarker(event));
+              if (terminal) {
+                // The run is over, so there is nothing to wait for the socket
+                // to say.
+                finish();
+              }
+            },
+            error: (error) =>
+              endOfAttempt(
+                error instanceof Error ? error.message : String(error),
+                error,
+              ),
+            // A stream that ends without a terminal event is a dropped
+            // connection wearing a clean close.
+            complete: () =>
+              endOfAttempt("the stream ended before the run finished"),
+          }),
+        );
+      };
+
+      try {
+        attach();
+      } catch (error) {
+        // Mirrors the retry path, so a throw here cannot escape before the
+        // teardown below exists to remove the abort listener.
+        giveUp(error instanceof Error ? error.message : String(error));
+      }
+
+      return () => {
+        stop();
+        attempts.unsubscribe();
+      };
+    });
+  }
+
+  public clone(): AgnoAgent {
+    const cloned = super.clone() as AgnoAgent;
+
+    cloned.background = this.background;
+    cloned.maxReconnectAttempts = this.maxReconnectAttempts;
+    cloned.reconnectDelayMs = this.reconnectDelayMs;
+    return cloned;
+  }
+}


### PR DESCRIPTION
## Summary

Teaches `AgnoAgent` to survive a dropped connection during a background run.

Agno's AG-UI interface is gaining opt-in background execution, where a run outlives the request that started it and every event carries a resume cursor. This is the client half: it sends the opt-in, tracks the cursor, and reconnects on its own when a stream dies before the run finishes. Until now the package was a one-line `HttpAgent` subclass with no reconnect or event-index behavior at all, so a dropped connection simply ended the run for the user.

**Behavior**

Default behavior is unchanged. Without the `background` option the agent is the plain `HttpAgent` it has always been, and no marker is added to requests.

With background enabled, the agent sends the opt-in on every attempt and records the cursor stamped on each event. If the stream ends without a terminal event, it reconnects from the last cursor it saw, discards anything at or before that position, and continues. The consumer sees one uninterrupted run. Attempts are budgeted and backed off exponentially, and the budget resets whenever an attempt makes progress, so a long run that keeps producing events is never cut short while a run that keeps failing at the same point still gives up.

A deliberate abort ends the run as an abort rather than triggering a reconnect. A server that stamps no cursors, including any Agno release predating the interface change, is detected on the first event and the run proceeds as an ordinary non-resumable stream. There is no version check anywhere in this; the capability is inferred from what arrives.

Raises the `@ag-ui/core` and `@ag-ui/client` peer floor to the first release carrying per-event metadata, which is what the cursor rides on.

## Notes

The server half ships separately in the Agno repository and on its own schedule, which is why these are two pull requests. This one is inert until an Agno release carries the interface change, and harmless in the meantime.

Reconnection here covers a dropped connection within a live page session. Resuming across a full page reload additionally requires the application to persist the run id and cursor, which is left to the application rather than assumed here.
