### PR TITLE
fix(mcp-apps): secure proxy sessions and support current UI metadata

### DIFF
--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -18,9 +18,13 @@ import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 const agent = new YourAgent().use(
   new MCPAppsMiddleware({
     mcpServers: [
-      { type: "http", url: "http://localhost:3001/mcp", serverId: "weather-server" }
+      {
+        type: "http",
+        url: "http://localhost:3001/mcp",
+        serverId: "weather-server",
+      },
     ],
-  })
+  }),
 );
 ```
 
@@ -40,12 +44,18 @@ interface MCPAppsMiddlewareConfig {
 
 type MCPClientConfig =
   | { type: "http"; url: string; serverId?: string }
-  | { type: "sse"; url: string; headers?: Record<string, string>; serverId?: string };
+  | {
+      type: "sse";
+      url: string;
+      headers?: Record<string, string>;
+      serverId?: string;
+    };
 ```
 
 ### Server ID
 
 The optional `serverId` field provides a stable identifier for the server. This is useful when:
+
 - Server URLs may change (e.g., different environments)
 - You want human-readable server identification
 - Frontend code needs to reference servers by name
@@ -79,9 +89,9 @@ The middleware supports proxied MCP requests from the frontend. Pass a `ProxiedM
 
 ```typescript
 interface ProxiedMCPRequest {
-  serverHash: string;      // MD5 hash of server config
-  serverId?: string;     // Optional server ID for lookup
-  method: string;          // MCP method (e.g., "resources/read", "tools/call")
+  serverHash: string; // MD5 hash of server config
+  serverId?: string; // Optional server ID for lookup
+  method: string; // MCP method (e.g., "resources/read", "tools/call")
   params?: Record<string, unknown>;
 }
 ```
@@ -92,11 +102,18 @@ Server lookup prefers `serverId` if provided, falling back to `serverHash`.
 
 ```typescript
 import {
-  MCPAppsActivityType,  // "mcp-apps" constant
-  getServerHash         // Generate server hash from config
+  MCPAppsActivityType, // "mcp-apps" constant
+  getServerHash, // Generate server hash from config
 } from "@ag-ui/mcp-apps-middleware";
 ```
 
 ## License
 
 MIT
+
+## Proxy connections
+
+The middleware accepts only `tools/call`, `resources/read`, `notifications/message`, and `ping` from an iframe proxy request.
+It rejects other methods before it connects to the MCP server.
+HTTP discovery, tool calls, and proxy requests delete their MCP sessions before closing the client.
+If a server rejects session deletion, the client still closes and preserves the original operation result.

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -117,3 +117,9 @@ The middleware accepts only `tools/call`, `resources/read`, `notifications/messa
 It rejects other methods before it connects to the MCP server.
 HTTP discovery, tool calls, and proxy requests delete their MCP sessions before closing the client.
 If a server rejects session deletion, the client still closes and preserves the original operation result.
+
+Server hashes exclude headers so browser-visible references do not contain a checksum of credentials.
+This changes hashes for servers configured with headers. Recreate activity messages after upgrading;
+use stable `serverId` values for references that must survive configuration changes.
+If multiple configurations share a transport type and URL, each must have a distinct `serverId`.
+Hash-only requests for that endpoint are rejected because they cannot identify the intended credential scope.

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -123,6 +123,7 @@ The lockfile pins this package's SDK to 1.15.0 so CI tests the minimum supported
 The middleware accepts only `tools/call`, `resources/read`, `notifications/message`, and `ping` from an iframe proxy request.
 It rejects other methods before it connects to the MCP server.
 HTTP discovery, tool calls, and proxy requests delete their MCP sessions before closing the client.
+Session deletion uses its own three-second abort signal so cleanup can run after a failed handshake aborts the SDK signal.
 If a server rejects session deletion or does not respond within three seconds, the client still closes and preserves the original operation result.
 
 Server hashes exclude headers so browser-visible references do not contain a checksum of credentials.

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -123,3 +123,6 @@ This changes hashes for servers configured with headers. Recreate activity messa
 use stable `serverId` values for references that must survive configuration changes.
 If multiple configurations share a transport type and URL, each must have a distinct `serverId`.
 Hash-only requests for that endpoint are rejected because they cannot identify the intended credential scope.
+
+MCP connections do not follow redirects, and transport requests must stay on the configured origin.
+URLs must use HTTP(S) and must not contain embedded user credentials.

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -126,3 +126,7 @@ Hash-only requests for that endpoint are rejected because they cannot identify t
 
 MCP connections do not follow redirects, and transport requests must stay on the configured origin.
 URLs must use HTTP(S) and must not contain embedded user credentials.
