### PR TITLE
docs(interrupts): fix the lifecycle diagram broken by a semicolon

### DIFF
--- a/docs/concepts/interrupts.mdx
+++ b/docs/concepts/interrupts.mdx
@@ -25,7 +25,7 @@ sequenceDiagram
   Note over Agent,Client: User resolves interrupts
   Client-->>Agent: RunAgentInput { threadId, resume: [{interruptId, status, payload?}, ...] }
 
-  Note over Agent,Client: Run 2 begins; resume[].interruptId links back to run 1's interrupts
+  Note over Agent,Client: Run 2 begins, resume[].interruptId links back to run 1's interrupts
   Agent-->>Client: RunStarted (runId: r2)
   Agent-->>Client: ...continue / ToolCallResult / ...
   Agent-->>Client: RunFinished { outcome: { type: "success" }, result }


### PR DESCRIPTION
Fixes #2738.

## The cause

Line 28 of `docs/concepts/interrupts.mdx` had a semicolon inside a `Note`:

```
Note over Agent,Client: Run 2 begins; resume[].interruptId links back to run 1's interrupts
```

Mermaid treats `;` as a statement separator, so the note ended at `Run 2 begins` and the rest of the line was parsed as a new statement. That statement is not valid, the parse failed, and the Lifecycle diagram showed "Failed to render the Mermaid diagram."

## The change

The semicolon is now a comma. The note reads the same, and the block parses.

## How I checked

With the Mermaid 11 parser (`mermaid.parse`), the block fails before this change, with `Parse error on line 14 ... got 'NEWLINE'`, and parses after it. I also parsed every mermaid block under `docs/` on `main`, 27 in all, and this was the only one that failed, so there is nothing else of this kind to fix.

## Scope

This file does not pass `prettier --check` on `main`. The diagram is outside everything prettier wants to change, so I left the rest of the file alone rather than reformat unrelated lines.
