### PR TITLE
fix(aws-strands): preserve multimodal snapshots and report dropped media

### DIFF
--- a/integrations/aws-strands/python/README.md
+++ b/integrations/aws-strands/python/README.md
@@ -111,11 +111,11 @@ value that has to differ per thread, build it in
 `StrandsAgentConfig.thread_agent_kwargs`, which runs per request and wins over
 both routes above.
 
-| Scenario                                                | Support boundary                                                                                                                                                        |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `hooks=[...]`                                           | Supported on every release this package supports.                                                                                                                        |
-| `plugins=[...]`                                         | Requires `strands-agents >= 1.28.0`, the release that added `plugins` to `Agent`. On an older release the wrapper raises `TypeError` when it is constructed, not on the first request. |
-| `hooks` / `plugins` with a multi-agent orchestrator     | Ignored. An orchestrator is invoked directly, so there is no per-thread agent to attach them to.                                                                          |
+| Scenario                                            | Support boundary                                                                                                                                                                       |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hooks=[...]`                                       | Supported on every release this package supports.                                                                                                                                      |
+| `plugins=[...]`                                     | Requires `strands-agents >= 1.28.0`, the release that added `plugins` to `Agent`. On an older release the wrapper raises `TypeError` when it is constructed, not on the first request. |
+| `hooks` / `plugins` with a multi-agent orchestrator | Ignored. An orchestrator is invoked directly, so there is no per-thread agent to attach them to.                                                                                       |
 
 ## Key Files
 
@@ -531,6 +531,15 @@ transport would resolve the host again at connection time.
 
 A run whose media all fail conversion with no text fallback ends with
 `RUN_ERROR` under `MEDIA_RESOLUTION_FAILED`.
+
+When an attachment is dropped, the run emits a `CUSTOM` event named
+`MediaDropped` before invoking the model or reporting that terminal error.
+Its `value` contains `dropped` entries with `type` and `reason`, plus the number
+of successfully converted attachments in `delivered`. Reasons distinguish
+unsupported or malformed MIME types, empty content, and unresolved sources.
+Text that survives conversion can still reach the model. Drop details do not
+include attachment bytes or source URLs, and message snapshots retain the
+original user attachment parts for display.
 
 ## Supported AG-UI Events
 

--- a/integrations/aws-strands/python/src/ag_ui_strands/agent.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/agent.py
@@ -5288,12 +5288,26 @@ class StrandsAgent:
                                 for item in msg.content
                             )
                             if has_media:
+                                dropped_media: List[Dict[str, str]] = []
                                 user_message = await asyncio.to_thread(
                                     convert_agui_content_to_strands,
                                     msg.content,
                                     self.config.url_fetch_policy,
                                     message_id=getattr(msg, "id", None),
+                                    dropped=dropped_media,
                                 )
+                                if dropped_media:
+                                    yield CustomEvent(
+                                        type=EventType.CUSTOM,
+                                        name="MediaDropped",
+                                        value={
+                                            "dropped": dropped_media,
+                                            "delivered": sum(
+                                                any(kind in block for kind in ("image", "document", "video"))
+                                                for block in user_message
+                                            ),
+                                        },
+                                    )
                                 if not user_message:
                                     text_fallback = flatten_content_to_text(msg.content)
                                     if not text_fallback:

--- a/integrations/aws-strands/python/src/ag_ui_strands/utils.py
+++ b/integrations/aws-strands/python/src/ag_ui_strands/utils.py
@@ -84,7 +84,11 @@ def _mime_to_format(mime_type: Optional[str], allowed: Set[str]) -> Optional[str
         logger.warning("No MIME type provided, cannot determine format")
         return None
     # Strip MIME parameters (e.g. "; charset=utf-8") before parsing the subtype
-    fmt = mime_type.split(";", 1)[0].strip().rsplit("/", 1)[-1].lower()
+    parts = mime_type.split(";", 1)[0].strip().lower().split("/")
+    if len(parts) != 2 or not all(part.strip() for part in parts):
+        logger.warning("Malformed MIME type, cannot determine format")
+        return None
+    fmt = parts[1]
     # Resolve well-known aliases before checking the allowed set
     fmt = _MIME_FORMAT_ALIASES.get(fmt, fmt)
     if fmt in allowed:
@@ -744,6 +748,7 @@ def convert_agui_content_to_strands(
     budget: Optional[_FetchBudget] = None,
     *,
     message_id: Optional[str] = None,
+    dropped: Optional[List[Dict[str, str]]] = None,
 ) -> List[Dict[str, Any]]:
     """Convert an AG-UI ``InputContent`` list to Strands ``ContentBlock`` dicts.
 
@@ -765,23 +770,42 @@ def convert_agui_content_to_strands(
     ``message_id`` should be the stable AG-UI message id when the content is
     part of conversation history. Direct callers may omit it and receive a
     deterministic source-based fallback.
+
+    When supplied, ``dropped`` receives one safe, client-visible reason per
+    skipped attachment. It never includes source URLs or payload bytes.
     """
     blocks: List[Dict[str, Any]] = []
     if budget is None:
         budget = _FetchBudget(policy)
     document_index = 0
 
+    def drop(kind: str, reason: str) -> None:
+        if dropped is not None:
+            dropped.append({"type": kind, "reason": reason})
+
+    def resolve(item: Any, allowed: Set[str]) -> Optional[tuple[bytes, str]]:
+        fmt = _mime_to_format(_get_mime_type(item.source), allowed)
+        if fmt is None:
+            drop(item.type, "unsupported media type")
+            return None
+        raw = _resolve_source_bytes(item.source, policy, budget)
+        if raw is None:
+            drop(item.type, "content could not be resolved")
+            return None
+        if not raw:
+            drop(item.type, "content was empty")
+            return None
+        return raw, fmt
+
     for item in content:
         if isinstance(item, TextInputContent):
             blocks.append({"text": item.text})
 
         elif isinstance(item, ImageInputContent):
-            raw = _resolve_source_bytes(item.source, policy, budget)
-            if raw is None:
+            resolved = resolve(item, _IMAGE_FORMATS)
+            if resolved is None:
                 continue
-            fmt = _mime_to_format(_get_mime_type(item.source), _IMAGE_FORMATS)
-            if fmt is None:
-                continue
+            raw, fmt = resolved
             blocks.append({
                 "image": {
                     "format": fmt,
@@ -792,12 +816,10 @@ def convert_agui_content_to_strands(
         elif isinstance(item, DocumentInputContent):
             current_document_index = document_index
             document_index += 1
-            raw = _resolve_source_bytes(item.source, policy, budget)
-            if raw is None:
+            resolved = resolve(item, _DOCUMENT_FORMATS)
+            if resolved is None:
                 continue
-            fmt = _mime_to_format(_get_mime_type(item.source), _DOCUMENT_FORMATS)
-            if fmt is None:
-                continue
+            raw, fmt = resolved
             blocks.append({
                 "document": {
                     "format": fmt,
@@ -812,12 +834,10 @@ def convert_agui_content_to_strands(
             })
 
         elif isinstance(item, VideoInputContent):
-            raw = _resolve_source_bytes(item.source, policy, budget)
-            if raw is None:
+            resolved = resolve(item, _VIDEO_FORMATS)
+            if resolved is None:
                 continue
-            fmt = _mime_to_format(_get_mime_type(item.source), _VIDEO_FORMATS)
-            if fmt is None:
-                continue
+            raw, fmt = resolved
             blocks.append({
                 "video": {
                     "format": fmt,
@@ -826,6 +846,7 @@ def convert_agui_content_to_strands(
             })
 
         elif isinstance(item, AudioInputContent):
+            drop("audio", "Strands has no audio support")
             logger.warning(
                 "Skipping audio content block: Strands does not support audio input."
             )
@@ -838,15 +859,21 @@ def convert_agui_content_to_strands(
                     raw_bytes = base64.b64decode(item.data)
                 except Exception:
                     logger.warning("Skipping binary content: invalid base64 data")
+                    drop("binary", "content could not be resolved")
                     continue
             elif item.url:
                 raw_bytes = _fetch_url_bytes(item.url, policy, budget)
             if raw_bytes is None:
                 logger.warning("Skipping binary content: could not resolve bytes")
+                drop("binary", "content could not be resolved")
+                continue
+            if not raw_bytes:
+                drop("binary", "content was empty")
                 continue
             fmt = _mime_to_format(item.mime_type, _IMAGE_FORMATS)
             if fmt is None:
                 logger.warning("Skipping binary content: unsupported MIME type '%s'", item.mime_type)
+                drop("binary", "unsupported media type")
                 continue
             blocks.append({
                 "image": {

--- a/integrations/aws-strands/python/tests/test_multimodal_conversion.py
+++ b/integrations/aws-strands/python/tests/test_multimodal_conversion.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ag_ui.core import (
+    EventType,
     AudioInputContent,
+    BinaryInputContent,
     DocumentInputContent,
     ImageInputContent,
     InputContentDataSource,
@@ -25,6 +27,30 @@ from ag_ui_strands.utils import (
     flatten_content_to_text,
     _mime_to_format,
 )
+from ag_ui_strands.agent import StrandsAgent, _build_strands_history, _build_snapshot_messages
+
+
+@pytest.mark.parametrize("media_class,mime", [
+    (ImageInputContent, "image/png"),
+    (DocumentInputContent, "application/pdf"),
+    (VideoInputContent, "video/mp4"),
+])
+@pytest.mark.parametrize("source_type", ["data", "url"])
+@pytest.mark.parametrize("failure", ["malformed", "empty"])
+def test_invalid_media_is_never_delivered(media_class, mime, source_type, failure):
+    source_class = InputContentDataSource if source_type == "data" else InputContentUrlSource
+    value = "" if failure == "empty" else base64.b64encode(b"file").decode()
+    source = source_class(
+        value=value if source_type == "data" else "https://example.com/file",
+        mime_type="invalid/" + mime if failure == "malformed" else mime,
+    )
+    with patch("ag_ui_strands.utils._fetch_url_bytes", return_value=b"" if failure == "empty" else b"file"):
+        assert convert_agui_content_to_strands([media_class(source=source)]) == []
+
+
+@pytest.mark.parametrize("mime", ["png", "/png", "image/extra/png", "image/", " /png"])
+def test_malformed_mime_is_rejected(mime):
+    assert _mime_to_format(mime, {"png"}) is None
 
 
 # ---------------------------------------------------------------------------
@@ -269,10 +295,7 @@ class TestConvertAguiContentToStrands:
 
     def test_binary_input_content_with_data(self):
         """Test deprecated BinaryInputContent with base64 data."""
-        from ag_ui.core import BinaryInputContent
-        from ag_ui_strands.utils import convert_agui_content_to_strands
 
-        import base64
         b64_data = base64.b64encode(b"binary-img").decode()
         content = [
             BinaryInputContent(type="binary", mime_type="image/png", data=b64_data)
@@ -286,8 +309,6 @@ class TestConvertAguiContentToStrands:
 
     def test_binary_input_content_with_url(self):
         """Test deprecated BinaryInputContent with URL."""
-        from ag_ui.core import BinaryInputContent
-        from ag_ui_strands.utils import convert_agui_content_to_strands
 
         content = [
             BinaryInputContent(type="binary", mime_type="image/jpeg", url="https://example.com/img.jpg")
@@ -301,7 +322,6 @@ class TestConvertAguiContentToStrands:
 
     def test_malformed_base64_skipped(self):
         """Test that malformed base64 in data source is skipped gracefully."""
-        from ag_ui_strands.utils import convert_agui_content_to_strands
 
         content = [
             ImageInputContent(
@@ -471,8 +491,57 @@ def _make_input(messages):
 class TestAgentMultimodalIntegration:
     """Integration tests verifying multimodal content flows through agent.run()."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("with_text", [True, False])
+    @pytest.mark.parametrize("mime,payload,reason", [
+        ("invalid/image/png", "ZmlsZQ==", "unsupported media type"),
+        ("image/bmp", "ZmlsZQ==", "unsupported media type"),
+        ("image/png", "", "content was empty"),
+        ("image/png", "a", "content could not be resolved"),
+    ])
+    async def test_media_drop_is_visible_before_terminal_event(self, with_text, mime, payload, reason):
+        core = MockStrandsAgentForMultimodal()
+        agent = StrandsAgent(MockStrandsAgentForMultimodal(), name="test", description="test")
+        agent._agents_by_thread["test-thread"] = core
+        content = [TextInputContent(text="hello")] if with_text else []
+        content.append(ImageInputContent(source=InputContentDataSource(value=payload, mime_type=mime)))
+        message = UserMessage(id="upload", content=content)
+
+        events = [event async for event in agent.run(_make_input([message]))]
+
+        drops = [event for event in events if event.type == EventType.CUSTOM and event.name == "MediaDropped"]
+        assert len(drops) == 1
+        assert drops[0].value == {"dropped": [{"type": "image", "reason": reason}], "delivered": 0}
+        assert events.index(drops[0]) < len(events) - 1
+        assert core.stream_calls == int(with_text)
+        assert events[-1].type == (EventType.RUN_FINISHED if with_text else EventType.RUN_ERROR)
+        if not with_text:
+            assert events[-1].code == "MEDIA_RESOLUTION_FAILED"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload,reason", [
+        (None, "content could not be resolved"),
+        (b"", "content was empty"),
+    ])
+    async def test_url_drop_reports_reason_and_delivered_attachment_count(self, payload, reason):
+        core = MockStrandsAgentForMultimodal()
+        agent = StrandsAgent(MockStrandsAgentForMultimodal(), name="test", description="test")
+        agent._agents_by_thread["test-thread"] = core
+        message = UserMessage(id="upload", content=[
+            TextInputContent(text="Describe my files"),
+            ImageInputContent(source=InputContentDataSource(value="ZmlsZQ==", mime_type="image/png")),
+            DocumentInputContent(source=InputContentUrlSource(value="https://example.com/private.pdf?token=secret", mime_type="application/pdf")),
+        ])
+        with patch("ag_ui_strands.utils._fetch_url_bytes", return_value=payload):
+            events = [event async for event in agent.run(_make_input([message]))]
+        drops = [event for event in events if event.type == EventType.CUSTOM and event.name == "MediaDropped"]
+        assert len(drops) == 1
+        assert drops[0].value == {"dropped": [{"type": "document", "reason": reason}], "delivered": 1}
+        assert events[-1].type == EventType.RUN_FINISHED
+        assert core.stream_calls == 1
+        assert all("document" not in block for block in core.messages[-1]["content"])
+
     def test_replayed_history_keeps_document_names_stable_across_turns(self):
-        from ag_ui_strands.agent import _build_strands_history
 
         raw_bytes = b"identical-document-bytes"
         b64_value = base64.b64encode(raw_bytes).decode()
@@ -514,7 +583,6 @@ class TestAgentMultimodalIntegration:
 
     @pytest.mark.asyncio
     async def test_session_manager_prompt_uses_message_scoped_document_name(self):
-        from ag_ui_strands.agent import StrandsAgent
 
         mock_base = MockStrandsAgentForMultimodal()
         agent = StrandsAgent(mock_base, name="test", description="test")
@@ -550,7 +618,6 @@ class TestAgentMultimodalIntegration:
     @pytest.mark.asyncio
     async def test_multimodal_user_message_converted(self):
         """When user message has image content, stream_async receives a list."""
-        from ag_ui_strands.agent import StrandsAgent
 
         # Build a mock base agent to satisfy the StrandsAgent constructor
         mock_base = MockStrandsAgentForMultimodal()
@@ -592,8 +659,6 @@ class TestAgentMultimodalIntegration:
     @pytest.mark.asyncio
     async def test_unconvertible_media_with_no_text_fails_the_run(self):
         """A prompt stripped of everything the user sent is not worth sending."""
-        from ag_ui.core import EventType
-        from ag_ui_strands.agent import StrandsAgent
 
         agent = StrandsAgent(
             MockStrandsAgentForMultimodal(), name="test", description="test"
@@ -630,8 +695,6 @@ class TestAgentMultimodalIntegration:
         yields nothing for a mapping, so the whole prompt is empty and the
         fallback has to recover the text instead of failing the run.
         """
-        from ag_ui.core import EventType
-        from ag_ui_strands.agent import StrandsAgent
 
         agent = StrandsAgent(
             MockStrandsAgentForMultimodal(), name="test", description="test"
@@ -668,7 +731,6 @@ class TestAgentMultimodalIntegration:
     @pytest.mark.asyncio
     async def test_text_only_list_flattened_to_string(self):
         """When user message content is a list of text-only items, it's flattened to a string."""
-        from ag_ui_strands.agent import StrandsAgent
 
         mock_base = MockStrandsAgentForMultimodal()
         agent = StrandsAgent(mock_base, name="test", description="test")
@@ -696,7 +758,6 @@ class TestAgentMultimodalIntegration:
     @pytest.mark.asyncio
     async def test_plain_string_message_unchanged(self):
         """When content is a plain string, it passes through unchanged."""
-        from ag_ui_strands.agent import StrandsAgent
 
         mock_base = MockStrandsAgentForMultimodal()
         agent = StrandsAgent(mock_base, name="test", description="test")
@@ -742,7 +803,6 @@ class TestBuildSnapshotMessages:
         return msg
 
     def test_string_content_preserved(self):
-        from ag_ui_strands.agent import _build_snapshot_messages
 
         msg = self._make_msg("user", "hello")
         result = _build_snapshot_messages([msg])
@@ -753,7 +813,6 @@ class TestBuildSnapshotMessages:
     def test_list_content_preserved_as_list(self):
         """List content (multimodal) must not be stringified — it should reach
         the MessagesSnapshotEvent intact so the frontend can render images."""
-        from ag_ui_strands.agent import _build_snapshot_messages
 
         list_content = [
             TextInputContent(type="text", text="look at this"),
@@ -777,7 +836,6 @@ class TestBuildSnapshotMessages:
 
     def test_unexpected_type_coerced_to_string(self):
         """Non-str/non-list content (e.g. an int) falls back to _coerce_text."""
-        from ag_ui_strands.agent import _build_snapshot_messages
 
         msg = self._make_msg("user", 42)
         result = _build_snapshot_messages([msg])

--- a/integrations/aws-strands/typescript/src/__tests__/multimodal-snapshot.test.ts
+++ b/integrations/aws-strands/typescript/src/__tests__/multimodal-snapshot.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { EventType, type InputContent, type UserMessage } from "@ag-ui/core";
+import { buildSnapshotMessages } from "../agent";
+import {
+  collect,
+  minimalRunInput,
+  scriptedStrandsAgent,
+  stream,
+} from "./helpers";
+
+const attachments: InputContent[] = [
+  {
+    type: "image",
+    source: { type: "data", mimeType: "image/png", value: "aW1hZ2U=" },
+    metadata: { filename: "photo.png", width: 20 },
+  },
+  {
+    type: "document",
+    source: {
+      type: "url",
+      mimeType: "application/pdf",
+      value: "http://127.0.0.1/file.pdf",
+    },
+    metadata: { filename: "file.pdf" },
+  },
+  {
+    type: "video",
+    source: { type: "data", mimeType: "video/mp4", value: "dmlkZW8=" },
+    metadata: { filename: "clip.mp4" },
+  },
+];
+
+describe("multimodal snapshot fidelity", () => {
+  it.each(attachments)("preserves $type parts and metadata", (attachment) => {
+    const message: UserMessage = {
+      id: "u1",
+      role: "user",
+      metadata: { origin: "upload" },
+      content: [{ type: "text", text: "Describe this file" }, attachment],
+    };
+    expect(buildSnapshotMessages([message])).toEqual([message]);
+  });
+
+  it("preserves attachments in every snapshot, including failed media and history", async () => {
+    const orderedAttachments = [
+      ...attachments.filter((attachment) => attachment.type !== "document"),
+      ...attachments.filter((attachment) => attachment.type === "document"),
+    ];
+    const messages: UserMessage[] = orderedAttachments.map(
+      (attachment, index) => ({
+        id: `u${index}`,
+        role: "user",
+        metadata: { origin: "upload" },
+        content: [{ type: "text", text: "Describe this file" }, attachment],
+      }),
+    );
+    // Default policy refusal avoids network access while exercising a real
+    // dropped URL attachment. The snapshot must still retain the user's file.
+    const agent = scriptedStrandsAgent([stream.textDelta("response")]);
+    const events = await collect(agent, minimalRunInput({ messages }));
+    expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: EventType.CUSTOM,
+        name: "MediaDropped",
+        value: {
+          dropped: [
+            { type: "document", reason: "content could not be resolved" },
+          ],
+          delivered: 0,
+        },
+      }),
+    );
+    const snapshots = events.filter(
+      (event) => event.type === EventType.MESSAGES_SNAPSHOT,
+    );
+    expect(snapshots.length).toBeGreaterThanOrEqual(2);
+    for (const snapshot of snapshots) {
+      expect(snapshot).toMatchObject({
+        messages: expect.arrayContaining(messages),
+      });
+    }
+  });
+});

--- a/integrations/aws-strands/typescript/src/agent.ts
+++ b/integrations/aws-strands/typescript/src/agent.ts
@@ -1613,7 +1613,9 @@ export function buildSnapshotMessages(
       const user: AguiUserMessage = {
         id: msgId,
         role: "user",
-        content: _coerceText(msg.content),
+        content: Array.isArray(msg.content)
+          ? msg.content
+          : _coerceText(msg.content),
       };
       const userMetadata = _carriedMetadata(msg);
       if (userMetadata) user.metadata = userMetadata;


### PR DESCRIPTION
User attachments reached the model but disappeared from TypeScript's `MESSAGES_SNAPSHOT`: snapshot construction flattened user content to text. Preserve the original content array, including attachment source and metadata, so images and file chips remain visible after completion.

Python now rejects malformed MIME shapes and empty attachment bytes. When an attachment cannot be delivered, it emits the sibling `CUSTOM / MediaDropped` event with per-item reasons and a delivered count before invoking the model or reporting `MEDIA_RESOLUTION_FAILED`. Surviving text still reaches the model. The converter's existing list return type remains compatible.

Regression coverage verifies complete user objects in initial and terminal snapshots, including a refused current URL attachment, and Python validation/drop events for inline and URL sources. The Python README documents the new event.

Validation on commit `9f0f397b6`:

- TypeScript: 1,771 tests passed; explicit typecheck and build passed.
- Python: 1,444 passed, 18 skipped; wheel and source distribution builds passed.
- Formatting and diff checks passed; independent code review found no blocker.
- Real dojo and OpenAI `gpt-5.4`: 28 retained runs, comprising 24 provider completions and four expected attachment-only refusals. All runs preserved user attachment parts in every snapshot, had exactly one terminal event, and made no tool calls.
- Actual browser image uploads answered `red, blue` in both languages. PDF uploads answered the file's exact code, `LANTERN-582`. All four ended in `RUN_FINISHED`; PDF chips remained visible and the TypeScript image remained loaded after completion.
- URL images produced descriptions of the fixture's cap, glasses, uniform and U.S. flag. URL PDFs returned exactly `Dummy PDF file`. All ended in `RUN_FINISHED`. The image descriptions included incidental inaccuracies, so this establishes delivery rather than perfect model accuracy.
- Malformed MIME, empty inline data and refused URLs emitted the expected `MediaDropped` reasons. With text, the provider answered `NO_ATTACHMENT` and finished successfully. Attachment-only refusals emitted `RUN_ERROR / MEDIA_RESOLUTION_FAILED` before provider invocation.

Representative real run IDs:

| Bridge | Source | Run ID |
|---|---|---|
| TypeScript | Browser image | `e838d5f9-c256-46ef-96e5-2b3e263d7500` |
| TypeScript | Browser PDF | `6e5c9bdc-f3ad-48a3-b67f-673e355b9945` |
| TypeScript | URL image | `c8d27993-50e7-4e52-b2af-8a935fff1e07` |
| TypeScript | URL PDF | `c642b5e2-bf94-4003-9e0a-3b767ed92634` |
| Python | Browser image | `da9a99ec-31a1-4bbc-8eac-35a780fcc0c9` |
| Python | Browser PDF | `b761caf6-4acf-4783-9eca-953e56358f2d` |
| Python | URL image | `57418bcf-59d3-49b1-a6a8-04fd2a2158a7` |
| Python | URL PDF | `1a4f9077-b0d5-454c-a33f-b40a25a009fd` |

The upstream Strands video-provider limitations and separately reported tool-call/reasoning snapshot losses are outside this change.