+
+Discovery continues past unavailable servers by default. Set `discoveryFailureMode: "throw"`
+to stop before invoking the agent if any configured server cannot provide its tools.
+Proxy errors and discovery diagnostics omit raw upstream response bodies.

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -40,10 +40,16 @@ const agent = new YourAgent().use(
 ```typescript
 interface MCPAppsMiddlewareConfig {
   mcpServers?: MCPClientConfig[];
+  discoveryFailureMode?: "continue" | "throw"; // Default: "continue"
 }
 
 type MCPClientConfig =
-  | { type: "http"; url: string; serverId?: string }
+  | {
+      type: "http";
+      url: string;
+      headers?: Record<string, string>;
+      serverId?: string;
+    }
   | {
       type: "sse";
       url: string;
@@ -60,7 +66,7 @@ The optional `serverId` field provides a stable identifier for the server. This 
 - You want human-readable server identification
 - Frontend code needs to reference servers by name
 
-If `serverId` is not provided, the server is identified by an MD5 hash of its configuration.
+If `serverId` is not provided, the server is identified by an MD5 hash of its transport `type` and `url` only.
 
 ## Activity Snapshot
 
@@ -73,7 +79,7 @@ The middleware emits activity snapshots with the following structure:
   content: {
     result: MCPToolCallResult,     // Result from the tool execution
     resourceUri: string,           // URI of the UI resource to fetch
-    serverHash: string,            // MD5 hash of server config
+    serverHash: string,            // MD5 hash of transport type and URL only
     serverId?: string,           // Server ID (if configured)
     toolInput: Record<string, unknown>  // Arguments passed to the tool
   },
@@ -89,7 +95,7 @@ The middleware supports proxied MCP requests from the frontend. Pass a `ProxiedM
 
 ```typescript
 interface ProxiedMCPRequest {
-  serverHash: string; // MD5 hash of server config
+  serverHash: string; // MD5 hash of transport type and URL only
   serverId?: string; // Optional server ID for lookup
   method: string; // MCP method (e.g., "resources/read", "tools/call")
   params?: Record<string, unknown>;
@@ -103,15 +109,16 @@ Server lookup prefers `serverId` if provided, falling back to `serverHash`.
 ```typescript
 import {
   MCPAppsActivityType, // "mcp-apps" constant
-  getServerHash, // Generate server hash from config
+  getServerHash, // Hash transport type and URL; excludes headers
 } from "@ag-ui/mcp-apps-middleware";
 ```
 
-## License
-
-MIT
-
 ## Proxy connections
+
+Requires `@modelcontextprotocol/sdk >=1.15.0`. Version 1.15.0 is the first release
+with custom `fetch` support in both HTTP and SSE client transports, and it includes
+HTTP `terminateSession()`. These APIs enforce the origin guard and session cleanup.
+The lockfile pins this package's SDK to 1.15.0 so CI tests the minimum supported version.
 
 The middleware accepts only `tools/call`, `resources/read`, `notifications/message`, and `ping` from an iframe proxy request.
 It rejects other methods before it connects to the MCP server.
@@ -129,4 +136,18 @@ URLs must use HTTP(S) and must not contain embedded user credentials.
 
 Discovery continues past unavailable servers by default. Set `discoveryFailureMode: "throw"`
 to stop before invoking the agent if any configured server cannot provide its tools.
-Proxy errors and discovery diagnostics omit raw upstream response bodies.
+Proxy responses and thrown discovery errors omit raw upstream response bodies.
+Server-side diagnostics include `serverId`, the credential-free server hash, and the
+original error in both discovery modes and on proxy failures. Treat these logs as
+operator-only data: upstream errors can include private response bodies.
+
+## Tool visibility
+
+Discovery reads `_meta.ui.resourceUri`, with `_meta["ui/resourceUri"]` as a legacy fallback.
+When `_meta.ui.visibility` is omitted, tools remain visible to the model by default.
+An explicit visibility list must include `"model"` for model-facing discovery.
+Tools marked `["app"]` stay hidden from the model and remain callable through the iframe proxy.
+
+## License
+
+MIT

--- a/middlewares/mcp-apps-middleware/README.md
+++ b/middlewares/mcp-apps-middleware/README.md
@@ -116,7 +116,7 @@ MIT
 The middleware accepts only `tools/call`, `resources/read`, `notifications/message`, and `ping` from an iframe proxy request.
 It rejects other methods before it connects to the MCP server.
 HTTP discovery, tool calls, and proxy requests delete their MCP sessions before closing the client.
-If a server rejects session deletion, the client still closes and preserves the original operation result.
+If a server rejects session deletion or does not respond within three seconds, the client still closes and preserves the original operation result.
 
 Server hashes exclude headers so browser-visible references do not contain a checksum of credentials.
 This changes hashes for servers configured with headers. Recreate activity messages after upgrading;

--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -486,6 +486,8 @@ describe("MCPAppsMiddleware", () => {
       expect(events.length).toBeGreaterThanOrEqual(2);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "MCP tool discovery failed",
+        expect.objectContaining({ serverHash: expect.any(String) }),
+        expect.any(Error),
       );
 
       consoleErrorSpy.mockRestore();
@@ -560,7 +562,10 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockHTTPTransportCalls).toHaveLength(1);
-      expect(mockHTTPTransportOpts[0]).toEqual({ requestInit: { headers, redirect: "error" }, fetch: expect.any(Function) });
+      expect(mockHTTPTransportOpts[0]).toEqual({
+        requestInit: { headers, redirect: "error" },
+        fetch: expect.any(Function),
+      });
     });
 
     it("forwards configured headers to the SSE transport (#1862)", async () => {
@@ -580,7 +585,10 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockSSETransportCalls).toHaveLength(1);
-      expect(mockSSETransportOpts[0]).toEqual({ requestInit: { headers, redirect: "error" }, fetch: expect.any(Function) });
+      expect(mockSSETransportOpts[0]).toEqual({
+        requestInit: { headers, redirect: "error" },
+        fetch: expect.any(Function),
+      });
     });
 
     it("retains redirect protection when no headers are configured", async () => {
@@ -597,7 +605,10 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockHTTPTransportCalls).toHaveLength(1);
-      expect(mockHTTPTransportOpts[0]).toEqual({ requestInit: { headers: undefined, redirect: "error" }, fetch: expect.any(Function) });
+      expect(mockHTTPTransportOpts[0]).toEqual({
+        requestInit: { headers: undefined, redirect: "error" },
+        fetch: expect.any(Function),
+      });
     });
 
     it("getServerHash excludes HTTP credentials from the browser-visible reference", () => {
@@ -1553,7 +1564,9 @@ describe("MCPAppsMiddleware", () => {
       const finishedEvent = events.find(
         (e) => e.type === EventType.RUN_FINISHED,
       );
-      expect((finishedEvent as any).result.error).toBe("Error: MCP request failed");
+      expect((finishedEvent as any).result.error).toBe(
+        "Error: MCP request failed",
+      );
     });
 
     it("emits error for unknown serverHash", async () => {

--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -561,7 +561,7 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockHTTPTransportCalls).toHaveLength(1);
-      expect(mockHTTPTransportOpts[0]).toEqual({ requestInit: { headers } });
+      expect(mockHTTPTransportOpts[0]).toEqual({ requestInit: { headers, redirect: "error" }, fetch: expect.any(Function) });
     });
 
     it("forwards configured headers to the SSE transport (#1862)", async () => {
@@ -581,10 +581,10 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockSSETransportCalls).toHaveLength(1);
-      expect(mockSSETransportOpts[0]).toEqual({ requestInit: { headers } });
+      expect(mockSSETransportOpts[0]).toEqual({ requestInit: { headers, redirect: "error" }, fetch: expect.any(Function) });
     });
 
-    it("passes no transport options when no headers are configured", async () => {
+    it("retains redirect protection when no headers are configured", async () => {
       mockListTools.mockResolvedValue({ tools: [] });
 
       const middleware = new MCPAppsMiddleware({
@@ -598,7 +598,7 @@ describe("MCPAppsMiddleware", () => {
       await collectEvents(middleware.run(createRunAgentInput(), agent));
 
       expect(mockHTTPTransportCalls).toHaveLength(1);
-      expect(mockHTTPTransportOpts[0]).toBeUndefined();
+      expect(mockHTTPTransportOpts[0]).toEqual({ requestInit: { headers: undefined, redirect: "error" }, fetch: expect.any(Function) });
     });
 
     it("getServerHash excludes HTTP credentials from the browser-visible reference", () => {

--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -601,13 +601,13 @@ describe("MCPAppsMiddleware", () => {
       expect(mockHTTPTransportOpts[0]).toBeUndefined();
     });
 
-    it("getServerHash distinguishes HTTP servers that differ only by headers (#1862)", () => {
+    it("getServerHash excludes HTTP credentials from the browser-visible reference", () => {
       const base = { type: "http" as const, url: "http://localhost:3000" };
       const withAuth = { ...base, headers: { Authorization: "Bearer a" } };
       const withOtherAuth = { ...base, headers: { Authorization: "Bearer b" } };
 
-      expect(getServerHash(base)).not.toBe(getServerHash(withAuth));
-      expect(getServerHash(withAuth)).not.toBe(getServerHash(withOtherAuth));
+      expect(getServerHash(base)).toBe(getServerHash(withAuth));
+      expect(getServerHash(withAuth)).toBe(getServerHash(withOtherAuth));
     });
 
     it("aggregates tools from multiple servers", async () => {
@@ -1650,7 +1650,7 @@ describe("MCPAppsMiddleware", () => {
       expect(getServerHash(config1)).not.toBe(getServerHash(config2));
     });
 
-    it("generates different serverHashes for SSE configs with different headers", () => {
+    it("excludes SSE headers from public serverHashes", () => {
       const config1: MCPClientConfig = {
         type: "sse",
         url: "http://localhost:3000",
@@ -1661,7 +1661,7 @@ describe("MCPAppsMiddleware", () => {
         url: "http://localhost:3000",
         headers: { Authorization: "token2" },
       };
-      expect(getServerHash(config1)).not.toBe(getServerHash(config2));
+      expect(getServerHash(config1)).toBe(getServerHash(config2));
     });
 
     it("includes serverHash in ACTIVITY_SNAPSHOT content", async () => {

--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -485,8 +485,7 @@ describe("MCPAppsMiddleware", () => {
 
       expect(events.length).toBeGreaterThanOrEqual(2);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to fetch tools from MCP server"),
-        expect.any(Error),
+        "MCP tool discovery failed",
       );
 
       consoleErrorSpy.mockRestore();
@@ -1554,9 +1553,7 @@ describe("MCPAppsMiddleware", () => {
       const finishedEvent = events.find(
         (e) => e.type === EventType.RUN_FINISHED,
       );
-      expect((finishedEvent as any).result.error).toContain(
-        "Connection refused",
-      );
+      expect((finishedEvent as any).result.error).toBe("Error: MCP request failed");
     });
 
     it("emits error for unknown serverHash", async () => {

--- a/middlewares/mcp-apps-middleware/__tests__/transport-origin.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/transport-origin.test.ts
@@ -1,0 +1,108 @@
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { firstValueFrom, toArray } from "rxjs";
+import { expect, test, vi } from "vitest";
+import { MCPAppsMiddleware } from "../src/index";
+import { createTrustedFetch } from "../src/trusted-fetch";
+import { MockAgent, createRunAgentInput } from "./test-utils";
+
+/** Two listening origins expose accidental credential forwarding over real HTTP. */
+async function setup() {
+  const requests: Array<{ origin: string; authorization?: string }> = [];
+  const capture = createServer((request, response) => {
+    requests.push({
+      origin: "capture",
+      authorization: request.headers.authorization,
+    });
+    response.writeHead(200).end();
+  });
+  capture.listen(0, "127.0.0.1");
+  await once(capture, "listening");
+  const captureAddress = capture.address();
+  if (!captureAddress || typeof captureAddress === "string")
+    throw new Error("No capture address");
+  const captureUrl = `http://127.0.0.1:${captureAddress.port}`;
+  const source = createServer((request, response) => {
+    requests.push({
+      origin: "source",
+      authorization: request.headers.authorization,
+    });
+    if (request.url === "/sse") {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write(`event: endpoint\ndata: ${captureUrl}/messages\n\n`);
+    } else response.writeHead(200).end();
+  });
+  source.listen(0, "127.0.0.1");
+  await once(source, "listening");
+  const sourceAddress = source.address();
+  if (!sourceAddress || typeof sourceAddress === "string")
+    throw new Error("No source address");
+  return {
+    sourceUrl: `http://127.0.0.1:${sourceAddress.port}`,
+    captureUrl,
+    requests,
+    async teardown() {
+      for (const server of [source, capture]) {
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  };
+}
+
+test("origin guard rejects a credentialed cross-origin request before fetch", async () => {
+  const { sourceUrl, captureUrl, requests, teardown } = await setup();
+  const headers = { Authorization: "Bearer origin-fixture" };
+  try {
+    const fetch = createTrustedFetch(sourceUrl);
+    expect((await fetch(sourceUrl, { headers })).status).toBe(200);
+    await expect(fetch(new Request(captureUrl, { headers }))).rejects.toThrow(
+      "MCP transport changed origin",
+    );
+    expect(requests).toEqual([
+      { origin: "source", authorization: headers.Authorization },
+    ]);
+  } finally {
+    await teardown();
+  }
+});
+
+test("legacy SSE endpoint events cannot send credentials to a second origin", async () => {
+  const { sourceUrl, requests, teardown } = await setup();
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const middleware = new MCPAppsMiddleware({
+      mcpServers: [
+        {
+          type: "sse",
+          url: sourceUrl + "/sse",
+          serverId: "legacy",
+          headers: { Authorization: "Bearer origin-fixture" },
+        },
+      ],
+    });
+    const agent = new MockAgent();
+    const events = await firstValueFrom(
+      middleware
+        .run(
+          createRunAgentInput({
+            forwardedProps: {
+              __proxiedMCPRequest: { serverId: "legacy", method: "ping" },
+            },
+          }),
+          agent,
+        )
+        .pipe(toArray()),
+    );
+    expect(events.at(-1)).toMatchObject({
+      result: { error: "Error: MCP request failed" },
+    });
+    expect(agent.runCalls).toEqual([]);
+    expect(requests).toEqual([
+      { origin: "source", authorization: "Bearer origin-fixture" },
+    ]);
+  } finally {
+    log.mockRestore();
+    await teardown();
+  }
+});

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -22,6 +22,7 @@ async function setup(
   redirect = false,
   rejectAuth = false,
   metadata: "legacy" | "nested" | "both" = "legacy",
+  visibility?: string[],
 ) {
   const requests: Array<{
     method: string;
@@ -78,7 +79,10 @@ async function setup(
                     metadata === "legacy"
                       ? { "ui/resourceUri": "ui://card" }
                       : {
-                          ui: { resourceUri: "ui://card" },
+                          ui: {
+                            resourceUri: "ui://card",
+                            ...(visibility ? { visibility } : {}),
+                          },
                           ...(metadata === "both"
                             ? { "ui/resourceUri": "ui://legacy" }
                             : {}),
@@ -106,7 +110,7 @@ async function setup(
     throw new Error("Fixture did not listen");
   const url = `http://127.0.0.1:${address.port}`;
   const config = {
-    discoveryFailureMode: "throw" as const,
+    discoveryFailureMode: "throw" as "throw" | "continue",
     mcpServers: [
       {
         type: "http" as const,
@@ -131,6 +135,7 @@ async function setup(
   return {
     requests,
     agent,
+    config,
     discover: () =>
       firstValueFrom(
         middleware.run(createRunAgentInput(), agent).pipe(toArray()),
@@ -149,7 +154,10 @@ async function setup(
                   serverId: hashOnly ? undefined : serverId,
                   serverHash: getServerHash({ type: "http", url }),
                   method,
-                  params: { uri: "ui://card" },
+                  params:
+                    method === "tools/call"
+                      ? { name: "card", arguments: {} }
+                      : { uri: "ui://card" },
                 },
               },
             }),
@@ -315,9 +323,15 @@ test("strict discovery failures stop the agent without exposing upstream diagnos
   try {
     await expect(discover()).rejects.toThrow("MCP tool discovery failed");
     expect(agent.runCalls).toEqual([]);
-    expect(JSON.stringify(log.mock.calls)).not.toContain(
-      "private-auth-diagnostic",
+    expect(log).toHaveBeenCalledWith(
+      "MCP tool discovery failed",
+      expect.objectContaining({
+        serverId: "cards",
+        serverHash: expect.any(String),
+      }),
+      expect.any(Error),
     );
+    expect(String(log.mock.calls[0][2])).toContain("private-auth-diagnostic");
   } finally {
     log.mockRestore();
     await teardown();
@@ -326,13 +340,24 @@ test("strict discovery failures stop the agent without exposing upstream diagnos
 
 test("proxy errors do not expose upstream diagnostics", async () => {
   const { run, teardown } = await setup(false, false, false, true);
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
   try {
     const events = await run("resources/read");
     expect(events.at(-1)).toMatchObject({
       result: { error: "Error: MCP request failed" },
     });
     expect(JSON.stringify(events)).not.toContain("private-auth-diagnostic");
+    expect(log).toHaveBeenCalledWith(
+      "MCP proxy request failed",
+      expect.objectContaining({
+        serverId: "cards",
+        serverHash: expect.any(String),
+      }),
+      expect.any(Error),
+    );
+    expect(String(log.mock.calls[0][2])).toContain("private-auth-diagnostic");
   } finally {
+    log.mockRestore();
     await teardown();
   }
 });
@@ -466,3 +491,62 @@ test.each(["nested", "both"] as const)(
     }
   },
 );
+
+test.each([undefined, ["model"], ["app"], ["app", "model"]])(
+  "discovery respects tool visibility %j",
+  async (visibility) => {
+    const { discover, agent, run, requests, teardown } = await setup(
+      false,
+      false,
+      false,
+      false,
+      "nested",
+      visibility,
+    );
+    try {
+      await discover();
+      expect(agent.runCalls[0].tools.some((tool) => tool.name === "card")).toBe(
+        visibility === undefined || visibility.includes("model"),
+      );
+      if (visibility?.length === 1 && visibility[0] === "app") {
+        const events = await run("tools/call");
+        expect(events.at(-1)).toMatchObject({
+          result: { content: [{ text: "Card result" }] },
+        });
+        expect(requests.some((request) => request.rpc === "tools/call")).toBe(
+          true,
+        );
+        expect(agent.runCalls).toHaveLength(1);
+      }
+    } finally {
+      await teardown();
+    }
+  },
+);
+
+test("continue discovery names the failing server and retains the error", async () => {
+  const { discover, agent, config, teardown } = await setup(
+    false,
+    false,
+    false,
+    true,
+  );
+  config.discoveryFailureMode = "continue";
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await discover();
+    expect(agent.runCalls).toHaveLength(1);
+    expect(log).toHaveBeenCalledWith(
+      "MCP tool discovery failed",
+      expect.objectContaining({
+        serverId: "cards",
+        serverHash: expect.any(String),
+      }),
+      expect.any(Error),
+    );
+    expect(String(log.mock.calls[0][2])).toContain("private-auth-diagnostic");
+  } finally {
+    log.mockRestore();
+    await teardown();
+  }
+});

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { once } from "node:events";
@@ -673,3 +674,44 @@ test("rejected session cleanup preserves the private handshake failure", async (
     await fixture.teardown();
   }
 });
+
+test.each([false, true])(
+  "proxy preserves its result when client close rejects (handshake failure: %s)",
+  async (failHandshake) => {
+    const fixture = await setup(false, false, false, false, "legacy", {
+      initializationFailure: failHandshake ? "unsupported-version" : undefined,
+    });
+    const closeError = new Error(
+      "private-close-diagnostic: Bearer fixture-token",
+    );
+    const originalClose = Client.prototype.close;
+    const close = vi
+      .spyOn(Client.prototype, "close")
+      .mockImplementation(async function (this: Client) {
+        await originalClose.call(this);
+        throw closeError;
+      });
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const events = await fixture.run("resources/read");
+      expect(events.at(-1)).toMatchObject({
+        result: failHandshake
+          ? { error: "Error: MCP request failed" }
+          : { contents: [{ text: "Card" }] },
+      });
+      expect(JSON.stringify(events)).not.toContain("private-close-diagnostic");
+      expect(log).toHaveBeenCalledWith(
+        "MCP session cleanup failed",
+        {
+          serverId: "cards",
+          serverHash: getServerHash(fixture.config.mcpServers[0]),
+        },
+        closeError,
+      );
+    } finally {
+      close.mockRestore();
+      log.mockRestore();
+      await fixture.teardown();
+    }
+  },
+);

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -1,0 +1,131 @@
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { expect, test } from "vitest";
+import { firstValueFrom, toArray } from "rxjs";
+import { MCPAppsMiddleware } from "../src/index";
+import { MockAgent, createRunAgentInput } from "./test-utils";
+
+/** Serve the MCP HTTP protocol and record transport effects on real sockets. */
+async function setup() {
+  const requests: Array<{
+    method: string;
+    authorization?: string;
+    rpc?: string;
+  }> = [];
+  const server = createServer(async (request, response) => {
+    const entry = {
+      method: request.method!,
+      authorization: request.headers.authorization,
+      rpc: undefined as string | undefined,
+    };
+    requests.push(entry);
+    if (request.method === "DELETE") {
+      response.writeHead(204).end();
+      return;
+    }
+    if (request.method === "GET") {
+      response.writeHead(405).end();
+      return;
+    }
+    let raw = "";
+    for await (const chunk of request) raw += chunk;
+    const message = JSON.parse(raw);
+    entry.rpc = message.method;
+    if (message.id === undefined) {
+      response.writeHead(202).end();
+      return;
+    }
+    const result =
+      message.method === "initialize"
+        ? {
+            protocolVersion: message.params.protocolVersion,
+            capabilities: { resources: {} },
+            serverInfo: { name: "fixture", version: "1" },
+          }
+        : {
+            contents: [
+              { uri: "ui://card", text: "Card", mimeType: "text/html+mcp" },
+            ],
+          };
+    response.writeHead(200, {
+      "content-type": "application/json",
+      "mcp-session-id": "fixture-session",
+    });
+    response.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Fixture did not listen");
+  const middleware = new MCPAppsMiddleware({
+    mcpServers: [
+      {
+        type: "http",
+        url: `http://127.0.0.1:${address.port}`,
+        serverId: "cards",
+        headers: { Authorization: "Bearer fixture-token" },
+      },
+    ],
+  });
+  const agent = new MockAgent();
+  return {
+    requests,
+    agent,
+    run: (method: string) =>
+      firstValueFrom(
+        middleware
+          .run(
+            createRunAgentInput({
+              forwardedProps: {
+                __proxiedMCPRequest: {
+                  serverId: "cards",
+                  method,
+                  params: { uri: "ui://card" },
+                },
+              },
+            }),
+            agent,
+          )
+          .pipe(toArray()),
+      ),
+    teardown: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+test("blocked proxy methods do not initialize an MCP session", async () => {
+  const { run, requests, agent, teardown } = await setup();
+  try {
+    const events = await run("tools/list");
+    expect(events.at(-1)).toMatchObject({
+      result: { error: expect.stringContaining("not allowed") },
+    });
+    expect(requests).toEqual([]);
+    expect(agent.runCalls).toEqual([]);
+  } finally {
+    await teardown();
+  }
+});
+
+test("successful HTTP proxy requests delete their authenticated MCP session", async () => {
+  const { run, requests, teardown } = await setup();
+  try {
+    const events = await run("resources/read");
+    expect(events.at(-1)).toMatchObject({
+      result: { contents: [{ text: "Card" }] },
+    });
+    expect(
+      requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(1);
+    expect(
+      requests.every(
+        (request) => request.authorization === "Bearer fixture-token",
+      ),
+    ).toBe(true);
+  } finally {
+    await teardown();
+  }
+});

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -22,17 +22,24 @@ async function setup(
   redirect = false,
   rejectAuth = false,
   metadata: "legacy" | "nested" | "both" = "legacy",
-  visibility?: string[],
+  options: {
+    visibility?: string[];
+    initializationFailure?: "initialized-error" | "unsupported-version";
+    rejectDelete?: boolean;
+  } = {},
 ) {
   const requests: Array<{
     method: string;
     authorization?: string;
     rpc?: string;
+    sessionId?: string;
   }> = [];
+  let stalledDeleteClosed = false;
   const server = createServer(async (request, response) => {
     const entry = {
       method: request.method!,
       authorization: request.headers.authorization,
+      sessionId: request.headers["mcp-session-id"]?.toString(),
       rpc: undefined as string | undefined,
     };
     requests.push(entry);
@@ -45,7 +52,16 @@ async function setup(
       return;
     }
     if (request.method === "DELETE") {
-      if (stallDelete) return;
+      if (stallDelete) {
+        response.on("close", () => {
+          stalledDeleteClosed = true;
+        });
+        return;
+      }
+      if (options.rejectDelete) {
+        response.writeHead(500).end("private-cleanup-diagnostic");
+        return;
+      }
       response.writeHead(204).end();
       return;
     }
@@ -57,6 +73,13 @@ async function setup(
     for await (const chunk of request) raw += chunk;
     const message = JSON.parse(raw);
     entry.rpc = message.method;
+    if (
+      message.method === "notifications/initialized" &&
+      options.initializationFailure === "initialized-error"
+    ) {
+      response.writeHead(500).end("private-initialization-diagnostic");
+      return;
+    }
     if (message.id === undefined) {
       response.writeHead(202).end();
       return;
@@ -64,7 +87,10 @@ async function setup(
     const result =
       message.method === "initialize"
         ? {
-            protocolVersion: message.params.protocolVersion,
+            protocolVersion:
+              options.initializationFailure === "unsupported-version"
+                ? "2099-01-01"
+                : message.params.protocolVersion,
             capabilities: { resources: {}, tools: {} },
             serverInfo: { name: "fixture", version: "1" },
           }
@@ -81,7 +107,9 @@ async function setup(
                       : {
                           ui: {
                             resourceUri: "ui://card",
-                            ...(visibility ? { visibility } : {}),
+                            ...(options.visibility
+                              ? { visibility: options.visibility }
+                              : {}),
                           },
                           ...(metadata === "both"
                             ? { "ui/resourceUri": "ui://legacy" }
@@ -134,6 +162,7 @@ async function setup(
   const agent = new MockAgent();
   return {
     requests,
+    isStalledDeleteClosed: () => stalledDeleteClosed,
     agent,
     config,
     discover: () =>
@@ -492,7 +521,7 @@ test.each(["nested", "both"] as const)(
   },
 );
 
-test.each([undefined, ["model"], ["app"], ["app", "model"]])(
+test.each([undefined, [], ["model"], ["app"], ["app", "model"]])(
   "discovery respects tool visibility %j",
   async (visibility) => {
     const { discover, agent, run, requests, teardown } = await setup(
@@ -501,7 +530,7 @@ test.each([undefined, ["model"], ["app"], ["app", "model"]])(
       false,
       false,
       "nested",
-      visibility,
+      { visibility },
     );
     try {
       await discover();
@@ -548,5 +577,99 @@ test("continue discovery names the failing server and retains the error", async 
   } finally {
     log.mockRestore();
     await teardown();
+  }
+});
+
+test.each(["nested", "both"] as const)(
+  "app-only %s metadata stays hidden from the model",
+  async (metadata) => {
+    const fixture = await setup(false, false, false, false, metadata, {
+      visibility: ["app"],
+    });
+    try {
+      await fixture.discover();
+      expect(fixture.agent.runCalls[0].tools).toEqual([]);
+    } finally {
+      await fixture.teardown();
+    }
+  },
+);
+
+test.each([
+  ["proxy", "initialized-error"],
+  ["proxy", "unsupported-version"],
+  ["discovery", "initialized-error"],
+  ["discovery", "unsupported-version"],
+] as const)(
+  "%s deletes authenticated session after %s",
+  async (operation, initializationFailure) => {
+    const fixture = await setup(false, false, false, false, "legacy", {
+      initializationFailure,
+    });
+    try {
+      if (operation === "proxy") {
+        expect((await fixture.run("resources/read")).at(-1)).toMatchObject({
+          result: { error: "Error: MCP request failed" },
+        });
+      } else {
+        await expect(fixture.discover()).rejects.toThrow(
+          "MCP tool discovery failed",
+        );
+      }
+      expect(fixture.agent.runCalls).toEqual([]);
+      expect(
+        fixture.requests.filter((request) => request.method === "DELETE"),
+      ).toEqual([
+        expect.objectContaining({
+          authorization: "Bearer fixture-token",
+          sessionId: "fixture-session",
+        }),
+      ]);
+    } finally {
+      await fixture.teardown();
+    }
+  },
+);
+
+test("failed handshake bounds and aborts stalled session cleanup", async () => {
+  const fixture = await setup(false, true, false, false, "legacy", {
+    initializationFailure: "initialized-error",
+  });
+  try {
+    const started = Date.now();
+    expect((await fixture.run("resources/read")).at(-1)).toMatchObject({
+      result: { error: "Error: MCP request failed" },
+    });
+    expect(Date.now() - started).toBeLessThan(4500);
+    expect(
+      fixture.requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(1);
+    await vi.waitFor(() => expect(fixture.isStalledDeleteClosed()).toBe(true));
+    expect(fixture.agent.runCalls).toEqual([]);
+  } finally {
+    await fixture.teardown();
+  }
+}, 6000);
+
+test("rejected session cleanup preserves the private handshake failure", async () => {
+  const fixture = await setup(false, false, false, false, "legacy", {
+    initializationFailure: "initialized-error",
+    rejectDelete: true,
+  });
+  try {
+    const events = await fixture.run("resources/read");
+    expect(events.at(-1)).toMatchObject({
+      result: { error: "Error: MCP request failed" },
+    });
+    expect(
+      fixture.requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(1);
+    expect(JSON.stringify(events)).not.toContain("private-cleanup-diagnostic");
+    expect(JSON.stringify(events)).not.toContain(
+      "private-initialization-diagnostic",
+    );
+    expect(fixture.agent.runCalls).toEqual([]);
+  } finally {
+    await fixture.teardown();
   }
 });

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -6,7 +6,7 @@ import { MCPAppsMiddleware, getServerHash } from "../src/index";
 import { MockAgent, createRunAgentInput } from "./test-utils";
 
 /** Serve the MCP HTTP protocol and record transport effects on real sockets. */
-async function setup(sharedEndpoint = false) {
+async function setup(sharedEndpoint = false, stallDelete = false) {
   const requests: Array<{
     method: string;
     authorization?: string;
@@ -20,6 +20,7 @@ async function setup(sharedEndpoint = false) {
     };
     requests.push(entry);
     if (request.method === "DELETE") {
+      if (stallDelete) return;
       response.writeHead(204).end();
       return;
     }
@@ -221,3 +222,28 @@ test("duplicate explicit server IDs are rejected", () => {
       }),
   ).toThrow("distinct serverId");
 });
+
+test("an unresponsive DELETE cannot hold a completed proxy result", async () => {
+  const { run, requests, teardown } = await setup(false, true);
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const events = await Promise.race([
+      run("resources/read"),
+      new Promise<never>((_, reject) => {
+        deadline = setTimeout(
+          () => reject(new Error("session cleanup did not finish")),
+          4500,
+        );
+      }),
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      result: { contents: [{ text: "Card" }] },
+    });
+    expect(
+      requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(1);
+  } finally {
+    clearTimeout(deadline);
+    await teardown();
+  }
+}, 6000);

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -6,7 +6,11 @@ import { MCPAppsMiddleware, getServerHash } from "../src/index";
 import { MockAgent, createRunAgentInput } from "./test-utils";
 
 /** Serve the MCP HTTP protocol and record transport effects on real sockets. */
-async function setup(sharedEndpoint = false, stallDelete = false) {
+async function setup(
+  sharedEndpoint = false,
+  stallDelete = false,
+  redirect = false,
+) {
   const requests: Array<{
     method: string;
     authorization?: string;
@@ -19,6 +23,10 @@ async function setup(sharedEndpoint = false, stallDelete = false) {
       rpc: undefined as string | undefined,
     };
     requests.push(entry);
+    if (redirect && request.url !== "/capture") {
+      response.writeHead(307, { location: "/capture" }).end();
+      return;
+    }
     if (request.method === "DELETE") {
       if (stallDelete) return;
       response.writeHead(204).end();
@@ -247,3 +255,13 @@ test("an unresponsive DELETE cannot hold a completed proxy result", async () => 
     await teardown();
   }
 }, 6000);
+
+test("MCP redirects cannot forward configured credentials", async () => {
+  const { run, requests, teardown } = await setup(false, false, true);
+  try {
+    await run("resources/read");
+    expect(requests).toHaveLength(1);
+  } finally {
+    await teardown();
+  }
+});

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -2,11 +2,11 @@ import { createServer } from "node:http";
 import { once } from "node:events";
 import { expect, test } from "vitest";
 import { firstValueFrom, toArray } from "rxjs";
-import { MCPAppsMiddleware } from "../src/index";
+import { MCPAppsMiddleware, getServerHash } from "../src/index";
 import { MockAgent, createRunAgentInput } from "./test-utils";
 
 /** Serve the MCP HTTP protocol and record transport effects on real sockets. */
-async function setup() {
+async function setup(sharedEndpoint = false) {
   const requests: Array<{
     method: string;
     authorization?: string;
@@ -58,28 +58,44 @@ async function setup() {
   const address = server.address();
   if (!address || typeof address === "string")
     throw new Error("Fixture did not listen");
+  const url = `http://127.0.0.1:${address.port}`;
   const middleware = new MCPAppsMiddleware({
     mcpServers: [
       {
         type: "http",
-        url: `http://127.0.0.1:${address.port}`,
+        url,
         serverId: "cards",
         headers: { Authorization: "Bearer fixture-token" },
       },
+      ...(sharedEndpoint
+        ? [
+            {
+              type: "http" as const,
+              url,
+              serverId: "other",
+              headers: { Authorization: "Bearer other-token" },
+            },
+          ]
+        : []),
     ],
   });
   const agent = new MockAgent();
   return {
     requests,
     agent,
-    run: (method: string) =>
+    run: (
+      method: string,
+      serverId: string | undefined = "cards",
+      hashOnly = false,
+    ) =>
       firstValueFrom(
         middleware
           .run(
             createRunAgentInput({
               forwardedProps: {
                 __proxiedMCPRequest: {
-                  serverId: "cards",
+                  serverId: hashOnly ? undefined : serverId,
+                  serverHash: getServerHash({ type: "http", url }),
                   method,
                   params: { uri: "ui://card" },
                 },
@@ -128,4 +144,80 @@ test("successful HTTP proxy requests delete their authenticated MCP session", as
   } finally {
     await teardown();
   }
+});
+
+test.each(["http", "sse"] as const)(
+  "%s server hashes do not expose a credential checksum",
+  (type) => {
+    const publicServer = { type, url: "https://mcp.example.test" };
+    expect(
+      getServerHash({
+        ...publicServer,
+        headers: { Authorization: "guessable-token" },
+      }),
+    ).toBe(getServerHash(publicServer));
+  },
+);
+
+test("servers sharing a public endpoint require distinct server IDs", () => {
+  expect(
+    () =>
+      new MCPAppsMiddleware({
+        mcpServers: [
+          {
+            type: "http",
+            url: "https://mcp.example.test",
+            headers: { Authorization: "first" },
+          },
+          {
+            type: "http",
+            url: "https://mcp.example.test",
+            headers: { Authorization: "second" },
+          },
+        ],
+      }),
+  ).toThrow("distinct serverId");
+});
+
+test("explicit IDs select the right credentials on a shared endpoint", async () => {
+  const { run, requests, teardown } = await setup(true);
+  try {
+    const events = await run("resources/read", "other");
+    expect(events.at(-1)).toMatchObject({
+      result: { contents: [{ text: "Card" }] },
+    });
+    expect(requests.length).toBeGreaterThan(0);
+    expect(
+      requests.every(
+        (request) => request.authorization === "Bearer other-token",
+      ),
+    ).toBe(true);
+  } finally {
+    await teardown();
+  }
+});
+
+test("hash-only requests cannot select an ambiguous credential scope", async () => {
+  const { run, requests, teardown } = await setup(true);
+  try {
+    const events = await run("resources/read", undefined, true);
+    expect(events.at(-1)).toMatchObject({
+      result: { error: expect.stringContaining("Unknown server") },
+    });
+    expect(requests).toEqual([]);
+  } finally {
+    await teardown();
+  }
+});
+
+test("duplicate explicit server IDs are rejected", () => {
+  expect(
+    () =>
+      new MCPAppsMiddleware({
+        mcpServers: [
+          { type: "http", url: "https://one.example.test", serverId: "cards" },
+          { type: "http", url: "https://two.example.test", serverId: "cards" },
+        ],
+      }),
+  ).toThrow("distinct serverId");
 });

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { once } from "node:events";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { firstValueFrom, toArray } from "rxjs";
 import { MCPAppsMiddleware, getServerHash } from "../src/index";
 import { MockAgent, createRunAgentInput } from "./test-utils";
@@ -10,6 +12,7 @@ async function setup(
   sharedEndpoint = false,
   stallDelete = false,
   redirect = false,
+  rejectAuth = false,
 ) {
   const requests: Array<{
     method: string;
@@ -23,6 +26,10 @@ async function setup(
       rpc: undefined as string | undefined,
     };
     requests.push(entry);
+    if (rejectAuth) {
+      response.writeHead(401).end("private-auth-diagnostic");
+      return;
+    }
     if (redirect && request.url !== "/capture") {
       response.writeHead(307, { location: "/capture" }).end();
       return;
@@ -68,10 +75,11 @@ async function setup(
   if (!address || typeof address === "string")
     throw new Error("Fixture did not listen");
   const url = `http://127.0.0.1:${address.port}`;
-  const middleware = new MCPAppsMiddleware({
+  const config = {
+    discoveryFailureMode: "throw" as const,
     mcpServers: [
       {
-        type: "http",
+        type: "http" as const,
         url,
         serverId: "cards",
         headers: { Authorization: "Bearer fixture-token" },
@@ -87,11 +95,16 @@ async function setup(
           ]
         : []),
     ],
-  });
+  };
+  const middleware = new MCPAppsMiddleware(config);
   const agent = new MockAgent();
   return {
     requests,
     agent,
+    discover: () =>
+      firstValueFrom(
+        middleware.run(createRunAgentInput(), agent).pipe(toArray()),
+      ),
     run: (
       method: string,
       serverId: string | undefined = "cards",
@@ -263,5 +276,103 @@ test("MCP redirects cannot forward configured credentials", async () => {
     expect(requests).toHaveLength(1);
   } finally {
     await teardown();
+  }
+});
+
+test("strict discovery failures stop the agent without exposing upstream diagnostics", async () => {
+  const { discover, agent, teardown } = await setup(false, false, false, true);
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await expect(discover()).rejects.toThrow("MCP tool discovery failed");
+    expect(agent.runCalls).toEqual([]);
+    expect(JSON.stringify(log.mock.calls)).not.toContain(
+      "private-auth-diagnostic",
+    );
+  } finally {
+    log.mockRestore();
+    await teardown();
+  }
+});
+
+test("proxy errors do not expose upstream diagnostics", async () => {
+  const { run, teardown } = await setup(false, false, false, true);
+  try {
+    const events = await run("resources/read");
+    expect(events.at(-1)).toMatchObject({
+      result: { error: "Error: MCP request failed" },
+    });
+    expect(JSON.stringify(events)).not.toContain("private-auth-diagnostic");
+  } finally {
+    await teardown();
+  }
+});
+
+test("legacy SSE reentry keeps trusted authentication on GET and POST", async () => {
+  const requests: Array<{ method?: string; authorization?: string }> = [];
+  const sdkServer = new Server(
+    { name: "legacy-fixture", version: "1" },
+    { capabilities: {} },
+  );
+  let transport: SSEServerTransport | undefined;
+  const server = createServer(async (request, response) => {
+    requests.push({
+      method: request.method,
+      authorization: request.headers.authorization,
+    });
+    if (request.headers.authorization !== "Bearer legacy-secret") {
+      response.writeHead(401).end();
+      return;
+    }
+    if (request.method === "GET") {
+      transport = new SSEServerTransport("/messages", response);
+      await sdkServer.connect(transport);
+    } else if (transport) {
+      await transport.handlePostMessage(request, response);
+    } else {
+      response.writeHead(404).end();
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("No fixture address");
+    const middleware = new MCPAppsMiddleware({
+      mcpServers: [
+        {
+          type: "sse",
+          url: `http://127.0.0.1:${address.port}/sse`,
+          serverId: "legacy",
+          headers: { Authorization: "Bearer legacy-secret" },
+        },
+      ],
+    });
+    const agent = new MockAgent();
+    const events = await firstValueFrom(
+      middleware
+        .run(
+          createRunAgentInput({
+            forwardedProps: {
+              __proxiedMCPRequest: { serverId: "legacy", method: "ping" },
+            },
+          }),
+          agent,
+        )
+        .pipe(toArray()),
+    );
+    expect(events.at(-1)).toMatchObject({ type: "RUN_FINISHED", result: {} });
+    expect(agent.runCalls).toEqual([]);
+    expect(requests.some((request) => request.method === "GET")).toBe(true);
+    expect(requests.some((request) => request.method === "POST")).toBe(true);
+    expect(
+      requests.every(
+        (request) => request.authorization === "Bearer legacy-secret",
+      ),
+    ).toBe(true);
+  } finally {
+    await sdkServer.close();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 });

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -21,6 +21,7 @@ async function setup(
   stallDelete = false,
   redirect = false,
   rejectAuth = false,
+  metadata: "legacy" | "nested" | "both" = "legacy",
 ) {
   const requests: Array<{
     method: string;
@@ -73,7 +74,15 @@ async function setup(
                   name: "card",
                   description: "Card",
                   inputSchema: { type: "object", properties: {} },
-                  _meta: { "ui/resourceUri": "ui://card" },
+                  _meta:
+                    metadata === "legacy"
+                      ? { "ui/resourceUri": "ui://card" }
+                      : {
+                          ui: { resourceUri: "ui://card" },
+                          ...(metadata === "both"
+                            ? { "ui/resourceUri": "ui://legacy" }
+                            : {}),
+                        },
                 },
               ],
             }
@@ -426,3 +435,34 @@ test("authenticated discovery and tool execution delete both sessions", async ()
     await teardown();
   }
 });
+
+test.each(["nested", "both"] as const)(
+  "discovery uses current MCP metadata (%s)",
+  async (metadata) => {
+    const { discover, agent, teardown } = await setup(
+      false,
+      false,
+      false,
+      false,
+      metadata,
+    );
+    agent.setEvents([
+      createRunStartedEvent(),
+      createToolCallStartEvent("call", "card"),
+      createToolCallArgsEvent("call", "{}"),
+      createToolCallEndEvent("call"),
+      createRunFinishedEvent(),
+    ]);
+    try {
+      const events = await discover();
+      expect(agent.runCalls[0].tools.map((tool) => tool.name)).toContain(
+        "card",
+      );
+      expect(
+        events.find((event) => event.type === "ACTIVITY_SNAPSHOT"),
+      ).toMatchObject({ content: { resourceUri: "ui://card" } });
+    } finally {
+      await teardown();
+    }
+  },
+);

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -5,7 +5,15 @@ import { once } from "node:events";
 import { expect, test, vi } from "vitest";
 import { firstValueFrom, toArray } from "rxjs";
 import { MCPAppsMiddleware, getServerHash } from "../src/index";
-import { MockAgent, createRunAgentInput } from "./test-utils";
+import {
+  MockAgent,
+  createRunAgentInput,
+  createRunStartedEvent,
+  createRunFinishedEvent,
+  createToolCallStartEvent,
+  createToolCallArgsEvent,
+  createToolCallEndEvent,
+} from "./test-utils";
 
 /** Serve the MCP HTTP protocol and record transport effects on real sockets. */
 async function setup(
@@ -55,14 +63,27 @@ async function setup(
       message.method === "initialize"
         ? {
             protocolVersion: message.params.protocolVersion,
-            capabilities: { resources: {} },
+            capabilities: { resources: {}, tools: {} },
             serverInfo: { name: "fixture", version: "1" },
           }
-        : {
-            contents: [
-              { uri: "ui://card", text: "Card", mimeType: "text/html+mcp" },
-            ],
-          };
+        : message.method === "tools/list"
+          ? {
+              tools: [
+                {
+                  name: "card",
+                  description: "Card",
+                  inputSchema: { type: "object", properties: {} },
+                  _meta: { "ui/resourceUri": "ui://card" },
+                },
+              ],
+            }
+          : message.method === "tools/call"
+            ? { content: [{ type: "text", text: "Card result" }] }
+            : {
+                contents: [
+                  { uri: "ui://card", text: "Card", mimeType: "text/html+mcp" },
+                ],
+              };
     response.writeHead(200, {
       "content-type": "application/json",
       "mcp-session-id": "fixture-session",
@@ -374,5 +395,34 @@ test("legacy SSE reentry keeps trusted authentication on GET and POST", async ()
     await sdkServer.close();
     server.closeAllConnections();
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("authenticated discovery and tool execution delete both sessions", async () => {
+  const { discover, agent, requests, teardown } = await setup();
+  agent.setEvents([
+    createRunStartedEvent(),
+    createToolCallStartEvent("call", "card"),
+    createToolCallArgsEvent("call", "{}"),
+    createToolCallEndEvent("call"),
+    createRunFinishedEvent(),
+  ]);
+  try {
+    const events = await discover();
+    expect(agent.runCalls[0].tools.map((tool) => tool.name)).toContain("card");
+    expect(events.some((event) => event.type === "ACTIVITY_SNAPSHOT")).toBe(
+      true,
+    );
+    expect(events.at(-1)).toMatchObject({ type: "RUN_FINISHED" });
+    expect(
+      requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(2);
+    expect(
+      requests.every(
+        (request) => request.authorization === "Bearer fixture-token",
+      ),
+    ).toBe(true);
+  } finally {
+    await teardown();
   }
 });

--- a/middlewares/mcp-apps-middleware/package.json
+++ b/middlewares/mcp-apps-middleware/package.json
@@ -30,7 +30,7 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.15.0"
   },
   "peerDependencies": {
     "@ag-ui/client": ">=0.0.40",
@@ -38,10 +38,10 @@
   },
   "devDependencies": {
     "@ag-ui/client": "workspace:*",
+    "@arethetypeswrong/cli": "^0.17.4",
     "@types/node": "^20.11.19",
     "@vitest/coverage-istanbul": "^4.0.18",
     "publint": "^0.3.12",
-    "@arethetypeswrong/cli": "^0.17.4",
     "rxjs": "7.8.1",
     "tsdown": "^0.20.1",
     "typescript": "^5.3.3",

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -449,7 +449,18 @@ export class MCPAppsMiddleware extends Middleware {
       // Keep operator diagnostics on the server, never in the iframe response.
       throw new Error("MCP request failed");
     } finally {
-      await closeMCPConnection(client, transport);
+      try {
+        await closeMCPConnection(client, transport);
+      } catch (error) {
+        console.error(
+          "MCP session cleanup failed",
+          {
+            serverId: serverConfig.serverId,
+            serverHash: getServerHash(serverConfig),
+          },
+          error,
+        );
+      }
     }
   }
 

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -170,6 +170,8 @@ export interface MCPAppsMiddlewareConfig {
    * List of MCP server configurations
    */
   mcpServers?: MCPClientConfig[];
+  /** Continue without unavailable servers by default, or stop before invoking the agent. */
+  discoveryFailureMode?: "continue" | "throw";
 }
 
 /**
@@ -414,6 +416,9 @@ export class MCPAppsMiddleware extends Middleware {
         default:
           throw new Error(`MCP method not allowed for UI proxy: ${method}`);
       }
+    } catch {
+      // Transport errors can contain server response bodies and credentials.
+      throw new Error("MCP request failed");
     } finally {
       await closeMCPConnection(client, transport);
     }
@@ -634,11 +639,11 @@ export class MCPAppsMiddleware extends Middleware {
       try {
         const tools = await this.fetchToolsFromServer(serverConfig);
         allUITools.push(...tools);
-      } catch (error) {
-        console.error(
-          `Failed to fetch tools from MCP server ${serverConfig.url}:`,
-          error,
-        );
+      } catch {
+        if (this.config.discoveryFailureMode === "throw") {
+          throw new Error("MCP tool discovery failed");
+        }
+        console.error("MCP tool discovery failed");
       }
     }
 

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -107,9 +107,27 @@ export function getServerHash(config: MCPClientConfig): string {
  * back and throws.
  */
 async function buildMCPTransport(config: MCPClientConfig) {
-  const options = config.headers
-    ? { requestInit: { headers: config.headers } }
-    : undefined;
+  const endpoint = new URL(config.url);
+  if (
+    !["http:", "https:"].includes(endpoint.protocol) ||
+    endpoint.username ||
+    endpoint.password
+  ) {
+    throw new Error("MCP URL must use HTTP(S) without embedded credentials");
+  }
+  const trustedFetch: typeof fetch = (target, init) => {
+    const url = new URL(
+      target instanceof Request ? target.url : String(target),
+    );
+    if (url.origin !== endpoint.origin) {
+      return Promise.reject(new Error("MCP transport changed origin"));
+    }
+    return fetch(target, { ...init, redirect: "error" });
+  };
+  const options = {
+    requestInit: { headers: config.headers, redirect: "error" as const },
+    fetch: trustedFetch,
+  };
   if (config.type === "sse") {
     const { SSEClientTransport } = await import(
       "@modelcontextprotocol/sdk/client/sse.js"

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -16,6 +16,7 @@ import { Observable, from, switchMap } from "rxjs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { randomUUID, createHash } from "crypto";
+import { createTrustedFetch } from "./trusted-fetch";
 
 /**
  * Activity type for MCP Apps events
@@ -115,15 +116,7 @@ async function buildMCPTransport(config: MCPClientConfig) {
   ) {
     throw new Error("MCP URL must use HTTP(S) without embedded credentials");
   }
-  const trustedFetch: typeof fetch = (target, init) => {
-    const url = new URL(
-      target instanceof Request ? target.url : String(target),
-    );
-    if (url.origin !== endpoint.origin) {
-      return Promise.reject(new Error("MCP transport changed origin"));
-    }
-    return fetch(target, { ...init, redirect: "error" });
-  };
+  const trustedFetch = createTrustedFetch(endpoint.origin);
   const options = {
     requestInit: { headers: config.headers, redirect: "error" as const },
     fetch: trustedFetch,
@@ -175,10 +168,19 @@ export interface MCPAppsMiddlewareConfig {
 }
 
 /**
- * Check if a tool has a UI resource attached (per SEP-1865)
+ * Check for a UI resource that the server allows the model to discover
  */
-function hasUIResource(tool: { _meta?: Record<string, unknown> }): boolean {
-  return getUIResourceUri(tool) !== undefined;
+function isModelVisibleUITool(tool: { _meta?: Record<string, unknown> }): boolean {
+  const ui = tool._meta?.ui;
+  const visibility =
+    ui && typeof ui === "object" && "visibility" in ui
+      ? ui.visibility
+      : undefined;
+  return (
+    getUIResourceUri(tool) !== undefined &&
+    (visibility === undefined ||
+      (Array.isArray(visibility) && visibility.includes("model")))
+  );
 }
 
 /** Read current MCP Apps metadata first, with the legacy flat key as fallback. */
@@ -412,8 +414,7 @@ export class MCPAppsMiddleware extends Middleware {
     try {
       await client.connect(transport);
 
-      // Per SEP-1865: Forward any method that doesn't start with "ui/"
-      // Methods starting with "ui/" are handled by the host, not the MCP server
+      // Dispatch only methods admitted by the UI proxy allowlist.
       switch (method) {
         case "tools/call":
           return await client.callTool(
@@ -431,10 +432,19 @@ export class MCPAppsMiddleware extends Middleware {
         case "ping":
           return await client.ping();
         default:
+          // Defensive assertion: the pre-connection allowlist covers every case above.
           throw new Error(`MCP method not allowed for UI proxy: ${method}`);
       }
-    } catch {
-      // Transport errors can contain server response bodies and credentials.
+    } catch (error) {
+      console.error(
+        "MCP proxy request failed",
+        {
+          serverId: serverConfig.serverId,
+          serverHash: getServerHash(serverConfig),
+        },
+        error,
+      );
+      // Keep operator diagnostics on the server, never in the iframe response.
       throw new Error("MCP request failed");
     } finally {
       await closeMCPConnection(client, transport);
@@ -656,11 +666,18 @@ export class MCPAppsMiddleware extends Middleware {
       try {
         const tools = await this.fetchToolsFromServer(serverConfig);
         allUITools.push(...tools);
-      } catch {
+      } catch (error) {
+        console.error(
+          "MCP tool discovery failed",
+          {
+            serverId: serverConfig.serverId,
+            serverHash: getServerHash(serverConfig),
+          },
+          error,
+        );
         if (this.config.discoveryFailureMode === "throw") {
           throw new Error("MCP tool discovery failed");
         }
-        console.error("MCP tool discovery failed");
       }
     }
 
@@ -696,7 +713,7 @@ export class MCPAppsMiddleware extends Middleware {
       const response = await client.listTools();
 
       // Filter for tools with UI resources and convert to AG-UI format with server config
-      const uiTools = response.tools.filter(hasUIResource).map((mcpTool) => ({
+      const uiTools = response.tools.filter(isModelVisibleUITool).map((mcpTool) => ({
         tool: convertMCPToolToAGUITool(mcpTool),
         serverConfig,
         resourceUri: getUIResourceUri(mcpTool)!,

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -150,7 +150,7 @@ async function closeMCPConnection(
     // Session cleanup must not replace a successful operation or its error.
   } finally {
     clearTimeout(deadline);
-    // Closing aborts the SDK transport, including an outstanding DELETE.
+    // Close the SDK transport; DELETE has its own bounded signal.
     await client.close();
   }
 }
@@ -170,7 +170,9 @@ export interface MCPAppsMiddlewareConfig {
 /**
  * Check for a UI resource that the server allows the model to discover
  */
-function isModelVisibleUITool(tool: { _meta?: Record<string, unknown> }): boolean {
+function isModelVisibleUITool(tool: {
+  _meta?: Record<string, unknown>;
+}): boolean {
   const ui = tool._meta?.ui;
   const visibility =
     ui && typeof ui === "object" && "visibility" in ui
@@ -713,11 +715,13 @@ export class MCPAppsMiddleware extends Middleware {
       const response = await client.listTools();
 
       // Filter for tools with UI resources and convert to AG-UI format with server config
-      const uiTools = response.tools.filter(isModelVisibleUITool).map((mcpTool) => ({
-        tool: convertMCPToolToAGUITool(mcpTool),
-        serverConfig,
-        resourceUri: getUIResourceUri(mcpTool)!,
-      }));
+      const uiTools = response.tools
+        .filter(isModelVisibleUITool)
+        .map((mcpTool) => ({
+          tool: convertMCPToolToAGUITool(mcpTool),
+          serverConfig,
+          resourceUri: getUIResourceUri(mcpTool)!,
+        }));
 
       return uiTools;
     } finally {

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -82,14 +82,13 @@ export interface MCPClientConfigSSE {
 export type MCPClientConfig = MCPClientConfigHTTP | MCPClientConfigSSE;
 
 /**
- * Generate a stable server hash from config using MD5 hash.
+ * Generate a stable reference from the public endpoint, excluding credentials.
  * This allows the frontend to reference servers without knowing their URLs.
  */
 export function getServerHash(config: MCPClientConfig): string {
   const serialized = JSON.stringify({
     type: config.type,
     url: config.url,
-    headers: config.headers,
   });
   return createHash("md5").update(serialized).digest("hex");
 }
@@ -196,6 +195,7 @@ export class MCPAppsMiddleware extends Middleware {
   private serverConfigMapByHash: Map<string, MCPClientConfig> = new Map();
   /** Map of serverId -> server config for proxied requests */
   private serverConfigMapById: Map<string, MCPClientConfig> = new Map();
+  private ambiguousServerHashes = new Set<string>();
 
   constructor(config: MCPAppsMiddlewareConfig = {}) {
     super();
@@ -203,8 +203,22 @@ export class MCPAppsMiddleware extends Middleware {
     // Build server config maps for proxied requests
     for (const serverConfig of config.mcpServers || []) {
       const serverHash = getServerHash(serverConfig);
-      this.serverConfigMapByHash.set(serverHash, serverConfig);
+      const previous = this.serverConfigMapByHash.get(serverHash);
+      if (previous || this.ambiguousServerHashes.has(serverHash)) {
+        if (!serverConfig.serverId || (previous && !previous.serverId)) {
+          throw new Error(
+            "MCP servers sharing an endpoint require distinct serverId values",
+          );
+        }
+        this.serverConfigMapByHash.delete(serverHash);
+        this.ambiguousServerHashes.add(serverHash);
+      } else {
+        this.serverConfigMapByHash.set(serverHash, serverConfig);
+      }
       if (serverConfig.serverId) {
+        if (this.serverConfigMapById.has(serverConfig.serverId)) {
+          throw new Error("MCP servers require distinct serverId values");
+        }
         this.serverConfigMapById.set(serverConfig.serverId, serverConfig);
       }
     }

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -124,14 +124,22 @@ async function closeMCPConnection(
   client: Client,
   transport: Awaited<ReturnType<typeof buildMCPTransport>>,
 ): Promise<void> {
+  let deadline: ReturnType<typeof setTimeout> | undefined;
   try {
     if (transport instanceof StreamableHTTPClientTransport) {
-      // Older servers can reject DELETE. Still close the local connection.
-      await transport.terminateSession();
+      // Do not hold a completed operation behind an unresponsive DELETE.
+      await Promise.race([
+        transport.terminateSession(),
+        new Promise<void>((resolve) => {
+          deadline = setTimeout(resolve, 3_000);
+        }),
+      ]);
     }
   } catch {
     // Session cleanup must not replace a successful operation or its error.
   } finally {
+    clearTimeout(deadline);
+    // Closing aborts the SDK transport, including an outstanding DELETE.
     await client.close();
   }
 }

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -178,7 +178,24 @@ export interface MCPAppsMiddlewareConfig {
  * Check if a tool has a UI resource attached (per SEP-1865)
  */
 function hasUIResource(tool: { _meta?: Record<string, unknown> }): boolean {
-  return typeof tool._meta?.["ui/resourceUri"] === "string";
+  return getUIResourceUri(tool) !== undefined;
+}
+
+/** Read current MCP Apps metadata first, with the legacy flat key as fallback. */
+function getUIResourceUri(tool: {
+  _meta?: Record<string, unknown>;
+}): string | undefined {
+  const ui = tool._meta?.ui;
+  if (
+    ui &&
+    typeof ui === "object" &&
+    "resourceUri" in ui &&
+    typeof ui.resourceUri === "string"
+  ) {
+    return ui.resourceUri;
+  }
+  const legacy = tool._meta?.["ui/resourceUri"];
+  return typeof legacy === "string" ? legacy : undefined;
 }
 
 /**
@@ -206,7 +223,7 @@ function convertMCPToolToAGUITool(mcpTool: {
 
   // Store UI resource URI in the description for now
   // TODO: Once AG-UI Tool type supports _meta, use that instead
-  const uiResourceUri = mcpTool._meta?.["ui/resourceUri"];
+  const uiResourceUri = getUIResourceUri(mcpTool);
   if (typeof uiResourceUri === "string") {
     tool.description = `${tool.description}\n[UI Resource: ${uiResourceUri}]`;
   }
@@ -682,7 +699,7 @@ export class MCPAppsMiddleware extends Middleware {
       const uiTools = response.tools.filter(hasUIResource).map((mcpTool) => ({
         tool: convertMCPToolToAGUITool(mcpTool),
         serverConfig,
-        resourceUri: mcpTool._meta!["ui/resourceUri"] as string,
+        resourceUri: getUIResourceUri(mcpTool)!,
       }));
 
       return uiTools;

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -120,6 +120,23 @@ async function buildMCPTransport(config: MCPClientConfig) {
   return new StreamableHTTPClientTransport(new URL(config.url), options);
 }
 
+/** Release a short-lived HTTP session before closing its transport. */
+async function closeMCPConnection(
+  client: Client,
+  transport: Awaited<ReturnType<typeof buildMCPTransport>>,
+): Promise<void> {
+  try {
+    if (transport instanceof StreamableHTTPClientTransport) {
+      // Older servers can reject DELETE. Still close the local connection.
+      await transport.terminateSession();
+    }
+  } catch {
+    // Session cleanup must not replace a successful operation or its error.
+  } finally {
+    await client.close();
+  }
+}
+
 /**
  * Configuration for MCPAppsMiddleware
  */
@@ -307,6 +324,17 @@ export class MCPAppsMiddleware extends Middleware {
     method: string,
     params?: Record<string, unknown>,
   ): Promise<unknown> {
+    // Reject iframe methods before creating a credentialed MCP connection.
+    if (
+      ![
+        "tools/call",
+        "resources/read",
+        "notifications/message",
+        "ping",
+      ].includes(method)
+    ) {
+      throw new Error(`MCP method not allowed for UI proxy: ${method}`);
+    }
     const transport = await buildMCPTransport(serverConfig);
 
     const client = new Client(
@@ -347,7 +375,7 @@ export class MCPAppsMiddleware extends Middleware {
           throw new Error(`MCP method not allowed for UI proxy: ${method}`);
       }
     } finally {
-      await client.close();
+      await closeMCPConnection(client, transport);
     }
   }
 
@@ -503,7 +531,7 @@ export class MCPAppsMiddleware extends Middleware {
 
       return result;
     } finally {
-      await client.close();
+      await closeMCPConnection(client, transport);
     }
   }
 
@@ -615,7 +643,7 @@ export class MCPAppsMiddleware extends Middleware {
       return uiTools;
     } finally {
       // Always close the connection
-      await client.close();
+      await closeMCPConnection(client, transport);
     }
   }
 }

--- a/middlewares/mcp-apps-middleware/src/trusted-fetch.ts
+++ b/middlewares/mcp-apps-middleware/src/trusted-fetch.ts
@@ -1,0 +1,12 @@
+/** Bind transport requests to one origin and reject redirects before credentials leave it. */
+export function createTrustedFetch(origin: string): typeof fetch {
+  return (target, init) => {
+    const url = new URL(
+      target instanceof Request ? target.url : String(target),
+    );
+    if (url.origin !== origin) {
+      return Promise.reject(new Error("MCP transport changed origin"));
+    }
+    return fetch(target, { ...init, redirect: "error" });
+  };
+}

--- a/middlewares/mcp-apps-middleware/src/trusted-fetch.ts
+++ b/middlewares/mcp-apps-middleware/src/trusted-fetch.ts
@@ -7,6 +7,13 @@ export function createTrustedFetch(origin: string): typeof fetch {
     if (url.origin !== origin) {
       return Promise.reject(new Error("MCP transport changed origin"));
     }
-    return fetch(target, { ...init, redirect: "error" });
+    return fetch(target, {
+      ...init,
+      redirect: "error",
+      // A failed handshake may have already aborted the SDK signal.
+      ...(init?.method === "DELETE"
+        ? { signal: AbortSignal.timeout(3_000) }
+        : {}),
+    });
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,8 +1376,8 @@ importers:
   middlewares/mcp-apps-middleware:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.0.0
-        version: 1.20.0
+        specifier: ^1.15.0
+        version: 1.15.0
     devDependencies:
       '@ag-ui/client':
         specifier: workspace:*
@@ -4858,8 +4858,8 @@ packages:
       react-dom:
         optional: true
 
-  '@modelcontextprotocol/sdk@1.20.0':
-    resolution: {integrity: sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==}
+  '@modelcontextprotocol/sdk@1.15.0':
+    resolution: {integrity: sha512-67hnl/ROKdb03Vuu0YOr+baKTvf1/5YBHBm9KnZdjdAh8hjt4FRCPD5ucwxGB237sBpzlqQsLy1PFu7z/ekZ9Q==}
     engines: {node: '>=18'}
 
   '@modelcontextprotocol/sdk@1.29.0':
@@ -17936,20 +17936,20 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@modelcontextprotocol/sdk@1.20.0':
+  '@modelcontextprotocol/sdk@1.15.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
       zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
MCP iframe requests could open authenticated sessions before validation, expose credential-derived hashes, and forward headers through redirects. This change guards those connections and closes short-lived HTTP sessions with a bounded cleanup deadline.

## Changes

- Reject unsupported proxy methods before connecting; keep transport requests on the configured origin and reject redirects.
- Delete HTTP sessions after discovery, tool execution, and proxy calls, with a three-second cleanup deadline.
- Hash only transport type and URL. Multiple credential scopes at one endpoint require distinct server IDs; ambiguous hash-only requests are rejected.
- Support current nested UI metadata and legacy fallback. Model discovery respects `ui.visibility`; app-only tools remain callable through the iframe proxy.
- Keep frontend errors generic, while server-side logs retain the original error plus server ID/hash. Discovery defaults to continuing, with an optional strict mode.

## Review follow-up at `78bd24c0`

The SDK dependency now requires `^1.15.0`, and the lockfile selects 1.15.0 to test the minimum. Inspection of published SDK artifacts found custom fetch options absent in 1.14.0 and present in both transports in 1.15.0, which also includes HTTP session deletion. This prevents older lockfiles from silently omitting those controls.

The README now states that floor, documents HTTP headers and `discoveryFailureMode`, describes the hash consistently, explains tool visibility and server-side diagnostics, and places the security section before the license. The unreachable switch default is marked as a defensive assertion.

Session deletion now has its own three-second abort signal. A failed handshake can abort the SDK signal before cleanup starts; the independent signal lets DELETE release the authenticated session. Stalled or rejected cleanup preserves the original generic operation error.

Proxy cleanup also catches and logs a rejected client close, preserving the original response. Two fault-injection tests failed before this guard and now pass for successful requests and failed handshakes. This is defensive coverage; no live close rejection was reproduced.

## Validation

`NX_DAEMON=false pnpm nx run-many -t test,typecheck,build -p @ag-ui/mcp-apps-middleware` passes with SDK 1.15.0 and 1.20.0: **102 tests**, typecheck, and build.

- Six failed-handshake cleanup cases failed before the signal fix, then passed. They cover proxy and discovery failures during initialization, authenticated session IDs, stalled DELETE cancellation, and rejected DELETE error redaction. Empty and mixed-format visibility cases also pass.
- New regressions failed before the visibility and diagnostic fixes. They cover omitted visibility, model-only, app-only, and combined visibility; app-only proxy calls; and diagnostics in both discovery modes and proxy failures.
- A real SSE endpoint points its POST target at a second listening origin; no request reaches that origin. A separate real-HTTP test exercises our own origin guard. Disabling that guard made the test fail, independently of SDK protection.
- Existing tests cover authenticated HTTP and SSE, session deletion, the cleanup deadline, credential-free hashes, ambiguous server selection, and redirects.
- Frozen-lockfile installation, formatting, and `git diff --check` pass. The lockfile change is limited to this SDK dependency. GitHub checks are running on the new head.

The extracted middleware belongs here rather than in a CopilotKit-local fork. CopilotKit/CopilotKit#6967 currently pins the earlier `258fa169` preview and must consume a released version containing these fixes before merge. Its clean-package checks reject the unpublished URL dependency with `ERR_PNPM_EXOTIC_SUBDEP`.

No package release is included in this PR work.


