### PR TITLE
fix(adk): accept non-object JSON frontend tool results

### DIFF
--- a/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
+++ b/integrations/adk-middleware/python/src/ag_ui_adk/adk_agent.py
@@ -1938,6 +1938,10 @@ class ADKAgent:
                 if content and content.strip():
                     try:
                         result = json.loads(content)
+                        # Gemini requires an object, but frontend handlers may
+                        # return any JSON value. Preserve objects as-is.
+                        if not isinstance(result, dict):
+                            result = {"result": result}
                     except json.JSONDecodeError:
                         # Not valid JSON - treat as plain string result.
                         result = {"success": True, "result": content, "status": "completed"}

--- a/integrations/adk-middleware/python/tests/test_tool_result_json_values.py
+++ b/integrations/adk-middleware/python/tests/test_tool_result_json_values.py
@@ -1,0 +1,26 @@
+"""Frontend handlers may return any JSON value, not only objects."""
+
+import json
+
+import pytest
+from ag_ui.core import ToolMessage
+from ag_ui_adk import ADKAgent
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[{"id": "INC-1041"}], [], "approved", 42, False, None, {"records": []}],
+)
+def test_function_response_accepts_json_values(value):
+    message = ToolMessage(
+        id="result", role="tool", tool_call_id="client-call", content=json.dumps(value)
+    )
+    parts = ADKAgent._build_function_response_parts(
+        None,
+        [{"message": message, "tool_name": "get_records"}],
+        {"client-call": "adk-call"},
+    )
+    response = parts[0].function_response
+    assert response.response == (value if isinstance(value, dict) else {"result": value})
+    assert response.name == "get_records"
+    assert response.id == "adk-call"


### PR DESCRIPTION
## Problem

A frontend tool handler returning an array produces an empty assistant response. The ADK return leg parses JSON, then passes the array directly to Google's object-only `FunctionResponse.response` field.

## Why

Frontend handlers can return any JSON value. Valid JSON arrays, strings, numbers, booleans, and null all bypassed the existing plain-text fallback and failed Pydantic validation.

Reproduced against main using the real ADK adapter and Runner with a deterministic local model:

```text
Array result: [{"id":"INC-1041"}]
Before: RUN_STARTED → RUN_ERROR
Input should be a valid dictionary [type=dict_type, input_type=list]
Assistant text: (empty); model invocations: 1
After: RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT
       → TEXT_MESSAGE_END → STATE_SNAPSHOT → RUN_FINISHED
Assistant text: All tools are done.; model invocations: 2
```

## Fix

Wrap parsed non-object JSON values in `{"result": value}`. Preserve existing objects, plain-text handling, empty-result handling, tool names, and correlation IDs. Four production lines; parameterized regressions cover arrays (including empty), strings, numbers, booleans, null, and objects.

Validation: new regression suite was **6 failed / 1 passed** before the fix. After: **37 passed** across the new suite and `test_tool_result_flow.py`, run through `nx exec --projects=@ag-ui/adk`. One existing mock-runner coroutine warning remains. The deterministic return-leg reproduction also passes; this is protocol evidence, not a browser/Gemini live-model test.
