### PR TITLE
fix(mastra): emit TOOL_CALL triple before RESULT on resume of a suspended tool

### DIFF
--- a/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
@@ -1108,16 +1108,99 @@ describe("interrupt bridge: resume path", () => {
     expect(endAt).toBeGreaterThan(argsAt);
     expect(resultAt).toBeGreaterThan(endAt);
 
-    const start = events[startAt] as { toolCallId: string; toolCallName: string };
+    const start = events[startAt] as import("@ag-ui/client").ToolCallStartEvent;
     expect(start.toolCallId).toBe("tc-1");
     expect(start.toolCallName).toBe("process-expense");
-    const args = events[argsAt] as { toolCallId: string; delta: string };
+    const args = events[argsAt] as import("@ag-ui/client").ToolCallArgsEvent;
     expect(args.toolCallId).toBe("tc-1");
     expect(JSON.parse(args.delta)).toEqual({
       amount: 250,
       description: "team dinner",
     });
-    expect((events[resultAt] as { toolCallId: string }).toolCallId).toBe("tc-1");
+    const result = events[resultAt] as import("@ag-ui/client").ToolCallResultEvent;
+    expect(result.toolCallId).toBe("tc-1");
+  });
+
+  it("uses tool-result args on standard resume when the interrupt has none", async () => {
+    const resumeChunks = [
+      {
+        type: "tool-result",
+        payload: {
+          toolCallId: "tc-1",
+          toolName: "process-expense",
+          args: { amount: 250, description: "team dinner" },
+          result: { approved: true },
+        },
+      },
+    ];
+    const { agent: localAgent } = makeFakeLocalAgentWithResumeStream(resumeChunks);
+    const { agent: remoteAgent } =
+      makeFakeRemoteAgentWithResumeStream(resumeChunks);
+
+    const resumeInput = makeInput({
+      resume: [
+        {
+          interruptId: "original-run-id::tc-1",
+          status: "resolved",
+          payload: { approved: true },
+        },
+      ],
+    } as any);
+
+    for (const agent of [localAgent, remoteAgent]) {
+      const events = await collectEvents(agent, resumeInput);
+      const argsEvent = events.find((e) => e.type === EventType.TOOL_CALL_ARGS);
+      expect(argsEvent).toBeDefined();
+      expect(
+        JSON.parse((argsEvent as import("@ag-ui/client").ToolCallArgsEvent).delta),
+      ).toEqual({ amount: 250, description: "team dinner" });
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+    }
+  });
+
+  it("does not replay START after text-delta already flushed the buffered call", async () => {
+    const resumeChunks = [
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tc-1",
+          toolName: "process-expense",
+          args: { amount: 250 },
+        },
+      },
+      { type: "text-delta", payload: { text: "working" } },
+      {
+        type: "tool-result",
+        payload: {
+          toolCallId: "tc-1",
+          toolName: "process-expense",
+          args: { amount: 250 },
+          result: { approved: true },
+        },
+      },
+    ];
+    const { agent: localAgent } = makeFakeLocalAgentWithResumeStream(resumeChunks);
+    const { agent: remoteAgent } =
+      makeFakeRemoteAgentWithResumeStream(resumeChunks);
+
+    const resumeInput = makeInput({
+      resume: [
+        {
+          interruptId: "original-run-id::tc-1",
+          status: "resolved",
+          payload: { approved: true },
+        },
+      ],
+    } as any);
+
+    for (const agent of [localAgent, remoteAgent]) {
+      const events = await collectEvents(agent, resumeInput);
+      expect(
+        events.filter((e) => e.type === EventType.TOOL_CALL_START),
+      ).toHaveLength(1);
+    }
   });
 
   it("handles interruptEvent passed as an object (not just JSON string)", async () => {

--- a/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
+++ b/integrations/mastra/typescript/src/__tests__/interrupt-bridge.test.ts
@@ -1076,6 +1076,50 @@ describe("interrupt bridge: resume path", () => {
     expect(events[events.length - 1].type).toBe(EventType.RUN_FINISHED);
   });
 
+  it("emits TOOL_CALL_START/ARGS/END before RESULT on resume of a suspended tool", async () => {
+    // First run discarded the triple on tool-call-suspended. Resume streams
+    // only tool-result, so the adapter must introduce the id before RESULT
+    // or CopilotKit drops the orphan tool message (#2668).
+    const { agent } = makeFakeLocalAgentWithResumeStream([
+      {
+        type: "tool-result",
+        payload: { toolCallId: "tc-1", result: { approved: true } },
+      },
+    ]);
+
+    const events = await collectEvents(
+      agent,
+      makeResumeInput({
+        type: "mastra_suspend",
+        toolCallId: "tc-1",
+        toolName: "process-expense",
+        args: { amount: 250, description: "team dinner" },
+        runId: "original-run-id",
+      }),
+    );
+
+    const types = events.map((e) => e.type);
+    const startAt = types.indexOf(EventType.TOOL_CALL_START);
+    const argsAt = types.indexOf(EventType.TOOL_CALL_ARGS);
+    const endAt = types.indexOf(EventType.TOOL_CALL_END);
+    const resultAt = types.indexOf(EventType.TOOL_CALL_RESULT);
+    expect(startAt).toBeGreaterThan(-1);
+    expect(argsAt).toBeGreaterThan(startAt);
+    expect(endAt).toBeGreaterThan(argsAt);
+    expect(resultAt).toBeGreaterThan(endAt);
+
+    const start = events[startAt] as { toolCallId: string; toolCallName: string };
+    expect(start.toolCallId).toBe("tc-1");
+    expect(start.toolCallName).toBe("process-expense");
+    const args = events[argsAt] as { toolCallId: string; delta: string };
+    expect(args.toolCallId).toBe("tc-1");
+    expect(JSON.parse(args.delta)).toEqual({
+      amount: 250,
+      description: "team dinner",
+    });
+    expect((events[resultAt] as { toolCallId: string }).toolCallId).toBe("tc-1");
+  });
+
   it("handles interruptEvent passed as an object (not just JSON string)", async () => {
     const { agent, calls } = makeFakeLocalAgentWithResumeStream([]);
 

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -889,6 +889,18 @@ export class MastraAgent extends AbstractAgent {
             };
           }
 
+          const resumeReplay =
+            interruptEvent.toolCallId != null
+              ? {
+                  toolCallId: String(interruptEvent.toolCallId),
+                  toolName:
+                    typeof interruptEvent.toolName === "string"
+                      ? interruptEvent.toolName
+                      : undefined,
+                  args: interruptEvent.args,
+                }
+              : null;
+
           const callbacks = this.makeStreamCallbacks(
             subscriber,
             () => messageId,
@@ -949,6 +961,9 @@ export class MastraAgent extends AbstractAgent {
                   },
                 },
                 abortController.signal,
+                new Set(),
+                {},
+                resumeReplay,
               );
 
               // Cancelled resumes are settled by the abort listener in run();
@@ -997,12 +1012,17 @@ export class MastraAgent extends AbstractAgent {
 
               let stopped = false;
               const { handleChunk, flush, getUsage } =
-                this.createChunkProcessor({
-                  ...callbacks,
-                  onError: (error) => {
-                    subscriber.error(error);
+                this.createChunkProcessor(
+                  {
+                    ...callbacks,
+                    onError: (error) => {
+                      subscriber.error(error);
+                    },
                   },
-                });
+                  new Set(),
+                  {},
+                  resumeReplay,
+                );
 
               await response.processDataStream({
                 onChunk: async (chunk: any) => {
@@ -1636,6 +1656,11 @@ export class MastraAgent extends AbstractAgent {
     callbacks: MastraAgentStreamOptions,
     clientToolNames: Set<string> = new Set(),
     initialState: Record<string, any> = {},
+    replaySuspendedToolCall?: {
+      toolCallId: string;
+      toolName?: string;
+      args?: any;
+    } | null,
   ) {
     // Remote processDataStream responses report token usage on the terminal
     // `finish` chunk rather than on the response object. Keep only that
@@ -2306,7 +2331,37 @@ export class MastraAgent extends AbstractAgent {
             backgroundToolCalls.delete(chunk.payload.toolCallId);
             break;
           }
+          const flushedId = pendingToolCall?.toolCallId;
           flush();
+          // Resume of a tool that suspended on the previous run: that run
+          // discarded TOOL_CALL_START/ARGS/END (by design), so CopilotKit
+          // never registered the id. Emit the triple now from the interrupt
+          // snapshot before TOOL_CALL_RESULT, otherwise the result is
+          // orphaned (#2668). Skip when this resumed stream already flushed
+          // a matching buffered tool-call, or when START was streamed live.
+          // Do not emit on the first-run suspend path (replay is unset).
+          if (
+            replaySuspendedToolCall &&
+            replaySuspendedToolCall.toolCallId === chunk.payload.toolCallId &&
+            flushedId !== chunk.payload.toolCallId &&
+            !streamedStarted.has(chunk.payload.toolCallId)
+          ) {
+            const toolCallId = replaySuspendedToolCall.toolCallId;
+            const toolName =
+              replaySuspendedToolCall.toolName ||
+              chunk.payload.toolName ||
+              "tool";
+            callbacks.onToolCallStart?.({ toolCallId, toolName });
+            callbacks.onToolCallArgs?.({
+              toolCallId,
+              argsTextDelta: JSON.stringify(
+                replaySuspendedToolCall.args ?? {},
+              ),
+            });
+            callbacks.onToolCallEnd?.({ toolCallId });
+            streamedStarted.add(toolCallId);
+            streamedEnded.add(toolCallId);
+          }
           callbacks.onToolResultPart?.({
             toolCallId: chunk.payload.toolCallId,
             result: chunk.payload.result,
@@ -2616,11 +2671,17 @@ export class MastraAgent extends AbstractAgent {
     abortSignal: AbortSignal,
     clientToolNames: Set<string> = new Set(),
     initialState: Record<string, any> = {},
+    replaySuspendedToolCall?: {
+      toolCallId: string;
+      toolName?: string;
+      args?: any;
+    } | null,
   ): Promise<"completed" | "cancelled" | "error"> {
     const { handleChunk, flush } = this.createChunkProcessor(
       callbacks,
       clientToolNames,
       initialState,
+      replaySuspendedToolCall,
     );
     for await (const chunk of stream) {
       // Cancelled (unsubscribe or abortRun): stop pulling from the source

--- a/integrations/mastra/typescript/src/mastra.ts
+++ b/integrations/mastra/typescript/src/mastra.ts
@@ -1791,6 +1791,8 @@ export class MastraAgent extends AbstractAgent {
           argsTextDelta: JSON.stringify(args ?? {}),
         });
         callbacks.onToolCallEnd?.({ toolCallId });
+        streamedStarted.add(toolCallId);
+        streamedEnded.add(toolCallId);
       }
     };
 
@@ -2331,19 +2333,18 @@ export class MastraAgent extends AbstractAgent {
             backgroundToolCalls.delete(chunk.payload.toolCallId);
             break;
           }
-          const flushedId = pendingToolCall?.toolCallId;
           flush();
           // Resume of a tool that suspended on the previous run: that run
           // discarded TOOL_CALL_START/ARGS/END (by design), so CopilotKit
           // never registered the id. Emit the triple now from the interrupt
           // snapshot before TOOL_CALL_RESULT, otherwise the result is
-          // orphaned (#2668). Skip when this resumed stream already flushed
-          // a matching buffered tool-call, or when START was streamed live.
-          // Do not emit on the first-run suspend path (replay is unset).
+          // orphaned (#2668). Skip when START was already emitted (buffered
+          // flush or live deltas). Do not emit on the first-run suspend path
+          // (replay is unset). Standard input.resume does not round-trip
+          // args; Mastra puts them on tool-result instead.
           if (
             replaySuspendedToolCall &&
             replaySuspendedToolCall.toolCallId === chunk.payload.toolCallId &&
-            flushedId !== chunk.payload.toolCallId &&
             !streamedStarted.has(chunk.payload.toolCallId)
           ) {
             const toolCallId = replaySuspendedToolCall.toolCallId;
@@ -2355,7 +2356,7 @@ export class MastraAgent extends AbstractAgent {
             callbacks.onToolCallArgs?.({
               toolCallId,
               argsTextDelta: JSON.stringify(
-                replaySuspendedToolCall.args ?? {},
+                replaySuspendedToolCall.args ?? chunk.payload.args ?? {},
               ),
             });
             callbacks.onToolCallEnd?.({ toolCallId });


### PR DESCRIPTION
## Summary

A suspended Mastra server tool never appears on the first run. The buffered TOOL_CALL_START/ARGS/END are discarded on `tool-call-suspended` on purpose. Resume then emitted TOOL_CALL_RESULT for an id CopilotKit never registered, so the tool renderer dropped it.

On resume, if the stream has a matching `tool-result` and START was never sent, emit the triple from the interrupt snapshot (toolName + args) first. First-run suppression is unchanged.

## Test plan

- [x] `vitest run src/__tests__/interrupt-bridge.test.ts` (68 passed, including the new resume triple case)
- [ ] CI green on this PR

Fixes #2668
