### PR TITLE
fix(strands): avoid forwarding template-bound managers

### DIFF
--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -3440,11 +3440,20 @@ class StrandsAgent:
         if self._orchestrator is None:
             self._model = agent.model
             self._system_prompt = agent.system_prompt
-            self._tools = (
-                list(agent.tool_registry.registry.values())
-                if hasattr(agent, "tool_registry")
-                else []
-            )
+            # A plugin's tool can retain a callback bound to the template's
+            # manager even when that manager is excluded from the kwargs.
+            self._tools = [
+                tool
+                for tool in (
+                    agent.tool_registry.registry.values()
+                    if hasattr(agent, "tool_registry")
+                    else []
+                )
+                if not _references_agent(
+                    getattr(getattr(tool, "_tool_func", None), "__self__", None),
+                    agent,
+                )
+            ]
             (
                 self._agent_kwargs,
                 self._unreadable_params,

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -304,9 +304,12 @@ def _resolve_template_param(agent: Any, name: str, annotation: Any = None) -> An
         if value is _MISSING:
             continue
 
+        # Managers may live directly under a parameter's name (for example,
+        # Strands background_tasks), not only under a registry alias.
+        if _references_agent(value, agent):
+            return _AGENT_BOUND
+
         if attr.endswith("_registry") and not name.endswith("_registry"):
-            if _references_agent(value, agent):
-                return _AGENT_BOUND
             contents = _registry_contents(value)
             if contents is _MISSING:
                 continue

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -765,6 +765,49 @@ def test_value_holding_the_agent_is_not_forwarded(attribute, weak):
     assert _resolve_template_param(fake, "setting") is _AGENT_BOUND
 
 
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    "background_tasks" not in inspect.signature(Agent.__init__).parameters,
+    reason="this Strands release has no background tasks",
+)
+@pytest.mark.parametrize(
+    "thread_kwargs",
+    [{}, {"background_tasks": False}, {"background_tasks": True}],
+    ids=["omitted", "disabled", "enabled"],
+)
+async def test_background_task_tools_belong_to_the_thread(thread_kwargs):
+    from strands import tool
+    from ag_ui_strands.config import StrandsAgentConfig
+
+    @tool
+    def echo(value: str) -> str:
+        """Return the supplied value."""
+        return value
+
+    template = Agent(model=_mock_model(), tools=[echo], background_tasks=True)
+    config = StrandsAgentConfig(thread_agent_kwargs=lambda _: thread_kwargs)
+    adapter = StrandsAgent(template, name="test", config=config)
+    threads = [
+        await _trigger_thread_creation(adapter, thread_id)
+        for thread_id in ("a", "b")
+    ]
+
+    for thread in threads:
+        registry = thread.tool_registry.registry
+        assert registry["echo"] is template.tool_registry.registry["echo"]
+        manager_tool = registry.get("strands_manage_background_task")
+        if thread_kwargs.get("background_tasks"):
+            assert thread._background_tasks is not template._background_tasks
+            assert manager_tool is not None
+            assert manager_tool._tool_func.__self__ is thread._background_tasks
+        else:
+            assert thread._background_tasks is None
+            assert manager_tool is None
+
+    if thread_kwargs.get("background_tasks"):
+        assert threads[0]._background_tasks is not threads[1]._background_tasks
+
+
 def test_registry_holding_an_unrelated_agent_is_still_forwarded():
     """The reference has to be to THIS agent, not to any agent at all.
 

--- a/integrations/aws-strands/python/tests/test_template_agent_propagation.py
+++ b/integrations/aws-strands/python/tests/test_template_agent_propagation.py
@@ -750,26 +750,19 @@ def test_reads_a_dict_backed_registry_from_its_backing_field():
     assert recovered[0] is plugin
 
 
-def test_registry_holding_the_agent_is_not_forwarded():
-    """A registry that keeps a reference to its own agent must not be shared.
-
-    Registration hands the owning agent to whatever the registry holds, so its
-    contents are wired to that agent and cannot serve a second one.
-    """
-    import weakref
-
-    param = _first_forwardable_param()
-    singular = param[:-1] if param.endswith("s") else param
-
-    class OwnedRegistry:
-        def __init__(self, owner, contents):
-            self._agent_ref = weakref.ref(owner)
-            self._contents = contents
-
+@pytest.mark.parametrize(
+    "attribute", ["setting", "_setting", "_default_setting", "_setting_registry"]
+)
+@pytest.mark.parametrize("weak", [False, True])
+def test_value_holding_the_agent_is_not_forwarded(attribute, weak):
+    """Agent-owned managers are unsafe to forward regardless of storage name."""
     fake = type("FakeAgent", (), {})()
-    setattr(fake, f"_{singular}_registry", OwnedRegistry(fake, [object()]))
-
-    assert _resolve_template_param(fake, param) is _AGENT_BOUND
+    holder = types.SimpleNamespace(
+        _agent=weakref.ref(fake) if weak else fake,
+        _contents=[object()],
+    )
+    setattr(fake, attribute, holder)
+    assert _resolve_template_param(fake, "setting") is _AGENT_BOUND
 
 
 def test_registry_holding_an_unrelated_agent_is_still_forwarded():


### PR DESCRIPTION
## Problem

The `aws-strands-python-latest` CI check fails with Strands 1.55.1, including on the unrelated ADK PR #2720. Setting `Agent(background_tasks=True)` causes template-parameter extraction to forward an internal `_BackgroundTasks` manager as the next agent's constructor argument, instead of a boolean or configuration dictionary.

## Why

The manager holds a reference to the template agent. The existing ownership check only guarded attributes ending in `_registry`, so the `_background_tasks` private attribute bypassed it.

Reproduced on fresh main with the same SDK version as CI: **2 failed, 70 passed** in `test_template_agent_propagation.py`. Expanded storage-convention coverage reproduces six additional failures for direct/private/default aliases with strong or weak references to the template.

## Fix

Apply the existing agent-ownership check before interpreting any candidate attribute. Bound managers now take the adapter's existing `_AGENT_BOUND` reporting path instead of being handed to another agent. Callers enable background tasks per thread through `StrandsAgentConfig.thread_agent_kwargs`; the existing warning names the uncarried setting and explains that path. This does not automatically clone a manager's configuration or share its task state.

Exclude management tools whose bound callback retains the template agent, while preserving ordinary tools. Per-thread background-task configuration creates a fresh manager and management tool for each thread. Regression cases cover omitted, disabled, and enabled background tasks across two threads; the omitted and disabled cases fail before this fix.

Generalize the existing ownership regression to public, private, default, and registry attributes with strong and weak references. No dependency pins or lockfiles change.

Validation through Nx:
- Strands 1.55.1: targeted suite **82 passed**.
- Locked Strands 1.18.0: **58 passed, 4 skipped**.
- Declared floor Strands 1.15.0: **58 passed, 4 skipped**.
- `git diff --check` passes for both changed files.
- Full Strands suite on 1.55.1: **1,424 passed, 15 skipped**, with seven existing warnings (141.88 seconds).
