### PR TITLE
feat(spec): name pending frontend tool calls on the success outcome (PNI-428)

### DIFF
--- a/docs/spec/draft/basic/patterns/interrupt-resume.mdx
+++ b/docs/spec/draft/basic/patterns/interrupt-resume.mdx
@@ -24,8 +24,9 @@ with nothing to do.
   where the producer names what it is waiting for and resume entries answer
   it. A run that stopped by calling a
   [frontend tool](/spec/draft/events/tool-calls#frontend-tools) is the other,
-  ordinary path: it finishes as success and the answer rides the next input's
-  messages.
+  ordinary path: it finishes as success, naming the unanswered calls in the
+  success outcome's `pendingToolCallIds`, and the answer rides the next
+  input's messages.
 - Each interrupt's `id` MUST be unique within the run; a resume entry answers
   it by this id.
 - An interrupt's `reason` is an open string — the protocol does not attempt to

--- a/docs/spec/draft/changelog.mdx
+++ b/docs/spec/draft/changelog.mdx
@@ -83,19 +83,23 @@ specification.
 3. Absent means absent: optional fields are omitted, never `null`
    ([The event model](/spec/draft/basic#absent-means-absent)).
 4. `RUN_FINISHED` and `RUN_ERROR` MAY carry per-provider token usage.
-5. Input messages MAY carry multimodal content parts (text, image, audio,
+5. A run that stops on a frontend tool call finishes as success, never as an
+   interrupt, and the success outcome MAY name the calls it left unanswered
+   in `pendingToolCallIds`
+   ([Tool calls](/spec/draft/events/tool-calls#frontend-tools)).
+6. Input messages MAY carry multimodal content parts (text, image, audio,
    video, document), by URL or inline data
    ([Run input](/spec/draft/basic/run-input)).
-6. `TOOL_CALL_RESULT` is a message in its own right and does not reopen the
+7. `TOOL_CALL_RESULT` is a message in its own right and does not reopen the
    call it answers ([Tool calls](/spec/draft/events/tool-calls)).
-7. A late `RUN_ERROR` after `RUN_FINISHED` is admitted, reporting a failure
+8. A late `RUN_ERROR` after `RUN_FINISHED` is admitted, reporting a failure
    that surfaced after success was already reported
    ([Runs and steps](/spec/draft/events/lifecycle)).
-8. A consumer keeps a stream it rejects apart from a run that reports its own
+9. A consumer keeps a stream it rejects apart from a run that reports its own
    failure, and "treat the run as failed" is defined: surface it, never report
    success, with the API shape left to the implementation
    ([Runs and steps](/spec/draft/events/lifecycle#error-handling)).
-9. The protocol version travels in-band: consumers declare theirs on
+10. The protocol version travels in-band: consumers declare theirs on
    `RunAgentInput.protocolVersion`, producers answer with their own on
    `RUN_STARTED.protocolVersion`, and absence identifies a pre-versioning
    peer ([Versioning](/spec/draft/basic/versioning#version-negotiation)).

--- a/docs/spec/draft/events/lifecycle.mdx
+++ b/docs/spec/draft/events/lifecycle.mdx
@@ -50,7 +50,13 @@ Closes a run that did not fail, and reports how it ended:
 - Its `outcome` distinguishes a run that completed from one interrupted
   awaiting outside input; an absent outcome means success. The interrupt
   outcome and what follows it are specified in
-  [Interrupts and Resume](/spec/draft/basic/patterns/interrupt-resume).
+  [Interrupts and Resume](/spec/draft/basic/patterns/interrupt-resume). The
+  outcome reports what the producer knows about why the run ended: a run
+  that stopped on a [frontend tool call](/spec/draft/events/tool-calls#frontend-tools)
+  is a completed run whose success outcome MAY name the calls it left
+  unanswered in `pendingToolCallIds`, because whether the application
+  continues the thread after such a call is the application's decision, not
+  the producer's.
 - A producer MUST NOT send an outcome value the schema does not describe.
 - `result` is OPTIONAL and carries the run's return value, if it has one.
 - `usage` is OPTIONAL and reports token usage, one entry per provider and

--- a/docs/spec/draft/events/tool-calls.mdx
+++ b/docs/spec/draft/events/tool-calls.mdx
@@ -107,10 +107,21 @@ cross a run boundary — which gives the round-trip its shape:
 - A producer that calls a frontend tool MUST NOT answer it: no
   `TOOL_CALL_RESULT`, no fabricated tool message. The result is the
   application's to produce.
-- The producer finishes the run with the call unanswered — `RUN_FINISHED`,
-  ordinary success outcome — and SHOULD do so promptly once nothing remains
-  that does not depend on the result. Several frontend calls MAY be left
-  unanswered by one run; the application answers them all at once.
+- The producer finishes the run with the call unanswered. It MUST use the
+  success outcome, or none, and MUST NOT report the run as interrupted — and
+  it SHOULD finish promptly once nothing remains that does not depend on the
+  result. Several frontend calls MAY be left unanswered by one run; the
+  application answers them all at once.
+- The success outcome's `pendingToolCallIds` names the calls left unanswered,
+  in the order they were made. A producer SHOULD send it when a run leaves
+  calls pending; when it does, the list MUST contain exactly the tool calls
+  the run started and did not answer with `TOOL_CALL_RESULT`. `RUN_FINISHED`
+  alone does not say whether a run left work for the application: when the
+  list is absent or empty, a consumer that needs to know derives it from the
+  stream — every tool call the run started that received no result — and
+  MUST NOT read absence as "nothing pending". On an interrupted run the
+  pending calls are derived the same way; the interrupt outcome does not
+  carry them.
 - After the run finishes, the application disposes of each unanswered
   frontend call — executing it, or declining it, with whatever consent its
   own rules require. A thread that continues MUST answer every one of them
@@ -126,6 +137,19 @@ This is a different round-trip from
 [interrupts](/spec/draft/basic/patterns/interrupt-resume): an interrupt is the
 producer explicitly stopping to ask, answered by resume entries; a frontend
 tool call rides the ordinary message loop, answered by conversation history.
+
+<Note>
+  A run that stops on a frontend tool call is a completed run, not an
+  interrupted one, and it is not a third kind of ending either. The outcome
+  reports what the producer knows about why the run ended, and here the
+  producer does not know whether it is waiting: a frontend tool is often a
+  terminal effect — render a chart, navigate, highlight — and whether its
+  result starts another run is the application's decision, made by the
+  application's rules for that tool. So the producer says what it does know —
+  the run is complete, and these calls are unanswered — as detail on the
+  success outcome, where an older consumer that strips the field still reads a
+  successful run and derives the pending calls as it always has.
+</Note>
 
 A producer SHOULD call frontend tools only from the advertised list; a call
 naming a tool the input did not advertise is not by itself a protocol

--- a/docs/spec/draft/schema.json
+++ b/docs/spec/draft/schema.json
@@ -886,9 +886,17 @@
     "RunFinishedSuccessOutcome": {
       "$anchor": "RunFinishedSuccessOutcome",
       "type": "object",
-      "description": "The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension.",
+      "description": "The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension. A completed run may still have left frontend tool calls for the application to answer; pendingToolCallIds names them.",
       "properties": {
-        "type": { "const": "success", "description": "Discriminator." }
+        "type": { "const": "success", "description": "Discriminator." },
+        "pendingToolCallIds": {
+          "type": "array",
+          "description": "The tool calls this run started and left unanswered — no TOOL_CALL_RESULT in the run — for the application to answer in the next input's messages, in the order they were made. Absent or empty means the producer named none, and a consumer derives the list from the stream; otherwise it is the list, and it agrees with the stream. On the success outcome rather than the event because a run that stopped on a frontend tool call is a completed run: whether the application continues the thread is its own decision, so the producer reports what it knows and no more.",
+          "items": {
+            "type": "string",
+            "description": "A tool call id, as carried by TOOL_CALL_START."
+          }
+        }
       },
       "required": ["type"],
       "unevaluatedProperties": false

--- a/docs/spec/draft/schema.mdx
+++ b/docs/spec/draft/schema.mdx
@@ -970,11 +970,12 @@ How runs and subagents report ending, and what an interrupted run is waiting for
 
 ### `RunFinishedSuccessOutcome`
 
-The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension.
+The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension. A completed run may still have left frontend tool calls for the application to answer; pendingToolCallIds names them.
 
 **Fields:**
 
 - `type` — `"success"`, **required**. Discriminator.
+- `pendingToolCallIds` — array of `string`, optional. The tool calls this run started and left unanswered — no TOOL_CALL_RESULT in the run — for the application to answer in the next input's messages, in the order they were made. Absent or empty means the producer named none, and a consumer derives the list from the stream; otherwise it is the list, and it agrees with the stream. On the success outcome rather than the event because a run that stopped on a frontend tool call is a completed run: whether the application continues the thread is its own decision, so the producer reports what it knows and no more. Each entry: A tool call id, as carried by TOOL_CALL_START.
 
 Closed object: the schema rejects members not listed here.
 

--- a/sdks/dotnet/src/AGUI.Abstractions/Generated/AGUITypes.g.cs
+++ b/sdks/dotnet/src/AGUI.Abstractions/Generated/AGUITypes.g.cs
@@ -944,7 +944,9 @@ public abstract class RunFinishedOutcome
 /// The run completed. Equivalent to an absent outcome. Closed like every other
 /// object, which is also what keeps it from carrying the suspended sibling's
 /// interrupts — a success with an interrupt still pending would be a
-/// contradiction, not an extension.
+/// contradiction, not an extension. A completed run may still have left
+/// frontend tool calls for the application to answer; pendingToolCallIds names
+/// them.
 /// </summary>
 public sealed class RunFinishedSuccessOutcome : RunFinishedOutcome
 {
@@ -953,6 +955,20 @@ public sealed class RunFinishedSuccessOutcome : RunFinishedOutcome
     /// </summary>
     [JsonPropertyName("type")]
     public override string Type => RunFinishedOutcomeTypes.Success;
+
+    /// <summary>
+    /// The tool calls this run started and left unanswered — no
+    /// TOOL_CALL_RESULT in the run — for the application to answer in the next
+    /// input's messages, in the order they were made. Absent or empty means the
+    /// producer named none, and a consumer derives the list from the stream;
+    /// otherwise it is the list, and it agrees with the stream. On the success
+    /// outcome rather than the event because a run that stopped on a frontend
+    /// tool call is a completed run: whether the application continues the
+    /// thread is its own decision, so the producer reports what it knows and no
+    /// more.
+    /// </summary>
+    [JsonPropertyName("pendingToolCallIds")]
+    public IList<string>? PendingToolCallIds { get; set; }
 }
 
 /// <summary>

--- a/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
+++ b/sdks/dotnet/src/AGUI.Abstractions/PublicAPI.Unshipped.txt
@@ -506,6 +506,8 @@ AGUI.Abstractions.RunFinishedOutcomeJsonConverter.RunFinishedOutcomeJsonConverte
 AGUI.Abstractions.RunFinishedOutcomeTypes
 AGUI.Abstractions.RunFinishedSuccessOutcome
 AGUI.Abstractions.RunFinishedSuccessOutcome.RunFinishedSuccessOutcome() -> void
+AGUI.Abstractions.RunFinishedSuccessOutcome.PendingToolCallIds.get -> System.Collections.Generic.IList<string!>?
+AGUI.Abstractions.RunFinishedSuccessOutcome.PendingToolCallIds.set -> void
 AGUI.Abstractions.RunStartedEvent
 AGUI.Abstractions.RunStartedEvent.Input.get -> AGUI.Abstractions.RunAgentInput?
 AGUI.Abstractions.RunStartedEvent.Input.set -> void

--- a/sdks/dotnet/src/AGUI.Protobuf/Generated/ProtoEventMapper.g.cs
+++ b/sdks/dotnet/src/AGUI.Protobuf/Generated/ProtoEventMapper.g.cs
@@ -352,9 +352,16 @@ internal static class ProtoEventMapper
                         proto.Interrupts.Add(ProtoMessageMapper.ToProtoInterrupt(interrupt));
                     }
                 }
-                else if (e.Outcome is RunFinishedSuccessOutcome)
+                else if (e.Outcome is RunFinishedSuccessOutcome successOutcome)
                 {
                     proto.Outcome = "success";
+                    if (successOutcome.PendingToolCallIds is not null)
+                    {
+                        foreach (var pendingToolCallId in successOutcome.PendingToolCallIds)
+                        {
+                            proto.PendingToolCallIds.Add(pendingToolCallId);
+                        }
+                    }
                 }
                 else
                 {
@@ -1067,6 +1074,14 @@ internal static class ProtoEventMapper
                     "Invalid event: interrupt outcome carries no interrupts.");
             }
 
+            // Pending tool call ids belong to the success outcome: an
+            // interrupted run names what it waits for through its interrupts.
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                throw new System.IO.InvalidDataException(
+                    "Invalid event: outcome interrupt cannot carry pendingToolCallIds.");
+            }
+
             var outcome = new RunFinishedInterruptOutcome();
             foreach (var interrupt in proto.Interrupts)
             {
@@ -1087,7 +1102,13 @@ internal static class ProtoEventMapper
                     "Invalid event: outcome success cannot carry interrupts.");
             }
 
-            return new RunFinishedSuccessOutcome();
+            var outcome = new RunFinishedSuccessOutcome();
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                outcome.PendingToolCallIds = new List<string>(proto.PendingToolCallIds);
+            }
+
+            return outcome;
         }
 
         if (proto.Outcome.Length == 0)
@@ -1096,6 +1117,12 @@ internal static class ProtoEventMapper
             {
                 throw new System.IO.InvalidDataException(
                     "Invalid event: absent outcome cannot carry interrupts.");
+            }
+
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                throw new System.IO.InvalidDataException(
+                    "Invalid event: absent outcome cannot carry pendingToolCallIds.");
             }
 
             return null;

--- a/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/RunFinishedEventTest.cs
+++ b/sdks/dotnet/tests/AGUI.Abstractions.UnitTests/RunFinishedEventTest.cs
@@ -60,6 +60,52 @@ public sealed class RunFinishedEventTest
     }
 
     [Fact]
+    public void Serialization_WithPendingToolCallIds()
+    {
+        var evt = new RunFinishedEvent
+        {
+            ThreadId = "t1",
+            RunId = "r1",
+            Outcome = new RunFinishedSuccessOutcome { PendingToolCallIds = ["tc-1", "tc-2"] }
+        };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.RunFinishedEvent);
+        using var doc = JsonDocument.Parse(json);
+
+        var outcome = doc.RootElement.GetProperty("outcome");
+        Assert.Equal("success", outcome.GetProperty("type").GetString());
+        var pending = outcome.GetProperty("pendingToolCallIds");
+        Assert.Equal(2, pending.GetArrayLength());
+        Assert.Equal("tc-1", pending[0].GetString());
+        Assert.Equal("tc-2", pending[1].GetString());
+    }
+
+    [Fact]
+    public void Serialization_SuccessOmitsPendingToolCallIdsWhenUnset()
+    {
+        var evt = new RunFinishedEvent { ThreadId = "t1", RunId = "r1", Outcome = new RunFinishedSuccessOutcome() };
+
+        var json = JsonSerializer.Serialize(evt, AGUIJsonSerializerContext.Default.RunFinishedEvent);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.GetProperty("outcome").TryGetProperty("pendingToolCallIds", out _));
+    }
+
+    [Fact]
+    public void Deserialization_WithPendingToolCallIds()
+    {
+        const string json = """
+            {"type":"RUN_FINISHED","threadId":"t1","runId":"r1","outcome":{"type":"success","pendingToolCallIds":["tc-1"]}}
+            """;
+
+        var evt = JsonSerializer.Deserialize(json, AGUIJsonSerializerContext.Default.RunFinishedEvent);
+
+        Assert.NotNull(evt);
+        var outcome = Assert.IsType<RunFinishedSuccessOutcome>(evt.Outcome);
+        Assert.Equal(new[] { "tc-1" }, outcome.PendingToolCallIds);
+    }
+
+    [Fact]
     public void Serialization_OmitsNullProperties()
     {
         var evt = new RunFinishedEvent();

--- a/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/EventRoundTripTest.cs
+++ b/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/EventRoundTripTest.cs
@@ -86,6 +86,34 @@ public sealed class EventRoundTripTest
     }
 
     [Fact]
+    public void RunFinished_SuccessWithPendingToolCallIds_RoundTrips()
+    {
+        var result = RoundTrip(new RunFinishedEvent
+        {
+            ThreadId = "thread-1",
+            RunId = "run-1",
+            Outcome = new RunFinishedSuccessOutcome { PendingToolCallIds = ["tc-1", "tc-2"] },
+        });
+
+        var outcome = Assert.IsType<RunFinishedSuccessOutcome>(result.Outcome);
+        Assert.Equal(new[] { "tc-1", "tc-2" }, outcome.PendingToolCallIds);
+    }
+
+    [Fact]
+    public void RunFinished_SuccessWithoutPendingToolCallIds_RoundTripsToNull()
+    {
+        var result = RoundTrip(new RunFinishedEvent
+        {
+            ThreadId = "thread-1",
+            RunId = "run-1",
+            Outcome = new RunFinishedSuccessOutcome(),
+        });
+
+        var outcome = Assert.IsType<RunFinishedSuccessOutcome>(result.Outcome);
+        Assert.Null(outcome.PendingToolCallIds);
+    }
+
+    [Fact]
     public void RunFinished_NoOutcome_RoundTripsToNull()
     {
         var result = RoundTrip(new RunFinishedEvent { ThreadId = "t", RunId = "r" });

--- a/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/Fixtures/bytes-dotnet/RunFinishedEvent__outcome-success-pending-tool-call-ids.json.bin
+++ b/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/Fixtures/bytes-dotnet/RunFinishedEvent__outcome-success-pending-tool-call-ids.json.bin
@@ -1,0 +1,2 @@
+j%
+t1r1*successBcall-1Bcall-2

--- a/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/WireGuardTest.cs
+++ b/sdks/dotnet/tests/AGUI.Protobuf.UnitTests/WireGuardTest.cs
@@ -137,6 +137,35 @@ public sealed class WireGuardTest
     }
 
     [Fact]
+    public void InterruptOutcomeCarryingPendingToolCallIds_Throws()
+    {
+        var proto = new Proto.RunFinishedEvent
+        {
+            BaseEvent = new Proto.BaseEvent { Type = Proto.EventType.RunFinished },
+            ThreadId = "t1",
+            RunId = "r1",
+            Outcome = "interrupt",
+        };
+        proto.Interrupts.Add(new Proto.Interrupt { Id = "i1", Reason = "r" });
+        proto.PendingToolCallIds.Add("tc-1");
+        Assert.Throws<InvalidDataException>(() => AGUIProtobuf.Decode(Wrap(new Proto.Event { RunFinished = proto })));
+    }
+
+    [Fact]
+    public void AbsentOutcomeCarryingPendingToolCallIds_Throws()
+    {
+        var proto = new Proto.RunFinishedEvent
+        {
+            BaseEvent = new Proto.BaseEvent { Type = Proto.EventType.RunFinished },
+            ThreadId = "t1",
+            RunId = "r1",
+            Outcome = string.Empty,
+        };
+        proto.PendingToolCallIds.Add("tc-1");
+        Assert.Throws<InvalidDataException>(() => AGUIProtobuf.Decode(Wrap(new Proto.Event { RunFinished = proto })));
+    }
+
+    [Fact]
     public void UnknownPatchOperation_Throws()
     {
         var stateDelta = new Proto.StateDeltaEvent

--- a/sdks/python/ag_ui/_generated/models.py
+++ b/sdks/python/ag_ui/_generated/models.py
@@ -1562,11 +1562,25 @@ class RunFinishedSuccessOutcome(GeneratedBaseModel):
     The run completed. Equivalent to an absent outcome. Closed like every
     other object, which is also what keeps it from carrying the suspended
     sibling's interrupts — a success with an interrupt still pending would
-    be a contradiction, not an extension.
+    be a contradiction, not an extension. A completed run may still have
+    left frontend tool calls for the application to answer;
+    pendingToolCallIds names them.
     """
 
     type: Literal["success"] = "success"
     """Discriminator."""
+    pending_tool_call_ids: Optional[List[str]] = Field(default=None)
+    """
+    The tool calls this run started and left unanswered — no
+    TOOL_CALL_RESULT in the run — for the application to answer in the next
+    input's messages, in the order they were made. Absent or empty means the
+    producer named none, and a consumer derives the list from the stream;
+    otherwise it is the list, and it agrees with the stream. On the success
+    outcome rather than the event because a run that stopped on a frontend
+    tool call is a completed run: whether the application continues the
+    thread is its own decision, so the producer reports what it knows and no
+    more. Each item: A tool call id, as carried by TOOL_CALL_START.
+    """
 
 
 class Interrupt(GeneratedBaseModel):

--- a/sdks/python/tests/test_generated_models.py
+++ b/sdks/python/tests/test_generated_models.py
@@ -77,6 +77,7 @@ TOLERATED_INVALID = {
     "ReasoningMessageStartEvent/invalid/role-missing.json": "const-fills-in",
     "RunFinishedEvent/invalid/outcome-null.json": "null-means-absent",
     "RunFinishedEvent/invalid/outcome-success-carrying-interrupts.json": "unknown-keys",
+    "RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.json": "unknown-keys",
     "SubagentErrorEvent/invalid/code-null.json": "null-means-absent",
     "SubagentFinishedEvent/invalid/outcome-null.json": "null-means-absent",
     "SubagentFinishedEvent/invalid/outcome-success-carrying-interrupt-ids.json": "unknown-keys",

--- a/sdks/python/tests/test_run_finished_event.py
+++ b/sdks/python/tests/test_run_finished_event.py
@@ -87,6 +87,50 @@ class RunFinishedEventTest(unittest.TestCase):
         self.assertEqual(dumped["outcome"]["type"], "interrupt")
         self.assertEqual(dumped["outcome"]["interrupts"][0]["toolCallId"], "tc-1")
 
+    def test_success_outcome_with_pending_tool_call_ids(self):
+        e = RunFinishedEvent(
+            thread_id="t-1",
+            run_id="r-1",
+            outcome=RunFinishedSuccessOutcome(pending_tool_call_ids=["tc-1", "tc-2"]),
+        )
+        assert isinstance(e.outcome, RunFinishedSuccessOutcome)
+        self.assertEqual(e.outcome.pending_tool_call_ids, ["tc-1", "tc-2"])
+        dumped = e.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(
+            dumped["outcome"],
+            {"type": "success", "pendingToolCallIds": ["tc-1", "tc-2"]},
+        )
+
+    def test_success_outcome_omits_pending_tool_call_ids_when_unset(self):
+        e = RunFinishedEvent(
+            thread_id="t-1", run_id="r-1", outcome=RunFinishedSuccessOutcome()
+        )
+        dumped = e.model_dump(by_alias=True, exclude_none=True)
+        self.assertEqual(dumped["outcome"], {"type": "success"})
+
+    def test_pending_tool_call_ids_via_dict(self):
+        e = RunFinishedEvent.model_validate(
+            {
+                "type": "RUN_FINISHED",
+                "threadId": "t-1",
+                "runId": "r-1",
+                "outcome": {"type": "success", "pendingToolCallIds": ["tc-1"]},
+            }
+        )
+        assert isinstance(e.outcome, RunFinishedSuccessOutcome)
+        self.assertEqual(e.outcome.pending_tool_call_ids, ["tc-1"])
+
+    def test_pending_tool_call_ids_rejects_non_string_items(self):
+        with self.assertRaises(ValidationError):
+            RunFinishedEvent.model_validate(
+                {
+                    "type": "RUN_FINISHED",
+                    "threadId": "t-1",
+                    "runId": "r-1",
+                    "outcome": {"type": "success", "pendingToolCallIds": [42]},
+                }
+            )
+
     def test_legacy_event_serialization_omits_outcome(self):
         e = RunFinishedEvent(thread_id="t-1", run_id="r-1")
         dumped = e.model_dump(by_alias=True, exclude_none=True)

--- a/sdks/typescript/packages/client/src/agent/__tests__/agent-pending-tool-calls.test.ts
+++ b/sdks/typescript/packages/client/src/agent/__tests__/agent-pending-tool-calls.test.ts
@@ -1,0 +1,150 @@
+import { AbstractAgent } from "../agent";
+import { AgentSubscriber } from "../subscriber";
+import { BaseEvent, EventType, RunAgentInput } from "@ag-ui/core";
+import { Observable, of } from "rxjs";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/verify", () => ({
+  verifyEvents: vi.fn(() => (source$: Observable<any>) => source$),
+}));
+
+vi.mock("@/chunks", () => ({
+  transformChunks: vi.fn(() => (source$: Observable<any>) => source$),
+}));
+
+class TestAgent extends AbstractAgent {
+  private eventsToEmit: BaseEvent[] = [];
+
+  setEventsToEmit(events: BaseEvent[]) {
+    this.eventsToEmit = events;
+  }
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return of(...this.eventsToEmit);
+  }
+}
+
+const runStarted = { type: EventType.RUN_STARTED, threadId: "t", runId: "r" } as BaseEvent;
+const toolCall = (id: string): BaseEvent[] => [
+  { type: EventType.TOOL_CALL_START, toolCallId: id, toolCallName: "frontend_tool" } as BaseEvent,
+  { type: EventType.TOOL_CALL_ARGS, toolCallId: id, delta: "{}" } as BaseEvent,
+  { type: EventType.TOOL_CALL_END, toolCallId: id } as BaseEvent,
+];
+const toolResult = (id: string): BaseEvent =>
+  ({
+    type: EventType.TOOL_CALL_RESULT,
+    messageId: `result-${id}`,
+    toolCallId: id,
+    content: "done",
+  }) as BaseEvent;
+
+/** Runs the stream and returns what onRunFinishedEvent saw. */
+async function finishedParams(events: BaseEvent[]): Promise<any> {
+  const agent = new TestAgent({ threadId: "t" });
+  agent.setEventsToEmit(events);
+  const onRunFinishedEvent = vi.fn();
+  const subscriber: AgentSubscriber = { onRunFinishedEvent };
+  await agent.runAgent({}, subscriber);
+  expect(onRunFinishedEvent).toHaveBeenCalledTimes(1);
+  return onRunFinishedEvent.mock.calls[0][0];
+}
+
+describe("RUN_FINISHED pendingToolCallIds", () => {
+  it("is empty when the run left nothing unanswered", async () => {
+    const params = await finishedParams([
+      runStarted,
+      { type: EventType.RUN_FINISHED, threadId: "t", runId: "r" } as BaseEvent,
+    ]);
+    expect(params.outcome).toBe("success");
+    expect(params.pendingToolCallIds).toEqual([]);
+  });
+
+  it("derives the unanswered tool calls from the stream when the producer names none", async () => {
+    const params = await finishedParams([
+      runStarted,
+      ...toolCall("tc-1"),
+      ...toolCall("tc-2"),
+      toolResult("tc-1"),
+      ...toolCall("tc-3"),
+      { type: EventType.RUN_FINISHED, threadId: "t", runId: "r" } as BaseEvent,
+    ]);
+    expect(params.pendingToolCallIds).toEqual(["tc-2", "tc-3"]);
+  });
+
+  it("derives the list under an explicit success outcome without the field", async () => {
+    const params = await finishedParams([
+      runStarted,
+      ...toolCall("tc-1"),
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "t",
+        runId: "r",
+        outcome: { type: "success" },
+      } as BaseEvent,
+    ]);
+    expect(params.pendingToolCallIds).toEqual(["tc-1"]);
+  });
+
+  it("trusts the producer's list over the tally when it names one", async () => {
+    const params = await finishedParams([
+      runStarted,
+      ...toolCall("tc-1"),
+      ...toolCall("tc-2"),
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "t",
+        runId: "r",
+        outcome: { type: "success", pendingToolCallIds: ["tc-2"] },
+      } as BaseEvent,
+    ]);
+    expect(params.pendingToolCallIds).toEqual(["tc-2"]);
+  });
+
+  it("does not let a subscriber mutate the producer's list through aliasing", async () => {
+    const named = ["tc-1"];
+    const params = await finishedParams([
+      runStarted,
+      ...toolCall("tc-1"),
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "t",
+        runId: "r",
+        outcome: { type: "success", pendingToolCallIds: named },
+      } as BaseEvent,
+    ]);
+    params.pendingToolCallIds.push("tc-9");
+    expect(named).toEqual(["tc-1"]);
+  });
+
+  it("is not reported on an interrupted run", async () => {
+    const params = await finishedParams([
+      runStarted,
+      ...toolCall("tc-1"),
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "t",
+        runId: "r",
+        outcome: { type: "interrupt", interrupts: [{ id: "i-1", reason: "approval" }] },
+      } as BaseEvent,
+    ]);
+    expect(params.outcome).toBe("interrupt");
+    expect(params).not.toHaveProperty("pendingToolCallIds");
+  });
+
+  it("starts a fresh tally for each run in one stream", async () => {
+    const agent = new TestAgent({ threadId: "t" });
+    agent.setEventsToEmit([
+      { type: EventType.RUN_STARTED, threadId: "t", runId: "r-1" } as BaseEvent,
+      ...toolCall("tc-1"),
+      { type: EventType.RUN_FINISHED, threadId: "t", runId: "r-1" } as BaseEvent,
+      { type: EventType.RUN_STARTED, threadId: "t", runId: "r-2" } as BaseEvent,
+      ...toolCall("tc-2"),
+      { type: EventType.RUN_FINISHED, threadId: "t", runId: "r-2" } as BaseEvent,
+    ]);
+    const onRunFinishedEvent = vi.fn();
+    await agent.runAgent({}, { onRunFinishedEvent });
+    expect(onRunFinishedEvent).toHaveBeenCalledTimes(2);
+    expect(onRunFinishedEvent.mock.calls[0][0].pendingToolCallIds).toEqual(["tc-1"]);
+    expect(onRunFinishedEvent.mock.calls[1][0].pendingToolCallIds).toEqual(["tc-2"]);
+  });
+});

--- a/sdks/typescript/packages/client/src/agent/subscriber.ts
+++ b/sdks/typescript/packages/client/src/agent/subscriber.ts
@@ -79,7 +79,18 @@ export interface AgentSubscriber {
   ): MaybePromise<AgentStateMutation | void>;
   onRunFinishedEvent?(
     params: (
-      | { event: RunFinishedEvent; outcome: "success"; result?: unknown }
+      | {
+          event: RunFinishedEvent;
+          outcome: "success";
+          result?: unknown;
+          /**
+           * Tool calls the run left for the application to answer, in order.
+           * The producer's `outcome.pendingToolCallIds` when it named them;
+           * otherwise derived from the stream: every tool call this run
+           * started that received no TOOL_CALL_RESULT.
+           */
+          pendingToolCallIds: string[];
+        }
       | { event: RunFinishedEvent; outcome: "interrupt"; interrupts: Interrupt[] }
     ) &
       AgentSubscriberParams,

--- a/sdks/typescript/packages/client/src/apply/default.ts
+++ b/sdks/typescript/packages/client/src/apply/default.ts
@@ -143,6 +143,19 @@ export const defaultApplyEvents = (
   let state = structuredClone_(input.state);
   let currentMutation: AgentStateMutation = {};
 
+  // The tool calls this run has started and answered so far. RUN_FINISHED
+  // reads them when the success outcome names no `pendingToolCallIds`: the
+  // specification lets a consumer derive the pending list from the stream —
+  // every call the run started that got no TOOL_CALL_RESULT — and a producer
+  // that names the list is trusted over the tally.
+  let runToolCallIds: string[] = [];
+  let answeredToolCallIds = new Set<string>();
+  const pendingToolCallIdsOf = (e: RunFinishedEvent): string[] => {
+    const named = e.outcome?.type === "success" ? e.outcome.pendingToolCallIds : undefined;
+    if (named !== undefined && named.length > 0) return [...named];
+    return runToolCallIds.filter((id) => !answeredToolCallIds.has(id));
+  };
+
   const applyMutation = (mutation: AgentStateMutation) => {
     if (mutation.messages !== undefined) {
       messages = mutation.messages;
@@ -386,6 +399,7 @@ export const defaultApplyEvents = (
           if (mutation.stopPropagation !== true) {
             const { toolCallId, toolCallName, parentMessageId, subagentRunId } =
               event as ToolCallStartEvent;
+            if (!runToolCallIds.includes(toolCallId)) runToolCallIds.push(toolCallId);
 
             // Applying a start event must be idempotent. The same start can
             // reach this reducer twice — a tool call already carried in
@@ -608,6 +622,7 @@ export const defaultApplyEvents = (
           if (mutation.stopPropagation !== true) {
             const { messageId, toolCallId, content, role, subagentRunId } =
               event as ToolCallResultEvent;
+            answeredToolCallIds.add(toolCallId);
 
             const toolMessage: ToolMessage = {
               id: messageId,
@@ -1028,6 +1043,9 @@ export const defaultApplyEvents = (
               }),
           );
           applyMutation(mutation);
+          // A new run starts a new tally: pending calls are run-scoped.
+          runToolCallIds = [];
+          answeredToolCallIds = new Set<string>();
 
           // Handle input.messages if present and stopPropagation is not set
           if (mutation.stopPropagation !== true) {
@@ -1069,7 +1087,12 @@ export const defaultApplyEvents = (
                   outcome: "interrupt" as const,
                   interrupts: e.outcome.interrupts,
                 } as const)
-              : ({ event: e, outcome: "success" as const, result: e.result } as const);
+              : ({
+                  event: e,
+                  outcome: "success" as const,
+                  result: e.result,
+                  pendingToolCallIds: pendingToolCallIdsOf(e),
+                } as const);
           const mutation = await runSubscribersWithMutation(
             subscribers,
             messages,

--- a/sdks/typescript/packages/core/src/__tests__/event-factories.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/event-factories.test.ts
@@ -193,7 +193,15 @@ describe("event factories", () => {
     const started = createRunStartedEvent({
       threadId: "t1",
       runId: "r1",
-      input: { threadId: "t1", runId: "r1", state: {}, messages: [], tools: [], context: [], forwardedProps: {} },
+      input: {
+        threadId: "t1",
+        runId: "r1",
+        state: {},
+        messages: [],
+        tools: [],
+        context: [],
+        forwardedProps: {},
+      },
     });
     const finished = createRunFinishedEvent({ threadId: "t1", runId: "r1", result: { ok: true } });
     const error = createRunErrorEvent({ message: "boom", code: "E_FAIL" });
@@ -224,6 +232,22 @@ describe("createRunFinishedSuccessEvent", () => {
     expect(e.type).toBe(EventType.RUN_FINISHED);
     expect(e.outcome).toEqual({ type: "success" });
     expect(e.result).toEqual({ ok: true });
+  });
+});
+
+describe("createRunFinishedSuccessEvent — pendingToolCallIds", () => {
+  it("names the tool calls the run left unanswered on the success outcome", () => {
+    const e = createRunFinishedSuccessEvent({
+      threadId: "t-1",
+      runId: "r-1",
+      pendingToolCallIds: ["tc-1", "tc-2"],
+    });
+    expect(e.outcome).toEqual({ type: "success", pendingToolCallIds: ["tc-1", "tc-2"] });
+  });
+
+  it("omits pendingToolCallIds when none are given", () => {
+    const e = createRunFinishedSuccessEvent({ threadId: "t-1", runId: "r-1" });
+    expect(e.outcome).toEqual({ type: "success" });
   });
 });
 

--- a/sdks/typescript/packages/core/src/__tests__/run-finished-event.test.ts
+++ b/sdks/typescript/packages/core/src/__tests__/run-finished-event.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { EventType } from "../index";
-import {
-  EventSchemas,
-  RunFinishedEventSchema,
-  RunFinishedOutcomeSchema,
-} from "../schemas";
+import { EventSchemas, RunFinishedEventSchema, RunFinishedOutcomeSchema } from "../schemas";
 
 describe("RunFinishedEventSchema — outcome is optional and back-compat", () => {
   it("parses a legacy event with no outcome", () => {
@@ -52,6 +48,16 @@ describe("RunFinishedEventSchema — outcome is optional and back-compat", () =>
     expect(parsed.result).toEqual({ answer: 42 });
   });
 
+  it("parses outcome={ type: 'success', pendingToolCallIds: [...] }", () => {
+    const parsed = RunFinishedEventSchema.parse({
+      type: EventType.RUN_FINISHED,
+      threadId: "t-1",
+      runId: "r-1",
+      outcome: { type: "success", pendingToolCallIds: ["tc-1", "tc-2"] },
+    });
+    expect(parsed.outcome).toEqual({ type: "success", pendingToolCallIds: ["tc-1", "tc-2"] });
+  });
+
   it("parses outcome={ type: 'interrupt', interrupts: [...] }", () => {
     const parsed = RunFinishedEventSchema.parse({
       type: EventType.RUN_FINISHED,
@@ -71,8 +77,12 @@ describe("RunFinishedEventSchema — outcome is optional and back-compat", () =>
 
 describe("RunFinishedOutcomeSchema — discriminated union", () => {
   it("rejects outcome with empty interrupts", () => {
+    expect(() => RunFinishedOutcomeSchema.parse({ type: "interrupt", interrupts: [] })).toThrow();
+  });
+
+  it("rejects success pendingToolCallIds that are not strings", () => {
     expect(() =>
-      RunFinishedOutcomeSchema.parse({ type: "interrupt", interrupts: [] }),
+      RunFinishedOutcomeSchema.parse({ type: "success", pendingToolCallIds: [42] }),
     ).toThrow();
   });
 

--- a/sdks/typescript/packages/core/src/event-factories.ts
+++ b/sdks/typescript/packages/core/src/event-factories.ts
@@ -256,14 +256,23 @@ export const createRunFinishedEvent = (props: RunFinishedEventProps): RunFinishe
 
 /**
  * Creates a RUN_FINISHED event with `outcome: { type: "success" }`.
+ *
+ * `pendingToolCallIds` names the tool calls the run left for the application
+ * to answer — frontend tool calls with no TOOL_CALL_RESULT in the run. Omit it
+ * when the run left none, or when the consumer should derive the list itself.
  */
 export const createRunFinishedSuccessEvent = (
-  props: Omit<RunFinishedEventProps, "outcome">,
-): RunFinishedEvent =>
-  buildEvent(EventType.RUN_FINISHED, RunFinishedEventSchema, {
-    ...props,
-    outcome: { type: "success" },
+  props: Omit<RunFinishedEventProps, "outcome"> & { pendingToolCallIds?: string[] },
+): RunFinishedEvent => {
+  const { pendingToolCallIds, ...rest } = props;
+  return buildEvent(EventType.RUN_FINISHED, RunFinishedEventSchema, {
+    ...rest,
+    outcome: {
+      type: "success",
+      ...(pendingToolCallIds !== undefined ? { pendingToolCallIds } : {}),
+    },
   });
+};
 
 /**
  * Creates a RUN_FINISHED event with `outcome: { type: "interrupt", interrupts }`.

--- a/sdks/typescript/packages/core/src/generated/schemas.ts
+++ b/sdks/typescript/packages/core/src/generated/schemas.ts
@@ -736,10 +736,13 @@ export const RunStartedEventSchema = z.looseObject({
  * The run completed. Equivalent to an absent outcome. Closed like every other
  * object, which is also what keeps it from carrying the suspended sibling's
  * interrupts — a success with an interrupt still pending would be a
- * contradiction, not an extension.
+ * contradiction, not an extension. A completed run may still have left
+ * frontend tool calls for the application to answer; pendingToolCallIds names
+ * them.
  */
 export const RunFinishedSuccessOutcomeSchema = z.looseObject({
   type: z.literal("success"),
+  pendingToolCallIds: z.array(z.string()).optional(),
 });
 
 /**

--- a/sdks/typescript/packages/core/src/generated/serialization.ts
+++ b/sdks/typescript/packages/core/src/generated/serialization.ts
@@ -182,7 +182,7 @@ const shapes: Record<string, Shape> = {
     optional: ["timestamp", "rawEvent", "metadata", "protocolVersion", "parentRunId", "input"],
     fields: { input: "RunAgentInput" },
   },
-  RunFinishedSuccessOutcome: { optional: [], fields: {} },
+  RunFinishedSuccessOutcome: { optional: ["pendingToolCallIds"], fields: {} },
   Interrupt: {
     optional: ["subagentRunId", "message", "toolCallId", "responseSchema", "expiresAt", "metadata"],
     fields: {},

--- a/sdks/typescript/packages/core/src/generated/types.ts
+++ b/sdks/typescript/packages/core/src/generated/types.ts
@@ -1622,13 +1622,27 @@ export type RunStartedEvent = {
  * The run completed. Equivalent to an absent outcome. Closed like every other
  * object, which is also what keeps it from carrying the suspended sibling's
  * interrupts — a success with an interrupt still pending would be a
- * contradiction, not an extension.
+ * contradiction, not an extension. A completed run may still have left
+ * frontend tool calls for the application to answer; pendingToolCallIds names
+ * them.
  */
 export type RunFinishedSuccessOutcome = {
   /**
    * Discriminator.
    */
   type: "success";
+  /**
+   * The tool calls this run started and left unanswered — no TOOL_CALL_RESULT
+   * in the run — for the application to answer in the next input's messages,
+   * in the order they were made. Absent or empty means the producer named
+   * none, and a consumer derives the list from the stream; otherwise it is the
+   * list, and it agrees with the stream. On the success outcome rather than
+   * the event because a run that stopped on a frontend tool call is a
+   * completed run: whether the application continues the thread is its own
+   * decision, so the producer reports what it knows and no more. Each item: A
+   * tool call id, as carried by TOOL_CALL_START.
+   */
+  pendingToolCallIds?: string[];
 };
 
 /**

--- a/sdks/typescript/packages/proto/__tests__/__fixtures__/bytes/RunFinishedEvent__outcome-success-pending-tool-call-ids.json.bin
+++ b/sdks/typescript/packages/proto/__tests__/__fixtures__/bytes/RunFinishedEvent__outcome-success-pending-tool-call-ids.json.bin
@@ -1,0 +1,2 @@
+j%
+t1r1*successBcall-1Bcall-2

--- a/sdks/typescript/packages/proto/__tests__/schema-corpus.test.ts
+++ b/sdks/typescript/packages/proto/__tests__/schema-corpus.test.ts
@@ -430,6 +430,7 @@ describe("flattened outcome guards", () => {
           outcome: "cancelled",
           interrupts: [],
           usage: [],
+          pendingToolCallIds: [],
         },
       }),
     ) as unknown as { outcome?: unknown };
@@ -449,6 +450,7 @@ describe("flattened outcome guards", () => {
           outcome: "cancelled",
           interrupts: [{ id: "i1", reason: "r" }],
           usage: [],
+          pendingToolCallIds: [],
         },
       }),
     ) as unknown as { outcome?: { type?: string; interrupts?: unknown[] } };
@@ -471,6 +473,7 @@ describe("flattened outcome guards", () => {
           outcome: "success",
           interrupts: [{ id: "i1", reason: "r" }],
           usage: [],
+          pendingToolCallIds: [],
         },
       }),
     ) as unknown as { outcome?: { type?: string; interrupts?: unknown[] } };
@@ -492,6 +495,7 @@ describe("flattened outcome guards", () => {
           outcome: "",
           interrupts: [{ id: "i1", reason: "r" }],
           usage: [],
+          pendingToolCallIds: [],
         },
       }),
     ) as unknown as { outcome?: unknown; interrupts?: unknown[] };

--- a/sdks/typescript/packages/proto/src/generated/events.ts
+++ b/sdks/typescript/packages/proto/src/generated/events.ts
@@ -550,6 +550,17 @@ export interface RunFinishedEvent {
    * totals sums across the entries.
    */
   usage: Usage[];
+  /**
+   * The tool calls this run started and left unanswered — no TOOL_CALL_RESULT in
+   * the run — for the application to answer in the next input's messages, in the
+   * order they were made. Absent or empty means the producer named none, and a
+   * consumer derives the list from the stream; otherwise it is the list, and it
+   * agrees with the stream. On the success outcome rather than the event because
+   * a run that stopped on a frontend tool call is a completed run: whether the
+   * application continues the thread is its own decision, so the producer
+   * reports what it knows and no more.
+   */
+  pendingToolCallIds: string[];
 }
 
 /**
@@ -2568,7 +2579,16 @@ export const RunStartedEvent: MessageFns<RunStartedEvent> = {
 };
 
 function createBaseRunFinishedEvent(): RunFinishedEvent {
-  return { baseEvent: undefined, threadId: "", runId: "", result: undefined, outcome: "", interrupts: [], usage: [] };
+  return {
+    baseEvent: undefined,
+    threadId: "",
+    runId: "",
+    result: undefined,
+    outcome: "",
+    interrupts: [],
+    usage: [],
+    pendingToolCallIds: [],
+  };
 }
 
 export const RunFinishedEvent: MessageFns<RunFinishedEvent> = {
@@ -2593,6 +2613,9 @@ export const RunFinishedEvent: MessageFns<RunFinishedEvent> = {
     }
     for (const v of message.usage) {
       Usage.encode(v!, writer.uint32(58).fork()).join();
+    }
+    for (const v of message.pendingToolCallIds) {
+      writer.uint32(66).string(v!);
     }
     return writer;
   },
@@ -2660,6 +2683,14 @@ export const RunFinishedEvent: MessageFns<RunFinishedEvent> = {
           message.usage.push(Usage.decode(reader, reader.uint32()));
           continue;
         }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.pendingToolCallIds.push(reader.string());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2683,6 +2714,7 @@ export const RunFinishedEvent: MessageFns<RunFinishedEvent> = {
     message.outcome = object.outcome ?? "";
     message.interrupts = object.interrupts?.map((e) => Interrupt.fromPartial(e)) || [];
     message.usage = object.usage?.map((e) => Usage.fromPartial(e)) || [];
+    message.pendingToolCallIds = object.pendingToolCallIds?.map((e) => e) || [];
     return message;
   },
 };

--- a/sdks/typescript/packages/proto/src/proto.ts
+++ b/sdks/typescript/packages/proto/src/proto.ts
@@ -498,11 +498,13 @@ export function encode(event: BaseEvent): Uint8Array {
   }
   if (type === "RUN_FINISHED") {
     const outcomeRecord = asRecord(rest.outcome);
+    rest.pendingToolCallIds = [];
     rest.interrupts = [];
     if (rest.outcome === undefined) {
       rest.outcome = "";
     } else if (outcomeRecord?.type === "success") {
       rest.outcome = "success";
+      rest.pendingToolCallIds = asArray(outcomeRecord?.pendingToolCallIds);
     } else if (outcomeRecord?.type === "interrupt") {
       rest.outcome = "interrupt";
       rest.interrupts = asArray(outcomeRecord?.interrupts);
@@ -1247,10 +1249,15 @@ export function decode(data: Uint8Array): BaseEvent {
         ? (record.outcome as string)
         : undefined;
     const payload: LooseRecord = {};
+    payload.pendingToolCallIds = record.pendingToolCallIds;
+    delete record.pendingToolCallIds;
     payload.interrupts = record.interrupts;
     delete record.interrupts;
     delete record.outcome;
     if (wireOutcome === undefined) {
+      if (asArray(payload.pendingToolCallIds).length > 0) {
+        record.pendingToolCallIds = payload.pendingToolCallIds;
+      }
       if (asArray(payload.interrupts).length > 0) {
         record.interrupts = payload.interrupts;
       }
@@ -1258,11 +1265,20 @@ export function decode(data: Uint8Array): BaseEvent {
     if (wireOutcome === "success") {
       record.outcome = {
         type: "success",
+        ...(asArray(payload.pendingToolCallIds).length > 0
+          ? { pendingToolCallIds: payload.pendingToolCallIds }
+          : {}),
         ...(asArray(payload.interrupts).length > 0 ? { interrupts: payload.interrupts } : {}),
       };
     }
     if (wireOutcome === "interrupt") {
-      record.outcome = { type: "interrupt", interrupts: asArray(payload.interrupts) };
+      record.outcome = {
+        type: "interrupt",
+        interrupts: asArray(payload.interrupts),
+        ...(asArray(payload.pendingToolCallIds).length > 0
+          ? { pendingToolCallIds: payload.pendingToolCallIds }
+          : {}),
+      };
     }
     // An unrecognised outcome is still representable as JSON, so it
     // is rebuilt as it was sent rather than judged here. Decoding bytes into
@@ -1274,6 +1290,9 @@ export function decode(data: Uint8Array): BaseEvent {
     if (wireOutcome !== undefined && !["success", "interrupt"].includes(wireOutcome)) {
       record.outcome = {
         type: wireOutcome,
+        ...(asArray(payload.pendingToolCallIds).length > 0
+          ? { pendingToolCallIds: payload.pendingToolCallIds }
+          : {}),
         ...(asArray(payload.interrupts).length > 0 ? { interrupts: payload.interrupts } : {}),
       };
     }

--- a/sdks/typescript/packages/proto/src/proto/events.proto
+++ b/sdks/typescript/packages/proto/src/proto/events.proto
@@ -372,6 +372,15 @@ message RunFinishedEvent {
   // invoked several models keeps them separate. A consumer that only wants
   // totals sums across the entries.
   repeated Usage usage = 7;
+  // The tool calls this run started and left unanswered — no TOOL_CALL_RESULT in
+  // the run — for the application to answer in the next input's messages, in the
+  // order they were made. Absent or empty means the producer named none, and a
+  // consumer derives the list from the stream; otherwise it is the list, and it
+  // agrees with the stream. On the success outcome rather than the event because
+  // a run that stopped on a frontend tool call is a completed run: whether the
+  // application continues the thread is its own decision, so the producer
+  // reports what it knows and no more.
+  repeated string pending_tool_call_ids = 8;
 }
 
 // Ends a run that failed. Run-scoped, so it carries no subagent attribution; a

--- a/spec/RECONCILIATION.md
+++ b/spec/RECONCILIATION.md
@@ -415,9 +415,10 @@ as optional.
 
 ## RunFinishedSuccessOutcome
 
-| field | TypeScript | Python   | .NET     | schema   |
-| ----- | ---------- | -------- | -------- | -------- |
-| type  | required   | required | required | required |
+| field              | TypeScript | Python             | .NET               | schema   |
+| ------------------ | ---------- | ------------------ | ------------------ | -------- |
+| pendingToolCallIds | optional   | optional, nullable | optional, nullable | optional |
+| type               | required   | required           | required           | required |
 
 ## RunFinishedInterruptOutcome
 

--- a/spec/draft/fixtures/MANIFEST.txt
+++ b/spec/draft/fixtures/MANIFEST.txt
@@ -117,6 +117,8 @@ RunAgentInput/valid/without-tools-or-context.json
 RunErrorEvent/invalid/usage-item-not-a-token-usage.expect.json
 RunErrorEvent/invalid/usage-item-not-a-token-usage.json
 RunErrorEvent/valid/minimal.json
+RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.expect.json
+RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.json
 RunFinishedEvent/invalid/outcome-interrupt-item-not-an-interrupt.expect.json
 RunFinishedEvent/invalid/outcome-interrupt-item-not-an-interrupt.json
 RunFinishedEvent/invalid/outcome-interrupt-with-no-interrupts.expect.json
@@ -125,6 +127,8 @@ RunFinishedEvent/invalid/outcome-null.expect.json
 RunFinishedEvent/invalid/outcome-null.json
 RunFinishedEvent/invalid/outcome-success-carrying-interrupts.expect.json
 RunFinishedEvent/invalid/outcome-success-carrying-interrupts.json
+RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.expect.json
+RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.json
 RunFinishedEvent/invalid/usage-item-not-a-token-usage.expect.json
 RunFinishedEvent/invalid/usage-item-not-a-token-usage.json
 RunFinishedEvent/invalid/usage-negative-token-count.expect.json
@@ -133,6 +137,7 @@ RunFinishedEvent/valid/minimal.json
 RunFinishedEvent/valid/outcome-absent.json
 RunFinishedEvent/valid/outcome-interrupt-full.json
 RunFinishedEvent/valid/outcome-interrupt.json
+RunFinishedEvent/valid/outcome-success-pending-tool-call-ids.json
 RunFinishedEvent/valid/outcome-success.json
 RunFinishedEvent/valid/result-array.json
 RunFinishedEvent/valid/result-number.json

--- a/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.expect.json
+++ b/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.expect.json
@@ -1,0 +1,5 @@
+{
+  "keyword": "unevaluatedProperties",
+  "instanceLocation": "/outcome",
+  "keywordLocation": "#/unevaluatedProperties"
+}

--- a/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.json
+++ b/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-interrupt-carrying-pending-tool-call-ids.json
@@ -1,0 +1,15 @@
+{
+  "type": "RUN_FINISHED",
+  "threadId": "t1",
+  "runId": "r1",
+  "outcome": {
+    "type": "interrupt",
+    "interrupts": [
+      {
+        "id": "i1",
+        "reason": "tool_approval"
+      }
+    ],
+    "pendingToolCallIds": ["call-1"]
+  }
+}

--- a/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.expect.json
+++ b/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.expect.json
@@ -1,0 +1,5 @@
+{
+  "keyword": "type",
+  "instanceLocation": "/outcome/pendingToolCallIds/0",
+  "keywordLocation": "#/$defs/RunFinishedSuccessOutcome/properties/pendingToolCallIds/items/type"
+}

--- a/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.json
+++ b/spec/draft/fixtures/RunFinishedEvent/invalid/outcome-success-pending-tool-call-id-not-a-string.json
@@ -1,0 +1,9 @@
+{
+  "type": "RUN_FINISHED",
+  "threadId": "t1",
+  "runId": "r1",
+  "outcome": {
+    "type": "success",
+    "pendingToolCallIds": [42]
+  }
+}

--- a/spec/draft/fixtures/RunFinishedEvent/valid/outcome-success-pending-tool-call-ids.json
+++ b/spec/draft/fixtures/RunFinishedEvent/valid/outcome-success-pending-tool-call-ids.json
@@ -1,0 +1,9 @@
+{
+  "type": "RUN_FINISHED",
+  "threadId": "t1",
+  "runId": "r1",
+  "outcome": {
+    "type": "success",
+    "pendingToolCallIds": ["call-1", "call-2"]
+  }
+}

--- a/spec/draft/proto-freeze.txt
+++ b/spec/draft/proto-freeze.txt
@@ -190,6 +190,7 @@ RunErrorEvent.usage = 4
 RunFinishedEvent.base_event = 1
 RunFinishedEvent.interrupts = 6
 RunFinishedEvent.outcome = 5
+RunFinishedEvent.pending_tool_call_ids = 8
 RunFinishedEvent.result = 4
 RunFinishedEvent.run_id = 3
 RunFinishedEvent.thread_id = 2

--- a/spec/draft/schema.json
+++ b/spec/draft/schema.json
@@ -886,9 +886,17 @@
     "RunFinishedSuccessOutcome": {
       "$anchor": "RunFinishedSuccessOutcome",
       "type": "object",
-      "description": "The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension.",
+      "description": "The run completed. Equivalent to an absent outcome. Closed like every other object, which is also what keeps it from carrying the suspended sibling's interrupts — a success with an interrupt still pending would be a contradiction, not an extension. A completed run may still have left frontend tool calls for the application to answer; pendingToolCallIds names them.",
       "properties": {
-        "type": { "const": "success", "description": "Discriminator." }
+        "type": { "const": "success", "description": "Discriminator." },
+        "pendingToolCallIds": {
+          "type": "array",
+          "description": "The tool calls this run started and left unanswered — no TOOL_CALL_RESULT in the run — for the application to answer in the next input's messages, in the order they were made. Absent or empty means the producer named none, and a consumer derives the list from the stream; otherwise it is the list, and it agrees with the stream. On the success outcome rather than the event because a run that stopped on a frontend tool call is a completed run: whether the application continues the thread is its own decision, so the producer reports what it knows and no more.",
+          "items": {
+            "type": "string",
+            "description": "A tool call id, as carried by TOOL_CALL_START."
+          }
+        }
       },
       "required": ["type"],
       "unevaluatedProperties": false

--- a/spec/generator/dotnet.ts
+++ b/spec/generator/dotnet.ts
@@ -496,6 +496,7 @@ const MAPPED_FIELDS: Record<string, Record<string, string>> = {
   },
   RunFinishedSuccessOutcome: {
     type: "required literal(success)",
+    pendingToolCallIds: "optional string[]",
   },
   RunFinishedInterruptOutcome: {
     type: "required literal(interrupt)",
@@ -767,9 +768,16 @@ export function emitDotnet(
                         proto.Interrupts.Add(ProtoMessageMapper.ToProtoInterrupt(interrupt));
                     }
                 }
-                else if (e.Outcome is RunFinishedSuccessOutcome)
+                else if (e.Outcome is RunFinishedSuccessOutcome successOutcome)
                 {
                     proto.Outcome = "success";
+                    if (successOutcome.PendingToolCallIds is not null)
+                    {
+                        foreach (var pendingToolCallId in successOutcome.PendingToolCallIds)
+                        {
+                            proto.PendingToolCallIds.Add(pendingToolCallId);
+                        }
+                    }
                 }
                 else
                 {
@@ -979,6 +987,14 @@ ${decodeCases}
                     "Invalid event: interrupt outcome carries no interrupts.");
             }
 
+            // Pending tool call ids belong to the success outcome: an
+            // interrupted run names what it waits for through its interrupts.
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                throw new System.IO.InvalidDataException(
+                    "Invalid event: outcome interrupt cannot carry pendingToolCallIds.");
+            }
+
             var outcome = new RunFinishedInterruptOutcome();
             foreach (var interrupt in proto.Interrupts)
             {
@@ -999,7 +1015,13 @@ ${decodeCases}
                     "Invalid event: outcome success cannot carry interrupts.");
             }
 
-            return new RunFinishedSuccessOutcome();
+            var outcome = new RunFinishedSuccessOutcome();
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                outcome.PendingToolCallIds = new List<string>(proto.PendingToolCallIds);
+            }
+
+            return outcome;
         }
 
         if (proto.Outcome.Length == 0)
@@ -1008,6 +1030,12 @@ ${decodeCases}
             {
                 throw new System.IO.InvalidDataException(
                     "Invalid event: absent outcome cannot carry interrupts.");
+            }
+
+            if (proto.PendingToolCallIds.Count > 0)
+            {
+                throw new System.IO.InvalidDataException(
+                    "Invalid event: absent outcome cannot carry pendingToolCallIds.");
             }
 
             return null;


### PR DESCRIPTION
Stacked on `mme/json-schema-codegen`. Resolves [PNI-428](https://linear.app/copilotkit/issue/PNI-428/decide-whether-a-run-that-stops-on-a-frontend-tool-call-needs-a), raised in [discussion #2608](https://github.com/ag-ui-protocol/ag-ui/discussions/2608#discussioncomment-18387733) ("should there be `done` vs `stopped to ask`?").

## Decision

A run that stops on a frontend tool call is a **completed run**, not an interrupted one, and not a third kind of ending. The outcome reports what the producer knows about why the run ended, and here the producer does not know whether it is waiting: whether a frontend tool's result starts another run is the application's decision. So the producer says what it does know, as detail on the success outcome:

```json
{ "type": "RUN_FINISHED", "outcome": { "type": "success", "pendingToolCallIds": ["call-1", "call-2"] } }
```

- Producers **MUST** finish such a run with the success outcome (or none) and **MUST NOT** report it as interrupted.
- Producers **SHOULD** send `pendingToolCallIds`; when present it **MUST** list exactly the tool calls the run started and did not answer with `TOOL_CALL_RESULT`.
- Absent or empty, a consumer derives the list from the stream. Older consumers strip the field and still read a successful run.

Why not reuse the interrupt outcome: interrupts are answered by resume entries, frontend calls by tool messages in history, so reusing it would force double bookkeeping. Why not a new outcome: it would strip to success on older consumers anyway, and every shipping integration sends a bare `RUN_FINISHED` here today. Why on the success outcome rather than the event: the field is meaningful only for a completed run; on an interrupted run the calls are derived from the stream.

## Changes

- **Schema**: `RunFinishedSuccessOutcome.pendingToolCallIds` (optional `string[]`). Fixtures: accepted shape, non-string item, interrupt outcome carrying it. `RECONCILIATION.md` regenerated.
- **Generated (TS / Python / .NET / proto)**: models regenerated; proto slot `RunFinishedEvent.pending_tool_call_ids = 8` appended to the freeze; byte fixtures pinned on both runtimes. The .NET mapper encodes/decodes the field on success and rejects it on interrupt or absent outcomes, mirroring the existing `interrupts` guards.
- **TypeScript client**: `onRunFinishedEvent` success params now carry `pendingToolCallIds: string[]`, taken from the producer's list when present and otherwise derived from a run-scoped tally of started vs. answered tool calls.
- **TypeScript core**: `createRunFinishedSuccessEvent` accepts `pendingToolCallIds`.
- **Spec prose**: tool-calls page states the rule in RFC 2119 language plus a Note with the reasoning; lifecycle, interrupt-resume and changelog pages made consistent.

## Verification

| Suite | Result |
| --- | --- |
| `@ag-ui/spec` (fixtures, generator drift, conformance) | 1441 passed |
| `@ag-ui/core` | 234 passed |
| `@ag-ui/client` | 1100 passed |
| `@ag-ui/proto` (incl. byte corpus both directions) | 473 passed |
| Python SDK | 233 passed |
| .NET (all test projects, net8/9/10) | all passed |

Typecheck and lint clean on core, client, proto and spec.

## Follow-up (not in this PR)

- Reply on the discussion thread pointing at the updated tool-calls page once this lands.
- Producers in `integrations/` can start emitting `pendingToolCallIds`; the client fallback keeps them conformant meanwhile.
