### PR TITLE
docs: list Material 3 Expressive as a community AG-UI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ AG-UI was born from CopilotKit's initial **partnership** with LangChain and Crew
 | Terminal + Agent | ✅ Supported | ➡️ [Getting Started](https://docs.ag-ui.com/quickstart/clients) | Community |
 | Chat platforms (Slack, Microsoft Teams) | ✅ Supported | ➡️ [Channels SDK](https://github.com/CopilotKit/channels-sdk) 🎮 [OpenTag example](https://github.com/CopilotKit/OpenTag) | 1st Party |
 | [React Native](https://reactnative.dev/) | ✅ Supported | ➡️ [Example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/v2/react-native/demo) | 1st Party |
+| [Material 3 Expressive (React)](https://github.com/Language-Lit/material3-expressive-ag-ui) | ✅ Supported | ➡️ [Docs](https://m3e.language-lit.com/docs/ag-ui-getting-started/) 🎮 [Demo](https://m3e.language-lit.com/ag-ui/) | Community |
 
 [View all supported integrations →](https://docs.ag-ui.com/introduction#supported-integrations)
 

--- a/docs/integrations.mdx
+++ b/docs/integrations.mdx
@@ -62,6 +62,7 @@ that demonstrate the protocol's capabilities and versatility.
 | [Terminal + Agent](https://docs.ag-ui.com/quickstart/clients)
 | [Chat platforms — Slack, Microsoft Teams](https://github.com/CopilotKit/channels-sdk)
 | [React Native](https://github.com/CopilotKit/CopilotKit/tree/main/examples/v2/react-native/demo)
+| [Material 3 Expressive (React)](https://m3e.language-lit.com/ag-ui/)
 
 
 Join [Discord](https://discord.gg/Jd3FzfdJa8) to engage with the AG-UI community.


### PR DESCRIPTION
## Summary

Adds `@language-lit/material3-expressive-ag-ui` to the Clients tables as a community client: the row in the README and the matching line in `docs/integrations.mdx`. Docs only, no code changes.

It is a React component library for AG-UI agent interfaces built on Material 3 Expressive: streaming conversations, reasoning disclosures, tool-call cards, generative UI, human approval prompts, and a composer, all sharing one theme with the rest of a Material app. It works with plain `@ag-ui/client` subscriptions and with CopilotKit, so it complements the first-party client rather than replacing it.

- Source: https://github.com/Language-Lit/material3-expressive-ag-ui
- npm: https://www.npmjs.com/package/@language-lit/material3-expressive-ag-ui
- Live demo and docs: https://m3e.language-lit.com/ag-ui/
- Announcement: #2723

Independent community implementation, MIT licensed.