### PR TITLE
fix(mcp-apps): advertise the standard HTML MIME type

### DIFF
--- a/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/mcp-apps-middleware.test.ts
@@ -317,7 +317,7 @@ describe("MCPAppsMiddleware", () => {
         capabilities: {
           extensions: {
             "io.modelcontextprotocol/ui": {
-              mimeTypes: ["text/html+mcp"],
+              mimeTypes: ["text/html;profile=mcp-app"],
             },
           },
         },

--- a/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
+++ b/middlewares/mcp-apps-middleware/__tests__/trusted-proxy.test.ts
@@ -34,6 +34,7 @@ async function setup(
     authorization?: string;
     rpc?: string;
     sessionId?: string;
+    mimeTypes?: unknown;
   }> = [];
   let stalledDeleteClosed = false;
   const server = createServer(async (request, response) => {
@@ -42,6 +43,7 @@ async function setup(
       authorization: request.headers.authorization,
       sessionId: request.headers["mcp-session-id"]?.toString(),
       rpc: undefined as string | undefined,
+      mimeTypes: undefined as unknown,
     };
     requests.push(entry);
     if (rejectAuth) {
@@ -74,6 +76,11 @@ async function setup(
     for await (const chunk of request) raw += chunk;
     const message = JSON.parse(raw);
     entry.rpc = message.method;
+    if (message.method === "initialize")
+      entry.mimeTypes =
+        message.params.capabilities?.extensions?.[
+          "io.modelcontextprotocol/ui"
+        ]?.mimeTypes;
     if (
       message.method === "notifications/initialized" &&
       options.initializationFailure === "initialized-error"
@@ -123,7 +130,11 @@ async function setup(
             ? { content: [{ type: "text", text: "Card result" }] }
             : {
                 contents: [
-                  { uri: "ui://card", text: "Card", mimeType: "text/html+mcp" },
+                  {
+                    uri: "ui://card",
+                    text: "Card",
+                    mimeType: "text/html;profile=mcp-app",
+                  },
                 ],
               };
     response.writeHead(200, {
@@ -715,3 +726,28 @@ test.each([false, true])(
     }
   },
 );
+
+test("all HTTP connections advertise the standard MCP Apps MIME type", async () => {
+  const { discover, run, agent, requests, teardown } = await setup();
+  agent.setEvents([
+    createRunStartedEvent(),
+    createToolCallStartEvent("mime-call", "card"),
+    createToolCallArgsEvent("mime-call", "{}"),
+    createToolCallEndEvent("mime-call"),
+    createRunFinishedEvent(),
+  ]);
+  try {
+    await discover();
+    await run("resources/read");
+    await run("tools/call");
+    const initializations = requests.filter(
+      (request) => request.rpc === "initialize",
+    );
+    expect(initializations.length).toBeGreaterThanOrEqual(4);
+    for (const request of initializations) {
+      expect(request.mimeTypes).toContain("text/html;profile=mcp-app");
+    }
+  } finally {
+    await teardown();
+  }
+});

--- a/middlewares/mcp-apps-middleware/src/index.ts
+++ b/middlewares/mcp-apps-middleware/src/index.ts
@@ -406,7 +406,7 @@ export class MCPAppsMiddleware extends Middleware {
         capabilities: {
           extensions: {
             "io.modelcontextprotocol/ui": {
-              mimeTypes: ["text/html+mcp"],
+              mimeTypes: ["text/html;profile=mcp-app"],
             },
           },
         },
@@ -599,7 +599,7 @@ export class MCPAppsMiddleware extends Middleware {
         capabilities: {
           extensions: {
             "io.modelcontextprotocol/ui": {
-              mimeTypes: ["text/html+mcp"],
+              mimeTypes: ["text/html;profile=mcp-app"],
             },
           },
         },
@@ -712,7 +712,7 @@ export class MCPAppsMiddleware extends Middleware {
           // Advertise MCP Apps UI support per SEP-1865
           extensions: {
             "io.modelcontextprotocol/ui": {
-              mimeTypes: ["text/html+mcp"],
+              mimeTypes: ["text/html;profile=mcp-app"],
             },
           },
         },


### PR DESCRIPTION
MCP Apps servers can withhold UI tools when the host advertises `text/html+mcp`. The January 26 extension spec requires `text/html;profile=mcp-app`.

Update all three client construction sites: discovery, agent tool execution, and iframe proxy calls. Add a real HTTP regression that exercises all three paths and checks every initialize request. Align the existing capability assertion and resource fixture with the standard MIME type.

This corrects the January MCP Apps extension while preserving the existing core MCP negotiation. It does not migrate to the July core protocol.

Validation: the new wire test failed before the fix. All 103 middleware tests, typecheck, build, formatter, and diff checks pass afterward. The same correction is being tested through CopilotKit PR #6967's shared cross-language harness.

Spec: https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx#clientserver-capability-negotiation

A patch release is needed so CopilotKit can consume this correction without a local middleware fork.
